### PR TITLE
 Async profiler: V1 (TaskAsync) instrumentation + tests.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -1179,7 +1179,7 @@ namespace System.Runtime.CompilerServices
                     Continuation? nextContinuation = state.SentinelContinuation!.Next;
                     if (nextContinuation != null)
                     {
-                        AsyncProfiler.CreateAsyncContext.Create((ulong)task.Id, nextContinuation);
+                        AsyncProfiler.CreateAsyncContext.Create(task, nextContinuation);
                     }
                 }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -983,12 +983,13 @@ namespace System.Runtime.CompilerServices
                 {
                     Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
                     Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
+                    Continuation? nextContinuation = curContinuation.Next;
                     try
                     {
-                        Continuation? nextContinuation = curContinuation.Next;
-                        asyncDispatcherInfo.NextContinuation = nextContinuation;
+                        RuntimeAsyncInstrumentationHelpers.SyncPointCheck(ref asyncDispatcherInfo, flags);
 
                         Debug.Assert(awaitState.CurrentThread != null);
+
                         if (curContinuation.TryGetExecutionContext(out ExecutionContext? execContext))
                         {
                             RestoreExecutionContext(awaitState.CurrentThread, execContext);
@@ -1002,6 +1003,7 @@ namespace System.Runtime.CompilerServices
                         if (newContinuation != null)
                         {
                             newContinuation.Next = nextContinuation;
+                            asyncDispatcherInfo.NextContinuation = awaitState.SentinelContinuation!.Next ?? newContinuation;
 
                             RuntimeAsyncInstrumentationHelpers.AwaitSuspendedRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation, newContinuation, awaitState.SentinelContinuation!.Next);
                             InstrumentedHandleSuspended(flags, ref awaitState);
@@ -1011,10 +1013,14 @@ namespace System.Runtime.CompilerServices
                             return;
                         }
 
+                        asyncDispatcherInfo.NextContinuation = nextContinuation;
+
                         RuntimeAsyncInstrumentationHelpers.CompleteRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
                     }
                     catch (Exception ex)
                     {
+                        asyncDispatcherInfo.NextContinuation = nextContinuation;
+
                         uint unwindedFrames = 1; // Count current frame.
                         Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
                         if (handlerContinuation == null)
@@ -1511,6 +1517,15 @@ namespace System.Runtime.CompilerServices
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void SyncPointCheck(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
+            {
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                {
+                    AsyncProfiler.SyncPoint.Check(ref info.AsyncProfilerInfo);
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static void ResumeRuntimeAsyncContext(Task task, ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
             {
                 info.CurrentTask = task;
@@ -1645,20 +1660,17 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                 {
-                    AsyncProfiler.ContinuationWrapper.IncrementIndex(ref info.AsyncProfilerInfo);
-                }
-
-                if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
-                {
-                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
                     {
                         AsyncProfiler.CompleteAsyncMethod.Complete(ref info.AsyncProfilerInfo);
                     }
 
-                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
-                    {
-                        AsyncDebugger.CompleteAsyncMethod(curContinuation);
-                    }
+                    AsyncProfiler.ContinuationWrapper.IncrementIndex(ref info.AsyncProfilerInfo);
+                }
+
+                if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags) && AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
+                {
+                    AsyncDebugger.CompleteAsyncMethod(curContinuation);
                 }
             }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -1586,7 +1586,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                     {
-                        AsyncProfiler.CompleteAsyncContext.Complete(ref info.AsyncProfilerInfo);
+                        AsyncProfiler.CompleteAsyncContext.Complete(ref info);
                     }
 
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
@@ -1607,7 +1607,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                     {
-                        AsyncProfiler.AsyncMethodException.Unhandled(ref info.AsyncProfilerInfo, unwindedFrames);
+                        AsyncProfiler.AsyncMethodException.Unhandled(ref info, unwindedFrames);
                     }
 
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
@@ -1628,7 +1628,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                     {
-                        AsyncProfiler.AsyncMethodException.Handled(ref info.AsyncProfilerInfo, unwindedFrames);
+                        AsyncProfiler.AsyncMethodException.Handled(ref info, unwindedFrames);
                     }
 
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
@@ -1645,7 +1645,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                     {
-                        AsyncProfiler.ResumeAsyncMethod.Resume(ref info.AsyncProfilerInfo);
+                        AsyncProfiler.ResumeAsyncMethod.Resume(ref info);
                     }
 
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
@@ -1662,7 +1662,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
                     {
-                        AsyncProfiler.CompleteAsyncMethod.Complete(ref info.AsyncProfilerInfo);
+                        AsyncProfiler.CompleteAsyncMethod.Complete(ref info);
                     }
 
                     AsyncProfiler.ContinuationWrapper.IncrementIndex(ref info.AsyncProfilerInfo);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -983,13 +983,14 @@ namespace System.Runtime.CompilerServices
                 {
                     Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
                     Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
-                    Continuation? nextContinuation = curContinuation.Next;
                     try
                     {
-                        RuntimeAsyncInstrumentationHelpers.SyncPointCheck(ref asyncDispatcherInfo, flags);
+                        Continuation? nextContinuation = curContinuation.Next;
+                        asyncDispatcherInfo.NextContinuation = nextContinuation;
+
+                        RuntimeAsyncInstrumentationHelpers.SyncPointCheck(ref asyncDispatcherInfo, flags, curContinuation);
 
                         Debug.Assert(awaitState.CurrentThread != null);
-
                         if (curContinuation.TryGetExecutionContext(out ExecutionContext? execContext))
                         {
                             RestoreExecutionContext(awaitState.CurrentThread, execContext);
@@ -1003,7 +1004,6 @@ namespace System.Runtime.CompilerServices
                         if (newContinuation != null)
                         {
                             newContinuation.Next = nextContinuation;
-                            asyncDispatcherInfo.NextContinuation = awaitState.SentinelContinuation!.Next ?? newContinuation;
 
                             RuntimeAsyncInstrumentationHelpers.AwaitSuspendedRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation, newContinuation, awaitState.SentinelContinuation!.Next);
                             InstrumentedHandleSuspended(flags, ref awaitState);
@@ -1013,14 +1013,10 @@ namespace System.Runtime.CompilerServices
                             return;
                         }
 
-                        asyncDispatcherInfo.NextContinuation = nextContinuation;
-
                         RuntimeAsyncInstrumentationHelpers.CompleteRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
                     }
                     catch (Exception ex)
                     {
-                        asyncDispatcherInfo.NextContinuation = nextContinuation;
-
                         uint unwindedFrames = 1; // Count current frame.
                         Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
                         if (handlerContinuation == null)
@@ -1517,10 +1513,11 @@ namespace System.Runtime.CompilerServices
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static void SyncPointCheck(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
+            public static void SyncPointCheck(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Continuation curContinuation)
             {
                 if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                 {
+                    info.AsyncProfilerInfo.CurrentContinuation = curContinuation;
                     AsyncProfiler.SyncPoint.Check(ref info.AsyncProfilerInfo);
                 }
             }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -464,7 +464,7 @@ namespace System.Runtime.CompilerServices
                 {
                     CaptureRuntimeAsyncCallstackState state = default;
                     state.Continuation = asyncCallstack;
-                    EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, state);
+                    EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, ref state);
                 }
             }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -600,11 +600,13 @@ namespace System.Runtime.CompilerServices
                     return true;
                 }
 
-                byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, (buffer.Length - index) / MaxRuntimeAsyncMethodFrameSize);
-                if (maxAsyncCallstackFrames == 0)
+                int remainingFrames = (buffer.Length - index) / MaxRuntimeAsyncMethodFrameSize;
+                if (remainingFrames == 0)
                 {
                     return false;
                 }
+
+                byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, state.Count + remainingFrames);
 
                 Span<byte> callstackSpan = buffer.AsSpan(index);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -403,25 +403,34 @@ namespace System.Runtime.CompilerServices
             private static ContinuationWrapperTable s_continuationWrappers = InitContinuationWrappers();
         }
 
-        private static partial class SyncPoint
+        internal static partial class SyncPoint
         {
             private static unsafe void ResumeAsyncCallstacks(AsyncThreadContext context)
             {
-                //Write recursively all the resume async callstack events.
-                AsyncDispatcherInfo* info = AsyncDispatcherInfo.t_current;
-                if (info != null)
-                {
-                    ResumeRuntimeAsyncCallstacks(info, context);
-                }
+                //Write recursively all the resume async callstack events for both AsyncDispatcherInfo (V2) and AsyncTaskDispatcherInfo (V1).
+                //Ordered by their stack location, largest address first (assumes stack grow downwards).
+                AsyncDispatcherInfo* runtimeAsyncInfo = AsyncDispatcherInfo.t_current;
+                AsyncTaskDispatcherInfo* taskAsyncInfo = AsyncTaskDispatcherInfo.t_current;
 
+                ResumeAsyncCallstacks(runtimeAsyncInfo, taskAsyncInfo, context);
             }
 
-            private static unsafe void ResumeRuntimeAsyncCallstacks(AsyncDispatcherInfo* info, AsyncThreadContext context)
+            private static unsafe void ResumeAsyncCallstacks(AsyncDispatcherInfo* runtimeAsyncInfo, AsyncTaskDispatcherInfo* taskAsyncInfo, AsyncThreadContext context)
             {
-                if (info != null)
+                if (runtimeAsyncInfo == null && taskAsyncInfo == null)
                 {
-                    ResumeRuntimeAsyncCallstacks(info->Next, context);
-                    ResumeAsyncContext.Resume(ref *info, context, ResumeAsyncContext.GetId(ref *info), Config.ActiveEventKeywords);
+                    return;
+                }
+
+                if (taskAsyncInfo == null || (runtimeAsyncInfo != null && (void*)runtimeAsyncInfo < (void*)taskAsyncInfo))
+                {
+                    ResumeAsyncCallstacks(runtimeAsyncInfo->Next, taskAsyncInfo, context);
+                    ResumeAsyncContext.Resume(ref *runtimeAsyncInfo, context, ResumeAsyncContext.GetId(ref *runtimeAsyncInfo), Config.ActiveEventKeywords);
+                }
+                else
+                {
+                    ResumeAsyncCallstacks(runtimeAsyncInfo, taskAsyncInfo->Next, context);
+                    ResumeAsyncContext.Resume(ref *taskAsyncInfo, context, ResumeAsyncContext.GetId(ref *taskAsyncInfo), Config.ActiveEventKeywords);
                 }
             }
         }
@@ -449,7 +458,9 @@ namespace System.Runtime.CompilerServices
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id, Continuation? asyncCallstack)
             {
-                EmitEvent(context, currentTimestamp, AsyncEventID.ResumeAsyncCallstack, id, asyncCallstack);
+                CaptureRuntimeAsyncCallstackState state = default;
+                state.Continuation = asyncCallstack;
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.ResumeAsyncCallstack, id, ref state);
             }
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, Continuation? asyncCallstack)
@@ -464,9 +475,14 @@ namespace System.Runtime.CompilerServices
 
             private static bool CaptureRuntimeAsyncCallstack(byte[] buffer, ref int index, ref CaptureRuntimeAsyncCallstackState state)
             {
-                if (index > buffer.Length || state.Continuation == null)
+                if (index > buffer.Length)
                 {
                     return false;
+                }
+
+                if (state.Continuation == null)
+                {
+                    return true;
                 }
 
                 byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, (buffer.Length - index) / MaxRuntimeAsyncMethodFrameSize);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -25,12 +25,12 @@ namespace System.Runtime.CompilerServices
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     if (IsEnabled.CreateAsyncContextEvent(eventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, id);
+                        EmitEvent(context, currentTimestamp, id, AsyncEventID.RuntimeAsync_CreateAsyncContext);
                     }
 
                     if (IsEnabled.CreateAsyncCallstackEvent(eventKeywords) && nextContinuation != null)
                     {
-                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.CreateAsyncCallstack, id, nextContinuation);
+                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_CreateAsyncCallstack, id, nextContinuation);
                     }
                 }
 
@@ -70,13 +70,13 @@ namespace System.Runtime.CompilerServices
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     if (IsEnabled.ResumeAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, id);
+                        EmitEvent(context, currentTimestamp, id, AsyncEventID.RuntimeAsync_ResumeAsyncContext);
                     }
 
                     if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
                     {
                         byte wrapperIndex = (byte)(info.AsyncProfilerInfo.ContinuationIndex & ContinuationWrapper.COUNT_MASK);
-                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.ResumeAsyncCallstack, id, wrapperIndex, info.NextContinuation);
+                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, id, wrapperIndex, info.NextContinuation);
                     }
                 }
             }
@@ -97,12 +97,12 @@ namespace System.Runtime.CompilerServices
 
                     if (IsEnabled.SuspendAsyncCallstackEvent(activeEventKeywords) && nextContinuation != null)
                     {
-                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.SuspendAsyncCallstack, GetId(ref info), nextContinuation);
+                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, GetId(ref info), nextContinuation);
                     }
 
                     if (IsEnabled.SuspendAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp);
+                        EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_SuspendAsyncContext);
                     }
                 }
 
@@ -116,6 +116,95 @@ namespace System.Runtime.CompilerServices
                     return (ulong)info.CurrentTask.Id;
                 }
                 return 0;
+            }
+
+            private static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
+            {
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID, 0);
+            }
+        }
+
+        internal static partial class CompleteAsyncContext
+        {
+            public static void Complete(ref AsyncDispatcherInfo info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
+
+                SyncPoint.Check(context);
+
+                if (IsEnabled.CompleteAsyncContextEvent(context.ActiveEventKeywords))
+                {
+                    EmitEvent(context, Stopwatch.GetTimestamp(), AsyncEventID.RuntimeAsync_CompleteAsyncContext);
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+        }
+
+        internal static partial class AsyncMethodException
+        {
+            public static void Unhandled(ref AsyncDispatcherInfo info, uint unwindedFrames)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
+
+                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
+                {
+                    long currentTimestamp = Stopwatch.GetTimestamp();
+                    if (IsEnabled.UnwindAsyncExceptionEvent(activeEventKeywords))
+                    {
+                        EmitEvent(context, currentTimestamp, unwindedFrames, AsyncEventID.RuntimeAsync_UnwindAsyncException);
+                    }
+
+                    if (IsEnabled.CompleteAsyncContextEvent(activeEventKeywords))
+                    {
+                        CompleteAsyncContext.EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_CompleteAsyncContext);
+                    }
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+
+            public static void Handled(ref AsyncDispatcherInfo info, uint unwindedFrames)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
+
+                if (IsEnabled.UnwindAsyncExceptionEvent(context.ActiveEventKeywords))
+                {
+                    EmitEvent(context, Stopwatch.GetTimestamp(), unwindedFrames, AsyncEventID.RuntimeAsync_UnwindAsyncException);
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+        }
+
+        internal static partial class ResumeAsyncMethod
+        {
+            public static void Resume(ref AsyncDispatcherInfo info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
+
+                if (IsEnabled.ResumeAsyncMethodEvent(context.ActiveEventKeywords))
+                {
+                    EmitEvent(context, AsyncEventID.RuntimeAsync_ResumeAsyncMethod);
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+        }
+
+        internal static partial class CompleteAsyncMethod
+        {
+            public static void Complete(ref AsyncDispatcherInfo info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
+
+                if (IsEnabled.CompleteAsyncMethodEvent(context.ActiveEventKeywords))
+                {
+                    EmitEvent(context, AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
+                }
+
+                AsyncThreadContext.Release(context);
             }
         }
 
@@ -456,12 +545,13 @@ namespace System.Runtime.CompilerServices
                     return result;
                 }
 
-                public static AsyncCallstackType CallstackType => AsyncCallstackType.Runtime;
                 public static int MaxAsyncMethodFrameSize => MaxRuntimeAsyncMethodFrameSize;
             }
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, Continuation? asyncCallstack)
             {
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncCallstack || eventID == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack || eventID == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack);
+
                 CaptureRuntimeAsyncCallstackState state = default;
                 state.Continuation = asyncCallstack;
                 EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, 0, ref state);
@@ -469,6 +559,8 @@ namespace System.Runtime.CompilerServices
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, byte continuationIndex, Continuation? asyncCallstack)
             {
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncCallstack || eventID == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack || eventID == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack);
+
                 CaptureRuntimeAsyncCallstackState state = default;
                 state.Continuation = asyncCallstack;
                 EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, continuationIndex, ref state);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -408,8 +408,11 @@ namespace System.Runtime.CompilerServices
         {
             private static unsafe void ResumeAsyncCallstacks(AsyncThreadContext context)
             {
-                //Write recursively all the resume async callstack events for both AsyncDispatcherInfo (V2) and AsyncTaskDispatcherInfo (V1).
-                //Ordered by their stack location, largest address first (assumes stack grow downwards).
+                // Replay suspended dispatchers in original execution (push) order. Both TLS chains
+                // (V2 AsyncDispatcherInfo and V1 AsyncTaskDispatcherInfo) are linked head=most-recent,
+                // so head has the smallest stack address (downward-growing stacks). The walker
+                // recurses to Next BEFORE emitting, producing oldest-first emission, and merges the
+                // two chains by always recursing on the smaller-address node first.
                 AsyncDispatcherInfo* runtimeAsyncInfo = AsyncDispatcherInfo.t_current;
                 AsyncTaskDispatcherInfo* taskAsyncInfo = AsyncTaskDispatcherInfo.t_current;
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -4,15 +4,48 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Threading.Tasks;
 using Serializer = System.Runtime.CompilerServices.AsyncProfiler.EventBuffer.Serializer;
 
 namespace System.Runtime.CompilerServices
 {
     internal static partial class AsyncProfiler
     {
+        internal static class RuntimeAsyncIds
+        {
+            public static ulong GetDispatcherId(Task dispatcher) => (ulong)dispatcher.Id;
+
+            public static ulong GetDispatcherId(ref AsyncDispatcherInfo info)
+            {
+                if (info.CurrentTask != null)
+                {
+                    return (ulong)info.CurrentTask.Id;
+                }
+                return 0;
+            }
+        }
+
+        internal static unsafe ulong CaptureParentDispatcherId()
+        {
+            AsyncDispatcherInfo* v2 = AsyncDispatcherInfo.t_current;
+            AsyncTaskDispatcherInfo* v1 = AsyncTaskDispatcherInfo.t_current;
+
+            Task? parent = null;
+            if (v2 != null && (v1 == null || (void*)v2 < (void*)v1))
+            {
+                parent = v2->CurrentTask;
+            }
+            else if (v1 != null)
+            {
+                parent = v1->Dispatcher;
+            }
+
+            return parent != null ? (ulong)parent.Id : 0;
+        }
+
         internal static partial class CreateAsyncContext
         {
-            public static void Create(ulong id, Continuation nextContinuation)
+            public static void Create(Task dispatcher, Continuation nextContinuation)
             {
                 Info info = default;
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
@@ -22,15 +55,18 @@ namespace System.Runtime.CompilerServices
                 EventKeywords eventKeywords = context.ActiveEventKeywords;
                 if (IsEnabled.AnyAsyncEvents(eventKeywords))
                 {
+                    ulong parentDispatcherId = CaptureParentDispatcherId();
+                    ulong dispatcherId = RuntimeAsyncIds.GetDispatcherId(dispatcher);
                     long currentTimestamp = Stopwatch.GetTimestamp();
+
                     if (IsEnabled.CreateAsyncContextEvent(eventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, id, AsyncEventID.RuntimeAsync_CreateAsyncContext);
+                        EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.RuntimeAsync_CreateAsyncContext);
                     }
 
                     if (IsEnabled.CreateAsyncCallstackEvent(eventKeywords) && nextContinuation != null)
                     {
-                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_CreateAsyncCallstack, id, nextContinuation);
+                        AsyncCallstack.EmitCreateEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, nextContinuation);
                     }
                 }
 
@@ -40,25 +76,16 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class ResumeAsyncContext
         {
-            public static ulong GetId(ref AsyncDispatcherInfo info)
-            {
-                if (info.CurrentTask != null)
-                {
-                    return (ulong)info.CurrentTask.Id;
-                }
-                return 0;
-            }
-
             public static void Resume(ref AsyncDispatcherInfo info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                Resume(ref info, context, GetId(ref info), context.ActiveEventKeywords);
+                Resume(ref info, context, RuntimeAsyncIds.GetDispatcherId(ref info), context.ActiveEventKeywords);
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void Resume(ref AsyncDispatcherInfo info, AsyncThreadContext context, ulong id, EventKeywords activeEventKeywords)
+            public static void Resume(ref AsyncDispatcherInfo info, AsyncThreadContext context, ulong dispatcherId, EventKeywords activeEventKeywords)
             {
                 if (SyncPoint.Check(context))
                 {
@@ -70,13 +97,13 @@ namespace System.Runtime.CompilerServices
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     if (IsEnabled.ResumeAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, id, AsyncEventID.RuntimeAsync_ResumeAsyncContext);
+                        EmitEvent(context, currentTimestamp, dispatcherId, AsyncEventID.RuntimeAsync_ResumeAsyncContext);
                     }
 
                     if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
                     {
                         byte wrapperIndex = (byte)(info.AsyncProfilerInfo.ContinuationIndex & ContinuationWrapper.COUNT_MASK);
-                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, id, wrapperIndex, info.NextContinuation);
+                        AsyncCallstack.EmitResumeEvent(context, currentTimestamp, dispatcherId, wrapperIndex, info.NextContinuation);
                     }
                 }
             }
@@ -97,7 +124,7 @@ namespace System.Runtime.CompilerServices
 
                     if (IsEnabled.SuspendAsyncCallstackEvent(activeEventKeywords) && nextContinuation != null)
                     {
-                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, GetId(ref info), nextContinuation);
+                        AsyncCallstack.EmitSuspendEvent(context, currentTimestamp, RuntimeAsyncIds.GetDispatcherId(ref info), nextContinuation);
                     }
 
                     if (IsEnabled.SuspendAsyncContextEvent(activeEventKeywords))
@@ -107,15 +134,6 @@ namespace System.Runtime.CompilerServices
                 }
 
                 AsyncThreadContext.Release(context);
-            }
-
-            private static ulong GetId(ref AsyncDispatcherInfo info)
-            {
-                if (info.CurrentTask != null)
-                {
-                    return (ulong)info.CurrentTask.Id;
-                }
-                return 0;
             }
 
             private static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
@@ -518,12 +536,12 @@ namespace System.Runtime.CompilerServices
                 if (taskAsyncInfo == null || (runtimeAsyncInfo != null && (void*)runtimeAsyncInfo < (void*)taskAsyncInfo))
                 {
                     ResumeAsyncCallstacks(runtimeAsyncInfo->Next, taskAsyncInfo, context);
-                    ResumeAsyncContext.Resume(ref *runtimeAsyncInfo, context, ResumeAsyncContext.GetId(ref *runtimeAsyncInfo), Config.ActiveEventKeywords);
+                    ResumeAsyncContext.Resume(ref *runtimeAsyncInfo, context, RuntimeAsyncIds.GetDispatcherId(ref *runtimeAsyncInfo), Config.ActiveEventKeywords);
                 }
                 else
                 {
                     ResumeAsyncCallstacks(runtimeAsyncInfo, taskAsyncInfo->Next, context);
-                    ResumeAsyncContext.Resume(ref *taskAsyncInfo, context, ResumeAsyncContext.GetId(ref *taskAsyncInfo), Config.ActiveEventKeywords);
+                    ResumeAsyncContext.Resume(ref *taskAsyncInfo, context, TaskAsyncIds.GetDispatcherId(ref *taskAsyncInfo), Config.ActiveEventKeywords);
                 }
             }
         }
@@ -548,22 +566,25 @@ namespace System.Runtime.CompilerServices
                 public static int MaxAsyncMethodFrameSize => MaxRuntimeAsyncMethodFrameSize;
             }
 
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, Continuation? asyncCallstack)
+            public static void EmitCreateEvent(AsyncThreadContext context, long currentTimestamp, ulong parentDispatcherId, ulong dispatcherId, Continuation? asyncCallstack)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncCallstack || eventID == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack || eventID == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack);
-
                 CaptureRuntimeAsyncCallstackState state = default;
                 state.Continuation = asyncCallstack;
-                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, 0, ref state);
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.RuntimeAsync_CreateAsyncCallstack, parentDispatcherId, dispatcherId, 0, ref state);
             }
 
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, byte continuationIndex, Continuation? asyncCallstack)
+            public static void EmitSuspendEvent(AsyncThreadContext context, long currentTimestamp, ulong dispatcherId, Continuation? asyncCallstack)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncCallstack || eventID == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack || eventID == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack);
-
                 CaptureRuntimeAsyncCallstackState state = default;
                 state.Continuation = asyncCallstack;
-                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, continuationIndex, ref state);
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, 0, dispatcherId, 0, ref state);
+            }
+
+            public static void EmitResumeEvent(AsyncThreadContext context, long currentTimestamp, ulong dispatcherId, byte continuationIndex, Continuation? asyncCallstack)
+            {
+                CaptureRuntimeAsyncCallstackState state = default;
+                state.Continuation = asyncCallstack;
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, 0, dispatcherId, continuationIndex, ref state);
             }
 
             private static bool CaptureRuntimeAsyncCallstack(byte[] buffer, ref int index, ref CaptureRuntimeAsyncCallstackState state)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -93,14 +93,15 @@ namespace System.Runtime.CompilerServices
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.SuspendAsyncContextEvent(activeEventKeywords))
-                    {
-                        EmitEvent(context, currentTimestamp);
-                    }
 
                     if (IsEnabled.SuspendAsyncCallstackEvent(activeEventKeywords))
                     {
                         AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.SuspendAsyncCallstack, GetId(ref info), nextContinuation);
+                    }
+
+                    if (IsEnabled.SuspendAsyncContextEvent(activeEventKeywords))
+                    {
+                        EmitEvent(context, currentTimestamp);
                     }
                 }
 
@@ -433,23 +434,48 @@ namespace System.Runtime.CompilerServices
 
         private static partial class AsyncCallstack
         {
-            private const int MaxAsyncMethodFrameSize = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt32Size;
+            private const int MaxRuntimeAsyncMethodFrameSize = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt32Size;
 
-            public ref struct CaptureRuntimeAsyncCallstackState
+            private ref struct CaptureRuntimeAsyncCallstackState : ICaptureAsyncCallstack
             {
                 public Continuation? Continuation;
                 public ulong LastNativeIP;
                 public byte Count;
+
+                public bool Capture(byte[] buffer, ref int index, out byte count)
+                {
+                    bool result = CaptureRuntimeAsyncCallstack(buffer, ref index, ref this);
+                    count = Count;
+                    return result;
+                }
+
+                public static AsyncCallstackType CallstackType => AsyncCallstackType.Runtime;
+                public static int MaxAsyncMethodFrameSize => MaxRuntimeAsyncMethodFrameSize;
             }
 
-            public static bool CaptureRuntimeAsyncCallstack(byte[] buffer, ref int index, ref CaptureRuntimeAsyncCallstackState state)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id, Continuation? asyncCallstack)
+            {
+                EmitEvent(context, currentTimestamp, AsyncEventID.ResumeAsyncCallstack, id, asyncCallstack);
+            }
+
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, Continuation? asyncCallstack)
+            {
+                if (asyncCallstack != null)
+                {
+                    CaptureRuntimeAsyncCallstackState state = default;
+                    state.Continuation = asyncCallstack;
+                    EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, state);
+                }
+            }
+
+            private static bool CaptureRuntimeAsyncCallstack(byte[] buffer, ref int index, ref CaptureRuntimeAsyncCallstackState state)
             {
                 if (index > buffer.Length || state.Continuation == null)
                 {
                     return false;
                 }
 
-                byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, (buffer.Length - index) / MaxAsyncMethodFrameSize);
+                byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, (buffer.Length - index) / MaxRuntimeAsyncMethodFrameSize);
                 if (maxAsyncCallstackFrames == 0)
                 {
                     return false;
@@ -504,130 +530,6 @@ namespace System.Runtime.CompilerServices
                 index += callstackSpanIndex;
 
                 return state.Continuation == null || state.Count == byte.MaxValue;
-            }
-
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id, Continuation? asyncCallstack)
-            {
-                EmitEvent(context, currentTimestamp, AsyncEventID.ResumeAsyncCallstack, id, AsyncCallstackType.Runtime, asyncCallstack);
-            }
-
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, Continuation? asyncCallstack)
-            {
-                EmitEvent(context, currentTimestamp, eventID, id, AsyncCallstackType.Runtime, asyncCallstack);
-            }
-
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, AsyncCallstackType type, Continuation? asyncCallstack)
-            {
-                EmitEvent(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, type, asyncCallstack);
-            }
-
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong id, AsyncCallstackType type, Continuation? asyncCallstack)
-            {
-                if (asyncCallstack != null)
-                {
-                    ref EventBuffer eventBuffer = ref context.EventBuffer;
-
-                    // Max callstack data that can fit in the buffer after flush.
-                    int maxCallstackBytes = Math.Min(
-                        byte.MaxValue * MaxAsyncMethodFrameSize,
-                        eventBuffer.Data.Length);
-
-                    CaptureRuntimeAsyncCallstackState state = default;
-                    state.Continuation = asyncCallstack;
-
-                    // Static callstack payload: type (1) + callstackId (1) + frameCount (1) + id (max 10 bytes compressed).
-                    const int MaxStaticEventPayloadSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
-
-                    if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, MaxStaticEventPayloadSize, out Serializer.AsyncEventHeaderRollbackData rollbackData))
-                    {
-                        int frameCountOffset = CallstackHeader(ref eventBuffer, id, type, 0);
-
-                        byte[] buffer = eventBuffer.Data;
-                        int startIndex = eventBuffer.Index;
-                        int currentIndex = startIndex;
-
-                        if (!CaptureRuntimeAsyncCallstack(buffer, ref currentIndex, ref state))
-                        {
-                            byte[]? rentedArray = RentArray(maxCallstackBytes);
-                            if (rentedArray != null)
-                            {
-                                int length = currentIndex - startIndex;
-                                int index = length;
-
-                                Buffer.BlockCopy(buffer, startIndex, rentedArray, 0, length);
-                                CaptureRuntimeAsyncCallstack(rentedArray, ref index, ref state);
-
-                                // Rollback async event header before flushing.
-                                Serializer.RollbackAsyncEventHeader(context, in rollbackData);
-                                context.Flush();
-
-                                // Write the callstack again.
-                                if (Serializer.AsyncEventHeader(context, ref eventBuffer, context.LastEventTimestamp, 0, eventID, MaxStaticEventPayloadSize + index))
-                                {
-                                    CallstackHeader(ref eventBuffer, id, type, state.Count);
-                                    CallstackData(ref eventBuffer, rentedArray, index);
-                                }
-
-                                ArrayPool<byte>.Shared.Return(rentedArray);
-                            }
-                            else
-                            {
-                                // Rollback async event header since we can't write the callstack.
-                                Serializer.RollbackAsyncEventHeader(context, in rollbackData);
-                            }
-                        }
-                        else
-                        {
-                            // Patch frame count in the event buffer using the offset from CallstackHeader.
-                            eventBuffer.Data[frameCountOffset] = state.Count;
-                            eventBuffer.Index += currentIndex - startIndex;
-                        }
-                    }
-                }
-            }
-
-            private static int CallstackHeader(ref EventBuffer eventBuffer, ulong id, AsyncCallstackType type, byte callstackFrameCount)
-            {
-                // Callstack header layout: type (1 byte) + callstackId (1 byte, reserved for future use) + frameCount (1 byte) + id (max 10 bytes compressed).
-                const int MaxCallstackHeaderSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
-
-                ref int index = ref eventBuffer.Index;
-
-                Span<byte> callstackHeaderSpan = eventBuffer.Data.AsSpan(index, MaxCallstackHeaderSize);
-                int spanIndex = 0;
-
-                callstackHeaderSpan[spanIndex++] = (byte)type;
-                callstackHeaderSpan[spanIndex++] = 0; // Reserved callstack ID for future callstack interning.
-
-                int frameCountOffset = index + spanIndex;
-                callstackHeaderSpan[spanIndex++] = callstackFrameCount;
-
-                spanIndex += Serializer.WriteCompressedUInt64(callstackHeaderSpan.Slice(spanIndex), id);
-                eventBuffer.Index += spanIndex;
-
-                return frameCountOffset;
-            }
-
-            private static void CallstackData(ref EventBuffer eventBuffer, byte[] callstackData, int callstackDataByteCount)
-            {
-                ref int index = ref eventBuffer.Index;
-                Buffer.BlockCopy(callstackData, 0, eventBuffer.Data, index, callstackDataByteCount);
-                index += callstackDataByteCount;
-            }
-
-            private static byte[]? RentArray(int minimumLength)
-            {
-                byte[]? rentedArray = null;
-                try
-                {
-                    rentedArray = ArrayPool<byte>.Shared.Rent(minimumLength);
-                }
-                catch
-                {
-                    //AsyncProfiler can't throw, return null if renting fails.
-                }
-
-                return rentedArray;
             }
         }
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -148,12 +148,6 @@ namespace System.Runtime.CompilerServices
             /// </summary>
             public const string NameTemplate = "Continuation_Wrapper_{0}";
 
-            /// <summary>
-            /// Number of distinct wrapper methods. The wrapper index rotates modulo this value.
-            /// </summary>
-            public const byte COUNT = 32;
-            public const byte COUNT_MASK = COUNT - 1;
-
             public static void InitInfo(ref Info info)
             {
                 info.ContinuationTable = ref Unsafe.As<ContinuationWrapperTable, nint>(ref s_continuationWrappers);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -141,12 +141,6 @@ namespace System.Runtime.CompilerServices
 
                 AsyncThreadContext.Release(context);
             }
-
-            private static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
-            {
-                Debug.Assert(eventID == AsyncEventID.SuspendRuntimeAsyncContext);
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID);
-            }
         }
 
         internal static partial class CompleteAsyncContext

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -438,7 +438,7 @@ namespace System.Runtime.CompilerServices
 
         private static partial class AsyncCallstack
         {
-            private const int MaxRuntimeAsyncMethodFrameSize = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt32Size;
+            private const int MaxRuntimeAsyncMethodFrameSize = Serializer.MaxCompressedUInt64Size;
 
             private ref struct CaptureRuntimeAsyncCallstackState : ICaptureAsyncCallstack
             {
@@ -513,8 +513,6 @@ namespace System.Runtime.CompilerServices
                     callstackSpanIndex += Serializer.WriteCompressedInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt64Size), (long)(currentNativeIP - previousNativeIP));
                 }
 
-                // Handrolled continuations (like RuntimeAsyncTaskContinuation) are indicated with a null DiagnosticIP. For these we always write 0 as the state since the state number is not meaningful.
-                callstackSpanIndex += Serializer.WriteCompressedInt32(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt32Size), currentNativeIP == 0 ? 0 : state.Continuation.State);
                 state.Count++;
 
                 state.Continuation = state.Continuation.Next;
@@ -528,7 +526,6 @@ namespace System.Runtime.CompilerServices
                     }
 
                     callstackSpanIndex += Serializer.WriteCompressedInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt64Size), (long)(currentNativeIP - previousNativeIP));
-                    callstackSpanIndex += Serializer.WriteCompressedInt32(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt32Size), currentNativeIP == 0 ? 0 : state.Continuation.State);
 
                     state.Count++;
                     state.Continuation = state.Continuation.Next;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -11,10 +11,8 @@ namespace System.Runtime.CompilerServices
 {
     internal static partial class AsyncProfiler
     {
-        internal static class RuntimeAsyncIds
+        internal static partial class DispatcherIds
         {
-            public static ulong GetDispatcherId(Task dispatcher) => (ulong)dispatcher.Id;
-
             public static ulong GetDispatcherId(ref AsyncDispatcherInfo info)
             {
                 if (info.CurrentTask != null)
@@ -23,24 +21,24 @@ namespace System.Runtime.CompilerServices
                 }
                 return 0;
             }
-        }
 
-        internal static unsafe ulong CaptureParentDispatcherId()
-        {
-            AsyncDispatcherInfo* v2 = AsyncDispatcherInfo.t_current;
-            AsyncTaskDispatcherInfo* v1 = AsyncTaskDispatcherInfo.t_current;
-
-            Task? parent = null;
-            if (v2 != null && (v1 == null || (void*)v2 < (void*)v1))
+            public static unsafe ulong CaptureParentDispatcherId()
             {
-                parent = v2->CurrentTask;
-            }
-            else if (v1 != null)
-            {
-                parent = v1->Dispatcher;
-            }
+                AsyncDispatcherInfo* v2 = AsyncDispatcherInfo.t_current;
+                AsyncTaskDispatcherInfo* v1 = AsyncTaskDispatcherInfo.t_current;
 
-            return parent != null ? (ulong)parent.Id : 0;
+                Task? parent = null;
+                if (v2 != null && (v1 == null || (void*)v2 < (void*)v1))
+                {
+                    parent = v2->CurrentTask;
+                }
+                else if (v1 != null)
+                {
+                    parent = v1->Dispatcher;
+                }
+
+                return parent != null ? (ulong)parent.Id : 0;
+            }
         }
 
         internal static partial class CreateAsyncContext
@@ -55,8 +53,8 @@ namespace System.Runtime.CompilerServices
                 EventKeywords eventKeywords = context.ActiveEventKeywords;
                 if (IsEnabled.AnyAsyncEvents(eventKeywords))
                 {
-                    ulong parentDispatcherId = CaptureParentDispatcherId();
-                    ulong dispatcherId = RuntimeAsyncIds.GetDispatcherId(dispatcher);
+                    ulong parentDispatcherId = DispatcherIds.CaptureParentDispatcherId();
+                    ulong dispatcherId = DispatcherIds.GetDispatcherId(dispatcher);
                     long currentTimestamp = Stopwatch.GetTimestamp();
 
                     if (IsEnabled.CreateAsyncContextEvent(eventKeywords))
@@ -80,7 +78,7 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                Resume(ref info, context, RuntimeAsyncIds.GetDispatcherId(ref info), context.ActiveEventKeywords);
+                Resume(ref info, context, DispatcherIds.GetDispatcherId(ref info), context.ActiveEventKeywords);
 
                 AsyncThreadContext.Release(context);
             }
@@ -124,7 +122,7 @@ namespace System.Runtime.CompilerServices
 
                     if (IsEnabled.SuspendAsyncCallstackEvent(activeEventKeywords) && nextContinuation != null)
                     {
-                        AsyncCallstack.EmitSuspendEvent(context, currentTimestamp, RuntimeAsyncIds.GetDispatcherId(ref info), nextContinuation);
+                        AsyncCallstack.EmitSuspendEvent(context, currentTimestamp, DispatcherIds.GetDispatcherId(ref info), nextContinuation);
                     }
 
                     if (IsEnabled.SuspendAsyncContextEvent(activeEventKeywords))
@@ -536,12 +534,12 @@ namespace System.Runtime.CompilerServices
                 if (taskAsyncInfo == null || (runtimeAsyncInfo != null && (void*)runtimeAsyncInfo < (void*)taskAsyncInfo))
                 {
                     ResumeAsyncCallstacks(runtimeAsyncInfo->Next, taskAsyncInfo, context);
-                    ResumeAsyncContext.Resume(ref *runtimeAsyncInfo, context, RuntimeAsyncIds.GetDispatcherId(ref *runtimeAsyncInfo), Config.ActiveEventKeywords);
+                    ResumeAsyncContext.Resume(ref *runtimeAsyncInfo, context, DispatcherIds.GetDispatcherId(ref *runtimeAsyncInfo), Config.ActiveEventKeywords);
                 }
                 else
                 {
                     ResumeAsyncCallstacks(runtimeAsyncInfo, taskAsyncInfo->Next, context);
-                    ResumeAsyncContext.Resume(ref *taskAsyncInfo, context, TaskAsyncIds.GetDispatcherId(ref *taskAsyncInfo), Config.ActiveEventKeywords);
+                    ResumeAsyncContext.Resume(ref *taskAsyncInfo, context, DispatcherIds.GetDispatcherId(ref *taskAsyncInfo), Config.ActiveEventKeywords);
                 }
             }
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -101,7 +101,15 @@ namespace System.Runtime.CompilerServices
                     if (IsEnabled.ResumeRuntimeAsyncCallstackEvent(activeEventKeywords))
                     {
                         byte wrapperIndex = (byte)(info.AsyncProfilerInfo.ContinuationIndex & ContinuationWrapper.COUNT_MASK);
-                        AsyncCallstack.EmitResumeEvent(context, currentTimestamp, dispatcherId, wrapperIndex, info.NextContinuation);
+                        if (info.AsyncProfilerInfo.CurrentContinuation != null)
+                        {
+                            Debug.Assert(info.AsyncProfilerInfo.CurrentContinuation is Continuation);
+                            AsyncCallstack.EmitResumeEvent(context, currentTimestamp, dispatcherId, wrapperIndex, Unsafe.As<Continuation>(info.AsyncProfilerInfo.CurrentContinuation));
+                        }
+                        else
+                        {
+                            AsyncCallstack.EmitResumeEvent(context, currentTimestamp, dispatcherId, wrapperIndex, info.NextContinuation);
+                        }
                     }
                 }
             }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -28,7 +28,7 @@ namespace System.Runtime.CompilerServices
                         EmitEvent(context, currentTimestamp, id);
                     }
 
-                    if (IsEnabled.CreateAsyncCallstackEvent(eventKeywords))
+                    if (IsEnabled.CreateAsyncCallstackEvent(eventKeywords) && nextContinuation != null)
                     {
                         AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.CreateAsyncCallstack, id, nextContinuation);
                     }
@@ -75,7 +75,8 @@ namespace System.Runtime.CompilerServices
 
                     if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
                     {
-                        AsyncCallstack.EmitEvent(context, currentTimestamp, id, info.NextContinuation);
+                        byte wrapperIndex = (byte)(info.AsyncProfilerInfo.ContinuationIndex & ContinuationWrapper.COUNT_MASK);
+                        AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.ResumeAsyncCallstack, id, wrapperIndex, info.NextContinuation);
                     }
                 }
             }
@@ -94,7 +95,7 @@ namespace System.Runtime.CompilerServices
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
 
-                    if (IsEnabled.SuspendAsyncCallstackEvent(activeEventKeywords))
+                    if (IsEnabled.SuspendAsyncCallstackEvent(activeEventKeywords) && nextContinuation != null)
                     {
                         AsyncCallstack.EmitEvent(context, currentTimestamp, AsyncEventID.SuspendAsyncCallstack, GetId(ref info), nextContinuation);
                     }
@@ -456,21 +457,18 @@ namespace System.Runtime.CompilerServices
                 public static int MaxAsyncMethodFrameSize => MaxRuntimeAsyncMethodFrameSize;
             }
 
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id, Continuation? asyncCallstack)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, Continuation? asyncCallstack)
             {
                 CaptureRuntimeAsyncCallstackState state = default;
                 state.Continuation = asyncCallstack;
-                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.ResumeAsyncCallstack, id, ref state);
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, 0, ref state);
             }
 
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, Continuation? asyncCallstack)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID, ulong id, byte continuationIndex, Continuation? asyncCallstack)
             {
-                if (asyncCallstack != null)
-                {
-                    CaptureRuntimeAsyncCallstackState state = default;
-                    state.Continuation = asyncCallstack;
-                    EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, ref state);
-                }
+                CaptureRuntimeAsyncCallstackState state = default;
+                state.Continuation = asyncCallstack;
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, continuationIndex, ref state);
             }
 
             private static bool CaptureRuntimeAsyncCallstack(byte[] buffer, ref int index, ref CaptureRuntimeAsyncCallstackState state)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -136,7 +136,8 @@ namespace System.Runtime.CompilerServices
 
             private static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
             {
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID, 0);
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_SuspendAsyncContext || eventID == AsyncEventID.TaskAsync_SuspendAsyncContext);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID);
             }
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -25,7 +25,7 @@ namespace System.Runtime.CompilerServices
             public static unsafe ulong CaptureParentDispatcherId()
             {
                 AsyncDispatcherInfo* v2 = AsyncDispatcherInfo.t_current;
-                AsyncTaskDispatcherInfo* v1 = AsyncTaskDispatcherInfo.t_current;
+                AsyncStateMachineDispatcherInfo* v1 = AsyncStateMachineDispatcherInfo.t_current;
 
                 Task? parent = null;
                 if (v2 != null && (v1 == null || (void*)v2 < (void*)v1))
@@ -57,12 +57,12 @@ namespace System.Runtime.CompilerServices
                     ulong dispatcherId = DispatcherIds.GetDispatcherId(dispatcher);
                     long currentTimestamp = Stopwatch.GetTimestamp();
 
-                    if (IsEnabled.CreateAsyncContextEvent(eventKeywords))
+                    if (IsEnabled.CreateRuntimeAsyncContextEvent(eventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.RuntimeAsync_CreateAsyncContext);
+                        EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.CreateRuntimeAsyncContext);
                     }
 
-                    if (IsEnabled.CreateAsyncCallstackEvent(eventKeywords) && nextContinuation != null)
+                    if (IsEnabled.CreateRuntimeAsyncCallstackEvent(eventKeywords) && nextContinuation != null)
                     {
                         AsyncCallstack.EmitCreateEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, nextContinuation);
                     }
@@ -93,12 +93,12 @@ namespace System.Runtime.CompilerServices
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.ResumeAsyncContextEvent(activeEventKeywords))
+                    if (IsEnabled.ResumeRuntimeAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, dispatcherId, AsyncEventID.RuntimeAsync_ResumeAsyncContext);
+                        EmitEvent(context, currentTimestamp, dispatcherId, AsyncEventID.ResumeRuntimeAsyncContext);
                     }
 
-                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
+                    if (IsEnabled.ResumeRuntimeAsyncCallstackEvent(activeEventKeywords))
                     {
                         byte wrapperIndex = (byte)(info.AsyncProfilerInfo.ContinuationIndex & ContinuationWrapper.COUNT_MASK);
                         AsyncCallstack.EmitResumeEvent(context, currentTimestamp, dispatcherId, wrapperIndex, info.NextContinuation);
@@ -120,14 +120,14 @@ namespace System.Runtime.CompilerServices
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
 
-                    if (IsEnabled.SuspendAsyncCallstackEvent(activeEventKeywords) && nextContinuation != null)
+                    if (IsEnabled.SuspendRuntimeAsyncCallstackEvent(activeEventKeywords) && nextContinuation != null)
                     {
                         AsyncCallstack.EmitSuspendEvent(context, currentTimestamp, DispatcherIds.GetDispatcherId(ref info), nextContinuation);
                     }
 
-                    if (IsEnabled.SuspendAsyncContextEvent(activeEventKeywords))
+                    if (IsEnabled.SuspendRuntimeAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_SuspendAsyncContext);
+                        EmitEvent(context, currentTimestamp, AsyncEventID.SuspendRuntimeAsyncContext);
                     }
                 }
 
@@ -136,7 +136,7 @@ namespace System.Runtime.CompilerServices
 
             private static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_SuspendAsyncContext || eventID == AsyncEventID.TaskAsync_SuspendAsyncContext);
+                Debug.Assert(eventID == AsyncEventID.SuspendRuntimeAsyncContext);
                 Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID);
             }
         }
@@ -149,9 +149,9 @@ namespace System.Runtime.CompilerServices
 
                 SyncPoint.Check(context);
 
-                if (IsEnabled.CompleteAsyncContextEvent(context.ActiveEventKeywords))
+                if (IsEnabled.CompleteRuntimeAsyncContextEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp(), AsyncEventID.RuntimeAsync_CompleteAsyncContext);
+                    EmitEvent(context, Stopwatch.GetTimestamp(), AsyncEventID.CompleteRuntimeAsyncContext);
                 }
 
                 AsyncThreadContext.Release(context);
@@ -168,14 +168,14 @@ namespace System.Runtime.CompilerServices
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.UnwindAsyncExceptionEvent(activeEventKeywords))
+                    if (IsEnabled.UnwindRuntimeAsyncExceptionEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, unwindedFrames, AsyncEventID.RuntimeAsync_UnwindAsyncException);
+                        EmitEvent(context, currentTimestamp, unwindedFrames, AsyncEventID.UnwindRuntimeAsyncException);
                     }
 
-                    if (IsEnabled.CompleteAsyncContextEvent(activeEventKeywords))
+                    if (IsEnabled.CompleteRuntimeAsyncContextEvent(activeEventKeywords))
                     {
-                        CompleteAsyncContext.EmitEvent(context, currentTimestamp, AsyncEventID.RuntimeAsync_CompleteAsyncContext);
+                        CompleteAsyncContext.EmitEvent(context, currentTimestamp, AsyncEventID.CompleteRuntimeAsyncContext);
                     }
                 }
 
@@ -186,9 +186,9 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                if (IsEnabled.UnwindAsyncExceptionEvent(context.ActiveEventKeywords))
+                if (IsEnabled.UnwindRuntimeAsyncExceptionEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp(), unwindedFrames, AsyncEventID.RuntimeAsync_UnwindAsyncException);
+                    EmitEvent(context, Stopwatch.GetTimestamp(), unwindedFrames, AsyncEventID.UnwindRuntimeAsyncException);
                 }
 
                 AsyncThreadContext.Release(context);
@@ -201,9 +201,9 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                if (IsEnabled.ResumeAsyncMethodEvent(context.ActiveEventKeywords))
+                if (IsEnabled.ResumeRuntimeAsyncMethodEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, AsyncEventID.RuntimeAsync_ResumeAsyncMethod);
+                    EmitEvent(context, AsyncEventID.ResumeRuntimeAsyncMethod);
                 }
 
                 AsyncThreadContext.Release(context);
@@ -216,9 +216,9 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                if (IsEnabled.CompleteAsyncMethodEvent(context.ActiveEventKeywords))
+                if (IsEnabled.CompleteRuntimeAsyncMethodEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
+                    EmitEvent(context, AsyncEventID.CompleteRuntimeAsyncMethod);
                 }
 
                 AsyncThreadContext.Release(context);
@@ -515,32 +515,32 @@ namespace System.Runtime.CompilerServices
             private static unsafe void ResumeAsyncCallstacks(AsyncThreadContext context)
             {
                 // Replay suspended dispatchers in original execution (push) order. Both TLS chains
-                // (V2 AsyncDispatcherInfo and V1 AsyncTaskDispatcherInfo) are linked head=most-recent,
+                // (V2 AsyncDispatcherInfo and V1 AsyncStateMachineDispatcherInfo) are linked head=most-recent,
                 // so head has the smallest stack address (downward-growing stacks). The walker
                 // recurses to Next BEFORE emitting, producing oldest-first emission, and merges the
                 // two chains by always recursing on the smaller-address node first.
                 AsyncDispatcherInfo* runtimeAsyncInfo = AsyncDispatcherInfo.t_current;
-                AsyncTaskDispatcherInfo* taskAsyncInfo = AsyncTaskDispatcherInfo.t_current;
+                AsyncStateMachineDispatcherInfo* stateMachineAsyncInfo = AsyncStateMachineDispatcherInfo.t_current;
 
-                ResumeAsyncCallstacks(runtimeAsyncInfo, taskAsyncInfo, context);
+                ResumeAsyncCallstacks(runtimeAsyncInfo, stateMachineAsyncInfo, context);
             }
 
-            private static unsafe void ResumeAsyncCallstacks(AsyncDispatcherInfo* runtimeAsyncInfo, AsyncTaskDispatcherInfo* taskAsyncInfo, AsyncThreadContext context)
+            private static unsafe void ResumeAsyncCallstacks(AsyncDispatcherInfo* runtimeAsyncInfo, AsyncStateMachineDispatcherInfo* stateMachineAsyncInfo, AsyncThreadContext context)
             {
-                if (runtimeAsyncInfo == null && taskAsyncInfo == null)
+                if (runtimeAsyncInfo == null && stateMachineAsyncInfo == null)
                 {
                     return;
                 }
 
-                if (taskAsyncInfo == null || (runtimeAsyncInfo != null && (void*)runtimeAsyncInfo < (void*)taskAsyncInfo))
+                if (stateMachineAsyncInfo == null || (runtimeAsyncInfo != null && (void*)runtimeAsyncInfo < (void*)stateMachineAsyncInfo))
                 {
-                    ResumeAsyncCallstacks(runtimeAsyncInfo->Next, taskAsyncInfo, context);
+                    ResumeAsyncCallstacks(runtimeAsyncInfo->Next, stateMachineAsyncInfo, context);
                     ResumeAsyncContext.Resume(ref *runtimeAsyncInfo, context, DispatcherIds.GetDispatcherId(ref *runtimeAsyncInfo), Config.ActiveEventKeywords);
                 }
                 else
                 {
-                    ResumeAsyncCallstacks(runtimeAsyncInfo, taskAsyncInfo->Next, context);
-                    ResumeAsyncContext.Resume(ref *taskAsyncInfo, context, DispatcherIds.GetDispatcherId(ref *taskAsyncInfo), Config.ActiveEventKeywords);
+                    ResumeAsyncCallstacks(runtimeAsyncInfo, stateMachineAsyncInfo->Next, context);
+                    ResumeAsyncContext.Resume(ref *stateMachineAsyncInfo, context, DispatcherIds.GetDispatcherId(ref *stateMachineAsyncInfo), Config.ActiveEventKeywords);
                 }
             }
         }
@@ -569,21 +569,21 @@ namespace System.Runtime.CompilerServices
             {
                 CaptureRuntimeAsyncCallstackState state = default;
                 state.Continuation = asyncCallstack;
-                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.RuntimeAsync_CreateAsyncCallstack, parentDispatcherId, dispatcherId, 0, ref state);
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.CreateRuntimeAsyncCallstack, parentDispatcherId, dispatcherId, 0, ref state);
             }
 
             public static void EmitSuspendEvent(AsyncThreadContext context, long currentTimestamp, ulong dispatcherId, Continuation? asyncCallstack)
             {
                 CaptureRuntimeAsyncCallstackState state = default;
                 state.Continuation = asyncCallstack;
-                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, 0, dispatcherId, 0, ref state);
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.SuspendRuntimeAsyncCallstack, 0, dispatcherId, 0, ref state);
             }
 
             public static void EmitResumeEvent(AsyncThreadContext context, long currentTimestamp, ulong dispatcherId, byte continuationIndex, Continuation? asyncCallstack)
             {
                 CaptureRuntimeAsyncCallstackState state = default;
                 state.Continuation = asyncCallstack;
-                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, 0, dispatcherId, continuationIndex, ref state);
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.ResumeRuntimeAsyncCallstack, 0, dispatcherId, continuationIndex, ref state);
             }
 
             private static bool CaptureRuntimeAsyncCallstack(byte[] buffer, ref int index, ref CaptureRuntimeAsyncCallstackState state)

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -946,7 +946,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\YieldAwaitable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncProfiler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncProfilerEventSource.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncTaskDispatcher.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncStateMachineDispatcher.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\ConstrainedExecution\Cer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\ConstrainedExecution\Consistency.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\ConstrainedExecution\CriticalFinalizerObject.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -836,12 +836,13 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncMethodBuilderAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncMethodBuilderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncStateMachineAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncStateMachineDiagnostics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncTaskMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncTaskMethodBuilderT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilderT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncVoidMethodBuilder.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncInstrumentation.cs" Condition="'$(FeatureMono)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncInstrumentation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CastCache.cs" Condition="'$(FeatureMono)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\GenericCache.cs" Condition="'$(FeatureMono)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CallerArgumentExpressionAttribute.cs" />
@@ -943,9 +944,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\UnionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ValueTaskAwaiter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\YieldAwaitable.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncProfiler.cs" Condition="'$(FeatureMono)' != 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncProfilerEventSource.cs" Condition="'$(FeatureMono)' != 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncTaskDispatcher.cs" Condition="'$(FeatureMono)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncProfiler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncProfilerEventSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncTaskDispatcher.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\ConstrainedExecution\Cer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\ConstrainedExecution\Consistency.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\ConstrainedExecution\CriticalFinalizerObject.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -945,6 +945,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\YieldAwaitable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncProfiler.cs" Condition="'$(FeatureMono)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncProfilerEventSource.cs" Condition="'$(FeatureMono)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncTaskDispatcher.cs" Condition="'$(FeatureMono)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\ConstrainedExecution\Cer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\ConstrainedExecution\Consistency.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\ConstrainedExecution\CriticalFinalizerObject.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
@@ -127,6 +127,20 @@ namespace System.Runtime.CompilerServices
                 wrapper._innerTask :           // A wrapped continuation, created by an awaiter
                 continuation.Target as Task;   // The continuation targets a task directly, such as with AsyncStateMachineBox
 
+        internal static IAsyncStateMachineBox? TryGetStateMachineBox(Action continuation)
+        {
+            object? target = continuation.Target;
+            if (target is IAsyncStateMachineBox box)
+            {
+                return box;
+            }
+            if (target is ContinuationWrapper cw)
+            {
+                return TryGetStateMachineBox(cw._continuation);
+            }
+            return null;
+        }
+
         /// <summary>
         /// Logically we pass just an Action (delegate) to a task for its action to 'ContinueWith' when it completes.
         /// However debuggers and profilers need more information about what that action is. (In particular what

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -12,9 +12,6 @@ using System.Diagnostics.Tracing;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using static System.Runtime.CompilerServices.AsyncInstrumentation;
-using static System.Runtime.CompilerServices.AsyncProfiler;
-using static System.Runtime.CompilerServices.AsyncProfilerEventSource;
 using Serializer = System.Runtime.CompilerServices.AsyncProfiler.EventBuffer.Serializer;
 
 namespace System.Runtime.CompilerServices
@@ -656,7 +653,7 @@ namespace System.Runtime.CompilerServices
 
                 try
                 {
-                    Log.AsyncEvents(eventBuffer.Data.AsSpan(0, eventBuffer.Index));
+                    AsyncProfilerEventSource.Log.AsyncEvents(eventBuffer.Data.AsSpan(0, eventBuffer.Index));
                 }
                 catch
                 {
@@ -715,7 +712,7 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class CreateAsyncContext
         {
-            public static void Create(AsyncTaskDispatcher dispatcher, ref Info info, ulong id)
+            public static void Create(AsyncTaskDispatcher dispatcher, ref Info info, ulong parentDispatcherId, ulong dispatcherId)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
@@ -732,14 +729,14 @@ namespace System.Runtime.CompilerServices
 
                     if (IsEnabled.CreateAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, id, AsyncEventID.TaskAsync_CreateAsyncContext);
+                        EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.TaskAsync_CreateAsyncContext);
                     }
                 }
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void Create(AsyncTaskDispatcher dispatcher)
+            public static void Create(ulong parentDispatcherId, ulong dispatcherId)
             {
                 Info info = default;
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
@@ -748,50 +745,56 @@ namespace System.Runtime.CompilerServices
 
                 if (IsEnabled.CreateAsyncContextEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp(), (ulong)dispatcher.ContextId, AsyncEventID.TaskAsync_CreateAsyncContext);
+                    EmitEvent(context, Stopwatch.GetTimestamp(), parentDispatcherId, dispatcherId, AsyncEventID.TaskAsync_CreateAsyncContext);
                 }
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id, AsyncEventID eventID)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong parentDispatcherId, ulong dispatcherId, AsyncEventID eventID)
             {
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncContext || eventID == AsyncEventID.TaskAsync_CreateAsyncContext);
 
-                const int MaxEventPayloadSize = Serializer.MaxCompressedUInt64Size;
+                const int MaxEventPayloadSize = 2 * Serializer.MaxCompressedUInt64Size;
 
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
                 if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, MaxEventPayloadSize))
                 {
-                    eventBuffer.Index += Serializer.WriteCompressedUInt64(eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize), id);
+                    Span<byte> payload = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize);
+                    int offset = 0;
+                    offset += Serializer.WriteCompressedUInt64(payload.Slice(offset), parentDispatcherId);
+                    offset += Serializer.WriteCompressedUInt64(payload.Slice(offset), dispatcherId);
+                    eventBuffer.Index += offset;
                 }
+            }
+        }
+
+        internal static class TaskAsyncIds
+        {
+            public static ulong GetDispatcherId(Task dispatcher) => (ulong)dispatcher.Id;
+
+            public static ulong GetDispatcherId(ref AsyncTaskDispatcherInfo info)
+            {
+                if (info.Dispatcher != null)
+                {
+                    return GetDispatcherId(info.Dispatcher);
+                }
+                return 0;
             }
         }
 
         internal static partial class ResumeAsyncContext
         {
-            public static ulong GetId(AsyncTaskDispatcher dispatcher) => dispatcher.ContextId;
-
-            public static ulong GetId(ref AsyncTaskDispatcherInfo info)
-            {
-                if (info.Dispatcher != null)
-                {
-                    return info.Dispatcher.ContextId;
-                }
-
-                return 0;
-            }
-
             public static void Resume(ref AsyncTaskDispatcherInfo info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                Resume(ref info, context, GetId(ref info), context.ActiveEventKeywords);
+                Resume(ref info, context, TaskAsyncIds.GetDispatcherId(ref info), context.ActiveEventKeywords);
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void Resume(ref AsyncTaskDispatcherInfo info, AsyncThreadContext context, ulong id, EventKeywords activeEventKeywords)
+            public static void Resume(ref AsyncTaskDispatcherInfo info, AsyncThreadContext context, ulong dispatcherId, EventKeywords activeEventKeywords)
             {
                 if (SyncPoint.Check(context))
                 {
@@ -803,12 +806,12 @@ namespace System.Runtime.CompilerServices
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     if (IsEnabled.ResumeAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, id, AsyncEventID.TaskAsync_ResumeAsyncContext);
+                        EmitEvent(context, currentTimestamp, dispatcherId, AsyncEventID.TaskAsync_ResumeAsyncContext);
                     }
 
                     if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords) && info.Dispatcher != null)
                     {
-                        AsyncCallstack.EmitEvent(info.Dispatcher, context, currentTimestamp, id);
+                        AsyncCallstack.EmitEvent(info.Dispatcher, context, currentTimestamp, dispatcherId);
                     }
                 }
             }
@@ -817,7 +820,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
                 {
-                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.ContinuationForDiagnostics, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, GetId(dispatcher));
+                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.ContinuationForDiagnostics, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, TaskAsyncIds.GetDispatcherId(dispatcher));
                 }
             }
 
@@ -827,12 +830,12 @@ namespace System.Runtime.CompilerServices
                 {
                     if (!ReferenceEquals(enteringBox, dispatcher.LastContinuation))
                     {
-                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, GetId(dispatcher));
+                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, TaskAsyncIds.GetDispatcherId(dispatcher));
                     }
                 }
             }
 
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id, AsyncEventID eventID)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong dispatcherId, AsyncEventID eventID)
             {
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncContext || eventID == AsyncEventID.TaskAsync_ResumeAsyncContext);
 
@@ -841,7 +844,10 @@ namespace System.Runtime.CompilerServices
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
                 if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, MaxEventPayloadSize))
                 {
-                    eventBuffer.Index += Serializer.WriteCompressedUInt64(eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize), id);
+                    Span<byte> payload = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize);
+                    int offset = 0;
+                    offset += Serializer.WriteCompressedUInt64(payload.Slice(offset), dispatcherId);
+                    eventBuffer.Index += offset;
                 }
             }
         }
@@ -1099,7 +1105,7 @@ namespace System.Runtime.CompilerServices
                 if (info != null)
                 {
                     ResumeAsyncTaskCallstacks(info->Next, context);
-                    ResumeAsyncContext.Resume(ref *info, context, ResumeAsyncContext.GetId(ref *info), Config.ActiveEventKeywords);
+                    ResumeAsyncContext.Resume(ref *info, context, TaskAsyncIds.GetDispatcherId(ref *info), Config.ActiveEventKeywords);
                 }
             }
 #endif
@@ -1112,17 +1118,17 @@ namespace System.Runtime.CompilerServices
 
         private static class IsEnabled
         {
-            public static bool CreateAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.CreateAsyncContext) != 0;
-            public static bool ResumeAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.ResumeAsyncContext) != 0;
-            public static bool SuspendAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.SuspendAsyncContext) != 0;
-            public static bool CompleteAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.CompleteAsyncContext) != 0;
-            public static bool UnwindAsyncExceptionEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.UnwindAsyncException) != 0;
-            public static bool CreateAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.CreateAsyncCallstack) != 0;
-            public static bool ResumeAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.ResumeAsyncCallstack) != 0;
-            public static bool SuspendAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.SuspendAsyncCallstack) != 0;
-            public static bool ResumeAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.ResumeAsyncMethod) != 0;
-            public static bool CompleteAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & Keywords.CompleteAsyncMethod) != 0;
-            public static bool AnyAsyncEvents(EventKeywords eventKeywords) => (eventKeywords & AsyncEventKeywords) != 0;
+            public static bool CreateAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CreateAsyncContext) != 0;
+            public static bool ResumeAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeAsyncContext) != 0;
+            public static bool SuspendAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.SuspendAsyncContext) != 0;
+            public static bool CompleteAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteAsyncContext) != 0;
+            public static bool UnwindAsyncExceptionEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.UnwindAsyncException) != 0;
+            public static bool CreateAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CreateAsyncCallstack) != 0;
+            public static bool ResumeAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeAsyncCallstack) != 0;
+            public static bool SuspendAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.SuspendAsyncCallstack) != 0;
+            public static bool ResumeAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeAsyncMethod) != 0;
+            public static bool CompleteAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteAsyncMethod) != 0;
+            public static bool AnyAsyncEvents(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.AsyncEventKeywords) != 0;
         }
 
         private static class AsyncThreadContextCache
@@ -1346,14 +1352,14 @@ namespace System.Runtime.CompilerServices
                 public static int MaxAsyncMethodFrameSize => MaxTaskAsyncMethodFrameSize;
             }
 
-            public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp, ulong id)
+            public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp, ulong dispatcherId)
             {
                 IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(dispatcher.CurrentContinuation);
 
                 CaptureTaskAsyncCallstackState state = default;
                 state.Continuation = box;
 
-                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.TaskAsync_ResumeAsyncCallstack, id, ref state);
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.TaskAsync_ResumeAsyncCallstack, 0, dispatcherId, ref state);
 
                 IAsyncStateMachineBox? last = ResolveAsyncStateMachineBox(state.LastContinuation);
                 if (last != null)
@@ -1369,7 +1375,7 @@ namespace System.Runtime.CompilerServices
                 dispatcher.ReachedLastContinuation = false;
             }
 
-            public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong id)
+            public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong dispatcherId)
             {
                 Debug.Assert(eventID == AsyncEventID.TaskAsync_ResumeAsyncCallstack || eventID == AsyncEventID.TaskAsync_AppendAsyncCallstack);
 
@@ -1381,7 +1387,7 @@ namespace System.Runtime.CompilerServices
                         CaptureTaskAsyncCallstackState state = default;
                         state.Continuation = box;
 
-                        EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, ref state);
+                        EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, 0, dispatcherId, ref state);
 
                         box = ResolveAsyncStateMachineBox(state.LastContinuation);
                         if (box != null)
@@ -1520,13 +1526,13 @@ namespace System.Runtime.CompilerServices
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong id, ref T captureCallstack)
+            private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong parentDispatcherId, ulong dispatcherId, ref T captureCallstack)
                 where T : ICaptureAsyncCallstack, allows ref struct
             {
-                EmitAsyncCallstack(context, currentTimestamp, delta, eventID, id, 0, ref captureCallstack);
+                EmitAsyncCallstack(context, currentTimestamp, delta, eventID, parentDispatcherId, dispatcherId, 0, ref captureCallstack);
             }
 
-            private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong id, byte continuationIndex, ref T captureCallstack)
+            private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong parentDispatcherId, ulong dispatcherId, byte continuationIndex, ref T captureCallstack)
                 where T : ICaptureAsyncCallstack, allows ref struct
             {
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncCallstack ||
@@ -1540,12 +1546,12 @@ namespace System.Runtime.CompilerServices
                 // Max callstack data that can fit in the buffer after flush.
                 int maxCallstackBytes = Math.Min(byte.MaxValue * T.MaxAsyncMethodFrameSize, eventBuffer.Data.Length);
 
-                // Static callstack payload: callstackId (1) + continuationIndex (1) + frameCount (1) + id (max 10 bytes compressed).
-                const int MaxStaticEventPayloadSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
+                // Static callstack payload: callstackId (1) + continuationIndex (1) + frameCount (1) + parentDispatcherId + dispatcherId (max 10 bytes compressed each).
+                const int MaxStaticEventPayloadSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + 2 * Serializer.MaxCompressedUInt64Size;
 
                 if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, MaxStaticEventPayloadSize, out Serializer.AsyncEventHeaderRollbackData rollbackData))
                 {
-                    int frameCountOffset = CallstackHeader(ref eventBuffer, id, continuationIndex, 0);
+                    int frameCountOffset = CallstackHeader(ref eventBuffer, eventID, parentDispatcherId, dispatcherId, continuationIndex, 0);
 
                     byte[] buffer = eventBuffer.Data;
                     int startIndex = eventBuffer.Index;
@@ -1569,7 +1575,7 @@ namespace System.Runtime.CompilerServices
                             // Write the callstack again.
                             if (Serializer.AsyncEventHeader(context, ref eventBuffer, context.LastEventTimestamp, 0, eventID, MaxStaticEventPayloadSize + index))
                             {
-                                CallstackHeader(ref eventBuffer, id, continuationIndex, count);
+                                CallstackHeader(ref eventBuffer, eventID, parentDispatcherId, dispatcherId, continuationIndex, count);
                                 CallstackData(ref eventBuffer, rentedArray, index);
                             }
 
@@ -1590,10 +1596,10 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            private static int CallstackHeader(ref EventBuffer eventBuffer, ulong id, byte continuationIndex, byte callstackFrameCount)
+            private static int CallstackHeader(ref EventBuffer eventBuffer, AsyncEventID eventID, ulong parentDispatcherId, ulong dispatcherId, byte continuationIndex, byte callstackFrameCount)
             {
-                // Callstack header layout: callstackId (1 byte, reserved for future use) + continuationIndex (1 byte) + frameCount (1 byte) + id (max 10 bytes compressed).
-                const int MaxCallstackHeaderSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
+                // Callstack header layout: callstackId (1 byte, reserved) + continuationIndex (1 byte) + frameCount (1 byte) + parentDispatcherId + dispatcherId (max 10 bytes compressed each).
+                const int MaxCallstackHeaderSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + 2 * Serializer.MaxCompressedUInt64Size;
 
                 ref int index = ref eventBuffer.Index;
 
@@ -1606,7 +1612,12 @@ namespace System.Runtime.CompilerServices
                 int frameCountOffset = index + spanIndex;
                 callstackHeaderSpan[spanIndex++] = callstackFrameCount;
 
-                spanIndex += Serializer.WriteCompressedUInt64(callstackHeaderSpan.Slice(spanIndex), id);
+                if (eventID == AsyncEventID.RuntimeAsync_CreateAsyncCallstack)
+                {
+                    spanIndex += Serializer.WriteCompressedUInt64(callstackHeaderSpan.Slice(spanIndex), parentDispatcherId);
+                }
+
+                spanIndex += Serializer.WriteCompressedUInt64(callstackHeaderSpan.Slice(spanIndex), dispatcherId);
                 eventBuffer.Index += spanIndex;
 
                 return frameCountOffset;
@@ -1634,5 +1645,19 @@ namespace System.Runtime.CompilerServices
                 return rentedArray;
             }
         }
+
+#if !RUNTIME_ASYNC_SUPPORTED
+        internal static unsafe ulong CaptureParentDispatcherId()
+        {
+            AsyncTaskDispatcherInfo* v1 = AsyncTaskDispatcherInfo.t_current;
+            if (v1 == null)
+            {
+                return 0;
+            }
+
+            AsyncTaskDispatcher? parent = v1->Dispatcher;
+            return parent is not null ? (ulong)parent.Id : 0;
+        }
+#endif
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -777,6 +777,14 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
+            public static void Append(AsyncTaskDispatcher dispatcher, IAsyncStateMachineBox enteringBox, AsyncThreadContext context, long currentTimestamp)
+            {
+                if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ReachedLastContinuation)
+                {
+                    AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
+                }
+            }
+
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id)
             {
                 const int MaxEventPayloadSize = Serializer.MaxCompressedUInt64Size;
@@ -926,7 +934,7 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class ResumeAsyncMethod
         {
-            public static void Resume(AsyncTaskDispatcher dispatcher, ref Info info)
+            public static void Resume(AsyncTaskDispatcher dispatcher, IAsyncStateMachineBox box, ref Info info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
@@ -938,7 +946,7 @@ namespace System.Runtime.CompilerServices
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
                     {
-                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
+                        ResumeAsyncContext.Append(dispatcher, box, context, currentTimestamp);
                     }
 
                     if (IsEnabled.ResumeAsyncMethodEvent(activeEventKeywords))
@@ -1340,6 +1348,8 @@ namespace System.Runtime.CompilerServices
                     {
                         dispatcher.LastContinuation = null;
                     }
+
+                    dispatcher.ReachedLastContinuation = false;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -1292,7 +1292,7 @@ namespace System.Runtime.CompilerServices
                 if (info != null)
                 {
                     ResumeAsyncTaskCallstacks(info->Next, context);
-                    ResumeAsyncContext.Resume(ref *info, context, TaskAsyncIds.GetDispatcherId(ref *info), Config.ActiveEventKeywords);
+                    ResumeAsyncContext.Resume(ref *info, context, DispatcherIds.GetDispatcherId(ref *info), Config.ActiveEventKeywords);
                 }
             }
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -35,18 +35,19 @@ namespace System.Runtime.CompilerServices
             // V1 (StateMachineAsync) events.
             CreateStateMachineAsyncContext = 11,
             ResumeStateMachineAsyncContext = 12,
-            CompleteStateMachineAsyncContext = 13,
-            UnwindStateMachineAsyncException = 14,
-            ResumeStateMachineAsyncCallstack = 15,
-            ResumeStateMachineAsyncMethod = 16,
-            CompleteStateMachineAsyncMethod = 17,
-            AppendStateMachineAsyncCallstack = 18,
+            SuspendStateMachineAsyncContext = 13,
+            CompleteStateMachineAsyncContext = 14,
+            UnwindStateMachineAsyncException = 15,
+            ResumeStateMachineAsyncCallstack = 16,
+            ResumeStateMachineAsyncMethod = 17,
+            CompleteStateMachineAsyncMethod = 18,
+            AppendStateMachineAsyncCallstack = 19,
 
             // Neutral profiler events.
-            ResetAsyncThreadContext = 19,
-            ResetAsyncContinuationWrapperIndex = 20,
-            AsyncProfilerMetadata = 21,
-            AsyncProfilerSyncClock = 22,
+            ResetAsyncThreadContext = 20,
+            ResetAsyncContinuationWrapperIndex = 21,
+            AsyncProfilerMetadata = 22,
+            AsyncProfilerSyncClock = 23,
         }
 
         // Per-event manifest entry: schema version + payload length-prefix size.
@@ -125,6 +126,7 @@ namespace System.Runtime.CompilerServices
 
                     new EventManifestEntry(AsyncEventID.CreateStateMachineAsyncContext, 1, CreateAsyncContextPayloadLengthFieldSize),
                     new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncContext, 1, ResumeAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.SuspendStateMachineAsyncContext, 1, SuspendAsyncContextPayloadLengthFieldSize),
                     new EventManifestEntry(AsyncEventID.CompleteStateMachineAsyncContext, 1, CompleteAsyncContextPayloadLengthFieldSize),
                     new EventManifestEntry(AsyncEventID.UnwindStateMachineAsyncException, 1, UnwindAsyncExceptionPayloadLengthFieldSize),
                     new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncCallstack, 1, ResumeAsyncCallstackPayloadLengthFieldSize),
@@ -361,6 +363,7 @@ namespace System.Runtime.CompilerServices
                 flags |= IsEnabled.CompleteRuntimeAsyncMethodEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CompleteAsyncMethod : AsyncInstrumentation.Flags.Disabled;
                 flags |= IsEnabled.CreateStateMachineAsyncContextEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CreateAsyncContext : AsyncInstrumentation.Flags.Disabled;
                 flags |= IsEnabled.ResumeStateMachineAsyncContextEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncContext : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.SuspendStateMachineAsyncContextEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.SuspendAsyncContext : AsyncInstrumentation.Flags.Disabled;
                 flags |= IsEnabled.CompleteStateMachineAsyncContextEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CompleteAsyncContext : AsyncInstrumentation.Flags.Disabled;
                 flags |= IsEnabled.UnwindStateMachineAsyncExceptionEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.UnwindAsyncException : AsyncInstrumentation.Flags.Disabled;
                 flags |= IsEnabled.ResumeStateMachineAsyncCallstackEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncContext : AsyncInstrumentation.Flags.Disabled;
@@ -1045,6 +1048,39 @@ namespace System.Runtime.CompilerServices
             }
         }
 
+        internal static partial class SuspendAsyncContext
+        {
+            public static void Suspend(AsyncStateMachineDispatcher dispatcher, ref Info info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+
+                SyncPoint.Check(context);
+
+                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
+                {
+                    long currentTimestamp = Stopwatch.GetTimestamp();
+                    if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
+                    {
+                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
+                    }
+
+                    if (IsEnabled.SuspendStateMachineAsyncContextEvent(activeEventKeywords))
+                    {
+                        EmitEvent(context, currentTimestamp, AsyncEventID.SuspendStateMachineAsyncContext);
+                    }
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
+            {
+                Debug.Assert(eventID == AsyncEventID.SuspendRuntimeAsyncContext || eventID == AsyncEventID.SuspendStateMachineAsyncContext);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID);
+            }
+        }
+
         internal static partial class CompleteAsyncContext
         {
             public static void Complete(AsyncStateMachineDispatcher dispatcher, ref Info info)
@@ -1324,6 +1360,7 @@ namespace System.Runtime.CompilerServices
             public static bool CompleteRuntimeAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteRuntimeAsyncMethod) != 0;
             public static bool CreateStateMachineAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CreateStateMachineAsyncContext) != 0;
             public static bool ResumeStateMachineAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeStateMachineAsyncContext) != 0;
+            public static bool SuspendStateMachineAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.SuspendStateMachineAsyncContext) != 0;
             public static bool CompleteStateMachineAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteStateMachineAsyncContext) != 0;
             public static bool UnwindStateMachineAsyncExceptionEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.UnwindStateMachineAsyncException) != 0;
             public static bool ResumeStateMachineAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeStateMachineAsyncCallstack) != 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -771,17 +771,9 @@ namespace System.Runtime.CompilerServices
 
             public static void Append(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp)
             {
-                if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords))
+                if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
                 {
-                    Task? lastTask = dispatcher.LastContinuation;
-                    if (lastTask != null)
-                    {
-                        object? newContinuation = lastTask.DiagnosticContinuationObject;
-                        if (newContinuation != null)
-                        {
-                            AsyncCallstack.EmitEvent(dispatcher, context, newContinuation, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
-                        }
-                    }
+                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.DiagnosticContinuationObject, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
                 }
             }
 
@@ -1331,7 +1323,7 @@ namespace System.Runtime.CompilerServices
                         CaptureTaskAsyncCallstackState state = default;
                         state.Continuation = box;
 
-                        EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, state);
+                        EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, ref state);
 
                         box = ResolveAsyncStateMachineBox(state.LastContinuation);
                         if (box != null)
@@ -1461,7 +1453,7 @@ namespace System.Runtime.CompilerServices
                 return null;
             }
 
-            private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong id, T captureCallstack)
+            private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong id, ref T captureCallstack)
                 where T : ICaptureAsyncCallstack, allows ref struct
             {
                 ref EventBuffer eventBuffer = ref context.EventBuffer;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -50,6 +50,107 @@ namespace System.Runtime.CompilerServices
             AsyncProfilerSyncClock = 23,
         }
 
+        // Per-event manifest entry: schema version + payload length-prefix size.
+        // The runtime emits this table in the AsyncProfilerMetadata event so parsers can
+        // discover the current version of each event id and skip payloads of events they do
+        // not understand by reading a fixed-width little-endian length prefix that precedes
+        // the payload. A FieldSize of NoPayload indicates the event carries no payload at all
+        // (no prefix written). Bumping an entry's Version signals any schema change.
+        internal readonly struct EventManifestEntry
+        {
+            public enum PayloadLengthFieldSize : byte
+            {
+                NoPayload = 0,
+                Byte = 1,
+                UShort = 2
+            }
+
+            public readonly AsyncEventID EventId;
+            public readonly byte Version;
+            public readonly PayloadLengthFieldSize FieldSize;
+
+            public EventManifestEntry(AsyncEventID eventId, byte version, PayloadLengthFieldSize fieldSize)
+            {
+                EventId = eventId;
+                Version = version;
+                FieldSize = fieldSize;
+            }
+        }
+
+        internal static class EventManifest
+        {
+            // Per-event payload size.
+            public const EventManifestEntry.PayloadLengthFieldSize CreateAsyncContextPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.Byte;
+            public const EventManifestEntry.PayloadLengthFieldSize ResumeAsyncContextPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.Byte;
+            public const EventManifestEntry.PayloadLengthFieldSize SuspendAsyncContextPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.NoPayload;
+            public const EventManifestEntry.PayloadLengthFieldSize CompleteAsyncContextPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.NoPayload;
+            public const EventManifestEntry.PayloadLengthFieldSize UnwindAsyncExceptionPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.Byte;
+            public const EventManifestEntry.PayloadLengthFieldSize CallstackPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.UShort;
+            public const EventManifestEntry.PayloadLengthFieldSize CreateAsyncCallstackPayloadLengthFieldSize = CallstackPayloadLengthFieldSize;
+            public const EventManifestEntry.PayloadLengthFieldSize ResumeAsyncCallstackPayloadLengthFieldSize = CallstackPayloadLengthFieldSize;
+            public const EventManifestEntry.PayloadLengthFieldSize SuspendAsyncCallstackPayloadLengthFieldSize = CallstackPayloadLengthFieldSize;
+            public const EventManifestEntry.PayloadLengthFieldSize ResumeAsyncMethodPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.NoPayload;
+            public const EventManifestEntry.PayloadLengthFieldSize CompleteAsyncMethodPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.NoPayload;
+            public const EventManifestEntry.PayloadLengthFieldSize AppendAsyncCallstackPayloadLengthFieldSize = CallstackPayloadLengthFieldSize;
+
+            public const EventManifestEntry.PayloadLengthFieldSize ResetAsyncThreadContextPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.NoPayload;
+            public const EventManifestEntry.PayloadLengthFieldSize ResetAsyncContinuationWrapperIndexPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.NoPayload;
+            public const EventManifestEntry.PayloadLengthFieldSize AsyncProfilerMetadataPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.UShort;
+            public const EventManifestEntry.PayloadLengthFieldSize AsyncProfilerSyncClockPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.Byte;
+
+            public static readonly EventManifestEntry[] Entries = BuildEntries();
+
+            public static EventManifestEntry.PayloadLengthFieldSize GetPayloadLengthFieldSize(AsyncEventID eventID)
+            {
+                Debug.Assert(eventID == Entries[(byte)eventID - 1].EventId);
+                return Entries[(byte)eventID - 1].FieldSize;
+            }
+
+            private static EventManifestEntry[] BuildEntries()
+            {
+                // Entries must be appended in order of ascending (byte)AsyncEventID so that
+                // Entries[(byte)id - 1] yields the entry for id. BuildEntries asserts this
+                // invariant after construction.
+                EventManifestEntry[] entries =
+                [
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_CreateAsyncContext, 1, CreateAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncContext, 1, ResumeAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_SuspendAsyncContext, 1, SuspendAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_CompleteAsyncContext, 1, CompleteAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_UnwindAsyncException, 1, UnwindAsyncExceptionPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, 1, CreateAsyncCallstackPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, 1, ResumeAsyncCallstackPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, 1, SuspendAsyncCallstackPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncMethod, 1, ResumeAsyncMethodPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.RuntimeAsync_CompleteAsyncMethod, 1, CompleteAsyncMethodPayloadLengthFieldSize),
+
+                    new EventManifestEntry(AsyncEventID.TaskAsync_CreateAsyncContext, 1, CreateAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncContext, 1, ResumeAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.TaskAsync_SuspendAsyncContext, 1, SuspendAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.TaskAsync_CompleteAsyncContext, 1, CompleteAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.TaskAsync_UnwindAsyncException, 1, UnwindAsyncExceptionPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncCallstack, 1, ResumeAsyncCallstackPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncMethod, 1, ResumeAsyncMethodPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.TaskAsync_CompleteAsyncMethod, 1, CompleteAsyncMethodPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.TaskAsync_AppendAsyncCallstack, 1, AppendAsyncCallstackPayloadLengthFieldSize),
+
+                    new EventManifestEntry(AsyncEventID.ResetAsyncThreadContext, 1, ResetAsyncThreadContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.ResetAsyncContinuationWrapperIndex, 1, ResetAsyncContinuationWrapperIndexPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.AsyncProfilerMetadata, 1, AsyncProfilerMetadataPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.AsyncProfilerSyncClock, 1, AsyncProfilerSyncClockPayloadLengthFieldSize),
+                ];
+
+#if DEBUG
+                for (int i = 0; i < entries.Length; i++)
+                {
+                    Debug.Assert((byte)entries[i].EventId == i + 1, "EventManifest.Entries must be dense and ordered by ascending AsyncEventID starting at 1.");
+                }
+#endif
+
+                return entries;
+            }
+        }
+
         internal ref struct Info
         {
             public object? Context;
@@ -122,14 +223,20 @@ namespace System.Runtime.CompilerServices
                             // [utcSync (compressed uint64)]
                             // [eventBufferSize (compressed uint32)]
                             // [wrapperCount byte]
-                            const int MaxStaticEventPayloadSize = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt32Size + 1;
+                            // [eventManifestEntryCount byte] -- number of entries that follow
+                            // [for each manifest entry: eventId (byte), version (byte), payloadLengthFieldSize (byte)]
+                            EventManifestEntry[] entries = EventManifest.Entries;
+                            Debug.Assert(entries.Length <= byte.MaxValue);
+                            int maxPayloadLength =
+                                Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt32Size + 1
+                                + 1 + entries.Length * 3;
 
                             ref EventBuffer eventBuffer = ref context.EventBuffer;
-                            if (Serializer.AsyncEventHeader(context, ref eventBuffer, AsyncEventID.AsyncProfilerMetadata, MaxStaticEventPayloadSize))
+                            if (Serializer.AsyncEventHeader(context, ref eventBuffer, AsyncEventID.AsyncProfilerMetadata, EventManifest.AsyncProfilerMetadataPayloadLengthFieldSize, maxPayloadLength, out int payloadLengthFieldOffset))
                             {
                                 SyncClock(out long utcTimeSync, out long qpcSync);
 
-                                Span<byte> payloadSpan = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxStaticEventPayloadSize);
+                                Span<byte> payloadSpan = eventBuffer.Data.AsSpan(eventBuffer.Index, maxPayloadLength);
                                 int payloadSpanIndex = 0;
 
                                 payloadSpanIndex += Serializer.WriteCompressedUInt64(payloadSpan.Slice(payloadSpanIndex), (ulong)Stopwatch.Frequency);
@@ -139,7 +246,19 @@ namespace System.Runtime.CompilerServices
 
                                 payloadSpan[payloadSpanIndex++] = ContinuationWrapper.COUNT;
 
+                                // Event manifest: one entry per defined AsyncEventID, three bytes each.
+                                payloadSpan[payloadSpanIndex++] = (byte)entries.Length;
+                                for (int i = 0; i < entries.Length; i++)
+                                {
+                                    EventManifestEntry entry = entries[i];
+                                    payloadSpan[payloadSpanIndex++] = (byte)entry.EventId;
+                                    payloadSpan[payloadSpanIndex++] = entry.Version;
+                                    payloadSpan[payloadSpanIndex++] = (byte)entry.FieldSize;
+                                }
+
                                 eventBuffer.Index += payloadSpanIndex;
+
+                                Serializer.WriteAsyncEventPayloadLength(ref eventBuffer, AsyncEventID.AsyncProfilerMetadata, EventManifest.AsyncProfilerMetadataPayloadLengthFieldSize, payloadLengthFieldOffset);
 
                                 // Force flush to deliver event promptly.
                                 context.Flush();
@@ -175,20 +294,22 @@ namespace System.Runtime.CompilerServices
                     // SyncClock payload:
                     // [qpcSync (compressed uint64)]
                     // [utcSync (compressed uint64)]
-                    const int MaxEventPayloadSize = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt64Size;
+                    const int MaxPayloadLength = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt64Size;
 
                     ref EventBuffer eventBuffer = ref transientContext.EventBuffer;
-                    if (Serializer.AsyncEventHeader(transientContext, ref eventBuffer, AsyncEventID.AsyncProfilerSyncClock, MaxEventPayloadSize))
+                    if (Serializer.AsyncEventHeader(transientContext, ref eventBuffer, AsyncEventID.AsyncProfilerSyncClock, EventManifest.AsyncProfilerSyncClockPayloadLengthFieldSize, MaxPayloadLength, out int payloadLengthFieldOffset))
                     {
                         SyncClock(out long utcTimeSync, out long qpcSync);
 
-                        Span<byte> payloadSpan = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize);
+                        Span<byte> payloadSpan = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxPayloadLength);
                         int payloadSpanIndex = 0;
 
                         payloadSpanIndex += Serializer.WriteCompressedUInt64(payloadSpan.Slice(payloadSpanIndex), (ulong)qpcSync);
                         payloadSpanIndex += Serializer.WriteCompressedUInt64(payloadSpan.Slice(payloadSpanIndex), (ulong)utcTimeSync);
 
                         eventBuffer.Index += payloadSpanIndex;
+
+                        Serializer.WriteAsyncEventPayloadLength(ref eventBuffer, AsyncEventID.AsyncProfilerSyncClock, EventManifest.AsyncProfilerSyncClockPayloadLengthFieldSize, payloadLengthFieldOffset);
 
                         // Force flush to deliver event promptly.
                         transientContext.Flush();
@@ -387,35 +508,52 @@ namespace System.Runtime.CompilerServices
                     eventBuffer.Index = headerSpanIndex;
                 }
 
-                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, AsyncEventID eventID, int maxEventPayloadSize)
+                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, AsyncEventID eventID, EventManifestEntry.PayloadLengthFieldSize payloadLengthFieldSize, int maxPayloadLength, out int payloadLengthFieldOffset)
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     long delta = currentTimestamp - context.LastEventTimestamp;
-                    return AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, maxEventPayloadSize);
+                    return AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, payloadLengthFieldSize, maxPayloadLength, out payloadLengthFieldOffset);
                 }
 
-                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, long currentTimestamp, AsyncEventID eventID, int maxEventPayloadSize)
+                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, AsyncEventID eventID)
+                {
+                    Debug.Assert(EventManifest.GetPayloadLengthFieldSize(eventID) == EventManifestEntry.PayloadLengthFieldSize.NoPayload);
+                    return AsyncEventHeader(context, ref eventBuffer, eventID, EventManifestEntry.PayloadLengthFieldSize.NoPayload, 0, out _);
+                }
+
+                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, long currentTimestamp, AsyncEventID eventID, EventManifestEntry.PayloadLengthFieldSize payloadLengthFieldSize, int maxPayloadLength, out int payloadLengthFieldOffset)
                 {
                     long delta = currentTimestamp - context.LastEventTimestamp;
-                    return AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, maxEventPayloadSize);
+                    return AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, payloadLengthFieldSize, maxPayloadLength, out payloadLengthFieldOffset);
                 }
 
-                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, long currentTimestamp, long delta, AsyncEventID eventID, int maxEventPayloadSize, out AsyncEventHeaderRollbackData rollbackData)
+                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, long currentTimestamp, AsyncEventID eventID)
                 {
+                    Debug.Assert(EventManifest.GetPayloadLengthFieldSize(eventID) == EventManifestEntry.PayloadLengthFieldSize.NoPayload);
+                    return AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, EventManifestEntry.PayloadLengthFieldSize.NoPayload, 0, out _);
+                }
+
+                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, long currentTimestamp, long delta, AsyncEventID eventID, EventManifestEntry.PayloadLengthFieldSize payloadLengthFieldSize, int maxPayloadLength, out int payloadLengthFieldOffset, out AsyncEventHeaderRollbackData rollbackData)
+                {
+                    Debug.Assert(payloadLengthFieldSize == EventManifest.GetPayloadLengthFieldSize(eventID));
+
                     byte[] buffer = eventBuffer.Data;
                     int index = eventBuffer.Index;
                     long previousTimestamp = context.LastEventTimestamp;
 
-                    if ((index + MaxAsyncEventHeaderSize + maxEventPayloadSize) <= buffer.Length && delta >= 0)
+                    int reservedSize = MaxAsyncEventHeaderSize + (byte)payloadLengthFieldSize + maxPayloadLength;
+
+                    if ((index + reservedSize) <= buffer.Length && delta >= 0)
                     {
                         context.LastEventTimestamp = currentTimestamp;
                     }
                     else
                     {
                         // Event is too big for buffer, drop it.
-                        if (MaxAsyncEventHeaderSize + maxEventPayloadSize > buffer.Length)
+                        if (reservedSize > buffer.Length)
                         {
                             rollbackData = default;
+                            payloadLengthFieldOffset = 0;
                             return false;
                         }
 
@@ -441,25 +579,34 @@ namespace System.Runtime.CompilerServices
                     headerSpanIndex += WriteCompressedUInt64(headerSpan.Slice(headerSpanIndex), (ulong)delta); // Timestamp delta from last event
 
                     eventBuffer.Index += headerSpanIndex;
+
+                    payloadLengthFieldOffset = eventBuffer.Index;
+                    eventBuffer.Index += (byte)payloadLengthFieldSize;
+
                     eventBuffer.EventCount++;
 
                     return true;
                 }
 
-                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, long currentTimestamp, long delta, AsyncEventID eventID, int maxEventPayloadSize)
+                public static bool AsyncEventHeader(AsyncThreadContext context, ref EventBuffer eventBuffer, long currentTimestamp, long delta, AsyncEventID eventID, EventManifestEntry.PayloadLengthFieldSize payloadLengthFieldSize, int maxPayloadLength, out int payloadLengthFieldOffset)
                 {
+                    Debug.Assert(payloadLengthFieldSize == EventManifest.GetPayloadLengthFieldSize(eventID));
+
                     byte[] buffer = eventBuffer.Data;
                     int index = eventBuffer.Index;
 
-                    if ((index + MaxAsyncEventHeaderSize + maxEventPayloadSize) <= buffer.Length && delta >= 0)
+                    int reservedSize = MaxAsyncEventHeaderSize + (byte)payloadLengthFieldSize + maxPayloadLength;
+
+                    if ((index + reservedSize) <= buffer.Length && delta >= 0)
                     {
                         context.LastEventTimestamp = currentTimestamp;
                     }
                     else
                     {
                         // Event is too big for buffer, drop it.
-                        if (MaxAsyncEventHeaderSize + maxEventPayloadSize > buffer.Length)
+                        if (reservedSize > buffer.Length)
                         {
+                            payloadLengthFieldOffset = 0;
                             return false;
                         }
 
@@ -476,9 +623,32 @@ namespace System.Runtime.CompilerServices
                     headerSpanIndex += WriteCompressedUInt64(headerSpan.Slice(headerSpanIndex), (ulong)delta); // Timestamp delta from last event
 
                     eventBuffer.Index += headerSpanIndex;
+
+                    payloadLengthFieldOffset = eventBuffer.Index;
+                    eventBuffer.Index += (byte)payloadLengthFieldSize;
+
                     eventBuffer.EventCount++;
 
                     return true;
+                }
+
+                public static void WriteAsyncEventPayloadLength(ref EventBuffer eventBuffer, AsyncEventID eventID, EventManifestEntry.PayloadLengthFieldSize payloadLengthFieldSize, int payloadLengthFieldOffset)
+                {
+                    Debug.Assert(payloadLengthFieldSize == EventManifest.GetPayloadLengthFieldSize(eventID));
+
+                    int payloadLength = eventBuffer.Index - payloadLengthFieldOffset - (byte)payloadLengthFieldSize;
+
+                    if (payloadLengthFieldSize == EventManifestEntry.PayloadLengthFieldSize.Byte)
+                    {
+                        Debug.Assert(payloadLength <= byte.MaxValue);
+                        eventBuffer.Data[payloadLengthFieldOffset] = (byte)payloadLength;
+                    }
+                    else
+                    {
+                        Debug.Assert(payloadLengthFieldSize == EventManifestEntry.PayloadLengthFieldSize.UShort);
+                        Debug.Assert(payloadLength <= ushort.MaxValue);
+                        BinaryPrimitives.WriteUInt16LittleEndian(eventBuffer.Data.AsSpan(payloadLengthFieldOffset), (ushort)payloadLength);
+                    }
                 }
 
                 public static void RollbackAsyncEventHeader(AsyncThreadContext context, in AsyncEventHeaderRollbackData rollbackData)
@@ -783,16 +953,17 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncContext || eventID == AsyncEventID.TaskAsync_CreateAsyncContext);
 
-                const int MaxEventPayloadSize = 2 * Serializer.MaxCompressedUInt64Size;
+                const int MaxPayloadLength = 2 * Serializer.MaxCompressedUInt64Size;
 
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
-                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, MaxEventPayloadSize))
+                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, EventManifest.CreateAsyncContextPayloadLengthFieldSize, MaxPayloadLength, out int payloadLengthFieldOffset))
                 {
-                    Span<byte> payload = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize);
+                    Span<byte> payload = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxPayloadLength);
                     int offset = 0;
                     offset += Serializer.WriteCompressedUInt64(payload.Slice(offset), parentDispatcherId);
                     offset += Serializer.WriteCompressedUInt64(payload.Slice(offset), dispatcherId);
                     eventBuffer.Index += offset;
+                    Serializer.WriteAsyncEventPayloadLength(ref eventBuffer, eventID, EventManifest.CreateAsyncContextPayloadLengthFieldSize, payloadLengthFieldOffset);
                 }
             }
         }
@@ -853,15 +1024,16 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncContext || eventID == AsyncEventID.TaskAsync_ResumeAsyncContext);
 
-                const int MaxEventPayloadSize = Serializer.MaxCompressedUInt64Size;
+                const int MaxPayloadLength = Serializer.MaxCompressedUInt64Size;
 
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
-                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, MaxEventPayloadSize))
+                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, EventManifest.ResumeAsyncContextPayloadLengthFieldSize, MaxPayloadLength, out int payloadLengthFieldOffset))
                 {
-                    Span<byte> payload = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize);
+                    Span<byte> payload = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxPayloadLength);
                     int offset = 0;
                     offset += Serializer.WriteCompressedUInt64(payload.Slice(offset), dispatcherId);
                     eventBuffer.Index += offset;
+                    Serializer.WriteAsyncEventPayloadLength(ref eventBuffer, eventID, EventManifest.ResumeAsyncContextPayloadLengthFieldSize, payloadLengthFieldOffset);
                 }
             }
         }
@@ -895,7 +1067,7 @@ namespace System.Runtime.CompilerServices
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
             {
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CompleteAsyncContext || eventID == AsyncEventID.TaskAsync_CompleteAsyncContext);
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID, 0);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID);
             }
         }
 
@@ -918,12 +1090,13 @@ namespace System.Runtime.CompilerServices
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_UnwindAsyncException ||  eventID == AsyncEventID.TaskAsync_UnwindAsyncException);
 
                 // unwinded frames
-                const int MaxEventPayloadSize = Serializer.MaxCompressedUInt32Size;
+                const int MaxPayloadLength = Serializer.MaxCompressedUInt32Size;
 
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
-                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, MaxEventPayloadSize))
+                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, EventManifest.UnwindAsyncExceptionPayloadLengthFieldSize, MaxPayloadLength, out int payloadLengthFieldOffset))
                 {
-                    eventBuffer.Index += Serializer.WriteCompressedUInt32(eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize), unwindedFrames);
+                    eventBuffer.Index += Serializer.WriteCompressedUInt32(eventBuffer.Data.AsSpan(eventBuffer.Index, MaxPayloadLength), unwindedFrames);
+                    Serializer.WriteAsyncEventPayloadLength(ref eventBuffer, eventID, EventManifest.UnwindAsyncExceptionPayloadLengthFieldSize, payloadLengthFieldOffset);
                 }
             }
         }
@@ -955,13 +1128,13 @@ namespace System.Runtime.CompilerServices
             public static void EmitEvent(AsyncThreadContext context, AsyncEventID eventID)
             {
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncMethod || eventID == AsyncEventID.TaskAsync_ResumeAsyncMethod);
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, eventID, 0);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, eventID);
             }
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
             {
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncMethod || eventID == AsyncEventID.TaskAsync_ResumeAsyncMethod);
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID, 0);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID);
             }
         }
 
@@ -982,7 +1155,7 @@ namespace System.Runtime.CompilerServices
             public static void EmitEvent(AsyncThreadContext context, AsyncEventID eventID)
             {
                 Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CompleteAsyncMethod || eventID == AsyncEventID.TaskAsync_CompleteAsyncMethod);
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, eventID, 0);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, eventID);
             }
         }
 
@@ -1037,7 +1210,7 @@ namespace System.Runtime.CompilerServices
 
             private static void EmitEvent(AsyncThreadContext context)
             {
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, AsyncEventID.ResetAsyncContinuationWrapperIndex, 0);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, AsyncEventID.ResetAsyncContinuationWrapperIndex);
             }
         }
 
@@ -1126,7 +1299,7 @@ namespace System.Runtime.CompilerServices
 
             private static void EmitEvent(AsyncThreadContext context)
             {
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, AsyncEventID.ResetAsyncThreadContext, 0);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, AsyncEventID.ResetAsyncThreadContext);
             }
         }
 
@@ -1561,9 +1734,9 @@ namespace System.Runtime.CompilerServices
                 int maxCallstackBytes = Math.Min(byte.MaxValue * T.MaxAsyncMethodFrameSize, eventBuffer.Data.Length);
 
                 // Static callstack payload: callstackId (1) + continuationIndex (1) + frameCount (1) + parentDispatcherId + dispatcherId (max 10 bytes compressed each).
-                const int MaxStaticEventPayloadSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + 2 * Serializer.MaxCompressedUInt64Size;
+                const int MaxPayloadLength = sizeof(byte) + sizeof(byte) + sizeof(byte) + 2 * Serializer.MaxCompressedUInt64Size;
 
-                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, MaxStaticEventPayloadSize, out Serializer.AsyncEventHeaderRollbackData rollbackData))
+                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, EventManifest.CallstackPayloadLengthFieldSize, MaxPayloadLength, out int payloadLengthFieldOffset, out Serializer.AsyncEventHeaderRollbackData rollbackData))
                 {
                     int frameCountOffset = CallstackHeader(ref eventBuffer, eventID, parentDispatcherId, dispatcherId, continuationIndex, 0);
 
@@ -1587,10 +1760,11 @@ namespace System.Runtime.CompilerServices
                             context.Flush();
 
                             // Write the callstack again.
-                            if (Serializer.AsyncEventHeader(context, ref eventBuffer, context.LastEventTimestamp, 0, eventID, MaxStaticEventPayloadSize + index))
+                            if (Serializer.AsyncEventHeader(context, ref eventBuffer, context.LastEventTimestamp, 0, eventID, EventManifest.CallstackPayloadLengthFieldSize, MaxPayloadLength + index, out payloadLengthFieldOffset))
                             {
                                 CallstackHeader(ref eventBuffer, eventID, parentDispatcherId, dispatcherId, continuationIndex, count);
                                 CallstackData(ref eventBuffer, rentedArray, index);
+                                Serializer.WriteAsyncEventPayloadLength(ref eventBuffer, eventID, EventManifest.CallstackPayloadLengthFieldSize, payloadLengthFieldOffset);
                             }
 
                             ArrayPool<byte>.Shared.Return(rentedArray);
@@ -1606,6 +1780,7 @@ namespace System.Runtime.CompilerServices
                         // Patch frame count in the event buffer using the offset from CallstackHeader.
                         eventBuffer.Data[frameCountOffset] = count;
                         eventBuffer.Index += currentIndex - startIndex;
+                        Serializer.WriteAsyncEventPayloadLength(ref eventBuffer, eventID, EventManifest.CallstackPayloadLengthFieldSize, payloadLengthFieldOffset);
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -1565,7 +1565,14 @@ namespace System.Runtime.CompilerServices
                 return null;
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong id, ref T captureCallstack)
+                where T : ICaptureAsyncCallstack, allows ref struct
+            {
+                EmitAsyncCallstack(context, currentTimestamp, delta, eventID, id, 0, ref captureCallstack);
+            }
+
+            private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong id, byte continuationIndex, ref T captureCallstack)
                 where T : ICaptureAsyncCallstack, allows ref struct
             {
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
@@ -1573,12 +1580,12 @@ namespace System.Runtime.CompilerServices
                 // Max callstack data that can fit in the buffer after flush.
                 int maxCallstackBytes = Math.Min(byte.MaxValue * T.MaxAsyncMethodFrameSize, eventBuffer.Data.Length);
 
-                // Static callstack payload: type (1) + callstackId (1) + frameCount (1) + id (max 10 bytes compressed).
-                const int MaxStaticEventPayloadSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
+                // Static callstack payload: type (1) + callstackId (1) + continuationIndex (1) + frameCount (1) + id (max 10 bytes compressed).
+                const int MaxStaticEventPayloadSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
 
                 if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, MaxStaticEventPayloadSize, out Serializer.AsyncEventHeaderRollbackData rollbackData))
                 {
-                    int frameCountOffset = CallstackHeader(ref eventBuffer, id, T.CallstackType, 0);
+                    int frameCountOffset = CallstackHeader(ref eventBuffer, id, T.CallstackType, continuationIndex, 0);
 
                     byte[] buffer = eventBuffer.Data;
                     int startIndex = eventBuffer.Index;
@@ -1602,7 +1609,7 @@ namespace System.Runtime.CompilerServices
                             // Write the callstack again.
                             if (Serializer.AsyncEventHeader(context, ref eventBuffer, context.LastEventTimestamp, 0, eventID, MaxStaticEventPayloadSize + index))
                             {
-                                CallstackHeader(ref eventBuffer, id, T.CallstackType, count);
+                                CallstackHeader(ref eventBuffer, id, T.CallstackType, continuationIndex, count);
                                 CallstackData(ref eventBuffer, rentedArray, index);
                             }
 
@@ -1623,10 +1630,10 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            private static int CallstackHeader(ref EventBuffer eventBuffer, ulong id, AsyncCallstackType type, byte callstackFrameCount)
+            private static int CallstackHeader(ref EventBuffer eventBuffer, ulong id, AsyncCallstackType type, byte continuationIndex, byte callstackFrameCount)
             {
-                // Callstack header layout: type (1 byte) + callstackId (1 byte, reserved for future use) + frameCount (1 byte) + id (max 10 bytes compressed).
-                const int MaxCallstackHeaderSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
+                // Callstack header layout: type (1 byte) + callstackId (1 byte, reserved for future use) + continuationIndex (1 byte) + frameCount (1 byte) + id (max 10 bytes compressed).
+                const int MaxCallstackHeaderSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
 
                 ref int index = ref eventBuffer.Index;
 
@@ -1635,6 +1642,7 @@ namespace System.Runtime.CompilerServices
 
                 callstackHeaderSpan[spanIndex++] = (byte)type;
                 callstackHeaderSpan[spanIndex++] = 0; // Reserved callstack ID for future callstack interning.
+                callstackHeaderSpan[spanIndex++] = continuationIndex;
 
                 int frameCountOffset = index + spanIndex;
                 callstackHeaderSpan[spanIndex++] = callstackFrameCount;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -55,7 +55,6 @@ namespace System.Runtime.CompilerServices
         internal static void InitInfo(ref Info info)
         {
             info.Context = null;
-            info.ContinuationIndex = 0;
             ContinuationWrapper.InitInfo(ref info);
         }
 
@@ -1008,6 +1007,20 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class ContinuationWrapper
         {
+            /// <summary>
+            /// Number of distinct wrapper methods. The wrapper index rotates modulo this value.
+            /// </summary>
+            public const byte COUNT = 32;
+            public const byte COUNT_MASK = COUNT - 1;
+
+#if MONO
+            public static void InitInfo(ref Info info)
+            {
+                info.ContinuationTable = 0;
+                info.ContinuationIndex = 0;
+            }
+#endif
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static void IncrementIndex(ref Info info)
             {
@@ -1073,8 +1086,9 @@ namespace System.Runtime.CompilerServices
                     Config.EmitAsyncProfilerMetadataIfNeeded(context);
                     EmitEvent(context);
                 }
-
+#if !MONO
                 ResumeAsyncCallstacks(context);
+#endif
             }
 
             private static void EmitEvent(AsyncThreadContext context)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -1,12 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
+using static System.Runtime.CompilerServices.AsyncInstrumentation;
 using static System.Runtime.CompilerServices.AsyncProfiler;
 using static System.Runtime.CompilerServices.AsyncProfilerEventSource;
 using Serializer = System.Runtime.CompilerServices.AsyncProfiler.EventBuffer.Serializer;
@@ -38,7 +41,8 @@ namespace System.Runtime.CompilerServices
             ResetAsyncThreadContext = 11,
             ResetAsyncContinuationWrapperIndex = 12,
             AsyncProfilerMetadata = 13,
-            AsyncProfilerSyncClock = 14
+            AsyncProfilerSyncClock = 14,
+            AppendAsyncCallstack = 15
         }
 
         internal ref struct Info
@@ -726,6 +730,8 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class ResumeAsyncContext
         {
+            public static ulong GetId(AsyncTaskDispatcher dispatcher) => dispatcher.ContextId;
+
             public static ulong GetId(ref AsyncTaskDispatcherInfo info)
             {
                 if (info.Dispatcher != null)
@@ -744,12 +750,39 @@ namespace System.Runtime.CompilerServices
                 // Temporarily bypass so Resume always fires.
                 SyncPoint.Check(context);
 
-                if (IsEnabled.ResumeAsyncContextEvent(context.ActiveEventKeywords))
+                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp(), GetId(ref info));
+                    long currentTimestamp = Stopwatch.GetTimestamp();
+                    ulong id = GetId(ref info);
+                    if (IsEnabled.ResumeAsyncContextEvent(activeEventKeywords))
+                    {
+                        EmitEvent(context, currentTimestamp, id);
+                    }
+
+                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords) && info.Dispatcher != null)
+                    {
+                        AsyncCallstack.EmitEvent(info.Dispatcher, context, currentTimestamp, id);
+                    }
                 }
 
                 AsyncThreadContext.Release(context);
+            }
+
+            public static void Append(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp)
+            {
+                if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords))
+                {
+                    Task? lastTask = dispatcher.LastContinuation;
+                    if (lastTask != null)
+                    {
+                        object? newContinuation = lastTask.DiagnosticContinuationObject;
+                        if (newContinuation != null)
+                        {
+                            AsyncCallstack.EmitEvent(dispatcher, context, newContinuation, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
+                        }
+                    }
+                }
             }
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id)
@@ -766,15 +799,25 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class SuspendAsyncContext
         {
-            public static void Suspend(ref Info info)
+            public static void Suspend(AsyncTaskDispatcher dispatcher, ref Info info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
                 SyncPoint.Check(context);
 
-                if (IsEnabled.SuspendAsyncContextEvent(context.ActiveEventKeywords))
+                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp());
+                    long currentTimestamp = Stopwatch.GetTimestamp();
+                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
+                    {
+                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
+                    }
+
+                    if (IsEnabled.SuspendAsyncContextEvent(activeEventKeywords))
+                    {
+                        EmitEvent(context, currentTimestamp);
+                    }
                 }
 
                 AsyncThreadContext.Release(context);
@@ -788,6 +831,30 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class CompleteAsyncContext
         {
+            public static void Complete(AsyncTaskDispatcher dispatcher, ref Info info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+
+                SyncPoint.Check(context);
+
+                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
+                {
+                    long currentTimestamp = Stopwatch.GetTimestamp();
+                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
+                    {
+                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
+                    }
+
+                    if (IsEnabled.CompleteAsyncContextEvent(activeEventKeywords))
+                    {
+                        EmitEvent(context, currentTimestamp);
+                    }
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+
             public static void Complete(ref Info info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
@@ -867,6 +934,30 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class ResumeAsyncMethod
         {
+            public static void Resume(AsyncTaskDispatcher dispatcher, ref Info info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+
+                SyncPoint.Check(context);
+
+                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
+                {
+                    long currentTimestamp = Stopwatch.GetTimestamp();
+                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
+                    {
+                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
+                    }
+
+                    if (IsEnabled.ResumeAsyncMethodEvent(activeEventKeywords))
+                    {
+                        EmitEvent(context, currentTimestamp);
+                    }
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+
             public static void Resume(ref Info info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
@@ -883,6 +974,11 @@ namespace System.Runtime.CompilerServices
             public static void EmitEvent(AsyncThreadContext context)
             {
                 Serializer.AsyncEventHeader(context, ref context.EventBuffer, AsyncEventID.ResumeAsyncMethod, 0);
+            }
+
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp)
+            {
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, AsyncEventID.ResumeAsyncMethod, 0);
             }
         }
 
@@ -1188,6 +1284,284 @@ namespace System.Runtime.CompilerServices
             private static Timer? s_cleanupTimer;
 
             private static List<AsyncThreadContextHolder> s_cache = new List<AsyncThreadContextHolder>();
+        }
+
+        private static partial class AsyncCallstack
+        {
+            private const int MaxTaskAsyncMethodFrameSize = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt32Size;
+
+            private interface ICaptureAsyncCallstack
+            {
+                bool Capture(byte[] buffer, ref int index, out byte count);
+
+                static abstract AsyncCallstackType CallstackType { get; }
+                static abstract int MaxAsyncMethodFrameSize {  get; }
+            }
+
+            private ref struct CaptureTaskAsyncCallstackState : ICaptureAsyncCallstack
+            {
+                public object? Continuation;
+                public object? LastContinuation;
+                public ulong LastMethodId;
+                public byte Count;
+
+                public bool Capture(byte[] buffer, ref int index, out byte count)
+                {
+                    bool result = CaptureTaskAsyncCallstack(buffer, ref index, ref this);
+                    count = Count;
+                    return result;
+                }
+
+                public static AsyncCallstackType CallstackType => AsyncCallstackType.Compiler;
+                public static int MaxAsyncMethodFrameSize => MaxTaskAsyncMethodFrameSize;
+            }
+
+            public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp, ulong id)
+            {
+                EmitEvent(dispatcher, context, dispatcher.InnerBox, currentTimestamp, AsyncEventID.ResumeAsyncCallstack, id);
+            }
+
+            public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong id)
+            {
+                if (continuation != null)
+                {
+                    IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(continuation);
+                    if (box != null)
+                    {
+                        CaptureTaskAsyncCallstackState state = default;
+                        state.Continuation = box;
+
+                        EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, id, state);
+
+                        box = ResolveAsyncStateMachineBox(state.LastContinuation);
+                        if (box != null)
+                        {
+                            Debug.Assert(box is Task);
+                            dispatcher.LastContinuation = Unsafe.As<Task>(box);
+                        }
+                        else
+                        {
+                            dispatcher.LastContinuation = null;
+                        }
+                    }
+                    else
+                    {
+                        dispatcher.LastContinuation = null;
+                    }
+                }
+            }
+
+            private static bool CaptureTaskAsyncCallstack(byte[] buffer, ref int index, ref CaptureTaskAsyncCallstackState state)
+            {
+                if (index > buffer.Length || state.Continuation == null)
+                {
+                    return false;
+                }
+
+                byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, (buffer.Length - index) / MaxTaskAsyncMethodFrameSize);
+                if (maxAsyncCallstackFrames == 0)
+                {
+                    return false;
+                }
+
+                Span<byte> callstackSpan = buffer.AsSpan(index);
+                int callstackSpanIndex = 0;
+                ulong previousMethodId = state.LastMethodId;
+
+                state.LastContinuation = state.Continuation;
+
+                if (!GetFrameDiagnosticsData(state.Continuation, out ulong currentMethodId, out int methodState, out object? nextContinuation))
+                {
+                    return false;
+                }
+
+                state.Continuation = nextContinuation;
+
+                if (state.Count == 0)
+                {
+                    callstackSpanIndex += Serializer.WriteCompressedUInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedUInt64Size), currentMethodId);
+                }
+                else
+                {
+                    callstackSpanIndex += Serializer.WriteCompressedInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt64Size), (long)(currentMethodId - previousMethodId));
+                }
+
+                callstackSpanIndex += Serializer.WriteCompressedInt32(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt32Size), methodState);
+                state.Count++;
+
+                while (state.Count < maxAsyncCallstackFrames && state.Continuation != null)
+                {
+                    previousMethodId = currentMethodId;
+                    state.LastContinuation = state.Continuation;
+
+                    if (!GetFrameDiagnosticsData(state.Continuation, out currentMethodId, out methodState, out nextContinuation))
+                    {
+                        state.Continuation = nextContinuation;
+                        continue;
+                    }
+
+                    callstackSpanIndex += Serializer.WriteCompressedInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt64Size), (long)(currentMethodId - previousMethodId));
+                    callstackSpanIndex += Serializer.WriteCompressedInt32(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt32Size), methodState);
+
+                    state.Count++;
+                    state.Continuation = nextContinuation;
+                }
+
+                state.LastMethodId = currentMethodId;
+                index += callstackSpanIndex;
+
+                return state.Continuation == null || state.Count == byte.MaxValue;
+            }
+
+            private static bool GetFrameDiagnosticsData(object? continuationObject, out ulong methodId, out int state, out object? nextContinuation)
+            {
+                IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(continuationObject);
+                if (box != null)
+                {
+                    box.GetDiagnosticData(out methodId, out state, out nextContinuation);
+                    return true;
+                }
+
+                methodId = 0;
+                state = -1;
+                nextContinuation = null;
+
+                return false;
+            }
+
+            private static IAsyncStateMachineBox? ResolveAsyncStateMachineBox(object? continuationObject)
+            {
+                if (continuationObject == null)
+                {
+                    return null;
+                }
+
+                if (continuationObject is IAsyncStateMachineBox box)
+                {
+                    return box;
+                }
+
+                if (continuationObject is Action action)
+                {
+                    return AsyncMethodBuilderCore.TryGetStateMachineBox(action);
+                }
+
+                if (continuationObject is List<object?> list)
+                {
+                    for (int i = 0; i < list.Count; i++)
+                    {
+                        IAsyncStateMachineBox? resolved = ResolveAsyncStateMachineBox(list[i]);
+                        if (resolved is not null)
+                        {
+                            return resolved;
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong id, T captureCallstack)
+                where T : ICaptureAsyncCallstack, allows ref struct
+            {
+                ref EventBuffer eventBuffer = ref context.EventBuffer;
+
+                // Max callstack data that can fit in the buffer after flush.
+                int maxCallstackBytes = Math.Min(byte.MaxValue * T.MaxAsyncMethodFrameSize, eventBuffer.Data.Length);
+
+                // Static callstack payload: type (1) + callstackId (1) + frameCount (1) + id (max 10 bytes compressed).
+                const int MaxStaticEventPayloadSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
+
+                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, MaxStaticEventPayloadSize, out Serializer.AsyncEventHeaderRollbackData rollbackData))
+                {
+                    int frameCountOffset = CallstackHeader(ref eventBuffer, id, T.CallstackType, 0);
+
+                    byte[] buffer = eventBuffer.Data;
+                    int startIndex = eventBuffer.Index;
+                    int currentIndex = startIndex;
+
+                    if (!captureCallstack.Capture(buffer, ref currentIndex, out byte count))
+                    {
+                        byte[]? rentedArray = RentArray(maxCallstackBytes);
+                        if (rentedArray != null)
+                        {
+                            int length = currentIndex - startIndex;
+                            int index = length;
+
+                            Buffer.BlockCopy(buffer, startIndex, rentedArray, 0, length);
+                            captureCallstack.Capture(rentedArray, ref index, out count);
+
+                            // Rollback async event header before flushing.
+                            Serializer.RollbackAsyncEventHeader(context, in rollbackData);
+                            context.Flush();
+
+                            // Write the callstack again.
+                            if (Serializer.AsyncEventHeader(context, ref eventBuffer, context.LastEventTimestamp, 0, eventID, MaxStaticEventPayloadSize + index))
+                            {
+                                CallstackHeader(ref eventBuffer, id, T.CallstackType, count);
+                                CallstackData(ref eventBuffer, rentedArray, index);
+                            }
+
+                            ArrayPool<byte>.Shared.Return(rentedArray);
+                        }
+                        else
+                        {
+                            // Rollback async event header since we can't write the callstack.
+                            Serializer.RollbackAsyncEventHeader(context, in rollbackData);
+                        }
+                    }
+                    else
+                    {
+                        // Patch frame count in the event buffer using the offset from CallstackHeader.
+                        eventBuffer.Data[frameCountOffset] = count;
+                        eventBuffer.Index += currentIndex - startIndex;
+                    }
+                }
+            }
+
+            private static int CallstackHeader(ref EventBuffer eventBuffer, ulong id, AsyncCallstackType type, byte callstackFrameCount)
+            {
+                // Callstack header layout: type (1 byte) + callstackId (1 byte, reserved for future use) + frameCount (1 byte) + id (max 10 bytes compressed).
+                const int MaxCallstackHeaderSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
+
+                ref int index = ref eventBuffer.Index;
+
+                Span<byte> callstackHeaderSpan = eventBuffer.Data.AsSpan(index, MaxCallstackHeaderSize);
+                int spanIndex = 0;
+
+                callstackHeaderSpan[spanIndex++] = (byte)type;
+                callstackHeaderSpan[spanIndex++] = 0; // Reserved callstack ID for future callstack interning.
+
+                int frameCountOffset = index + spanIndex;
+                callstackHeaderSpan[spanIndex++] = callstackFrameCount;
+
+                spanIndex += Serializer.WriteCompressedUInt64(callstackHeaderSpan.Slice(spanIndex), id);
+                eventBuffer.Index += spanIndex;
+
+                return frameCountOffset;
+            }
+
+            private static void CallstackData(ref EventBuffer eventBuffer, byte[] callstackData, int callstackDataByteCount)
+            {
+                ref int index = ref eventBuffer.Index;
+                Buffer.BlockCopy(callstackData, 0, eventBuffer.Data, index, callstackDataByteCount);
+                index += callstackDataByteCount;
+            }
+
+            private static byte[]? RentArray(int minimumLength)
+            {
+                byte[]? rentedArray = null;
+                try
+                {
+                    rentedArray = ArrayPool<byte>.Shared.Rent(minimumLength);
+                }
+                catch
+                {
+                    //AsyncProfiler can't throw, return null if renting fails.
+                }
+
+                return rentedArray;
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -21,33 +21,32 @@ namespace System.Runtime.CompilerServices
         internal enum AsyncEventID : byte
         {
             // V2 (RuntimeAsync) events.
-            RuntimeAsync_CreateAsyncContext = 1,
-            RuntimeAsync_ResumeAsyncContext = 2,
-            RuntimeAsync_SuspendAsyncContext = 3,
-            RuntimeAsync_CompleteAsyncContext = 4,
-            RuntimeAsync_UnwindAsyncException = 5,
-            RuntimeAsync_CreateAsyncCallstack = 6,
-            RuntimeAsync_ResumeAsyncCallstack = 7,
-            RuntimeAsync_SuspendAsyncCallstack = 8,
-            RuntimeAsync_ResumeAsyncMethod = 9,
-            RuntimeAsync_CompleteAsyncMethod = 10,
+            CreateRuntimeAsyncContext = 1,
+            ResumeRuntimeAsyncContext = 2,
+            SuspendRuntimeAsyncContext = 3,
+            CompleteRuntimeAsyncContext = 4,
+            UnwindRuntimeAsyncException = 5,
+            CreateRuntimeAsyncCallstack = 6,
+            ResumeRuntimeAsyncCallstack = 7,
+            SuspendRuntimeAsyncCallstack = 8,
+            ResumeRuntimeAsyncMethod = 9,
+            CompleteRuntimeAsyncMethod = 10,
 
-            // V1 (TaskAsync) events.
-            TaskAsync_CreateAsyncContext = 11,
-            TaskAsync_ResumeAsyncContext = 12,
-            TaskAsync_SuspendAsyncContext = 13,
-            TaskAsync_CompleteAsyncContext = 14,
-            TaskAsync_UnwindAsyncException = 15,
-            TaskAsync_ResumeAsyncCallstack = 16,
-            TaskAsync_ResumeAsyncMethod = 17,
-            TaskAsync_CompleteAsyncMethod = 18,
-            TaskAsync_AppendAsyncCallstack = 19,
+            // V1 (StateMachineAsync) events.
+            CreateStateMachineAsyncContext = 11,
+            ResumeStateMachineAsyncContext = 12,
+            CompleteStateMachineAsyncContext = 13,
+            UnwindStateMachineAsyncException = 14,
+            ResumeStateMachineAsyncCallstack = 15,
+            ResumeStateMachineAsyncMethod = 16,
+            CompleteStateMachineAsyncMethod = 17,
+            AppendStateMachineAsyncCallstack = 18,
 
             // Neutral profiler events.
-            ResetAsyncThreadContext = 20,
-            ResetAsyncContinuationWrapperIndex = 21,
-            AsyncProfilerMetadata = 22,
-            AsyncProfilerSyncClock = 23,
+            ResetAsyncThreadContext = 19,
+            ResetAsyncContinuationWrapperIndex = 20,
+            AsyncProfilerMetadata = 21,
+            AsyncProfilerSyncClock = 22,
         }
 
         // Per-event manifest entry: schema version + payload length-prefix size.
@@ -113,26 +112,25 @@ namespace System.Runtime.CompilerServices
                 // invariant after construction.
                 EventManifestEntry[] entries =
                 [
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_CreateAsyncContext, 1, CreateAsyncContextPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncContext, 1, ResumeAsyncContextPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_SuspendAsyncContext, 1, SuspendAsyncContextPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_CompleteAsyncContext, 1, CompleteAsyncContextPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_UnwindAsyncException, 1, UnwindAsyncExceptionPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, 1, CreateAsyncCallstackPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, 1, ResumeAsyncCallstackPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, 1, SuspendAsyncCallstackPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncMethod, 1, ResumeAsyncMethodPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.RuntimeAsync_CompleteAsyncMethod, 1, CompleteAsyncMethodPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.CreateRuntimeAsyncContext, 1, CreateAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.ResumeRuntimeAsyncContext, 1, ResumeAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.SuspendRuntimeAsyncContext, 1, SuspendAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.CompleteRuntimeAsyncContext, 1, CompleteAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.UnwindRuntimeAsyncException, 1, UnwindAsyncExceptionPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.CreateRuntimeAsyncCallstack, 1, CreateAsyncCallstackPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.ResumeRuntimeAsyncCallstack, 1, ResumeAsyncCallstackPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.SuspendRuntimeAsyncCallstack, 1, SuspendAsyncCallstackPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.ResumeRuntimeAsyncMethod, 1, ResumeAsyncMethodPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.CompleteRuntimeAsyncMethod, 1, CompleteAsyncMethodPayloadLengthFieldSize),
 
-                    new EventManifestEntry(AsyncEventID.TaskAsync_CreateAsyncContext, 1, CreateAsyncContextPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncContext, 1, ResumeAsyncContextPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.TaskAsync_SuspendAsyncContext, 1, SuspendAsyncContextPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.TaskAsync_CompleteAsyncContext, 1, CompleteAsyncContextPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.TaskAsync_UnwindAsyncException, 1, UnwindAsyncExceptionPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncCallstack, 1, ResumeAsyncCallstackPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncMethod, 1, ResumeAsyncMethodPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.TaskAsync_CompleteAsyncMethod, 1, CompleteAsyncMethodPayloadLengthFieldSize),
-                    new EventManifestEntry(AsyncEventID.TaskAsync_AppendAsyncCallstack, 1, AppendAsyncCallstackPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.CreateStateMachineAsyncContext, 1, CreateAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncContext, 1, ResumeAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.CompleteStateMachineAsyncContext, 1, CompleteAsyncContextPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.UnwindStateMachineAsyncException, 1, UnwindAsyncExceptionPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncCallstack, 1, ResumeAsyncCallstackPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncMethod, 1, ResumeAsyncMethodPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.CompleteStateMachineAsyncMethod, 1, CompleteAsyncMethodPayloadLengthFieldSize),
+                    new EventManifestEntry(AsyncEventID.AppendStateMachineAsyncCallstack, 1, AppendAsyncCallstackPayloadLengthFieldSize),
 
                     new EventManifestEntry(AsyncEventID.ResetAsyncThreadContext, 1, ResetAsyncThreadContextPayloadLengthFieldSize),
                     new EventManifestEntry(AsyncEventID.ResetAsyncContinuationWrapperIndex, 1, ResetAsyncContinuationWrapperIndexPayloadLengthFieldSize),
@@ -352,13 +350,20 @@ namespace System.Runtime.CompilerServices
             private static void UpdateFlags()
             {
                 AsyncInstrumentation.Flags flags = AsyncInstrumentation.Flags.Disabled;
-                flags |= IsEnabled.CreateAsyncContextEvent(ActiveEventKeywords) || IsEnabled.CreateAsyncCallstackEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CreateAsyncContext : AsyncInstrumentation.Flags.Disabled;
-                flags |= IsEnabled.ResumeAsyncContextEvent(ActiveEventKeywords) || IsEnabled.ResumeAsyncCallstackEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncContext : AsyncInstrumentation.Flags.Disabled;
-                flags |= IsEnabled.SuspendAsyncContextEvent(ActiveEventKeywords) || IsEnabled.SuspendAsyncCallstackEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.SuspendAsyncContext : AsyncInstrumentation.Flags.Disabled;
-                flags |= IsEnabled.CompleteAsyncContextEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CompleteAsyncContext : AsyncInstrumentation.Flags.Disabled;
-                flags |= IsEnabled.UnwindAsyncExceptionEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.UnwindAsyncException : AsyncInstrumentation.Flags.Disabled;
-                flags |= IsEnabled.ResumeAsyncMethodEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncMethod : AsyncInstrumentation.Flags.Disabled;
-                flags |= IsEnabled.CompleteAsyncMethodEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CompleteAsyncMethod : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.CreateRuntimeAsyncContextEvent(ActiveEventKeywords) || IsEnabled.CreateRuntimeAsyncCallstackEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CreateAsyncContext : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.ResumeRuntimeAsyncContextEvent(ActiveEventKeywords) || IsEnabled.ResumeRuntimeAsyncCallstackEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncContext : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.SuspendRuntimeAsyncContextEvent(ActiveEventKeywords) || IsEnabled.SuspendRuntimeAsyncCallstackEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.SuspendAsyncContext : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.CompleteRuntimeAsyncContextEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CompleteAsyncContext : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.UnwindRuntimeAsyncExceptionEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.UnwindAsyncException : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.ResumeRuntimeAsyncMethodEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncMethod : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.CompleteRuntimeAsyncMethodEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CompleteAsyncMethod : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.CreateStateMachineAsyncContextEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CreateAsyncContext : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.ResumeStateMachineAsyncContextEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncContext : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.CompleteStateMachineAsyncContextEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CompleteAsyncContext : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.UnwindStateMachineAsyncExceptionEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.UnwindAsyncException : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.ResumeStateMachineAsyncCallstackEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncContext : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.ResumeStateMachineAsyncMethodEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncMethod : AsyncInstrumentation.Flags.Disabled;
+                flags |= IsEnabled.CompleteStateMachineAsyncMethodEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CompleteAsyncMethod : AsyncInstrumentation.Flags.Disabled;
 
                 AsyncInstrumentation.UpdateAsyncProfilerFlags(flags);
             }
@@ -884,7 +889,7 @@ namespace System.Runtime.CompilerServices
         {
             public static ulong GetDispatcherId(Task dispatcher) => (ulong)dispatcher.Id;
 
-            public static ulong GetDispatcherId(ref AsyncTaskDispatcherInfo info)
+            public static ulong GetDispatcherId(ref AsyncStateMachineDispatcherInfo info)
             {
                 if (info.Dispatcher != null)
                 {
@@ -896,13 +901,13 @@ namespace System.Runtime.CompilerServices
 #if !RUNTIME_ASYNC_SUPPORTED
             public static unsafe ulong CaptureParentDispatcherId()
             {
-                AsyncTaskDispatcherInfo* v1 = AsyncTaskDispatcherInfo.t_current;
-                if (v1 == null)
+                AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
+                if (info == null)
                 {
                     return 0;
                 }
 
-                AsyncTaskDispatcher? parent = v1->Dispatcher;
+                AsyncStateMachineDispatcher? parent = info->Dispatcher;
                 return parent is not null ? (ulong)parent.Id : 0;
             }
 #endif
@@ -910,7 +915,7 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class CreateAsyncContext
         {
-            public static void Create(AsyncTaskDispatcher dispatcher, ref Info info, ulong parentDispatcherId, ulong dispatcherId)
+            public static void Create(AsyncStateMachineDispatcher dispatcher, ref Info info, ulong parentDispatcherId, ulong dispatcherId)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
@@ -920,14 +925,14 @@ namespace System.Runtime.CompilerServices
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
+                    if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                     {
                         ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
                     }
 
-                    if (IsEnabled.CreateAsyncContextEvent(activeEventKeywords))
+                    if (IsEnabled.CreateStateMachineAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.TaskAsync_CreateAsyncContext);
+                        EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.CreateStateMachineAsyncContext);
                     }
                 }
 
@@ -941,9 +946,9 @@ namespace System.Runtime.CompilerServices
 
                 SyncPoint.Check(context);
 
-                if (IsEnabled.CreateAsyncContextEvent(context.ActiveEventKeywords))
+                if (IsEnabled.CreateStateMachineAsyncContextEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp(), parentDispatcherId, dispatcherId, AsyncEventID.TaskAsync_CreateAsyncContext);
+                    EmitEvent(context, Stopwatch.GetTimestamp(), parentDispatcherId, dispatcherId, AsyncEventID.CreateStateMachineAsyncContext);
                 }
 
                 AsyncThreadContext.Release(context);
@@ -951,7 +956,7 @@ namespace System.Runtime.CompilerServices
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong parentDispatcherId, ulong dispatcherId, AsyncEventID eventID)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncContext || eventID == AsyncEventID.TaskAsync_CreateAsyncContext);
+                Debug.Assert(eventID == AsyncEventID.CreateRuntimeAsyncContext || eventID == AsyncEventID.CreateStateMachineAsyncContext);
 
                 const int MaxPayloadLength = 2 * Serializer.MaxCompressedUInt64Size;
 
@@ -970,7 +975,7 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class ResumeAsyncContext
         {
-            public static void Resume(ref AsyncTaskDispatcherInfo info)
+            public static void Resume(ref AsyncStateMachineDispatcherInfo info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
@@ -979,7 +984,7 @@ namespace System.Runtime.CompilerServices
                 AsyncThreadContext.Release(context);
             }
 
-            public static void Resume(ref AsyncTaskDispatcherInfo info, AsyncThreadContext context, ulong dispatcherId, EventKeywords activeEventKeywords)
+            public static void Resume(ref AsyncStateMachineDispatcherInfo info, AsyncThreadContext context, ulong dispatcherId, EventKeywords activeEventKeywords)
             {
                 if (SyncPoint.Check(context))
                 {
@@ -989,40 +994,40 @@ namespace System.Runtime.CompilerServices
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.ResumeAsyncContextEvent(activeEventKeywords))
+                    if (IsEnabled.ResumeStateMachineAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, dispatcherId, AsyncEventID.TaskAsync_ResumeAsyncContext);
+                        EmitEvent(context, currentTimestamp, dispatcherId, AsyncEventID.ResumeStateMachineAsyncContext);
                     }
 
-                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords) && info.Dispatcher != null)
+                    if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords) && info.Dispatcher != null)
                     {
                         AsyncCallstack.EmitEvent(info.Dispatcher, context, currentTimestamp, dispatcherId);
                     }
                 }
             }
 
-            public static void Append(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp)
+            public static void Append(AsyncStateMachineDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp)
             {
-                if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
+                if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
                 {
-                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.ContinuationForDiagnostics, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, DispatcherIds.GetDispatcherId(dispatcher));
+                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.ContinuationForDiagnostics, currentTimestamp, AsyncEventID.AppendStateMachineAsyncCallstack, DispatcherIds.GetDispatcherId(dispatcher));
                 }
             }
 
-            public static void Append(AsyncTaskDispatcher dispatcher, IAsyncStateMachineBox enteringBox, AsyncThreadContext context, long currentTimestamp)
+            public static void Append(AsyncStateMachineDispatcher dispatcher, IAsyncStateMachineBox enteringBox, AsyncThreadContext context, long currentTimestamp)
             {
-                if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ReachedLastContinuation)
+                if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ReachedLastContinuation)
                 {
                     if (!ReferenceEquals(enteringBox, dispatcher.LastContinuation))
                     {
-                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, DispatcherIds.GetDispatcherId(dispatcher));
+                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.AppendStateMachineAsyncCallstack, DispatcherIds.GetDispatcherId(dispatcher));
                     }
                 }
             }
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong dispatcherId, AsyncEventID eventID)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncContext || eventID == AsyncEventID.TaskAsync_ResumeAsyncContext);
+                Debug.Assert(eventID == AsyncEventID.ResumeRuntimeAsyncContext || eventID == AsyncEventID.ResumeStateMachineAsyncContext);
 
                 const int MaxPayloadLength = Serializer.MaxCompressedUInt64Size;
 
@@ -1040,7 +1045,7 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class CompleteAsyncContext
         {
-            public static void Complete(AsyncTaskDispatcher dispatcher, ref Info info)
+            public static void Complete(AsyncStateMachineDispatcher dispatcher, ref Info info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
@@ -1050,14 +1055,14 @@ namespace System.Runtime.CompilerServices
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
+                    if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                     {
                         ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
                     }
 
-                    if (IsEnabled.CompleteAsyncContextEvent(activeEventKeywords))
+                    if (IsEnabled.CompleteStateMachineAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, AsyncEventID.TaskAsync_CompleteAsyncContext);
+                        EmitEvent(context, currentTimestamp, AsyncEventID.CompleteStateMachineAsyncContext);
                     }
                 }
 
@@ -1066,20 +1071,20 @@ namespace System.Runtime.CompilerServices
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CompleteAsyncContext || eventID == AsyncEventID.TaskAsync_CompleteAsyncContext);
+                Debug.Assert(eventID == AsyncEventID.CompleteRuntimeAsyncContext || eventID == AsyncEventID.CompleteStateMachineAsyncContext);
                 Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID);
             }
         }
 
         internal static partial class AsyncMethodException
         {
-            public static void UnwindFrames(ref AsyncTaskDispatcherInfo info, uint unwindedFrames)
+            public static void UnwindFrames(ref AsyncStateMachineDispatcherInfo info, uint unwindedFrames)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                if (IsEnabled.UnwindAsyncExceptionEvent(context.ActiveEventKeywords))
+                if (IsEnabled.UnwindStateMachineAsyncExceptionEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp(), unwindedFrames, AsyncEventID.TaskAsync_UnwindAsyncException);
+                    EmitEvent(context, Stopwatch.GetTimestamp(), unwindedFrames, AsyncEventID.UnwindStateMachineAsyncException);
                 }
 
                 AsyncThreadContext.Release(context);
@@ -1087,7 +1092,7 @@ namespace System.Runtime.CompilerServices
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, uint unwindedFrames, AsyncEventID eventID)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_UnwindAsyncException ||  eventID == AsyncEventID.TaskAsync_UnwindAsyncException);
+                Debug.Assert(eventID == AsyncEventID.UnwindRuntimeAsyncException ||  eventID == AsyncEventID.UnwindStateMachineAsyncException);
 
                 // unwinded frames
                 const int MaxPayloadLength = Serializer.MaxCompressedUInt32Size;
@@ -1103,7 +1108,7 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class ResumeAsyncMethod
         {
-            public static void Resume(AsyncTaskDispatcher dispatcher, IAsyncStateMachineBox box, ref Info info)
+            public static void Resume(AsyncStateMachineDispatcher dispatcher, IAsyncStateMachineBox box, ref Info info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
@@ -1111,14 +1116,14 @@ namespace System.Runtime.CompilerServices
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
+                    if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                     {
                         ResumeAsyncContext.Append(dispatcher, box, context, currentTimestamp);
                     }
 
-                    if (IsEnabled.ResumeAsyncMethodEvent(activeEventKeywords))
+                    if (IsEnabled.ResumeStateMachineAsyncMethodEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, AsyncEventID.TaskAsync_ResumeAsyncMethod);
+                        EmitEvent(context, currentTimestamp, AsyncEventID.ResumeStateMachineAsyncMethod);
                     }
                 }
 
@@ -1127,26 +1132,26 @@ namespace System.Runtime.CompilerServices
 
             public static void EmitEvent(AsyncThreadContext context, AsyncEventID eventID)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncMethod || eventID == AsyncEventID.TaskAsync_ResumeAsyncMethod);
+                Debug.Assert(eventID == AsyncEventID.ResumeRuntimeAsyncMethod || eventID == AsyncEventID.ResumeStateMachineAsyncMethod);
                 Serializer.AsyncEventHeader(context, ref context.EventBuffer, eventID);
             }
 
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncMethod || eventID == AsyncEventID.TaskAsync_ResumeAsyncMethod);
+                Debug.Assert(eventID == AsyncEventID.ResumeRuntimeAsyncMethod || eventID == AsyncEventID.ResumeStateMachineAsyncMethod);
                 Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID);
             }
         }
 
         internal static partial class CompleteAsyncMethod
         {
-            public static void Complete(ref AsyncTaskDispatcherInfo info)
+            public static void Complete(ref AsyncStateMachineDispatcherInfo info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                if (IsEnabled.CompleteAsyncMethodEvent(context.ActiveEventKeywords))
+                if (IsEnabled.CompleteStateMachineAsyncMethodEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, AsyncEventID.TaskAsync_CompleteAsyncMethod);
+                    EmitEvent(context, AsyncEventID.CompleteStateMachineAsyncMethod);
                 }
 
                 AsyncThreadContext.Release(context);
@@ -1154,7 +1159,7 @@ namespace System.Runtime.CompilerServices
 
             public static void EmitEvent(AsyncThreadContext context, AsyncEventID eventID)
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CompleteAsyncMethod || eventID == AsyncEventID.TaskAsync_CompleteAsyncMethod);
+                Debug.Assert(eventID == AsyncEventID.CompleteRuntimeAsyncMethod || eventID == AsyncEventID.CompleteStateMachineAsyncMethod);
                 Serializer.AsyncEventHeader(context, ref context.EventBuffer, eventID);
             }
         }
@@ -1274,24 +1279,24 @@ namespace System.Runtime.CompilerServices
 #if !RUNTIME_ASYNC_SUPPORTED
             private static unsafe void ResumeAsyncCallstacks(AsyncThreadContext context)
             {
-                ResumeAsyncTaskCallstacks(context);
+                ResumeStateMachineAsyncCallstacks(context);
             }
 
-            private static unsafe void ResumeAsyncTaskCallstacks(AsyncThreadContext context)
+            private static unsafe void ResumeStateMachineAsyncCallstacks(AsyncThreadContext context)
             {
                 //Write recursively all the resume async callstack events.
-                AsyncTaskDispatcherInfo* info = AsyncTaskDispatcherInfo.t_current;
+                AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
                 if (info != null)
                 {
-                    ResumeAsyncTaskCallstacks(info, context);
+                    ResumeStateMachineAsyncCallstacks(info, context);
                 }
             }
 
-            private static unsafe void ResumeAsyncTaskCallstacks(AsyncTaskDispatcherInfo* info, AsyncThreadContext context)
+            private static unsafe void ResumeStateMachineAsyncCallstacks(AsyncStateMachineDispatcherInfo* info, AsyncThreadContext context)
             {
                 if (info != null)
                 {
-                    ResumeAsyncTaskCallstacks(info->Next, context);
+                    ResumeStateMachineAsyncCallstacks(info->Next, context);
                     ResumeAsyncContext.Resume(ref *info, context, DispatcherIds.GetDispatcherId(ref *info), Config.ActiveEventKeywords);
                 }
             }
@@ -1305,16 +1310,23 @@ namespace System.Runtime.CompilerServices
 
         private static class IsEnabled
         {
-            public static bool CreateAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CreateAsyncContext) != 0;
-            public static bool ResumeAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeAsyncContext) != 0;
-            public static bool SuspendAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.SuspendAsyncContext) != 0;
-            public static bool CompleteAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteAsyncContext) != 0;
-            public static bool UnwindAsyncExceptionEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.UnwindAsyncException) != 0;
-            public static bool CreateAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CreateAsyncCallstack) != 0;
-            public static bool ResumeAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeAsyncCallstack) != 0;
-            public static bool SuspendAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.SuspendAsyncCallstack) != 0;
-            public static bool ResumeAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeAsyncMethod) != 0;
-            public static bool CompleteAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteAsyncMethod) != 0;
+            public static bool CreateRuntimeAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CreateRuntimeAsyncContext) != 0;
+            public static bool ResumeRuntimeAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeRuntimeAsyncContext) != 0;
+            public static bool SuspendRuntimeAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.SuspendRuntimeAsyncContext) != 0;
+            public static bool CompleteRuntimeAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteRuntimeAsyncContext) != 0;
+            public static bool UnwindRuntimeAsyncExceptionEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.UnwindRuntimeAsyncException) != 0;
+            public static bool CreateRuntimeAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CreateRuntimeAsyncCallstack) != 0;
+            public static bool ResumeRuntimeAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeRuntimeAsyncCallstack) != 0;
+            public static bool SuspendRuntimeAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.SuspendRuntimeAsyncCallstack) != 0;
+            public static bool ResumeRuntimeAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeRuntimeAsyncMethod) != 0;
+            public static bool CompleteRuntimeAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteRuntimeAsyncMethod) != 0;
+            public static bool CreateStateMachineAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CreateStateMachineAsyncContext) != 0;
+            public static bool ResumeStateMachineAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeStateMachineAsyncContext) != 0;
+            public static bool CompleteStateMachineAsyncContextEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteStateMachineAsyncContext) != 0;
+            public static bool UnwindStateMachineAsyncExceptionEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.UnwindStateMachineAsyncException) != 0;
+            public static bool ResumeStateMachineAsyncCallstackEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeStateMachineAsyncCallstack) != 0;
+            public static bool ResumeStateMachineAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeStateMachineAsyncMethod) != 0;
+            public static bool CompleteStateMachineAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteStateMachineAsyncMethod) != 0;
             public static bool AnyAsyncEvents(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.AsyncEventKeywords) != 0;
         }
 
@@ -1511,7 +1523,7 @@ namespace System.Runtime.CompilerServices
 
         private static partial class AsyncCallstack
         {
-            private const int MaxTaskAsyncMethodFrameSize = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt32Size;
+            private const int MaxStateMachineAsyncMethodFrameSize = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt32Size;
 
             private const int AsyncStateMachineCompletedState = -2;
 
@@ -1522,7 +1534,7 @@ namespace System.Runtime.CompilerServices
                 static abstract int MaxAsyncMethodFrameSize {  get; }
             }
 
-            private ref struct CaptureTaskAsyncCallstackState : ICaptureAsyncCallstack
+            private ref struct CaptureStateMachineAsyncCallstackState : ICaptureAsyncCallstack
             {
                 public object? Continuation;
                 public object? LastContinuation;
@@ -1531,22 +1543,22 @@ namespace System.Runtime.CompilerServices
 
                 public bool Capture(byte[] buffer, ref int index, out byte count)
                 {
-                    bool result = CaptureTaskAsyncCallstack(buffer, ref index, ref this);
+                    bool result = CaptureStateMachineAsyncCallstack(buffer, ref index, ref this);
                     count = Count;
                     return result;
                 }
 
-                public static int MaxAsyncMethodFrameSize => MaxTaskAsyncMethodFrameSize;
+                public static int MaxAsyncMethodFrameSize => MaxStateMachineAsyncMethodFrameSize;
             }
 
-            public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp, ulong dispatcherId)
+            public static void EmitEvent(AsyncStateMachineDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp, ulong dispatcherId)
             {
                 IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(dispatcher.CurrentContinuation);
 
-                CaptureTaskAsyncCallstackState state = default;
+                CaptureStateMachineAsyncCallstackState state = default;
                 state.Continuation = box;
 
-                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.TaskAsync_ResumeAsyncCallstack, 0, dispatcherId, ref state);
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.ResumeStateMachineAsyncCallstack, 0, dispatcherId, ref state);
 
                 IAsyncStateMachineBox? last = ResolveAsyncStateMachineBox(state.LastContinuation);
                 if (last != null)
@@ -1562,16 +1574,16 @@ namespace System.Runtime.CompilerServices
                 dispatcher.ReachedLastContinuation = false;
             }
 
-            public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong dispatcherId)
+            public static void EmitEvent(AsyncStateMachineDispatcher dispatcher, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong dispatcherId)
             {
-                Debug.Assert(eventID == AsyncEventID.TaskAsync_ResumeAsyncCallstack || eventID == AsyncEventID.TaskAsync_AppendAsyncCallstack);
+                Debug.Assert(eventID == AsyncEventID.ResumeStateMachineAsyncCallstack || eventID == AsyncEventID.AppendStateMachineAsyncCallstack);
 
                 if (continuation != null)
                 {
                     IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(continuation);
                     if (box != null)
                     {
-                        CaptureTaskAsyncCallstackState state = default;
+                        CaptureStateMachineAsyncCallstackState state = default;
                         state.Continuation = box;
 
                         EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, 0, dispatcherId, ref state);
@@ -1596,7 +1608,7 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            private static bool CaptureTaskAsyncCallstack(byte[] buffer, ref int index, ref CaptureTaskAsyncCallstackState state)
+            private static bool CaptureStateMachineAsyncCallstack(byte[] buffer, ref int index, ref CaptureStateMachineAsyncCallstackState state)
             {
                 if (index > buffer.Length)
                 {
@@ -1608,7 +1620,7 @@ namespace System.Runtime.CompilerServices
                     return true;
                 }
 
-                byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, (buffer.Length - index) / MaxTaskAsyncMethodFrameSize);
+                byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, (buffer.Length - index) / MaxStateMachineAsyncMethodFrameSize);
                 if (maxAsyncCallstackFrames == 0)
                 {
                     return false;
@@ -1621,7 +1633,7 @@ namespace System.Runtime.CompilerServices
 
                 while (state.Count < maxAsyncCallstackFrames && state.Continuation != null)
                 {
-                    if (state.Continuation is AsyncTaskDispatcher)
+                    if (state.Continuation is AsyncStateMachineDispatcher)
                     {
                         state.Continuation = null;
                         break;
@@ -1722,11 +1734,11 @@ namespace System.Runtime.CompilerServices
             private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong parentDispatcherId, ulong dispatcherId, byte continuationIndex, ref T captureCallstack)
                 where T : ICaptureAsyncCallstack, allows ref struct
             {
-                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncCallstack ||
-                    eventID == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack ||
-                    eventID == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack ||
-                    eventID == AsyncEventID.TaskAsync_ResumeAsyncCallstack ||
-                    eventID == AsyncEventID.TaskAsync_AppendAsyncCallstack);
+                Debug.Assert(eventID == AsyncEventID.CreateRuntimeAsyncCallstack ||
+                    eventID == AsyncEventID.ResumeRuntimeAsyncCallstack ||
+                    eventID == AsyncEventID.SuspendRuntimeAsyncCallstack ||
+                    eventID == AsyncEventID.ResumeStateMachineAsyncCallstack ||
+                    eventID == AsyncEventID.AppendStateMachineAsyncCallstack);
 
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
 
@@ -1801,7 +1813,7 @@ namespace System.Runtime.CompilerServices
                 int frameCountOffset = index + spanIndex;
                 callstackHeaderSpan[spanIndex++] = callstackFrameCount;
 
-                if (eventID == AsyncEventID.RuntimeAsync_CreateAsyncCallstack)
+                if (eventID == AsyncEventID.CreateRuntimeAsyncCallstack)
                 {
                     spanIndex += Serializer.WriteCompressedUInt64(callstackHeaderSpan.Slice(spanIndex), parentDispatcherId);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Runtime.InteropServices;
 using System.Threading;
+using static System.Runtime.CompilerServices.AsyncProfiler;
 using static System.Runtime.CompilerServices.AsyncProfilerEventSource;
 using Serializer = System.Runtime.CompilerServices.AsyncProfiler.EventBuffer.Serializer;
 
@@ -696,6 +697,21 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class CreateAsyncContext
         {
+            public static void Create(ulong id)
+            {
+                Info info = default;
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+
+                SyncPoint.Check(context);
+
+                if (IsEnabled.CreateAsyncContextEvent(context.ActiveEventKeywords))
+                {
+                    EmitEvent(context, Stopwatch.GetTimestamp(), id);
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id)
             {
                 const int MaxEventPayloadSize = Serializer.MaxCompressedUInt64Size;
@@ -710,6 +726,32 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class ResumeAsyncContext
         {
+            public static ulong GetId(ref AsyncTaskDispatcherInfo info)
+            {
+                if (info.Dispatcher != null)
+                {
+                    return info.Dispatcher.ContextId;
+                }
+
+                return 0;
+            }
+
+            public static void Resume(ref AsyncTaskDispatcherInfo info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
+
+                // TODO: SyncPoint.Check needs to re-emit V1 contexts (like V2 does).
+                // Temporarily bypass so Resume always fires.
+                SyncPoint.Check(context);
+
+                if (IsEnabled.ResumeAsyncContextEvent(context.ActiveEventKeywords))
+                {
+                    EmitEvent(context, Stopwatch.GetTimestamp(), GetId(ref info));
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id)
             {
                 const int MaxEventPayloadSize = Serializer.MaxCompressedUInt64Size;
@@ -724,6 +766,20 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class SuspendAsyncContext
         {
+            public static void Suspend(ref Info info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+
+                SyncPoint.Check(context);
+
+                if (IsEnabled.SuspendAsyncContextEvent(context.ActiveEventKeywords))
+                {
+                    EmitEvent(context, Stopwatch.GetTimestamp());
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp)
             {
                 Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, AsyncEventID.SuspendAsyncContext, 0);
@@ -779,6 +835,11 @@ namespace System.Runtime.CompilerServices
             }
 
             public static void Handled(ref Info info, uint unwindedFrames)
+            {
+                UnwindFrames(ref info, unwindedFrames);
+            }
+
+            public static void UnwindFrames(ref Info info, uint unwindedFrames)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -710,6 +710,34 @@ namespace System.Runtime.CompilerServices
             private static AsyncThreadContext? t_asyncThreadContext;
         }
 
+        internal static partial class DispatcherIds
+        {
+            public static ulong GetDispatcherId(Task dispatcher) => (ulong)dispatcher.Id;
+
+            public static ulong GetDispatcherId(ref AsyncTaskDispatcherInfo info)
+            {
+                if (info.Dispatcher != null)
+                {
+                    return GetDispatcherId(info.Dispatcher);
+                }
+                return 0;
+            }
+
+#if !RUNTIME_ASYNC_SUPPORTED
+            public static unsafe ulong CaptureParentDispatcherId()
+            {
+                AsyncTaskDispatcherInfo* v1 = AsyncTaskDispatcherInfo.t_current;
+                if (v1 == null)
+                {
+                    return 0;
+                }
+
+                AsyncTaskDispatcher? parent = v1->Dispatcher;
+                return parent is not null ? (ulong)parent.Id : 0;
+            }
+#endif
+        }
+
         internal static partial class CreateAsyncContext
         {
             public static void Create(AsyncTaskDispatcher dispatcher, ref Info info, ulong parentDispatcherId, ulong dispatcherId)
@@ -769,27 +797,13 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        internal static class TaskAsyncIds
-        {
-            public static ulong GetDispatcherId(Task dispatcher) => (ulong)dispatcher.Id;
-
-            public static ulong GetDispatcherId(ref AsyncTaskDispatcherInfo info)
-            {
-                if (info.Dispatcher != null)
-                {
-                    return GetDispatcherId(info.Dispatcher);
-                }
-                return 0;
-            }
-        }
-
         internal static partial class ResumeAsyncContext
         {
             public static void Resume(ref AsyncTaskDispatcherInfo info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                Resume(ref info, context, TaskAsyncIds.GetDispatcherId(ref info), context.ActiveEventKeywords);
+                Resume(ref info, context, DispatcherIds.GetDispatcherId(ref info), context.ActiveEventKeywords);
 
                 AsyncThreadContext.Release(context);
             }
@@ -820,7 +834,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
                 {
-                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.ContinuationForDiagnostics, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, TaskAsyncIds.GetDispatcherId(dispatcher));
+                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.ContinuationForDiagnostics, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, DispatcherIds.GetDispatcherId(dispatcher));
                 }
             }
 
@@ -830,7 +844,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (!ReferenceEquals(enteringBox, dispatcher.LastContinuation))
                     {
-                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, TaskAsyncIds.GetDispatcherId(dispatcher));
+                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, DispatcherIds.GetDispatcherId(dispatcher));
                     }
                 }
             }
@@ -1645,19 +1659,5 @@ namespace System.Runtime.CompilerServices
                 return rentedArray;
             }
         }
-
-#if !RUNTIME_ASYNC_SUPPORTED
-        internal static unsafe ulong CaptureParentDispatcherId()
-        {
-            AsyncTaskDispatcherInfo* v1 = AsyncTaskDispatcherInfo.t_current;
-            if (v1 == null)
-            {
-                return 0;
-            }
-
-            AsyncTaskDispatcher? parent = v1->Dispatcher;
-            return parent is not null ? (ulong)parent.Id : 0;
-        }
-#endif
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -701,6 +701,30 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class CreateAsyncContext
         {
+            public static void Create(AsyncTaskDispatcher dispatcher, ref Info info, ulong id)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+
+                SyncPoint.Check(context);
+
+                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
+                {
+                    long currentTimestamp = Stopwatch.GetTimestamp();
+                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
+                    {
+                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
+                    }
+
+                    if (IsEnabled.CreateAsyncContextEvent(activeEventKeywords))
+                    {
+                        EmitEvent(context, currentTimestamp, id);
+                    }
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+
             public static void Create(ulong id)
             {
                 Info info = default;
@@ -802,30 +826,6 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class SuspendAsyncContext
         {
-            public static void Suspend(AsyncTaskDispatcher dispatcher, ref Info info)
-            {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
-
-                SyncPoint.Check(context);
-
-                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
-                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
-                {
-                    long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords))
-                    {
-                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
-                    }
-
-                    if (IsEnabled.SuspendAsyncContextEvent(activeEventKeywords))
-                    {
-                        EmitEvent(context, currentTimestamp);
-                    }
-                }
-
-                AsyncThreadContext.Release(context);
-            }
-
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp)
             {
                 Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, AsyncEventID.SuspendAsyncContext, 0);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -1420,8 +1420,7 @@ namespace System.Runtime.CompilerServices
                 IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(continuationObject);
                 if (box != null)
                 {
-                    box.GetDiagnosticData(out methodId, out state, out nextContinuation);
-                    return true;
+                    return box.GetDiagnosticData(out methodId, out state, out nextContinuation);
                 }
 
                 methodId = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -1664,11 +1664,13 @@ namespace System.Runtime.CompilerServices
                     return true;
                 }
 
-                byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, (buffer.Length - index) / MaxStateMachineAsyncMethodFrameSize);
-                if (maxAsyncCallstackFrames == 0)
+                int remainingFrames = (buffer.Length - index) / MaxStateMachineAsyncMethodFrameSize;
+                if (remainingFrames == 0)
                 {
                     return false;
                 }
+
+                byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, state.Count + remainingFrames);
 
                 Span<byte> callstackSpan = buffer.AsSpan(index);
                 int callstackSpanIndex = 0;
@@ -1786,9 +1788,6 @@ namespace System.Runtime.CompilerServices
 
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
 
-                // Max callstack data that can fit in the buffer after flush.
-                int maxCallstackBytes = Math.Min(byte.MaxValue * T.MaxAsyncMethodFrameSize, eventBuffer.Data.Length);
-
                 // Static callstack payload: callstackId (1) + continuationIndex (1) + frameCount (1) + parentDispatcherId + dispatcherId (max 10 bytes compressed each).
                 const int MaxPayloadLength = sizeof(byte) + sizeof(byte) + sizeof(byte) + 2 * Serializer.MaxCompressedUInt64Size;
 
@@ -1802,6 +1801,9 @@ namespace System.Runtime.CompilerServices
 
                     if (!captureCallstack.Capture(buffer, ref currentIndex, out byte count))
                     {
+                        int maxReEmitOverhead = Serializer.MaxEventHeaderSize + Serializer.MaxAsyncEventHeaderSize + (byte)EventManifest.CallstackPayloadLengthFieldSize + MaxPayloadLength;
+                        int maxCallstackBytes = Math.Min(byte.MaxValue * T.MaxAsyncMethodFrameSize, eventBuffer.Data.Length - maxReEmitOverhead);
+
                         byte[]? rentedArray = RentArray(maxCallstackBytes);
                         if (rentedArray != null)
                         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -21,31 +21,36 @@ namespace System.Runtime.CompilerServices
 {
     internal static partial class AsyncProfiler
     {
-        [Flags]
-        public enum AsyncCallstackType : byte
-        {
-            Compiler = 0x1,
-            Runtime = 0x2,
-            Cached = 0x80
-        }
-
         internal enum AsyncEventID : byte
         {
-            CreateAsyncContext = 1,
-            ResumeAsyncContext = 2,
-            SuspendAsyncContext = 3,
-            CompleteAsyncContext = 4,
-            UnwindAsyncException = 5,
-            CreateAsyncCallstack = 6,
-            ResumeAsyncCallstack = 7,
-            SuspendAsyncCallstack = 8,
-            ResumeAsyncMethod = 9,
-            CompleteAsyncMethod = 10,
-            ResetAsyncThreadContext = 11,
-            ResetAsyncContinuationWrapperIndex = 12,
-            AsyncProfilerMetadata = 13,
-            AsyncProfilerSyncClock = 14,
-            AppendAsyncCallstack = 15
+            // V2 (RuntimeAsync) events.
+            RuntimeAsync_CreateAsyncContext = 1,
+            RuntimeAsync_ResumeAsyncContext = 2,
+            RuntimeAsync_SuspendAsyncContext = 3,
+            RuntimeAsync_CompleteAsyncContext = 4,
+            RuntimeAsync_UnwindAsyncException = 5,
+            RuntimeAsync_CreateAsyncCallstack = 6,
+            RuntimeAsync_ResumeAsyncCallstack = 7,
+            RuntimeAsync_SuspendAsyncCallstack = 8,
+            RuntimeAsync_ResumeAsyncMethod = 9,
+            RuntimeAsync_CompleteAsyncMethod = 10,
+
+            // V1 (TaskAsync) events.
+            TaskAsync_CreateAsyncContext = 11,
+            TaskAsync_ResumeAsyncContext = 12,
+            TaskAsync_SuspendAsyncContext = 13,
+            TaskAsync_CompleteAsyncContext = 14,
+            TaskAsync_UnwindAsyncException = 15,
+            TaskAsync_ResumeAsyncCallstack = 16,
+            TaskAsync_ResumeAsyncMethod = 17,
+            TaskAsync_CompleteAsyncMethod = 18,
+            TaskAsync_AppendAsyncCallstack = 19,
+
+            // Neutral profiler events.
+            ResetAsyncThreadContext = 20,
+            ResetAsyncContinuationWrapperIndex = 21,
+            AsyncProfilerMetadata = 22,
+            AsyncProfilerSyncClock = 23,
         }
 
         internal ref struct Info
@@ -435,7 +440,7 @@ namespace System.Runtime.CompilerServices
                     Span<byte> headerSpan = buffer.AsSpan(index, MaxAsyncEventHeaderSize);
                     int headerSpanIndex = 0;
 
-                    headerSpan[headerSpanIndex++] = (byte)eventID; // eventID
+                    headerSpan[headerSpanIndex++] = (byte)eventID;
                     headerSpanIndex += WriteCompressedUInt64(headerSpan.Slice(headerSpanIndex), (ulong)delta); // Timestamp delta from last event
 
                     eventBuffer.Index += headerSpanIndex;
@@ -470,7 +475,7 @@ namespace System.Runtime.CompilerServices
                     Span<byte> headerSpan = buffer.AsSpan(index, MaxAsyncEventHeaderSize);
                     int headerSpanIndex = 0;
 
-                    headerSpan[headerSpanIndex++] = (byte)eventID; // eventID
+                    headerSpan[headerSpanIndex++] = (byte)eventID;
                     headerSpanIndex += WriteCompressedUInt64(headerSpan.Slice(headerSpanIndex), (ulong)delta); // Timestamp delta from last event
 
                     eventBuffer.Index += headerSpanIndex;
@@ -727,14 +732,14 @@ namespace System.Runtime.CompilerServices
 
                     if (IsEnabled.CreateAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, id);
+                        EmitEvent(context, currentTimestamp, id, AsyncEventID.TaskAsync_CreateAsyncContext);
                     }
                 }
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void Create(ulong id)
+            public static void Create(AsyncTaskDispatcher dispatcher)
             {
                 Info info = default;
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
@@ -743,18 +748,20 @@ namespace System.Runtime.CompilerServices
 
                 if (IsEnabled.CreateAsyncContextEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp(), id);
+                    EmitEvent(context, Stopwatch.GetTimestamp(), (ulong)dispatcher.ContextId, AsyncEventID.TaskAsync_CreateAsyncContext);
                 }
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id, AsyncEventID eventID)
             {
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncContext || eventID == AsyncEventID.TaskAsync_CreateAsyncContext);
+
                 const int MaxEventPayloadSize = Serializer.MaxCompressedUInt64Size;
 
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
-                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, AsyncEventID.CreateAsyncContext, MaxEventPayloadSize))
+                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, MaxEventPayloadSize))
                 {
                     eventBuffer.Index += Serializer.WriteCompressedUInt64(eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize), id);
                 }
@@ -796,7 +803,7 @@ namespace System.Runtime.CompilerServices
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     if (IsEnabled.ResumeAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, id);
+                        EmitEvent(context, currentTimestamp, id, AsyncEventID.TaskAsync_ResumeAsyncContext);
                     }
 
                     if (IsEnabled.ResumeAsyncCallstackEvent(activeEventKeywords) && info.Dispatcher != null)
@@ -810,7 +817,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
                 {
-                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.ContinuationForDiagnostics, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
+                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.ContinuationForDiagnostics, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, GetId(dispatcher));
                 }
             }
 
@@ -820,28 +827,22 @@ namespace System.Runtime.CompilerServices
                 {
                     if (!ReferenceEquals(enteringBox, dispatcher.LastContinuation))
                     {
-                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
+                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.TaskAsync_AppendAsyncCallstack, GetId(dispatcher));
                     }
                 }
             }
 
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong id, AsyncEventID eventID)
             {
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncContext || eventID == AsyncEventID.TaskAsync_ResumeAsyncContext);
+
                 const int MaxEventPayloadSize = Serializer.MaxCompressedUInt64Size;
 
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
-                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, AsyncEventID.ResumeAsyncContext, MaxEventPayloadSize))
+                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, MaxEventPayloadSize))
                 {
                     eventBuffer.Index += Serializer.WriteCompressedUInt64(eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize), id);
                 }
-            }
-        }
-
-        internal static partial class SuspendAsyncContext
-        {
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp)
-            {
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, AsyncEventID.SuspendAsyncContext, 0);
             }
         }
 
@@ -864,81 +865,43 @@ namespace System.Runtime.CompilerServices
 
                     if (IsEnabled.CompleteAsyncContextEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp);
+                        EmitEvent(context, currentTimestamp, AsyncEventID.TaskAsync_CompleteAsyncContext);
                     }
                 }
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void Complete(ref Info info)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
             {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
-
-                SyncPoint.Check(context);
-
-                if (IsEnabled.CompleteAsyncContextEvent(context.ActiveEventKeywords))
-                {
-                    EmitEvent(context, Stopwatch.GetTimestamp());
-                }
-
-                AsyncThreadContext.Release(context);
-            }
-
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp)
-            {
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, AsyncEventID.CompleteAsyncContext, 0);
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CompleteAsyncContext || eventID == AsyncEventID.TaskAsync_CompleteAsyncContext);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID, 0);
             }
         }
 
         internal static partial class AsyncMethodException
         {
-            public static void Unhandled(ref Info info, uint unwindedFrames)
+            public static void UnwindFrames(ref AsyncTaskDispatcherInfo info, uint unwindedFrames)
             {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
-
-                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
-                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
-                {
-                    long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.UnwindAsyncExceptionEvent(activeEventKeywords))
-                    {
-                        EmitEvent(context, currentTimestamp, unwindedFrames);
-                    }
-
-                    if (IsEnabled.CompleteAsyncContextEvent(activeEventKeywords))
-                    {
-                        CompleteAsyncContext.EmitEvent(context, currentTimestamp);
-                    }
-                }
-
-                AsyncThreadContext.Release(context);
-            }
-
-            public static void Handled(ref Info info, uint unwindedFrames)
-            {
-                UnwindFrames(ref info, unwindedFrames);
-            }
-
-            public static void UnwindFrames(ref Info info, uint unwindedFrames)
-            {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
                 if (IsEnabled.UnwindAsyncExceptionEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp(), unwindedFrames);
+                    EmitEvent(context, Stopwatch.GetTimestamp(), unwindedFrames, AsyncEventID.TaskAsync_UnwindAsyncException);
                 }
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, uint unwindedFrames)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, uint unwindedFrames, AsyncEventID eventID)
             {
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_UnwindAsyncException ||  eventID == AsyncEventID.TaskAsync_UnwindAsyncException);
+
                 // unwinded frames
                 const int MaxEventPayloadSize = Serializer.MaxCompressedUInt32Size;
 
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
-                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, AsyncEventID.UnwindAsyncException, MaxEventPayloadSize))
+                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, eventID, MaxEventPayloadSize))
                 {
                     eventBuffer.Index += Serializer.WriteCompressedUInt32(eventBuffer.Data.AsSpan(eventBuffer.Index, MaxEventPayloadSize), unwindedFrames);
                 }
@@ -962,53 +925,44 @@ namespace System.Runtime.CompilerServices
 
                     if (IsEnabled.ResumeAsyncMethodEvent(activeEventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp);
+                        EmitEvent(context, currentTimestamp, AsyncEventID.TaskAsync_ResumeAsyncMethod);
                     }
                 }
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void Resume(ref Info info)
+            public static void EmitEvent(AsyncThreadContext context, AsyncEventID eventID)
             {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
-
-                if (IsEnabled.ResumeAsyncMethodEvent(context.ActiveEventKeywords))
-                {
-                    EmitEvent(context);
-                }
-
-                AsyncThreadContext.Release(context);
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncMethod || eventID == AsyncEventID.TaskAsync_ResumeAsyncMethod);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, eventID, 0);
             }
 
-            public static void EmitEvent(AsyncThreadContext context)
+            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, AsyncEventID eventID)
             {
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, AsyncEventID.ResumeAsyncMethod, 0);
-            }
-
-            public static void EmitEvent(AsyncThreadContext context, long currentTimestamp)
-            {
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, AsyncEventID.ResumeAsyncMethod, 0);
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_ResumeAsyncMethod || eventID == AsyncEventID.TaskAsync_ResumeAsyncMethod);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, currentTimestamp, eventID, 0);
             }
         }
 
         internal static partial class CompleteAsyncMethod
         {
-            public static void Complete(ref Info info)
+            public static void Complete(ref AsyncTaskDispatcherInfo info)
             {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
                 if (IsEnabled.CompleteAsyncMethodEvent(context.ActiveEventKeywords))
                 {
-                    EmitEvent(context);
+                    EmitEvent(context, AsyncEventID.TaskAsync_CompleteAsyncMethod);
                 }
 
                 AsyncThreadContext.Release(context);
             }
 
-            public static void EmitEvent(AsyncThreadContext context)
+            public static void EmitEvent(AsyncThreadContext context, AsyncEventID eventID)
             {
-                Serializer.AsyncEventHeader(context, ref context.EventBuffer, AsyncEventID.CompleteAsyncMethod, 0);
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CompleteAsyncMethod || eventID == AsyncEventID.TaskAsync_CompleteAsyncMethod);
+                Serializer.AsyncEventHeader(context, ref context.EventBuffer, eventID, 0);
             }
         }
 
@@ -1372,7 +1326,6 @@ namespace System.Runtime.CompilerServices
             {
                 bool Capture(byte[] buffer, ref int index, out byte count);
 
-                static abstract AsyncCallstackType CallstackType { get; }
                 static abstract int MaxAsyncMethodFrameSize {  get; }
             }
 
@@ -1390,7 +1343,6 @@ namespace System.Runtime.CompilerServices
                     return result;
                 }
 
-                public static AsyncCallstackType CallstackType => AsyncCallstackType.Compiler;
                 public static int MaxAsyncMethodFrameSize => MaxTaskAsyncMethodFrameSize;
             }
 
@@ -1401,7 +1353,7 @@ namespace System.Runtime.CompilerServices
                 CaptureTaskAsyncCallstackState state = default;
                 state.Continuation = box;
 
-                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.ResumeAsyncCallstack, id, ref state);
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.TaskAsync_ResumeAsyncCallstack, id, ref state);
 
                 IAsyncStateMachineBox? last = ResolveAsyncStateMachineBox(state.LastContinuation);
                 if (last != null)
@@ -1419,6 +1371,8 @@ namespace System.Runtime.CompilerServices
 
             public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong id)
             {
+                Debug.Assert(eventID == AsyncEventID.TaskAsync_ResumeAsyncCallstack || eventID == AsyncEventID.TaskAsync_AppendAsyncCallstack);
+
                 if (continuation != null)
                 {
                     IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(continuation);
@@ -1575,17 +1529,23 @@ namespace System.Runtime.CompilerServices
             private static void EmitAsyncCallstack<T>(AsyncThreadContext context, long currentTimestamp, long delta, AsyncEventID eventID, ulong id, byte continuationIndex, ref T captureCallstack)
                 where T : ICaptureAsyncCallstack, allows ref struct
             {
+                Debug.Assert(eventID == AsyncEventID.RuntimeAsync_CreateAsyncCallstack ||
+                    eventID == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack ||
+                    eventID == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack ||
+                    eventID == AsyncEventID.TaskAsync_ResumeAsyncCallstack ||
+                    eventID == AsyncEventID.TaskAsync_AppendAsyncCallstack);
+
                 ref EventBuffer eventBuffer = ref context.EventBuffer;
 
                 // Max callstack data that can fit in the buffer after flush.
                 int maxCallstackBytes = Math.Min(byte.MaxValue * T.MaxAsyncMethodFrameSize, eventBuffer.Data.Length);
 
-                // Static callstack payload: type (1) + callstackId (1) + continuationIndex (1) + frameCount (1) + id (max 10 bytes compressed).
-                const int MaxStaticEventPayloadSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
+                // Static callstack payload: callstackId (1) + continuationIndex (1) + frameCount (1) + id (max 10 bytes compressed).
+                const int MaxStaticEventPayloadSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
 
                 if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, delta, eventID, MaxStaticEventPayloadSize, out Serializer.AsyncEventHeaderRollbackData rollbackData))
                 {
-                    int frameCountOffset = CallstackHeader(ref eventBuffer, id, T.CallstackType, continuationIndex, 0);
+                    int frameCountOffset = CallstackHeader(ref eventBuffer, id, continuationIndex, 0);
 
                     byte[] buffer = eventBuffer.Data;
                     int startIndex = eventBuffer.Index;
@@ -1609,7 +1569,7 @@ namespace System.Runtime.CompilerServices
                             // Write the callstack again.
                             if (Serializer.AsyncEventHeader(context, ref eventBuffer, context.LastEventTimestamp, 0, eventID, MaxStaticEventPayloadSize + index))
                             {
-                                CallstackHeader(ref eventBuffer, id, T.CallstackType, continuationIndex, count);
+                                CallstackHeader(ref eventBuffer, id, continuationIndex, count);
                                 CallstackData(ref eventBuffer, rentedArray, index);
                             }
 
@@ -1630,17 +1590,16 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            private static int CallstackHeader(ref EventBuffer eventBuffer, ulong id, AsyncCallstackType type, byte continuationIndex, byte callstackFrameCount)
+            private static int CallstackHeader(ref EventBuffer eventBuffer, ulong id, byte continuationIndex, byte callstackFrameCount)
             {
-                // Callstack header layout: type (1 byte) + callstackId (1 byte, reserved for future use) + continuationIndex (1 byte) + frameCount (1 byte) + id (max 10 bytes compressed).
-                const int MaxCallstackHeaderSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
+                // Callstack header layout: callstackId (1 byte, reserved for future use) + continuationIndex (1 byte) + frameCount (1 byte) + id (max 10 bytes compressed).
+                const int MaxCallstackHeaderSize = sizeof(byte) + sizeof(byte) + sizeof(byte) + Serializer.MaxCompressedUInt64Size;
 
                 ref int index = ref eventBuffer.Index;
 
                 Span<byte> callstackHeaderSpan = eventBuffer.Data.AsSpan(index, MaxCallstackHeaderSize);
                 int spanIndex = 0;
 
-                callstackHeaderSpan[spanIndex++] = (byte)type;
                 callstackHeaderSpan[spanIndex++] = 0; // Reserved callstack ID for future callstack interning.
                 callstackHeaderSpan[spanIndex++] = continuationIndex;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -152,6 +152,7 @@ namespace System.Runtime.CompilerServices
         internal ref struct Info
         {
             public object? Context;
+            public object? CurrentContinuation;
             public ref nint ContinuationTable;
             public uint ContinuationIndex;
         }
@@ -159,6 +160,7 @@ namespace System.Runtime.CompilerServices
         internal static void InitInfo(ref Info info)
         {
             info.Context = null;
+            info.CurrentContinuation = null;
             ContinuationWrapper.InitInfo(ref info);
         }
 
@@ -999,9 +1001,9 @@ namespace System.Runtime.CompilerServices
                         EmitEvent(context, currentTimestamp, dispatcherId, AsyncEventID.ResumeStateMachineAsyncContext);
                     }
 
-                    if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords) && info.Dispatcher != null)
+                    if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                     {
-                        AsyncCallstack.EmitEvent(info.Dispatcher, context, currentTimestamp, dispatcherId);
+                        AsyncCallstack.EmitEvent(ref info, context, currentTimestamp, dispatcherId);
                     }
                 }
             }
@@ -1551,9 +1553,14 @@ namespace System.Runtime.CompilerServices
                 public static int MaxAsyncMethodFrameSize => MaxStateMachineAsyncMethodFrameSize;
             }
 
-            public static void EmitEvent(AsyncStateMachineDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp, ulong dispatcherId)
+            public static void EmitEvent(ref AsyncStateMachineDispatcherInfo info, AsyncThreadContext context, long currentTimestamp, ulong dispatcherId)
             {
-                IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(dispatcher.CurrentContinuation);
+                if (info.Dispatcher == null)
+                {
+                    return;
+                }
+
+                IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(info.AsyncProfilerInfo.CurrentContinuation);
 
                 CaptureStateMachineAsyncCallstackState state = default;
                 state.Continuation = box;
@@ -1564,14 +1571,14 @@ namespace System.Runtime.CompilerServices
                 if (last != null)
                 {
                     Debug.Assert(last is Task);
-                    dispatcher.LastContinuation = Unsafe.As<Task>(last);
+                    info.Dispatcher.LastContinuation = Unsafe.As<Task>(last);
                 }
                 else
                 {
-                    dispatcher.LastContinuation = null;
+                    info.Dispatcher.LastContinuation = null;
                 }
 
-                dispatcher.ReachedLastContinuation = false;
+                info.Dispatcher.ReachedLastContinuation = false;
             }
 
             public static void EmitEvent(AsyncStateMachineDispatcher dispatcher, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong dispatcherId)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -781,7 +781,10 @@ namespace System.Runtime.CompilerServices
             {
                 if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ReachedLastContinuation)
                 {
-                    AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
+                    if (!ReferenceEquals(enteringBox, dispatcher.LastContinuation))
+                    {
+                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
+                    }
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -1590,6 +1590,9 @@ namespace System.Runtime.CompilerServices
                 public static int MaxAsyncMethodFrameSize => MaxStateMachineAsyncMethodFrameSize;
             }
 
+            private static bool IsTruncated(in CaptureStateMachineAsyncCallstackState state) =>
+                state.Count == byte.MaxValue && state.Continuation != null;
+
             public static void EmitEvent(ref AsyncStateMachineDispatcherInfo info, AsyncThreadContext context, long currentTimestamp, ulong dispatcherId)
             {
                 if (info.Dispatcher == null)
@@ -1604,7 +1607,7 @@ namespace System.Runtime.CompilerServices
 
                 EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.ResumeStateMachineAsyncCallstack, 0, dispatcherId, ref state);
 
-                IAsyncStateMachineBox? last = ResolveAsyncStateMachineBox(state.LastContinuation);
+                IAsyncStateMachineBox? last = IsTruncated(in state) ? null : ResolveAsyncStateMachineBox(state.LastContinuation);
                 if (last != null)
                 {
                     Debug.Assert(last is Task);
@@ -1632,7 +1635,7 @@ namespace System.Runtime.CompilerServices
 
                         EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, 0, dispatcherId, ref state);
 
-                        box = ResolveAsyncStateMachineBox(state.LastContinuation);
+                        box = IsTruncated(in state) ? null : ResolveAsyncStateMachineBox(state.LastContinuation);
                         if (box != null)
                         {
                             Debug.Assert(box is Task);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -1,5 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+#if CORECLR || NATIVEAOT
+#define RUNTIME_ASYNC_SUPPORTED
+#endif
 
 using System.Buffers;
 using System.Buffers.Binary;
@@ -544,6 +547,18 @@ namespace System.Runtime.CompilerServices
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void Acquire(AsyncThreadContext context)
+            {
+                Debug.Assert(!context.InUse);
+
+                context.InUse = true;
+                if (context.BlockContext)
+                {
+                    WaitOnBlockedAsyncThreadContext(context);
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static void Release(AsyncThreadContext context)
             {
                 Debug.Assert(context.InUse);
@@ -591,12 +606,7 @@ namespace System.Runtime.CompilerServices
                     context.ActiveEventKeywords = Config.ActiveEventKeywords;
                 }
 
-                context.InUse = true;
-                if (context.BlockContext)
-                {
-                    WaitOnBlockedAsyncThreadContext(context);
-                }
-
+                Acquire(context);
                 return context;
             }
 
@@ -769,15 +779,21 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
-                // TODO: SyncPoint.Check needs to re-emit V1 contexts (like V2 does).
-                // Temporarily bypass so Resume always fires.
-                SyncPoint.Check(context);
+                Resume(ref info, context, GetId(ref info), context.ActiveEventKeywords);
 
-                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                AsyncThreadContext.Release(context);
+            }
+
+            public static void Resume(ref AsyncTaskDispatcherInfo info, AsyncThreadContext context, ulong id, EventKeywords activeEventKeywords)
+            {
+                if (SyncPoint.Check(context))
+                {
+                    return;
+                }
+
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
-                    ulong id = GetId(ref info);
                     if (IsEnabled.ResumeAsyncContextEvent(activeEventKeywords))
                     {
                         EmitEvent(context, currentTimestamp, id);
@@ -788,8 +804,6 @@ namespace System.Runtime.CompilerServices
                         AsyncCallstack.EmitEvent(info.Dispatcher, context, currentTimestamp, id);
                     }
                 }
-
-                AsyncThreadContext.Release(context);
             }
 
             public static void Append(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp)
@@ -883,8 +897,6 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
-                SyncPoint.Check(context);
-
                 EventKeywords activeEventKeywords = context.ActiveEventKeywords;
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
@@ -912,7 +924,6 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
-                SyncPoint.Check(context);
                 if (IsEnabled.UnwindAsyncExceptionEvent(context.ActiveEventKeywords))
                 {
                     EmitEvent(context, Stopwatch.GetTimestamp(), unwindedFrames);
@@ -940,8 +951,6 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
-                SyncPoint.Check(context);
-
                 EventKeywords activeEventKeywords = context.ActiveEventKeywords;
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
                 {
@@ -964,7 +973,6 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
-                SyncPoint.Check(context);
                 if (IsEnabled.ResumeAsyncMethodEvent(context.ActiveEventKeywords))
                 {
                     EmitEvent(context);
@@ -990,7 +998,6 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
-                SyncPoint.Check(context);
                 if (IsEnabled.CompleteAsyncMethodEvent(context.ActiveEventKeywords))
                 {
                     EmitEvent(context);
@@ -1013,7 +1020,7 @@ namespace System.Runtime.CompilerServices
             public const byte COUNT = 32;
             public const byte COUNT_MASK = COUNT - 1;
 
-#if MONO
+#if !RUNTIME_ASYNC_SUPPORTED
             public static void InitInfo(ref Info info)
             {
                 info.ContinuationTable = 0;
@@ -1046,7 +1053,6 @@ namespace System.Runtime.CompilerServices
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
-                SyncPoint.Check(context);
                 if (IsEnabled.AnyAsyncEvents(context.ActiveEventKeywords))
                 {
                     EmitEvent(context);
@@ -1061,8 +1067,28 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        private static partial class SyncPoint
+        internal static partial class SyncPoint
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void Check()
+            {
+                AsyncThreadContext context = AsyncThreadContext.Get();
+                if (Config.Changed(context))
+                {
+                    CheckSlow(context);
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void Check(ref Info info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Get(ref info);
+                if (Config.Changed(context))
+                {
+                    CheckSlow(context);
+                }
+            }
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool Check(AsyncThreadContext context)
             {
@@ -1072,6 +1098,14 @@ namespace System.Runtime.CompilerServices
                     return true;
                 }
                 return false;
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static void CheckSlow(AsyncThreadContext context)
+            {
+                AsyncThreadContext.Acquire(context);
+                ResetContext(context);
+                AsyncThreadContext.Release(context);
             }
 
             private static void ResetContext(AsyncThreadContext context)
@@ -1086,10 +1120,35 @@ namespace System.Runtime.CompilerServices
                     Config.EmitAsyncProfilerMetadataIfNeeded(context);
                     EmitEvent(context);
                 }
-#if !MONO
+
                 ResumeAsyncCallstacks(context);
-#endif
             }
+
+#if !RUNTIME_ASYNC_SUPPORTED
+            private static unsafe void ResumeAsyncCallstacks(AsyncThreadContext context)
+            {
+                ResumeAsyncTaskCallstacks(context);
+            }
+
+            private static unsafe void ResumeAsyncTaskCallstacks(AsyncThreadContext context)
+            {
+                //Write recursively all the resume async callstack events.
+                AsyncTaskDispatcherInfo* info = AsyncTaskDispatcherInfo.t_current;
+                if (info != null)
+                {
+                    ResumeAsyncTaskCallstacks(info, context);
+                }
+            }
+
+            private static unsafe void ResumeAsyncTaskCallstacks(AsyncTaskDispatcherInfo* info, AsyncThreadContext context)
+            {
+                if (info != null)
+                {
+                    ResumeAsyncTaskCallstacks(info->Next, context);
+                    ResumeAsyncContext.Resume(ref *info, context, ResumeAsyncContext.GetId(ref *info), Config.ActiveEventKeywords);
+                }
+            }
+#endif
 
             private static void EmitEvent(AsyncThreadContext context)
             {
@@ -1307,6 +1366,8 @@ namespace System.Runtime.CompilerServices
         {
             private const int MaxTaskAsyncMethodFrameSize = Serializer.MaxCompressedUInt64Size + Serializer.MaxCompressedUInt32Size;
 
+            private const int AsyncStateMachineCompletedState = -2;
+
             private interface ICaptureAsyncCallstack
             {
                 bool Capture(byte[] buffer, ref int index, out byte count);
@@ -1335,7 +1396,25 @@ namespace System.Runtime.CompilerServices
 
             public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp, ulong id)
             {
-                EmitEvent(dispatcher, context, dispatcher.InnerBox, currentTimestamp, AsyncEventID.ResumeAsyncCallstack, id);
+                IAsyncStateMachineBox? box = ResolveAsyncStateMachineBox(dispatcher.CurrentContinuation);
+
+                CaptureTaskAsyncCallstackState state = default;
+                state.Continuation = box;
+
+                EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.ResumeAsyncCallstack, id, ref state);
+
+                IAsyncStateMachineBox? last = ResolveAsyncStateMachineBox(state.LastContinuation);
+                if (last != null)
+                {
+                    Debug.Assert(last is Task);
+                    dispatcher.LastContinuation = Unsafe.As<Task>(last);
+                }
+                else
+                {
+                    dispatcher.LastContinuation = null;
+                }
+
+                dispatcher.ReachedLastContinuation = false;
             }
 
             public static void EmitEvent(AsyncTaskDispatcher dispatcher, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong id)
@@ -1372,9 +1451,14 @@ namespace System.Runtime.CompilerServices
 
             private static bool CaptureTaskAsyncCallstack(byte[] buffer, ref int index, ref CaptureTaskAsyncCallstackState state)
             {
-                if (index > buffer.Length || state.Continuation == null)
+                if (index > buffer.Length)
                 {
                     return false;
+                }
+
+                if (state.Continuation == null)
+                {
+                    return true;
                 }
 
                 byte maxAsyncCallstackFrames = (byte)Math.Min(byte.MaxValue, (buffer.Length - index) / MaxTaskAsyncMethodFrameSize);
@@ -1385,42 +1469,44 @@ namespace System.Runtime.CompilerServices
 
                 Span<byte> callstackSpan = buffer.AsSpan(index);
                 int callstackSpanIndex = 0;
-                ulong previousMethodId = state.LastMethodId;
-
-                state.LastContinuation = state.Continuation;
-
-                if (!GetFrameDiagnosticsData(state.Continuation, out ulong currentMethodId, out int methodState, out object? nextContinuation))
-                {
-                    return false;
-                }
-
-                state.Continuation = nextContinuation;
-
-                if (state.Count == 0)
-                {
-                    callstackSpanIndex += Serializer.WriteCompressedUInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedUInt64Size), currentMethodId);
-                }
-                else
-                {
-                    callstackSpanIndex += Serializer.WriteCompressedInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt64Size), (long)(currentMethodId - previousMethodId));
-                }
-
-                callstackSpanIndex += Serializer.WriteCompressedInt32(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt32Size), methodState);
-                state.Count++;
+                ulong previousMethodId;
+                ulong currentMethodId = state.LastMethodId;
 
                 while (state.Count < maxAsyncCallstackFrames && state.Continuation != null)
                 {
-                    previousMethodId = currentMethodId;
+                    if (state.Continuation is AsyncTaskDispatcher)
+                    {
+                        state.Continuation = null;
+                        break;
+                    }
+
                     state.LastContinuation = state.Continuation;
 
-                    if (!GetFrameDiagnosticsData(state.Continuation, out currentMethodId, out methodState, out nextContinuation))
+                    if (!GetFrameDiagnosticsData(state.Continuation, out ulong frameMethodId, out int frameState, out object? nextContinuation))
                     {
                         state.Continuation = nextContinuation;
                         continue;
                     }
 
-                    callstackSpanIndex += Serializer.WriteCompressedInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt64Size), (long)(currentMethodId - previousMethodId));
-                    callstackSpanIndex += Serializer.WriteCompressedInt32(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt32Size), methodState);
+                    if (frameState == AsyncStateMachineCompletedState)
+                    {
+                        state.Continuation = nextContinuation;
+                        continue;
+                    }
+
+                    previousMethodId = currentMethodId;
+                    currentMethodId = frameMethodId;
+
+                    if (state.Count == 0)
+                    {
+                        callstackSpanIndex += Serializer.WriteCompressedUInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedUInt64Size), currentMethodId);
+                    }
+                    else
+                    {
+                        callstackSpanIndex += Serializer.WriteCompressedInt64(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt64Size), (long)(currentMethodId - previousMethodId));
+                    }
+
+                    callstackSpanIndex += Serializer.WriteCompressedInt32(callstackSpan.Slice(callstackSpanIndex, Serializer.MaxCompressedInt32Size), frameState);
 
                     state.Count++;
                     state.Continuation = nextContinuation;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -797,7 +797,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
                 {
-                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.DiagnosticContinuationObject, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
+                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.GetContinuationForDiagnostics, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -797,7 +797,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (IsEnabled.ResumeAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
                 {
-                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.GetContinuationForDiagnostics, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
+                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.LastContinuation?.ContinuationForDiagnostics, currentTimestamp, AsyncEventID.AppendAsyncCallstack, GetId(dispatcher));
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
@@ -93,7 +93,13 @@ namespace System.Runtime.CompilerServices
                 return;
             }
 
-            AsyncProfiler.Config.Update(m_level, m_matchAnyKeyword);
+            EventKeywords keywords = m_matchAnyKeyword;
+            if (keywords == 0)
+            {
+                keywords = AsyncEventKeywords;
+            }
+
+            AsyncProfiler.Config.Update(m_level, keywords);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
@@ -28,11 +28,12 @@ namespace System.Runtime.CompilerServices
             public const EventKeywords CompleteRuntimeAsyncMethod = (EventKeywords)0x200;
             public const EventKeywords CreateStateMachineAsyncContext = (EventKeywords)0x400;
             public const EventKeywords ResumeStateMachineAsyncContext = (EventKeywords)0x800;
-            public const EventKeywords CompleteStateMachineAsyncContext = (EventKeywords)0x1000;
-            public const EventKeywords UnwindStateMachineAsyncException = (EventKeywords)0x2000;
-            public const EventKeywords ResumeStateMachineAsyncCallstack = (EventKeywords)0x4000;
-            public const EventKeywords ResumeStateMachineAsyncMethod = (EventKeywords)0x8000;
-            public const EventKeywords CompleteStateMachineAsyncMethod = (EventKeywords)0x10000;
+            public const EventKeywords SuspendStateMachineAsyncContext = (EventKeywords)0x1000;
+            public const EventKeywords CompleteStateMachineAsyncContext = (EventKeywords)0x2000;
+            public const EventKeywords UnwindStateMachineAsyncException = (EventKeywords)0x4000;
+            public const EventKeywords ResumeStateMachineAsyncCallstack = (EventKeywords)0x8000;
+            public const EventKeywords ResumeStateMachineAsyncMethod = (EventKeywords)0x10000;
+            public const EventKeywords CompleteStateMachineAsyncMethod = (EventKeywords)0x20000;
         }
 
         public const EventKeywords AsyncEventKeywords =
@@ -48,6 +49,7 @@ namespace System.Runtime.CompilerServices
             Keywords.CompleteRuntimeAsyncMethod |
             Keywords.CreateStateMachineAsyncContext |
             Keywords.ResumeStateMachineAsyncContext |
+            Keywords.SuspendStateMachineAsyncContext |
             Keywords.CompleteStateMachineAsyncContext |
             Keywords.UnwindStateMachineAsyncException |
             Keywords.ResumeStateMachineAsyncCallstack |

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
@@ -16,29 +16,44 @@ namespace System.Runtime.CompilerServices
 
         public static class Keywords // this name is important for EventSource
         {
-            public const EventKeywords CreateAsyncContext = (EventKeywords)0x1;
-            public const EventKeywords ResumeAsyncContext = (EventKeywords)0x2;
-            public const EventKeywords SuspendAsyncContext = (EventKeywords)0x4;
-            public const EventKeywords CompleteAsyncContext = (EventKeywords)0x8;
-            public const EventKeywords UnwindAsyncException = (EventKeywords)0x10;
-            public const EventKeywords CreateAsyncCallstack = (EventKeywords)0x20;
-            public const EventKeywords ResumeAsyncCallstack = (EventKeywords)0x40;
-            public const EventKeywords SuspendAsyncCallstack = (EventKeywords)0x80;
-            public const EventKeywords ResumeAsyncMethod = (EventKeywords)0x100;
-            public const EventKeywords CompleteAsyncMethod = (EventKeywords)0x200;
+            public const EventKeywords CreateRuntimeAsyncContext = (EventKeywords)0x1;
+            public const EventKeywords ResumeRuntimeAsyncContext = (EventKeywords)0x2;
+            public const EventKeywords SuspendRuntimeAsyncContext = (EventKeywords)0x4;
+            public const EventKeywords CompleteRuntimeAsyncContext = (EventKeywords)0x8;
+            public const EventKeywords UnwindRuntimeAsyncException = (EventKeywords)0x10;
+            public const EventKeywords CreateRuntimeAsyncCallstack = (EventKeywords)0x20;
+            public const EventKeywords ResumeRuntimeAsyncCallstack = (EventKeywords)0x40;
+            public const EventKeywords SuspendRuntimeAsyncCallstack = (EventKeywords)0x80;
+            public const EventKeywords ResumeRuntimeAsyncMethod = (EventKeywords)0x100;
+            public const EventKeywords CompleteRuntimeAsyncMethod = (EventKeywords)0x200;
+            public const EventKeywords CreateStateMachineAsyncContext = (EventKeywords)0x400;
+            public const EventKeywords ResumeStateMachineAsyncContext = (EventKeywords)0x800;
+            public const EventKeywords CompleteStateMachineAsyncContext = (EventKeywords)0x1000;
+            public const EventKeywords UnwindStateMachineAsyncException = (EventKeywords)0x2000;
+            public const EventKeywords ResumeStateMachineAsyncCallstack = (EventKeywords)0x4000;
+            public const EventKeywords ResumeStateMachineAsyncMethod = (EventKeywords)0x8000;
+            public const EventKeywords CompleteStateMachineAsyncMethod = (EventKeywords)0x10000;
         }
 
         public const EventKeywords AsyncEventKeywords =
-            Keywords.CreateAsyncContext |
-            Keywords.ResumeAsyncContext |
-            Keywords.SuspendAsyncContext |
-            Keywords.CompleteAsyncContext |
-            Keywords.CreateAsyncCallstack |
-            Keywords.ResumeAsyncCallstack |
-            Keywords.SuspendAsyncCallstack |
-            Keywords.UnwindAsyncException |
-            Keywords.ResumeAsyncMethod |
-            Keywords.CompleteAsyncMethod;
+            Keywords.CreateRuntimeAsyncContext |
+            Keywords.ResumeRuntimeAsyncContext |
+            Keywords.SuspendRuntimeAsyncContext |
+            Keywords.CompleteRuntimeAsyncContext |
+            Keywords.CreateRuntimeAsyncCallstack |
+            Keywords.ResumeRuntimeAsyncCallstack |
+            Keywords.SuspendRuntimeAsyncCallstack |
+            Keywords.UnwindRuntimeAsyncException |
+            Keywords.ResumeRuntimeAsyncMethod |
+            Keywords.CompleteRuntimeAsyncMethod |
+            Keywords.CreateStateMachineAsyncContext |
+            Keywords.ResumeStateMachineAsyncContext |
+            Keywords.CompleteStateMachineAsyncContext |
+            Keywords.UnwindStateMachineAsyncException |
+            Keywords.ResumeStateMachineAsyncCallstack |
+            Keywords.ResumeStateMachineAsyncMethod |
+            Keywords.CompleteStateMachineAsyncMethod;
+
 
         public const int FlushCommand = 1;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
@@ -111,7 +111,12 @@ namespace System.Runtime.CompilerServices
             }
 
             EventKeywords keywords = m_matchAnyKeyword;
-            if (keywords == 0)
+
+            // A keyword mask of 0 from an enable means "all keywords", so substitute the full async set.
+            // On disable EventSource also resets m_matchAnyKeyword to 0 (with m_level 0 == LogAlways) before
+            // this callback, so gate the substitution on IsEnabled() to avoid re-enabling instrumentation
+            // while the source is being disabled.
+            if (keywords == 0 && IsEnabled())
             {
                 keywords = AsyncEventKeywords;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDiagnostics.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDiagnostics.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class AsyncStateMachineDiagnostics<TStateMachine>
+        where TStateMachine : IAsyncStateMachine
+    {
+#if NATIVEAOT
+        // In NativeAOT we don't have reflection to resolve the method handle and state field offset.
+        // Due to the way the state machine is constructed, we can't get a direct pointer to its MoveNext method
+        // and using the interface dispatch to locate the method at slot 0 is unreliable due to Native AOT optimizations.
+        // The state field is also not guaranteed to be at a specific offset due to auto layout and Native AOT optimizations.
+        // To support this on Native AOT we would need to precompute this information in ILC and emit a
+        // hash table keyed by state machine MethodTable. At runtime we would still need to cache
+        // this data in static fields to avoid lookup cost when walking each continuation frame.
+        // On JIT these static fields are lazy evaluated and cached on initial access, but on Native AOT
+        // they will be pre-allocated, so code should be linked out when diagnostics is not supported.
+        // Given the added complexity on Native AOT, the fact that this is only used for diagnostics,
+        // and that Native AOT currently have limited asyncv1 diagnostics support in tooling, we can
+        // postpone the support until proven needed.
+        public static ulong MethodId
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetState(ref TStateMachine? _) => -1;
+#else
+        private static readonly ulong s_methodId = ResolveMethodId();
+        private static readonly int s_resolveStateFieldOffset = ResolveStateFieldOffset();
+
+        public static ulong MethodId
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => s_methodId;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetState(ref TStateMachine? stateMachine)
+        {
+            if (typeof(TStateMachine).IsValueType)
+            {
+                // Struct: state field is inline at offset within the struct
+                return Unsafe.As<byte, int>(ref Unsafe.AddByteOffset(ref Unsafe.As<TStateMachine?, byte>(ref stateMachine), (nint)s_resolveStateFieldOffset));
+            }
+            else
+            {
+                // Class (debug builds): StateMachine is a reference, dereference to get object data
+                if (stateMachine is not null)
+                {
+                    return Unsafe.As<byte, int>(ref Unsafe.AddByteOffset(ref RuntimeHelpers.GetRawData(stateMachine), (nint)s_resolveStateFieldOffset));
+                }
+            }
+
+            return -1;
+        }
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090", Justification = "State machine types are always preserved.")]
+        private static ulong ResolveMethodId()
+        {
+            MethodInfo? methodInfo = typeof(TStateMachine).GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (methodInfo is not null)
+            {
+                return (ulong)methodInfo.MethodHandle.Value;
+            }
+
+            return 0;
+        }
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090", Justification = "State machine types are always preserved.")]
+        private static int ResolveStateFieldOffset()
+        {
+            FieldInfo? stateField = typeof(TStateMachine).GetField("<>1__state", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (stateField is not null)
+            {
+#if MONO
+                return stateField.GetFieldOffset();
+#else
+                Debug.Assert(stateField is RtFieldInfo, $"Expected RtFieldInfo but got {stateField.GetType().Name}");
+                return RuntimeFieldHandle.GetInstanceFieldOffset((RtFieldInfo)stateField);
+#endif
+            }
+
+            return 0;
+        }
+#endif
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
@@ -112,7 +112,7 @@ namespace System.Runtime.CompilerServices
                 return;
             }
 
-            activeDispatcher.CurrentContinuation = box;
+            info->AsyncProfilerInfo.CurrentContinuation = box;
 
             AsyncProfiler.SyncPoint.Check(ref info->AsyncProfilerInfo);
 
@@ -157,8 +157,6 @@ namespace System.Runtime.CompilerServices
         private IAsyncStateMachineBox? _inner;
         private Action? _moveNextAction;
 
-        internal IAsyncStateMachineBox? CurrentContinuation;
-
         internal Task? LastContinuation;
 
         internal bool ReachedLastContinuation;
@@ -168,7 +166,6 @@ namespace System.Runtime.CompilerServices
         internal AsyncStateMachineDispatcher(IAsyncStateMachineBox inner) : base()
         {
             _inner = inner;
-            CurrentContinuation = inner;
         }
 
         internal sealed override void ExecuteDirectly(Thread? threadPoolThread) => MoveNext();
@@ -192,6 +189,8 @@ namespace System.Runtime.CompilerServices
             AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
             AsyncProfiler.InitInfo(ref info.AsyncProfilerInfo);
 
+            info.AsyncProfilerInfo.CurrentContinuation = inner;
+
             if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
                 AsyncProfiler.ResumeAsyncContext.Resume(ref info);
@@ -212,7 +211,6 @@ namespace System.Runtime.CompilerServices
 
                 if (IsCompleted)
                 {
-                    CurrentContinuation = null;
                     LastContinuation = null;
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
@@ -184,35 +184,18 @@ namespace System.Runtime.CompilerServices
             refInfo = &info;
             info.Next = refPreviousInfo;
 
-            info.Dispatcher = this;
-
-            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
             AsyncProfiler.InitInfo(ref info.AsyncProfilerInfo);
 
+            info.Dispatcher = this;
             info.AsyncProfilerInfo.CurrentContinuation = inner;
-
-            if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
-            {
-                AsyncProfiler.ResumeAsyncContext.Resume(ref info);
-            }
 
             try
             {
-                inner.MoveNext();
+                InstrumentedMoveNext(ref info, inner);
             }
             finally
             {
-                if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
-                {
-                    AsyncProfiler.CompleteAsyncContext.Complete(this, ref info.AsyncProfilerInfo);
-                }
-
                 refInfo = info.Next;
-
-                if (IsCompleted)
-                {
-                    LastContinuation = null;
-                }
             }
         }
 
@@ -228,6 +211,9 @@ namespace System.Runtime.CompilerServices
         {
             _inner?.ClearStateUponCompletion();
             _inner = null;
+
+            LastContinuation = null;
+            ReachedLastContinuation = false;
         }
 
         public bool GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
@@ -242,6 +228,40 @@ namespace System.Runtime.CompilerServices
             state = -1;
             nextContinuation = null;
             return false;
+        }
+
+        private void InstrumentedMoveNext(ref AsyncStateMachineDispatcherInfo info, IAsyncStateMachineBox inner)
+        {
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
+            try
+            {
+                flags = AsyncInstrumentation.SyncActiveFlags();
+                if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+                {
+                    AsyncProfiler.ResumeAsyncContext.Resume(ref info);
+                }
+
+                inner.MoveNext();
+            }
+            finally
+            {
+                if (info.AsyncProfilerInfo.CurrentContinuation is Task curContinuation)
+                {
+                    bool isCompleted = curContinuation.IsCompleted;
+                    if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags) && isCompleted)
+                    {
+                        AsyncProfiler.CompleteAsyncContext.Complete(this, ref info.AsyncProfilerInfo);
+                    }
+                    else if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags) && !isCompleted)
+                    {
+                        AsyncProfiler.SuspendAsyncContext.Suspend(this, ref info.AsyncProfilerInfo);
+                    }
+                }
+                else if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
+                {
+                    AsyncProfiler.CompleteAsyncContext.Complete(this, ref info.AsyncProfilerInfo);
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
@@ -9,17 +9,17 @@ using System.Threading.Tasks;
 namespace System.Runtime.CompilerServices
 {
     [StructLayout(LayoutKind.Explicit)]
-    internal unsafe ref struct AsyncTaskDispatcherInfo
+    internal unsafe ref struct AsyncStateMachineDispatcherInfo
     {
         [FieldOffset(0)]
-        public AsyncTaskDispatcherInfo* Next;
+        public AsyncStateMachineDispatcherInfo* Next;
 
 #if TARGET_64BIT
         [FieldOffset(8)]
 #else
         [FieldOffset(4)]
 #endif
-        public AsyncTaskDispatcher? Dispatcher;
+        public AsyncStateMachineDispatcher? Dispatcher;
 
 #if TARGET_64BIT
         [FieldOffset(16)]
@@ -29,7 +29,7 @@ namespace System.Runtime.CompilerServices
         public AsyncProfiler.Info AsyncProfilerInfo;
 
         [ThreadStatic]
-        internal static unsafe AsyncTaskDispatcherInfo* t_current;
+        internal static unsafe AsyncStateMachineDispatcherInfo* t_current;
 
         public static bool InstrumentCheckPoint
         {
@@ -56,26 +56,57 @@ namespace System.Runtime.CompilerServices
 #endif
         }
 
-        internal static unsafe AsyncTaskDispatcher? GetActiveDispatcher()
+        internal static unsafe AsyncStateMachineDispatcher? GetActiveDispatcher()
         {
-            AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
-            return current != null ? current->Dispatcher : null;
+            AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
+            return info != null ? info->Dispatcher : null;
+        }
+
+        internal static unsafe AsyncStateMachineDispatcher CreateDispatcher(IAsyncStateMachineBox box)
+        {
+            if (box is AsyncStateMachineDispatcher existing)
+            {
+                return existing;
+            }
+
+            AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
+            AsyncStateMachineDispatcher? activeDispatcher = info != null ? info->Dispatcher : null;
+
+            AsyncStateMachineDispatcher dispatcher = new AsyncStateMachineDispatcher(box);
+
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
+            if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+            {
+                ulong parentDispatcherId = AsyncProfiler.DispatcherIds.CaptureParentDispatcherId();
+                ulong dispatcherId = AsyncProfiler.DispatcherIds.GetDispatcherId(dispatcher);
+
+                if (activeDispatcher != null)
+                {
+                    AsyncProfiler.CreateAsyncContext.Create(activeDispatcher, ref info->AsyncProfilerInfo, parentDispatcherId, dispatcherId);
+                }
+                else
+                {
+                    AsyncProfiler.CreateAsyncContext.Create(parentDispatcherId, dispatcherId);
+                }
+            }
+
+            return dispatcher;
         }
 
         internal static unsafe void UnwindAsyncFrame()
         {
-            AsyncTaskDispatcherInfo* current = t_current;
-            if (current != null)
+            AsyncStateMachineDispatcherInfo* info = t_current;
+            if (info != null)
             {
-                AsyncProfiler.AsyncMethodException.UnwindFrames(ref *current, 1);
+                AsyncProfiler.AsyncMethodException.UnwindFrames(ref *info, 1);
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void ResumeAsyncMethod(IAsyncStateMachineBox box, AsyncInstrumentation.Flags flags)
         {
-            AsyncTaskDispatcherInfo* current = t_current;
-            AsyncTaskDispatcher? activeDispatcher = current != null ? current->Dispatcher : null;
+            AsyncStateMachineDispatcherInfo* info = t_current;
+            AsyncStateMachineDispatcher? activeDispatcher = info != null ? info->Dispatcher : null;
             if (activeDispatcher == null)
             {
                 return;
@@ -83,7 +114,7 @@ namespace System.Runtime.CompilerServices
 
             activeDispatcher.CurrentContinuation = box;
 
-            AsyncProfiler.SyncPoint.Check(ref current->AsyncProfilerInfo);
+            AsyncProfiler.SyncPoint.Check(ref info->AsyncProfilerInfo);
 
             bool methodEventEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags);
             bool callstackEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags);
@@ -92,10 +123,10 @@ namespace System.Runtime.CompilerServices
                 return;
             }
 
-            ResumeAsyncMethod(activeDispatcher, current, box, methodEventEnabled, callstackEnabled);
+            ResumeAsyncMethod(activeDispatcher, info, box, methodEventEnabled, callstackEnabled);
         }
 
-        private static unsafe void ResumeAsyncMethod(AsyncTaskDispatcher activeDispatcher, AsyncTaskDispatcherInfo* info, IAsyncStateMachineBox box, bool methodEventEnabled, bool callstackEnabled)
+        private static unsafe void ResumeAsyncMethod(AsyncStateMachineDispatcher activeDispatcher, AsyncStateMachineDispatcherInfo* info, IAsyncStateMachineBox box, bool methodEventEnabled, bool callstackEnabled)
         {
             bool callstackEventEnabled = callstackEnabled && activeDispatcher.ReachedLastContinuation;
 
@@ -113,15 +144,15 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void CompleteAsyncMethod()
         {
-            AsyncTaskDispatcherInfo* current = t_current;
-            if (current != null)
+            AsyncStateMachineDispatcherInfo* info = t_current;
+            if (info != null)
             {
-                AsyncProfiler.CompleteAsyncMethod.Complete(ref *current);
+                AsyncProfiler.CompleteAsyncMethod.Complete(ref *info);
             }
         }
     }
 
-    internal sealed class AsyncTaskDispatcher : Task<VoidTaskResult>, IAsyncStateMachineBox
+    internal sealed class AsyncStateMachineDispatcher : Task<VoidTaskResult>, IAsyncStateMachineBox
     {
         private IAsyncStateMachineBox? _inner;
         private Action? _moveNextAction;
@@ -134,41 +165,10 @@ namespace System.Runtime.CompilerServices
 
         internal bool ContinuationChainChanged => LastContinuation?.ContinuationForDiagnostics != null;
 
-        internal AsyncTaskDispatcher(IAsyncStateMachineBox inner) : base()
+        internal AsyncStateMachineDispatcher(IAsyncStateMachineBox inner) : base()
         {
             _inner = inner;
             CurrentContinuation = inner;
-        }
-
-        internal static unsafe AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
-        {
-            if (box is AsyncTaskDispatcher existing)
-            {
-                return existing;
-            }
-
-            AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
-            AsyncTaskDispatcher? activeDispatcher = current != null ? current->Dispatcher : null;
-
-            AsyncTaskDispatcher dispatcher = new AsyncTaskDispatcher(box);
-
-            AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
-            if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
-            {
-                ulong parentDispatcherId = AsyncProfiler.DispatcherIds.CaptureParentDispatcherId();
-                ulong dispatcherId = AsyncProfiler.DispatcherIds.GetDispatcherId(dispatcher);
-
-                if (activeDispatcher != null)
-                {
-                    AsyncProfiler.CreateAsyncContext.Create(activeDispatcher, ref current->AsyncProfilerInfo, parentDispatcherId, dispatcherId);
-                }
-                else
-                {
-                    AsyncProfiler.CreateAsyncContext.Create(parentDispatcherId, dispatcherId);
-                }
-            }
-
-            return dispatcher;
         }
 
         internal sealed override void ExecuteDirectly(Thread? threadPoolThread) => MoveNext();
@@ -181,20 +181,20 @@ namespace System.Runtime.CompilerServices
                 return;
             }
 
-            AsyncTaskDispatcherInfo dispatcherInfo;
-            ref AsyncTaskDispatcherInfo* refCurrent = ref AsyncTaskDispatcherInfo.t_current;
-            AsyncTaskDispatcherInfo* previous = refCurrent;
-            refCurrent = &dispatcherInfo;
-            dispatcherInfo.Next = previous;
+            AsyncStateMachineDispatcherInfo info;
+            ref AsyncStateMachineDispatcherInfo* refInfo = ref AsyncStateMachineDispatcherInfo.t_current;
+            AsyncStateMachineDispatcherInfo* refPreviousInfo = refInfo;
+            refInfo = &info;
+            info.Next = refPreviousInfo;
 
-            dispatcherInfo.Dispatcher = this;
+            info.Dispatcher = this;
 
             AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-            AsyncProfiler.InitInfo(ref dispatcherInfo.AsyncProfilerInfo);
+            AsyncProfiler.InitInfo(ref info.AsyncProfilerInfo);
 
             if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
-                AsyncProfiler.ResumeAsyncContext.Resume(ref dispatcherInfo);
+                AsyncProfiler.ResumeAsyncContext.Resume(ref info);
             }
 
             try
@@ -205,10 +205,10 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
                 {
-                    AsyncProfiler.CompleteAsyncContext.Complete(this, ref dispatcherInfo.AsyncProfilerInfo);
+                    AsyncProfiler.CompleteAsyncContext.Complete(this, ref info.AsyncProfilerInfo);
                 }
 
-                refCurrent = dispatcherInfo.Next;
+                refInfo = info.Next;
 
                 if (IsCompleted)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -69,15 +69,37 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        internal static unsafe void ResumeAsyncMethod(AsyncInstrumentation.Flags flags)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe void TryFireResumeAsyncMethod(IAsyncStateMachineBox box, AsyncInstrumentation.Flags flags)
         {
             AsyncTaskDispatcherInfo* current = t_current;
-            if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
+            if (current == null || current->Dispatcher is not AsyncTaskDispatcher activeDispatcher)
             {
-                if ((AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags) && activeDispatcher.ContinuationChainChanged) || AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
-                {
-                    AsyncProfiler.ResumeAsyncMethod.Resume(activeDispatcher, ref current->AsyncProfilerInfo);
-                }
+                return;
+            }
+
+            bool methodEventEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags);
+            bool callstackEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags);
+            if (!methodEventEnabled && !(callstackEnabled && activeDispatcher.LastContinuation != null))
+            {
+                return;
+            }
+
+            ResumeAsyncMethod(activeDispatcher, current, box, methodEventEnabled, callstackEnabled);
+        }
+
+        private static unsafe void ResumeAsyncMethod(AsyncTaskDispatcher activeDispatcher, AsyncTaskDispatcherInfo* info, IAsyncStateMachineBox box, bool methodEventEnabled, bool callstackEnabled)
+        {
+            bool callstackEventEnabled = callstackEnabled && activeDispatcher.ReachedLastContinuation;
+
+            if (!activeDispatcher.ReachedLastContinuation && ReferenceEquals(activeDispatcher.LastContinuation, box))
+            {
+                activeDispatcher.ReachedLastContinuation = true;
+            }
+
+            if (methodEventEnabled || callstackEventEnabled)
+            {
+                AsyncProfiler.ResumeAsyncMethod.Resume(activeDispatcher, box, ref info->AsyncProfilerInfo);
             }
         }
 
@@ -99,11 +121,11 @@ namespace System.Runtime.CompilerServices
 
         internal IAsyncStateMachineBox? InnerBox => _inner;
 
-        // Set by SuspendAsyncContext when this dispatcher's box yields during its single MoveNext.
-        // Dispatcher instances are one-shot (one MoveNext call per dispatcher), so default-false is sufficient.
         internal bool Suspended;
 
         internal Task? LastContinuation;
+
+        internal bool ReachedLastContinuation;
 
         internal AsyncTaskDispatcher(IAsyncStateMachineBox inner) : base()
         {
@@ -142,12 +164,10 @@ namespace System.Runtime.CompilerServices
             AsyncTaskDispatcher? activeDispatcher = AsyncTaskDispatcherInfo.SuspendAsyncContext(flags);
             if (activeDispatcher != null)
             {
-                Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Suspended Id={activeDispatcher.ContextId}, tid={Environment.CurrentManagedThreadId}");
                 return new AsyncTaskDispatcher(box, activeDispatcher);
             }
 
             AsyncTaskDispatcher newDispatcher = new AsyncTaskDispatcher(box);
-            Debug.WriteLine($"[AsyncTaskDispatcher.Create] New dispatcher Id={newDispatcher.ContextId}, tid={Environment.CurrentManagedThreadId}");
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(AsyncInstrumentation.SyncActiveFlags()))
             {
                 AsyncProfiler.CreateAsyncContext.Create((ulong)newDispatcher.ContextId);
@@ -166,8 +186,6 @@ namespace System.Runtime.CompilerServices
                 return;
             }
 
-            Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Thread={Environment.CurrentManagedThreadId}, Id={ContextId}, inner={inner.GetType().Name}, tid={Environment.CurrentManagedThreadId}");
-
             AsyncTaskDispatcherInfo dispatcherInfo;
             ref AsyncTaskDispatcherInfo* refCurrent = ref AsyncTaskDispatcherInfo.t_current;
             AsyncTaskDispatcherInfo* previous = refCurrent;
@@ -181,7 +199,6 @@ namespace System.Runtime.CompilerServices
 
             if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
-                Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Resuming Id={ContextId}, tid={Environment.CurrentManagedThreadId}");
                 AsyncProfiler.ResumeAsyncContext.Resume(ref dispatcherInfo);
             }
 
@@ -193,7 +210,6 @@ namespace System.Runtime.CompilerServices
             {
                 if (!Suspended && AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
                 {
-                    Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Completed Id={ContextId}, tid={Environment.CurrentManagedThreadId}");
                     AsyncProfiler.CompleteAsyncContext.Complete(this, ref dispatcherInfo.AsyncProfilerInfo);
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -20,44 +20,30 @@ namespace System.Runtime.CompilerServices
 #else
         [FieldOffset(4)]
 #endif
-        public IAsyncStateMachineBox? InnerBox;
+        public AsyncTaskDispatcher? Dispatcher;
 
 #if TARGET_64BIT
         [FieldOffset(16)]
 #else
         [FieldOffset(8)]
 #endif
-        public AsyncTaskDispatcher? Dispatcher;
-
-#if TARGET_64BIT
-        [FieldOffset(24)]
-#else
-        [FieldOffset(12)]
-#endif
-        public bool Suspended;
-
-#if TARGET_64BIT
-        [FieldOffset(32)]
-#else
-        [FieldOffset(16)]
-#endif
         public AsyncProfiler.Info AsyncProfilerInfo;
 
         [ThreadStatic]
         internal static unsafe AsyncTaskDispatcherInfo* t_current;
 
-        internal static bool IsSuspended => t_current != null && t_current->Suspended;
+        internal static bool IsSuspended => t_current != null && t_current->Dispatcher is { Suspended: true };
 
         internal static unsafe AsyncTaskDispatcher? SuspendAsyncContext()
         {
-            AsyncTaskDispatcherInfo* info = AsyncTaskDispatcherInfo.t_current;
-            if (info != null && info->Dispatcher is AsyncTaskDispatcher activeDispatcher)
+            AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
+            if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
             {
-                Debug.Assert(!info->Suspended);
-                info->Suspended = true;
+                Debug.Assert(!activeDispatcher.Suspended);
+                activeDispatcher.Suspended = true;
                 if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(AsyncInstrumentation.SyncActiveFlags()))
                 {
-                    AsyncProfiler.SuspendAsyncContext.Suspend(ref info->AsyncProfilerInfo);
+                    AsyncProfiler.SuspendAsyncContext.Suspend(activeDispatcher, ref current->AsyncProfilerInfo);
                 }
 
                 return activeDispatcher;
@@ -78,9 +64,9 @@ namespace System.Runtime.CompilerServices
         internal static unsafe void ResumeAsyncMethod()
         {
             AsyncTaskDispatcherInfo* current = t_current;
-            if (current != null)
+            if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
             {
-                AsyncProfiler.ResumeAsyncMethod.Resume(ref current->AsyncProfilerInfo);
+                AsyncProfiler.ResumeAsyncMethod.Resume(activeDispatcher, ref current->AsyncProfilerInfo);
             }
         }
 
@@ -99,6 +85,14 @@ namespace System.Runtime.CompilerServices
         private IAsyncStateMachineBox? _inner;
         private Action? _moveNextAction;
         private ulong _contextId;
+
+        internal IAsyncStateMachineBox? InnerBox => _inner;
+
+        // Set by SuspendAsyncContext when this dispatcher's box yields during its single MoveNext.
+        // Dispatcher instances are one-shot (one MoveNext call per dispatcher), so default-false is sufficient.
+        internal bool Suspended;
+
+        internal Task? LastContinuation;
 
         internal AsyncTaskDispatcher(IAsyncStateMachineBox inner) : base()
         {
@@ -127,7 +121,7 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>
         /// Creates a new dispatcher for the given box. If a dispatcher is already active on the
-        /// info thread (mid-chain yield), marks the info frame as suspended and emit a suspend event.
+        /// current thread (mid-chain yield), marks the current frame as suspended and emit a suspend event.
         /// </summary>
         internal static AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
         {
@@ -168,9 +162,7 @@ namespace System.Runtime.CompilerServices
             refCurrent = &dispatcherInfo;
             dispatcherInfo.Next = previous;
 
-            dispatcherInfo.InnerBox = inner;
             dispatcherInfo.Dispatcher = this;
-            dispatcherInfo.Suspended = false;
 
             AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
             AsyncProfiler.InitInfo(ref dispatcherInfo.AsyncProfilerInfo);
@@ -187,10 +179,10 @@ namespace System.Runtime.CompilerServices
             }
             finally
             {
-                if (!dispatcherInfo.Suspended && AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
+                if (!Suspended && AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
                 {
                     Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Completed Id={ContextId}, tid={Environment.CurrentManagedThreadId}");
-                    AsyncProfiler.CompleteAsyncContext.Complete(ref dispatcherInfo.AsyncProfilerInfo);
+                    AsyncProfiler.CompleteAsyncContext.Complete(this, ref dispatcherInfo.AsyncProfilerInfo);
                 }
 
                 // If Suspended, the Suspend event was already emitted inline by Create.
@@ -211,6 +203,20 @@ namespace System.Runtime.CompilerServices
         {
             _inner?.ClearStateUponCompletion();
             _inner = null;
+        }
+
+        public void GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
+        {
+            IAsyncStateMachineBox? inner = _inner;
+            if (inner != null)
+            {
+                inner.GetDiagnosticData(out methodId, out state, out nextContinuation);
+                return;
+            }
+
+            methodId = 0;
+            state = -1;
+            nextContinuation = null;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -56,7 +56,7 @@ namespace System.Runtime.CompilerServices
             AsyncTaskDispatcherInfo* current = t_current;
             if (current != null)
             {
-                AsyncProfiler.AsyncMethodException.UnwindFrames(ref current->AsyncProfilerInfo, 1);
+                AsyncProfiler.AsyncMethodException.UnwindFrames(ref *current, 1);
             }
         }
 
@@ -105,7 +105,7 @@ namespace System.Runtime.CompilerServices
             AsyncTaskDispatcherInfo* current = t_current;
             if (current != null)
             {
-                AsyncProfiler.CompleteAsyncMethod.Complete(ref current->AsyncProfilerInfo);
+                AsyncProfiler.CompleteAsyncMethod.Complete(ref *current);
             }
         }
     }
@@ -176,7 +176,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else
                 {
-                    AsyncProfiler.CreateAsyncContext.Create((ulong)dispatcher.ContextId);
+                    AsyncProfiler.CreateAsyncContext.Create(dispatcher);
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -1,0 +1,260 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Stack-allocated TLS frame for V1 (Task-based) async profiler dispatch.
+    /// Mirrors <c>AsyncDispatcherInfo</c> used by V2 (RuntimeAsync) dispatch.
+    /// Pushed/popped by <see cref="AsyncTaskDispatcher"/> during chain execution.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe ref struct AsyncTaskDispatcherInfo
+    {
+        /// <summary>Linked list pointer to the parent dispatcher info on the stack, or null if this is the outermost.</summary>
+        [FieldOffset(0)]
+        public AsyncTaskDispatcherInfo* Next;
+
+        /// <summary>The inner async state machine box being dispatched. Used by debugger/SOS to identify the async method.</summary>
+#if TARGET_64BIT
+        [FieldOffset(8)]
+#else
+        [FieldOffset(4)]
+#endif
+        public IAsyncStateMachineBox? InnerBox;
+
+        /// <summary>The dispatcher wrapping this chain. Used to identify the current dispatcher context.</summary>
+#if TARGET_64BIT
+        [FieldOffset(16)]
+#else
+        [FieldOffset(8)]
+#endif
+        public AsyncTaskDispatcher? Dispatcher;
+
+        /// <summary>Set to true when a method yields during dispatch (Create fires inside active frame).</summary>
+#if TARGET_64BIT
+        [FieldOffset(24)]
+#else
+        [FieldOffset(12)]
+#endif
+        public bool Suspended;
+
+        /// <summary>Set to true by SetException when an async method faults. Consumed by the next MoveNext to emit an unwind event.</summary>
+#if TARGET_64BIT
+        [FieldOffset(25)]
+#else
+        [FieldOffset(13)]
+#endif
+        public bool PendingUnwind;
+
+        /// <summary>Async profiler bulk buffer and continuation wrapper state.</summary>
+#if TARGET_64BIT
+        [FieldOffset(32)]
+#else
+        [FieldOffset(16)]
+#endif
+        public AsyncProfiler.Info AsyncProfilerInfo;
+
+        /// <summary>TLS linked list head for V1 async dispatch tracking.</summary>
+        [ThreadStatic]
+        internal static unsafe AsyncTaskDispatcherInfo* t_current;
+
+        /// <summary>
+        /// Marks a pending unwind on the current TLS frame. Called by SetException
+        /// so the next MoveNext in the chain emits the unwind event between methods.
+        /// </summary>
+        internal static unsafe void MarkPendingUnwind()
+        {
+            AsyncTaskDispatcherInfo* current = t_current;
+            if (current != null)
+            {
+                current->PendingUnwind = true;
+            }
+        }
+
+        /// <summary>
+        /// Checks and consumes a pending unwind on the current TLS frame.
+        /// Called at the top of MoveNext before the state machine runs.
+        /// </summary>
+        /// <returns>True if an unwind was pending and has been consumed.</returns>
+        internal static unsafe bool ConsumePendingUnwind()
+        {
+            AsyncTaskDispatcherInfo* current = t_current;
+            if (current != null && current->PendingUnwind)
+            {
+                current->PendingUnwind = false;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks and consumes the Suspended flag on the current TLS frame.
+        /// Called by CompleteAsyncMethod — if the frame was suspended but a method is completing,
+        /// the chain has resumed execution past the yield point.
+        /// </summary>
+        /// <returns>True if the frame was suspended and has been cleared.</returns>
+        internal static unsafe bool ConsumeSuspended()
+        {
+            AsyncTaskDispatcherInfo* current = t_current;
+            if (current != null && current->Suspended)
+            {
+                current->Suspended = false;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if a dispatcher context is active on the current thread.
+        /// Used to guard method-level events so they only emit inside a dispatch context.
+        /// </summary>
+        internal static unsafe bool IsActive => t_current != null;
+    }
+
+    /// <summary>
+    /// V1 (Task-based) async profiler dispatch node. Wraps an <see cref="IAsyncStateMachineBox"/>
+    /// to manage TLS context frame push/pop and emit context-level profiler events.
+    /// Each yield point creates a new dispatcher; the chain is linked via Suspend/Resume events.
+    /// </summary>
+    /// <remarks>
+    /// Injected at <c>UnsafeOnCompletedInternal</c> (when awaiting a non-async task)
+    /// and at <c>YieldAwaiter.AwaitUnsafeOnCompleted</c> (yield is always a root).
+    /// Only allocated when the async profiler is active. A new dispatcher is created
+    /// per yield; each runs independently with no shared mutable state.
+    /// </remarks>
+    internal sealed class AsyncTaskDispatcher : Task<VoidTaskResult>, IAsyncStateMachineBox
+    {
+        private IAsyncStateMachineBox? _inner;
+        private Action? _moveNextAction;
+        private readonly bool _resumesFromSuspension;
+
+        internal AsyncTaskDispatcher(IAsyncStateMachineBox inner, bool resumesFromSuspension = false) : base()
+        {
+            _inner = inner;
+            _resumesFromSuspension = resumesFromSuspension;
+        }
+
+        /// <summary>
+        /// Creates a new dispatcher for the given box. If a dispatcher is already active on the
+        /// current thread (mid-chain yield), marks the current frame as suspended and emits
+        /// a Suspend event. The new dispatcher is flagged to emit a Resume on its first PUSH.
+        /// </summary>
+        internal static unsafe AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
+        {
+            AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
+            if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
+            {
+                // Chain is yielding — mark current frame and emit Suspend inline
+                current->Suspended = true;
+                Debug.WriteLine($"[AsyncProfiler:V1] SuspendAsyncContext dispatcher={activeDispatcher.Id} thread={Environment.CurrentManagedThreadId}");
+
+                // New dispatcher continues the suspended chain
+                var dispatcher = new AsyncTaskDispatcher(box, resumesFromSuspension: true);
+                return dispatcher;
+            }
+
+            var newDispatcher = new AsyncTaskDispatcher(box);
+            Debug.WriteLine($"[AsyncProfiler:V1] CreateAsyncContext dispatcher={newDispatcher.Id} innerBox={((Task)box).Id} thread={Environment.CurrentManagedThreadId}");
+            return newDispatcher;
+        }
+
+        /// <summary>
+        /// Creates a new dispatcher for a continuation being queued (not inlined).
+        /// If a dispatcher is active, marks the frame as suspended and creates a new dispatcher
+        /// that will resume the chain. Otherwise returns the box unchanged (no dispatcher needed).
+        /// </summary>
+        internal static unsafe IAsyncStateMachineBox ReuseOrPassthrough(IAsyncStateMachineBox box)
+        {
+            AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
+            if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
+            {
+                // Chain is yielding — mark current frame and emit Suspend inline
+                current->Suspended = true;
+                Debug.WriteLine($"[AsyncProfiler:V1] SuspendAsyncContext dispatcher={activeDispatcher.Id} thread={Environment.CurrentManagedThreadId}");
+
+                // New dispatcher continues the suspended chain
+                var dispatcher = new AsyncTaskDispatcher(box, resumesFromSuspension: true);
+                return dispatcher;
+            }
+
+            return box;
+        }
+
+        internal sealed override void ExecuteFromThreadPool(Thread threadPoolThread)
+        {
+            MoveNext();
+        }
+
+        public void MoveNext()
+        {
+            IAsyncStateMachineBox? inner = _inner;
+            if (inner is null)
+                return;
+
+            unsafe
+            {
+                AsyncTaskDispatcherInfo dispatcherInfo;
+                ref AsyncTaskDispatcherInfo* refCurrent = ref AsyncTaskDispatcherInfo.t_current;
+                AsyncTaskDispatcherInfo* previous = refCurrent;
+                refCurrent = &dispatcherInfo;
+                dispatcherInfo.Next = previous;
+                dispatcherInfo.InnerBox = inner;
+                dispatcherInfo.Dispatcher = this;
+                dispatcherInfo.Suspended = false;
+                AsyncProfiler.InitInfo(ref dispatcherInfo.AsyncProfilerInfo);
+
+                if (_resumesFromSuspension)
+                {
+                    Debug.WriteLine($"[AsyncProfiler:V1] ResumeAsyncContext dispatcher={Id} innerBox={((Task)inner).Id} thread={Environment.CurrentManagedThreadId}");
+                }
+                else
+                {
+                    Debug.WriteLine($"[AsyncProfiler:V1] AsyncTaskDispatcher.MoveNext PUSH dispatcher={Id} innerBox={((Task)inner).Id} thread={Environment.CurrentManagedThreadId}");
+                }
+
+                try
+                {
+                    inner.MoveNext();
+                }
+                finally
+                {
+                    if (dispatcherInfo.PendingUnwind)
+                    {
+                        dispatcherInfo.PendingUnwind = false;
+                        Debug.WriteLine($"[AsyncProfiler:V1] UnwindAsyncException (escaped) dispatcher={Id} innerBox={((Task)inner).Id} thread={Environment.CurrentManagedThreadId}");
+                    }
+
+                    if (!dispatcherInfo.Suspended)
+                    {
+                        Debug.WriteLine($"[AsyncProfiler:V1] CompleteAsyncContext dispatcher={Id} innerBox={((Task)inner).Id} thread={Environment.CurrentManagedThreadId}");
+                    }
+                    // If Suspended, the Suspend event was already emitted inline by Create
+
+                    refCurrent = dispatcherInfo.Next;
+                }
+            }
+        }
+
+        public Action MoveNextAction => _moveNextAction ??= MoveNext;
+
+        public IAsyncStateMachine GetStateMachineObject()
+        {
+            IAsyncStateMachineBox? inner = _inner;
+            return inner is not null ? inner.GetStateMachineObject() : null!;
+        }
+
+        public void ClearStateUponCompletion()
+        {
+            _inner?.ClearStateUponCompletion();
+            _inner = null;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -48,18 +48,7 @@ namespace System.Runtime.CompilerServices
         internal static unsafe AsyncTaskDispatcher? GetActiveDispatcher()
         {
             AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
-            if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
-            {
-                // V1 dispatchers emit only Resume/Complete per MoveNext invocation — no Suspend
-                // events. Each dispatcher MoveNext is treated as a discrete unit. When a child
-                // wrapper is created here (parent box yielded), the parent's MoveNext will simply
-                // emit Complete on return; the child's lifecycle (Resume + Complete) fires later
-                // when its continuation runs. The logical context spans multiple dispatchers via
-                // shared contextId, with Resume count == Complete count as the balance invariant.
-                return activeDispatcher;
-            }
-
-            return null;
+            return current != null ? current->Dispatcher : null;
         }
 
         internal static unsafe void UnwindAsyncFrame()
@@ -72,13 +61,18 @@ namespace System.Runtime.CompilerServices
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe void TryFireResumeAsyncMethod(IAsyncStateMachineBox box, AsyncInstrumentation.Flags flags)
+        internal static unsafe void ResumeAsyncMethod(IAsyncStateMachineBox box, AsyncInstrumentation.Flags flags)
         {
             AsyncTaskDispatcherInfo* current = t_current;
-            if (current == null || current->Dispatcher is not AsyncTaskDispatcher activeDispatcher)
+            AsyncTaskDispatcher? activeDispatcher = current != null ? current->Dispatcher : null;
+            if (activeDispatcher == null)
             {
                 return;
             }
+
+            activeDispatcher.CurrentContinuation = box;
+
+            SyncPoint.Check(ref current->AsyncProfilerInfo);
 
             bool methodEventEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags);
             bool callstackEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags);
@@ -105,6 +99,7 @@ namespace System.Runtime.CompilerServices
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void CompleteAsyncMethod()
         {
             AsyncTaskDispatcherInfo* current = t_current;
@@ -118,10 +113,15 @@ namespace System.Runtime.CompilerServices
     internal sealed class AsyncTaskDispatcher : Task<VoidTaskResult>, IAsyncStateMachineBox
     {
         private IAsyncStateMachineBox? _inner;
+        private IAsyncStateMachineBox? _current;
         private Action? _moveNextAction;
         private ulong _contextId;
 
-        internal IAsyncStateMachineBox? InnerBox => _inner;
+        internal IAsyncStateMachineBox? CurrentContinuation
+        {
+            get { return _current; }
+            set { _current = value; }
+        }
 
         internal Task? LastContinuation;
 
@@ -130,12 +130,14 @@ namespace System.Runtime.CompilerServices
         internal AsyncTaskDispatcher(IAsyncStateMachineBox inner) : base()
         {
             _inner = inner;
+            _current = inner;
             _contextId = 0;
         }
 
         internal AsyncTaskDispatcher(IAsyncStateMachineBox inner, AsyncTaskDispatcher parent) : base()
         {
             _inner = inner;
+            _current = inner;
             _contextId = parent.ContextId;
         }
 
@@ -156,18 +158,21 @@ namespace System.Runtime.CompilerServices
 
         internal static unsafe AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
         {
-            AsyncTaskDispatcherInfo* activeInfo = AsyncTaskDispatcherInfo.t_current;
-            AsyncTaskDispatcher? activeDispatcher = (activeInfo != null && activeInfo->Dispatcher is AsyncTaskDispatcher d) ? d : null;
-            AsyncTaskDispatcher dispatcher = activeDispatcher != null
-                ? new AsyncTaskDispatcher(box, activeDispatcher)
-                : new AsyncTaskDispatcher(box);
+            if (box is AsyncTaskDispatcher existing)
+            {
+                return existing;
+            }
+
+            AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
+            AsyncTaskDispatcher? activeDispatcher = current != null ? current->Dispatcher : null;
+            AsyncTaskDispatcher dispatcher = activeDispatcher != null ? new AsyncTaskDispatcher(box, activeDispatcher) : new AsyncTaskDispatcher(box);
 
             AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
-                if (activeDispatcher is not null)
+                if (activeDispatcher != null)
                 {
-                    AsyncProfiler.CreateAsyncContext.Create(activeDispatcher, ref activeInfo->AsyncProfilerInfo, (ulong)dispatcher.ContextId);
+                    AsyncProfiler.CreateAsyncContext.Create(activeDispatcher, ref current->AsyncProfilerInfo, (ulong)dispatcher.ContextId);
                 }
                 else
                 {
@@ -224,7 +229,7 @@ namespace System.Runtime.CompilerServices
         public IAsyncStateMachine GetStateMachineObject()
         {
             IAsyncStateMachineBox? inner = _inner;
-            return inner is not null ? inner.GetStateMachineObject() : null!;
+            return inner != null ? inner.GetStateMachineObject() : null!;
         }
 
         public void ClearStateUponCompletion()

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -39,21 +39,17 @@ namespace System.Runtime.CompilerServices
             get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
         }
 
-        internal static bool IsSuspended => t_current != null && t_current->Dispatcher is { Suspended: true };
-
-        internal static unsafe AsyncTaskDispatcher? SuspendAsyncContext(AsyncInstrumentation.Flags flags)
+        internal static unsafe AsyncTaskDispatcher? GetActiveDispatcher()
         {
             AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
             if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
             {
-                Debug.Assert(!activeDispatcher.Suspended);
-                activeDispatcher.Suspended = true;
-
-                if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
-                {
-                    AsyncProfiler.SuspendAsyncContext.Suspend(activeDispatcher, ref current->AsyncProfilerInfo);
-                }
-
+                // V1 dispatchers emit only Resume/Complete per MoveNext invocation — no Suspend
+                // events. Each dispatcher MoveNext is treated as a discrete unit. When a child
+                // wrapper is created here (parent box yielded), the parent's MoveNext will simply
+                // emit Complete on return; the child's lifecycle (Resume + Complete) fires later
+                // when its continuation runs. The logical context spans multiple dispatchers via
+                // shared contextId, with Resume count == Complete count as the balance invariant.
                 return activeDispatcher;
             }
 
@@ -121,8 +117,6 @@ namespace System.Runtime.CompilerServices
 
         internal IAsyncStateMachineBox? InnerBox => _inner;
 
-        internal bool Suspended;
-
         internal Task? LastContinuation;
 
         internal bool ReachedLastContinuation;
@@ -133,10 +127,10 @@ namespace System.Runtime.CompilerServices
             _contextId = 0;
         }
 
-        internal AsyncTaskDispatcher(IAsyncStateMachineBox inner, AsyncTaskDispatcher suspended) : base()
+        internal AsyncTaskDispatcher(IAsyncStateMachineBox inner, AsyncTaskDispatcher parent) : base()
         {
             _inner = inner;
-            _contextId = suspended.ContextId;
+            _contextId = parent.ContextId;
         }
 
         internal ulong ContextId
@@ -156,24 +150,44 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>
         /// Creates a new dispatcher for the given box. If a dispatcher is already active on the
-        /// current thread (mid-chain yield), marks the current frame as suspended and emit a suspend event.
+        /// current thread (mid-chain yield), the new dispatcher becomes a child wrapping the box
+        /// and inherits the active dispatcher's contextId so subsequent events fold into the
+        /// same logical context. Every dispatcher (root or child) emits a CreateAsyncContext
+        /// event with its contextId — children share their parent's contextId, so multiple Create
+        /// events appear for the same logical context. Parsers can reconstruct Suspend semantics
+        /// via per-contextId refcounting: Complete events while refcount > 0 indicate a dispatcher
+        /// MoveNext ended but the chain continues; the final Complete (refcount → 0) marks the
+        /// logical context fully drained. Balance invariant: Create count == Complete count per
+        /// contextId.
+        ///
+        /// When created as a child (parent is mid-MoveNext, about to suspend), the parent
+        /// dispatcher emits an Append event here — this is the last synchronization point where
+        /// the chain state is known stable. Once we return and the new child dispatcher is
+        /// scheduled, other threads may race ahead and walk/mutate state before the parent's
+        /// Complete-time Append fires.
         /// </summary>
-        internal static AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
+        internal static unsafe AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
         {
+            AsyncTaskDispatcherInfo* activeInfo = AsyncTaskDispatcherInfo.t_current;
+            AsyncTaskDispatcher? activeDispatcher = (activeInfo != null && activeInfo->Dispatcher is AsyncTaskDispatcher d) ? d : null;
+            AsyncTaskDispatcher dispatcher = activeDispatcher != null
+                ? new AsyncTaskDispatcher(box, activeDispatcher)
+                : new AsyncTaskDispatcher(box);
+
             AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-            AsyncTaskDispatcher? activeDispatcher = AsyncTaskDispatcherInfo.SuspendAsyncContext(flags);
-            if (activeDispatcher != null)
+            if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
-                return new AsyncTaskDispatcher(box, activeDispatcher);
+                if (activeDispatcher is not null)
+                {
+                    AsyncProfiler.CreateAsyncContext.Create(activeDispatcher, ref activeInfo->AsyncProfilerInfo, (ulong)dispatcher.ContextId);
+                }
+                else
+                {
+                    AsyncProfiler.CreateAsyncContext.Create((ulong)dispatcher.ContextId);
+                }
             }
 
-            AsyncTaskDispatcher newDispatcher = new AsyncTaskDispatcher(box);
-            if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(AsyncInstrumentation.SyncActiveFlags()))
-            {
-                AsyncProfiler.CreateAsyncContext.Create((ulong)newDispatcher.ContextId);
-            }
-
-            return newDispatcher;
+            return dispatcher;
         }
 
         internal sealed override void ExecuteDirectly(Thread? threadPoolThread) => MoveNext();
@@ -208,15 +222,19 @@ namespace System.Runtime.CompilerServices
             }
             finally
             {
-                if (!Suspended && AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
+                // Always emit Complete in V1 — each dispatcher MoveNext is a discrete unit
+                // emitting one Resume + one Complete. The logical context (shared contextId)
+                // spans multiple dispatchers; Resume count == Complete count per context.
+                if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
                 {
                     AsyncProfiler.CompleteAsyncContext.Complete(this, ref dispatcherInfo.AsyncProfilerInfo);
                 }
 
-                // If Suspended, the Suspend event was already emitted inline by Create.
+                // Pop t_current inside finally so the TLS pointer is restored even if
+                // inner.MoveNext() throws. Otherwise t_current would dangle at a destroyed
+                // stack frame and pollute subsequent code on this thread.
+                refCurrent = dispatcherInfo.Next;
             }
-
-            refCurrent = dispatcherInfo.Next;
         }
 
         public Action MoveNextAction => _moveNextAction ??= MoveNext;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -149,7 +149,7 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        internal bool ContinuationChainChanged => LastContinuation?.GetContinuationForDiagnostics != null;
+        internal bool ContinuationChainChanged => LastContinuation?.ContinuationForDiagnostics != null;
 
         internal static unsafe AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -34,13 +34,26 @@ namespace System.Runtime.CompilerServices
         public static bool InstrumentCheckPoint
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if NATIVEAOT
+            // Asyncv1 instrumentation is disabled on Native AOT until support for
+            // async callstack IP and state has been implemented in ILC. Native AOT
+            // currently have limited asyncv1 diagnostic support in tooling, we can
+            // postpone the support until proven needed.
+            get => false;
+#else
             get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
+#endif
         }
 
         public static bool AsyncProfilerInstrumentCheckPoint
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if NATIVEAOT
+            // See InstrumentCheckPoint above for the rationale of disabling V1 on Native AOT.
+            get => false;
+#else
             get => InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags());
+#endif
         }
 
         internal static unsafe AsyncTaskDispatcher? GetActiveDispatcher()

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -33,13 +33,16 @@ namespace System.Runtime.CompilerServices
         [ThreadStatic]
         internal static unsafe AsyncTaskDispatcherInfo* t_current;
 
+        public static bool InstrumentCheckPoint
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
+        }
+
         public static bool AsyncProfilerInstrumentCheckPoint
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get =>
-                AsyncInstrumentation.IsSupported &&
-                AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled &&
-                AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags());
+            get => InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags());
         }
 
         internal static unsafe AsyncTaskDispatcher? GetActiveDispatcher()

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -221,6 +221,12 @@ namespace System.Runtime.CompilerServices
                 }
 
                 refCurrent = dispatcherInfo.Next;
+
+                if (IsCompleted)
+                {
+                    _current = null;
+                    LastContinuation = null;
+                }
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -33,10 +33,13 @@ namespace System.Runtime.CompilerServices
         [ThreadStatic]
         internal static unsafe AsyncTaskDispatcherInfo* t_current;
 
-        public static bool InstrumentCheckPoint
+        public static bool AsyncProfilerInstrumentCheckPoint
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
+            get =>
+                AsyncInstrumentation.IsSupported &&
+                AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled &&
+                AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags());
         }
 
         internal static unsafe AsyncTaskDispatcher? GetActiveDispatcher()
@@ -146,26 +149,8 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        internal bool ContinuationChainChanged => LastContinuation?.DiagnosticContinuationObject != null;
+        internal bool ContinuationChainChanged => LastContinuation?.GetContinuationForDiagnostics != null;
 
-        /// <summary>
-        /// Creates a new dispatcher for the given box. If a dispatcher is already active on the
-        /// current thread (mid-chain yield), the new dispatcher becomes a child wrapping the box
-        /// and inherits the active dispatcher's contextId so subsequent events fold into the
-        /// same logical context. Every dispatcher (root or child) emits a CreateAsyncContext
-        /// event with its contextId — children share their parent's contextId, so multiple Create
-        /// events appear for the same logical context. Parsers can reconstruct Suspend semantics
-        /// via per-contextId refcounting: Complete events while refcount > 0 indicate a dispatcher
-        /// MoveNext ended but the chain continues; the final Complete (refcount → 0) marks the
-        /// logical context fully drained. Balance invariant: Create count == Complete count per
-        /// contextId.
-        ///
-        /// When created as a child (parent is mid-MoveNext, about to suspend), the parent
-        /// dispatcher emits an Append event here — this is the last synchronization point where
-        /// the chain state is known stable. Once we return and the new child dispatcher is
-        /// scheduled, other threads may race ahead and walk/mutate state before the parent's
-        /// Complete-time Append fires.
-        /// </summary>
         internal static unsafe AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
         {
             AsyncTaskDispatcherInfo* activeInfo = AsyncTaskDispatcherInfo.t_current;
@@ -174,7 +159,7 @@ namespace System.Runtime.CompilerServices
                 ? new AsyncTaskDispatcher(box, activeDispatcher)
                 : new AsyncTaskDispatcher(box);
 
-            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
                 if (activeDispatcher is not null)
@@ -222,17 +207,11 @@ namespace System.Runtime.CompilerServices
             }
             finally
             {
-                // Always emit Complete in V1 — each dispatcher MoveNext is a discrete unit
-                // emitting one Resume + one Complete. The logical context (shared contextId)
-                // spans multiple dispatchers; Resume count == Complete count per context.
                 if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
                 {
                     AsyncProfiler.CompleteAsyncContext.Complete(this, ref dispatcherInfo.AsyncProfilerInfo);
                 }
 
-                // Pop t_current inside finally so the TLS pointer is restored even if
-                // inner.MoveNext() throws. Otherwise t_current would dangle at a destroyed
-                // stack frame and pollute subsequent code on this thread.
                 refCurrent = dispatcherInfo.Next;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using static System.Runtime.CompilerServices.AsyncInstrumentation;
 using static System.Runtime.CompilerServices.AsyncProfiler;
 
 namespace System.Runtime.CompilerServices
@@ -32,16 +33,23 @@ namespace System.Runtime.CompilerServices
         [ThreadStatic]
         internal static unsafe AsyncTaskDispatcherInfo* t_current;
 
+        public static bool InstrumentCheckPoint
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
+        }
+
         internal static bool IsSuspended => t_current != null && t_current->Dispatcher is { Suspended: true };
 
-        internal static unsafe AsyncTaskDispatcher? SuspendAsyncContext()
+        internal static unsafe AsyncTaskDispatcher? SuspendAsyncContext(AsyncInstrumentation.Flags flags)
         {
             AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
             if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
             {
                 Debug.Assert(!activeDispatcher.Suspended);
                 activeDispatcher.Suspended = true;
-                if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(AsyncInstrumentation.SyncActiveFlags()))
+
+                if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
                 {
                     AsyncProfiler.SuspendAsyncContext.Suspend(activeDispatcher, ref current->AsyncProfilerInfo);
                 }
@@ -61,12 +69,15 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        internal static unsafe void ResumeAsyncMethod()
+        internal static unsafe void ResumeAsyncMethod(AsyncInstrumentation.Flags flags)
         {
             AsyncTaskDispatcherInfo* current = t_current;
             if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
             {
-                AsyncProfiler.ResumeAsyncMethod.Resume(activeDispatcher, ref current->AsyncProfilerInfo);
+                if ((AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags) && activeDispatcher.ContinuationChainChanged) || AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
+                {
+                    AsyncProfiler.ResumeAsyncMethod.Resume(activeDispatcher, ref current->AsyncProfilerInfo);
+                }
             }
         }
 
@@ -119,15 +130,16 @@ namespace System.Runtime.CompilerServices
             }
         }
 
+        internal bool ContinuationChainChanged => LastContinuation?.DiagnosticContinuationObject != null;
+
         /// <summary>
         /// Creates a new dispatcher for the given box. If a dispatcher is already active on the
         /// current thread (mid-chain yield), marks the current frame as suspended and emit a suspend event.
         /// </summary>
         internal static AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
         {
-            Debug.WriteLine($"[AsyncTaskDispatcher.Create] Thread={Environment.CurrentManagedThreadId}, box={box.GetType().Name}, tid={Environment.CurrentManagedThreadId}");
-
-            AsyncTaskDispatcher? activeDispatcher = AsyncTaskDispatcherInfo.SuspendAsyncContext();
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+            AsyncTaskDispatcher? activeDispatcher = AsyncTaskDispatcherInfo.SuspendAsyncContext(flags);
             if (activeDispatcher != null)
             {
                 Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Suspended Id={activeDispatcher.ContextId}, tid={Environment.CurrentManagedThreadId}");

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -142,8 +142,8 @@ namespace System.Runtime.CompilerServices
             AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
-                ulong parentDispatcherId = AsyncProfiler.CaptureParentDispatcherId();
-                ulong dispatcherId = AsyncProfiler.TaskAsyncIds.GetDispatcherId(dispatcher);
+                ulong parentDispatcherId = AsyncProfiler.DispatcherIds.CaptureParentDispatcherId();
+                ulong dispatcherId = AsyncProfiler.DispatcherIds.GetDispatcherId(dispatcher);
 
                 if (activeDispatcher != null)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -5,22 +5,16 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using static System.Runtime.CompilerServices.AsyncProfiler;
 
 namespace System.Runtime.CompilerServices
 {
-    /// <summary>
-    /// Stack-allocated TLS frame for V1 (Task-based) async profiler dispatch.
-    /// Mirrors <c>AsyncDispatcherInfo</c> used by V2 (RuntimeAsync) dispatch.
-    /// Pushed/popped by <see cref="AsyncTaskDispatcher"/> during chain execution.
-    /// </summary>
     [StructLayout(LayoutKind.Explicit)]
     internal unsafe ref struct AsyncTaskDispatcherInfo
     {
-        /// <summary>Linked list pointer to the parent dispatcher info on the stack, or null if this is the outermost.</summary>
         [FieldOffset(0)]
         public AsyncTaskDispatcherInfo* Next;
 
-        /// <summary>The inner async state machine box being dispatched. Used by debugger/SOS to identify the async method.</summary>
 #if TARGET_64BIT
         [FieldOffset(8)]
 #else
@@ -28,7 +22,6 @@ namespace System.Runtime.CompilerServices
 #endif
         public IAsyncStateMachineBox? InnerBox;
 
-        /// <summary>The dispatcher wrapping this chain. Used to identify the current dispatcher context.</summary>
 #if TARGET_64BIT
         [FieldOffset(16)]
 #else
@@ -36,7 +29,6 @@ namespace System.Runtime.CompilerServices
 #endif
         public AsyncTaskDispatcher? Dispatcher;
 
-        /// <summary>Set to true when a method yields during dispatch (Create fires inside active frame).</summary>
 #if TARGET_64BIT
         [FieldOffset(24)]
 #else
@@ -44,15 +36,6 @@ namespace System.Runtime.CompilerServices
 #endif
         public bool Suspended;
 
-        /// <summary>Set to true by SetException when an async method faults. Consumed by the next MoveNext to emit an unwind event.</summary>
-#if TARGET_64BIT
-        [FieldOffset(25)]
-#else
-        [FieldOffset(13)]
-#endif
-        public bool PendingUnwind;
-
-        /// <summary>Async profiler bulk buffer and continuation wrapper state.</summary>
 #if TARGET_64BIT
         [FieldOffset(32)]
 #else
@@ -60,187 +43,160 @@ namespace System.Runtime.CompilerServices
 #endif
         public AsyncProfiler.Info AsyncProfilerInfo;
 
-        /// <summary>TLS linked list head for V1 async dispatch tracking.</summary>
         [ThreadStatic]
         internal static unsafe AsyncTaskDispatcherInfo* t_current;
 
-        /// <summary>
-        /// Marks a pending unwind on the current TLS frame. Called by SetException
-        /// so the next MoveNext in the chain emits the unwind event between methods.
-        /// </summary>
-        internal static unsafe void MarkPendingUnwind()
+        internal static bool IsSuspended => t_current != null && t_current->Suspended;
+
+        internal static unsafe AsyncTaskDispatcher? SuspendAsyncContext()
+        {
+            AsyncTaskDispatcherInfo* info = AsyncTaskDispatcherInfo.t_current;
+            if (info != null && info->Dispatcher is AsyncTaskDispatcher activeDispatcher)
+            {
+                Debug.Assert(!info->Suspended);
+                info->Suspended = true;
+                if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(AsyncInstrumentation.SyncActiveFlags()))
+                {
+                    AsyncProfiler.SuspendAsyncContext.Suspend(ref info->AsyncProfilerInfo);
+                }
+
+                return activeDispatcher;
+            }
+
+            return null;
+        }
+
+        internal static unsafe void UnwindAsyncFrame()
         {
             AsyncTaskDispatcherInfo* current = t_current;
             if (current != null)
             {
-                current->PendingUnwind = true;
+                AsyncProfiler.AsyncMethodException.UnwindFrames(ref current->AsyncProfilerInfo, 1);
             }
         }
 
-        /// <summary>
-        /// Checks and consumes a pending unwind on the current TLS frame.
-        /// Called at the top of MoveNext before the state machine runs.
-        /// </summary>
-        /// <returns>True if an unwind was pending and has been consumed.</returns>
-        internal static unsafe bool ConsumePendingUnwind()
+        internal static unsafe void ResumeAsyncMethod()
         {
             AsyncTaskDispatcherInfo* current = t_current;
-            if (current != null && current->PendingUnwind)
+            if (current != null)
             {
-                current->PendingUnwind = false;
-                return true;
+                AsyncProfiler.ResumeAsyncMethod.Resume(ref current->AsyncProfilerInfo);
             }
-
-            return false;
         }
 
-        /// <summary>
-        /// Checks and consumes the Suspended flag on the current TLS frame.
-        /// Called by CompleteAsyncMethod — if the frame was suspended but a method is completing,
-        /// the chain has resumed execution past the yield point.
-        /// </summary>
-        /// <returns>True if the frame was suspended and has been cleared.</returns>
-        internal static unsafe bool ConsumeSuspended()
+        internal static unsafe void CompleteAsyncMethod()
         {
             AsyncTaskDispatcherInfo* current = t_current;
-            if (current != null && current->Suspended)
+            if (current != null)
             {
-                current->Suspended = false;
-                return true;
+                AsyncProfiler.CompleteAsyncMethod.Complete(ref current->AsyncProfilerInfo);
             }
-
-            return false;
         }
-
-        /// <summary>
-        /// Returns true if a dispatcher context is active on the current thread.
-        /// Used to guard method-level events so they only emit inside a dispatch context.
-        /// </summary>
-        internal static unsafe bool IsActive => t_current != null;
     }
 
-    /// <summary>
-    /// V1 (Task-based) async profiler dispatch node. Wraps an <see cref="IAsyncStateMachineBox"/>
-    /// to manage TLS context frame push/pop and emit context-level profiler events.
-    /// Each yield point creates a new dispatcher; the chain is linked via Suspend/Resume events.
-    /// </summary>
-    /// <remarks>
-    /// Injected at <c>UnsafeOnCompletedInternal</c> (when awaiting a non-async task)
-    /// and at <c>YieldAwaiter.AwaitUnsafeOnCompleted</c> (yield is always a root).
-    /// Only allocated when the async profiler is active. A new dispatcher is created
-    /// per yield; each runs independently with no shared mutable state.
-    /// </remarks>
     internal sealed class AsyncTaskDispatcher : Task<VoidTaskResult>, IAsyncStateMachineBox
     {
         private IAsyncStateMachineBox? _inner;
         private Action? _moveNextAction;
-        private readonly bool _resumesFromSuspension;
+        private ulong _contextId;
 
-        internal AsyncTaskDispatcher(IAsyncStateMachineBox inner, bool resumesFromSuspension = false) : base()
+        internal AsyncTaskDispatcher(IAsyncStateMachineBox inner) : base()
         {
             _inner = inner;
-            _resumesFromSuspension = resumesFromSuspension;
+            _contextId = 0;
+        }
+
+        internal AsyncTaskDispatcher(IAsyncStateMachineBox inner, AsyncTaskDispatcher suspended) : base()
+        {
+            _inner = inner;
+            _contextId = suspended.ContextId;
+        }
+
+        internal ulong ContextId
+        {
+            get
+            {
+                if (_contextId == 0)
+                {
+                    return (ulong)this.Id;
+                }
+
+                return _contextId;
+            }
         }
 
         /// <summary>
         /// Creates a new dispatcher for the given box. If a dispatcher is already active on the
-        /// current thread (mid-chain yield), marks the current frame as suspended and emits
-        /// a Suspend event. The new dispatcher is flagged to emit a Resume on its first PUSH.
+        /// info thread (mid-chain yield), marks the info frame as suspended and emit a suspend event.
         /// </summary>
-        internal static unsafe AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
+        internal static AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
         {
-            AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
-            if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
-            {
-                // Chain is yielding — mark current frame and emit Suspend inline
-                current->Suspended = true;
-                Debug.WriteLine($"[AsyncProfiler:V1] SuspendAsyncContext dispatcher={activeDispatcher.Id} thread={Environment.CurrentManagedThreadId}");
+            Debug.WriteLine($"[AsyncTaskDispatcher.Create] Thread={Environment.CurrentManagedThreadId}, box={box.GetType().Name}, tid={Environment.CurrentManagedThreadId}");
 
-                // New dispatcher continues the suspended chain
-                var dispatcher = new AsyncTaskDispatcher(box, resumesFromSuspension: true);
-                return dispatcher;
+            AsyncTaskDispatcher? activeDispatcher = AsyncTaskDispatcherInfo.SuspendAsyncContext();
+            if (activeDispatcher != null)
+            {
+                Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Suspended Id={activeDispatcher.ContextId}, tid={Environment.CurrentManagedThreadId}");
+                return new AsyncTaskDispatcher(box, activeDispatcher);
             }
 
-            var newDispatcher = new AsyncTaskDispatcher(box);
-            Debug.WriteLine($"[AsyncProfiler:V1] CreateAsyncContext dispatcher={newDispatcher.Id} innerBox={((Task)box).Id} thread={Environment.CurrentManagedThreadId}");
+            AsyncTaskDispatcher newDispatcher = new AsyncTaskDispatcher(box);
+            Debug.WriteLine($"[AsyncTaskDispatcher.Create] New dispatcher Id={newDispatcher.ContextId}, tid={Environment.CurrentManagedThreadId}");
+            if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(AsyncInstrumentation.SyncActiveFlags()))
+            {
+                AsyncProfiler.CreateAsyncContext.Create((ulong)newDispatcher.ContextId);
+            }
+
             return newDispatcher;
         }
 
-        /// <summary>
-        /// Creates a new dispatcher for a continuation being queued (not inlined).
-        /// If a dispatcher is active, marks the frame as suspended and creates a new dispatcher
-        /// that will resume the chain. Otherwise returns the box unchanged (no dispatcher needed).
-        /// </summary>
-        internal static unsafe IAsyncStateMachineBox ReuseOrPassthrough(IAsyncStateMachineBox box)
-        {
-            AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
-            if (current != null && current->Dispatcher is AsyncTaskDispatcher activeDispatcher)
-            {
-                // Chain is yielding — mark current frame and emit Suspend inline
-                current->Suspended = true;
-                Debug.WriteLine($"[AsyncProfiler:V1] SuspendAsyncContext dispatcher={activeDispatcher.Id} thread={Environment.CurrentManagedThreadId}");
+        internal sealed override void ExecuteDirectly(Thread? threadPoolThread) => MoveNext();
 
-                // New dispatcher continues the suspended chain
-                var dispatcher = new AsyncTaskDispatcher(box, resumesFromSuspension: true);
-                return dispatcher;
-            }
-
-            return box;
-        }
-
-        internal sealed override void ExecuteFromThreadPool(Thread threadPoolThread)
-        {
-            MoveNext();
-        }
-
-        public void MoveNext()
+        public unsafe void MoveNext()
         {
             IAsyncStateMachineBox? inner = _inner;
             if (inner is null)
-                return;
-
-            unsafe
             {
-                AsyncTaskDispatcherInfo dispatcherInfo;
-                ref AsyncTaskDispatcherInfo* refCurrent = ref AsyncTaskDispatcherInfo.t_current;
-                AsyncTaskDispatcherInfo* previous = refCurrent;
-                refCurrent = &dispatcherInfo;
-                dispatcherInfo.Next = previous;
-                dispatcherInfo.InnerBox = inner;
-                dispatcherInfo.Dispatcher = this;
-                dispatcherInfo.Suspended = false;
-                AsyncProfiler.InitInfo(ref dispatcherInfo.AsyncProfilerInfo);
-
-                if (_resumesFromSuspension)
-                {
-                    Debug.WriteLine($"[AsyncProfiler:V1] ResumeAsyncContext dispatcher={Id} innerBox={((Task)inner).Id} thread={Environment.CurrentManagedThreadId}");
-                }
-                else
-                {
-                    Debug.WriteLine($"[AsyncProfiler:V1] AsyncTaskDispatcher.MoveNext PUSH dispatcher={Id} innerBox={((Task)inner).Id} thread={Environment.CurrentManagedThreadId}");
-                }
-
-                try
-                {
-                    inner.MoveNext();
-                }
-                finally
-                {
-                    if (dispatcherInfo.PendingUnwind)
-                    {
-                        dispatcherInfo.PendingUnwind = false;
-                        Debug.WriteLine($"[AsyncProfiler:V1] UnwindAsyncException (escaped) dispatcher={Id} innerBox={((Task)inner).Id} thread={Environment.CurrentManagedThreadId}");
-                    }
-
-                    if (!dispatcherInfo.Suspended)
-                    {
-                        Debug.WriteLine($"[AsyncProfiler:V1] CompleteAsyncContext dispatcher={Id} innerBox={((Task)inner).Id} thread={Environment.CurrentManagedThreadId}");
-                    }
-                    // If Suspended, the Suspend event was already emitted inline by Create
-
-                    refCurrent = dispatcherInfo.Next;
-                }
+                return;
             }
+
+            Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Thread={Environment.CurrentManagedThreadId}, Id={ContextId}, inner={inner.GetType().Name}, tid={Environment.CurrentManagedThreadId}");
+
+            AsyncTaskDispatcherInfo dispatcherInfo;
+            ref AsyncTaskDispatcherInfo* refCurrent = ref AsyncTaskDispatcherInfo.t_current;
+            AsyncTaskDispatcherInfo* previous = refCurrent;
+            refCurrent = &dispatcherInfo;
+            dispatcherInfo.Next = previous;
+
+            dispatcherInfo.InnerBox = inner;
+            dispatcherInfo.Dispatcher = this;
+            dispatcherInfo.Suspended = false;
+
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+            AsyncProfiler.InitInfo(ref dispatcherInfo.AsyncProfilerInfo);
+
+            if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+            {
+                Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Resuming Id={ContextId}, tid={Environment.CurrentManagedThreadId}");
+                AsyncProfiler.ResumeAsyncContext.Resume(ref dispatcherInfo);
+            }
+
+            try
+            {
+                inner.MoveNext();
+            }
+            finally
+            {
+                if (!dispatcherInfo.Suspended && AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
+                {
+                    Debug.WriteLine($"[AsyncTaskDispatcher.MoveNext] Completed Id={ContextId}, tid={Environment.CurrentManagedThreadId}");
+                    AsyncProfiler.CompleteAsyncContext.Complete(ref dispatcherInfo.AsyncProfilerInfo);
+                }
+
+                // If Suspended, the Suspend event was already emitted inline by Create.
+            }
+
+            refCurrent = dispatcherInfo.Next;
         }
 
         public Action MoveNextAction => _moveNextAction ??= MoveNext;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -5,8 +5,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using static System.Runtime.CompilerServices.AsyncInstrumentation;
-using static System.Runtime.CompilerServices.AsyncProfiler;
 
 namespace System.Runtime.CompilerServices
 {
@@ -72,7 +70,7 @@ namespace System.Runtime.CompilerServices
 
             activeDispatcher.CurrentContinuation = box;
 
-            SyncPoint.Check(ref current->AsyncProfilerInfo);
+            AsyncProfiler.SyncPoint.Check(ref current->AsyncProfilerInfo);
 
             bool methodEventEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags);
             bool callstackEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags);
@@ -113,48 +111,21 @@ namespace System.Runtime.CompilerServices
     internal sealed class AsyncTaskDispatcher : Task<VoidTaskResult>, IAsyncStateMachineBox
     {
         private IAsyncStateMachineBox? _inner;
-        private IAsyncStateMachineBox? _current;
         private Action? _moveNextAction;
-        private ulong _contextId;
 
-        internal IAsyncStateMachineBox? CurrentContinuation
-        {
-            get { return _current; }
-            set { _current = value; }
-        }
+        internal IAsyncStateMachineBox? CurrentContinuation;
 
         internal Task? LastContinuation;
 
         internal bool ReachedLastContinuation;
 
+        internal bool ContinuationChainChanged => LastContinuation?.ContinuationForDiagnostics != null;
+
         internal AsyncTaskDispatcher(IAsyncStateMachineBox inner) : base()
         {
             _inner = inner;
-            _current = inner;
-            _contextId = 0;
+            CurrentContinuation = inner;
         }
-
-        internal AsyncTaskDispatcher(IAsyncStateMachineBox inner, AsyncTaskDispatcher parent) : base()
-        {
-            _inner = inner;
-            _current = inner;
-            _contextId = parent.ContextId;
-        }
-
-        internal ulong ContextId
-        {
-            get
-            {
-                if (_contextId == 0)
-                {
-                    return (ulong)this.Id;
-                }
-
-                return _contextId;
-            }
-        }
-
-        internal bool ContinuationChainChanged => LastContinuation?.ContinuationForDiagnostics != null;
 
         internal static unsafe AsyncTaskDispatcher Create(IAsyncStateMachineBox box)
         {
@@ -165,18 +136,22 @@ namespace System.Runtime.CompilerServices
 
             AsyncTaskDispatcherInfo* current = AsyncTaskDispatcherInfo.t_current;
             AsyncTaskDispatcher? activeDispatcher = current != null ? current->Dispatcher : null;
-            AsyncTaskDispatcher dispatcher = activeDispatcher != null ? new AsyncTaskDispatcher(box, activeDispatcher) : new AsyncTaskDispatcher(box);
+
+            AsyncTaskDispatcher dispatcher = new AsyncTaskDispatcher(box);
 
             AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
+                ulong parentDispatcherId = AsyncProfiler.CaptureParentDispatcherId();
+                ulong dispatcherId = AsyncProfiler.TaskAsyncIds.GetDispatcherId(dispatcher);
+
                 if (activeDispatcher != null)
                 {
-                    AsyncProfiler.CreateAsyncContext.Create(activeDispatcher, ref current->AsyncProfilerInfo, (ulong)dispatcher.ContextId);
+                    AsyncProfiler.CreateAsyncContext.Create(activeDispatcher, ref current->AsyncProfilerInfo, parentDispatcherId, dispatcherId);
                 }
                 else
                 {
-                    AsyncProfiler.CreateAsyncContext.Create(dispatcher);
+                    AsyncProfiler.CreateAsyncContext.Create(parentDispatcherId, dispatcherId);
                 }
             }
 
@@ -224,7 +199,7 @@ namespace System.Runtime.CompilerServices
 
                 if (IsCompleted)
                 {
-                    _current = null;
+                    CurrentContinuation = null;
                     LastContinuation = null;
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskDispatcher.cs
@@ -233,18 +233,18 @@ namespace System.Runtime.CompilerServices
             _inner = null;
         }
 
-        public void GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
+        public bool GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
         {
             IAsyncStateMachineBox? inner = _inner;
             if (inner != null)
             {
-                inner.GetDiagnosticData(out methodId, out state, out nextContinuation);
-                return;
+                return inner.GetDiagnosticData(out methodId, out state, out nextContinuation);
             }
 
             methodId = 0;
             state = -1;
             nextContinuation = null;
+            return false;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -353,27 +354,17 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(!IsCompleted);
 
-                bool asyncProfilerActive = AsyncTaskDispatcherInfo.IsActive;
-                string? methodName = null;
-
-                if (asyncProfilerActive)
+                AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                 {
-                    methodName = typeof(TStateMachine).Name;
-
-                    if (AsyncTaskDispatcherInfo.ConsumePendingUnwind())
+                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
                     {
-                        Debug.WriteLine($"[AsyncProfiler:V1] UnwindAsyncException box={Id} method={methodName} thread={Environment.CurrentManagedThreadId}");
+                        Debug.WriteLine($"[AsyncTaskMethodBuilder.MoveNext] method={GetType().Name}, tid={Environment.CurrentManagedThreadId}");
+                        AsyncTaskDispatcherInfo.ResumeAsyncMethod();
                     }
-
-                    // If the frame was suspended (a sub-chain was spawned) but we're now resuming
-                    // a method on the same frame, the chain has resumed from suspension.
-                    if (AsyncTaskDispatcherInfo.ConsumeSuspended())
-                    {
-                        Debug.WriteLine($"[AsyncProfiler:V1] ResumeAsyncContext (inline) box={Id} method={methodName} thread={Environment.CurrentManagedThreadId}");
-                    }
-
-                    Debug.WriteLine($"[AsyncProfiler:V1] ResumeAsyncMethod box={Id} method={methodName} thread={Environment.CurrentManagedThreadId}");
                 }
+
+                Debug.Assert(!AsyncTaskDispatcherInfo.IsSuspended);
 
                 bool loggingOn = TplEventSource.Log.IsEnabled();
                 if (loggingOn)
@@ -402,10 +393,6 @@ namespace System.Runtime.CompilerServices
                 if (IsCompleted)
                 {
                     ClearStateUponCompletion();
-                }
-                else if (asyncProfilerActive)
-                {
-                    Debug.WriteLine($"[AsyncProfiler:V1] YieldAsyncMethod box={Id} method={methodName}");
                 }
 
                 if (loggingOn)
@@ -512,21 +499,14 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(task != null, "Expected non-null task");
 
-            if (AsyncTaskDispatcherInfo.IsActive)
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+            if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
             {
-                if (AsyncTaskDispatcherInfo.ConsumePendingUnwind())
+                if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
                 {
-                    Debug.WriteLine($"[AsyncProfiler:V1] UnwindAsyncException (caught) box={task.Id} thread={Environment.CurrentManagedThreadId}");
+                    Debug.WriteLine($"[AsyncTaskMethodBuilder.SetExistingTaskResult] method={task.GetType().Name}, tid={Environment.CurrentManagedThreadId}");
+                    AsyncTaskDispatcherInfo.CompleteAsyncMethod();
                 }
-
-                // If the frame was suspended (a sub-chain was spawned via GetOrCreate) but we're
-                // now completing a method, the chain has resumed — emit Resume and clear the flag.
-                if (AsyncTaskDispatcherInfo.ConsumeSuspended())
-                {
-                    Debug.WriteLine($"[AsyncProfiler:V1] ResumeAsyncContext (inline) thread={Environment.CurrentManagedThreadId}");
-                }
-
-                Debug.WriteLine($"[AsyncProfiler:V1] CompleteAsyncMethod box={task.Id} thread={Environment.CurrentManagedThreadId}");
             }
 
             if (TplEventSource.Log.IsEnabled())
@@ -559,7 +539,12 @@ namespace System.Runtime.CompilerServices
             // Get the task, forcing initialization if it hasn't already been initialized.
             Task<TResult> task = (taskField ??= new Task<TResult>());
 
-            AsyncTaskDispatcherInfo.MarkPendingUnwind();
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+            if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags) && AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
+            {
+                Debug.WriteLine($"[AsyncTaskMethodBuilder.SetException] method={taskField.GetType().Name}, tid={Environment.CurrentManagedThreadId}");
+                AsyncTaskDispatcherInfo.UnwindAsyncFrame();
+            }
 
             // If the exception represents cancellation, cancel the task.  Otherwise, fault the task.
             bool successfullySet = exception is OperationCanceledException oce ?

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -354,13 +354,9 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(!IsCompleted);
 
-                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint)
+                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
-                    AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
-                    {
-                        AsyncTaskDispatcherInfo.TryFireResumeAsyncMethod(this, flags);
-                    }
+                    AsyncTaskDispatcherInfo.TryFireResumeAsyncMethod(this, AsyncInstrumentation.ActiveFlags);
                 }
 
                 bool loggingOn = TplEventSource.Log.IsEnabled();
@@ -438,7 +434,7 @@ namespace System.Runtime.CompilerServices
                 {
                     methodId = TStateMachineDiagnosticData.MethodId;
                     state = TStateMachineDiagnosticData.GetState(ref StateMachine);
-                    nextContinuation = this.DiagnosticContinuationObject;
+                    nextContinuation = this.GetContinuationForDiagnostics;
                     return true;
                 }
                 else
@@ -587,10 +583,9 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(task != null, "Expected non-null task");
 
-            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-            if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+            if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
             {
-                if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
+                if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(AsyncInstrumentation.ActiveFlags))
                 {
                     AsyncTaskDispatcherInfo.CompleteAsyncMethod();
                 }
@@ -626,10 +621,12 @@ namespace System.Runtime.CompilerServices
             // Get the task, forcing initialization if it hasn't already been initialized.
             Task<TResult> task = (taskField ??= new Task<TResult>());
 
-            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-            if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags) && AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
+            if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
             {
-                AsyncTaskDispatcherInfo.UnwindAsyncFrame();
+                if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(AsyncInstrumentation.ActiveFlags))
+                {
+                    AsyncTaskDispatcherInfo.UnwindAsyncFrame();
+                }
             }
 
             // If the exception represents cancellation, cancel the task.  Otherwise, fault the task.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -357,7 +357,7 @@ namespace System.Runtime.CompilerServices
                 AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
                 if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
+                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
                     {
                         Debug.WriteLine($"[AsyncTaskMethodBuilder.MoveNext] method={GetType().Name}, tid={Environment.CurrentManagedThreadId}");
                         AsyncTaskDispatcherInfo.ResumeAsyncMethod();
@@ -434,6 +434,104 @@ namespace System.Runtime.CompilerServices
 
             /// <summary>Gets the state machine as a boxed object.  This should only be used for debugging purposes.</summary>
             IAsyncStateMachine IAsyncStateMachineBox.GetStateMachineObject() => StateMachine!; // likely boxes, only use for debugging
+
+            void IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
+            {
+                methodId = TStateMachineDiagnosticData.MethodId;
+                state = TStateMachineDiagnosticData.GetState(ref StateMachine);
+                nextContinuation = this.DiagnosticContinuationObject;
+            }
+
+            private static class TStateMachineDiagnosticData
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static int GetState(ref TStateMachine? stateMachine)
+                {
+                    if (typeof(TStateMachine).IsValueType)
+                    {
+                        // Struct: state field is inline at offset within the struct
+                        return Unsafe.As<byte, int>(ref Unsafe.AddByteOffset(ref Unsafe.As<TStateMachine?, byte>(ref stateMachine), (nint)s_resolveStateFieldOffset));
+                    }
+                    else
+                    {
+                        // Class (debug builds): StateMachine is a reference, dereference to get object data
+                        if (stateMachine != null)
+                        {
+                            return Unsafe.As<byte, int>(ref Unsafe.AddByteOffset(ref RuntimeHelpers.GetRawData(stateMachine), (nint)s_resolveStateFieldOffset));
+                        }
+                    }
+
+                    return -1;
+                }
+
+                public static ulong MethodId => s_methodId;
+
+                private static readonly ulong s_methodId = ResolveMethodId();
+                private static readonly int s_resolveStateFieldOffset = ResolveStateFieldOffset();
+
+#if NATIVEAOT
+                private static ulong ResolveMethodId()
+                {
+                    unsafe
+                    {
+                        MethodTable* instanceType = (MethodTable*)typeof(TStateMachine).TypeHandle.Value;
+                        MethodTable* interfaceType = (MethodTable*)typeof(IAsyncStateMachine).TypeHandle.Value;
+                        if (instanceType != null && interfaceType != null)
+                        {
+                            return (ulong)RuntimeImports.RhResolveDispatchOnType(instanceType, interfaceType, slot: 0);
+                        }
+                        return 0;
+                    }
+                }
+#else
+
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090", Justification = "State machine types are always preserved.")]
+                private static ulong ResolveMethodId()
+                {
+                    MethodInfo? methodInfo = typeof(TStateMachine).GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    if (methodInfo != null)
+                    {
+                        return (ulong)methodInfo.MethodHandle.Value;
+                    }
+
+                    return 0;
+                }
+#endif
+
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090", Justification = "State machine types are always preserved.")]
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2087", Justification = "Only reachable for class state machines (debug builds) where Roslyn always generates constructors. The type is guaranteed preserved because AsyncStateMachineBox<TStateMachine> directly instantiates and uses it.")]
+                private static int ResolveStateFieldOffset()
+                {
+                    FieldInfo? stateField = typeof(TStateMachine).GetField("<>1__state", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    if (stateField != null)
+                    {
+#if NATIVEAOT
+                        const int Sentinel = 0x7F345678;
+
+                        object instance = typeof(TStateMachine).IsValueType ? (object)default(TStateMachine)! : RuntimeHelpers.GetUninitializedObject(typeof(TStateMachine));
+                        stateField.SetValue(instance, Sentinel);
+
+                        int size = (int)RuntimeHelpers.GetRawObjectDataSize(instance);
+                        Debug.Assert(size >= sizeof(int), "TStateMachine object is too small to contain a state field.");
+
+                        ref byte data = ref RuntimeHelpers.GetRawData(instance);
+
+                        for (int i = 0; i < size; i += sizeof(int))
+                        {
+                            if (Unsafe.As<byte, int>(ref Unsafe.AddByteOffset(ref data, i)) == Sentinel)
+                            {
+                                return i;
+                            }
+                        }
+#else
+                        Debug.Assert(stateField is RtFieldInfo, $"Expected RtFieldInfo but got {stateField.GetType().Name}");
+                        return RuntimeFieldHandle.GetInstanceFieldOffset((RtFieldInfo)stateField);
+#endif
+                    }
+
+                    return 0;
+                }
+            }
         }
 
         /// <summary>Gets the <see cref="Task{TResult}"/> for this builder.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -354,17 +354,20 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(!IsCompleted);
 
-                AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint)
                 {
-                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
+                    AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                     {
-                        Debug.WriteLine($"[AsyncTaskMethodBuilder.MoveNext] method={GetType().Name}, tid={Environment.CurrentManagedThreadId}");
-                        AsyncTaskDispatcherInfo.ResumeAsyncMethod();
+                        if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
+                        {
+                            Debug.WriteLine($"[AsyncTaskMethodBuilder.MoveNext] method={GetType().Name}, tid={Environment.CurrentManagedThreadId}");
+                            AsyncTaskDispatcherInfo.ResumeAsyncMethod(flags);
+                        }
                     }
-                }
 
-                Debug.Assert(!AsyncTaskDispatcherInfo.IsSuspended);
+                    Debug.Assert(!AsyncTaskDispatcherInfo.IsSuspended);
+                }
 
                 bool loggingOn = TplEventSource.Log.IsEnabled();
                 if (loggingOn)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -429,20 +429,18 @@ namespace System.Runtime.CompilerServices
 
             bool IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
             {
-                if (AsyncInstrumentation.IsSupported)
+                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint)
                 {
                     methodId = AsyncStateMachineDiagnostics<TStateMachine>.MethodId;
                     state = AsyncStateMachineDiagnostics<TStateMachine>.GetState(ref StateMachine);
                     nextContinuation = this.ContinuationForDiagnostics;
                     return true;
                 }
-                else
-                {
-                    methodId = 0;
-                    state = -1;
-                    nextContinuation = null;
-                    return false;
-                }
+
+                methodId = 0;
+                state = -1;
+                nextContinuation = null;
+                return false;
             }
 
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -361,8 +361,6 @@ namespace System.Runtime.CompilerServices
                     {
                         AsyncTaskDispatcherInfo.TryFireResumeAsyncMethod(this, flags);
                     }
-
-                    Debug.Assert(!AsyncTaskDispatcherInfo.IsSuspended);
                 }
 
                 bool loggingOn = TplEventSource.Log.IsEnabled();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -353,9 +353,9 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(!IsCompleted);
 
-                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
-                    AsyncTaskDispatcherInfo.ResumeAsyncMethod(this, AsyncInstrumentation.ActiveFlags);
+                    AsyncStateMachineDispatcherInfo.ResumeAsyncMethod(this, AsyncInstrumentation.ActiveFlags);
                 }
 
                 bool loggingOn = TplEventSource.Log.IsEnabled();
@@ -429,7 +429,7 @@ namespace System.Runtime.CompilerServices
 
             bool IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
             {
-                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint)
+                if (AsyncStateMachineDispatcherInfo.InstrumentCheckPoint)
                 {
                     methodId = AsyncStateMachineDiagnostics<TStateMachine>.MethodId;
                     state = AsyncStateMachineDiagnostics<TStateMachine>.GetState(ref StateMachine);
@@ -508,11 +508,11 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(task != null, "Expected non-null task");
 
-            if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+            if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
             {
                 if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(AsyncInstrumentation.ActiveFlags))
                 {
-                    AsyncTaskDispatcherInfo.CompleteAsyncMethod();
+                    AsyncStateMachineDispatcherInfo.CompleteAsyncMethod();
                 }
             }
 
@@ -546,11 +546,11 @@ namespace System.Runtime.CompilerServices
             // Get the task, forcing initialization if it hasn't already been initialized.
             Task<TResult> task = (taskField ??= new Task<TResult>());
 
-            if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+            if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
             {
                 if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(AsyncInstrumentation.ActiveFlags))
                 {
-                    AsyncTaskDispatcherInfo.UnwindAsyncFrame();
+                    AsyncStateMachineDispatcherInfo.UnwindAsyncFrame();
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -355,7 +355,7 @@ namespace System.Runtime.CompilerServices
 
                 if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
-                    AsyncTaskDispatcherInfo.TryFireResumeAsyncMethod(this, AsyncInstrumentation.ActiveFlags);
+                    AsyncTaskDispatcherInfo.ResumeAsyncMethod(this, AsyncInstrumentation.ActiveFlags);
                 }
 
                 bool loggingOn = TplEventSource.Log.IsEnabled();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -434,15 +434,50 @@ namespace System.Runtime.CompilerServices
             /// <summary>Gets the state machine as a boxed object.  This should only be used for debugging purposes.</summary>
             IAsyncStateMachine IAsyncStateMachineBox.GetStateMachineObject() => StateMachine!; // likely boxes, only use for debugging
 
-            void IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
+            bool IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
             {
-                methodId = TStateMachineDiagnosticData.MethodId;
-                state = TStateMachineDiagnosticData.GetState(ref StateMachine);
-                nextContinuation = this.DiagnosticContinuationObject;
+                if (AsyncInstrumentation.IsSupported)
+                {
+                    methodId = TStateMachineDiagnosticData.MethodId;
+                    state = TStateMachineDiagnosticData.GetState(ref StateMachine);
+                    nextContinuation = this.DiagnosticContinuationObject;
+                    return true;
+                }
+                else
+                {
+                    methodId = 0;
+                    state = -1;
+                    nextContinuation = null;
+                    return false;
+                }
             }
 
             private static class TStateMachineDiagnosticData
             {
+#if NATIVEAOT
+                // In NativeAOT we don't have reflection to resolve the method handle and state field offset.
+                // Due to the way the state machine is constructed, we can't get a direct pointer to its MoveNext method
+                // and using the interface dispatch to locate the method at slot 0 is unreliable due to Native AOT optimizations.
+                // The state field is also not guaranteed to be at a specific offset due to auto layout and Native AOT optimizations.
+                // To support this on Native AOT we would need to precompute this information in ILC and emit a
+                // hash table keyed by state machine MethodTable. At runtime we would still need to cache
+                // this data in static fields to avoid lookup cost when walking each continuation frame.
+                // On JIT these static fields are lazy evaluated and cached on initial access, but on Native AOT
+                // they will be pre-allocated, so code should be linked out when diagnostics is not supported.
+                // Given the added complexity on Native AOT, the fact that this is only used for diagnostics,
+                // and that Native AOT currently have limited asyncv1 diagnostics support in tooling, we can
+                // postpone the support until proven needed.
+                public static ulong MethodId => 0;
+                public static int GetState(ref TStateMachine? _)
+                {
+                    return -1;
+                }
+#else
+                private static readonly ulong s_methodId = ResolveMethodId();
+                private static readonly int s_resolveStateFieldOffset = ResolveStateFieldOffset();
+
+                public static ulong MethodId => s_methodId;
+
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 public static int GetState(ref TStateMachine? stateMachine)
                 {
@@ -463,27 +498,6 @@ namespace System.Runtime.CompilerServices
                     return -1;
                 }
 
-                public static ulong MethodId => s_methodId;
-
-                private static readonly ulong s_methodId = ResolveMethodId();
-                private static readonly int s_resolveStateFieldOffset = ResolveStateFieldOffset();
-
-#if NATIVEAOT
-                private static ulong ResolveMethodId()
-                {
-                    unsafe
-                    {
-                        MethodTable* instanceType = (MethodTable*)typeof(TStateMachine).TypeHandle.Value;
-                        MethodTable* interfaceType = (MethodTable*)typeof(IAsyncStateMachine).TypeHandle.Value;
-                        if (instanceType != null && interfaceType != null)
-                        {
-                            return (ulong)RuntimeImports.RhResolveDispatchOnType(instanceType, interfaceType, slot: 0);
-                        }
-                        return 0;
-                    }
-                }
-#else
-
                 [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090", Justification = "State machine types are always preserved.")]
                 private static ulong ResolveMethodId()
                 {
@@ -495,41 +509,20 @@ namespace System.Runtime.CompilerServices
 
                     return 0;
                 }
-#endif
 
                 [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090", Justification = "State machine types are always preserved.")]
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2087", Justification = "Only reachable for class state machines (debug builds) where Roslyn always generates constructors. The type is guaranteed preserved because AsyncStateMachineBox<TStateMachine> directly instantiates and uses it.")]
                 private static int ResolveStateFieldOffset()
                 {
                     FieldInfo? stateField = typeof(TStateMachine).GetField("<>1__state", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                     if (stateField != null)
                     {
-#if NATIVEAOT
-                        const int Sentinel = 0x7F345678;
-
-                        object instance = typeof(TStateMachine).IsValueType ? (object)default(TStateMachine)! : RuntimeHelpers.GetUninitializedObject(typeof(TStateMachine));
-                        stateField.SetValue(instance, Sentinel);
-
-                        int size = (int)RuntimeHelpers.GetRawObjectDataSize(instance);
-                        Debug.Assert(size >= sizeof(int), "TStateMachine object is too small to contain a state field.");
-
-                        ref byte data = ref RuntimeHelpers.GetRawData(instance);
-
-                        for (int i = 0; i < size; i += sizeof(int))
-                        {
-                            if (Unsafe.As<byte, int>(ref Unsafe.AddByteOffset(ref data, i)) == Sentinel)
-                            {
-                                return i;
-                            }
-                        }
-#else
                         Debug.Assert(stateField is RtFieldInfo, $"Expected RtFieldInfo but got {stateField.GetType().Name}");
                         return RuntimeFieldHandle.GetInstanceFieldOffset((RtFieldInfo)stateField);
-#endif
                     }
 
                     return 0;
                 }
+#endif
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -359,11 +359,7 @@ namespace System.Runtime.CompilerServices
                     AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
                     if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                     {
-                        if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
-                        {
-                            Debug.WriteLine($"[AsyncTaskMethodBuilder.MoveNext] method={GetType().Name}, tid={Environment.CurrentManagedThreadId}");
-                            AsyncTaskDispatcherInfo.ResumeAsyncMethod(flags);
-                        }
+                        AsyncTaskDispatcherInfo.TryFireResumeAsyncMethod(this, flags);
                     }
 
                     Debug.Assert(!AsyncTaskDispatcherInfo.IsSuspended);
@@ -605,7 +601,6 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
                 {
-                    Debug.WriteLine($"[AsyncTaskMethodBuilder.SetExistingTaskResult] method={task.GetType().Name}, tid={Environment.CurrentManagedThreadId}");
                     AsyncTaskDispatcherInfo.CompleteAsyncMethod();
                 }
             }
@@ -643,7 +638,6 @@ namespace System.Runtime.CompilerServices
             AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
             if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags) && AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
             {
-                Debug.WriteLine($"[AsyncTaskMethodBuilder.SetException] method={taskField.GetType().Name}, tid={Environment.CurrentManagedThreadId}");
                 AsyncTaskDispatcherInfo.UnwindAsyncFrame();
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -432,9 +431,9 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsSupported)
                 {
-                    methodId = TStateMachineDiagnosticData.MethodId;
-                    state = TStateMachineDiagnosticData.GetState(ref StateMachine);
-                    nextContinuation = this.GetContinuationForDiagnostics;
+                    methodId = AsyncStateMachineDiagnostics<TStateMachine>.MethodId;
+                    state = AsyncStateMachineDiagnostics<TStateMachine>.GetState(ref StateMachine);
+                    nextContinuation = this.ContinuationForDiagnostics;
                     return true;
                 }
                 else
@@ -446,78 +445,6 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            private static class TStateMachineDiagnosticData
-            {
-#if NATIVEAOT
-                // In NativeAOT we don't have reflection to resolve the method handle and state field offset.
-                // Due to the way the state machine is constructed, we can't get a direct pointer to its MoveNext method
-                // and using the interface dispatch to locate the method at slot 0 is unreliable due to Native AOT optimizations.
-                // The state field is also not guaranteed to be at a specific offset due to auto layout and Native AOT optimizations.
-                // To support this on Native AOT we would need to precompute this information in ILC and emit a
-                // hash table keyed by state machine MethodTable. At runtime we would still need to cache
-                // this data in static fields to avoid lookup cost when walking each continuation frame.
-                // On JIT these static fields are lazy evaluated and cached on initial access, but on Native AOT
-                // they will be pre-allocated, so code should be linked out when diagnostics is not supported.
-                // Given the added complexity on Native AOT, the fact that this is only used for diagnostics,
-                // and that Native AOT currently have limited asyncv1 diagnostics support in tooling, we can
-                // postpone the support until proven needed.
-                public static ulong MethodId => 0;
-                public static int GetState(ref TStateMachine? _)
-                {
-                    return -1;
-                }
-#else
-                private static readonly ulong s_methodId = ResolveMethodId();
-                private static readonly int s_resolveStateFieldOffset = ResolveStateFieldOffset();
-
-                public static ulong MethodId => s_methodId;
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static int GetState(ref TStateMachine? stateMachine)
-                {
-                    if (typeof(TStateMachine).IsValueType)
-                    {
-                        // Struct: state field is inline at offset within the struct
-                        return Unsafe.As<byte, int>(ref Unsafe.AddByteOffset(ref Unsafe.As<TStateMachine?, byte>(ref stateMachine), (nint)s_resolveStateFieldOffset));
-                    }
-                    else
-                    {
-                        // Class (debug builds): StateMachine is a reference, dereference to get object data
-                        if (stateMachine != null)
-                        {
-                            return Unsafe.As<byte, int>(ref Unsafe.AddByteOffset(ref RuntimeHelpers.GetRawData(stateMachine), (nint)s_resolveStateFieldOffset));
-                        }
-                    }
-
-                    return -1;
-                }
-
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090", Justification = "State machine types are always preserved.")]
-                private static ulong ResolveMethodId()
-                {
-                    MethodInfo? methodInfo = typeof(TStateMachine).GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                    if (methodInfo != null)
-                    {
-                        return (ulong)methodInfo.MethodHandle.Value;
-                    }
-
-                    return 0;
-                }
-
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090", Justification = "State machine types are always preserved.")]
-                private static int ResolveStateFieldOffset()
-                {
-                    FieldInfo? stateField = typeof(TStateMachine).GetField("<>1__state", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                    if (stateField != null)
-                    {
-                        Debug.Assert(stateField is RtFieldInfo, $"Expected RtFieldInfo but got {stateField.GetType().Name}");
-                        return RuntimeFieldHandle.GetInstanceFieldOffset((RtFieldInfo)stateField);
-                    }
-
-                    return 0;
-                }
-#endif
-            }
         }
 
         /// <summary>Gets the <see cref="Task{TResult}"/> for this builder.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -353,6 +353,28 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(!IsCompleted);
 
+                bool asyncProfilerActive = AsyncTaskDispatcherInfo.IsActive;
+                string? methodName = null;
+
+                if (asyncProfilerActive)
+                {
+                    methodName = typeof(TStateMachine).Name;
+
+                    if (AsyncTaskDispatcherInfo.ConsumePendingUnwind())
+                    {
+                        Debug.WriteLine($"[AsyncProfiler:V1] UnwindAsyncException box={Id} method={methodName} thread={Environment.CurrentManagedThreadId}");
+                    }
+
+                    // If the frame was suspended (a sub-chain was spawned) but we're now resuming
+                    // a method on the same frame, the chain has resumed from suspension.
+                    if (AsyncTaskDispatcherInfo.ConsumeSuspended())
+                    {
+                        Debug.WriteLine($"[AsyncProfiler:V1] ResumeAsyncContext (inline) box={Id} method={methodName} thread={Environment.CurrentManagedThreadId}");
+                    }
+
+                    Debug.WriteLine($"[AsyncProfiler:V1] ResumeAsyncMethod box={Id} method={methodName} thread={Environment.CurrentManagedThreadId}");
+                }
+
                 bool loggingOn = TplEventSource.Log.IsEnabled();
                 if (loggingOn)
                 {
@@ -380,6 +402,10 @@ namespace System.Runtime.CompilerServices
                 if (IsCompleted)
                 {
                     ClearStateUponCompletion();
+                }
+                else if (asyncProfilerActive)
+                {
+                    Debug.WriteLine($"[AsyncProfiler:V1] YieldAsyncMethod box={Id} method={methodName}");
                 }
 
                 if (loggingOn)
@@ -486,6 +512,23 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(task != null, "Expected non-null task");
 
+            if (AsyncTaskDispatcherInfo.IsActive)
+            {
+                if (AsyncTaskDispatcherInfo.ConsumePendingUnwind())
+                {
+                    Debug.WriteLine($"[AsyncProfiler:V1] UnwindAsyncException (caught) box={task.Id} thread={Environment.CurrentManagedThreadId}");
+                }
+
+                // If the frame was suspended (a sub-chain was spawned via GetOrCreate) but we're
+                // now completing a method, the chain has resumed — emit Resume and clear the flag.
+                if (AsyncTaskDispatcherInfo.ConsumeSuspended())
+                {
+                    Debug.WriteLine($"[AsyncProfiler:V1] ResumeAsyncContext (inline) thread={Environment.CurrentManagedThreadId}");
+                }
+
+                Debug.WriteLine($"[AsyncProfiler:V1] CompleteAsyncMethod box={task.Id} thread={Environment.CurrentManagedThreadId}");
+            }
+
             if (TplEventSource.Log.IsEnabled())
             {
                 TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
@@ -515,6 +558,8 @@ namespace System.Runtime.CompilerServices
 
             // Get the task, forcing initialization if it hasn't already been initialized.
             Task<TResult> task = (taskField ??= new Task<TResult>());
+
+            AsyncTaskDispatcherInfo.MarkPendingUnwind();
 
             // If the exception represents cancellation, cancel the task.  Otherwise, fault the task.
             bool successfullySet = exception is OperationCanceledException oce ?

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -102,9 +102,9 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                    if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                     {
-                        box = AsyncTaskDispatcher.Create(box);
+                        box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
                     }
 
                     Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
@@ -212,9 +212,9 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                    if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                     {
-                        box = AsyncTaskDispatcher.Create(box);
+                        box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
                     }
 
                     Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -102,9 +102,11 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-#if !MONO
-                    box = AsyncTaskDispatcher.Create(box);
-#endif
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                    {
+                        box = AsyncTaskDispatcher.Create(box);
+                    }
+
                     Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }
@@ -210,9 +212,11 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-#if !MONO
-                    box = AsyncTaskDispatcher.Create(box);
-#endif
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                    {
+                        box = AsyncTaskDispatcher.Create(box);
+                    }
+
                     Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -102,7 +102,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                    if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
                     {
                         box = AsyncTaskDispatcher.Create(box);
                     }
@@ -212,7 +212,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                    if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
                     {
                         box = AsyncTaskDispatcher.Create(box);
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -102,7 +102,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                    if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                     {
                         box = AsyncTaskDispatcher.Create(box);
                     }
@@ -212,7 +212,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                    if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                     {
                         box = AsyncTaskDispatcher.Create(box);
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -102,6 +102,9 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
+#if !MONO
+                    box = AsyncTaskDispatcher.Create(box);
+#endif
                     Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }
@@ -207,6 +210,9 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
+#if !MONO
+                    box = AsyncTaskDispatcher.Create(box);
+#endif
                     Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IAsyncStateMachineBox.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IAsyncStateMachineBox.cs
@@ -22,5 +22,8 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Clears the state of the box.</summary>
         void ClearStateUponCompletion();
+
+        /// <summary>Gets the state machine diagnostic data.</summary>
+        void GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IAsyncStateMachineBox.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IAsyncStateMachineBox.cs
@@ -24,6 +24,6 @@ namespace System.Runtime.CompilerServices
         void ClearStateUponCompletion();
 
         /// <summary>Gets the state machine diagnostic data.</summary>
-        void GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation);
+        bool GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
@@ -399,7 +399,7 @@ namespace System.Runtime.CompilerServices
             void IThreadPoolWorkItem.Execute() => MoveNext();
 
             /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
-            // TODO-AsyncProfiler: This MoveNext lacks profiler instrumentation (Resume/Complete/Yield events).
+            // TODO-AsyncProfiler: This MoveNext lacks profiler instrumentation (Resume/Complete events).
             // The pooling builder is opt-in and uses ManualResetValueTaskSourceCore for completion instead of
             // Task.TrySetResult, so SetExistingTaskResult events don't fire here either. Needs dedicated
             // instrumentation similar to AsyncTaskMethodBuilder's AsyncStateMachineBox.MoveNext.
@@ -446,6 +446,14 @@ namespace System.Runtime.CompilerServices
 
             /// <summary>Gets the state machine as a boxed object.  This should only be used for debugging purposes.</summary>
             IAsyncStateMachine IAsyncStateMachineBox.GetStateMachineObject() => StateMachine!; // likely boxes, only use for debugging
+
+            void IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
+            {
+                // TODO-AsyncProfiler: Implement when pooling async builders are fully supported in AsyncProfiler. For now, return default values that won't cause confusion in the profiler.
+                methodId = 0;
+                state = -1;
+                nextContinuation = null;
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
@@ -447,12 +447,13 @@ namespace System.Runtime.CompilerServices
             /// <summary>Gets the state machine as a boxed object.  This should only be used for debugging purposes.</summary>
             IAsyncStateMachine IAsyncStateMachineBox.GetStateMachineObject() => StateMachine!; // likely boxes, only use for debugging
 
-            void IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
+            bool IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
             {
-                // TODO-AsyncProfiler: Implement when pooling async builders are fully supported in AsyncProfiler. For now, return default values that won't cause confusion in the profiler.
+                // TODO-AsyncProfiler: Implement when pooling async builders are fully supported in AsyncProfiler.
                 methodId = 0;
                 state = -1;
                 nextContinuation = null;
+                return false;
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
@@ -399,6 +399,10 @@ namespace System.Runtime.CompilerServices
             void IThreadPoolWorkItem.Execute() => MoveNext();
 
             /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
+            // TODO-AsyncProfiler: This MoveNext lacks profiler instrumentation (Resume/Complete/Yield events).
+            // The pooling builder is opt-in and uses ManualResetValueTaskSourceCore for completion instead of
+            // Task.TrySetResult, so SetExistingTaskResult events don't fire here either. Needs dedicated
+            // instrumentation similar to AsyncTaskMethodBuilder's AsyncStateMachineBox.MoveNext.
             public void MoveNext()
             {
                 ExecutionContext? context = Context;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
@@ -399,10 +399,6 @@ namespace System.Runtime.CompilerServices
             void IThreadPoolWorkItem.Execute() => MoveNext();
 
             /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
-            // TODO-AsyncProfiler: This MoveNext lacks profiler instrumentation (Resume/Complete events).
-            // The pooling builder is opt-in and uses ManualResetValueTaskSourceCore for completion instead of
-            // Task.TrySetResult, so SetExistingTaskResult events don't fire here either. Needs dedicated
-            // instrumentation similar to AsyncTaskMethodBuilder's AsyncStateMachineBox.MoveNext.
             public void MoveNext()
             {
                 ExecutionContext? context = Context;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -198,6 +198,8 @@ namespace System.Runtime.CompilerServices
             // and set up an ending event to be traced when the asynchronous await completes.
             if (TplEventSource.Log.IsEnabled() || Task.s_asyncDebuggingEnabled)
             {
+                // TODO: AsyncProfiler — the ETW path bypasses UnsafeSetContinuationForAwait and
+                // uses the Action-based SetContinuationForAwait. Dispatcher wrapping is not applied here.
                 task.SetContinuationForAwait(OutputWaitEtwEvents(task, stateMachineBox.MoveNextAction), continueOnCapturedContext, flowExecutionContext: false);
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -194,11 +194,11 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(stateMachineBox != null);
 
-            if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+            if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
             {
                 if (task is not IAsyncStateMachineBox)
                 {
-                    stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                    stateMachineBox = AsyncStateMachineDispatcherInfo.CreateDispatcher(stateMachineBox);
                 }
                 else if (continueOnCapturedContext)
                 {
@@ -206,7 +206,7 @@ namespace System.Runtime.CompilerServices
                     bool customTaskScheduler = TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default;
                     if (customSyncContext || customTaskScheduler)
                     {
-                        stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                        stateMachineBox = AsyncStateMachineDispatcherInfo.CreateDispatcher(stateMachineBox);
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -199,25 +199,18 @@ namespace System.Runtime.CompilerServices
                 AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
                 if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                 {
-                    if (continueOnCapturedContext)
-                    {
-                        if (SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext))
-                        {
-                            stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
-                        }
-                        else if (TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default)
-                        {
-                            stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
-                        }
-                    }
-
-                    // If we're awaiting a non-async task (I/O, Timer, TCS, etc.),
-                    // this box is the root of a V1 async chain. Wrap or reuse a dispatch box.
-                    // For mid-chain boxes (awaiting another async method), the continuation will
-                    // be inlined via RunContinuations, so no dispatcher wrapping is needed here.
                     if (task is not IAsyncStateMachineBox)
                     {
                         stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                    }
+                    else if (continueOnCapturedContext)
+                    {
+                        bool customSyncContext = SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext);
+                        bool customTaskScheduler = TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default;
+                        if (customSyncContext || customTaskScheduler)
+                        {
+                            stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -194,23 +194,19 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(stateMachineBox != null);
 
-            if (AsyncTaskDispatcherInfo.InstrumentCheckPoint)
+            if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
             {
-                AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                if (task is not IAsyncStateMachineBox)
                 {
-                    if (task is not IAsyncStateMachineBox)
+                    stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                }
+                else if (continueOnCapturedContext)
+                {
+                    bool customSyncContext = SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext);
+                    bool customTaskScheduler = TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default;
+                    if (customSyncContext || customTaskScheduler)
                     {
                         stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
-                    }
-                    else if (continueOnCapturedContext)
-                    {
-                        bool customSyncContext = SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext);
-                        bool customTaskScheduler = TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default;
-                        if (customSyncContext || customTaskScheduler)
-                        {
-                            stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
-                        }
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -194,28 +194,31 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(stateMachineBox != null);
 
-            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-            if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+            if (AsyncTaskDispatcherInfo.InstrumentCheckPoint)
             {
-                if (continueOnCapturedContext)
+                AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                 {
-                    if (SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext))
+                    if (continueOnCapturedContext)
                     {
-                        stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                        if (SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext))
+                        {
+                            stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                        }
+                        else if (TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default)
+                        {
+                            stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                        }
                     }
-                    else if (TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default)
-                    {
-                        stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
-                    }
-                }
 
-                // If we're awaiting a non-async task (I/O, Timer, TCS, etc.),
-                // this box is the root of a V1 async chain. Wrap or reuse a dispatch box.
-                // For mid-chain boxes (awaiting another async method), the continuation will
-                // be inlined via RunContinuations, so no dispatcher wrapping is needed here.
-                if (task is not IAsyncStateMachineBox)
-                {
-                    stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                    // If we're awaiting a non-async task (I/O, Timer, TCS, etc.),
+                    // this box is the root of a V1 async chain. Wrap or reuse a dispatch box.
+                    // For mid-chain boxes (awaiting another async method), the continuation will
+                    // be inlined via RunContinuations, so no dispatcher wrapping is needed here.
+                    if (task is not IAsyncStateMachineBox)
+                    {
+                        stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                    }
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -194,12 +194,35 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(stateMachineBox != null);
 
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+            if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+            {
+                if (continueOnCapturedContext)
+                {
+                    if (SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext))
+                    {
+                        stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                    }
+                    else if (TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default)
+                    {
+                        stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                    }
+                }
+
+                // If we're awaiting a non-async task (I/O, Timer, TCS, etc.),
+                // this box is the root of a V1 async chain. Wrap or reuse a dispatch box.
+                // For mid-chain boxes (awaiting another async method), the continuation will
+                // be inlined via RunContinuations, so no dispatcher wrapping is needed here.
+                if (task is not IAsyncStateMachineBox)
+                {
+                    stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                }
+            }
+
             // If TaskWait* ETW events are enabled, trace a beginning event for this await
             // and set up an ending event to be traced when the asynchronous await completes.
             if (TplEventSource.Log.IsEnabled() || Task.s_asyncDebuggingEnabled)
             {
-                // TODO: AsyncProfiler — the ETW path bypasses UnsafeSetContinuationForAwait and
-                // uses the Action-based SetContinuationForAwait. Dispatcher wrapping is not applied here.
                 task.SetContinuationForAwait(OutputWaitEtwEvents(task, stateMachineBox.MoveNextAction), continueOnCapturedContext, flowExecutionContext: false);
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -94,10 +94,6 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                // TODO-AsyncProfiler: Optimize by using a static delegate + original box as state instead of
-                // allocating a full AsyncTaskDispatcher (Task-derived). The IValueTaskSource.OnCompleted API
-                // already takes Action<object?> + state separately, so we can use a lightweight static callback
-                // that performs PUSH/MoveNext/POP inline without the Task overhead.
                 if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
                     box = AsyncTaskDispatcher.Create(box);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -94,13 +94,15 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-#if !MONO
                 // TODO-AsyncProfiler: Optimize by using a static delegate + original box as state instead of
                 // allocating a full AsyncTaskDispatcher (Task-derived). The IValueTaskSource.OnCompleted API
                 // already takes Action<object?> + state separately, so we can use a lightweight static callback
                 // that performs PUSH/MoveNext/POP inline without the Task overhead.
-                box = AsyncTaskDispatcher.Create(box);
-#endif
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                {
+                    box = AsyncTaskDispatcher.Create(box);
+                }
+
                 Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else
@@ -183,9 +185,11 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-#if !MONO
-                box = AsyncTaskDispatcher.Create(box);
-#endif
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                {
+                    box = AsyncTaskDispatcher.Create(box);
+                }
+
                 Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -94,9 +94,9 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
-                    box = AsyncTaskDispatcher.Create(box);
+                    box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
                 }
 
                 Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
@@ -181,9 +181,9 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
-                    box = AsyncTaskDispatcher.Create(box);
+                    box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
                 }
 
                 Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -98,7 +98,7 @@ namespace System.Runtime.CompilerServices
                 // allocating a full AsyncTaskDispatcher (Task-derived). The IValueTaskSource.OnCompleted API
                 // already takes Action<object?> + state separately, so we can use a lightweight static callback
                 // that performs PUSH/MoveNext/POP inline without the Task overhead.
-                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
                 {
                     box = AsyncTaskDispatcher.Create(box);
                 }
@@ -185,7 +185,7 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
                 {
                     box = AsyncTaskDispatcher.Create(box);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -98,7 +98,7 @@ namespace System.Runtime.CompilerServices
                 // allocating a full AsyncTaskDispatcher (Task-derived). The IValueTaskSource.OnCompleted API
                 // already takes Action<object?> + state separately, so we can use a lightweight static callback
                 // that performs PUSH/MoveNext/POP inline without the Task overhead.
-                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
                     box = AsyncTaskDispatcher.Create(box);
                 }
@@ -185,7 +185,7 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
                     box = AsyncTaskDispatcher.Create(box);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -94,6 +94,13 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
+#if !MONO
+                // TODO-AsyncProfiler: Optimize by using a static delegate + original box as state instead of
+                // allocating a full AsyncTaskDispatcher (Task-derived). The IValueTaskSource.OnCompleted API
+                // already takes Action<object?> + state separately, so we can use a lightweight static callback
+                // that performs PUSH/MoveNext/POP inline without the Task overhead.
+                box = AsyncTaskDispatcher.Create(box);
+#endif
                 Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else
@@ -176,6 +183,9 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
+#if !MONO
+                box = AsyncTaskDispatcher.Create(box);
+#endif
                 Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
@@ -116,7 +116,7 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(box != null);
 
-                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
                 {
                     box = AsyncTaskDispatcher.Create(box);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
@@ -116,9 +116,9 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(box != null);
 
-                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
-                    box = AsyncTaskDispatcher.Create(box);
+                    box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
                 }
 
                 // If tracing is enabled, delegate the Action-based implementation.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
@@ -116,7 +116,7 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(box != null);
 
-                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
                     box = AsyncTaskDispatcher.Create(box);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
@@ -116,6 +116,14 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(box != null);
 
+#if !MONO
+                // Yield is always a root — wrap or reuse a dispatch box when the async profiler is active.
+                if (true /* TODO: restore: AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.ActiveFlags) */)
+                {
+                    box = AsyncTaskDispatcher.Create(box);
+                }
+#endif
+
                 // If tracing is enabled, delegate the Action-based implementation.
                 if (TplEventSource.Log.IsEnabled())
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
@@ -116,13 +116,10 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(box != null);
 
-#if !MONO
-                // Yield is always a root — wrap or reuse a dispatch box when the async profiler is active.
-                if (true /* TODO: restore: AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.ActiveFlags) */)
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
                 {
                     box = AsyncTaskDispatcher.Create(box);
                 }
-#endif
 
                 // If tracing is enabled, delegate the Action-based implementation.
                 if (TplEventSource.Log.IsEnabled())

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -7224,6 +7224,9 @@ namespace System.Threading.Tasks
             return new UnwrapPromise<TResult>(outerTask, lookForOce);
         }
 
+        /// <summary>Gets the continuation object for async callstack diagnostics.</summary>
+        internal object? DiagnosticContinuationObject => m_continuationObject;
+
         internal virtual Delegate[]? GetDelegateContinuationsForDebugger()
         {
             // Avoid an infinite loop by making sure the continuation object is not a reference to istelf.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -7224,8 +7224,7 @@ namespace System.Threading.Tasks
             return new UnwrapPromise<TResult>(outerTask, lookForOce);
         }
 
-        /// <summary>Gets the continuation object for async callstack diagnostics.</summary>
-        internal object? DiagnosticContinuationObject => m_continuationObject;
+        internal object? GetContinuationForDiagnostics => m_continuationObject;
 
         internal virtual Delegate[]? GetDelegateContinuationsForDebugger()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2721,16 +2721,40 @@ namespace System.Threading.Tasks
             {
                 if (SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext))
                 {
+#if !MONO
+                    // Continuation will be queued to sync context — wrap in dispatcher to
+                    // maintain the async chain context across the scheduling boundary.
+                    Debug.WriteLine($"[AsyncProfiler:V1] USING none default Sync context!");
+                    stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+#endif
                     tc = new SynchronizationContextAwaitTaskContinuation(syncCtx, stateMachineBox.MoveNextAction, flowExecutionContext: false);
                     goto HaveTaskContinuation;
                 }
 
                 if (TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default)
                 {
+#if !MONO
+                    // Continuation will be queued to custom scheduler — wrap in dispatcher to
+                    // maintain the async chain context across the scheduling boundary.
+                    stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+                    Debug.WriteLine($"[AsyncProfiler:V1] USING none default task scheduler!");
+#endif
                     tc = new TaskSchedulerAwaitTaskContinuation(scheduler, stateMachineBox.MoveNextAction, flowExecutionContext: false);
                     goto HaveTaskContinuation;
                 }
             }
+
+#if !MONO
+            // If we're awaiting a non-async task (I/O, Timer, TCS, etc.),
+            // this box is the root of a V1 async chain. Wrap or reuse a dispatch box.
+            // For mid-chain boxes (awaiting another async method), the continuation will
+            // be inlined via RunContinuations, so no dispatcher wrapping is needed here.
+            if (this is not IAsyncStateMachineBox)
+            {
+                Debug.WriteLine($"[AsyncProfiler:V1] WAITING on non-async task!");
+                stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
+            }
+#endif
 
             // Otherwise, add the state machine box directly as the continuation.
             // If we're unable to because the task has already completed, queue it.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2721,40 +2721,16 @@ namespace System.Threading.Tasks
             {
                 if (SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext))
                 {
-#if !MONO
-                    // Continuation will be queued to sync context — wrap in dispatcher to
-                    // maintain the async chain context across the scheduling boundary.
-                    Debug.WriteLine($"[AsyncProfiler:V1] USING none default Sync context!");
-                    stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
-#endif
                     tc = new SynchronizationContextAwaitTaskContinuation(syncCtx, stateMachineBox.MoveNextAction, flowExecutionContext: false);
                     goto HaveTaskContinuation;
                 }
 
                 if (TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default)
                 {
-#if !MONO
-                    // Continuation will be queued to custom scheduler — wrap in dispatcher to
-                    // maintain the async chain context across the scheduling boundary.
-                    stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
-                    Debug.WriteLine($"[AsyncProfiler:V1] USING none default task scheduler!");
-#endif
                     tc = new TaskSchedulerAwaitTaskContinuation(scheduler, stateMachineBox.MoveNextAction, flowExecutionContext: false);
                     goto HaveTaskContinuation;
                 }
             }
-
-#if !MONO
-            // If we're awaiting a non-async task (I/O, Timer, TCS, etc.),
-            // this box is the root of a V1 async chain. Wrap or reuse a dispatch box.
-            // For mid-chain boxes (awaiting another async method), the continuation will
-            // be inlined via RunContinuations, so no dispatcher wrapping is needed here.
-            if (this is not IAsyncStateMachineBox)
-            {
-                Debug.WriteLine($"[AsyncProfiler:V1] WAITING on non-async task!");
-                stateMachineBox = AsyncTaskDispatcher.Create(stateMachineBox);
-            }
-#endif
 
             // Otherwise, add the state machine box directly as the continuation.
             // If we're unable to because the task has already completed, queue it.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -7224,7 +7224,7 @@ namespace System.Threading.Tasks
             return new UnwrapPromise<TResult>(outerTask, lookForOce);
         }
 
-        internal object? ContinuationForDiagnostics => m_continuationObject;
+        internal object? ContinuationForDiagnostics => m_continuationObject != this ? m_continuationObject : null;
 
         internal virtual Delegate[]? GetDelegateContinuationsForDebugger()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -7224,7 +7224,7 @@ namespace System.Threading.Tasks
             return new UnwrapPromise<TResult>(outerTask, lookForOce);
         }
 
-        internal object? GetContinuationForDiagnostics => m_continuationObject;
+        internal object? ContinuationForDiagnostics => m_continuationObject;
 
         internal virtual Delegate[]? GetDelegateContinuationsForDebugger()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -782,7 +782,7 @@ namespace System.Threading.Tasks
             // If we're not allowed to run here, schedule the action
             if (!allowInlining || !IsValidLocationForInlining)
             {
-                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
                 {
                     box = AsyncTaskDispatcher.Create(box);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -782,11 +782,10 @@ namespace System.Threading.Tasks
             // If we're not allowed to run here, schedule the action
             if (!allowInlining || !IsValidLocationForInlining)
             {
-#if !MONO
-                // If an async profiler dispatcher is active, reuse it so the queued
-                // continuation runs inside the same dispatcher context (preserving the chain).
-                box = AsyncTaskDispatcher.ReuseOrPassthrough(box);
-#endif
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                {
+                    box = AsyncTaskDispatcher.Create(box);
+                }
 
                 // If logging is disabled, we can simply queue the box itself as a custom work
                 // item, and its work item execution will just invoke its MoveNext.  However, if

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -782,6 +782,12 @@ namespace System.Threading.Tasks
             // If we're not allowed to run here, schedule the action
             if (!allowInlining || !IsValidLocationForInlining)
             {
+#if !MONO
+                // If an async profiler dispatcher is active, reuse it so the queued
+                // continuation runs inside the same dispatcher context (preserving the chain).
+                box = AsyncTaskDispatcher.ReuseOrPassthrough(box);
+#endif
+
                 // If logging is disabled, we can simply queue the box itself as a custom work
                 // item, and its work item execution will just invoke its MoveNext.  However, if
                 // logging is enabled, there is pre/post-work we need to do around logging to

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -782,7 +782,7 @@ namespace System.Threading.Tasks
             // If we're not allowed to run here, schedule the action
             if (!allowInlining || !IsValidLocationForInlining)
             {
-                if (AsyncTaskDispatcherInfo.InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags()))
+                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
                     box = AsyncTaskDispatcher.Create(box);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -782,9 +782,9 @@ namespace System.Threading.Tasks
             // If we're not allowed to run here, schedule the action
             if (!allowInlining || !IsValidLocationForInlining)
             {
-                if (AsyncTaskDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
                 {
-                    box = AsyncTaskDispatcher.Create(box);
+                    box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
                 }
 
                 // If logging is disabled, we can simply queue the box itself as a custom work

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -362,14 +362,16 @@ namespace System.Threading.Tasks.Tests
                 return;
             }
 
+            bool readState = callstackType == AsyncCallstackType.Compiler;
+
             ulong currentMethodId = ReadCompressedUInt64(buffer, ref index);
-            int state = ReadCompressedInt32(buffer, ref index);
+            int state = readState ? ReadCompressedInt32(buffer, ref index) : 0;
             frames.Add((currentMethodId, state));
 
             for (int i = 1; i < frameCount; i++)
             {
                 long delta = ReadCompressedInt64(buffer, ref index);
-                state = ReadCompressedInt32(buffer, ref index);
+                state = readState ? ReadCompressedInt32(buffer, ref index) : 0;
                 currentMethodId = (ulong)((long)currentMethodId + delta);
                 frames.Add((currentMethodId, state));
             }
@@ -911,6 +913,9 @@ namespace System.Threading.Tasks.Tests
             public ConcurrentQueue<EventWrittenEventArgs> Events { get; } = new();
         }
 
+        private static Task<CollectedEvents> CollectValueTaskEventsAsync(EventKeywords keywords, Func<ValueTask> scenario)
+            => CollectEventsAsync(keywords, () => scenario().AsTask());
+
         private static async Task<CollectedEvents> CollectEventsAsync(EventKeywords keywords, Func<Task> scenario)
         {
             var result = new CollectedEvents();
@@ -1413,10 +1418,15 @@ namespace System.Threading.Tasks.Tests
 
                 ulong previousMethodId;
                 ulong currentMethodId;
-                int state;
+                int state = 0;
+
+                bool readState = (AsyncCallstackType)type == AsyncCallstackType.Compiler;
 
                 Deserializer.ReadCompressedUInt64(buffer, ref index, out currentMethodId);
-                Deserializer.ReadCompressedInt32(buffer, ref index, out state);
+                if (readState)
+                {
+                    Deserializer.ReadCompressedInt32(buffer, ref index, out state);
+                }
 
                 OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, 0);
 
@@ -1424,7 +1434,10 @@ namespace System.Threading.Tasks.Tests
                 {
                     previousMethodId = currentMethodId;
                     Deserializer.ReadCompressedInt64(buffer, ref index, out long methodIdDelta);
-                    Deserializer.ReadCompressedInt32(buffer, ref index, out state);
+                    if (readState)
+                    {
+                        Deserializer.ReadCompressedInt32(buffer, ref index, out state);
+                    }
                     currentMethodId = previousMethodId + (ulong)methodIdDelta;
                     OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, i);
                 }
@@ -1435,7 +1448,14 @@ namespace System.Threading.Tasks.Tests
             private static void OutputAsyncFrame(AsyncCallstackType type, ulong methodId, int state, int frameIndex)
             {
                 string asyncMethodName = GetMethodNameFromMethodId(type, methodId) ?? "??";
-                Console.WriteLine($"    [{frameIndex}] {asyncMethodName} (0x{methodId:X}) (state={state})");
+                if (type == AsyncCallstackType.Compiler)
+                {
+                    Console.WriteLine($"    [{frameIndex}] {asyncMethodName} (0x{methodId:X}) (state={state})");
+                }
+                else
+                {
+                    Console.WriteLine($"    [{frameIndex}] {asyncMethodName} (0x{methodId:X})");
+                }
             }
         }
     }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -16,29 +16,40 @@ namespace System.Threading.Tasks.Tests
     // Mirrors AsyncProfiler.AsyncEventID from the runtime (which is internal and inaccessible from tests).
     public enum AsyncEventID : byte
     {
-        CreateAsyncContext = 1,
-        ResumeAsyncContext = 2,
-        SuspendAsyncContext = 3,
-        CompleteAsyncContext = 4,
-        UnwindAsyncException = 5,
-        CreateAsyncCallstack = 6,
-        ResumeAsyncCallstack = 7,
-        SuspendAsyncCallstack = 8,
-        ResumeAsyncMethod = 9,
-        CompleteAsyncMethod = 10,
-        ResetAsyncThreadContext = 11,
-        ResetAsyncContinuationWrapperIndex = 12,
-        AsyncProfilerMetadata = 13,
-        AsyncProfilerSyncClock = 14,
-        AppendAsyncCallstack = 15,
+        // V2 (RuntimeAsync) events.
+        RuntimeAsync_CreateAsyncContext = 1,
+        RuntimeAsync_ResumeAsyncContext = 2,
+        RuntimeAsync_SuspendAsyncContext = 3,
+        RuntimeAsync_CompleteAsyncContext = 4,
+        RuntimeAsync_UnwindAsyncException = 5,
+        RuntimeAsync_CreateAsyncCallstack = 6,
+        RuntimeAsync_ResumeAsyncCallstack = 7,
+        RuntimeAsync_SuspendAsyncCallstack = 8,
+        RuntimeAsync_ResumeAsyncMethod = 9,
+        RuntimeAsync_CompleteAsyncMethod = 10,
+
+        // V1 (TaskAsync) events.
+        TaskAsync_CreateAsyncContext = 11,
+        TaskAsync_ResumeAsyncContext = 12,
+        TaskAsync_SuspendAsyncContext = 13,
+        TaskAsync_CompleteAsyncContext = 14,
+        TaskAsync_UnwindAsyncException = 15,
+        TaskAsync_ResumeAsyncCallstack = 16,
+        TaskAsync_ResumeAsyncMethod = 17,
+        TaskAsync_CompleteAsyncMethod = 18,
+        TaskAsync_AppendAsyncCallstack = 19,
+
+        // Neutral profiler events.
+        ResetAsyncThreadContext = 20,
+        ResetAsyncContinuationWrapperIndex = 21,
+        AsyncProfilerMetadata = 22,
+        AsyncProfilerSyncClock = 23,
     }
 
-    //Mirrors AsyncProfiler.AsyncCallstackType from the runtime (which is internal and inaccessible from tests).
     public enum AsyncCallstackType : byte
     {
         Compiler = 0x1,
         Runtime = 0x2,
-        Cached = 0x80
     }
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/127951", TestPlatforms.Android | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
@@ -278,19 +289,40 @@ namespace System.Threading.Tasks.Tests
         {
             switch (eventId)
             {
-                case AsyncEventID.CreateAsyncContext:
-                case AsyncEventID.ResumeAsyncContext:
+                case AsyncEventID.RuntimeAsync_CreateAsyncContext:
+                case AsyncEventID.RuntimeAsync_ResumeAsyncContext:
+                case AsyncEventID.TaskAsync_CreateAsyncContext:
+                case AsyncEventID.TaskAsync_ResumeAsyncContext:
                 {
                     ReadCompressedUInt64(buffer, ref index);
                     return true;
                 }
-                case AsyncEventID.SuspendAsyncContext:
-                case AsyncEventID.CompleteAsyncContext:
-                case AsyncEventID.ResumeAsyncMethod:
-                case AsyncEventID.CompleteAsyncMethod:
+                case AsyncEventID.RuntimeAsync_SuspendAsyncContext:
+                case AsyncEventID.RuntimeAsync_CompleteAsyncContext:
+                case AsyncEventID.RuntimeAsync_ResumeAsyncMethod:
+                case AsyncEventID.RuntimeAsync_CompleteAsyncMethod:
+                case AsyncEventID.TaskAsync_SuspendAsyncContext:
+                case AsyncEventID.TaskAsync_CompleteAsyncContext:
+                case AsyncEventID.TaskAsync_ResumeAsyncMethod:
+                case AsyncEventID.TaskAsync_CompleteAsyncMethod:
                 case AsyncEventID.ResetAsyncThreadContext:
                 case AsyncEventID.ResetAsyncContinuationWrapperIndex:
                 {
+                    return true;
+                }
+                case AsyncEventID.RuntimeAsync_UnwindAsyncException:
+                case AsyncEventID.TaskAsync_UnwindAsyncException:
+                {
+                    ReadCompressedUInt32(buffer, ref index);
+                    return true;
+                }
+                case AsyncEventID.RuntimeAsync_CreateAsyncCallstack:
+                case AsyncEventID.RuntimeAsync_ResumeAsyncCallstack:
+                case AsyncEventID.RuntimeAsync_SuspendAsyncCallstack:
+                case AsyncEventID.TaskAsync_ResumeAsyncCallstack:
+                case AsyncEventID.TaskAsync_AppendAsyncCallstack:
+                {
+                    SkipCallstackPayload(buffer, ref index, CallstackTypeFromEventId(eventId));
                     return true;
                 }
                 case AsyncEventID.AsyncProfilerMetadata:
@@ -302,19 +334,6 @@ namespace System.Threading.Tasks.Tests
                 {
                     ReadCompressedUInt64(buffer, ref index); // qpcSync
                     ReadCompressedUInt64(buffer, ref index); // utcSync
-                    return true;
-                }
-                case AsyncEventID.UnwindAsyncException:
-                {
-                    ReadCompressedUInt32(buffer, ref index);
-                    return true;
-                }
-                case AsyncEventID.CreateAsyncCallstack:
-                case AsyncEventID.ResumeAsyncCallstack:
-                case AsyncEventID.SuspendAsyncCallstack:
-                case AsyncEventID.AppendAsyncCallstack:
-                {
-                    SkipCallstackPayload(buffer, ref index);
                     return true;
                 }
                 default:
@@ -336,21 +355,20 @@ namespace System.Threading.Tasks.Tests
             return value;
         }
 
-        private static void SkipCallstackPayload(ReadOnlySpan<byte> buffer, ref int index)
+        private static void SkipCallstackPayload(ReadOnlySpan<byte> buffer, ref int index, AsyncCallstackType callstackType)
         {
-            ReadCallstackPayload(buffer, ref index, out _, out _);
+            ReadCallstackPayload(buffer, ref index, callstackType, out _, out _, out _, out _);
         }
 
         private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index,
             out byte frameCount, out List<(ulong MethodId, int State)> frames)
         {
-            ReadCallstackPayload(buffer, ref index, out _, out _, out _, out frameCount, out frames);
+            ReadCallstackPayload(buffer, ref index, AsyncCallstackType.Runtime, out _, out _, out frameCount, out frames);
         }
 
-        private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index,
-            out ulong taskId, out AsyncCallstackType callstackType, out byte continuationIndex, out byte frameCount, out List<(ulong MethodId, int State)> frames)
+        private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index, AsyncCallstackType callstackType,
+            out ulong taskId, out byte continuationIndex, out byte frameCount, out List<(ulong MethodId, int State)> frames)
         {
-            callstackType = (AsyncCallstackType)buffer[index++];
             index++; // Reserved callstack ID (for future callstack interning).
             continuationIndex = buffer[index++];
             frameCount = buffer[index++];
@@ -359,6 +377,7 @@ namespace System.Threading.Tasks.Tests
 
             if (frameCount == 0)
             {
+                // Cached callstack reference (frame data resolved out-of-band by callstack id).
                 return;
             }
 
@@ -376,6 +395,15 @@ namespace System.Threading.Tasks.Tests
                 frames.Add((currentMethodId, state));
             }
         }
+
+        // Derive callstack type from the event id:
+        // V1 (TaskAsync_*) events carry compiler-built state machine frames;
+        // V2 (RuntimeAsync_*) events carry runtime-async frames.
+        private static AsyncCallstackType CallstackTypeFromEventId(AsyncEventID eventId)
+            => eventId is AsyncEventID.TaskAsync_ResumeAsyncCallstack
+                       or AsyncEventID.TaskAsync_AppendAsyncCallstack
+                ? AsyncCallstackType.Compiler
+                : AsyncCallstackType.Runtime;
 
         private static int ReadCompressedInt32(ReadOnlySpan<byte> buffer, ref int index)
         {
@@ -550,7 +578,16 @@ namespace System.Threading.Tasks.Tests
                 {
                     switch (evt.EventId)
                     {
-                        case AsyncEventID.ResumeAsyncCallstack:
+                        case AsyncEventID.RuntimeAsync_SuspendAsyncContext:
+                        case AsyncEventID.RuntimeAsync_CompleteAsyncContext:
+                        case AsyncEventID.TaskAsync_SuspendAsyncContext:
+                        case AsyncEventID.TaskAsync_CompleteAsyncContext:
+                        {
+                            openByTaskId.Remove(evt.TaskId);
+                            break;
+                        }
+                        case AsyncEventID.RuntimeAsync_ResumeAsyncCallstack:
+                        case AsyncEventID.TaskAsync_ResumeAsyncCallstack:
                         {
                             var merged = new ParsedEvent
                             {
@@ -569,7 +606,7 @@ namespace System.Threading.Tasks.Tests
 
                             break;
                         }
-                        case AsyncEventID.AppendAsyncCallstack:
+                        case AsyncEventID.TaskAsync_AppendAsyncCallstack:
                         {
                             if (openByTaskId.TryGetValue(evt.TaskId, out int idx))
                             {
@@ -590,12 +627,6 @@ namespace System.Threading.Tasks.Tests
                                 };
                             }
 
-                            break;
-                        }
-                        case AsyncEventID.SuspendAsyncContext:
-                        case AsyncEventID.CompleteAsyncContext:
-                        {
-                            openByTaskId.Remove(evt.TaskId);
                             break;
                         }
                     }
@@ -667,14 +698,17 @@ namespace System.Threading.Tasks.Tests
 
                     ParsedEvent evt = eventId switch
                     {
-                        AsyncEventID.CreateAsyncContext or AsyncEventID.ResumeAsyncContext =>
+                        AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.RuntimeAsync_ResumeAsyncContext or
+                        AsyncEventID.TaskAsync_CreateAsyncContext or AsyncEventID.TaskAsync_ResumeAsyncContext =>
                             ParseContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index, ref currentTaskId, taskIdStack),
 
-                        AsyncEventID.CompleteAsyncContext =>
-                            ParseCompleteContextEvent(baseTimestamp, osThreadId, ref currentTaskId, taskIdStack),
+                        AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_CompleteAsyncContext =>
+                            ParseCompleteContextEvent(eventId, baseTimestamp, osThreadId, ref currentTaskId, taskIdStack),
 
-                        AsyncEventID.SuspendAsyncContext or
-                        AsyncEventID.ResumeAsyncMethod or AsyncEventID.CompleteAsyncMethod =>
+                        AsyncEventID.RuntimeAsync_SuspendAsyncContext or
+                        AsyncEventID.RuntimeAsync_ResumeAsyncMethod or AsyncEventID.RuntimeAsync_CompleteAsyncMethod or
+                        AsyncEventID.TaskAsync_SuspendAsyncContext or
+                        AsyncEventID.TaskAsync_ResumeAsyncMethod or AsyncEventID.TaskAsync_CompleteAsyncMethod =>
                             new ParsedEvent
                             {
                                 EventId = eventId,
@@ -686,12 +720,13 @@ namespace System.Threading.Tasks.Tests
                         AsyncEventID.ResetAsyncThreadContext or AsyncEventID.ResetAsyncContinuationWrapperIndex =>
                             ParseResetEvent(eventId, baseTimestamp, osThreadId, ref currentTaskId),
 
-                        AsyncEventID.CreateAsyncCallstack or AsyncEventID.ResumeAsyncCallstack or
-                        AsyncEventID.SuspendAsyncCallstack or AsyncEventID.AppendAsyncCallstack =>
+                        AsyncEventID.RuntimeAsync_CreateAsyncCallstack or AsyncEventID.RuntimeAsync_ResumeAsyncCallstack or
+                        AsyncEventID.RuntimeAsync_SuspendAsyncCallstack or
+                        AsyncEventID.TaskAsync_ResumeAsyncCallstack or AsyncEventID.TaskAsync_AppendAsyncCallstack =>
                             ParseCallstackEvent(eventId, baseTimestamp, osThreadId, buffer, ref index, ref currentTaskId, taskIdStack),
 
-                        AsyncEventID.UnwindAsyncException =>
-                            ParseUnwindEvent(baseTimestamp, osThreadId, currentTaskId, buffer, ref index),
+                        AsyncEventID.RuntimeAsync_UnwindAsyncException or AsyncEventID.TaskAsync_UnwindAsyncException =>
+                            ParseUnwindEvent(eventId, baseTimestamp, osThreadId, currentTaskId, buffer, ref index),
 
                         AsyncEventID.AsyncProfilerMetadata =>
                             ParseMetadataEvent(baseTimestamp, osThreadId, currentTaskId, buffer, ref index),
@@ -712,7 +747,8 @@ namespace System.Threading.Tasks.Tests
                 ReadOnlySpan<byte> buffer, ref int index, ref ulong currentTaskId, Stack<ulong> taskIdStack)
             {
                 ulong id = ReadCompressedUInt64(buffer, ref index);
-                if (eventId == AsyncEventID.ResumeAsyncContext && id != currentTaskId)
+                bool isResume = eventId is AsyncEventID.RuntimeAsync_ResumeAsyncContext or AsyncEventID.TaskAsync_ResumeAsyncContext;
+                if (isResume && id != currentTaskId)
                 {
                     taskIdStack.Push(currentTaskId);
                 }
@@ -728,7 +764,7 @@ namespace System.Threading.Tasks.Tests
                 };
             }
 
-            static ParsedEvent ParseCompleteContextEvent(long timestamp, ulong osThreadId,
+            static ParsedEvent ParseCompleteContextEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
                 ref ulong currentTaskId, Stack<ulong> taskIdStack)
             {
                 ulong completedTaskId = currentTaskId;
@@ -736,7 +772,7 @@ namespace System.Threading.Tasks.Tests
 
                 return new ParsedEvent
                 {
-                    EventId = AsyncEventID.CompleteAsyncContext,
+                    EventId = eventId,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
                     TaskId = completedTaskId
@@ -763,7 +799,8 @@ namespace System.Threading.Tasks.Tests
             static ParsedEvent ParseCallstackEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
                 ReadOnlySpan<byte> buffer, ref int index, ref ulong currentTaskId, Stack<ulong> taskIdStack)
             {
-                ReadCallstackPayload(buffer, ref index, out ulong taskId, out AsyncCallstackType callstackType, out byte continuationIndex, out byte frameCount, out var frames);
+                AsyncCallstackType callstackType = CallstackTypeFromEventId(eventId);
+                ReadCallstackPayload(buffer, ref index, callstackType, out ulong taskId, out byte continuationIndex, out byte frameCount, out var frames);
                 if (taskId != currentTaskId)
                 {
                     taskIdStack.Push(currentTaskId);
@@ -783,14 +820,14 @@ namespace System.Threading.Tasks.Tests
                 };
             }
 
-            static ParsedEvent ParseUnwindEvent(long timestamp, ulong osThreadId, ulong currentTaskId,
+            static ParsedEvent ParseUnwindEvent(AsyncEventID eventId, long timestamp, ulong osThreadId, ulong currentTaskId,
                 ReadOnlySpan<byte> buffer, ref int index)
             {
                 uint unwindCount = ReadCompressedUInt32(buffer, ref index);
 
                 return new ParsedEvent
                 {
-                    EventId = AsyncEventID.UnwindAsyncException,
+                    EventId = eventId,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
                     TaskId = currentTaskId,
@@ -1006,9 +1043,14 @@ namespace System.Threading.Tasks.Tests
         // For a given context, simulates the async callstack depth by walking events in order:
         // ResumeAsyncCallstack sets the depth to frame count, CompleteAsyncMethod decrements,
         // UnwindAsyncException subtracts unwound frames. Asserts depth reaches zero.
+        // Handles both V1 (TaskAsync_*) and V2 (RuntimeAsync) event ids.
         private static void AssertCallstackSimulationReachesZero(ParsedEventStream stream, string markerMethodName)
         {
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, markerMethodName);
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, markerMethodName);
+            if (resumeStacks.Count == 0)
+            {
+                resumeStacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, markerMethodName);
+            }
             Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{markerMethodName}'");
 
             ulong taskId = resumeStacks[0].TaskId;
@@ -1020,12 +1062,14 @@ namespace System.Threading.Tasks.Tests
             {
                 switch (evt.EventId)
                 {
-                    case AsyncEventID.ResumeAsyncCallstack:
+                    case AsyncEventID.RuntimeAsync_ResumeAsyncCallstack:
+                    case AsyncEventID.TaskAsync_ResumeAsyncCallstack:
                     {
                         stackDepth = (int)evt.FrameCount;
                         break;
                     }
-                    case AsyncEventID.CompleteAsyncMethod:
+                    case AsyncEventID.RuntimeAsync_CompleteAsyncMethod:
+                    case AsyncEventID.TaskAsync_CompleteAsyncMethod:
                     {
                         if (stackDepth > 0)
                         {
@@ -1034,7 +1078,8 @@ namespace System.Threading.Tasks.Tests
 
                         break;
                     }
-                    case AsyncEventID.UnwindAsyncException:
+                    case AsyncEventID.RuntimeAsync_UnwindAsyncException:
+                    case AsyncEventID.TaskAsync_UnwindAsyncException:
                     {
                         stackDepth = Math.Max(0, stackDepth - (int)evt.UnwindFrameCount);
                         break;
@@ -1048,8 +1093,8 @@ namespace System.Threading.Tasks.Tests
         private static void AssertExactlyOneCreateAndComplete(ParsedEventStream stream, ulong taskId, string chainName)
         {
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
-            int creates = ids.Count(id => id == AsyncEventID.CreateAsyncContext);
-            int completes = ids.Count(id => id == AsyncEventID.CompleteAsyncContext);
+            int creates = ids.Count(id => id is AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.TaskAsync_CreateAsyncContext);
+            int completes = ids.Count(id => id is AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_CompleteAsyncContext);
             Assert.True(creates == 1, $"Expected exactly 1 CreateAsyncContext for {chainName} (TaskId {taskId}), got {creates}");
             Assert.True(completes == 1, $"Expected exactly 1 CompleteAsyncContext for {chainName} (TaskId {taskId}), got {completes}");
         }
@@ -1060,10 +1105,10 @@ namespace System.Threading.Tasks.Tests
         private static void AssertCreateEqualsCompleteForTask(ParsedEventStream stream, ulong taskId, string chainName)
         {
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
-            int creates = ids.Count(id => id == AsyncEventID.CreateAsyncContext);
-            int completes = ids.Count(id => id == AsyncEventID.CompleteAsyncContext);
-            Assert.True(creates >= 1, $"Expected at least 1 CreateAsyncContext for {chainName} (TaskId {taskId}), got {creates}");
-            Assert.True(creates == completes, $"Expected CreateAsyncContext count == CompleteAsyncContext count for {chainName} (TaskId {taskId}), got {creates} creates and {completes} completes");
+            int creates = ids.Count(id => id == AsyncEventID.TaskAsync_CreateAsyncContext);
+            int completes = ids.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
+            Assert.True(creates >= 1, $"Expected at least 1 TaskAsync_CreateAsyncContext for {chainName} (TaskId {taskId}), got {creates}");
+            Assert.True(creates == completes, $"Expected TaskAsync_CreateAsyncContext count == TaskAsync_CompleteAsyncContext count for {chainName} (TaskId {taskId}), got {creates} creates and {completes} completes");
         }
 
         private sealed class InlinePostSynchronizationContext : SynchronizationContext
@@ -1237,21 +1282,32 @@ namespace System.Threading.Tasks.Tests
                     {
                         index += eventId switch
                         {
-                            AsyncEventID.CreateAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
-                            AsyncEventID.ResumeAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
-                            AsyncEventID.SuspendAsyncContext => OutputSuspendAsyncContextEvent(),
-                            AsyncEventID.CompleteAsyncContext => OutputCompleteAsyncContextEvent(),
-                            AsyncEventID.UnwindAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
-                            AsyncEventID.CreateAsyncCallstack => OutputAsyncCallstackEvent(buffer.Slice(index)),
-                            AsyncEventID.ResumeAsyncCallstack => OutputAsyncCallstackEvent(buffer.Slice(index)),
-                            AsyncEventID.SuspendAsyncCallstack => OutputAsyncCallstackEvent(buffer.Slice(index)),
-                            AsyncEventID.AppendAsyncCallstack => OutputAsyncCallstackEvent(buffer.Slice(index)),
-                            AsyncEventID.ResumeAsyncMethod => OutputResumeAsyncMethodEvent(),
-                            AsyncEventID.CompleteAsyncMethod => OutputCompleteAsyncMethodEvent(),
+                            AsyncEventID.RuntimeAsync_CreateAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.RuntimeAsync_ResumeAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.RuntimeAsync_SuspendAsyncContext => OutputSuspendAsyncContextEvent(),
+                            AsyncEventID.RuntimeAsync_CompleteAsyncContext => OutputCompleteAsyncContextEvent(),
+                            AsyncEventID.RuntimeAsync_UnwindAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
+                            AsyncEventID.RuntimeAsync_CreateAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+                            AsyncEventID.RuntimeAsync_ResumeAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+                            AsyncEventID.RuntimeAsync_SuspendAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+                            AsyncEventID.RuntimeAsync_ResumeAsyncMethod => OutputResumeAsyncMethodEvent(),
+                            AsyncEventID.RuntimeAsync_CompleteAsyncMethod => OutputCompleteAsyncMethodEvent(),
+
+                            AsyncEventID.TaskAsync_CreateAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.TaskAsync_ResumeAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.TaskAsync_SuspendAsyncContext => OutputSuspendAsyncContextEvent(),
+                            AsyncEventID.TaskAsync_CompleteAsyncContext => OutputCompleteAsyncContextEvent(),
+                            AsyncEventID.TaskAsync_UnwindAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
+                            AsyncEventID.TaskAsync_ResumeAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+                            AsyncEventID.TaskAsync_ResumeAsyncMethod => OutputResumeAsyncMethodEvent(),
+                            AsyncEventID.TaskAsync_CompleteAsyncMethod => OutputCompleteAsyncMethodEvent(),
+                            AsyncEventID.TaskAsync_AppendAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+
                             AsyncEventID.ResetAsyncThreadContext => OutputResetAsyncThreadContextEvent(),
                             AsyncEventID.ResetAsyncContinuationWrapperIndex => OutputResetAsyncContinuationWrapperIndexEvent(),
                             AsyncEventID.AsyncProfilerMetadata => OutputAsyncProfilerMetadataEvent(buffer.Slice(index)),
                             AsyncEventID.AsyncProfilerSyncClock => OutputAsyncProfilerSyncClockEvent(buffer.Slice(index)),
+
                             _ => throw new InvalidOperationException($"Unknown eventId {eventId}."),
                         };
                     }
@@ -1390,23 +1446,24 @@ namespace System.Threading.Tasks.Tests
                 return index;
             }
 
-            private static int OutputAsyncCallstackEvent(ReadOnlySpan<byte> buffer)
+            private static int OutputAsyncCallstackEvent(AsyncEventID eventId, ReadOnlySpan<byte> buffer)
             {
                 ulong id;
-                byte type;
                 byte callstackId;
                 byte continuationIndex;
                 byte asyncCallstackLength;
                 int index = 0;
 
-                type = buffer[index++];
+                AsyncCallstackType type = (eventId is AsyncEventID.TaskAsync_ResumeAsyncCallstack
+                                                   or AsyncEventID.TaskAsync_AppendAsyncCallstack)
+                    ? AsyncCallstackType.Compiler
+                    : AsyncCallstackType.Runtime;
                 callstackId = buffer[index++];
                 continuationIndex = buffer[index++];
                 asyncCallstackLength = buffer[index++];
                 Deserializer.ReadCompressedUInt64(buffer, ref index, out id);
 
                 Console.WriteLine($"  ID: {id}");
-                Console.WriteLine($"  Type: {type}");
                 Console.WriteLine($"  CallstackId: {callstackId}");
                 Console.WriteLine($"  ContinuationIndex: {continuationIndex}");
                 Console.WriteLine($"  Length: {asyncCallstackLength}");
@@ -1420,7 +1477,7 @@ namespace System.Threading.Tasks.Tests
                 ulong currentMethodId;
                 int state = 0;
 
-                bool readState = (AsyncCallstackType)type == AsyncCallstackType.Compiler;
+                bool readState = type == AsyncCallstackType.Compiler;
 
                 Deserializer.ReadCompressedUInt64(buffer, ref index, out currentMethodId);
                 if (readState)
@@ -1428,7 +1485,7 @@ namespace System.Threading.Tasks.Tests
                     Deserializer.ReadCompressedInt32(buffer, ref index, out state);
                 }
 
-                OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, 0);
+                OutputAsyncFrame(type, currentMethodId, state, 0);
 
                 for (int i = 1; i < asyncCallstackLength; i++)
                 {
@@ -1439,7 +1496,7 @@ namespace System.Threading.Tasks.Tests
                         Deserializer.ReadCompressedInt32(buffer, ref index, out state);
                     }
                     currentMethodId = previousMethodId + (ulong)methodIdDelta;
-                    OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, i);
+                    OutputAsyncFrame(type, currentMethodId, state, i);
                 }
 
                 return index;

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -973,9 +973,20 @@ namespace System.Threading.Tasks.Tests
                 }
 
                 ulong osThreadId = header.Value.OsThreadId;
-                ulong currentDispatcherId = 0;
-                ulong currentParentDispatcherId = 0;
-                var dispatcherStack = new Stack<(ulong DispatcherId, ulong ParentDispatcherId)>();
+                // V1 (TaskAsync_*) and V2 (RuntimeAsync_*) are independent context dimensions that can
+                // interleave within a single thread's buffer (e.g. a V1 test-runner dispatcher active
+                // while a V2 test runs, which always happens on single-threaded WASM where everything
+                // shares one thread). Context-scoped events (Resume/Suspend/Complete context, the
+                // method events, and unwind events) omit the dispatcher id from the wire and inherit it
+                // from the enclosing Resume context, so each kind needs its own current-context stack.
+                // A single shared stack would let a TaskAsync_* Resume/Complete hijack the current
+                // dispatcher and mis-attribute interleaved RuntimeAsync_* events (and vice versa).
+                ulong v2CurrentDispatcherId = 0;
+                ulong v2CurrentParentDispatcherId = 0;
+                ulong v1CurrentDispatcherId = 0;
+                ulong v1CurrentParentDispatcherId = 0;
+                var v2DispatcherStack = new Stack<(ulong DispatcherId, ulong ParentDispatcherId)>();
+                var v1DispatcherStack = new Stack<(ulong DispatcherId, ulong ParentDispatcherId)>();
                 int index = HeaderSize;
                 long baseTimestamp = (long)header.Value.StartTimestamp;
 
@@ -998,45 +1009,65 @@ namespace System.Threading.Tasks.Tests
                         AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.TaskAsync_CreateAsyncContext =>
                             ParseCreateContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index),
 
-                        AsyncEventID.RuntimeAsync_ResumeAsyncContext or AsyncEventID.TaskAsync_ResumeAsyncContext =>
+                        AsyncEventID.RuntimeAsync_ResumeAsyncContext =>
                             ParseResumeContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index,
-                                ref currentDispatcherId, ref currentParentDispatcherId, dispatcherStack),
+                                ref v2CurrentDispatcherId, ref v2CurrentParentDispatcherId, v2DispatcherStack),
 
-                        AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_CompleteAsyncContext or
-                        AsyncEventID.RuntimeAsync_SuspendAsyncContext or AsyncEventID.TaskAsync_SuspendAsyncContext =>
+                        AsyncEventID.TaskAsync_ResumeAsyncContext =>
+                            ParseResumeContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index,
+                                ref v1CurrentDispatcherId, ref v1CurrentParentDispatcherId, v1DispatcherStack),
+
+                        AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.RuntimeAsync_SuspendAsyncContext =>
                             ParseEndContextEvent(eventId, baseTimestamp, osThreadId,
-                                ref currentDispatcherId, ref currentParentDispatcherId, dispatcherStack),
+                                ref v2CurrentDispatcherId, ref v2CurrentParentDispatcherId, v2DispatcherStack),
 
-                        AsyncEventID.RuntimeAsync_ResumeAsyncMethod or AsyncEventID.RuntimeAsync_CompleteAsyncMethod or
+                        AsyncEventID.TaskAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_SuspendAsyncContext =>
+                            ParseEndContextEvent(eventId, baseTimestamp, osThreadId,
+                                ref v1CurrentDispatcherId, ref v1CurrentParentDispatcherId, v1DispatcherStack),
+
+                        AsyncEventID.RuntimeAsync_ResumeAsyncMethod or AsyncEventID.RuntimeAsync_CompleteAsyncMethod =>
+                            new ParsedEvent
+                            {
+                                EventId = eventId,
+                                Timestamp = baseTimestamp,
+                                OsThreadId = osThreadId,
+                                ParentDispatcherId = v2CurrentParentDispatcherId,
+                                DispatcherId = v2CurrentDispatcherId,
+                            },
+
                         AsyncEventID.TaskAsync_ResumeAsyncMethod or AsyncEventID.TaskAsync_CompleteAsyncMethod =>
                             new ParsedEvent
                             {
                                 EventId = eventId,
                                 Timestamp = baseTimestamp,
                                 OsThreadId = osThreadId,
-                                ParentDispatcherId = currentParentDispatcherId,
-                                DispatcherId = currentDispatcherId,
+                                ParentDispatcherId = v1CurrentParentDispatcherId,
+                                DispatcherId = v1CurrentDispatcherId,
                             },
 
                         AsyncEventID.ResetAsyncThreadContext or AsyncEventID.ResetAsyncContinuationWrapperIndex =>
                             ParseResetEvent(eventId, baseTimestamp, osThreadId,
-                                ref currentDispatcherId, ref currentParentDispatcherId, dispatcherStack),
+                                ref v2CurrentDispatcherId, ref v2CurrentParentDispatcherId, v2DispatcherStack,
+                                ref v1CurrentDispatcherId, ref v1CurrentParentDispatcherId, v1DispatcherStack),
 
                         AsyncEventID.RuntimeAsync_CreateAsyncCallstack or AsyncEventID.RuntimeAsync_ResumeAsyncCallstack or
                         AsyncEventID.RuntimeAsync_SuspendAsyncCallstack or
                         AsyncEventID.TaskAsync_ResumeAsyncCallstack or AsyncEventID.TaskAsync_AppendAsyncCallstack =>
                             ParseCallstackEvent(eventId, baseTimestamp, osThreadId, buffer, ref index),
 
-                        AsyncEventID.RuntimeAsync_UnwindAsyncException or AsyncEventID.TaskAsync_UnwindAsyncException =>
-                            ParseUnwindEvent(eventId, baseTimestamp, osThreadId, currentDispatcherId, currentParentDispatcherId, buffer, ref index),
+                        AsyncEventID.RuntimeAsync_UnwindAsyncException =>
+                            ParseUnwindEvent(eventId, baseTimestamp, osThreadId, v2CurrentDispatcherId, v2CurrentParentDispatcherId, buffer, ref index),
+
+                        AsyncEventID.TaskAsync_UnwindAsyncException =>
+                            ParseUnwindEvent(eventId, baseTimestamp, osThreadId, v1CurrentDispatcherId, v1CurrentParentDispatcherId, buffer, ref index),
 
                         AsyncEventID.AsyncProfilerMetadata =>
-                            ParseMetadataEvent(baseTimestamp, osThreadId, currentDispatcherId, currentParentDispatcherId, buffer, ref index),
+                            ParseMetadataEvent(baseTimestamp, osThreadId, 0, 0, buffer, ref index),
 
                         AsyncEventID.AsyncProfilerSyncClock =>
-                            ParseSyncClockEvent(baseTimestamp, osThreadId, currentDispatcherId, currentParentDispatcherId, buffer, ref index),
+                            ParseSyncClockEvent(baseTimestamp, osThreadId, 0, 0, buffer, ref index),
 
-                        _ => ParseUnknownEvent(eventId, baseTimestamp, osThreadId, currentDispatcherId, currentParentDispatcherId, buffer, ref index)
+                        _ => ParseUnknownEvent(eventId, baseTimestamp, osThreadId, 0, 0, buffer, ref index)
                     };
 
                     Assert.Equal(payloadLength, index - payloadStartIndex);
@@ -1113,16 +1144,20 @@ namespace System.Threading.Tasks.Tests
             }
 
             static ParsedEvent ParseResetEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
-                ref ulong currentDispatcherId, ref ulong currentParentDispatcherId,
-                Stack<(ulong DispatcherId, ulong ParentDispatcherId)> dispatcherStack)
+                ref ulong v2CurrentDispatcherId, ref ulong v2CurrentParentDispatcherId,
+                Stack<(ulong DispatcherId, ulong ParentDispatcherId)> v2DispatcherStack,
+                ref ulong v1CurrentDispatcherId, ref ulong v1CurrentParentDispatcherId,
+                Stack<(ulong DispatcherId, ulong ParentDispatcherId)> v1DispatcherStack)
             {
-                ulong prevDispatcherId = currentDispatcherId;
-                ulong prevParentDispatcherId = currentParentDispatcherId;
+                // ResetAsyncThreadContext is a thread-level reset and clears both kind contexts.
                 if (eventId == AsyncEventID.ResetAsyncThreadContext)
                 {
-                    dispatcherStack.Clear();
-                    currentDispatcherId = 0;
-                    currentParentDispatcherId = 0;
+                    v2DispatcherStack.Clear();
+                    v2CurrentDispatcherId = 0;
+                    v2CurrentParentDispatcherId = 0;
+                    v1DispatcherStack.Clear();
+                    v1CurrentDispatcherId = 0;
+                    v1CurrentParentDispatcherId = 0;
                 }
 
                 return new ParsedEvent
@@ -1130,8 +1165,8 @@ namespace System.Threading.Tasks.Tests
                     EventId = eventId,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
-                    ParentDispatcherId = prevParentDispatcherId,
-                    DispatcherId = prevDispatcherId,
+                    ParentDispatcherId = 0,
+                    DispatcherId = 0,
                 };
             }
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -615,6 +615,80 @@ namespace System.Threading.Tasks.Tests
                 _events.Where(e => e.EventId == callstackEventId && e.HasMarkerFrame(markerMethodName)).ToList();
 
             /// <summary>
+            /// Reconstructs full resume callstacks by merging each ResumeAsyncCallstack with any subsequent
+            /// AppendAsyncCallstack events for the same context, up until the next Suspend/Complete on that
+            /// context.
+            ///
+            /// V1 dispatchers may emit a partial Resume callstack when the parent continuation hasn't yet
+            /// registered (race between dispatcher pickup and parent's AwaitUnsafeOnCompleted). Frames that
+            /// register later are emitted as AppendAsyncCallstack at the next hook point. Merging produces
+            /// the complete chain that was observable during the dispatcher's lifetime.
+            ///
+            /// Returns one ParsedEvent per Resume, with Frames and FrameCount reflecting the merged total.
+            /// </summary>
+            public List<ParsedEvent> MergedResumeCallstacks()
+            {
+                var result = new List<ParsedEvent>();
+                var openByTaskId = new Dictionary<ulong, int>(); // taskId → index into result
+
+                foreach (var evt in _events)
+                {
+                    switch (evt.EventId)
+                    {
+                        case AsyncEventID.ResumeAsyncCallstack:
+                            {
+                                var merged = new ParsedEvent
+                                {
+                                    EventId = evt.EventId,
+                                    Timestamp = evt.Timestamp,
+                                    OsThreadId = evt.OsThreadId,
+                                    TaskId = evt.TaskId,
+                                    CallstackType = evt.CallstackType,
+                                    FrameCount = evt.FrameCount,
+                                    Frames = new List<(ulong MethodId, int State)>(evt.Frames),
+                                };
+                                openByTaskId[evt.TaskId] = result.Count;
+                                result.Add(merged);
+                                break;
+                            }
+                        case AsyncEventID.AppendAsyncCallstack:
+                            {
+                                if (openByTaskId.TryGetValue(evt.TaskId, out int idx))
+                                {
+                                    var existing = result[idx];
+                                    var combinedFrames = new List<(ulong MethodId, int State)>(existing.Frames);
+                                    combinedFrames.AddRange(evt.Frames);
+                                    result[idx] = new ParsedEvent
+                                    {
+                                        EventId = existing.EventId,
+                                        Timestamp = existing.Timestamp,
+                                        OsThreadId = existing.OsThreadId,
+                                        TaskId = existing.TaskId,
+                                        CallstackType = existing.CallstackType,
+                                        FrameCount = (byte)Math.Min(combinedFrames.Count, byte.MaxValue),
+                                        Frames = combinedFrames,
+                                    };
+                                }
+                                break;
+                            }
+                        case AsyncEventID.SuspendAsyncContext:
+                        case AsyncEventID.CompleteAsyncContext:
+                            openByTaskId.Remove(evt.TaskId);
+                            break;
+                    }
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Get merged resume callstacks (Resume + subsequent Appends) that contain the marker method
+            /// in any of their merged frames.
+            /// </summary>
+            public List<ParsedEvent> MergedResumeCallstacksWithMarker(string markerMethodName) =>
+                MergedResumeCallstacks().Where(e => e.HasMarkerFrame(markerMethodName)).ToList();
+
+            /// <summary>
             /// Get callstack events (of specified type) that contain the marker method,
             /// taking only the first match per Task.Id (deepest chain by timestamp).
             /// </summary>

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -52,6 +52,52 @@ namespace System.Threading.Tasks.Tests
         Runtime = 0x2,
     }
 
+    internal readonly record struct EventManifestEntry(AsyncEventID EventId, byte Version, byte FieldSize);
+
+    internal static class EventManifest
+    {
+        // Default manifest matching the current runtime emit; replaced when the parser
+        // observes an AsyncProfilerMetadata event carrying a per-event manifest.
+        // Dense, ordered by ascending (byte)AsyncEventID; lookups use (byte)id - 1.
+        public static readonly EventManifestEntry[] DefaultEntries = BuildDefaultEntries();
+
+        private static EventManifestEntry[] BuildDefaultEntries()
+        {
+            const byte NoPayload = 0;
+            const byte BytePayloadLength = 1;
+            const byte UShortPayloadLength = 2;
+
+            return
+            [
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_CreateAsyncContext, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncContext, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_SuspendAsyncContext, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_CompleteAsyncContext, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_UnwindAsyncException, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncMethod, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.RuntimeAsync_CompleteAsyncMethod, 1, NoPayload),
+
+                new EventManifestEntry(AsyncEventID.TaskAsync_CreateAsyncContext, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncContext, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.TaskAsync_SuspendAsyncContext, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.TaskAsync_CompleteAsyncContext, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.TaskAsync_UnwindAsyncException, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncCallstack, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncMethod, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.TaskAsync_CompleteAsyncMethod, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.TaskAsync_AppendAsyncCallstack, 1, UShortPayloadLength),
+
+                new EventManifestEntry(AsyncEventID.ResetAsyncThreadContext, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.ResetAsyncContinuationWrapperIndex, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.AsyncProfilerMetadata, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.AsyncProfilerSyncClock, 1, BytePayloadLength),
+            ];
+        }
+    }
+
     [ActiveIssue("https://github.com/dotnet/runtime/issues/127951", TestPlatforms.Android | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
     public partial class AsyncProfilerTests
     {
@@ -255,6 +301,30 @@ namespace System.Threading.Tasks.Tests
 
         private delegate bool EventVisitorWithTimestamp(AsyncEventID eventId, long timestamp, ReadOnlySpan<byte> buffer, ref int index);
 
+        // Reads the per-event payload length prefix (0, 1, or 2 bytes depending on the event manifest)
+        // and advances the index past it. Returns the declared payload length so callers can validate
+        // that downstream parsers consume exactly the indicated bytes.
+        private static int ReadPayloadLengthPrefix(ReadOnlySpan<byte> buffer, AsyncEventID eventId, ref int index)
+        {
+            int eventIdIndex = (byte)eventId - 1;
+            int payloadLengthFieldSize = (uint)eventIdIndex < (uint)EventManifest.DefaultEntries.Length
+                ? EventManifest.DefaultEntries[eventIdIndex].FieldSize
+                : 0;
+
+            if (payloadLengthFieldSize == 0)
+            {
+                return 0;
+            }
+            if (payloadLengthFieldSize == 1)
+            {
+                return buffer[index++];
+            }
+
+            int payloadLength = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(index));
+            index += 2;
+            return payloadLength;
+        }
+
         private static void ParseEventBuffer(ReadOnlySpan<byte> buffer, EventVisitorWithTimestamp visitor)
         {
             EventBufferHeader? header = ParseEventBufferHeader(buffer);
@@ -278,10 +348,14 @@ namespace System.Threading.Tasks.Tests
                 long delta = (long)ReadCompressedUInt64(buffer, ref index);
                 baseTimestamp += delta;
 
+                int payloadLength = ReadPayloadLengthPrefix(buffer, eventId, ref index);
+                int payloadStartIndex = index;
                 if (!visitor(eventId, baseTimestamp, buffer, ref index))
                 {
                     break;
                 }
+
+                Assert.Equal(payloadLength, index - payloadStartIndex);
             }
         }
 
@@ -439,6 +513,10 @@ namespace System.Threading.Tasks.Tests
             utcSync = ReadCompressedUInt64(buffer, ref index);
             eventBufferSize = ReadCompressedUInt32(buffer, ref index);
             wrapperCount = buffer[index++];
+
+            // Per-event manifest: [count: byte] followed by [id, version, payloadLengthFieldSize] triples.
+            byte manifestCount = buffer[index++];
+            index += manifestCount * 3;
         }
 
         private record struct MetadataFromBuffer(ulong QpcFrequency, ulong QpcSync, ulong UtcSync, uint EventBufferSize, byte WrapperCount);
@@ -810,6 +888,9 @@ namespace System.Threading.Tasks.Tests
                     long delta = (long)ReadCompressedUInt64(buffer, ref index);
                     baseTimestamp += delta;
 
+                    int payloadLength = ReadPayloadLengthPrefix(buffer, eventId, ref index);
+                    int payloadStartIndex = index;
+
                     ParsedEvent evt = eventId switch
                     {
                         AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.TaskAsync_CreateAsyncContext =>
@@ -855,6 +936,8 @@ namespace System.Threading.Tasks.Tests
 
                         _ => ParseUnknownEvent(eventId, baseTimestamp, osThreadId, currentDispatcherId, currentParentDispatcherId, buffer, ref index)
                     };
+
+                    Assert.Equal(payloadLength, index - payloadStartIndex);
 
                     allEvents.Add(evt);
                 }
@@ -1435,6 +1518,7 @@ namespace System.Threading.Tasks.Tests
 
                     OutputHeader(eventCount, eventId, currentTimestamp);
 
+                    _ = ReadPayloadLengthPrefix(buffer, eventId, ref index);
                     int payloadStart = index;
                     try
                     {
@@ -1589,6 +1673,16 @@ namespace System.Threading.Tasks.Tests
 
                 byte wrapperCount = buffer[index++];
                 Console.WriteLine($"  WrapperCount: {wrapperCount}");
+
+                byte manifestCount = buffer[index++];
+                Console.WriteLine($"  EventManifestCount: {manifestCount}");
+                for (int i = 0; i < manifestCount; i++)
+                {
+                    byte id = buffer[index++];
+                    byte version = buffer[index++];
+                    byte payloadLengthFieldSize = buffer[index++];
+                    Console.WriteLine($"    [{(AsyncEventID)id}] version={version} payloadLengthFieldSize={payloadLengthFieldSize}");
+                }
 
                 return index;
             }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -115,11 +115,16 @@ namespace System.Threading.Tasks.Tests
         // StateMachine (StateMachineAsync_*) async-task instrumentation is opt-out on NativeAOT to avoid
         // ~100KB of per-state-machine generic instantiation overhead. Tests that depend
         // on StateMachine events must be gated on these properties so they are skipped on NAOT.
-        public static bool IsStateMachineAsyncInstrumentationSupported =>
+        public static bool IsStateMachineAsyncSupported =>
             IsRuntimeAsyncSupported && !PlatformDetection.IsNativeAot;
 
-        public static bool IsStateMachineAsyncInstrumentationAndThreadingSupported =>
+        public static bool IsStateMachineAsyncAndThreadingSupported =>
             IsRuntimeAsyncAndThreadingSupported && !PlatformDetection.IsNativeAot;
+
+        // Gate for tests that exercise a mixed V1 (StateMachine) + V2 (RuntimeAsync) chain: they need both
+        // instrumentation paths, and V1 is disabled on NativeAOT, so require both conditions.
+        public static bool IsStateMachineAsyncAndRuntimeAsyncAndThreadingSupported =>
+            IsStateMachineAsyncAndThreadingSupported && IsRuntimeAsyncAndThreadingSupported;
 
         private const string AsyncProfilerEventSourceName = "System.Runtime.CompilerServices.AsyncProfilerEventSource";
         private const string WrapperNameTemplate = "Continuation_Wrapper_{0}";

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -344,14 +344,15 @@ namespace System.Threading.Tasks.Tests
         private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index,
             out byte frameCount, out List<(ulong MethodId, int State)> frames)
         {
-            ReadCallstackPayload(buffer, ref index, out _, out _, out frameCount, out frames);
+            ReadCallstackPayload(buffer, ref index, out _, out _, out _, out frameCount, out frames);
         }
 
         private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index,
-            out ulong taskId, out AsyncCallstackType callstackType, out byte frameCount, out List<(ulong MethodId, int State)> frames)
+            out ulong taskId, out AsyncCallstackType callstackType, out byte continuationIndex, out byte frameCount, out List<(ulong MethodId, int State)> frames)
         {
             callstackType = (AsyncCallstackType)buffer[index++];
-            index++;
+            index++; // Reserved callstack ID (for future callstack interning).
+            continuationIndex = buffer[index++];
             frameCount = buffer[index++];
             taskId = ReadCompressedUInt64(buffer, ref index);
             frames = new List<(ulong, int)>(frameCount);
@@ -432,6 +433,7 @@ namespace System.Threading.Tasks.Tests
             public ulong TaskId { get; init; }
 
             public AsyncCallstackType CallstackType { get; init; }
+            public byte ContinuationIndex { get; init; }
             public byte FrameCount { get; init; }
             public List<(ulong MethodId, int State)> Frames { get; init; } = [];
 
@@ -555,6 +557,7 @@ namespace System.Threading.Tasks.Tests
                                 OsThreadId = evt.OsThreadId,
                                 TaskId = evt.TaskId,
                                 CallstackType = evt.CallstackType,
+                                ContinuationIndex = evt.ContinuationIndex,
                                 FrameCount = evt.FrameCount,
                                 Frames = new List<(ulong MethodId, int State)>(evt.Frames),
                             };
@@ -579,6 +582,7 @@ namespace System.Threading.Tasks.Tests
                                     OsThreadId = existing.OsThreadId,
                                     TaskId = existing.TaskId,
                                     CallstackType = existing.CallstackType,
+                                    ContinuationIndex = existing.ContinuationIndex,
                                     FrameCount = (byte)Math.Min(combinedFrames.Count, byte.MaxValue),
                                     Frames = combinedFrames,
                                 };
@@ -757,7 +761,7 @@ namespace System.Threading.Tasks.Tests
             static ParsedEvent ParseCallstackEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
                 ReadOnlySpan<byte> buffer, ref int index, ref ulong currentTaskId, Stack<ulong> taskIdStack)
             {
-                ReadCallstackPayload(buffer, ref index, out ulong taskId, out AsyncCallstackType callstackType, out byte frameCount, out var frames);
+                ReadCallstackPayload(buffer, ref index, out ulong taskId, out AsyncCallstackType callstackType, out byte continuationIndex, out byte frameCount, out var frames);
                 if (taskId != currentTaskId)
                 {
                     taskIdStack.Push(currentTaskId);
@@ -771,6 +775,7 @@ namespace System.Threading.Tasks.Tests
                     OsThreadId = osThreadId,
                     TaskId = taskId,
                     CallstackType = callstackType,
+                    ContinuationIndex = continuationIndex,
                     FrameCount = frameCount,
                     Frames = frames
                 };
@@ -1385,17 +1390,20 @@ namespace System.Threading.Tasks.Tests
                 ulong id;
                 byte type;
                 byte callstackId;
+                byte continuationIndex;
                 byte asyncCallstackLength;
                 int index = 0;
 
                 type = buffer[index++];
                 callstackId = buffer[index++];
+                continuationIndex = buffer[index++];
                 asyncCallstackLength = buffer[index++];
                 Deserializer.ReadCompressedUInt64(buffer, ref index, out id);
 
                 Console.WriteLine($"  ID: {id}");
                 Console.WriteLine($"  Type: {type}");
                 Console.WriteLine($"  CallstackId: {callstackId}");
+                Console.WriteLine($"  ContinuationIndex: {continuationIndex}");
                 Console.WriteLine($"  Length: {asyncCallstackLength}");
 
                 if (asyncCallstackLength == 0)

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -125,7 +125,19 @@ namespace System.Threading.Tasks.Tests
                 else if (callstackType == AsyncCallstackType.Compiler)
                 {
                     System.RuntimeMethodHandle handle = RuntimeMethodHandle.FromIntPtr((IntPtr)methodId);
-                    MethodBase? method = MethodBase.GetMethodFromHandle(handle);
+                    MethodBase? method = null;
+                    try
+                    {
+                        method = MethodBase.GetMethodFromHandle(handle);
+                    }
+                    catch (ArgumentException)
+                    {
+                        // The 1-arg GetMethodFromHandle cannot resolve handles whose declaring
+                        // type is generic (e.g. xUnit's TestClassRunner<TTestCase>+<...>d__N);
+                        // it requires the 2-arg overload with an explicit declaring type, which
+                        // we cannot recover from a bare MethodId. Real ETW/EventPipe consumers
+                        // get the declaring type from method-metadata rundown events.
+                    }
                     if (method != null)
                     {
                         string methodName = method.DeclaringType.Name;

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -30,6 +30,15 @@ namespace System.Threading.Tasks.Tests
         ResetAsyncContinuationWrapperIndex = 12,
         AsyncProfilerMetadata = 13,
         AsyncProfilerSyncClock = 14,
+        AppendAsyncCallstack = 15,
+    }
+
+    //Mirrors AsyncProfiler.AsyncCallstackType from the runtime (which is internal and inaccessible from tests).
+    public enum AsyncCallstackType : byte
+    {
+        Compiler = 0x1,
+        Runtime = 0x2,
+        Cached = 0x80
     }
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/127951", TestPlatforms.Android | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
@@ -95,19 +104,45 @@ namespace System.Threading.Tasks.Tests
                 ? typeof(StackFrame).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, new[] { typeof(IntPtr), typeof(bool) }, null)
                 : null;
 
-        internal static string? GetMethodNameFromNativeIP(ulong nativeIP)
+        internal static string? GetMethodNameFromMethodId(AsyncCallstackType callstackType, ulong methodId)
         {
-            if (s_getMethodFromNativeIPMethod is not null)
+            if (methodId != 0)
             {
-                var method = (MethodBase?)s_getMethodFromNativeIPMethod.Invoke(null, new object[] { (IntPtr)nativeIP });
-                return method?.Name;
-            }
+                if (callstackType == AsyncCallstackType.Runtime)
+                {
+                    if (s_getMethodFromNativeIPMethod is not null)
+                    {
+                        var method = (MethodBase?)s_getMethodFromNativeIPMethod.Invoke(null, new object[] { (IntPtr)methodId });
+                        return method?.Name;
+                    }
 
-            if (s_stackFrameFromIPCtor is not null)
-            {
-                var frame = (StackFrame)s_stackFrameFromIPCtor.Invoke(new object[] { (IntPtr)nativeIP, false })!;
-                var diagInfo = DiagnosticMethodInfo.Create(frame);
-                return diagInfo?.Name;
+                    if (s_stackFrameFromIPCtor is not null)
+                    {
+                        var frame = (StackFrame)s_stackFrameFromIPCtor.Invoke(new object[] { (IntPtr)methodId, false })!;
+                        var diagInfo = DiagnosticMethodInfo.Create(frame);
+                        return diagInfo?.Name;
+                    }
+                }
+                else if (callstackType == AsyncCallstackType.Compiler)
+                {
+                    System.RuntimeMethodHandle handle = RuntimeMethodHandle.FromIntPtr((IntPtr)methodId);
+                    MethodBase? method = MethodBase.GetMethodFromHandle(handle);
+                    if (method != null)
+                    {
+                        string methodName = method.DeclaringType.Name;
+
+                        int start = methodName.IndexOf('<');
+                        int end = methodName.IndexOf('>');
+
+                        start++;
+                        if (start > 0 && end > start)
+                        {
+                            methodName = methodName.Substring(start, end - start);
+                        }
+
+                        return methodName;
+                    }
+                }
             }
 
             return null;
@@ -370,6 +405,7 @@ namespace System.Threading.Tasks.Tests
                 case AsyncEventID.CreateAsyncCallstack:
                 case AsyncEventID.ResumeAsyncCallstack:
                 case AsyncEventID.SuspendAsyncCallstack:
+                case AsyncEventID.AppendAsyncCallstack:
                     SkipCallstackPayload(buffer, ref index);
                     return true;
                 default:
@@ -395,15 +431,15 @@ namespace System.Threading.Tasks.Tests
         }
 
         private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index,
-            out byte frameCount, out List<(ulong NativeIP, int State)> frames)
+            out byte frameCount, out List<(ulong MethodId, int State)> frames)
         {
-            ReadCallstackPayload(buffer, ref index, out _, out frameCount, out frames);
+            ReadCallstackPayload(buffer, ref index, out _, out _, out frameCount, out frames);
         }
 
         private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index,
-            out ulong taskId, out byte frameCount, out List<(ulong NativeIP, int State)> frames)
+            out ulong taskId, out AsyncCallstackType callstackType, out byte frameCount, out List<(ulong MethodId, int State)> frames)
         {
-            index++; // type
+            callstackType = (AsyncCallstackType)buffer[index++]; // type
             index++; // callstack ID (reserved)
             frameCount = buffer[index++];
             taskId = ReadCompressedUInt64(buffer, ref index);
@@ -412,16 +448,16 @@ namespace System.Threading.Tasks.Tests
             if (frameCount == 0)
                 return;
 
-            ulong currentNativeIP = ReadCompressedUInt64(buffer, ref index);
+            ulong currentMethodId = ReadCompressedUInt64(buffer, ref index);
             int state = ReadCompressedInt32(buffer, ref index);
-            frames.Add((currentNativeIP, state));
+            frames.Add((currentMethodId, state));
 
             for (int i = 1; i < frameCount; i++)
             {
                 long delta = ReadCompressedInt64(buffer, ref index);
                 state = ReadCompressedInt32(buffer, ref index);
-                currentNativeIP = (ulong)((long)currentNativeIP + delta);
-                frames.Add((currentNativeIP, state));
+                currentMethodId = (ulong)((long)currentMethodId + delta);
+                frames.Add((currentMethodId, state));
             }
         }
 
@@ -486,8 +522,9 @@ namespace System.Threading.Tasks.Tests
             public ulong TaskId { get; init; }
 
             // Callstack events (Create/Resume/Suspend): frames
+            public AsyncCallstackType CallstackType { get; init; }
             public byte FrameCount { get; init; }
-            public List<(ulong NativeIP, int State)> Frames { get; init; } = [];
+            public List<(ulong MethodId, int State)> Frames { get; init; } = [];
 
             // UnwindAsyncException: frame count unwound
             public uint UnwindFrameCount { get; init; }
@@ -507,9 +544,9 @@ namespace System.Threading.Tasks.Tests
             {
                 if (Frames.Count == 0)
                     return false;
-                foreach (var (nativeIP, _) in Frames)
+                foreach (var (methodId, _) in Frames)
                 {
-                    var methodName = GetMethodNameFromNativeIP(nativeIP);
+                    var methodName = GetMethodNameFromMethodId(CallstackType, methodId);
                     if (methodName is not null && methodName.Contains(markerMethodName, StringComparison.Ordinal))
                         return true;
                 }
@@ -614,6 +651,7 @@ namespace System.Threading.Tasks.Tests
 
                 ulong osThreadId = header.Value.OsThreadId;
                 ulong currentTaskId = 0;
+                var taskIdStack = new Stack<ulong>();
                 int index = HeaderSize;
                 long baseTimestamp = (long)header.Value.StartTimestamp;
 
@@ -629,9 +667,12 @@ namespace System.Threading.Tasks.Tests
                     ParsedEvent evt = eventId switch
                     {
                         AsyncEventID.CreateAsyncContext or AsyncEventID.ResumeAsyncContext =>
-                            ParseContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index, ref currentTaskId),
+                            ParseContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index, ref currentTaskId, taskIdStack),
 
-                        AsyncEventID.SuspendAsyncContext or AsyncEventID.CompleteAsyncContext or
+                        AsyncEventID.CompleteAsyncContext =>
+                            ParseCompleteContextEvent(baseTimestamp, osThreadId, ref currentTaskId, taskIdStack),
+
+                        AsyncEventID.SuspendAsyncContext or
                         AsyncEventID.ResumeAsyncMethod or AsyncEventID.CompleteAsyncMethod =>
                             new ParsedEvent
                             {
@@ -645,8 +686,8 @@ namespace System.Threading.Tasks.Tests
                             ParseResetEvent(eventId, baseTimestamp, osThreadId, ref currentTaskId),
 
                         AsyncEventID.CreateAsyncCallstack or AsyncEventID.ResumeAsyncCallstack or
-                        AsyncEventID.SuspendAsyncCallstack =>
-                            ParseCallstackEvent(eventId, baseTimestamp, osThreadId, buffer, ref index),
+                        AsyncEventID.SuspendAsyncCallstack or AsyncEventID.AppendAsyncCallstack =>
+                            ParseCallstackEvent(eventId, baseTimestamp, osThreadId, buffer, ref index, ref currentTaskId, taskIdStack),
 
                         AsyncEventID.UnwindAsyncException =>
                             ParseUnwindEvent(baseTimestamp, osThreadId, currentTaskId, buffer, ref index),
@@ -667,9 +708,11 @@ namespace System.Threading.Tasks.Tests
             return new ParsedEventStream(allEvents);
 
             static ParsedEvent ParseContextEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
-                ReadOnlySpan<byte> buffer, ref int index, ref ulong currentTaskId)
+                ReadOnlySpan<byte> buffer, ref int index, ref ulong currentTaskId, Stack<ulong> taskIdStack)
             {
                 ulong id = ReadCompressedUInt64(buffer, ref index);
+                if (eventId == AsyncEventID.ResumeAsyncContext && id != currentTaskId)
+                    taskIdStack.Push(currentTaskId);
                 currentTaskId = id;
                 return new ParsedEvent
                 {
@@ -677,6 +720,20 @@ namespace System.Threading.Tasks.Tests
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
                     TaskId = id
+                };
+            }
+
+            static ParsedEvent ParseCompleteContextEvent(long timestamp, ulong osThreadId,
+                ref ulong currentTaskId, Stack<ulong> taskIdStack)
+            {
+                ulong completedTaskId = currentTaskId;
+                currentTaskId = taskIdStack.Count > 0 ? taskIdStack.Pop() : 0;
+                return new ParsedEvent
+                {
+                    EventId = AsyncEventID.CompleteAsyncContext,
+                    Timestamp = timestamp,
+                    OsThreadId = osThreadId,
+                    TaskId = completedTaskId
                 };
             }
 
@@ -695,15 +752,21 @@ namespace System.Threading.Tasks.Tests
             }
 
             static ParsedEvent ParseCallstackEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
-                ReadOnlySpan<byte> buffer, ref int index)
+                ReadOnlySpan<byte> buffer, ref int index, ref ulong currentTaskId, Stack<ulong> taskIdStack)
             {
-                ReadCallstackPayload(buffer, ref index, out ulong taskId, out byte frameCount, out var frames);
+                ReadCallstackPayload(buffer, ref index, out ulong taskId, out AsyncCallstackType callstackType, out byte frameCount, out var frames);
+                if (taskId != currentTaskId)
+                {
+                    taskIdStack.Push(currentTaskId);
+                    currentTaskId = taskId;
+                }
                 return new ParsedEvent
                 {
                     EventId = eventId,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
                     TaskId = taskId,
+                    CallstackType = callstackType,
                     FrameCount = frameCount,
                     Frames = frames
                 };
@@ -793,8 +856,20 @@ namespace System.Threading.Tasks.Tests
 
         private static void RunScenarioAndFlush(Func<Task> scenario)
         {
-            Task.Run(scenario).GetAwaiter().GetResult();
-            SendFlushCommand();
+            // V1 (task-based) async: the dispatcher's finally block emits CompleteAsyncContext
+            // after inner.MoveNext() returns, but MoveNext() already set the task result which
+            // unblocks this thread. Brief sleep ensures the pool thread's finally completes.
+            // V2 (runtime-async) does not have this issue — Complete fires inside the dispatch
+            // loop before the task is signaled.
+            try
+            {
+                Task.Run(scenario).GetAwaiter().GetResult();
+            }
+            finally
+            {
+                Thread.Sleep(50);
+                SendFlushCommand();
+            }
         }
 
         private static void RunScenario(Func<Task> scenario)
@@ -870,7 +945,7 @@ namespace System.Threading.Tasks.Tests
             foreach (var cs in callstacks)
             {
                 var resolvedNames = cs.Frames
-                    .Select(f => GetMethodNameFromNativeIP(f.NativeIP))
+                    .Select(f => GetMethodNameFromMethodId(cs.CallstackType, f.MethodId))
                     .ToList();
 
                 int matchIndex = 0;
@@ -1119,7 +1194,7 @@ namespace System.Threading.Tasks.Tests
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in create callstack");
                 Assert.True(cs.TaskId != 0, "Expected non-zero task ID in create callstack");
-                Assert.True(cs.Frames[0].NativeIP != 0, "Expected non-zero NativeIP in first frame");
+                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
             });
         }
 
@@ -1173,7 +1248,7 @@ namespace System.Threading.Tasks.Tests
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in suspend callstack");
                 Assert.True(cs.TaskId != 0, "Expected non-zero task ID in suspend callstack");
-                Assert.True(cs.Frames[0].NativeIP != 0, "Expected non-zero NativeIP in first frame");
+                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
             });
         }
 
@@ -1339,7 +1414,7 @@ namespace System.Threading.Tasks.Tests
                 Assert.Equal(create.Frames.Count, matchingResume.Frames.Count);
                 for (int i = 0; i < create.Frames.Count; i++)
                 {
-                    Assert.Equal(create.Frames[i].NativeIP, matchingResume.Frames[i].NativeIP);
+                    Assert.Equal(create.Frames[i].MethodId, matchingResume.Frames[i].MethodId);
                 }
             }
 
@@ -1369,7 +1444,7 @@ namespace System.Threading.Tasks.Tests
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in callstack");
                 Assert.True(cs.TaskId != 0, "Expected non-zero task ID in resume callstack");
-                Assert.True(cs.Frames[0].NativeIP != 0, "Expected non-zero NativeIP in first frame");
+                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
             });
         }
 
@@ -1991,15 +2066,15 @@ namespace System.Threading.Tasks.Tests
             {
                 for (int i = 0; i < cs.Frames.Count; i++)
                 {
-                    var (nativeIP, _) = cs.Frames[i];
-                    Assert.True(nativeIP != 0, $"Frame {i} has zero NativeIP");
+                    var (methodId, _) = cs.Frames[i];
+                    Assert.True(methodId != 0, $"Frame {i} has zero MethodId");
 
-                    var method = GetMethodNameFromNativeIP(nativeIP);
-                    Assert.True(method is not null, $"Frame {i}: NativeIP 0x{nativeIP:X} does not resolve to a managed method");
+                    var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
+                    Assert.True(method is not null, $"Frame {i}: MethodId 0x{methodId:X} does not resolve to a managed method");
 
                     if (i > 0)
                     {
-                        long delta = (long)(cs.Frames[i].NativeIP - cs.Frames[i - 1].NativeIP);
+                        long delta = (long)(cs.Frames[i].MethodId - cs.Frames[i - 1].MethodId);
                         if (delta > 0)
                             hasPositiveDelta = true;
                         else if (delta < 0)
@@ -2060,11 +2135,11 @@ namespace System.Threading.Tasks.Tests
                 Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
                 for (int f = 0; f < cs.Frames.Count; f++)
                 {
-                    var (nativeIP, _) = cs.Frames[f];
-                    Assert.True(nativeIP != 0, $"Frame {f} has zero NativeIP");
+                    var (methodId, _) = cs.Frames[f];
+                    Assert.True(methodId != 0, $"Frame {f} has zero MethodId");
 
-                    var method = GetMethodNameFromNativeIP(nativeIP);
-                    Assert.True(method is not null, $"Frame {f}: NativeIP 0x{nativeIP:X} does not resolve to a managed method");
+                    var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
+                    Assert.True(method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
                 }
             }
 
@@ -2210,11 +2285,11 @@ namespace System.Threading.Tasks.Tests
                         Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
                         for (int f = 0; f < cs.Frames.Count; f++)
                         {
-                            var (nativeIP, _) = cs.Frames[f];
-                            Assert.True(nativeIP != 0, $"Overflow callstack frame {f} has zero NativeIP");
+                            var (methodId, _) = cs.Frames[f];
+                            Assert.True(methodId != 0, $"Overflow callstack frame {f} has zero MethodId");
 
-                            var method = GetMethodNameFromNativeIP(nativeIP);
-                            Assert.True(method is not null, $"Overflow callstack frame {f}: NativeIP 0x{nativeIP:X} does not resolve to a managed method");
+                            var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
+                            Assert.True(method is not null, $"Overflow callstack frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
                         }
                     }
                 }
@@ -2258,11 +2333,11 @@ namespace System.Threading.Tasks.Tests
             Assert.Equal((int)deepest.FrameCount, deepest.Frames.Count);
 
             // Verify all frames are valid.
-            foreach (var (nativeIP, _) in deepest.Frames)
+            foreach (var (methodId, _) in deepest.Frames)
             {
-                Assert.True(nativeIP != 0, "Frame has zero NativeIP");
-                var method = GetMethodNameFromNativeIP(nativeIP);
-                Assert.True(method is not null, $"NativeIP 0x{nativeIP:X} does not resolve to a managed method");
+                Assert.True(methodId != 0, "Frame has zero MethodId");
+                var method = GetMethodNameFromMethodId(deepest.CallstackType, methodId);
+                Assert.True(method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
             }
         }
 
@@ -2371,6 +2446,7 @@ namespace System.Threading.Tasks.Tests
                         AsyncEventID.CreateAsyncCallstack => OutputAsyncCallstackEvent("CreateAsyncCallstack", buffer.Slice(index)),
                         AsyncEventID.ResumeAsyncCallstack => OutputAsyncCallstackEvent("ResumeAsyncCallstack", buffer.Slice(index)),
                         AsyncEventID.SuspendAsyncCallstack => OutputAsyncCallstackEvent("SuspendAsyncCallstack", buffer.Slice(index)),
+                        AsyncEventID.AppendAsyncCallstack => OutputAsyncCallstackEvent("AppendAsyncCallstack", buffer.Slice(index)),
                         AsyncEventID.ResumeAsyncMethod => OutputResumeAsyncMethodEvent(),
                         AsyncEventID.CompleteAsyncMethod => OutputCompleteAsyncMethodEvent(),
                         AsyncEventID.ResetAsyncThreadContext => OutputResetAsyncThreadContextEvent(),
@@ -2539,32 +2615,32 @@ namespace System.Threading.Tasks.Tests
                 return index;
             }
 
-            ulong previousNativeIP;
-            ulong currentNativeIP;
+            ulong previousMethodId;
+            ulong currentMethodId;
             int state;
 
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out currentNativeIP);
+            Deserializer.ReadCompressedUInt64(buffer, ref index, out currentMethodId);
             Deserializer.ReadCompressedInt32(buffer, ref index, out state);
 
-            OutputAsyncFrame(currentNativeIP, state, 0);
+            OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, 0);
 
             for (int i = 1; i < asyncCallstackLength; i++)
             {
-                previousNativeIP = currentNativeIP;
-                Deserializer.ReadCompressedInt64(buffer, ref index, out long nativeIPDelta);
+                previousMethodId = currentMethodId;
+                Deserializer.ReadCompressedInt64(buffer, ref index, out long methodIdDelta);
                 Deserializer.ReadCompressedInt32(buffer, ref index, out state);
-                currentNativeIP = previousNativeIP + (ulong)nativeIPDelta;
-                OutputAsyncFrame(currentNativeIP, state, i);
+                currentMethodId = previousMethodId + (ulong)methodIdDelta;
+                OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, i);
             }
 
             return index;
         }
 
-        private static void OutputAsyncFrame(ulong nativeIP, int state, int frameIndex)
+        private static void OutputAsyncFrame(AsyncCallstackType type, ulong methodId, int state, int frameIndex)
         {
-            string asyncMethodName = AsyncProfilerTests.GetMethodNameFromNativeIP(nativeIP) ?? "??";
-            string nativeIPString = $"0x{nativeIP:X}";
-            Console.WriteLine($"  Frame {frameIndex}: AsyncMethod = {asyncMethodName}, NativeIP = {nativeIPString}, State = {state}");
+            string asyncMethodName = AsyncProfilerTests.GetMethodNameFromMethodId(type, methodId) ?? "??";
+            string methodIdString = $"0x{methodId:X}";
+            Console.WriteLine($"  Frame {frameIndex}: AsyncMethod = {asyncMethodName}, MethodId = {methodIdString}, State = {state}");
         }
 
         internal static class Deserializer

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -658,8 +658,14 @@ namespace System.Threading.Tasks.Tests
 
             public ParsedEventStream(List<ParsedEvent> events)
             {
-                _events = events;
-                _events.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
+                // Stable sort by timestamp: events that share a Stopwatch tick keep their original
+                // parse (emission) order, which preserves each thread's relative event order. The
+                // input list is built in emission order by the parser. List<T>.Sort is an UNSTABLE
+                // sort and would scramble same-timestamp events, breaking the ordering-sensitive
+                // assertions (e.g. Suspend-before-Complete, Create-before-Resume) on platforms where
+                // many events share a timestamp (e.g. single-threaded WASM). Enumerable.OrderBy is a
+                // documented stable sort.
+                _events = events.OrderBy(e => e.Timestamp).ToList();
             }
 
             // All events in timestamp order.
@@ -1284,6 +1290,41 @@ namespace System.Threading.Tasks.Tests
             EventBuffer.DumpAllEvents(events);
         }
 
+        // Runs a scenario whose synchronous prefix may install a custom SynchronizationContext (or
+        // TaskScheduler) on the running thread. On multi-threaded platforms the prefix runs on a
+        // dedicated, short-lived thread so that any context it installs -- and leaves in place when
+        // the await suspends -- dies with that throwaway thread instead of leaking onto a shared
+        // thread-pool thread. On single-threaded platforms (e.g. WASM) threads can't be created and
+        // the await resumes on the same (only) thread, so the scenario's own same-thread-guarded
+        // finally restores the context; there the scenario is simply run inline.
+        private static Task RunIsolatedScenarioAsync(Func<Task> scenario)
+        {
+            if (!PlatformDetection.IsMultithreadingSupported)
+            {
+                return scenario();
+            }
+
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    scenario().GetAwaiter().GetResult();
+                    tcs.SetResult();
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "AsyncProfilerIsolatedScenario"
+            };
+            thread.Start();
+            return tcs.Task;
+        }
+
         private static void RunScenarioAndFlush(Func<Task> scenario)
         {
             // V1 (task-based) async: the dispatcher's finally block emits CompleteAsyncContext
@@ -1415,11 +1456,27 @@ namespace System.Threading.Tasks.Tests
         //   unwind - UnwindFrameCount (for UnwindAsyncException events)
         private static string DescribeEvents(ParsedEventStream stream)
         {
-            var ordered = stream.All.OrderBy(e => e.Timestamp).ToList();
+            // stream.All is already stably sorted by timestamp (ties keep emission/thread order).
+            var ordered = stream.All;
             long t0 = ordered.Count > 0 ? ordered[0].Timestamp : 0;
             const string Header = "seq,delta,thread,event,disp,parent,frames,unwind";
-            var rows = ordered.Select((e, i) =>
-                $"{i},{e.Timestamp - t0},{e.OsThreadId},{e.EventId},{e.DispatcherId},{e.ParentDispatcherId},{e.FrameCount},{e.UnwindFrameCount}");
+            // Emit a strictly increasing delta so the CSV stays correctly ordered if it is re-sorted
+            // by the delta column downstream (e.g. after importing into a table): consecutive events
+            // that shared a timestamp get successive deltas instead of duplicates. A real timing gap
+            // still shows as a large jump, so cluster-vs-gap readability is preserved.
+            var rows = new List<string>(ordered.Count);
+            long prevDelta = long.MinValue;
+            for (int i = 0; i < ordered.Count; i++)
+            {
+                var e = ordered[i];
+                long delta = e.Timestamp - t0;
+                if (delta <= prevDelta)
+                {
+                    delta = prevDelta + 1;
+                }
+                prevDelta = delta;
+                rows.Add($"{i},{delta},{e.OsThreadId},{e.EventId},{e.DispatcherId},{e.ParentDispatcherId},{e.FrameCount},{e.UnwindFrameCount}");
+            }
             return "----- BEGIN ASYNC EVENTS (CSV) -----" + Environment.NewLine
                 + Header + Environment.NewLine
                 + string.Join(Environment.NewLine, rows) + Environment.NewLine

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -33,7 +33,7 @@ namespace System.Threading.Tasks.Tests
     }
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/127951", TestPlatforms.Android | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
-    public class AsyncProfilerTests
+    public partial class AsyncProfilerTests
     {
         // The test scenarios drive async work via Task.Run(...).GetAwaiter().GetResult() (see
         // RunScenarioAndFlush / RunScenario), which requires synchronous blocking waits. On
@@ -2376,6 +2376,7 @@ namespace System.Threading.Tasks.Tests
                         AsyncEventID.ResetAsyncThreadContext => OutputResetAsyncThreadContextEvent(),
                         AsyncEventID.ResetAsyncContinuationWrapperIndex => OutputResetAsyncContinuationWrapperIndexEvent(),
                         AsyncEventID.AsyncProfilerMetadata => OutputAsyncProfilerMetadataEvent(buffer.Slice(index)),
+                        AsyncEventID.AsyncProfilerSyncClock => OutputAsyncProfilerSyncClockEvent(buffer.Slice(index)),
                         _ => throw new InvalidOperationException($"Unknown eventId {eventId}."),
                     };
                 }
@@ -2494,6 +2495,21 @@ namespace System.Threading.Tasks.Tests
 
             byte wrapperCount = buffer[index++];
             Console.WriteLine($"  WrapperCount: {wrapperCount}");
+
+            Console.WriteLine("----------------------------");
+            return index;
+        }
+
+        private static int OutputAsyncProfilerSyncClockEvent(ReadOnlySpan<byte> buffer)
+        {
+            int index = 0;
+            Console.WriteLine("--- AsyncProfilerSyncClock ---");
+
+            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong qpcSync);
+            Console.WriteLine($"  QPCSync: {qpcSync}");
+
+            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong utcSync);
+            Console.WriteLine($"  UTCSync: {utcSync}");
 
             Console.WriteLine("----------------------------");
             return index;

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Reflection;
 using System.Linq;
-using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Threading.Tasks.Tests
@@ -16,39 +15,38 @@ namespace System.Threading.Tasks.Tests
     // Mirrors AsyncProfiler.AsyncEventID from the runtime (which is internal and inaccessible from tests).
     public enum AsyncEventID : byte
     {
-        // V2 (RuntimeAsync) events.
-        RuntimeAsync_CreateAsyncContext = 1,
-        RuntimeAsync_ResumeAsyncContext = 2,
-        RuntimeAsync_SuspendAsyncContext = 3,
-        RuntimeAsync_CompleteAsyncContext = 4,
-        RuntimeAsync_UnwindAsyncException = 5,
-        RuntimeAsync_CreateAsyncCallstack = 6,
-        RuntimeAsync_ResumeAsyncCallstack = 7,
-        RuntimeAsync_SuspendAsyncCallstack = 8,
-        RuntimeAsync_ResumeAsyncMethod = 9,
-        RuntimeAsync_CompleteAsyncMethod = 10,
+        // Runtime (RuntimeAsync) events.
+        CreateRuntimeAsyncContext = 1,
+        ResumeRuntimeAsyncContext = 2,
+        SuspendRuntimeAsyncContext = 3,
+        CompleteRuntimeAsyncContext = 4,
+        UnwindRuntimeAsyncException = 5,
+        CreateRuntimeAsyncCallstack = 6,
+        ResumeRuntimeAsyncCallstack = 7,
+        SuspendRuntimeAsyncCallstack = 8,
+        ResumeRuntimeAsyncMethod = 9,
+        CompleteRuntimeAsyncMethod = 10,
 
-        // V1 (TaskAsync) events.
-        TaskAsync_CreateAsyncContext = 11,
-        TaskAsync_ResumeAsyncContext = 12,
-        TaskAsync_SuspendAsyncContext = 13,
-        TaskAsync_CompleteAsyncContext = 14,
-        TaskAsync_UnwindAsyncException = 15,
-        TaskAsync_ResumeAsyncCallstack = 16,
-        TaskAsync_ResumeAsyncMethod = 17,
-        TaskAsync_CompleteAsyncMethod = 18,
-        TaskAsync_AppendAsyncCallstack = 19,
+        // StateMachine (StateMachineAsync) events.
+        CreateStateMachineAsyncContext = 11,
+        ResumeStateMachineAsyncContext = 12,
+        CompleteStateMachineAsyncContext = 13,
+        UnwindStateMachineAsyncException = 14,
+        ResumeStateMachineAsyncCallstack = 15,
+        ResumeStateMachineAsyncMethod = 16,
+        CompleteStateMachineAsyncMethod = 17,
+        AppendStateMachineAsyncCallstack = 18,
 
         // Neutral profiler events.
-        ResetAsyncThreadContext = 20,
-        ResetAsyncContinuationWrapperIndex = 21,
-        AsyncProfilerMetadata = 22,
-        AsyncProfilerSyncClock = 23,
+        ResetAsyncThreadContext = 19,
+        ResetAsyncContinuationWrapperIndex = 20,
+        AsyncProfilerMetadata = 21,
+        AsyncProfilerSyncClock = 22,
     }
 
     public enum AsyncCallstackType : byte
     {
-        Compiler = 0x1,
+        StateMachine = 0x1,
         Runtime = 0x2,
     }
 
@@ -69,26 +67,25 @@ namespace System.Threading.Tasks.Tests
 
             return
             [
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_CreateAsyncContext, 1, BytePayloadLength),
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncContext, 1, BytePayloadLength),
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_SuspendAsyncContext, 1, NoPayload),
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_CompleteAsyncContext, 1, NoPayload),
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_UnwindAsyncException, 1, BytePayloadLength),
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, 1, UShortPayloadLength),
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, 1, UShortPayloadLength),
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, 1, UShortPayloadLength),
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_ResumeAsyncMethod, 1, NoPayload),
-                new EventManifestEntry(AsyncEventID.RuntimeAsync_CompleteAsyncMethod, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.CreateRuntimeAsyncContext, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.ResumeRuntimeAsyncContext, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.SuspendRuntimeAsyncContext, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.CompleteRuntimeAsyncContext, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.UnwindRuntimeAsyncException, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.CreateRuntimeAsyncCallstack, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.ResumeRuntimeAsyncCallstack, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.SuspendRuntimeAsyncCallstack, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.ResumeRuntimeAsyncMethod, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.CompleteRuntimeAsyncMethod, 1, NoPayload),
 
-                new EventManifestEntry(AsyncEventID.TaskAsync_CreateAsyncContext, 1, BytePayloadLength),
-                new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncContext, 1, BytePayloadLength),
-                new EventManifestEntry(AsyncEventID.TaskAsync_SuspendAsyncContext, 1, NoPayload),
-                new EventManifestEntry(AsyncEventID.TaskAsync_CompleteAsyncContext, 1, NoPayload),
-                new EventManifestEntry(AsyncEventID.TaskAsync_UnwindAsyncException, 1, BytePayloadLength),
-                new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncCallstack, 1, UShortPayloadLength),
-                new EventManifestEntry(AsyncEventID.TaskAsync_ResumeAsyncMethod, 1, NoPayload),
-                new EventManifestEntry(AsyncEventID.TaskAsync_CompleteAsyncMethod, 1, NoPayload),
-                new EventManifestEntry(AsyncEventID.TaskAsync_AppendAsyncCallstack, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.CreateStateMachineAsyncContext, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncContext, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.CompleteStateMachineAsyncContext, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.UnwindStateMachineAsyncException, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncCallstack, 1, UShortPayloadLength),
+                new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncMethod, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.CompleteStateMachineAsyncMethod, 1, NoPayload),
+                new EventManifestEntry(AsyncEventID.AppendStateMachineAsyncCallstack, 1, UShortPayloadLength),
 
                 new EventManifestEntry(AsyncEventID.ResetAsyncThreadContext, 1, NoPayload),
                 new EventManifestEntry(AsyncEventID.ResetAsyncContinuationWrapperIndex, 1, NoPayload),
@@ -113,13 +110,13 @@ namespace System.Threading.Tasks.Tests
         // These tests use async Task methods with await instead of Task.Run blocking.
         public static bool IsRuntimeAsyncSupported => PlatformDetection.IsRuntimeAsyncSupported;
 
-        // V1 (TaskAsync_*) async-task instrumentation is opt-out on NativeAOT to avoid
+        // StateMachine (StateMachineAsync_*) async-task instrumentation is opt-out on NativeAOT to avoid
         // ~100KB of per-state-machine generic instantiation overhead. Tests that depend
-        // on V1 events must be gated on these properties so they are skipped on NAOT.
-        public static bool IsTaskAsyncInstrumentationSupported =>
+        // on StateMachine events must be gated on these properties so they are skipped on NAOT.
+        public static bool IsStateMachineAsyncInstrumentationSupported =>
             IsRuntimeAsyncSupported && !PlatformDetection.IsNativeAot;
 
-        public static bool IsTaskAsyncInstrumentationAndThreadingSupported =>
+        public static bool IsStateMachineAsyncInstrumentationAndThreadingSupported =>
             IsRuntimeAsyncAndThreadingSupported && !PlatformDetection.IsNativeAot;
 
         private const string AsyncProfilerEventSourceName = "System.Runtime.CompilerServices.AsyncProfilerEventSource";
@@ -130,34 +127,86 @@ namespace System.Threading.Tasks.Tests
         private const int HeaderSize = 1 + sizeof(uint) + sizeof(uint) + sizeof(ulong) + sizeof(uint) + sizeof(ulong) + sizeof(ulong);
 
         // AsyncProfilerEventSource Keywords matching the event source definition
-        private const EventKeywords CreateAsyncContextKeyword = (EventKeywords)0x1;
-        private const EventKeywords ResumeAsyncContextKeyword = (EventKeywords)0x2;
-        private const EventKeywords SuspendAsyncContextKeyword = (EventKeywords)0x4;
-        private const EventKeywords CompleteAsyncContextKeyword = (EventKeywords)0x8;
-        private const EventKeywords UnwindAsyncExceptionKeyword = (EventKeywords)0x10;
-        private const EventKeywords CreateAsyncCallstackKeyword = (EventKeywords)0x20;
-        private const EventKeywords ResumeAsyncCallstackKeyword = (EventKeywords)0x40;
-        private const EventKeywords SuspendAsyncCallstackKeyword = (EventKeywords)0x80;
-        private const EventKeywords ResumeAsyncMethodKeyword = (EventKeywords)0x100;
-        private const EventKeywords CompleteAsyncMethodKeyword = (EventKeywords)0x200;
+        private const EventKeywords CreateRuntimeAsyncContextKeyword = (EventKeywords)0x1;
+        private const EventKeywords ResumeRuntimeAsyncContextKeyword = (EventKeywords)0x2;
+        private const EventKeywords SuspendRuntimeAsyncContextKeyword = (EventKeywords)0x4;
+        private const EventKeywords CompleteRuntimeAsyncContextKeyword = (EventKeywords)0x8;
+        private const EventKeywords UnwindRuntimeAsyncExceptionKeyword = (EventKeywords)0x10;
+        private const EventKeywords CreateRuntimeAsyncCallstackKeyword = (EventKeywords)0x20;
+        private const EventKeywords ResumeRuntimeAsyncCallstackKeyword = (EventKeywords)0x40;
+        private const EventKeywords SuspendRuntimeAsyncCallstackKeyword = (EventKeywords)0x80;
+        private const EventKeywords ResumeRuntimeAsyncMethodKeyword = (EventKeywords)0x100;
+        private const EventKeywords CompleteRuntimeAsyncMethodKeyword = (EventKeywords)0x200;
+        private const EventKeywords CreateStateMachineAsyncContextKeyword = (EventKeywords)0x400;
+        private const EventKeywords ResumeStateMachineAsyncContextKeyword = (EventKeywords)0x800;
+        private const EventKeywords CompleteStateMachineAsyncContextKeyword = (EventKeywords)0x1000;
+        private const EventKeywords UnwindStateMachineAsyncExceptionKeyword = (EventKeywords)0x2000;
+        private const EventKeywords ResumeStateMachineAsyncCallstackKeyword = (EventKeywords)0x4000;
+        private const EventKeywords ResumeStateMachineAsyncMethodKeyword = (EventKeywords)0x8000;
+        private const EventKeywords CompleteStateMachineAsyncMethodKeyword = (EventKeywords)0x10000;
+
+        private const EventKeywords AllRuntimeAsyncKeywords =
+            CreateRuntimeAsyncContextKeyword |
+            ResumeRuntimeAsyncContextKeyword |
+            SuspendRuntimeAsyncContextKeyword |
+            CompleteRuntimeAsyncContextKeyword |
+            UnwindRuntimeAsyncExceptionKeyword |
+            CreateRuntimeAsyncCallstackKeyword |
+            ResumeRuntimeAsyncCallstackKeyword |
+            SuspendRuntimeAsyncCallstackKeyword |
+            ResumeRuntimeAsyncMethodKeyword |
+            CompleteRuntimeAsyncMethodKeyword;
+
+        private const EventKeywords AllStateMachineAsyncKeywords =
+            CreateStateMachineAsyncContextKeyword |
+            ResumeStateMachineAsyncContextKeyword |
+            CompleteStateMachineAsyncContextKeyword |
+            UnwindStateMachineAsyncExceptionKeyword |
+            ResumeStateMachineAsyncCallstackKeyword |
+            ResumeStateMachineAsyncMethodKeyword |
+            CompleteStateMachineAsyncMethodKeyword;
 
         private const EventKeywords AllKeywords =
-            CreateAsyncContextKeyword | ResumeAsyncContextKeyword | SuspendAsyncContextKeyword |
-            CompleteAsyncContextKeyword | UnwindAsyncExceptionKeyword |
-            CreateAsyncCallstackKeyword | ResumeAsyncCallstackKeyword | SuspendAsyncCallstackKeyword |
-            ResumeAsyncMethodKeyword | CompleteAsyncMethodKeyword;
+            AllRuntimeAsyncKeywords |
+            AllStateMachineAsyncKeywords;
 
-        private const EventKeywords CoreKeywords =
-            CreateAsyncContextKeyword | ResumeAsyncContextKeyword | SuspendAsyncContextKeyword | CompleteAsyncContextKeyword;
+        private const EventKeywords RuntimeAsyncCoreKeywords =
+            CreateRuntimeAsyncContextKeyword |
+            ResumeRuntimeAsyncContextKeyword |
+            SuspendRuntimeAsyncContextKeyword |
+            CompleteRuntimeAsyncContextKeyword;
 
-        private const EventKeywords MethodKeywords =
-            ResumeAsyncMethodKeyword | CompleteAsyncMethodKeyword;
+        private const EventKeywords StateMachineAsyncCoreKeywords =
+            CreateStateMachineAsyncContextKeyword |
+            ResumeStateMachineAsyncContextKeyword |
+            CompleteStateMachineAsyncContextKeyword;
 
-        private const EventKeywords CallstackKeywords =
-            CreateAsyncContextKeyword | CreateAsyncCallstackKeyword |
-            ResumeAsyncContextKeyword | ResumeAsyncCallstackKeyword |
-            SuspendAsyncContextKeyword | SuspendAsyncCallstackKeyword |
-            CompleteAsyncContextKeyword | CompleteAsyncMethodKeyword | UnwindAsyncExceptionKeyword;
+        private const EventKeywords RuntimeAsyncMethodKeywords =
+            ResumeRuntimeAsyncMethodKeyword |
+            CompleteRuntimeAsyncMethodKeyword;
+
+        private const EventKeywords StateMachineAsyncMethodKeywords =
+            ResumeStateMachineAsyncMethodKeyword |
+            CompleteStateMachineAsyncMethodKeyword;
+
+        private const EventKeywords RuntimeAsyncCallstackKeywords =
+            CreateRuntimeAsyncContextKeyword |
+            CreateRuntimeAsyncCallstackKeyword |
+            ResumeRuntimeAsyncContextKeyword |
+            ResumeRuntimeAsyncCallstackKeyword |
+            SuspendRuntimeAsyncContextKeyword |
+            SuspendRuntimeAsyncCallstackKeyword |
+            CompleteRuntimeAsyncContextKeyword |
+            CompleteRuntimeAsyncMethodKeyword |
+            UnwindRuntimeAsyncExceptionKeyword;
+
+        private const EventKeywords StateMachineAsyncCallstackKeywords =
+            CreateStateMachineAsyncContextKeyword |
+            ResumeStateMachineAsyncContextKeyword |
+            ResumeStateMachineAsyncCallstackKeyword |
+            CompleteStateMachineAsyncContextKeyword |
+            CompleteStateMachineAsyncMethodKeyword |
+            UnwindStateMachineAsyncExceptionKeyword;
 
         // CoreCLR has StackFrame.GetMethodFromNativeIP (static, non-public).
         private static readonly MethodInfo? s_getMethodFromNativeIPMethod =
@@ -172,7 +221,7 @@ namespace System.Threading.Tasks.Tests
         // The public 1-arg MethodBase.GetMethodFromHandle resolves the method but then deliberately
         // throws ArgumentException when the declaring type is generic. The internal
         // RuntimeType.GetMethodBase(RuntimeMethodHandle.GetMethodInfo()) it calls underneath has no
-        // such guard, so we invoke it directly to name V1 frames on generic declaring types.
+        // such guard, so we invoke it directly to name StateMachine frames on generic declaring types.
         private static readonly MethodInfo? s_runtimeMethodHandleGetMethodInfo =
             typeof(RuntimeMethodHandle).GetMethod("GetMethodInfo", BindingFlags.Instance | BindingFlags.NonPublic);
 
@@ -202,7 +251,7 @@ namespace System.Threading.Tasks.Tests
                         return diagInfo?.Name;
                     }
                 }
-                else if (callstackType == AsyncCallstackType.Compiler)
+                else if (callstackType == AsyncCallstackType.StateMachine)
                 {
                     System.RuntimeMethodHandle handle = RuntimeMethodHandle.FromIntPtr((IntPtr)methodId);
                     MethodBase? method = null;
@@ -246,7 +295,7 @@ namespace System.Threading.Tasks.Tests
             return null;
         }
 
-        // Test-only fallback used when a compiler (V1) MethodId handle cannot be resolved via the
+        // Test-only fallback used when a compiler (StateMachine) MethodId handle cannot be resolved via the
         // 1-arg MethodBase.GetMethodFromHandle because its declaring type is generic. Calls the
         // internal RuntimeType.GetMethodBase(handle.GetMethodInfo()) the public API uses underneath,
         // which has no generic-declaring-type guard, so it names methods on generic declaring types.
@@ -421,43 +470,42 @@ namespace System.Threading.Tasks.Tests
         {
             switch (eventId)
             {
-                case AsyncEventID.RuntimeAsync_CreateAsyncContext:
-                case AsyncEventID.TaskAsync_CreateAsyncContext:
+                case AsyncEventID.CreateRuntimeAsyncContext:
+                case AsyncEventID.CreateStateMachineAsyncContext:
                 {
                     ReadCompressedUInt64(buffer, ref index); // parentDispatcherId
                     ReadCompressedUInt64(buffer, ref index); // dispatcherId
                     return true;
                 }
-                case AsyncEventID.RuntimeAsync_ResumeAsyncContext:
-                case AsyncEventID.TaskAsync_ResumeAsyncContext:
+                case AsyncEventID.ResumeRuntimeAsyncContext:
+                case AsyncEventID.ResumeStateMachineAsyncContext:
                 {
                     ReadCompressedUInt64(buffer, ref index); // dispatcherId
                     return true;
                 }
-                case AsyncEventID.RuntimeAsync_SuspendAsyncContext:
-                case AsyncEventID.RuntimeAsync_CompleteAsyncContext:
-                case AsyncEventID.RuntimeAsync_ResumeAsyncMethod:
-                case AsyncEventID.RuntimeAsync_CompleteAsyncMethod:
-                case AsyncEventID.TaskAsync_SuspendAsyncContext:
-                case AsyncEventID.TaskAsync_CompleteAsyncContext:
-                case AsyncEventID.TaskAsync_ResumeAsyncMethod:
-                case AsyncEventID.TaskAsync_CompleteAsyncMethod:
+                case AsyncEventID.SuspendRuntimeAsyncContext:
+                case AsyncEventID.CompleteRuntimeAsyncContext:
+                case AsyncEventID.ResumeRuntimeAsyncMethod:
+                case AsyncEventID.CompleteRuntimeAsyncMethod:
+                case AsyncEventID.CompleteStateMachineAsyncContext:
+                case AsyncEventID.ResumeStateMachineAsyncMethod:
+                case AsyncEventID.CompleteStateMachineAsyncMethod:
                 case AsyncEventID.ResetAsyncThreadContext:
                 case AsyncEventID.ResetAsyncContinuationWrapperIndex:
                 {
                     return true;
                 }
-                case AsyncEventID.RuntimeAsync_UnwindAsyncException:
-                case AsyncEventID.TaskAsync_UnwindAsyncException:
+                case AsyncEventID.UnwindRuntimeAsyncException:
+                case AsyncEventID.UnwindStateMachineAsyncException:
                 {
                     ReadCompressedUInt32(buffer, ref index);
                     return true;
                 }
-                case AsyncEventID.RuntimeAsync_CreateAsyncCallstack:
-                case AsyncEventID.RuntimeAsync_ResumeAsyncCallstack:
-                case AsyncEventID.RuntimeAsync_SuspendAsyncCallstack:
-                case AsyncEventID.TaskAsync_ResumeAsyncCallstack:
-                case AsyncEventID.TaskAsync_AppendAsyncCallstack:
+                case AsyncEventID.CreateRuntimeAsyncCallstack:
+                case AsyncEventID.ResumeRuntimeAsyncCallstack:
+                case AsyncEventID.SuspendRuntimeAsyncCallstack:
+                case AsyncEventID.ResumeStateMachineAsyncCallstack:
+                case AsyncEventID.AppendStateMachineAsyncCallstack:
                 {
                     SkipCallstackPayload(buffer, ref index, eventId, CallstackTypeFromEventId(eventId));
                     return true;
@@ -509,8 +557,8 @@ namespace System.Threading.Tasks.Tests
             index++; // Reserved callstack ID (for future callstack interning).
             continuationIndex = buffer[index++];
             frameCount = buffer[index++];
-            // parentDispatcherId is only present on RuntimeAsync_CreateAsyncCallstack.
-            parentDispatcherId = eventId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack
+            // parentDispatcherId is only present on CreateRuntimeAsyncCallstack.
+            parentDispatcherId = eventId == AsyncEventID.CreateRuntimeAsyncCallstack
                 ? ReadCompressedUInt64(buffer, ref index)
                 : 0;
             dispatcherId = ReadCompressedUInt64(buffer, ref index);
@@ -522,7 +570,7 @@ namespace System.Threading.Tasks.Tests
                 return;
             }
 
-            bool readState = callstackType == AsyncCallstackType.Compiler;
+            bool readState = callstackType == AsyncCallstackType.StateMachine;
 
             ulong currentMethodId = ReadCompressedUInt64(buffer, ref index);
             int state = readState ? ReadCompressedInt32(buffer, ref index) : 0;
@@ -538,12 +586,12 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Derive callstack type from the event id:
-        // V1 (TaskAsync_*) events carry compiler-built state machine frames;
-        // V2 (RuntimeAsync_*) events carry runtime-async frames.
+        // StateMachine (StateMachineAsync*) events carry compiler-built state machine frames;
+        // Runtime (RuntimeAsync_*) events carry runtime-async frames.
         private static AsyncCallstackType CallstackTypeFromEventId(AsyncEventID eventId)
-            => eventId is AsyncEventID.TaskAsync_ResumeAsyncCallstack
-                       or AsyncEventID.TaskAsync_AppendAsyncCallstack
-                ? AsyncCallstackType.Compiler
+            => eventId is AsyncEventID.ResumeStateMachineAsyncCallstack
+                       or AsyncEventID.AppendStateMachineAsyncCallstack
+                ? AsyncCallstackType.StateMachine
                 : AsyncCallstackType.Runtime;
 
         private static int ReadCompressedInt32(ReadOnlySpan<byte> buffer, ref int index)
@@ -649,12 +697,12 @@ namespace System.Threading.Tasks.Tests
             private Dictionary<ulong, List<ulong>>? _childrenOfDispatcher;
             private Dictionary<ulong, DispatcherKind>? _dispatcherKind;
 
-            // V1 (TaskAsync_*) and V2 (RuntimeAsync_*) dispatchers can coexist on the same logical
-            // thread (e.g., a V1 test runner hosting a V2 test body). The runtime captures cross-kind
+            // StateMachine (StateMachineAsync_*) and Runtime (RuntimeAsync_*) dispatchers can coexist on the same logical
+            // thread (e.g., a StateMachine test runner hosting a Runtime test body). The runtime captures cross-kind
             // parent links in that case, but a single test typically wants to walk only its own kind's
-            // subtree. Tracking the kind per dispatcher lets the chain walk stop at V1<->V2 boundaries
+            // subtree. Tracking the kind per dispatcher lets the chain walk stop at StateMachine<->Runtime boundaries
             // by default.
-            internal enum DispatcherKind { Unknown, V1, V2 }
+            internal enum DispatcherKind { Unknown, StateMachine, Runtime }
 
             public ParsedEventStream(List<ParsedEvent> events)
             {
@@ -738,9 +786,9 @@ namespace System.Threading.Tasks.Tests
                 foreach (var evt in _events)
                 {
                     bool isCreate = evt.EventId is
-                        AsyncEventID.TaskAsync_CreateAsyncContext or
-                        AsyncEventID.RuntimeAsync_CreateAsyncContext or
-                        AsyncEventID.RuntimeAsync_CreateAsyncCallstack;
+                        AsyncEventID.CreateStateMachineAsyncContext or
+                        AsyncEventID.CreateRuntimeAsyncContext or
+                        AsyncEventID.CreateRuntimeAsyncCallstack;
 
                     if (isCreate && evt.DispatcherId != 0)
                     {
@@ -751,9 +799,9 @@ namespace System.Threading.Tasks.Tests
                 foreach (var evt in _events)
                 {
                     bool isCreate = evt.EventId is
-                        AsyncEventID.TaskAsync_CreateAsyncContext or
-                        AsyncEventID.RuntimeAsync_CreateAsyncContext or
-                        AsyncEventID.RuntimeAsync_CreateAsyncCallstack;
+                        AsyncEventID.CreateStateMachineAsyncContext or
+                        AsyncEventID.CreateRuntimeAsyncContext or
+                        AsyncEventID.CreateRuntimeAsyncCallstack;
 
                     if (!isCreate || evt.DispatcherId == 0)
                     {
@@ -762,9 +810,9 @@ namespace System.Threading.Tasks.Tests
 
                     DispatcherKind kind = evt.EventId switch
                     {
-                        AsyncEventID.TaskAsync_CreateAsyncContext => DispatcherKind.V1,
-                        AsyncEventID.RuntimeAsync_CreateAsyncContext or
-                        AsyncEventID.RuntimeAsync_CreateAsyncCallstack => DispatcherKind.V2,
+                        AsyncEventID.CreateStateMachineAsyncContext => DispatcherKind.StateMachine,
+                        AsyncEventID.CreateRuntimeAsyncContext or
+                        AsyncEventID.CreateRuntimeAsyncCallstack => DispatcherKind.Runtime,
                         _ => DispatcherKind.Unknown,
                     };
 
@@ -802,8 +850,8 @@ namespace System.Threading.Tasks.Tests
                     : DispatcherKind.Unknown;
 
             // Returns the root DispatcherId for the chain containing dispatcherId, by walking parent pointers.
-            // By default the climb stops at V1<->V2 boundaries so a V2 marker doesn't get pulled up into
-            // an enclosing V1 test-runner dispatcher (and vice versa). Pass crossKinds: true to walk to
+            // By default the climb stops at StateMachine<->Runtime boundaries so a Runtime marker doesn't get pulled up into
+            // an enclosing StateMachine test-runner dispatcher (and vice versa). Pass crossKinds: true to walk to
             // the absolute root regardless of dispatcher kind.
             public ulong RootOfDispatcher(ulong dispatcherId, bool crossKinds = false)
             {
@@ -825,9 +873,9 @@ namespace System.Threading.Tasks.Tests
 
             // Returns the set of all dispatcher ids in the same chain (connected component) as dispatcherId.
             // Walks up to the root via parent pointers, then collects all descendants via BFS. By default
-            // the walk is restricted to dispatchers of the same kind (V1 or V2) as dispatcherId so that a
-            // single test's chain doesn't span unrelated cross-kind activity (e.g., a V1 xunit test runner
-            // hosting a V2 test body). Pass crossKinds: true to walk the full connected component.
+            // the walk is restricted to dispatchers of the same kind (StateMachine or Runtime) as dispatcherId so that a
+            // single test's chain doesn't span unrelated cross-kind activity (e.g., a StateMachine xunit test runner
+            // hosting a Runtime test body). Pass crossKinds: true to walk the full connected component.
             public HashSet<ulong> ChainDispatcherIds(ulong dispatcherId, bool crossKinds = false)
             {
                 EnsureDispatcherTree();
@@ -879,7 +927,7 @@ namespace System.Threading.Tasks.Tests
             // AppendAsyncCallstack events for the same context, up until the next Suspend/Complete on that
             // context.
             //
-            // V1 dispatchers may emit a partial Resume callstack when the parent continuation hasn't yet
+            // StateMachine dispatchers may emit a partial Resume callstack when the parent continuation hasn't yet
             // registered (race between dispatcher pickup and parent's AwaitUnsafeOnCompleted). Frames that
             // register later are emitted as AppendAsyncCallstack at the next hook point. Merging produces
             // the complete chain that was observable during the dispatcher's lifetime.
@@ -894,16 +942,15 @@ namespace System.Threading.Tasks.Tests
                 {
                     switch (evt.EventId)
                     {
-                        case AsyncEventID.RuntimeAsync_SuspendAsyncContext:
-                        case AsyncEventID.RuntimeAsync_CompleteAsyncContext:
-                        case AsyncEventID.TaskAsync_SuspendAsyncContext:
-                        case AsyncEventID.TaskAsync_CompleteAsyncContext:
+                        case AsyncEventID.SuspendRuntimeAsyncContext:
+                        case AsyncEventID.CompleteRuntimeAsyncContext:
+                        case AsyncEventID.CompleteStateMachineAsyncContext:
                         {
                             openByDispatcherId.Remove(evt.DispatcherId);
                             break;
                         }
-                        case AsyncEventID.RuntimeAsync_ResumeAsyncCallstack:
-                        case AsyncEventID.TaskAsync_ResumeAsyncCallstack:
+                        case AsyncEventID.ResumeRuntimeAsyncCallstack:
+                        case AsyncEventID.ResumeStateMachineAsyncCallstack:
                         {
                             var merged = new ParsedEvent
                             {
@@ -923,7 +970,7 @@ namespace System.Threading.Tasks.Tests
 
                             break;
                         }
-                        case AsyncEventID.TaskAsync_AppendAsyncCallstack:
+                        case AsyncEventID.AppendStateMachineAsyncCallstack:
                         {
                             if (openByDispatcherId.TryGetValue(evt.DispatcherId, out int idx))
                             {
@@ -979,13 +1026,13 @@ namespace System.Threading.Tasks.Tests
                 }
 
                 ulong osThreadId = header.Value.OsThreadId;
-                // V1 (TaskAsync_*) and V2 (RuntimeAsync_*) are independent context dimensions that can
-                // interleave within a single thread's buffer (e.g. a V1 test-runner dispatcher active
-                // while a V2 test runs, which always happens on single-threaded WASM where everything
+                // StateMachine (StateMachineAsync_*) and Runtime (RuntimeAsync_*) are independent context dimensions that can
+                // interleave within a single thread's buffer (e.g. a StateMachine test-runner dispatcher active
+                // while a Runtime test runs, which always happens on single-threaded WASM where everything
                 // shares one thread). Context-scoped events (Resume/Suspend/Complete context, the
                 // method events, and unwind events) omit the dispatcher id from the wire and inherit it
                 // from the enclosing Resume context, so each kind needs its own current-context stack.
-                // A single shared stack would let a TaskAsync_* Resume/Complete hijack the current
+                // A single shared stack would let a StateMachineAsync_* Resume/Complete hijack the current
                 // dispatcher and mis-attribute interleaved RuntimeAsync_* events (and vice versa).
                 ulong v2CurrentDispatcherId = 0;
                 ulong v2CurrentParentDispatcherId = 0;
@@ -1012,26 +1059,26 @@ namespace System.Threading.Tasks.Tests
 
                     ParsedEvent evt = eventId switch
                     {
-                        AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.TaskAsync_CreateAsyncContext =>
+                        AsyncEventID.CreateRuntimeAsyncContext or AsyncEventID.CreateStateMachineAsyncContext =>
                             ParseCreateContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index),
 
-                        AsyncEventID.RuntimeAsync_ResumeAsyncContext =>
+                        AsyncEventID.ResumeRuntimeAsyncContext =>
                             ParseResumeContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index,
                                 ref v2CurrentDispatcherId, ref v2CurrentParentDispatcherId, v2DispatcherStack),
 
-                        AsyncEventID.TaskAsync_ResumeAsyncContext =>
+                        AsyncEventID.ResumeStateMachineAsyncContext =>
                             ParseResumeContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index,
                                 ref v1CurrentDispatcherId, ref v1CurrentParentDispatcherId, v1DispatcherStack),
 
-                        AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.RuntimeAsync_SuspendAsyncContext =>
+                        AsyncEventID.CompleteRuntimeAsyncContext or AsyncEventID.SuspendRuntimeAsyncContext =>
                             ParseEndContextEvent(eventId, baseTimestamp, osThreadId,
                                 ref v2CurrentDispatcherId, ref v2CurrentParentDispatcherId, v2DispatcherStack),
 
-                        AsyncEventID.TaskAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_SuspendAsyncContext =>
+                        AsyncEventID.CompleteStateMachineAsyncContext =>
                             ParseEndContextEvent(eventId, baseTimestamp, osThreadId,
                                 ref v1CurrentDispatcherId, ref v1CurrentParentDispatcherId, v1DispatcherStack),
 
-                        AsyncEventID.RuntimeAsync_ResumeAsyncMethod or AsyncEventID.RuntimeAsync_CompleteAsyncMethod =>
+                        AsyncEventID.ResumeRuntimeAsyncMethod or AsyncEventID.CompleteRuntimeAsyncMethod =>
                             new ParsedEvent
                             {
                                 EventId = eventId,
@@ -1041,7 +1088,7 @@ namespace System.Threading.Tasks.Tests
                                 DispatcherId = v2CurrentDispatcherId,
                             },
 
-                        AsyncEventID.TaskAsync_ResumeAsyncMethod or AsyncEventID.TaskAsync_CompleteAsyncMethod =>
+                        AsyncEventID.ResumeStateMachineAsyncMethod or AsyncEventID.CompleteStateMachineAsyncMethod =>
                             new ParsedEvent
                             {
                                 EventId = eventId,
@@ -1056,15 +1103,15 @@ namespace System.Threading.Tasks.Tests
                                 ref v2CurrentDispatcherId, ref v2CurrentParentDispatcherId, v2DispatcherStack,
                                 ref v1CurrentDispatcherId, ref v1CurrentParentDispatcherId, v1DispatcherStack),
 
-                        AsyncEventID.RuntimeAsync_CreateAsyncCallstack or AsyncEventID.RuntimeAsync_ResumeAsyncCallstack or
-                        AsyncEventID.RuntimeAsync_SuspendAsyncCallstack or
-                        AsyncEventID.TaskAsync_ResumeAsyncCallstack or AsyncEventID.TaskAsync_AppendAsyncCallstack =>
+                        AsyncEventID.CreateRuntimeAsyncCallstack or AsyncEventID.ResumeRuntimeAsyncCallstack or
+                        AsyncEventID.SuspendRuntimeAsyncCallstack or
+                        AsyncEventID.ResumeStateMachineAsyncCallstack or AsyncEventID.AppendStateMachineAsyncCallstack =>
                             ParseCallstackEvent(eventId, baseTimestamp, osThreadId, buffer, ref index),
 
-                        AsyncEventID.RuntimeAsync_UnwindAsyncException =>
+                        AsyncEventID.UnwindRuntimeAsyncException =>
                             ParseUnwindEvent(eventId, baseTimestamp, osThreadId, v2CurrentDispatcherId, v2CurrentParentDispatcherId, buffer, ref index),
 
-                        AsyncEventID.TaskAsync_UnwindAsyncException =>
+                        AsyncEventID.UnwindStateMachineAsyncException =>
                             ParseUnwindEvent(eventId, baseTimestamp, osThreadId, v1CurrentDispatcherId, v1CurrentParentDispatcherId, buffer, ref index),
 
                         AsyncEventID.AsyncProfilerMetadata =>
@@ -1327,10 +1374,10 @@ namespace System.Threading.Tasks.Tests
 
         private static void RunScenarioAndFlush(Func<Task> scenario)
         {
-            // V1 (task-based) async: the dispatcher's finally block emits CompleteAsyncContext
+            // StateMachine (task-based) async: the dispatcher's finally block emits CompleteAsyncContext
             // after inner.MoveNext() returns, but MoveNext() already set the task result which
             // unblocks this thread. Brief sleep ensures the pool thread's finally completes.
-            // V2 (runtime-async) does not have this issue -- Complete fires inside the dispatch
+            // Runtime (runtime-async) does not have this issue -- Complete fires inside the dispatch
             // loop before the task is signaled.
             //
             // Clear SynchronizationContext so RuntimeAsync continuations don't capture
@@ -1437,8 +1484,8 @@ namespace System.Threading.Tasks.Tests
         // Compact, single-string summary of the parsed event stream for CI failure diagnostics.
         // CI surfaces only the assertion message (no console access), so failing assertions embed
         // this so the event sequence shows up directly in the error. Events are listed in GLOBAL
-        // timestamp order (so cross-thread interleaving -- e.g. a V1 test-runner dispatcher
-        // interleaving with V2 events on single-threaded WASM -- is visible), each annotated with a
+        // timestamp order (so cross-thread interleaving -- e.g. a StateMachine test-runner dispatcher
+        // interleaving with Runtime events on single-threaded WASM -- is visible), each annotated with a
         // relative timestamp (+ticks from the first event) and its OS thread.
         // Format: "[+<deltaTicks>,T<osThreadId>]<EventId>(d<DispatcherId>[,p<ParentDispatcherId>][,f<FrameCount>]) ..."
         // Compact, machine-readable summary of the parsed event stream for CI failure diagnostics.
@@ -1448,10 +1495,10 @@ namespace System.Threading.Tasks.Tests
         // importable into a SQL table / spreadsheet (e.g. SQLite .import). Columns:
         //   seq    - global index in timestamp order
         //   delta  - relative timestamp (ticks from the first event); reveals inline-burst clusters vs scheduling gaps
-        //   thread - OS thread id; reveals thread hops / cross-thread interleaving (e.g. V1 runner vs V2 on single-threaded WASM)
+        //   thread - OS thread id; reveals thread hops / cross-thread interleaving (e.g. StateMachine runner vs Runtime on single-threaded WASM)
         //   event  - AsyncEventID name
         //   disp   - DispatcherId
-        //   parent - ParentDispatcherId (0 if none; non-zero shows V1<->V2 parent capture)
+        //   parent - ParentDispatcherId (0 if none; non-zero shows StateMachine<->Runtime parent capture)
         //   frames - callstack FrameCount (0 for non-callstack events)
         //   unwind - UnwindFrameCount (for UnwindAsyncException events)
         private static string DescribeEvents(ParsedEventStream stream)
@@ -1577,13 +1624,13 @@ namespace System.Threading.Tasks.Tests
         // For a given context, simulates the async callstack depth by walking events in order:
         // ResumeAsyncCallstack sets the depth to frame count, CompleteAsyncMethod decrements,
         // UnwindAsyncException subtracts unwound frames. Asserts depth reaches zero.
-        // Handles both V1 (TaskAsync_*) and V2 (RuntimeAsync) event ids.
+        // Handles both StateMachine (StateMachineAsync_*) and Runtime (RuntimeAsync) event ids.
         private static void AssertCallstackSimulationReachesZero(ParsedEventStream stream, string markerMethodName)
         {
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, markerMethodName);
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, markerMethodName);
             if (resumeStacks.Count == 0)
             {
-                resumeStacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, markerMethodName);
+                resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, markerMethodName);
             }
             AssertTrue(stream, resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{markerMethodName}'");
 
@@ -1596,14 +1643,14 @@ namespace System.Threading.Tasks.Tests
             {
                 switch (evt.EventId)
                 {
-                    case AsyncEventID.RuntimeAsync_ResumeAsyncCallstack:
-                    case AsyncEventID.TaskAsync_ResumeAsyncCallstack:
+                    case AsyncEventID.ResumeRuntimeAsyncCallstack:
+                    case AsyncEventID.ResumeStateMachineAsyncCallstack:
                     {
                         stackDepth = (int)evt.FrameCount;
                         break;
                     }
-                    case AsyncEventID.RuntimeAsync_CompleteAsyncMethod:
-                    case AsyncEventID.TaskAsync_CompleteAsyncMethod:
+                    case AsyncEventID.CompleteRuntimeAsyncMethod:
+                    case AsyncEventID.CompleteStateMachineAsyncMethod:
                     {
                         if (stackDepth > 0)
                         {
@@ -1612,8 +1659,8 @@ namespace System.Threading.Tasks.Tests
 
                         break;
                     }
-                    case AsyncEventID.RuntimeAsync_UnwindAsyncException:
-                    case AsyncEventID.TaskAsync_UnwindAsyncException:
+                    case AsyncEventID.UnwindRuntimeAsyncException:
+                    case AsyncEventID.UnwindStateMachineAsyncException:
                     {
                         stackDepth = Math.Max(0, stackDepth - (int)evt.UnwindFrameCount);
                         break;
@@ -1627,22 +1674,22 @@ namespace System.Threading.Tasks.Tests
         private static void AssertExactlyOneCreateAndComplete(ParsedEventStream stream, ulong dispatcherId, string chainName)
         {
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
-            int creates = ids.Count(id => id is AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.TaskAsync_CreateAsyncContext);
-            int completes = ids.Count(id => id is AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_CompleteAsyncContext);
+            int creates = ids.Count(id => id is AsyncEventID.CreateRuntimeAsyncContext or AsyncEventID.CreateStateMachineAsyncContext);
+            int completes = ids.Count(id => id is AsyncEventID.CompleteRuntimeAsyncContext or AsyncEventID.CompleteStateMachineAsyncContext);
             AssertTrue(stream, creates == 1, $"Expected exactly 1 CreateAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
             AssertTrue(stream, completes == 1, $"Expected exactly 1 CompleteAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {completes}");
         }
 
-        // V1-friendly variant: V1's per-MoveNext dispatcher model emits one Create per await
+        // StateMachine-friendly variant: StateMachine's per-MoveNext dispatcher model emits one Create per await
         // suspension, so a method with N awaits produces N dispatchers / N Creates within the
         // same dispatcher tree. The invariant we can still assert is creates == completes (both >= 1).
         private static void AssertCreateEqualsCompleteInChain(ParsedEventStream stream, ulong dispatcherId, string chainName)
         {
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
-            int creates = ids.Count(id => id == AsyncEventID.TaskAsync_CreateAsyncContext);
-            int completes = ids.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
-            AssertTrue(stream, creates >= 1, $"Expected at least 1 TaskAsync_CreateAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
-            AssertTrue(stream, creates == completes, $"Expected TaskAsync_CreateAsyncContext count == TaskAsync_CompleteAsyncContext count for {chainName} (DispatcherId {dispatcherId}), got {creates} creates and {completes} completes");
+            int creates = ids.Count(id => id == AsyncEventID.CreateStateMachineAsyncContext);
+            int completes = ids.Count(id => id == AsyncEventID.CompleteStateMachineAsyncContext);
+            AssertTrue(stream, creates >= 1, $"Expected at least 1 CreateStateMachineAsyncContextKeyword for {chainName} (DispatcherId {dispatcherId}), got {creates}");
+            AssertTrue(stream, creates == completes, $"Expected CreateStateMachineAsyncContextKeyword count == CompleteStateMachineAsyncContextKeyword count for {chainName} (DispatcherId {dispatcherId}), got {creates} creates and {completes} completes");
         }
 
         private sealed class InlinePostSynchronizationContext : SynchronizationContext
@@ -1817,26 +1864,25 @@ namespace System.Threading.Tasks.Tests
                     {
                         index += eventId switch
                         {
-                            AsyncEventID.RuntimeAsync_CreateAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
-                            AsyncEventID.RuntimeAsync_ResumeAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
-                            AsyncEventID.RuntimeAsync_SuspendAsyncContext => OutputSuspendAsyncContextEvent(),
-                            AsyncEventID.RuntimeAsync_CompleteAsyncContext => OutputCompleteAsyncContextEvent(),
-                            AsyncEventID.RuntimeAsync_UnwindAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
-                            AsyncEventID.RuntimeAsync_CreateAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
-                            AsyncEventID.RuntimeAsync_ResumeAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
-                            AsyncEventID.RuntimeAsync_SuspendAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
-                            AsyncEventID.RuntimeAsync_ResumeAsyncMethod => OutputResumeAsyncMethodEvent(),
-                            AsyncEventID.RuntimeAsync_CompleteAsyncMethod => OutputCompleteAsyncMethodEvent(),
+                            AsyncEventID.CreateRuntimeAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.ResumeRuntimeAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.SuspendRuntimeAsyncContext => OutputSuspendAsyncContextEvent(),
+                            AsyncEventID.CompleteRuntimeAsyncContext => OutputCompleteAsyncContextEvent(),
+                            AsyncEventID.UnwindRuntimeAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
+                            AsyncEventID.CreateRuntimeAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+                            AsyncEventID.ResumeRuntimeAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+                            AsyncEventID.SuspendRuntimeAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+                            AsyncEventID.ResumeRuntimeAsyncMethod => OutputResumeAsyncMethodEvent(),
+                            AsyncEventID.CompleteRuntimeAsyncMethod => OutputCompleteAsyncMethodEvent(),
 
-                            AsyncEventID.TaskAsync_CreateAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
-                            AsyncEventID.TaskAsync_ResumeAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
-                            AsyncEventID.TaskAsync_SuspendAsyncContext => OutputSuspendAsyncContextEvent(),
-                            AsyncEventID.TaskAsync_CompleteAsyncContext => OutputCompleteAsyncContextEvent(),
-                            AsyncEventID.TaskAsync_UnwindAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
-                            AsyncEventID.TaskAsync_ResumeAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
-                            AsyncEventID.TaskAsync_ResumeAsyncMethod => OutputResumeAsyncMethodEvent(),
-                            AsyncEventID.TaskAsync_CompleteAsyncMethod => OutputCompleteAsyncMethodEvent(),
-                            AsyncEventID.TaskAsync_AppendAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+                            AsyncEventID.CreateStateMachineAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.ResumeStateMachineAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.CompleteStateMachineAsyncContext => OutputCompleteAsyncContextEvent(),
+                            AsyncEventID.UnwindStateMachineAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
+                            AsyncEventID.ResumeStateMachineAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
+                            AsyncEventID.ResumeStateMachineAsyncMethod => OutputResumeAsyncMethodEvent(),
+                            AsyncEventID.CompleteStateMachineAsyncMethod => OutputCompleteAsyncMethodEvent(),
+                            AsyncEventID.AppendStateMachineAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),
 
                             AsyncEventID.ResetAsyncThreadContext => OutputResetAsyncThreadContextEvent(),
                             AsyncEventID.ResetAsyncContinuationWrapperIndex => OutputResetAsyncContinuationWrapperIndexEvent(),
@@ -2002,20 +2048,20 @@ namespace System.Threading.Tasks.Tests
                 byte asyncCallstackLength;
                 int index = 0;
 
-                AsyncCallstackType type = (eventId is AsyncEventID.TaskAsync_ResumeAsyncCallstack
-                                                   or AsyncEventID.TaskAsync_AppendAsyncCallstack)
-                    ? AsyncCallstackType.Compiler
+                AsyncCallstackType type = (eventId is AsyncEventID.ResumeStateMachineAsyncCallstack
+                                                   or AsyncEventID.AppendStateMachineAsyncCallstack)
+                    ? AsyncCallstackType.StateMachine
                     : AsyncCallstackType.Runtime;
                 callstackId = buffer[index++];
                 continuationIndex = buffer[index++];
                 asyncCallstackLength = buffer[index++];
-                if (eventId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack)
+                if (eventId == AsyncEventID.CreateRuntimeAsyncCallstack)
                 {
                     Deserializer.ReadCompressedUInt64(buffer, ref index, out parentDispatcherId);
                 }
                 Deserializer.ReadCompressedUInt64(buffer, ref index, out dispatcherId);
 
-                if (eventId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack)
+                if (eventId == AsyncEventID.CreateRuntimeAsyncCallstack)
                 {
                     Console.WriteLine($"  ParentDispatcherId: {parentDispatcherId}");
                 }
@@ -2033,7 +2079,7 @@ namespace System.Threading.Tasks.Tests
                 ulong currentMethodId;
                 int state = 0;
 
-                bool readState = type == AsyncCallstackType.Compiler;
+                bool readState = type == AsyncCallstackType.StateMachine;
 
                 Deserializer.ReadCompressedUInt64(buffer, ref index, out currentMethodId);
                 if (readState)
@@ -2061,7 +2107,7 @@ namespace System.Threading.Tasks.Tests
             private static void OutputAsyncFrame(AsyncCallstackType type, ulong methodId, int state, int frameIndex)
             {
                 string asyncMethodName = GetMethodNameFromMethodId(type, methodId) ?? "??";
-                if (type == AsyncCallstackType.Compiler)
+                if (type == AsyncCallstackType.StateMachine)
                 {
                     Console.WriteLine($"    [{frameIndex}] {asyncMethodName} (0x{methodId:X}) (state={state})");
                 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -1393,6 +1393,105 @@ namespace System.Threading.Tasks.Tests
             return result;
         }
 
+        // Compact, single-string summary of the parsed event stream for CI failure diagnostics.
+        // CI surfaces only the assertion message (no console access), so failing assertions embed
+        // this so the event sequence shows up directly in the error. Events are listed in GLOBAL
+        // timestamp order (so cross-thread interleaving -- e.g. a V1 test-runner dispatcher
+        // interleaving with V2 events on single-threaded WASM -- is visible), each annotated with a
+        // relative timestamp (+ticks from the first event) and its OS thread.
+        // Format: "[+<deltaTicks>,T<osThreadId>]<EventId>(d<DispatcherId>[,p<ParentDispatcherId>][,f<FrameCount>]) ..."
+        // Compact, machine-readable summary of the parsed event stream for CI failure diagnostics.
+        // CI surfaces only the assertion message (no console access), so failing assertions embed
+        // this so the event sequence shows up directly in the error. Emitted as CSV (one event per
+        // line, header first) in GLOBAL timestamp order so it is both human-readable and trivially
+        // importable into a SQL table / spreadsheet (e.g. SQLite .import). Columns:
+        //   seq    - global index in timestamp order
+        //   delta  - relative timestamp (ticks from the first event); reveals inline-burst clusters vs scheduling gaps
+        //   thread - OS thread id; reveals thread hops / cross-thread interleaving (e.g. V1 runner vs V2 on single-threaded WASM)
+        //   event  - AsyncEventID name
+        //   disp   - DispatcherId
+        //   parent - ParentDispatcherId (0 if none; non-zero shows V1<->V2 parent capture)
+        //   frames - callstack FrameCount (0 for non-callstack events)
+        //   unwind - UnwindFrameCount (for UnwindAsyncException events)
+        private static string DescribeEvents(ParsedEventStream stream)
+        {
+            var ordered = stream.All.OrderBy(e => e.Timestamp).ToList();
+            long t0 = ordered.Count > 0 ? ordered[0].Timestamp : 0;
+            const string Header = "seq,delta,thread,event,disp,parent,frames,unwind";
+            var rows = ordered.Select((e, i) =>
+                $"{i},{e.Timestamp - t0},{e.OsThreadId},{e.EventId},{e.DispatcherId},{e.ParentDispatcherId},{e.FrameCount},{e.UnwindFrameCount}");
+            return "----- BEGIN ASYNC EVENTS (CSV) -----" + Environment.NewLine
+                + Header + Environment.NewLine
+                + string.Join(Environment.NewLine, rows) + Environment.NewLine
+                + "----- END ASYNC EVENTS -----";
+        }
+
+        // Lets the stream-aware asserts accept EITHER an already-parsed ParsedEventStream or the raw
+        // CollectedEvents (parsed lazily, only on failure). Tests that have a parsed stream pass it
+        // directly; tests that only have the collected events pass those. The implicit conversions
+        // keep the assert helpers to a single overload set.
+        private readonly struct EventDump
+        {
+            private readonly ParsedEventStream _stream;
+            private readonly CollectedEvents _events;
+
+            private EventDump(ParsedEventStream stream, CollectedEvents events)
+            {
+                _stream = stream;
+                _events = events;
+            }
+
+            public static implicit operator EventDump(ParsedEventStream stream) => new EventDump(stream, null);
+            public static implicit operator EventDump(CollectedEvents events) => new EventDump(null, events);
+
+            public string Describe() => DescribeEvents(_stream ?? ParseAllEvents(_events));
+        }
+
+        // Stream-aware assert helpers: thin wrappers over the corresponding xunit asserts that, on
+        // failure, append the compact event stream (DescribeEvents) to xunit's own failure message.
+        // CI surfaces only the assertion string (no console), so these make a failing assert
+        // self-diagnosing. The dump is computed lazily -- only when the assertion actually fails --
+        // so passing asserts pay nothing, and xunit's native message (e.g. Equal's expected/actual
+        // diff) is preserved. The first argument accepts either a ParsedEventStream or CollectedEvents.
+        // Every test that has either in scope should use these instead of the raw Assert.* methods so
+        // any CI failure carries the event trace.
+        private static void Wrap(EventDump dump, Action assert)
+        {
+            try
+            {
+                assert();
+            }
+            catch (Xunit.Sdk.XunitException ex)
+            {
+                throw new Xunit.Sdk.XunitException($"{ex.Message}{Environment.NewLine}{dump.Describe()}");
+            }
+        }
+
+        private static void AssertTrue(EventDump dump, bool condition, string message = null) => Wrap(dump, () => Assert.True(condition, message));
+
+        private static void AssertFalse(EventDump dump, bool condition, string message = null) => Wrap(dump, () => Assert.False(condition, message));
+
+        private static void AssertNotEmpty<T>(EventDump dump, IEnumerable<T> collection) => Wrap(dump, () => Assert.NotEmpty(collection));
+
+        private static void AssertEmpty<T>(EventDump dump, IEnumerable<T> collection) => Wrap(dump, () => Assert.Empty(collection));
+
+        private static void AssertEqual<T>(EventDump dump, T expected, T actual) => Wrap(dump, () => Assert.Equal(expected, actual));
+
+        private static void AssertNotNull(EventDump dump, object @object) => Wrap(dump, () => Assert.NotNull(@object));
+
+        private static void AssertSingle<T>(EventDump dump, IEnumerable<T> collection) => Wrap(dump, () => Assert.Single(collection));
+
+        private static void AssertContains<T>(EventDump dump, T expected, IEnumerable<T> collection) => Wrap(dump, () => Assert.Contains(expected, collection));
+
+        private static void AssertContains(EventDump dump, string expectedSubstring, string actualString) => Wrap(dump, () => Assert.Contains(expectedSubstring, actualString));
+
+        private static void AssertContains<T>(EventDump dump, IEnumerable<T> collection, Predicate<T> filter) => Wrap(dump, () => Assert.Contains(collection, filter));
+
+        private static void AssertDoesNotContain<T>(EventDump dump, T expected, IEnumerable<T> collection) => Wrap(dump, () => Assert.DoesNotContain(expected, collection));
+
+        private static void AssertAll<T>(EventDump dump, IEnumerable<T> collection, Action<T> action) => Wrap(dump, () => Assert.All(collection, action));
+
+
         private static bool HasCallstackWithExpectedFrames(List<ParsedEvent> callstacks, string[] expectedFrames)
         {
             foreach (var cs in callstacks)
@@ -1429,7 +1528,7 @@ namespace System.Threading.Tasks.Tests
             {
                 resumeStacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, markerMethodName);
             }
-            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{markerMethodName}'");
+            AssertTrue(stream, resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{markerMethodName}'");
 
             ulong dispatcherId = resumeStacks[0].DispatcherId;
 
@@ -1465,7 +1564,7 @@ namespace System.Threading.Tasks.Tests
                 }
             }
 
-            Assert.Equal(0, stackDepth);
+            AssertTrue(stream, stackDepth == 0, $"Expected callstack simulation for '{markerMethodName}' (DispatcherId {dispatcherId}) to reach 0, got {stackDepth}");
         }
 
         private static void AssertExactlyOneCreateAndComplete(ParsedEventStream stream, ulong dispatcherId, string chainName)
@@ -1473,8 +1572,8 @@ namespace System.Threading.Tasks.Tests
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
             int creates = ids.Count(id => id is AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.TaskAsync_CreateAsyncContext);
             int completes = ids.Count(id => id is AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_CompleteAsyncContext);
-            Assert.True(creates == 1, $"Expected exactly 1 CreateAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
-            Assert.True(completes == 1, $"Expected exactly 1 CompleteAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {completes}");
+            AssertTrue(stream, creates == 1, $"Expected exactly 1 CreateAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
+            AssertTrue(stream, completes == 1, $"Expected exactly 1 CompleteAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {completes}");
         }
 
         // V1-friendly variant: V1's per-MoveNext dispatcher model emits one Create per await
@@ -1485,8 +1584,8 @@ namespace System.Threading.Tasks.Tests
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
             int creates = ids.Count(id => id == AsyncEventID.TaskAsync_CreateAsyncContext);
             int completes = ids.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
-            Assert.True(creates >= 1, $"Expected at least 1 TaskAsync_CreateAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
-            Assert.True(creates == completes, $"Expected TaskAsync_CreateAsyncContext count == TaskAsync_CompleteAsyncContext count for {chainName} (DispatcherId {dispatcherId}), got {creates} creates and {completes} completes");
+            AssertTrue(stream, creates >= 1, $"Expected at least 1 TaskAsync_CreateAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
+            AssertTrue(stream, creates == completes, $"Expected TaskAsync_CreateAsyncContext count == TaskAsync_CompleteAsyncContext count for {chainName} (DispatcherId {dispatcherId}), got {creates} creates and {completes} completes");
         }
 
         private sealed class InlinePostSynchronizationContext : SynchronizationContext

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -519,12 +519,12 @@ namespace System.Threading.Tasks.Tests
             // AppendAsyncCallstack events for the same context, up until the next Suspend/Complete on that
             // context.
             //
-            /// V1 dispatchers may emit a partial Resume callstack when the parent continuation hasn't yet
-            /// registered (race between dispatcher pickup and parent's AwaitUnsafeOnCompleted). Frames that
-            /// register later are emitted as AppendAsyncCallstack at the next hook point. Merging produces
-            /// the complete chain that was observable during the dispatcher's lifetime.
-            ///
-            /// Returns one ParsedEvent per Resume, with Frames and FrameCount reflecting the merged total.
+            // V1 dispatchers may emit a partial Resume callstack when the parent continuation hasn't yet
+            // registered (race between dispatcher pickup and parent's AwaitUnsafeOnCompleted). Frames that
+            // register later are emitted as AppendAsyncCallstack at the next hook point. Merging produces
+            // the complete chain that was observable during the dispatcher's lifetime.
+            //
+            // Returns one ParsedEvent per Resume, with Frames and FrameCount reflecting the merged total.
             public List<ParsedEvent> MergedResumeCallstacks()
             {
                 var result = new List<ParsedEvent>();

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -113,6 +113,15 @@ namespace System.Threading.Tasks.Tests
         // These tests use async Task methods with await instead of Task.Run blocking.
         public static bool IsRuntimeAsyncSupported => PlatformDetection.IsRuntimeAsyncSupported;
 
+        // V1 (TaskAsync_*) async-task instrumentation is opt-out on NativeAOT to avoid
+        // ~100KB of per-state-machine generic instantiation overhead. Tests that depend
+        // on V1 events must be gated on these properties so they are skipped on NAOT.
+        public static bool IsTaskAsyncInstrumentationSupported =>
+            IsRuntimeAsyncSupported && !PlatformDetection.IsNativeAot;
+
+        public static bool IsTaskAsyncInstrumentationAndThreadingSupported =>
+            IsRuntimeAsyncAndThreadingSupported && !PlatformDetection.IsNativeAot;
+
         private const string AsyncProfilerEventSourceName = "System.Runtime.CompilerServices.AsyncProfilerEventSource";
         private const string WrapperNameTemplate = "Continuation_Wrapper_{0}";
         private static readonly string WrapperNamePrefix = WrapperNameTemplate.Substring(0, WrapperNameTemplate.IndexOf("{0}", StringComparison.Ordinal));
@@ -160,6 +169,20 @@ namespace System.Threading.Tasks.Tests
                 ? typeof(StackFrame).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, new[] { typeof(IntPtr), typeof(bool) }, null)
                 : null;
 
+        // The public 1-arg MethodBase.GetMethodFromHandle resolves the method but then deliberately
+        // throws ArgumentException when the declaring type is generic. The internal
+        // RuntimeType.GetMethodBase(RuntimeMethodHandle.GetMethodInfo()) it calls underneath has no
+        // such guard, so we invoke it directly to name V1 frames on generic declaring types.
+        private static readonly MethodInfo? s_runtimeMethodHandleGetMethodInfo =
+            typeof(RuntimeMethodHandle).GetMethod("GetMethodInfo", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        private static readonly MethodInfo? s_runtimeTypeGetMethodBase =
+            // typeof(object) is a RuntimeType instance; its runtime type is System.RuntimeType.
+            typeof(object).GetType().GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+                .FirstOrDefault(m => m.Name == "GetMethodBase"
+                    && m.GetParameters() is { Length: 1 } p
+                    && p[0].ParameterType.Name == "IRuntimeMethodInfo");
+
         private static string? GetMethodNameFromMethodId(AsyncCallstackType callstackType, ulong methodId)
         {
             if (methodId != 0)
@@ -194,10 +217,17 @@ namespace System.Threading.Tasks.Tests
                         // it requires the 2-arg overload with an explicit declaring type, which
                         // we cannot recover from a bare MethodId. Real ETW/EventPipe consumers
                         // get the declaring type from method-metadata rundown events.
+                        //
+                        // As a test-only fallback, resolve via the internal
+                        // RuntimeType.GetMethodBase the public API uses before its generic guard,
+                        // which does name methods on generic declaring types. This mirrors what a
+                        // rundown-backed consumer would achieve.
+                        method = ResolveCompilerMethodOnGenericType(handle);
                     }
-                    if (method != null)
+
+                    if (method?.DeclaringType is Type declaringType)
                     {
-                        string methodName = method.DeclaringType.Name;
+                        string methodName = declaringType.Name;
 
                         int start = methodName.IndexOf('<');
                         int end = methodName.IndexOf('>');
@@ -214,6 +244,34 @@ namespace System.Threading.Tasks.Tests
             }
 
             return null;
+        }
+
+        // Test-only fallback used when a compiler (V1) MethodId handle cannot be resolved via the
+        // 1-arg MethodBase.GetMethodFromHandle because its declaring type is generic. Calls the
+        // internal RuntimeType.GetMethodBase(handle.GetMethodInfo()) the public API uses underneath,
+        // which has no generic-declaring-type guard, so it names methods on generic declaring types.
+        // Returns null if the internals are unavailable (e.g. NativeAOT) or resolution throws.
+        private static MethodBase? ResolveCompilerMethodOnGenericType(RuntimeMethodHandle handle)
+        {
+            if (s_runtimeMethodHandleGetMethodInfo is null || s_runtimeTypeGetMethodBase is null)
+            {
+                return null;
+            }
+
+            try
+            {
+                object? methodInfo = s_runtimeMethodHandleGetMethodInfo.Invoke(handle, null);
+                if (methodInfo is null)
+                {
+                    return null;
+                }
+
+                return (MethodBase?)s_runtimeTypeGetMethodBase.Invoke(null, new object[] { methodInfo });
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
 
         private static TestEventListener CreateListener(EventKeywords keywords)
@@ -589,6 +647,14 @@ namespace System.Threading.Tasks.Tests
             private Dictionary<ulong, List<ParsedEvent>>? _byDispatcherId;
             private Dictionary<ulong, ulong>? _parentOfDispatcher;
             private Dictionary<ulong, List<ulong>>? _childrenOfDispatcher;
+            private Dictionary<ulong, DispatcherKind>? _dispatcherKind;
+
+            // V1 (TaskAsync_*) and V2 (RuntimeAsync_*) dispatchers can coexist on the same logical
+            // thread (e.g., a V1 test runner hosting a V2 test body). The runtime captures cross-kind
+            // parent links in that case, but a single test typically wants to walk only its own kind's
+            // subtree. Tracking the kind per dispatcher lets the chain walk stop at V1<->V2 boundaries
+            // by default.
+            internal enum DispatcherKind { Unknown, V1, V2 }
 
             public ParsedEventStream(List<ParsedEvent> events)
             {
@@ -660,6 +726,7 @@ namespace System.Threading.Tasks.Tests
 
                 _parentOfDispatcher = new Dictionary<ulong, ulong>();
                 _childrenOfDispatcher = new Dictionary<ulong, List<ulong>>();
+                _dispatcherKind = new Dictionary<ulong, DispatcherKind>();
 
                 HashSet<ulong> dispatchersWithCreate = new HashSet<ulong>();
                 foreach (var evt in _events)
@@ -687,6 +754,19 @@ namespace System.Threading.Tasks.Tests
                         continue;
                     }
 
+                    DispatcherKind kind = evt.EventId switch
+                    {
+                        AsyncEventID.TaskAsync_CreateAsyncContext => DispatcherKind.V1,
+                        AsyncEventID.RuntimeAsync_CreateAsyncContext or
+                        AsyncEventID.RuntimeAsync_CreateAsyncCallstack => DispatcherKind.V2,
+                        _ => DispatcherKind.Unknown,
+                    };
+
+                    if (kind != DispatcherKind.Unknown)
+                    {
+                        _dispatcherKind![evt.DispatcherId] = kind;
+                    }
+
                     ulong parent = evt.ParentDispatcherId;
                     if (parent == 0 || !dispatchersWithCreate.Contains(parent))
                     {
@@ -710,15 +790,27 @@ namespace System.Threading.Tasks.Tests
                 }
             }
 
+            private DispatcherKind KindOf(ulong dispatcherId) =>
+                _dispatcherKind is not null && _dispatcherKind.TryGetValue(dispatcherId, out var k)
+                    ? k
+                    : DispatcherKind.Unknown;
+
             // Returns the root DispatcherId for the chain containing dispatcherId, by walking parent pointers.
-            // If no parent information is found (no Create event), returns dispatcherId itself.
-            public ulong RootOfDispatcher(ulong dispatcherId)
+            // By default the climb stops at V1<->V2 boundaries so a V2 marker doesn't get pulled up into
+            // an enclosing V1 test-runner dispatcher (and vice versa). Pass crossKinds: true to walk to
+            // the absolute root regardless of dispatcher kind.
+            public ulong RootOfDispatcher(ulong dispatcherId, bool crossKinds = false)
             {
                 EnsureDispatcherTree();
 
+                DispatcherKind startKind = KindOf(dispatcherId);
                 ulong current = dispatcherId;
                 while (_parentOfDispatcher!.TryGetValue(current, out ulong parent) && parent != 0)
                 {
+                    if (!crossKinds && startKind != DispatcherKind.Unknown && KindOf(parent) != startKind)
+                    {
+                        break;
+                    }
                     current = parent;
                 }
 
@@ -726,12 +818,16 @@ namespace System.Threading.Tasks.Tests
             }
 
             // Returns the set of all dispatcher ids in the same chain (connected component) as dispatcherId.
-            // Walks up to the root via parent pointers, then collects all descendants via BFS.
-            public HashSet<ulong> ChainDispatcherIds(ulong dispatcherId)
+            // Walks up to the root via parent pointers, then collects all descendants via BFS. By default
+            // the walk is restricted to dispatchers of the same kind (V1 or V2) as dispatcherId so that a
+            // single test's chain doesn't span unrelated cross-kind activity (e.g., a V1 xunit test runner
+            // hosting a V2 test body). Pass crossKinds: true to walk the full connected component.
+            public HashSet<ulong> ChainDispatcherIds(ulong dispatcherId, bool crossKinds = false)
             {
                 EnsureDispatcherTree();
 
-                ulong root = RootOfDispatcher(dispatcherId);
+                DispatcherKind startKind = KindOf(dispatcherId);
+                ulong root = RootOfDispatcher(dispatcherId, crossKinds);
 
                 var chain = new HashSet<ulong> { root };
                 var queue = new Queue<ulong>();
@@ -744,6 +840,11 @@ namespace System.Threading.Tasks.Tests
                     {
                         foreach (var kid in kids)
                         {
+                            if (!crossKinds && startKind != DispatcherKind.Unknown && KindOf(kid) != startKind)
+                            {
+                                continue;
+                            }
+
                             if (chain.Add(kid))
                             {
                                 queue.Enqueue(kid);
@@ -756,9 +857,10 @@ namespace System.Threading.Tasks.Tests
             }
 
             // Returns all events whose DispatcherId is in the same chain as dispatcherId, in timestamp order.
-            public List<ParsedEvent> ChainEventsFromDispatcher(ulong dispatcherId)
+            // The chain is restricted to the same dispatcher kind by default (see ChainDispatcherIds).
+            public List<ParsedEvent> ChainEventsFromDispatcher(ulong dispatcherId, bool crossKinds = false)
             {
-                HashSet<ulong> chain = ChainDispatcherIds(dispatcherId);
+                HashSet<ulong> chain = ChainDispatcherIds(dispatcherId, crossKinds);
                 return _events.Where(e => chain.Contains(e.DispatcherId)).ToList();
             }
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -94,17 +94,16 @@ namespace System.Threading.Tasks.Tests
             CompleteAsyncContextKeyword | CompleteAsyncMethodKeyword | UnwindAsyncExceptionKeyword;
 
         // CoreCLR has StackFrame.GetMethodFromNativeIP (static, non-public).
-        // NativeAOT lacks that but has an internal StackFrame(IntPtr, bool) constructor;
-        // we resolve the name via DiagnosticMethodInfo.Create(frame).
         private static readonly MethodInfo? s_getMethodFromNativeIPMethod =
             typeof(StackFrame).GetMethod("GetMethodFromNativeIP", BindingFlags.Static | BindingFlags.NonPublic);
 
+        // NativeAOT has DiagnosticMethodInfo.Create(StackFrame) (instance, non-public).
         private static readonly ConstructorInfo? s_stackFrameFromIPCtor =
             s_getMethodFromNativeIPMethod is null
                 ? typeof(StackFrame).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, new[] { typeof(IntPtr), typeof(bool) }, null)
                 : null;
 
-        internal static string? GetMethodNameFromMethodId(AsyncCallstackType callstackType, ulong methodId)
+        private static string? GetMethodNameFromMethodId(AsyncCallstackType callstackType, ulong methodId)
         {
             if (methodId != 0)
             {
@@ -112,14 +111,14 @@ namespace System.Threading.Tasks.Tests
                 {
                     if (s_getMethodFromNativeIPMethod is not null)
                     {
-                        var method = (MethodBase?)s_getMethodFromNativeIPMethod.Invoke(null, new object[] { (IntPtr)methodId });
+                        MethodBase? method = (MethodBase?)s_getMethodFromNativeIPMethod.Invoke(null, new object[] { (IntPtr)methodId });
                         return method?.Name;
                     }
 
                     if (s_stackFrameFromIPCtor is not null)
                     {
-                        var frame = (StackFrame)s_stackFrameFromIPCtor.Invoke(new object[] { (IntPtr)methodId, false })!;
-                        var diagInfo = DiagnosticMethodInfo.Create(frame);
+                        StackFrame frame = (StackFrame)s_stackFrameFromIPCtor.Invoke(new object[] { (IntPtr)methodId, false })!;
+                        DiagnosticMethodInfo? diagInfo = DiagnosticMethodInfo.Create(frame);
                         return diagInfo?.Name;
                     }
                 }
@@ -146,135 +145,6 @@ namespace System.Threading.Tasks.Tests
             }
 
             return null;
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SingleAsyncYield()
-        {
-            await Task.Yield();
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task ChainedAsyncYield()
-        {
-            await InnerAsyncYield();
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task InnerAsyncYield()
-        {
-            await Task.Yield();
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task OuterCatches()
-        {
-            try
-            {
-                await InnerThrows();
-            }
-            catch (InvalidOperationException)
-            {
-            }
-            await Task.Yield();
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task InnerThrows()
-        {
-            await Task.Yield();
-            throw new InvalidOperationException("inner");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task DeepOuterCatches()
-        {
-            try
-            {
-                await DeepMiddle();
-            }
-            catch (InvalidOperationException)
-            {
-            }
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task DeepMiddle()
-        {
-            await DeepInnerThrows();
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task DeepInnerThrows()
-        {
-            await Task.Yield();
-            throw new InvalidOperationException("deep inner");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task DeepUnhandledOuter()
-        {
-            await DeepUnhandledMiddle();
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task DeepUnhandledMiddle()
-        {
-            await DeepUnhandledInnerThrows();
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task DeepUnhandledInnerThrows()
-        {
-            await Task.Yield();
-            throw new InvalidOperationException("deep unhandled");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task RecursiveAsyncChain(int depth)
-        {
-            if (depth <= 1)
-            {
-                await Task.Yield();
-                return;
-            }
-            await RecursiveAsyncChain(depth - 1);
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task WrapperTestA(List<(string MethodName, int WrapperSlot)> captures)
-        {
-            await WrapperTestB(captures);
-            captures.Add((nameof(WrapperTestA), GetCurrentWrapperSlot(nameof(WrapperTestA))));
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task WrapperTestB(List<(string MethodName, int WrapperSlot)> captures)
-        {
-            await WrapperTestC(captures);
-            captures.Add((nameof(WrapperTestB), GetCurrentWrapperSlot(nameof(WrapperTestB))));
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task WrapperTestC(List<(string MethodName, int WrapperSlot)> captures)
-        {
-            await Task.Yield();
-            captures.Add((nameof(WrapperTestC), GetCurrentWrapperSlot(nameof(WrapperTestC))));
         }
 
         private static TestEventListener CreateListener(EventKeywords keywords)
@@ -312,40 +182,47 @@ namespace System.Threading.Tasks.Tests
                 string? name = GetFrameMethodName(st.GetFrame(i));
                 if (name is not null && name.Contains(resumedMethodName))
                 {
-                    // Scan subsequent frames, skipping unresolvable stubs (e.g. delegate invoke thunks on NativeAOT).
                     for (int j = i + 1; j < st.FrameCount; j++)
                     {
                         string? wrapperName = GetFrameMethodName(st.GetFrame(j));
                         if (wrapperName is null)
+                        {
                             continue;
+                        }
+
                         if (wrapperName.StartsWith(WrapperNamePrefix, StringComparison.Ordinal))
                         {
                             string wrapperSuffix = wrapperName.Substring(WrapperNamePrefix.Length);
                             return int.TryParse(wrapperSuffix, out int wrapperSlot) ? wrapperSlot : -1;
                         }
+
                         break;
                     }
+
                     return -1;
                 }
             }
+
             return -1;
         }
 
         private static string? GetFrameMethodName(StackFrame? frame)
         {
             if (frame is null)
+            {
                 return null;
+            }
+
             string? name = frame.GetMethod()?.Name;
             if (name is null)
             {
                 name = DiagnosticMethodInfo.Create(frame)?.Name;
             }
+
             return name;
         }
 
         private delegate bool EventVisitor(AsyncEventID eventId, ReadOnlySpan<byte> buffer, ref int index);
-
-        private delegate bool EventVisitorWithTimestamp(AsyncEventID eventId, long timestamp, ReadOnlySpan<byte> buffer, ref int index);
 
         private static void ParseEventBuffer(ReadOnlySpan<byte> buffer, EventVisitor visitor)
         {
@@ -353,11 +230,15 @@ namespace System.Threading.Tasks.Tests
                 visitor(eventId, buf, ref idx));
         }
 
+        private delegate bool EventVisitorWithTimestamp(AsyncEventID eventId, long timestamp, ReadOnlySpan<byte> buffer, ref int index);
+
         private static void ParseEventBuffer(ReadOnlySpan<byte> buffer, EventVisitorWithTimestamp visitor)
         {
             EventBufferHeader? header = ParseEventBufferHeader(buffer);
             if (header is null)
+            {
                 return;
+            }
 
             int index = HeaderSize;
             long baseTimestamp = (long)header.Value.StartTimestamp;
@@ -365,7 +246,9 @@ namespace System.Threading.Tasks.Tests
             while (index < buffer.Length)
             {
                 if (index + 2 > buffer.Length)
+                {
                     break;
+                }
 
                 AsyncEventID eventId = (AsyncEventID)buffer[index++];
 
@@ -373,7 +256,9 @@ namespace System.Threading.Tasks.Tests
                 baseTimestamp += delta;
 
                 if (!visitor(eventId, baseTimestamp, buffer, ref index))
+                {
                     break;
+                }
             }
         }
 
@@ -383,45 +268,59 @@ namespace System.Threading.Tasks.Tests
             {
                 case AsyncEventID.CreateAsyncContext:
                 case AsyncEventID.ResumeAsyncContext:
+                {
                     ReadCompressedUInt64(buffer, ref index);
                     return true;
+                }
                 case AsyncEventID.SuspendAsyncContext:
                 case AsyncEventID.CompleteAsyncContext:
                 case AsyncEventID.ResumeAsyncMethod:
                 case AsyncEventID.CompleteAsyncMethod:
                 case AsyncEventID.ResetAsyncThreadContext:
                 case AsyncEventID.ResetAsyncContinuationWrapperIndex:
+                {
                     return true;
+                }
                 case AsyncEventID.AsyncProfilerMetadata:
+                {
                     SkipMetadataPayload(buffer, ref index);
                     return true;
+                }
                 case AsyncEventID.AsyncProfilerSyncClock:
+                {
                     ReadCompressedUInt64(buffer, ref index); // qpcSync
                     ReadCompressedUInt64(buffer, ref index); // utcSync
                     return true;
+                }
                 case AsyncEventID.UnwindAsyncException:
+                {
                     ReadCompressedUInt32(buffer, ref index);
                     return true;
+                }
                 case AsyncEventID.CreateAsyncCallstack:
                 case AsyncEventID.ResumeAsyncCallstack:
                 case AsyncEventID.SuspendAsyncCallstack:
                 case AsyncEventID.AppendAsyncCallstack:
+                {
                     SkipCallstackPayload(buffer, ref index);
                     return true;
+                }
                 default:
+                {
                     return false;
+                }
             }
         }
 
         private static uint ReadCompressedUInt32(ReadOnlySpan<byte> buffer, ref int index)
         {
-            EventBuffer.Deserializer.ReadCompressedUInt32(buffer, ref index, out uint value);
+            Deserializer.ReadCompressedUInt32(buffer, ref index, out uint value);
             return value;
         }
 
         private static ulong ReadCompressedUInt64(ReadOnlySpan<byte> buffer, ref int index)
         {
-            EventBuffer.Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong value);
+            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong value);
             return value;
         }
 
@@ -439,14 +338,16 @@ namespace System.Threading.Tasks.Tests
         private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index,
             out ulong taskId, out AsyncCallstackType callstackType, out byte frameCount, out List<(ulong MethodId, int State)> frames)
         {
-            callstackType = (AsyncCallstackType)buffer[index++]; // type
-            index++; // callstack ID (reserved)
+            callstackType = (AsyncCallstackType)buffer[index++];
+            index++;
             frameCount = buffer[index++];
             taskId = ReadCompressedUInt64(buffer, ref index);
             frames = new List<(ulong, int)>(frameCount);
 
             if (frameCount == 0)
+            {
                 return;
+            }
 
             ulong currentMethodId = ReadCompressedUInt64(buffer, ref index);
             int state = ReadCompressedInt32(buffer, ref index);
@@ -463,13 +364,13 @@ namespace System.Threading.Tasks.Tests
 
         private static int ReadCompressedInt32(ReadOnlySpan<byte> buffer, ref int index)
         {
-            EventBuffer.Deserializer.ReadCompressedInt32(buffer, ref index, out int value);
+            Deserializer.ReadCompressedInt32(buffer, ref index, out int value);
             return value;
         }
 
         private static long ReadCompressedInt64(ReadOnlySpan<byte> buffer, ref int index)
         {
-            EventBuffer.Deserializer.ReadCompressedInt64(buffer, ref index, out long value);
+            Deserializer.ReadCompressedInt64(buffer, ref index, out long value);
             return value;
         }
 
@@ -495,15 +396,17 @@ namespace System.Threading.Tasks.Tests
         private static EventBufferHeader? ParseEventBufferHeader(ReadOnlySpan<byte> buffer)
         {
             if (buffer.Length < HeaderSize || buffer[0] != 1)
+            {
                 return null;
+            }
 
             int index = 1;
-            EventBuffer.Deserializer.ReadUInt32(buffer, ref index, out uint totalSize);
-            EventBuffer.Deserializer.ReadUInt32(buffer, ref index, out uint contextId);
-            EventBuffer.Deserializer.ReadUInt64(buffer, ref index, out ulong threadId);
-            EventBuffer.Deserializer.ReadUInt32(buffer, ref index, out uint eventCount);
-            EventBuffer.Deserializer.ReadUInt64(buffer, ref index, out ulong startTs);
-            EventBuffer.Deserializer.ReadUInt64(buffer, ref index, out ulong endTs);
+            Deserializer.ReadUInt32(buffer, ref index, out uint totalSize);
+            Deserializer.ReadUInt32(buffer, ref index, out uint contextId);
+            Deserializer.ReadUInt64(buffer, ref index, out ulong threadId);
+            Deserializer.ReadUInt32(buffer, ref index, out uint eventCount);
+            Deserializer.ReadUInt64(buffer, ref index, out ulong startTs);
+            Deserializer.ReadUInt64(buffer, ref index, out ulong endTs);
 
             return new EventBufferHeader(buffer[0], totalSize, contextId, threadId, eventCount, startTs, endTs);
         }
@@ -514,42 +417,35 @@ namespace System.Threading.Tasks.Tests
             public long Timestamp { get; init; }
             public ulong OsThreadId { get; init; }
 
-            /// <summary>
-            /// The Task.Id associated with this event. For context events (Create/Resume),
-            /// this is the payload ID. For callstack events, this is the ID from the callstack
-            /// header. For other events, this is the active task ID at the time of emission.
-            /// </summary>
             public ulong TaskId { get; init; }
 
-            // Callstack events (Create/Resume/Suspend): frames
             public AsyncCallstackType CallstackType { get; init; }
             public byte FrameCount { get; init; }
             public List<(ulong MethodId, int State)> Frames { get; init; } = [];
 
-            // UnwindAsyncException: frame count unwound
             public uint UnwindFrameCount { get; init; }
 
-            // Metadata
             public MetadataFromBuffer? Metadata { get; init; }
 
-            // SyncClock
             public ulong SyncClockQpc { get; init; }
             public ulong SyncClockUtc { get; init; }
 
-            /// <summary>
-            /// Returns true if any frame in this event's callstack resolves to a method
-            /// whose name contains the specified marker string.
-            /// </summary>
             public bool HasMarkerFrame(string markerMethodName)
             {
                 if (Frames.Count == 0)
+                {
                     return false;
+                }
+
                 foreach (var (methodId, _) in Frames)
                 {
-                    var methodName = GetMethodNameFromMethodId(CallstackType, methodId);
+                    string? methodName = GetMethodNameFromMethodId(CallstackType, methodId);
                     if (methodName is not null && methodName.Contains(markerMethodName, StringComparison.Ordinal))
+                    {
                         return true;
+                    }
                 }
+
                 return false;
             }
         }
@@ -565,151 +461,160 @@ namespace System.Threading.Tasks.Tests
                 _events.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
             }
 
-            /// <summary>All events in timestamp order.</summary>
+            // All events in timestamp order.
             public IReadOnlyList<ParsedEvent> All => _events;
 
-            /// <summary>All distinct event IDs present in the stream.</summary>
+            // All distinct event IDs present in the stream.
             public IEnumerable<AsyncEventID> EventIds => _events.Select(e => e.EventId).Distinct();
 
-            /// <summary>Filter events by event ID, in timestamp order.</summary>
+            // Filter events by event ID, in timestamp order.
             public IEnumerable<ParsedEvent> OfType(AsyncEventID eventId) =>
                 _events.Where(e => e.EventId == eventId);
 
-            /// <summary>Filter events by multiple event IDs, in timestamp order.</summary>
+            // Filter events by multiple event IDs, in timestamp order.
             public IEnumerable<ParsedEvent> OfTypes(params AsyncEventID[] eventIds)
             {
                 var set = new HashSet<AsyncEventID>(eventIds);
                 return _events.Where(e => set.Contains(e.EventId));
             }
 
-            /// <summary>Get events grouped by Task.Id, each group in timestamp order.</summary>
+            // Get events grouped by Task.Id, each group in timestamp order.
             public Dictionary<ulong, List<ParsedEvent>> ByTaskId()
             {
                 if (_byTaskId is not null)
+                {
                     return _byTaskId;
+                }
 
                 _byTaskId = new Dictionary<ulong, List<ParsedEvent>>();
                 foreach (var evt in _events)
                 {
                     if (evt.TaskId == 0)
+                    {
                         continue;
+                    }
+
                     if (!_byTaskId.TryGetValue(evt.TaskId, out var list))
                     {
                         list = new List<ParsedEvent>();
                         _byTaskId[evt.TaskId] = list;
                     }
+
                     list.Add(evt);
                 }
+
                 return _byTaskId;
             }
 
-            /// <summary>Get events for a specific Task.Id in timestamp order.</summary>
+            // Get events for a specific Task.Id in timestamp order.
             public List<ParsedEvent> ForTask(ulong taskId) =>
                 ByTaskId().TryGetValue(taskId, out var list) ? list : new List<ParsedEvent>();
 
-            /// <summary>
-            /// Get callstack events (of specified type) that contain the marker method in their frames.
-            /// Results are in timestamp order.
-            /// </summary>
+            // Get callstack events (of specified type) that contain the marker method in their frames.
+            // Results are in timestamp order.
             public List<ParsedEvent> CallstacksWithMarker(AsyncEventID callstackEventId, string markerMethodName) =>
                 _events.Where(e => e.EventId == callstackEventId && e.HasMarkerFrame(markerMethodName)).ToList();
 
-            /// <summary>
-            /// Reconstructs full resume callstacks by merging each ResumeAsyncCallstack with any subsequent
-            /// AppendAsyncCallstack events for the same context, up until the next Suspend/Complete on that
-            /// context.
-            ///
+            // Reconstructs full resume callstacks by merging each ResumeAsyncCallstack with any subsequent
+            // AppendAsyncCallstack events for the same context, up until the next Suspend/Complete on that
+            // context.
+            //
             /// V1 dispatchers may emit a partial Resume callstack when the parent continuation hasn't yet
             /// registered (race between dispatcher pickup and parent's AwaitUnsafeOnCompleted). Frames that
             /// register later are emitted as AppendAsyncCallstack at the next hook point. Merging produces
             /// the complete chain that was observable during the dispatcher's lifetime.
             ///
             /// Returns one ParsedEvent per Resume, with Frames and FrameCount reflecting the merged total.
-            /// </summary>
             public List<ParsedEvent> MergedResumeCallstacks()
             {
                 var result = new List<ParsedEvent>();
-                var openByTaskId = new Dictionary<ulong, int>(); // taskId → index into result
+                var openByTaskId = new Dictionary<ulong, int>();
 
                 foreach (var evt in _events)
                 {
                     switch (evt.EventId)
                     {
                         case AsyncEventID.ResumeAsyncCallstack:
+                        {
+                            var merged = new ParsedEvent
                             {
-                                var merged = new ParsedEvent
-                                {
-                                    EventId = evt.EventId,
-                                    Timestamp = evt.Timestamp,
-                                    OsThreadId = evt.OsThreadId,
-                                    TaskId = evt.TaskId,
-                                    CallstackType = evt.CallstackType,
-                                    FrameCount = evt.FrameCount,
-                                    Frames = new List<(ulong MethodId, int State)>(evt.Frames),
-                                };
-                                openByTaskId[evt.TaskId] = result.Count;
-                                result.Add(merged);
-                                break;
-                            }
+                                EventId = evt.EventId,
+                                Timestamp = evt.Timestamp,
+                                OsThreadId = evt.OsThreadId,
+                                TaskId = evt.TaskId,
+                                CallstackType = evt.CallstackType,
+                                FrameCount = evt.FrameCount,
+                                Frames = new List<(ulong MethodId, int State)>(evt.Frames),
+                            };
+
+                            openByTaskId[evt.TaskId] = result.Count;
+                            result.Add(merged);
+
+                            break;
+                        }
                         case AsyncEventID.AppendAsyncCallstack:
+                        {
+                            if (openByTaskId.TryGetValue(evt.TaskId, out int idx))
                             {
-                                if (openByTaskId.TryGetValue(evt.TaskId, out int idx))
+                                ParsedEvent existing = result[idx];
+                                var combinedFrames = new List<(ulong MethodId, int State)>(existing.Frames);
+                                combinedFrames.AddRange(evt.Frames);
+
+                                result[idx] = new ParsedEvent
                                 {
-                                    var existing = result[idx];
-                                    var combinedFrames = new List<(ulong MethodId, int State)>(existing.Frames);
-                                    combinedFrames.AddRange(evt.Frames);
-                                    result[idx] = new ParsedEvent
-                                    {
-                                        EventId = existing.EventId,
-                                        Timestamp = existing.Timestamp,
-                                        OsThreadId = existing.OsThreadId,
-                                        TaskId = existing.TaskId,
-                                        CallstackType = existing.CallstackType,
-                                        FrameCount = (byte)Math.Min(combinedFrames.Count, byte.MaxValue),
-                                        Frames = combinedFrames,
-                                    };
-                                }
-                                break;
+                                    EventId = existing.EventId,
+                                    Timestamp = existing.Timestamp,
+                                    OsThreadId = existing.OsThreadId,
+                                    TaskId = existing.TaskId,
+                                    CallstackType = existing.CallstackType,
+                                    FrameCount = (byte)Math.Min(combinedFrames.Count, byte.MaxValue),
+                                    Frames = combinedFrames,
+                                };
                             }
+
+                            break;
+                        }
                         case AsyncEventID.SuspendAsyncContext:
                         case AsyncEventID.CompleteAsyncContext:
+                        {
                             openByTaskId.Remove(evt.TaskId);
                             break;
+                        }
                     }
                 }
 
                 return result;
             }
 
-            /// <summary>
-            /// Get merged resume callstacks (Resume + subsequent Appends) that contain the marker method
-            /// in any of their merged frames.
-            /// </summary>
+            // Get merged resume callstacks (Resume + subsequent Appends) that contain the marker method
+            // in any of their merged frames.
             public List<ParsedEvent> MergedResumeCallstacksWithMarker(string markerMethodName) =>
                 MergedResumeCallstacks().Where(e => e.HasMarkerFrame(markerMethodName)).ToList();
 
-            /// <summary>
-            /// Get callstack events (of specified type) that contain the marker method,
-            /// taking only the first match per Task.Id (deepest chain by timestamp).
-            /// </summary>
+            // Get callstack events (of specified type) that contain the marker method,
+            // taking only the first match per Task.Id (deepest chain by timestamp).
             public List<ParsedEvent> CallstacksWithMarkerFirstPerTask(AsyncEventID callstackEventId, string markerMethodName)
             {
-                var matched = CallstacksWithMarker(callstackEventId, markerMethodName);
+                List<ParsedEvent> matched = CallstacksWithMarker(callstackEventId, markerMethodName);
                 var seen = new HashSet<ulong>();
                 var result = new List<ParsedEvent>();
+
                 foreach (var evt in matched)
                 {
                     if (evt.TaskId != 0 && seen.Add(evt.TaskId))
+                    {
                         result.Add(evt);
+                    }
                 }
+
                 return result;
             }
 
-            /// <summary>Get all metadata events.</summary>
+            // Get all metadata events.
             public List<MetadataFromBuffer> MetadataEvents =>
                 _events.Where(e => e.Metadata.HasValue).Select(e => e.Metadata!.Value).ToList();
 
-            /// <summary>Get distinct OS thread IDs across all events.</summary>
+            // Get distinct OS thread IDs across all events.
             public HashSet<ulong> OsThreadIds => new(_events.Select(e => e.OsThreadId).Where(id => id != 0));
         }
 
@@ -721,7 +626,9 @@ namespace System.Threading.Tasks.Tests
             {
                 EventBufferHeader? header = ParseEventBufferHeader(buffer);
                 if (header is null)
+                {
                     return;
+                }
 
                 ulong osThreadId = header.Value.OsThreadId;
                 ulong currentTaskId = 0;
@@ -732,7 +639,9 @@ namespace System.Threading.Tasks.Tests
                 while (index < buffer.Length)
                 {
                     if (index + 2 > buffer.Length)
+                    {
                         break;
+                    }
 
                     AsyncEventID eventId = (AsyncEventID)buffer[index++];
                     long delta = (long)ReadCompressedUInt64(buffer, ref index);
@@ -786,8 +695,12 @@ namespace System.Threading.Tasks.Tests
             {
                 ulong id = ReadCompressedUInt64(buffer, ref index);
                 if (eventId == AsyncEventID.ResumeAsyncContext && id != currentTaskId)
+                {
                     taskIdStack.Push(currentTaskId);
+                }
+
                 currentTaskId = id;
+
                 return new ParsedEvent
                 {
                     EventId = eventId,
@@ -802,6 +715,7 @@ namespace System.Threading.Tasks.Tests
             {
                 ulong completedTaskId = currentTaskId;
                 currentTaskId = taskIdStack.Count > 0 ? taskIdStack.Pop() : 0;
+
                 return new ParsedEvent
                 {
                     EventId = AsyncEventID.CompleteAsyncContext,
@@ -815,7 +729,10 @@ namespace System.Threading.Tasks.Tests
             {
                 ulong prevTaskId = currentTaskId;
                 if (eventId == AsyncEventID.ResetAsyncThreadContext)
+                {
                     currentTaskId = 0;
+                }
+
                 return new ParsedEvent
                 {
                     EventId = eventId,
@@ -834,6 +751,7 @@ namespace System.Threading.Tasks.Tests
                     taskIdStack.Push(currentTaskId);
                     currentTaskId = taskId;
                 }
+
                 return new ParsedEvent
                 {
                     EventId = eventId,
@@ -850,6 +768,7 @@ namespace System.Threading.Tasks.Tests
                 ReadOnlySpan<byte> buffer, ref int index)
             {
                 uint unwindCount = ReadCompressedUInt32(buffer, ref index);
+
                 return new ParsedEvent
                 {
                     EventId = AsyncEventID.UnwindAsyncException,
@@ -864,6 +783,7 @@ namespace System.Threading.Tasks.Tests
                 ReadOnlySpan<byte> buffer, ref int index)
             {
                 ReadMetadataPayload(buffer, ref index, out ulong freq, out ulong qpcSync, out ulong utcSync, out uint bufSize, out byte wrapperCount);
+
                 return new ParsedEvent
                 {
                     EventId = AsyncEventID.AsyncProfilerMetadata,
@@ -879,6 +799,7 @@ namespace System.Threading.Tasks.Tests
             {
                 ulong qpcSync = ReadCompressedUInt64(buffer, ref index);
                 ulong utcSync = ReadCompressedUInt64(buffer, ref index);
+
                 return new ParsedEvent
                 {
                     EventId = AsyncEventID.AsyncProfilerSyncClock,
@@ -894,6 +815,7 @@ namespace System.Threading.Tasks.Tests
                 ulong currentTaskId, ReadOnlySpan<byte> buffer, ref int index)
             {
                 SkipEventPayload(eventId, buffer, ref index);
+
                 return new ParsedEvent
                 {
                     EventId = eventId,
@@ -925,7 +847,7 @@ namespace System.Threading.Tasks.Tests
         // Uncomment at callsite to dump all collected event buffers to console for diagnostics:
         private static void DumpAllEvents(CollectedEvents events)
         {
-            ForEachEventBufferPayload(events.Events, buffer => EventBuffer.OutputEventBuffer(buffer));
+            EventBuffer.DumpAllEvents(events);
         }
 
         private static void RunScenarioAndFlush(Func<Task> scenario)
@@ -935,6 +857,13 @@ namespace System.Threading.Tasks.Tests
             // unblocks this thread. Brief sleep ensures the pool thread's finally completes.
             // V2 (runtime-async) does not have this issue — Complete fires inside the dispatch
             // loop before the task is signaled.
+            //
+            // Clear SynchronizationContext so RuntimeAsync continuations don't capture
+            // xunit's context, which would cause per-frame re-queuing instead of inlining.
+            SynchronizationContext? prevCtx = SynchronizationContext.Current;
+            int originalThreadId = Environment.CurrentManagedThreadId;
+            SynchronizationContext.SetSynchronizationContext(null);
+
             try
             {
                 Task.Run(scenario).GetAwaiter().GetResult();
@@ -942,6 +871,15 @@ namespace System.Threading.Tasks.Tests
             finally
             {
                 Thread.Sleep(50);
+
+                // Only restore the SynchronizationContext if we're still on the same thread.
+                // ConfigureAwait(false) may resume on a different thread pool thread, and
+                // setting the original thread's context there would be incorrect.
+                if (Environment.CurrentManagedThreadId == originalThreadId)
+                {
+                    SynchronizationContext.SetSynchronizationContext(prevCtx);
+                }
+
                 SendFlushCommand();
             }
         }
@@ -965,11 +903,13 @@ namespace System.Threading.Tasks.Tests
                 {
                     SendFlushCommand();
                     result.Events.Clear();
+
                     // Clear SynchronizationContext so RuntimeAsync continuations don't capture
                     // xunit's context, which would cause per-frame re-queuing instead of inlining.
-                    var prevCtx = SynchronizationContext.Current;
+                    SynchronizationContext? prevCtx = SynchronizationContext.Current;
                     int originalThreadId = Environment.CurrentManagedThreadId;
                     SynchronizationContext.SetSynchronizationContext(null);
+
                     try
                     {
                         await scenario().ConfigureAwait(false);
@@ -983,8 +923,12 @@ namespace System.Threading.Tasks.Tests
                         {
                             SynchronizationContext.SetSynchronizationContext(prevCtx);
                         }
+
+                        // Post-flush inside finally so buffered events from before an exception
+                        // still reach the listener (otherwise on a scenario throw the trace would
+                        // be truncated, hiding what happened up to the failure point).
+                        SendFlushCommand();
                     }
-                    SendFlushCommand();
                 }).ConfigureAwait(false);
             }
             return result;
@@ -1004,16 +948,14 @@ namespace System.Threading.Tasks.Tests
                 {
                     SendFlushCommand();
                     result.Events.Clear();
+
                     callback(result, keywords);
                 });
             }
+
             return result;
         }
 
-        /// <summary>
-        /// Returns true if any callstack event contains all expected method names as frames,
-        /// appearing in the given order (index 0 = innermost/deepest frame).
-        /// </summary>
         private static bool HasCallstackWithExpectedFrames(List<ParsedEvent> callstacks, string[] expectedFrames)
         {
             foreach (var cs in callstacks)
@@ -1026,23 +968,24 @@ namespace System.Threading.Tasks.Tests
                 for (int i = 0; i < resolvedNames.Count && matchIndex < expectedFrames.Length; i++)
                 {
                     if (resolvedNames[i] is not null && resolvedNames[i]!.Contains(expectedFrames[matchIndex], StringComparison.Ordinal))
+                    {
                         matchIndex++;
+                    }
                 }
 
                 if (matchIndex == expectedFrames.Length)
+                {
                     return true;
+                }
             }
             return false;
         }
 
-        /// <summary>
-        /// For a given context, simulates the async callstack depth by walking events in order:
-        /// ResumeAsyncCallstack sets the depth to frame count, CompleteAsyncMethod decrements,
-        /// UnwindAsyncException subtracts unwound frames. Asserts depth reaches zero.
-        /// </summary>
+        // For a given context, simulates the async callstack depth by walking events in order:
+        // ResumeAsyncCallstack sets the depth to frame count, CompleteAsyncMethod decrements,
+        // UnwindAsyncException subtracts unwound frames. Asserts depth reaches zero.
         private static void AssertCallstackSimulationReachesZero(ParsedEventStream stream, string markerMethodName)
         {
-            // Find context ID via marker on a resume callstack
             var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, markerMethodName);
             Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{markerMethodName}'");
 
@@ -1056,1668 +999,31 @@ namespace System.Threading.Tasks.Tests
                 switch (evt.EventId)
                 {
                     case AsyncEventID.ResumeAsyncCallstack:
+                    {
                         stackDepth = (int)evt.FrameCount;
                         break;
+                    }
                     case AsyncEventID.CompleteAsyncMethod:
+                    {
                         if (stackDepth > 0)
+                        {
                             stackDepth--;
+                        }
+
                         break;
+                    }
                     case AsyncEventID.UnwindAsyncException:
+                    {
                         stackDepth = Math.Max(0, stackDepth - (int)evt.UnwindFrameCount);
                         break;
+                    }
                 }
             }
 
             Assert.Equal(0, stackDepth);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_EventBufferHeaderFormat()
-        {
-            var events = await CollectEventsAsync(CoreKeywords, SingleAsyncYield);
-
-            // DumpAllEvents(events);
-
-            int buffersChecked = 0;
-            ForEachEventBufferPayload(events, buffer =>
-            {
-                EventBufferHeader? parsed = ParseEventBufferHeader(buffer);
-                Assert.NotNull(parsed);
-                EventBufferHeader header = parsed.Value;
-
-                Assert.Equal(1, header.Version);
-                Assert.Equal((uint)buffer.Length, header.TotalSize);
-                Assert.True(header.AsyncThreadContextId > 0, "Async thread context ID should be positive");
-                Assert.True(header.OsThreadId != 0, "OS thread ID should be non-zero");
-                Assert.True(header.StartTimestamp > 0, "Start timestamp should be positive");
-                Assert.True(header.EndTimestamp >= header.StartTimestamp, $"End timestamp ({header.EndTimestamp}) should be >= start timestamp ({header.StartTimestamp})");
-
-                int eventCount = 0;
-                ParseEventBuffer(buffer, (AsyncEventID eventId, ReadOnlySpan<byte> buf, ref int idx) =>
-                {
-                    eventCount++;
-                    return SkipEventPayload(eventId, buf, ref idx);
-                });
-
-                Assert.Equal(header.EventCount, (uint)eventCount);
-                Assert.True(header.EventCount > 0, "Expected at least one event in buffer");
-
-                buffersChecked++;
-            });
-
-            Assert.True(buffersChecked > 0, "Expected at least one buffer");
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_EventsEmitted()
-        {
-            var events = await CollectEventsAsync(AllKeywords, SingleAsyncYield);
-
-            // DumpAllEvents(events);
-
-            Assert.True(events.Events.Count > 0, "Expected at least one AsyncEvents event to be emitted");
-            Assert.Contains(events.Events, e => e.EventId == AsyncEventsId);
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendResumeCompleteMarker()
-        {
-            await Task.Yield();
-            await SingleAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_SuspendResumeCompleteEvents()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendResumeCompleteMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // Find our context via marker callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(SuspendResumeCompleteMarker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with SuspendResumeCompleteMarker");
-
-            ulong taskId = markerCallstacks[0].TaskId;
-            var taskEvts = stream.ForTask(taskId);
-            var ids = taskEvts.Select(e => e.EventId).ToList();
-
-            Assert.Contains(AsyncEventID.ResumeAsyncContext, ids);
-            Assert.Contains(AsyncEventID.SuspendAsyncContext, ids);
-            Assert.Contains(AsyncEventID.CompleteAsyncContext, ids);
-        }
-
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task ContextLifecycleMarker()
-        {
-            await Task.Yield();
-            await SingleAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_ContextEventIdLifecycle()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, ContextLifecycleMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // Find events in the context that contains our marker method.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ContextLifecycleMarker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with ContextLifecycleMarker");
-
-            ulong taskId = markerCallstacks[0].TaskId;
-            Assert.True(taskId > 0, "Context ID should be non-zero");
-
-            var taskEvts = stream.ForTask(taskId);
-            var ids = taskEvts.Select(e => e.EventId).ToList();
-
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext in context events");
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after CreateAsyncContext");
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_ResumeCompleteMethodEvents()
-        {
-            var events = await CollectEventsAsync(MethodKeywords, ChainedAsyncYield);
-
-            // DumpAllEvents(events);
-
-            var ids = ParseAllEvents(events).EventIds;
-
-            Assert.Contains(AsyncEventID.ResumeAsyncMethod, ids);
-            Assert.Contains(AsyncEventID.CompleteAsyncMethod, ids);
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task EventSequenceOrderMarker()
-        {
-            await Task.Yield();
-            await SingleAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_EventSequenceOrder()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, EventSequenceOrderMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // Find our context via marker callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(EventSequenceOrderMarker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with EventSequenceOrderMarker");
-
-            ulong taskId = markerCallstacks[0].TaskId;
-            var taskEvts = stream.ForTask(taskId);
-            var ids = taskEvts.Select(e => e.EventId).ToList();
-
-            // Verify the expected lifecycle sequence exists in order.
-            int resumeIdx1 = ids.IndexOf(AsyncEventID.ResumeAsyncContext);
-            Assert.True(resumeIdx1 >= 0, "Expected first ResumeAsyncContext");
-
-            int suspendIdx = ids.IndexOf(AsyncEventID.SuspendAsyncContext, resumeIdx1 + 1);
-            Assert.True(suspendIdx > resumeIdx1, "Expected SuspendAsyncContext after first Resume");
-
-            int resumeIdx2 = ids.IndexOf(AsyncEventID.ResumeAsyncContext, suspendIdx + 1);
-            Assert.True(resumeIdx2 > suspendIdx, "Expected second ResumeAsyncContext after Suspend");
-
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx2 + 1);
-            Assert.True(completeIdx > resumeIdx2, "Expected CompleteAsyncContext after second Resume");
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CreateAsyncContextEmittedOnFirstAwait()
-        {
-            var events = await CollectEventsAsync(CreateAsyncContextKeyword | CompleteAsyncContextKeyword, SingleAsyncYield);
-
-            // DumpAllEvents(events);
-
-            var ids = ParseAllEvents(events).EventIds;
-            Assert.Contains(AsyncEventID.CreateAsyncContext, ids);
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CreateCallstackMarker()
-        {
-            await SingleAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, CreateCallstackMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreateCallstackMarker));
-
-            Assert.NotEmpty(createCallstacks);
-            Assert.All(createCallstacks, cs =>
-            {
-                Assert.True(cs.FrameCount > 0, "Expected at least one frame in create callstack");
-                Assert.True(cs.TaskId != 0, "Expected non-zero task ID in create callstack");
-                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
-            });
-        }
-
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CreateCallstackDepthMarker()
-        {
-            await ChainedAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CreateCallstackDepthMatchesChain()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, CreateCallstackDepthMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreateCallstackDepthMarker));
-
-            // The expected [NoInlining] frames in order (innermost first):
-            // InnerAsyncYield -> ChainedAsyncYield -> CreateCallstackDepthMarker
-            Assert.NotEmpty(createCallstacks);
-            string[] expectedFrames = [nameof(InnerAsyncYield), nameof(ChainedAsyncYield), nameof(CreateCallstackDepthMarker)];
-            Assert.True(
-                HasCallstackWithExpectedFrames(createCallstacks, expectedFrames),
-                $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendCallstackMarker()
-        {
-            await Task.Yield();
-            await SingleAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendCallstackMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendCallstackMarker));
-
-            Assert.NotEmpty(suspendCallstacks);
-            Assert.All(suspendCallstacks, cs =>
-            {
-                Assert.True(cs.FrameCount > 0, "Expected at least one frame in suspend callstack");
-                Assert.True(cs.TaskId != 0, "Expected non-zero task ID in suspend callstack");
-                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
-            });
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendDepthMarker()
-        {
-            await Task.Yield();
-            await ChainedAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_SuspendCallstackDepthMatchesChain()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendDepthMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendDepthMarker));
-
-            // The expected [NoInlining] frames in order (innermost first):
-            // InnerAsyncYield -> ChainedAsyncYield -> SuspendDepthMarker
-            Assert.NotEmpty(suspendCallstacks);
-            string[] expectedFrames = [nameof(InnerAsyncYield), nameof(ChainedAsyncYield), nameof(SuspendDepthMarker)];
-            Assert.True(
-                HasCallstackWithExpectedFrames(suspendCallstacks, expectedFrames),
-                $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendPrecedesCompleteMarker()
-        {
-            await Task.Yield();
-            await InnerAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_SuspendCallstackPrecedesComplete()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendPrecedesCompleteMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // Find the suspend callstack via marker to get the context ID
-            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendPrecedesCompleteMarker));
-            Assert.True(suspendStacks.Count >= 1, $"Expected at least one suspend callstack with marker, got {suspendStacks.Count}");
-
-            ulong taskId = suspendStacks[0].TaskId;
-            Assert.True(taskId > 0, "Expected non-zero context ID");
-
-            var taskEvts = stream.ForTask(taskId);
-            var ids = taskEvts.Select(e => e.EventId).ToList();
-
-            int suspendIdx = ids.IndexOf(AsyncEventID.SuspendAsyncCallstack);
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext);
-
-            Assert.True(suspendIdx >= 0, "Expected SuspendAsyncCallstack in context events");
-            Assert.True(completeIdx >= 0, "Expected CompleteAsyncContext in context events");
-            Assert.True(suspendIdx < completeIdx, $"SuspendAsyncCallstack (index {suspendIdx}) should precede CompleteAsyncContext (index {completeIdx})");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendDeeperMarker()
-        {
-            await Task.Yield();
-            await InnerAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_SuspendCallstackDeeperThanInitialResume()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendDeeperMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(SuspendDeeperMarker));
-            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendDeeperMarker));
-
-            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker, got {resumeStacks.Count}");
-            Assert.True(suspendStacks.Count >= 1, $"Expected at least one suspend callstack with marker, got {suspendStacks.Count}");
-
-            // First resume (after initial Yield) should be shallow, first suspend (InnerAsyncYield's Yield) should be deeper
-            var firstResume = resumeStacks[0];
-            var firstSuspend = suspendStacks[0];
-
-            Assert.True(firstSuspend.FrameCount > firstResume.FrameCount, $"First suspend callstack depth ({firstSuspend.FrameCount}) should be deeper than first resume callstack depth ({firstResume.FrameCount})");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CreatePrecedesResumeMarker()
-        {
-            await Task.Yield();
-            await InnerAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CreateCallstackPrecedesResumeCallstack()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, CreatePrecedesResumeMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreatePrecedesResumeMarker));
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CreatePrecedesResumeMarker));
-
-            Assert.NotEmpty(createStacks);
-            Assert.NotEmpty(resumeStacks);
-
-            // For each task that has both Create and Resume callstacks, verify Create timestamp precedes Resume.
-            int matchedPairs = 0;
-            foreach (var create in createStacks)
-            {
-                var matchingResume = resumeStacks.FirstOrDefault(r => r.TaskId == create.TaskId);
-                if (matchingResume is null)
-                    continue;
-
-                matchedPairs++;
-                Assert.True(create.Timestamp <= matchingResume.Timestamp, $"For task {create.TaskId}: CreateAsyncCallstack (ts {create.Timestamp}) should precede ResumeAsyncCallstack (ts {matchingResume.Timestamp})");
-            }
-
-            Assert.True(matchedPairs >= 1, $"Expected at least one matching Create/Resume callstack pair, but found {matchedPairs}");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CreateResumeMatchMarker()
-        {
-            await Task.Yield();
-            await InnerAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CreateAndFirstResumeCallstacksMatch()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, CreateResumeMatchMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreateResumeMatchMarker));
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CreateResumeMatchMarker));
-
-            Assert.NotEmpty(createStacks);
-            Assert.NotEmpty(resumeStacks);
-
-            // For each create callstack, find the first resume with the same task ID and verify frames match.
-            int matchedPairs = 0;
-            foreach (var create in createStacks)
-            {
-                var matchingResume = resumeStacks.FirstOrDefault(r => r.TaskId == create.TaskId);
-                if (matchingResume is null)
-                    continue;
-
-                matchedPairs++;
-                Assert.Equal(create.Frames.Count, matchingResume.Frames.Count);
-                for (int i = 0; i < create.Frames.Count; i++)
-                {
-                    Assert.Equal(create.Frames[i].MethodId, matchingResume.Frames[i].MethodId);
-                }
-            }
-
-            Assert.True(matchedPairs >= 1, $"Expected at least one matching Create/Resume callstack pair, but found {matchedPairs}");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CallstackOnResumeMarker()
-        {
-            await Task.Yield();
-            await InnerAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CallstackEmittedOnResume()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, CallstackOnResumeMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CallstackOnResumeMarker));
-
-            Assert.NotEmpty(callstacks);
-            Assert.All(callstacks, cs =>
-            {
-                Assert.True(cs.FrameCount > 0, "Expected at least one frame in callstack");
-                Assert.True(cs.TaskId != 0, "Expected non-zero task ID in resume callstack");
-                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
-            });
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CallstackDepthMarker()
-        {
-            await Task.Yield();
-            await InnerAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CallstackDepthMatchesChain()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, CallstackDepthMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CallstackDepthMarker));
-
-            // The expected [NoInlining] frames in order (innermost first):
-            // InnerAsyncYield -> CallstackDepthMarker
-            Assert.NotEmpty(callstacks);
-            string[] expectedFrames = [nameof(InnerAsyncYield), nameof(CallstackDepthMarker)];
-            Assert.True(
-                HasCallstackWithExpectedFrames(callstacks, expectedFrames),
-                $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SimulationNormalMarker()
-        {
-            await Task.Yield();
-            await InnerAsyncYield();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CallstackSimulation_NormalCompletion()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, SimulationNormalMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            AssertCallstackSimulationReachesZero(stream, nameof(SimulationNormalMarker));
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SimulationHandledMarker()
-        {
-            await DeepOuterCatches();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CallstackSimulation_HandledException()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, SimulationHandledMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            AssertCallstackSimulationReachesZero(stream, nameof(SimulationHandledMarker));
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SimulationUnhandledMarker()
-        {
-            await DeepUnhandledOuter();
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(false)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SimulationUnhandledMarkerCatcher()
-        {
-            try
-            {
-                await SimulationUnhandledMarker();
-            }
-            catch (InvalidOperationException)
-            {
-            }
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CallstackSimulation_UnhandledException()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, SimulationUnhandledMarkerCatcher);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            AssertCallstackSimulationReachesZero(stream, nameof(SimulationUnhandledMarker));
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task UnhandledUnwindMarker()
-        {
-            await DeepUnhandledOuter();
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(false)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task UnhandledUnwindCatcher()
-        {
-            try
-            {
-                await UnhandledUnwindMarker();
-            }
-            catch (InvalidOperationException)
-            {
-            }
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_UnhandledExceptionUnwind()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, UnhandledUnwindCatcher);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(UnhandledUnwindMarker));
-            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{nameof(UnhandledUnwindMarker)}'");
-
-            ulong taskId = resumeStacks[0].TaskId;
-
-            var taskEvts = stream.ForTask(taskId);
-            var eventIds = taskEvts.Select(e => e.EventId).ToList();
-
-            Assert.Contains(AsyncEventID.ResumeAsyncContext, eventIds);
-            Assert.Contains(AsyncEventID.UnwindAsyncException, eventIds);
-            Assert.Contains(AsyncEventID.CompleteAsyncContext, eventIds);
-
-            // Verify unwind frame count for this task
-            // UnhandledUnwindMarker -> DeepUnhandledOuter -> DeepUnhandledMiddle -> DeepUnhandledInnerThrows, 4 frames deep after the initial resume.
-            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.UnwindAsyncException).ToList();
-            Assert.NotEmpty(unwindEvents);
-            Assert.All(unwindEvents, e => Assert.Equal(4u, e.UnwindFrameCount));
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task HandledUnwindMarker()
-        {
-            await DeepOuterCatches();
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_HandledExceptionUnwind()
-        {
-            var events = await CollectEventsAsync(CallstackKeywords, HandledUnwindMarker);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(HandledUnwindMarker));
-            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{nameof(HandledUnwindMarker)}'");
-
-            ulong taskId = resumeStacks[0].TaskId;
-
-            var taskEvts = stream.ForTask(taskId);
-            var eventIds = taskEvts.Select(e => e.EventId).ToList();
-
-            Assert.Contains(AsyncEventID.ResumeAsyncContext, eventIds);
-            Assert.Contains(AsyncEventID.UnwindAsyncException, eventIds);
-            Assert.Contains(AsyncEventID.CompleteAsyncContext, eventIds);
-
-            // Verify unwind frame count for this task
-            // DeepMiddle -> DeepInnerThrows, 2 frames deep after the initial resume.
-            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.UnwindAsyncException).ToList();
-            Assert.NotEmpty(unwindEvents);
-            Assert.All(unwindEvents, e => Assert.Equal(2u, e.UnwindFrameCount));
-        }
-
-        // Requires threading:
-        // Wrapper index tests use RunScenarioAndFlush (Task.Run) to escape xunit's
-        // AsyncTestSyncContext. With a SynchronizationContext present, each level in the
-        // async chain re-dispatches through the sync context, creating a separate
-        // DispatchContinuations call that resets the wrapper index to 0. Task.Run ensures
-        // the entire continuation chain executes in a single dispatch loop where the
-        // wrapper index increments sequentially across resumptions.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_WrapperIndexMatchesCallstack()
-        {
-            var captures = new List<(string MethodName, int WrapperSlot)>();
-
-            var events = CollectEvents(ResumeAsyncCallstackKeyword, () =>
-            {
-                RunScenarioAndFlush(async () =>
-                {
-                    await WrapperTestA(captures);
-                });
-            });
-
-            // DumpAllEvents(events);
-
-            Assert.True(captures.Count == 3, $"Expected 3 wrapper captures, got {captures.Count}");
-
-            Assert.All(captures, c => Assert.True(c.WrapperSlot >= 0, $"{c.MethodName} did not find wrapper frame on stack (slot={c.WrapperSlot})"));
-
-            int slotC = captures.First(c => c.MethodName == nameof(WrapperTestC)).WrapperSlot;
-            int slotB = captures.First(c => c.MethodName == nameof(WrapperTestB)).WrapperSlot;
-            int slotA = captures.First(c => c.MethodName == nameof(WrapperTestA)).WrapperSlot;
-
-            Assert.Equal(slotC + 1, slotB);
-            Assert.Equal(slotB + 1, slotA);
-        }
-
-        // Requires threading:
-        // Same comment as RuntimeAsync_WrapperIndexMatchesCallstack regarding Task.Run and wrapper index behavior.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_WrapperIndexResetEmitted()
-        {
-            var events = CollectEvents(AllKeywords, () =>
-            {
-                // Recursive chain 34 levels deep crosses the 32-slot boundary,
-                // triggering at least one ResetAsyncContinuationWrapperIndex event.
-                RunScenarioAndFlush(async () =>
-                {
-                    await RecursiveAsyncChain(34);
-                });
-            });
-
-            // DumpAllEvents(events);
-
-            var ids = ParseAllEvents(events).EventIds;
-
-            Assert.Contains(AsyncEventID.ResetAsyncContinuationWrapperIndex, ids);
-        }
-
-        // Requires threading:
-        // Same comment as RuntimeAsync_WrapperIndexMatchesCallstack regarding Task.Run and wrapper index behavior.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_WrapperIndexNoResetUnder32()
-        {
-            var events = CollectEvents(AllKeywords, () =>
-            {
-                // A shallow chain stays within the first 32 slots —
-                // no reset event should be emitted.
-                RunScenarioAndFlush(async () =>
-                {
-                    await RecursiveAsyncChain(2);
-                });
-            });
-
-            // DumpAllEvents(events);
-
-            var ids = ParseAllEvents(events).EventIds;
-
-            Assert.DoesNotContain(AsyncEventID.ResetAsyncContinuationWrapperIndex, ids);
-        }
-
-        // Requires threading:
-        // The periodic flush timer runs on a background thread.
-        // On single-threaded runtimes there is no background thread to fire the timer.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_PeriodicTimerFlush()
-        {
-            static bool IsRequestedEvent(AsyncEventID id) =>
-                id == AsyncEventID.CreateAsyncContext ||
-                id == AsyncEventID.ResumeAsyncContext ||
-                id == AsyncEventID.SuspendAsyncContext ||
-                id == AsyncEventID.CompleteAsyncContext;
-
-            var events = CollectEvents(CoreKeywords, (collectedEvents, _) =>
-            {
-                // Run scenario - do NOT flush explicitly afterwards.
-                RunScenario(async () =>
-                {
-                    await SingleAsyncYield();
-                });
-
-                // Wait for the periodic flush timer (1s interval) to detect the idle buffer and flush it automatically.
-                Thread.Sleep(1000);
-
-                // Poll to make sure the expected buffer got flush.
-                bool flushed = SpinWait.SpinUntil(() =>
-                {
-                    var stream = ParseAllEvents(collectedEvents);
-                    return stream.EventIds.Any(id => IsRequestedEvent(id));
-                }, TimeSpan.FromSeconds(20));
-
-                Assert.True(flushed, "Expected periodic timer to flush buffer with core lifecycle events within timeout");
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            int coreEventCount = stream.EventIds.Count(id => IsRequestedEvent(id));
-
-            Assert.True(coreEventCount > 0, "Expected periodic timer to flush buffer with core lifecycle events");
-        }
-
-        // Requires threading:
-        // Verifies the background flush timer preserves the owning thread's OS thread ID,
-        // which needs both a dedicated worker thread and the timer thread.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_PeriodicTimerFlush_PreservesOwnerThreadId()
-        {
-            // This test verifies that when the background flush timer flushes a thread's buffer,
-            // the new header written afterwards preserves the owning thread's OS thread ID
-            // (not the timer thread's ID).
-            //
-            // Strategy: run async work on a dedicated thread so its profiler context gets events.
-            // Between two batches of work, wait for the flush timer to fire. Both buffer flushes
-            // from the dedicated thread should carry the same OsThreadId.
-
-            ulong workerOsThreadId = 0;
-            var workerIdReady = new ManualResetEventSlim(false);
-            var firstBatchDone = new ManualResetEventSlim(false);
-            var firstFlushSeen = new ManualResetEventSlim(false);
-            var events = new CollectedEvents();
-
-            using (var listener = CreateListener(CoreKeywords))
-            {
-                listener.RunWithCallback(e =>
-                {
-                    if (!workerIdReady.IsSet)
-                        return;
-                    if (e.EventId != AsyncEventsId || e.Payload is null || e.Payload.Count == 0)
-                        return;
-                    if (e.Payload[0] is not byte[] payload)
-                        return;
-                    EventBufferHeader? header = ParseEventBufferHeader(payload);
-                    if (header is not null && header.Value.OsThreadId == workerOsThreadId)
-                        events.Events.Enqueue(e);
-                }, () =>
-                {
-                    SendFlushCommand();
-
-                    var thread = new Thread(() =>
-                    {
-                        workerOsThreadId = GetCurrentOSThreadId();
-                        workerIdReady.Set();
-
-                        // First batch: generate events on this thread's profiler context.
-                        SingleAsyncYield().GetAwaiter().GetResult();
-                        firstBatchDone.Set();
-
-                        // Wait for the flush to deliver our first buffer before generating more events.
-                        bool flushed = firstFlushSeen.Wait(TimeSpan.FromSeconds(20));
-                        Assert.True(flushed, "Expected first flush of core lifecycle events within timeout");
-
-                        // Second batch: generate more events on the same thread's context.
-                        SingleAsyncYield().GetAwaiter().GetResult();
-                    });
-
-                    thread.IsBackground = true;
-                    thread.Start();
-
-                    // Wait for the worker to finish its first batch, then force flush.
-                    firstBatchDone.Wait(TimeSpan.FromSeconds(20));
-                    SendFlushCommand();
-
-                    // Poll for first buffer from our worker thread.
-                    bool firstFlush = SpinWait.SpinUntil(() => events.Events.Count >= 1, TimeSpan.FromSeconds(20));
-                    Assert.True(firstFlush, "Expected periodic timer to flush core lifecycle events within timeout");
-
-                    firstFlushSeen.Set();
-
-                    // Wait for the worker to finish its second batch.
-                    bool joined = thread.Join(TimeSpan.FromSeconds(20));
-                    Assert.True(joined, "Expected worker thread to terminate within timeout after second batch of work");
-
-                    // Force a flush to deliver the second batch.
-                    SendFlushCommand();
-
-                    // Poll for second buffer from our worker thread.
-                    bool secondFlush = SpinWait.SpinUntil(() => events.Events.Count >= 2, TimeSpan.FromSeconds(20));
-                    Assert.True(secondFlush, "Expected periodic timer to flush core lifecycle events within timeout");
-                });
-            }
-
-            // DumpAllEvents(events);
-
-            Assert.True(workerOsThreadId != 0, "Failed to capture worker OS thread ID");
-
-            // The key assertion: find buffers that contain CreateAsyncContext events (our work batches).
-            // There must be at least 2 such buffers (one per SingleAsyncYield() call), and ALL of them must
-            // have the worker's OsThreadId - proving the timer flush didn't corrupt the header.
-            var stream = ParseAllEvents(events);
-            var createEvents = stream.OfType(AsyncEventID.CreateAsyncContext).ToList();
-            Assert.True(createEvents.Count >= 2, $"Expected at least 2 CreateAsyncContext events from the worker thread, got {createEvents.Count}");
-            Assert.All(createEvents, e => Assert.Equal(workerOsThreadId, e.OsThreadId));
-        }
-
-        // Requires threading:
-        // Spawns a dedicated thread that exits, then waits for the background flush timer
-        // to detect and flush the orphaned thread-local buffer.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_DeadThreadFlush()
-        {
-            static bool IsRequestedEvent(AsyncEventID id) =>
-                id == AsyncEventID.CreateAsyncContext ||
-                id == AsyncEventID.ResumeAsyncContext ||
-                id == AsyncEventID.SuspendAsyncContext ||
-                id == AsyncEventID.CompleteAsyncContext;
-
-            var events = CollectEvents(CoreKeywords, (collectedEvents, _) =>
-            {
-                // Spawn a dedicated thread that runs async work then exits.
-                // Its thread-local buffer becomes orphaned when the thread dies.
-                var thread = new Thread(() =>
-                {
-                    RunScenario(async () =>
-                    {
-                        await SingleAsyncYield();
-                    });
-                });
-
-                thread.IsBackground = true;
-                thread.Start();
-                bool joined = thread.Join(TimeSpan.FromSeconds(20));
-                Assert.True(joined, "Expected worker thread to terminate within timeout before waiting for orphaned buffer flush");
-
-                // Do NOT send a flush command.
-                // Wait for the periodic flush timer to detect the dead thread and flush its orphaned buffer.
-                Thread.Sleep(1000);
-
-                // Poll to make sure the expected buffer got flush.
-                bool flushed = SpinWait.SpinUntil(() =>
-                {
-                    var stream = ParseAllEvents(collectedEvents);
-                    return stream.EventIds.Any(id => IsRequestedEvent(id));
-                }, TimeSpan.FromSeconds(20));
-
-                Assert.True(flushed, "Expected periodic timer to flush buffer with core lifecycle events within timeout");
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            int coreEventCount = stream.EventIds.Count(id => IsRequestedEvent(id));
-
-            Assert.True(coreEventCount > 0, "Expected periodic timer to flush dead thread's buffer");
-        }
-
-        // This test is sensitive to event noise - it asserts a specific clock event is absent.
-        // It cannot run in parallel with other async profiler scenarios that might produce
-        // clock events. Test parallelization is disabled via XunitAssemblyAttributes.cs.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_NoSyncClockEventBeforeInterval()
-        {
-            var events = await CollectEventsAsync(CoreKeywords, SingleAsyncYield);
-
-            var ids = ParseAllEvents(events).EventIds;
-
-            Assert.DoesNotContain(AsyncEventID.AsyncProfilerSyncClock, ids);
-        }
-
-        // This test is sensitive to event noise - it asserts zero context events appear
-        // after enabling the listener. It cannot run in parallel with other async profiler
-        // scenarios that might produce events on the same thread context.
-        // Test parallelization is already disabled via XunitAssemblyAttributes.cs.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_NoEventsWhenDisabled()
-        {
-            // Run async work WITHOUT a listener attached
-            for (int i = 0; i < 50; i++)
-            {
-                await SingleAsyncYield();
-            }
-
-            // Now attach listener but don't run any RuntimeAsync work inside —
-            // just call a synchronous no-op. Verify no stale events from above leak through.
-            var events = await CollectEventsAsync(CoreKeywords, () => Task.CompletedTask);
-
-            // There may be meta data related events, but there should be no suspend/resume/complete events from the earlier work.
-            var ids = ParseAllEvents(events).EventIds;
-
-            int contextEvents = ids.Count(id => id == AsyncEventID.ResumeAsyncContext || id == AsyncEventID.SuspendAsyncContext || id == AsyncEventID.CompleteAsyncContext);
-
-            Assert.Equal(0, contextEvents);
-        }
-
-        public static IEnumerable<object[]> KeywordGatekeepingData()
-        {
-            yield return new object[] { (long)CreateAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CreateAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)ResumeAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)SuspendAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.SuspendAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)CompleteAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CompleteAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)UnwindAsyncExceptionKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.UnwindAsyncException, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)CreateAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CreateAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)ResumeAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)SuspendAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.SuspendAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)ResumeAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)CompleteAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CompleteAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task KeywordGatekeepingMarker()
-        {
-            await OuterCatches();
-            await ChainedAsyncYield();
-        }
-
-        // This test is sensitive to event noise - it asserts that ONLY the expected event
-        // types appear for a given keyword. It cannot run in parallel with other async
-        // profiler scenarios that might produce events on the same thread context.
-        // Test parallelization is already disabled via XunitAssemblyAttributes.cs.
-        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        [MemberData(nameof(KeywordGatekeepingData))]
-        public async Task RuntimeAsync_KeywordGatekeeping(long keywordValue, AsyncEventID[] allowedEventIds)
-        {
-            EventKeywords kw = (EventKeywords)keywordValue;
-            var allowed = new HashSet<AsyncEventID>(allowedEventIds);
-
-            // Run a scenario that exercises all event types: resume, suspend,
-            // complete, method events, callstacks, and exception unwinds.
-            // Only the events matching the enabled keyword should be emitted.
-            var events = await CollectEventsAsync(kw, KeywordGatekeepingMarker);
-
-            var stream = ParseAllEvents(events);
-            var unexpected = stream.EventIds.Where(id => !allowed.Contains(id)).ToList();
-
-            Assert.True(unexpected.Count == 0, $"Keyword 0x{(long)kw:X}: unexpected event IDs [{string.Join(", ", unexpected)}], " + $"allowed [{string.Join(", ", allowed)}]");
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_ResetAsyncThreadContextEvent()
-        {
-            var events = await CollectEventsAsync(CoreKeywords, SingleAsyncYield);
-
-            // DumpAllEvents(events);
-
-            var ids = ParseAllEvents(events).EventIds;
-
-            Assert.Contains(AsyncEventID.ResetAsyncThreadContext, ids);
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_MetadataEventEmittedOnEnable()
-        {
-            var events = await CollectEventsAsync(AllKeywords, SingleAsyncYield);
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var metadataList = stream.MetadataEvents;
-            Assert.True(metadataList.Count >= 1, "Expected at least one metadata event in buffer");
-
-            MetadataFromBuffer meta = metadataList[0];
-            Assert.True(meta.QpcFrequency > 0, $"QPC frequency should be positive, got {meta.QpcFrequency}");
-            Assert.True(meta.QpcSync > 0, $"QPC sync timestamp should be positive, got {meta.QpcSync}");
-            Assert.True(meta.UtcSync > 0, $"UTC sync timestamp should be positive, got {meta.UtcSync}");
-            Assert.True(meta.EventBufferSize > 0, $"Event buffer size should be positive, got {meta.EventBufferSize}");
-            Assert.True(meta.WrapperCount > 0, "Wrapper count should be positive");
-        }
-
-        // Requires threading:
-        // Spawns 8 threads with a Barrier to verify metadata is
-        // emitted exactly once under concurrent enable pressure.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_MetadataEventEmittedOnceAcrossThreads()
-        {
-            const int threadCount = 8;
-
-            var events = CollectEvents(AllKeywords, () =>
-            {
-                using var barrier = new Barrier(threadCount);
-                var tasks = new Task[threadCount];
-                for (int i = 0; i < threadCount; i++)
-                {
-                    tasks[i] = Task.Factory.StartNew(() =>
-                    {
-                        barrier.SignalAndWait();
-                        SingleAsyncYield().GetAwaiter().GetResult();
-                    }, TaskCreationOptions.LongRunning);
-                }
-                Task.WaitAll(tasks);
-                SendFlushCommand();
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var metadataList = stream.MetadataEvents;
-            Assert.True(metadataList.Count == 1, $"Expected exactly 1 metadata event across {threadCount} threads, got {metadataList.Count}");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task NativeIPDeltaRoundtripMarker()
-        {
-            await ChainedAsyncYield();
-            await DeepOuterCatches();
-            await RecursiveAsyncChain(10);
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_CallstackNativeIPDeltaRoundtrip()
-        {
-            // Verify that delta-encoded NativeIPs in callstacks roundtrip correctly,
-            // including both positive and negative deltas. With multiple distinct async
-            // methods at different JIT-assigned addresses, the deltas between consecutive
-            // NativeIPs will naturally span both directions. This exercises the full
-            // zigzag + LEB128 encode/decode path through the production serializer.
-            var events = await CollectEventsAsync(CallstackKeywords, NativeIPDeltaRoundtripMarker);
-
-            var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(NativeIPDeltaRoundtripMarker));
-            Assert.NotEmpty(callstacks);
-
-            // Find callstacks with 3+ frames — enough depth for meaningful deltas.
-            var deepCallstacks = callstacks.Where(cs => cs.FrameCount >= 3).ToList();
-
-            Assert.True(deepCallstacks.Count > 0, "Expected at least one callstack with 3+ frames for delta verification");
-
-            bool hasPositiveDelta = false;
-            bool hasNegativeDelta = false;
-
-            foreach (var cs in deepCallstacks)
-            {
-                for (int i = 0; i < cs.Frames.Count; i++)
-                {
-                    var (methodId, _) = cs.Frames[i];
-                    Assert.True(methodId != 0, $"Frame {i} has zero MethodId");
-
-                    var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
-                    Assert.True(method is not null, $"Frame {i}: MethodId 0x{methodId:X} does not resolve to a managed method");
-
-                    if (i > 0)
-                    {
-                        long delta = (long)(cs.Frames[i].MethodId - cs.Frames[i - 1].MethodId);
-                        if (delta > 0)
-                            hasPositiveDelta = true;
-                        else if (delta < 0)
-                            hasNegativeDelta = true;
-                    }
-                }
-            }
-
-            // With multiple distinct async methods at different addresses, we expect
-            // both positive and negative deltas. If the JIT happens to lay out all
-            // methods monotonically (extremely unlikely), at minimum we must see
-            // non-zero deltas proving the encoding works.
-            Assert.True(hasPositiveDelta || hasNegativeDelta, "Expected at least one non-zero NativeIP delta across all callstack frames");
-        }
-
-        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CallstackStressMarker(int depth)
-        {
-            await RecursiveAsyncChain(depth);
-        }
-
-        // Requires threading:
-        // The recursive async chain must execute in a single dispatch
-        // loop (no sync context) to produce full-depth callstacks. Under xunit's
-        // AsyncTestSyncContext, each await re-dispatches, fragmenting the chain.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_CallstackStressWithVaryingDepths()
-        {
-            // Stress test: run many async calls with varying callstack depths.
-            // Varying sizes mean some callstacks will land at buffer boundaries,
-            // naturally exercising the overflow/rewind path in callstack emission.
-            // lambda -> CallstackStressMarker(d) -> RecursiveAsyncChain(d) produces d + 2 frames.
-            const int iterations = 200;
-            int[] depths = new int[iterations];
-            var rng = new Random(42);
-            for (int i = 0; i < iterations; i++)
-                depths[i] = rng.Next(1, 120);
-
-            var events = CollectEvents(CallstackKeywords, () =>
-            {
-                RunScenarioAndFlush(async () =>
-                {
-                    for (int i = 0; i < iterations; i++)
-                        await CallstackStressMarker(depths[i]);
-                });
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CallstackStressMarker));
-
-            // Verify all callstacks have valid frame data that resolves to managed methods.
-            foreach (var cs in callstacks)
-            {
-                Assert.True(cs.FrameCount > 0, "Callstack has 0 frames");
-                Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
-                for (int f = 0; f < cs.Frames.Count; f++)
-                {
-                    var (methodId, _) = cs.Frames[f];
-                    Assert.True(methodId != 0, $"Frame {f} has zero MethodId");
-
-                    var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
-                    Assert.True(method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
-                }
-            }
-
-            // One resume callstack per iteration (marker filters out noise).
-            // lambda -> CallstackStressMarker -> RecursiveAsyncChain(d) produces d + 2 frames.
-            Assert.True(callstacks.Count >= iterations, $"Expected at least {iterations} callstacks with marker, got {callstacks.Count}");
-
-            for (int i = 0; i < iterations; i++)
-            {
-                // lambda + CallstackStressMarker + RecursiveAsyncChain(d) = d + 2
-                int expected = depths[i] + 2;
-                int actual = callstacks[i].FrameCount;
-                Assert.True(actual == expected, $"Iteration {i}: expected depth {expected} (lambda -> CallstackStressMarker -> RecursiveAsyncChain({depths[i]})), got {actual}");
-            }
-
-            // Verify multiple buffer flushes occurred.
-            int bufferCount = 0;
-            ForEachEventBufferPayload(events, _ => bufferCount++);
-            Assert.True(bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
-        }
-
-        // Requires threading:
-        // Deep recursive chains must execute in a single dispatch loop (no sync context)
-        // to produce full-depth callstacks that trigger overflow.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_CallstackOverflowPathProducesValidFrames()
-        {
-            // Targeted test: run random-depth callstacks until we detect the overflow
-            // path was exercised, then validate the affected callstack.
-            // The overflow path fires when a large callstack doesn't fit inline in the
-            // remaining buffer space — the code rewinds, flushes the partial buffer,
-            // and re-writes the callstack as the first event in a fresh buffer.
-            //
-            // To prove overflow occurred we check consecutive buffer pairs:
-            //   Buffer N: not full (has remaining capacity, but not enough for the next callstack)
-            //   Buffer N+1: first event is a large callstack
-            // This proves the runtime detected insufficient space, rewound, and flushed.
-            bool overflowDetected = false;
-            var rng = new Random(42);
-
-            for (int attempt = 0; attempt < 10 && !overflowDetected; attempt++)
-            {
-                int iterations = 500;
-                int[] depths = new int[iterations];
-                for (int i = 0; i < iterations; i++)
-                    depths[i] = rng.Next(50, 250);
-
-                var events = CollectEvents(AllKeywords, () =>
-                {
-                    RunScenarioAndFlush(async () =>
-                    {
-                        for (int i = 0; i < iterations; i++)
-                            await RecursiveAsyncChain(depths[i]);
-                    });
-                });
-
-                // Get buffer capacity from metadata.
-                var stream = ParseAllEvents(events);
-                var metadataList = stream.MetadataEvents;
-                if (metadataList.Count == 0)
-                    continue;
-                uint bufferCapacity = metadataList[0].EventBufferSize;
-
-                // Collect per-buffer info grouped by async thread context.
-                // Consecutive buffers from the same context represent the overflow sequence.
-                var buffersByContext = new Dictionary<uint, List<(int UsedSize, AsyncEventID FirstEventId, byte FirstFrameCount)>>();
-                ForEachEventBufferPayload(events, buffer =>
-                {
-                    EventBufferHeader? header = ParseEventBufferHeader(buffer);
-                    if (header is null)
-                        return;
-
-                    uint contextId = header.Value.AsyncThreadContextId;
-
-                    // Parse the first event in this buffer.
-                    int index = HeaderSize;
-                    if (index >= buffer.Length)
-                        return;
-
-                    AsyncEventID firstId = (AsyncEventID)buffer[index++];
-                    // Skip timestamp delta
-                    ReadCompressedUInt64(buffer, ref index);
-
-                    byte frameCount = 0;
-                    if (firstId == AsyncEventID.ResumeAsyncCallstack ||
-                        firstId == AsyncEventID.CreateAsyncCallstack ||
-                        firstId == AsyncEventID.SuspendAsyncCallstack)
-                    {
-                        // Callstack payload: type(1) + callstackId(1) + frameCount(1) + compressed taskId + frames...
-                        index++; // type byte
-                        index++; // callstack ID (reserved)
-                        if (index < buffer.Length)
-                            frameCount = buffer[index];
-                    }
-
-                    if (!buffersByContext.TryGetValue(contextId, out var list))
-                    {
-                        list = new List<(int, AsyncEventID, byte)>();
-                        buffersByContext[contextId] = list;
-                    }
-                    list.Add((buffer.Length, firstId, frameCount));
-                });
-
-                // Look for overflow evidence within the same thread context:
-                // buffer N not full, buffer N+1 starts with large callstack.
-                foreach (var bufferInfos in buffersByContext.Values)
-                {
-                    for (int i = 0; i < bufferInfos.Count - 1; i++)
-                    {
-                        var current = bufferInfos[i];
-                        var next = bufferInfos[i + 1];
-
-                        Assert.True((uint)current.UsedSize <= bufferCapacity, $"Buffer used size {current.UsedSize} exceeds capacity {bufferCapacity}.");
-
-                        uint remaining = bufferCapacity - (uint)current.UsedSize;
-                        bool currentNotFull = remaining > 0;
-                        bool nextStartsWithLargeCallstack =
-                            (next.FirstEventId == AsyncEventID.ResumeAsyncCallstack ||
-                             next.FirstEventId == AsyncEventID.CreateAsyncCallstack ||
-                             next.FirstEventId == AsyncEventID.SuspendAsyncCallstack) &&
-                            next.FirstFrameCount > 30;
-
-                        if (currentNotFull && nextStartsWithLargeCallstack)
-                        {
-                            overflowDetected = true;
-                            break;
-                        }
-                    }
-
-                    if (overflowDetected)
-                        break;
-                }
-
-                // Validate all large callstacks in the stream have correct frames.
-                if (overflowDetected)
-                {
-                    var largeCallstacks = stream.OfType(AsyncEventID.ResumeAsyncCallstack)
-                        .Where(e => e.FrameCount > 30)
-                        .ToList();
-
-                    foreach (var cs in largeCallstacks)
-                    {
-                        Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
-                        for (int f = 0; f < cs.Frames.Count; f++)
-                        {
-                            var (methodId, _) = cs.Frames[f];
-                            Assert.True(methodId != 0, $"Overflow callstack frame {f} has zero MethodId");
-
-                            var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
-                            Assert.True(method is not null, $"Overflow callstack frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
-                        }
-                    }
-                }
-            }
-
-            Assert.True(overflowDetected, "Failed to trigger callstack buffer overflow after 10 attempts — " +
-                "no consecutive buffer pair found where buffer N has remaining capacity and buffer N+1 starts with a large callstack");
-        }
-
-        // Requires threading:
-        // Deep recursive chains must execute in a single dispatch
-        // loop (no sync context) to produce chains exceeding the 255-frame cap.
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_CallstackDepthCappedAtMaxFrames()
-        {
-            // Verify that callstack depth is capped when the continuation chain
-            // exceeds the maximum frame count (255, limited by byte storage).
-            // RecursiveAsyncChain(300) produces a 300-deep chain + 1 lambda = 301 frames.
-            const int requestedDepth = 300;
-
-            var events = CollectEvents(ResumeAsyncCallstackKeyword, () =>
-            {
-                RunScenarioAndFlush(async () =>
-                {
-                    await RecursiveAsyncChain(requestedDepth);
-                });
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var callstacks = stream.OfType(AsyncEventID.ResumeAsyncCallstack).ToList();
-            Assert.True(callstacks.Count >= 1, "Expected at least one callstack");
-
-            // Find the callstack from our deep RecursiveAsyncChain call.
-            // The max frame count is capped at 255 (byte.MaxValue) since the
-            // CaptureRuntimeAsyncCallstackState.Count is a byte.
-            // RecursiveAsyncChain(300) + 1 lambda = 301 frames, capped to 255.
-            var deepest = callstacks.MaxBy(cs => cs.FrameCount);
-            Assert.Equal(255, (int)deepest!.FrameCount);
-            Assert.Equal((int)deepest.FrameCount, deepest.Frames.Count);
-
-            // Verify all frames are valid.
-            foreach (var (methodId, _) in deepest.Frames)
-            {
-                Assert.True(methodId != 0, "Frame has zero MethodId");
-                var method = GetMethodNameFromMethodId(deepest.CallstackType, methodId);
-                Assert.True(method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
-            }
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task RuntimeAsync_MetadataMatchesWrapperMethods()
-        {
-            var events = await CollectEventsAsync(AllKeywords, SingleAsyncYield);
-
-            var stream = ParseAllEvents(events);
-            var metadataList = stream.MetadataEvents;
-            Assert.True(metadataList.Count >= 1, "Expected at least one metadata event in buffer");
-
-            MetadataFromBuffer meta = metadataList[0];
-            Assert.True(meta.WrapperCount > 0, "Expected positive wrapper count in metadata");
-
-            // On CoreCLR, verify via reflection that the contract-defined template produces names matching real methods.
-            // This catches accidental renames of wrapper methods without updating the contract.
-            if (PlatformDetection.IsCoreCLR)
-            {
-                Type? wrapperType = typeof(System.Runtime.CompilerServices.AsyncTaskMethodBuilder)
-                    .Assembly.GetType("System.Runtime.CompilerServices.AsyncProfiler+ContinuationWrapper");
-                Assert.NotNull(wrapperType);
-                for (int i = 0; i < meta.WrapperCount; i++)
-                {
-                    string expectedName = string.Format(WrapperNameTemplate, i);
-                    var method = wrapperType.GetMethod(expectedName,
-                        System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
-                    Assert.True(method is not null, $"Expected method '{expectedName}' not found on ContinuationWrapper type");
-                }
-
-                // Verify that the wrapper count matches the actual number of wrapper methods on the type.
-                int actualCount = wrapperType.GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public)
-                    .Count(m => m.Name.StartsWith(WrapperNamePrefix, StringComparison.Ordinal));
-                Assert.Equal(meta.WrapperCount, actualCount);
-            }
-        }
-    }
-
-    internal static class EventBuffer
-    {
-        public static int OutputEventBuffer(ReadOnlySpan<byte> buffer)
-        {
-            Console.WriteLine("--- AsyncEvents ---");
-
-            int index = 0;
-
-            if ((uint)buffer.Length < 1)
-            {
-                Console.WriteLine("Buffer too small.");
-                Console.WriteLine("----------------------------------");
-                return index;
-            }
-
-            byte version = buffer[index++];
-            Console.WriteLine($"Version: {version}");
-
-            if (version != 1)
-            {
-                Console.WriteLine($"Unsupported version: {version}");
-                Console.WriteLine("----------------------------------");
-                return index;
-            }
-
-            Deserializer.ReadUInt32(buffer, ref index, out uint totalSize);
-            Deserializer.ReadUInt32(buffer, ref index, out uint contextId);
-            Deserializer.ReadUInt64(buffer, ref index, out ulong osThreadId);
-            Deserializer.ReadUInt32(buffer, ref index, out uint totalEventCount);
-            Deserializer.ReadUInt64(buffer, ref index, out ulong startTimestamp);
-            Deserializer.ReadUInt64(buffer, ref index, out ulong endTimestamp);
-
-            Console.WriteLine($"TotalSize (bytes): {totalSize}");
-            Console.WriteLine($"AsyncThreadContextId: {contextId}");
-            Console.WriteLine($"OSThreadId: {osThreadId}");
-            Console.WriteLine($"TotalEventCount: {totalEventCount}");
-            Console.WriteLine($"StartTimestamp: 0x{startTimestamp:X16}");
-            Console.WriteLine($"EndTimestamp: 0x{endTimestamp:X16}");
-
-            int eventCount = 0;
-            ulong currentTimestamp = startTimestamp;
-
-            while (index < buffer.Length)
-            {
-                if (index + 2 > buffer.Length)
-                {
-                    Console.WriteLine($"Trailing bytes: {buffer.Length - index} (incomplete entry header).");
-                    break;
-                }
-
-                AsyncEventID eventId = (AsyncEventID)buffer[index++];
-
-                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong delta);
-                currentTimestamp += delta;
-
-                Console.WriteLine($"Entry[{eventCount}]: Timestamp=0x{currentTimestamp:X16}, EventId={eventId}");
-
-                int payloadStart = index;
-                try
-                {
-                    index += eventId switch
-                    {
-                        AsyncEventID.CreateAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
-                        AsyncEventID.ResumeAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
-                        AsyncEventID.SuspendAsyncContext => OutputSuspendAsyncContextEvent(),
-                        AsyncEventID.CompleteAsyncContext => OutputCompleteAsyncContextEvent(),
-                        AsyncEventID.UnwindAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
-                        AsyncEventID.CreateAsyncCallstack => OutputAsyncCallstackEvent("CreateAsyncCallstack", buffer.Slice(index)),
-                        AsyncEventID.ResumeAsyncCallstack => OutputAsyncCallstackEvent("ResumeAsyncCallstack", buffer.Slice(index)),
-                        AsyncEventID.SuspendAsyncCallstack => OutputAsyncCallstackEvent("SuspendAsyncCallstack", buffer.Slice(index)),
-                        AsyncEventID.AppendAsyncCallstack => OutputAsyncCallstackEvent("AppendAsyncCallstack", buffer.Slice(index)),
-                        AsyncEventID.ResumeAsyncMethod => OutputResumeAsyncMethodEvent(),
-                        AsyncEventID.CompleteAsyncMethod => OutputCompleteAsyncMethodEvent(),
-                        AsyncEventID.ResetAsyncThreadContext => OutputResetAsyncThreadContextEvent(),
-                        AsyncEventID.ResetAsyncContinuationWrapperIndex => OutputResetAsyncContinuationWrapperIndexEvent(),
-                        AsyncEventID.AsyncProfilerMetadata => OutputAsyncProfilerMetadataEvent(buffer.Slice(index)),
-                        AsyncEventID.AsyncProfilerSyncClock => OutputAsyncProfilerSyncClockEvent(buffer.Slice(index)),
-                        _ => throw new InvalidOperationException($"Unknown eventId {eventId}."),
-                    };
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"  Failed decoding entry payload at offset {payloadStart}: {ex.GetType().Name}: {ex.Message}");
-                    break;
-                }
-
-                eventCount++;
-            }
-
-            Console.WriteLine($"TotalEntriesDecoded: {eventCount}");
-            Console.WriteLine("----------------------------------");
-
-            return index;
-        }
-
-        private static int OutputCreateAsyncContextEvent(ReadOnlySpan<byte> buffer)
-        {
-            int index = 0;
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong id);
-            Console.WriteLine("--- CreateAsyncContext ---");
-            Console.WriteLine($"  ID: {id}");
-            Console.WriteLine("----------------------------");
-            return index;
-        }
-
-        private static int OutputResumeAsyncContextEvent(ReadOnlySpan<byte> buffer)
-        {
-            int index = 0;
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong id);
-            Console.WriteLine("--- ResumeAsyncContext ---");
-            Console.WriteLine($"  ID: {id}");
-            Console.WriteLine("----------------------------");
-            return index;
-        }
-
-        private static int OutputSuspendAsyncContextEvent()
-        {
-            Console.WriteLine("--- SuspendAsyncContext ---");
-            Console.WriteLine("----------------------------");
-            return 0;
-        }
-
-        private static int OutputCompleteAsyncContextEvent()
-        {
-            Console.WriteLine("--- CompleteAsyncContext ---");
-            Console.WriteLine("----------------------------");
-            return 0;
-        }
-
-        private static int OutputUnwindAsyncExceptionEvent(ReadOnlySpan<byte> buffer)
-        {
-            uint unwindedFrames;
-            int index = 0;
-
-            Deserializer.ReadCompressedUInt32(buffer, ref index, out unwindedFrames);
-            index += OutputUnwindAsyncExceptionEvent(unwindedFrames);
-
-            return index;
-        }
-
-        private static int OutputUnwindAsyncExceptionEvent(uint unwindedFrames)
-        {
-            Console.WriteLine("--- UnwindAsyncException ---");
-            Console.WriteLine($"Unwinded Frames: {unwindedFrames}");
-            Console.WriteLine("----------------------------");
-            return 0;
-        }
-
-        private static int OutputResumeAsyncMethodEvent()
-        {
-            Console.WriteLine("--- ResumeAsyncMethod ---");
-            Console.WriteLine("----------------------------");
-            return 0;
-        }
-
-        private static int OutputCompleteAsyncMethodEvent()
-        {
-            Console.WriteLine("--- CompleteAsyncMethod ---");
-            Console.WriteLine("----------------------------");
-            return 0;
-        }
-
-        private static int OutputResetAsyncContinuationWrapperIndexEvent()
-        {
-            Console.WriteLine("--- ResetAsyncContinuationWrapperIndex ---");
-            Console.WriteLine("----------------------------");
-            return 0;
-        }
-
-        private static int OutputResetAsyncThreadContextEvent()
-        {
-            Console.WriteLine("--- ResetAsyncThreadContext ---");
-            Console.WriteLine("----------------------------");
-            return 0;
-        }
-
-        private static int OutputAsyncProfilerMetadataEvent(ReadOnlySpan<byte> buffer)
-        {
-            int index = 0;
-            Console.WriteLine("--- AsyncProfilerMetadata ---");
-
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong qpcFrequency);
-            Console.WriteLine($"  QPCFrequency: {qpcFrequency}");
-
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong qpcSync);
-            Console.WriteLine($"  QPCSync: {qpcSync}");
-
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong utcSync);
-            Console.WriteLine($"  UTCSync: {utcSync}");
-
-            Deserializer.ReadCompressedUInt32(buffer, ref index, out uint eventBufferSize);
-            Console.WriteLine($"  EventBufferSize: {eventBufferSize}");
-
-            byte wrapperCount = buffer[index++];
-            Console.WriteLine($"  WrapperCount: {wrapperCount}");
-
-            Console.WriteLine("----------------------------");
-            return index;
-        }
-
-        private static int OutputAsyncProfilerSyncClockEvent(ReadOnlySpan<byte> buffer)
-        {
-            int index = 0;
-            Console.WriteLine("--- AsyncProfilerSyncClock ---");
-
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong qpcSync);
-            Console.WriteLine($"  QPCSync: {qpcSync}");
-
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong utcSync);
-            Console.WriteLine($"  UTCSync: {utcSync}");
-
-            Console.WriteLine("----------------------------");
-            return index;
-        }
-
-        private static int OutputAsyncCallstackEvent(string eventName, ReadOnlySpan<byte> buffer)
-        {
-            ulong id;
-            byte type;
-            byte callstackId;
-            byte asyncCallstackLength;
-            int index = 0;
-
-            type = buffer[index++];
-            callstackId = buffer[index++];
-            asyncCallstackLength = buffer[index++];
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out id);
-
-            Console.WriteLine($"--- {eventName} ---");
-            Console.WriteLine($"ID: {id}");
-            Console.WriteLine($"Type: {type}");
-            Console.WriteLine($"CallstackId: {callstackId}");
-            Console.WriteLine($"Length: {asyncCallstackLength}");
-
-            if (asyncCallstackLength == 0)
-            {
-                return index;
-            }
-
-            ulong previousMethodId;
-            ulong currentMethodId;
-            int state;
-
-            Deserializer.ReadCompressedUInt64(buffer, ref index, out currentMethodId);
-            Deserializer.ReadCompressedInt32(buffer, ref index, out state);
-
-            OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, 0);
-
-            for (int i = 1; i < asyncCallstackLength; i++)
-            {
-                previousMethodId = currentMethodId;
-                Deserializer.ReadCompressedInt64(buffer, ref index, out long methodIdDelta);
-                Deserializer.ReadCompressedInt32(buffer, ref index, out state);
-                currentMethodId = previousMethodId + (ulong)methodIdDelta;
-                OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, i);
-            }
-
-            return index;
-        }
-
-        private static void OutputAsyncFrame(AsyncCallstackType type, ulong methodId, int state, int frameIndex)
-        {
-            string asyncMethodName = AsyncProfilerTests.GetMethodNameFromMethodId(type, methodId) ?? "??";
-            string methodIdString = $"0x{methodId:X}";
-            Console.WriteLine($"  Frame {frameIndex}: AsyncMethod = {asyncMethodName}, MethodId = {methodIdString}, State = {state}");
-        }
-
-        internal static class Deserializer
+        private static class Deserializer
         {
             public static void ReadInt32(ReadOnlySpan<byte> buffer, ref int index, out int value)
             {
@@ -2790,6 +1096,278 @@ namespace System.Threading.Tasks.Tests
             private static int ZigzagDecodeInt32(uint value) => (int)((value >> 1) ^ (~(value & 1) + 1));
 
             private static long ZigzagDecodeInt64(ulong value) => (long)((value >> 1) ^ (~(value & 1) + 1));
+        }
+
+        private static class EventBuffer
+        {
+            public static void DumpAllEvents(CollectedEvents events)
+            {
+                ForEachEventBufferPayload(events.Events, buffer => EventBuffer.OutputEventBuffer(buffer));
+                OutputFooter();
+            }
+
+            private static int OutputEventBuffer(ReadOnlySpan<byte> buffer)
+            {
+                OutputHeader("Async Event Buffer");
+
+                int index = 0;
+
+                if ((uint)buffer.Length < 1)
+                {
+                    Console.WriteLine("Buffer too small.");
+                    OutputFooter();
+                    return index;
+                }
+
+                byte version = buffer[index++];
+                Console.WriteLine($"Version: {version}");
+
+                if (version != 1)
+                {
+                    Console.WriteLine($"Unsupported version: {version}");
+                    OutputFooter();
+                    return index;
+                }
+
+                Deserializer.ReadUInt32(buffer, ref index, out uint totalSize);
+                Deserializer.ReadUInt32(buffer, ref index, out uint contextId);
+                Deserializer.ReadUInt64(buffer, ref index, out ulong osThreadId);
+                Deserializer.ReadUInt32(buffer, ref index, out uint totalEventCount);
+                Deserializer.ReadUInt64(buffer, ref index, out ulong startTimestamp);
+                Deserializer.ReadUInt64(buffer, ref index, out ulong endTimestamp);
+
+                Console.WriteLine($"TotalSize: {totalSize}");
+                Console.WriteLine($"AsyncThreadContextId: {contextId}");
+                Console.WriteLine($"OSThreadId: {osThreadId}");
+                Console.WriteLine($"TotalEventCount: {totalEventCount}");
+                Console.WriteLine($"StartTimestamp: 0x{startTimestamp:X16}");
+                Console.WriteLine($"EndTimestamp: 0x{endTimestamp:X16}");
+
+                int eventCount = 0;
+                ulong currentTimestamp = startTimestamp;
+
+                while (index < buffer.Length)
+                {
+                    if (index + 2 > buffer.Length)
+                    {
+                        Console.WriteLine($"Trailing bytes: {buffer.Length - index} (incomplete entry header).");
+                        break;
+                    }
+
+                    AsyncEventID eventId = (AsyncEventID)buffer[index++];
+
+                    Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong delta);
+                    currentTimestamp += delta;
+
+                    OutputHeader(eventCount, eventId, currentTimestamp);
+
+                    int payloadStart = index;
+                    try
+                    {
+                        index += eventId switch
+                        {
+                            AsyncEventID.CreateAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.ResumeAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.SuspendAsyncContext => OutputSuspendAsyncContextEvent(),
+                            AsyncEventID.CompleteAsyncContext => OutputCompleteAsyncContextEvent(),
+                            AsyncEventID.UnwindAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
+                            AsyncEventID.CreateAsyncCallstack => OutputAsyncCallstackEvent(buffer.Slice(index)),
+                            AsyncEventID.ResumeAsyncCallstack => OutputAsyncCallstackEvent(buffer.Slice(index)),
+                            AsyncEventID.SuspendAsyncCallstack => OutputAsyncCallstackEvent(buffer.Slice(index)),
+                            AsyncEventID.AppendAsyncCallstack => OutputAsyncCallstackEvent(buffer.Slice(index)),
+                            AsyncEventID.ResumeAsyncMethod => OutputResumeAsyncMethodEvent(),
+                            AsyncEventID.CompleteAsyncMethod => OutputCompleteAsyncMethodEvent(),
+                            AsyncEventID.ResetAsyncThreadContext => OutputResetAsyncThreadContextEvent(),
+                            AsyncEventID.ResetAsyncContinuationWrapperIndex => OutputResetAsyncContinuationWrapperIndexEvent(),
+                            AsyncEventID.AsyncProfilerMetadata => OutputAsyncProfilerMetadataEvent(buffer.Slice(index)),
+                            AsyncEventID.AsyncProfilerSyncClock => OutputAsyncProfilerSyncClockEvent(buffer.Slice(index)),
+                            _ => throw new InvalidOperationException($"Unknown eventId {eventId}."),
+                        };
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"  Failed decoding entry payload at offset {payloadStart}: {ex.GetType().Name}: {ex.Message}");
+                        break;
+                    }
+
+                    eventCount++;
+                }
+
+                return index;
+            }
+
+            private const int OutputEventSeparatorWidth = 80;
+
+            private static void OutputHeader()
+            {
+                Console.WriteLine($"{new string('-', OutputEventSeparatorWidth)}");
+            }
+
+            private static void OutputHeader(string header) => Console.WriteLine($"{FormatCenteredLabel(header)}");
+
+            private static void OutputHeader(int eventCount, AsyncEventID id, ulong timestamp) =>
+                Console.WriteLine($"[{eventCount}] {id} (0x{timestamp:X16})");
+
+            private static string FormatCenteredLabel(string label)
+            {
+                int totalDashes = Math.Max(6, OutputEventSeparatorWidth - label.Length - 2);
+                int leftDashes = totalDashes / 2;
+                int rightDashes = totalDashes - leftDashes;
+                return $"{new string('-', leftDashes)} {label} {new string('-', rightDashes)}";
+            }
+
+            private static void OutputFooter()
+            {
+                Console.WriteLine(new string('-', OutputEventSeparatorWidth));
+            }
+
+            private static int OutputCreateAsyncContextEvent(ReadOnlySpan<byte> buffer)
+            {
+                int index = 0;
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong id);
+                Console.WriteLine($"  ID: {id}");
+                return index;
+            }
+
+            private static int OutputResumeAsyncContextEvent(ReadOnlySpan<byte> buffer)
+            {
+                int index = 0;
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong id);
+                Console.WriteLine($"  ID: {id}");
+                return index;
+            }
+
+            private static int OutputSuspendAsyncContextEvent()
+            {
+                return 0;
+            }
+
+            private static int OutputCompleteAsyncContextEvent()
+            {
+                return 0;
+            }
+
+            private static int OutputUnwindAsyncExceptionEvent(ReadOnlySpan<byte> buffer)
+            {
+                uint unwindedFrames;
+                int index = 0;
+
+                Deserializer.ReadCompressedUInt32(buffer, ref index, out unwindedFrames);
+                index += OutputUnwindAsyncExceptionEvent(unwindedFrames);
+
+                return index;
+            }
+
+            private static int OutputUnwindAsyncExceptionEvent(uint unwindedFrames)
+            {
+                Console.WriteLine($"  Unwinded Frames: {unwindedFrames}");
+                return 0;
+            }
+
+            private static int OutputResumeAsyncMethodEvent()
+            {
+                return 0;
+            }
+
+            private static int OutputCompleteAsyncMethodEvent()
+            {
+                return 0;
+            }
+
+            private static int OutputResetAsyncContinuationWrapperIndexEvent()
+            {
+                return 0;
+            }
+
+            private static int OutputResetAsyncThreadContextEvent()
+            {
+                return 0;
+            }
+
+            private static int OutputAsyncProfilerMetadataEvent(ReadOnlySpan<byte> buffer)
+            {
+                int index = 0;
+
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong qpcFrequency);
+                Console.WriteLine($"  QPCFrequency: {qpcFrequency}");
+
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong qpcSync);
+                Console.WriteLine($"  QPCSync: {qpcSync}");
+
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong utcSync);
+                Console.WriteLine($"  UTCSync: {utcSync}");
+
+                Deserializer.ReadCompressedUInt32(buffer, ref index, out uint eventBufferSize);
+                Console.WriteLine($"  EventBufferSize: {eventBufferSize}");
+
+                byte wrapperCount = buffer[index++];
+                Console.WriteLine($"  WrapperCount: {wrapperCount}");
+
+                return index;
+            }
+
+            private static int OutputAsyncProfilerSyncClockEvent(ReadOnlySpan<byte> buffer)
+            {
+                int index = 0;
+
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong qpcSync);
+                Console.WriteLine($"  QPCSync: {qpcSync}");
+
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong utcSync);
+                Console.WriteLine($"  UTCSync: {utcSync}");
+
+                return index;
+            }
+
+            private static int OutputAsyncCallstackEvent(ReadOnlySpan<byte> buffer)
+            {
+                ulong id;
+                byte type;
+                byte callstackId;
+                byte asyncCallstackLength;
+                int index = 0;
+
+                type = buffer[index++];
+                callstackId = buffer[index++];
+                asyncCallstackLength = buffer[index++];
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out id);
+
+                Console.WriteLine($"  ID: {id}");
+                Console.WriteLine($"  Type: {type}");
+                Console.WriteLine($"  CallstackId: {callstackId}");
+                Console.WriteLine($"  Length: {asyncCallstackLength}");
+
+                if (asyncCallstackLength == 0)
+                {
+                    return index;
+                }
+
+                ulong previousMethodId;
+                ulong currentMethodId;
+                int state;
+
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out currentMethodId);
+                Deserializer.ReadCompressedInt32(buffer, ref index, out state);
+
+                OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, 0);
+
+                for (int i = 1; i < asyncCallstackLength; i++)
+                {
+                    previousMethodId = currentMethodId;
+                    Deserializer.ReadCompressedInt64(buffer, ref index, out long methodIdDelta);
+                    Deserializer.ReadCompressedInt32(buffer, ref index, out state);
+                    currentMethodId = previousMethodId + (ulong)methodIdDelta;
+                    OutputAsyncFrame((AsyncCallstackType)type, currentMethodId, state, i);
+                }
+
+                return index;
+            }
+
+            private static void OutputAsyncFrame(AsyncCallstackType type, ulong methodId, int state, int frameIndex)
+            {
+                string asyncMethodName = GetMethodNameFromMethodId(type, methodId) ?? "??";
+                Console.WriteLine($"    [{frameIndex}] {asyncMethodName} (0x{methodId:X}) (state={state})");
+            }
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -855,7 +855,7 @@ namespace System.Threading.Tasks.Tests
             // V1 (task-based) async: the dispatcher's finally block emits CompleteAsyncContext
             // after inner.MoveNext() returns, but MoveNext() already set the task result which
             // unblocks this thread. Brief sleep ensures the pool thread's finally completes.
-            // V2 (runtime-async) does not have this issue — Complete fires inside the dispatch
+            // V2 (runtime-async) does not have this issue -- Complete fires inside the dispatch
             // loop before the task is signaled.
             //
             // Clear SynchronizationContext so RuntimeAsync continuations don't capture
@@ -1021,6 +1021,55 @@ namespace System.Threading.Tasks.Tests
             }
 
             Assert.Equal(0, stackDepth);
+        }
+
+        private static void AssertExactlyOneCreateAndComplete(ParsedEventStream stream, ulong taskId, string chainName)
+        {
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            int creates = ids.Count(id => id == AsyncEventID.CreateAsyncContext);
+            int completes = ids.Count(id => id == AsyncEventID.CompleteAsyncContext);
+            Assert.True(creates == 1, $"Expected exactly 1 CreateAsyncContext for {chainName} (TaskId {taskId}), got {creates}");
+            Assert.True(completes == 1, $"Expected exactly 1 CompleteAsyncContext for {chainName} (TaskId {taskId}), got {completes}");
+        }
+
+        // V1-friendly variant: V1's per-MoveNext dispatcher model emits one Create per await
+        // suspension, so a method with N awaits produces N dispatchers / N Creates on the same
+        // TaskId. The invariant we can still assert is creates == completes (both >= 1).
+        private static void AssertCreateEqualsCompleteForTask(ParsedEventStream stream, ulong taskId, string chainName)
+        {
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            int creates = ids.Count(id => id == AsyncEventID.CreateAsyncContext);
+            int completes = ids.Count(id => id == AsyncEventID.CompleteAsyncContext);
+            Assert.True(creates >= 1, $"Expected at least 1 CreateAsyncContext for {chainName} (TaskId {taskId}), got {creates}");
+            Assert.True(creates == completes, $"Expected CreateAsyncContext count == CompleteAsyncContext count for {chainName} (TaskId {taskId}), got {creates} creates and {completes} completes");
+        }
+
+        private sealed class InlinePostSynchronizationContext : SynchronizationContext
+        {
+            private int _postCount;
+            public int PostCount => _postCount;
+
+            public override void Post(SendOrPostCallback d, object? state)
+            {
+                Interlocked.Increment(ref _postCount);
+                d(state);
+            }
+        }
+
+        private sealed class InlineRunTaskScheduler : TaskScheduler
+        {
+            private int _queuedCount;
+            public int QueuedCount => _queuedCount;
+
+            protected override void QueueTask(Task task)
+            {
+                Interlocked.Increment(ref _queuedCount);
+                TryExecuteTask(task);
+            }
+
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+            protected override IEnumerable<Task>? GetScheduledTasks() => null;
         }
 
         private static class Deserializer

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -30,18 +30,19 @@ namespace System.Threading.Tasks.Tests
         // StateMachine (StateMachineAsync) events.
         CreateStateMachineAsyncContext = 11,
         ResumeStateMachineAsyncContext = 12,
-        CompleteStateMachineAsyncContext = 13,
-        UnwindStateMachineAsyncException = 14,
-        ResumeStateMachineAsyncCallstack = 15,
-        ResumeStateMachineAsyncMethod = 16,
-        CompleteStateMachineAsyncMethod = 17,
-        AppendStateMachineAsyncCallstack = 18,
+        SuspendStateMachineAsyncContext = 13,
+        CompleteStateMachineAsyncContext = 14,
+        UnwindStateMachineAsyncException = 15,
+        ResumeStateMachineAsyncCallstack = 16,
+        ResumeStateMachineAsyncMethod = 17,
+        CompleteStateMachineAsyncMethod = 18,
+        AppendStateMachineAsyncCallstack = 19,
 
         // Neutral profiler events.
-        ResetAsyncThreadContext = 19,
-        ResetAsyncContinuationWrapperIndex = 20,
-        AsyncProfilerMetadata = 21,
-        AsyncProfilerSyncClock = 22,
+        ResetAsyncThreadContext = 20,
+        ResetAsyncContinuationWrapperIndex = 21,
+        AsyncProfilerMetadata = 22,
+        AsyncProfilerSyncClock = 23,
     }
 
     public enum AsyncCallstackType : byte
@@ -80,6 +81,7 @@ namespace System.Threading.Tasks.Tests
 
                 new EventManifestEntry(AsyncEventID.CreateStateMachineAsyncContext, 1, BytePayloadLength),
                 new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncContext, 1, BytePayloadLength),
+                new EventManifestEntry(AsyncEventID.SuspendStateMachineAsyncContext, 1, NoPayload),
                 new EventManifestEntry(AsyncEventID.CompleteStateMachineAsyncContext, 1, NoPayload),
                 new EventManifestEntry(AsyncEventID.UnwindStateMachineAsyncException, 1, BytePayloadLength),
                 new EventManifestEntry(AsyncEventID.ResumeStateMachineAsyncCallstack, 1, UShortPayloadLength),
@@ -139,11 +141,12 @@ namespace System.Threading.Tasks.Tests
         private const EventKeywords CompleteRuntimeAsyncMethodKeyword = (EventKeywords)0x200;
         private const EventKeywords CreateStateMachineAsyncContextKeyword = (EventKeywords)0x400;
         private const EventKeywords ResumeStateMachineAsyncContextKeyword = (EventKeywords)0x800;
-        private const EventKeywords CompleteStateMachineAsyncContextKeyword = (EventKeywords)0x1000;
-        private const EventKeywords UnwindStateMachineAsyncExceptionKeyword = (EventKeywords)0x2000;
-        private const EventKeywords ResumeStateMachineAsyncCallstackKeyword = (EventKeywords)0x4000;
-        private const EventKeywords ResumeStateMachineAsyncMethodKeyword = (EventKeywords)0x8000;
-        private const EventKeywords CompleteStateMachineAsyncMethodKeyword = (EventKeywords)0x10000;
+        private const EventKeywords SuspendStateMachineAsyncContextKeyword = (EventKeywords)0x1000;
+        private const EventKeywords CompleteStateMachineAsyncContextKeyword = (EventKeywords)0x2000;
+        private const EventKeywords UnwindStateMachineAsyncExceptionKeyword = (EventKeywords)0x4000;
+        private const EventKeywords ResumeStateMachineAsyncCallstackKeyword = (EventKeywords)0x8000;
+        private const EventKeywords ResumeStateMachineAsyncMethodKeyword = (EventKeywords)0x10000;
+        private const EventKeywords CompleteStateMachineAsyncMethodKeyword = (EventKeywords)0x20000;
 
         private const EventKeywords AllRuntimeAsyncKeywords =
             CreateRuntimeAsyncContextKeyword |
@@ -160,6 +163,7 @@ namespace System.Threading.Tasks.Tests
         private const EventKeywords AllStateMachineAsyncKeywords =
             CreateStateMachineAsyncContextKeyword |
             ResumeStateMachineAsyncContextKeyword |
+            SuspendStateMachineAsyncContextKeyword |
             CompleteStateMachineAsyncContextKeyword |
             UnwindStateMachineAsyncExceptionKeyword |
             ResumeStateMachineAsyncCallstackKeyword |
@@ -179,6 +183,7 @@ namespace System.Threading.Tasks.Tests
         private const EventKeywords StateMachineAsyncCoreKeywords =
             CreateStateMachineAsyncContextKeyword |
             ResumeStateMachineAsyncContextKeyword |
+            SuspendStateMachineAsyncContextKeyword |
             CompleteStateMachineAsyncContextKeyword;
 
         private const EventKeywords RuntimeAsyncMethodKeywords =
@@ -203,6 +208,7 @@ namespace System.Threading.Tasks.Tests
         private const EventKeywords StateMachineAsyncCallstackKeywords =
             CreateStateMachineAsyncContextKeyword |
             ResumeStateMachineAsyncContextKeyword |
+            SuspendStateMachineAsyncContextKeyword |
             ResumeStateMachineAsyncCallstackKeyword |
             CompleteStateMachineAsyncContextKeyword |
             CompleteStateMachineAsyncMethodKeyword |
@@ -487,6 +493,7 @@ namespace System.Threading.Tasks.Tests
                 case AsyncEventID.CompleteRuntimeAsyncContext:
                 case AsyncEventID.ResumeRuntimeAsyncMethod:
                 case AsyncEventID.CompleteRuntimeAsyncMethod:
+                case AsyncEventID.SuspendStateMachineAsyncContext:
                 case AsyncEventID.CompleteStateMachineAsyncContext:
                 case AsyncEventID.ResumeStateMachineAsyncMethod:
                 case AsyncEventID.CompleteStateMachineAsyncMethod:
@@ -944,6 +951,7 @@ namespace System.Threading.Tasks.Tests
                     {
                         case AsyncEventID.SuspendRuntimeAsyncContext:
                         case AsyncEventID.CompleteRuntimeAsyncContext:
+                        case AsyncEventID.SuspendStateMachineAsyncContext:
                         case AsyncEventID.CompleteStateMachineAsyncContext:
                         {
                             openByDispatcherId.Remove(evt.DispatcherId);
@@ -1074,7 +1082,7 @@ namespace System.Threading.Tasks.Tests
                             ParseEndContextEvent(eventId, baseTimestamp, osThreadId,
                                 ref v2CurrentDispatcherId, ref v2CurrentParentDispatcherId, v2DispatcherStack),
 
-                        AsyncEventID.CompleteStateMachineAsyncContext =>
+                        AsyncEventID.CompleteStateMachineAsyncContext or AsyncEventID.SuspendStateMachineAsyncContext =>
                             ParseEndContextEvent(eventId, baseTimestamp, osThreadId,
                                 ref v1CurrentDispatcherId, ref v1CurrentParentDispatcherId, v1DispatcherStack),
 
@@ -1682,14 +1690,17 @@ namespace System.Threading.Tasks.Tests
 
         // StateMachine-friendly variant: StateMachine's per-MoveNext dispatcher model emits one Create per await
         // suspension, so a method with N awaits produces N dispatchers / N Creates within the
-        // same dispatcher tree. The invariant we can still assert is creates == completes (both >= 1).
-        private static void AssertCreateEqualsCompleteInChain(ParsedEventStream stream, ulong dispatcherId, string chainName)
+        // same dispatcher tree. Each dispatcher ends in exactly one Suspend (it yielded) or one
+        // Complete (it finished), so every Create is balanced by a Suspend or a Complete:
+        // creates == completes + suspends (creates >= 1).
+        private static void AssertCreateBalancesSuspendAndCompleteInChain(ParsedEventStream stream, ulong dispatcherId, string chainName)
         {
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
             int creates = ids.Count(id => id == AsyncEventID.CreateStateMachineAsyncContext);
+            int suspends = ids.Count(id => id == AsyncEventID.SuspendStateMachineAsyncContext);
             int completes = ids.Count(id => id == AsyncEventID.CompleteStateMachineAsyncContext);
-            AssertTrue(stream, creates >= 1, $"Expected at least 1 CreateStateMachineAsyncContextKeyword for {chainName} (DispatcherId {dispatcherId}), got {creates}");
-            AssertTrue(stream, creates == completes, $"Expected CreateStateMachineAsyncContextKeyword count == CompleteStateMachineAsyncContextKeyword count for {chainName} (DispatcherId {dispatcherId}), got {creates} creates and {completes} completes");
+            AssertTrue(stream, creates >= 1, $"Expected at least 1 CreateStateMachineAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
+            AssertTrue(stream, creates == completes + suspends, $"Expected CreateStateMachineAsyncContext count == CompleteStateMachineAsyncContext + SuspendStateMachineAsyncContext count for {chainName} (DispatcherId {dispatcherId}), got {creates} creates, {completes} completes, {suspends} suspends");
         }
 
         private sealed class InlinePostSynchronizationContext : SynchronizationContext
@@ -1877,6 +1888,7 @@ namespace System.Threading.Tasks.Tests
 
                             AsyncEventID.CreateStateMachineAsyncContext => OutputCreateAsyncContextEvent(buffer.Slice(index)),
                             AsyncEventID.ResumeStateMachineAsyncContext => OutputResumeAsyncContextEvent(buffer.Slice(index)),
+                            AsyncEventID.SuspendStateMachineAsyncContext => OutputSuspendAsyncContextEvent(),
                             AsyncEventID.CompleteStateMachineAsyncContext => OutputCompleteAsyncContextEvent(),
                             AsyncEventID.UnwindStateMachineAsyncException => OutputUnwindAsyncExceptionEvent(buffer.Slice(index)),
                             AsyncEventID.ResumeStateMachineAsyncCallstack => OutputAsyncCallstackEvent(eventId, buffer.Slice(index)),

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -290,11 +290,16 @@ namespace System.Threading.Tasks.Tests
             switch (eventId)
             {
                 case AsyncEventID.RuntimeAsync_CreateAsyncContext:
-                case AsyncEventID.RuntimeAsync_ResumeAsyncContext:
                 case AsyncEventID.TaskAsync_CreateAsyncContext:
+                {
+                    ReadCompressedUInt64(buffer, ref index); // parentDispatcherId
+                    ReadCompressedUInt64(buffer, ref index); // dispatcherId
+                    return true;
+                }
+                case AsyncEventID.RuntimeAsync_ResumeAsyncContext:
                 case AsyncEventID.TaskAsync_ResumeAsyncContext:
                 {
-                    ReadCompressedUInt64(buffer, ref index);
+                    ReadCompressedUInt64(buffer, ref index); // dispatcherId
                     return true;
                 }
                 case AsyncEventID.RuntimeAsync_SuspendAsyncContext:
@@ -322,7 +327,7 @@ namespace System.Threading.Tasks.Tests
                 case AsyncEventID.TaskAsync_ResumeAsyncCallstack:
                 case AsyncEventID.TaskAsync_AppendAsyncCallstack:
                 {
-                    SkipCallstackPayload(buffer, ref index, CallstackTypeFromEventId(eventId));
+                    SkipCallstackPayload(buffer, ref index, eventId, CallstackTypeFromEventId(eventId));
                     return true;
                 }
                 case AsyncEventID.AsyncProfilerMetadata:
@@ -355,24 +360,28 @@ namespace System.Threading.Tasks.Tests
             return value;
         }
 
-        private static void SkipCallstackPayload(ReadOnlySpan<byte> buffer, ref int index, AsyncCallstackType callstackType)
+        private static void SkipCallstackPayload(ReadOnlySpan<byte> buffer, ref int index, AsyncEventID eventId, AsyncCallstackType callstackType)
         {
-            ReadCallstackPayload(buffer, ref index, callstackType, out _, out _, out _, out _);
+            ReadCallstackPayload(buffer, ref index, eventId, callstackType, out _, out _, out _, out _, out _);
         }
 
-        private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index,
+        private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index, AsyncEventID eventId,
             out byte frameCount, out List<(ulong MethodId, int State)> frames)
         {
-            ReadCallstackPayload(buffer, ref index, AsyncCallstackType.Runtime, out _, out _, out frameCount, out frames);
+            ReadCallstackPayload(buffer, ref index, eventId, AsyncCallstackType.Runtime, out _, out _, out _, out frameCount, out frames);
         }
 
-        private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index, AsyncCallstackType callstackType,
-            out ulong taskId, out byte continuationIndex, out byte frameCount, out List<(ulong MethodId, int State)> frames)
+        private static void ReadCallstackPayload(ReadOnlySpan<byte> buffer, ref int index, AsyncEventID eventId, AsyncCallstackType callstackType,
+            out ulong parentDispatcherId, out ulong dispatcherId, out byte continuationIndex, out byte frameCount, out List<(ulong MethodId, int State)> frames)
         {
             index++; // Reserved callstack ID (for future callstack interning).
             continuationIndex = buffer[index++];
             frameCount = buffer[index++];
-            taskId = ReadCompressedUInt64(buffer, ref index);
+            // parentDispatcherId is only present on RuntimeAsync_CreateAsyncCallstack.
+            parentDispatcherId = eventId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack
+                ? ReadCompressedUInt64(buffer, ref index)
+                : 0;
+            dispatcherId = ReadCompressedUInt64(buffer, ref index);
             frames = new List<(ulong, int)>(frameCount);
 
             if (frameCount == 0)
@@ -445,13 +454,13 @@ namespace System.Threading.Tasks.Tests
 
             int index = 1;
             Deserializer.ReadUInt32(buffer, ref index, out uint totalSize);
-            Deserializer.ReadUInt32(buffer, ref index, out uint contextId);
+            Deserializer.ReadUInt32(buffer, ref index, out uint asyncThreadContextId);
             Deserializer.ReadUInt64(buffer, ref index, out ulong threadId);
             Deserializer.ReadUInt32(buffer, ref index, out uint eventCount);
             Deserializer.ReadUInt64(buffer, ref index, out ulong startTs);
             Deserializer.ReadUInt64(buffer, ref index, out ulong endTs);
 
-            return new EventBufferHeader(buffer[0], totalSize, contextId, threadId, eventCount, startTs, endTs);
+            return new EventBufferHeader(buffer[0], totalSize, asyncThreadContextId, threadId, eventCount, startTs, endTs);
         }
 
         private sealed class ParsedEvent
@@ -460,7 +469,9 @@ namespace System.Threading.Tasks.Tests
             public long Timestamp { get; init; }
             public ulong OsThreadId { get; init; }
 
-            public ulong TaskId { get; init; }
+            public ulong ParentDispatcherId { get; init; }
+
+            public ulong DispatcherId { get; init; }
 
             public AsyncCallstackType CallstackType { get; init; }
             public byte ContinuationIndex { get; init; }
@@ -497,7 +508,9 @@ namespace System.Threading.Tasks.Tests
         private sealed class ParsedEventStream
         {
             private readonly List<ParsedEvent> _events;
-            private Dictionary<ulong, List<ParsedEvent>>? _byTaskId;
+            private Dictionary<ulong, List<ParsedEvent>>? _byDispatcherId;
+            private Dictionary<ulong, ulong>? _parentOfDispatcher;
+            private Dictionary<ulong, List<ulong>>? _childrenOfDispatcher;
 
             public ParsedEventStream(List<ParsedEvent> events)
             {
@@ -522,37 +535,154 @@ namespace System.Threading.Tasks.Tests
                 return _events.Where(e => set.Contains(e.EventId));
             }
 
-            // Get events grouped by Task.Id, each group in timestamp order.
-            public Dictionary<ulong, List<ParsedEvent>> ByTaskId()
+            // Get events grouped by DispatcherId (the dispatcher that produced the event), each group in timestamp order.
+            public Dictionary<ulong, List<ParsedEvent>> ByDispatcherId()
             {
-                if (_byTaskId is not null)
+                if (_byDispatcherId is not null)
                 {
-                    return _byTaskId;
+                    return _byDispatcherId;
                 }
 
-                _byTaskId = new Dictionary<ulong, List<ParsedEvent>>();
+                _byDispatcherId = new Dictionary<ulong, List<ParsedEvent>>();
                 foreach (var evt in _events)
                 {
-                    if (evt.TaskId == 0)
+                    if (evt.DispatcherId == 0)
                     {
                         continue;
                     }
 
-                    if (!_byTaskId.TryGetValue(evt.TaskId, out var list))
+                    if (!_byDispatcherId.TryGetValue(evt.DispatcherId, out var list))
                     {
                         list = new List<ParsedEvent>();
-                        _byTaskId[evt.TaskId] = list;
+                        _byDispatcherId[evt.DispatcherId] = list;
                     }
 
                     list.Add(evt);
                 }
 
-                return _byTaskId;
+                return _byDispatcherId;
             }
 
-            // Get events for a specific Task.Id in timestamp order.
-            public List<ParsedEvent> ForTask(ulong taskId) =>
-                ByTaskId().TryGetValue(taskId, out var list) ? list : new List<ParsedEvent>();
+            // Get events for a specific DispatcherId in timestamp order.
+            public List<ParsedEvent> ForDispatcher(ulong dispatcherId) =>
+                ByDispatcherId().TryGetValue(dispatcherId, out var list) ? list : new List<ParsedEvent>();
+
+            // Walks Create events to build a dispatcher tree (parent and children maps).
+            // A parent edge is recorded only when the parent dispatcher itself has an observed
+            // Create event. If the parent was created before profiler attach (or otherwise not
+            // observed), the dispatcher is treated as a root: this prevents unrelated dispatchers
+            // that share an unobserved ancestor (e.g., the test harness) from being merged into
+            // one tree.
+            private void EnsureDispatcherTree()
+            {
+                if (_parentOfDispatcher is not null)
+                {
+                    return;
+                }
+
+                _parentOfDispatcher = new Dictionary<ulong, ulong>();
+                _childrenOfDispatcher = new Dictionary<ulong, List<ulong>>();
+
+                HashSet<ulong> dispatchersWithCreate = new HashSet<ulong>();
+                foreach (var evt in _events)
+                {
+                    bool isCreate = evt.EventId is
+                        AsyncEventID.TaskAsync_CreateAsyncContext or
+                        AsyncEventID.RuntimeAsync_CreateAsyncContext or
+                        AsyncEventID.RuntimeAsync_CreateAsyncCallstack;
+
+                    if (isCreate && evt.DispatcherId != 0)
+                    {
+                        dispatchersWithCreate.Add(evt.DispatcherId);
+                    }
+                }
+
+                foreach (var evt in _events)
+                {
+                    bool isCreate = evt.EventId is
+                        AsyncEventID.TaskAsync_CreateAsyncContext or
+                        AsyncEventID.RuntimeAsync_CreateAsyncContext or
+                        AsyncEventID.RuntimeAsync_CreateAsyncCallstack;
+
+                    if (!isCreate || evt.DispatcherId == 0)
+                    {
+                        continue;
+                    }
+
+                    ulong parent = evt.ParentDispatcherId;
+                    if (parent == 0 || !dispatchersWithCreate.Contains(parent))
+                    {
+                        // Parent not observed in this stream; treat this dispatcher as a root.
+                        _parentOfDispatcher[evt.DispatcherId] = 0;
+                        continue;
+                    }
+
+                    _parentOfDispatcher[evt.DispatcherId] = parent;
+
+                    if (!_childrenOfDispatcher.TryGetValue(parent, out var kids))
+                    {
+                        kids = new List<ulong>();
+                        _childrenOfDispatcher[parent] = kids;
+                    }
+
+                    if (!kids.Contains(evt.DispatcherId))
+                    {
+                        kids.Add(evt.DispatcherId);
+                    }
+                }
+            }
+
+            // Returns the root DispatcherId for the chain containing dispatcherId, by walking parent pointers.
+            // If no parent information is found (no Create event), returns dispatcherId itself.
+            public ulong RootOfDispatcher(ulong dispatcherId)
+            {
+                EnsureDispatcherTree();
+
+                ulong current = dispatcherId;
+                while (_parentOfDispatcher!.TryGetValue(current, out ulong parent) && parent != 0)
+                {
+                    current = parent;
+                }
+
+                return current;
+            }
+
+            // Returns the set of all dispatcher ids in the same chain (connected component) as dispatcherId.
+            // Walks up to the root via parent pointers, then collects all descendants via BFS.
+            public HashSet<ulong> ChainDispatcherIds(ulong dispatcherId)
+            {
+                EnsureDispatcherTree();
+
+                ulong root = RootOfDispatcher(dispatcherId);
+
+                var chain = new HashSet<ulong> { root };
+                var queue = new Queue<ulong>();
+                queue.Enqueue(root);
+
+                while (queue.Count > 0)
+                {
+                    ulong cur = queue.Dequeue();
+                    if (_childrenOfDispatcher!.TryGetValue(cur, out var kids))
+                    {
+                        foreach (var kid in kids)
+                        {
+                            if (chain.Add(kid))
+                            {
+                                queue.Enqueue(kid);
+                            }
+                        }
+                    }
+                }
+
+                return chain;
+            }
+
+            // Returns all events whose DispatcherId is in the same chain as dispatcherId, in timestamp order.
+            public List<ParsedEvent> ChainEventsFromDispatcher(ulong dispatcherId)
+            {
+                HashSet<ulong> chain = ChainDispatcherIds(dispatcherId);
+                return _events.Where(e => chain.Contains(e.DispatcherId)).ToList();
+            }
 
             // Get callstack events (of specified type) that contain the marker method in their frames.
             // Results are in timestamp order.
@@ -572,7 +702,7 @@ namespace System.Threading.Tasks.Tests
             public List<ParsedEvent> MergedResumeCallstacks()
             {
                 var result = new List<ParsedEvent>();
-                var openByTaskId = new Dictionary<ulong, int>();
+                var openByDispatcherId = new Dictionary<ulong, int>();
 
                 foreach (var evt in _events)
                 {
@@ -583,7 +713,7 @@ namespace System.Threading.Tasks.Tests
                         case AsyncEventID.TaskAsync_SuspendAsyncContext:
                         case AsyncEventID.TaskAsync_CompleteAsyncContext:
                         {
-                            openByTaskId.Remove(evt.TaskId);
+                            openByDispatcherId.Remove(evt.DispatcherId);
                             break;
                         }
                         case AsyncEventID.RuntimeAsync_ResumeAsyncCallstack:
@@ -594,21 +724,22 @@ namespace System.Threading.Tasks.Tests
                                 EventId = evt.EventId,
                                 Timestamp = evt.Timestamp,
                                 OsThreadId = evt.OsThreadId,
-                                TaskId = evt.TaskId,
+                                ParentDispatcherId = evt.ParentDispatcherId,
+                                DispatcherId = evt.DispatcherId,
                                 CallstackType = evt.CallstackType,
                                 ContinuationIndex = evt.ContinuationIndex,
                                 FrameCount = evt.FrameCount,
                                 Frames = new List<(ulong MethodId, int State)>(evt.Frames),
                             };
 
-                            openByTaskId[evt.TaskId] = result.Count;
+                            openByDispatcherId[evt.DispatcherId] = result.Count;
                             result.Add(merged);
 
                             break;
                         }
                         case AsyncEventID.TaskAsync_AppendAsyncCallstack:
                         {
-                            if (openByTaskId.TryGetValue(evt.TaskId, out int idx))
+                            if (openByDispatcherId.TryGetValue(evt.DispatcherId, out int idx))
                             {
                                 ParsedEvent existing = result[idx];
                                 var combinedFrames = new List<(ulong MethodId, int State)>(existing.Frames);
@@ -619,7 +750,8 @@ namespace System.Threading.Tasks.Tests
                                     EventId = existing.EventId,
                                     Timestamp = existing.Timestamp,
                                     OsThreadId = existing.OsThreadId,
-                                    TaskId = existing.TaskId,
+                                    ParentDispatcherId = existing.ParentDispatcherId,
+                                    DispatcherId = existing.DispatcherId,
                                     CallstackType = existing.CallstackType,
                                     ContinuationIndex = existing.ContinuationIndex,
                                     FrameCount = (byte)Math.Min(combinedFrames.Count, byte.MaxValue),
@@ -639,25 +771,6 @@ namespace System.Threading.Tasks.Tests
             // in any of their merged frames.
             public List<ParsedEvent> MergedResumeCallstacksWithMarker(string markerMethodName) =>
                 MergedResumeCallstacks().Where(e => e.HasMarkerFrame(markerMethodName)).ToList();
-
-            // Get callstack events (of specified type) that contain the marker method,
-            // taking only the first match per Task.Id (deepest chain by timestamp).
-            public List<ParsedEvent> CallstacksWithMarkerFirstPerTask(AsyncEventID callstackEventId, string markerMethodName)
-            {
-                List<ParsedEvent> matched = CallstacksWithMarker(callstackEventId, markerMethodName);
-                var seen = new HashSet<ulong>();
-                var result = new List<ParsedEvent>();
-
-                foreach (var evt in matched)
-                {
-                    if (evt.TaskId != 0 && seen.Add(evt.TaskId))
-                    {
-                        result.Add(evt);
-                    }
-                }
-
-                return result;
-            }
 
             // Get all metadata events.
             public List<MetadataFromBuffer> MetadataEvents =>
@@ -680,8 +793,9 @@ namespace System.Threading.Tasks.Tests
                 }
 
                 ulong osThreadId = header.Value.OsThreadId;
-                ulong currentTaskId = 0;
-                var taskIdStack = new Stack<ulong>();
+                ulong currentDispatcherId = 0;
+                ulong currentParentDispatcherId = 0;
+                var dispatcherStack = new Stack<(ulong DispatcherId, ulong ParentDispatcherId)>();
                 int index = HeaderSize;
                 long baseTimestamp = (long)header.Value.StartTimestamp;
 
@@ -698,43 +812,48 @@ namespace System.Threading.Tasks.Tests
 
                     ParsedEvent evt = eventId switch
                     {
-                        AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.RuntimeAsync_ResumeAsyncContext or
-                        AsyncEventID.TaskAsync_CreateAsyncContext or AsyncEventID.TaskAsync_ResumeAsyncContext =>
-                            ParseContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index, ref currentTaskId, taskIdStack),
+                        AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.TaskAsync_CreateAsyncContext =>
+                            ParseCreateContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index),
 
-                        AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_CompleteAsyncContext =>
-                            ParseCompleteContextEvent(eventId, baseTimestamp, osThreadId, ref currentTaskId, taskIdStack),
+                        AsyncEventID.RuntimeAsync_ResumeAsyncContext or AsyncEventID.TaskAsync_ResumeAsyncContext =>
+                            ParseResumeContextEvent(eventId, baseTimestamp, osThreadId, buffer, ref index,
+                                ref currentDispatcherId, ref currentParentDispatcherId, dispatcherStack),
 
-                        AsyncEventID.RuntimeAsync_SuspendAsyncContext or
+                        AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_CompleteAsyncContext or
+                        AsyncEventID.RuntimeAsync_SuspendAsyncContext or AsyncEventID.TaskAsync_SuspendAsyncContext =>
+                            ParseEndContextEvent(eventId, baseTimestamp, osThreadId,
+                                ref currentDispatcherId, ref currentParentDispatcherId, dispatcherStack),
+
                         AsyncEventID.RuntimeAsync_ResumeAsyncMethod or AsyncEventID.RuntimeAsync_CompleteAsyncMethod or
-                        AsyncEventID.TaskAsync_SuspendAsyncContext or
                         AsyncEventID.TaskAsync_ResumeAsyncMethod or AsyncEventID.TaskAsync_CompleteAsyncMethod =>
                             new ParsedEvent
                             {
                                 EventId = eventId,
                                 Timestamp = baseTimestamp,
                                 OsThreadId = osThreadId,
-                                TaskId = currentTaskId
+                                ParentDispatcherId = currentParentDispatcherId,
+                                DispatcherId = currentDispatcherId,
                             },
 
                         AsyncEventID.ResetAsyncThreadContext or AsyncEventID.ResetAsyncContinuationWrapperIndex =>
-                            ParseResetEvent(eventId, baseTimestamp, osThreadId, ref currentTaskId),
+                            ParseResetEvent(eventId, baseTimestamp, osThreadId,
+                                ref currentDispatcherId, ref currentParentDispatcherId, dispatcherStack),
 
                         AsyncEventID.RuntimeAsync_CreateAsyncCallstack or AsyncEventID.RuntimeAsync_ResumeAsyncCallstack or
                         AsyncEventID.RuntimeAsync_SuspendAsyncCallstack or
                         AsyncEventID.TaskAsync_ResumeAsyncCallstack or AsyncEventID.TaskAsync_AppendAsyncCallstack =>
-                            ParseCallstackEvent(eventId, baseTimestamp, osThreadId, buffer, ref index, ref currentTaskId, taskIdStack),
+                            ParseCallstackEvent(eventId, baseTimestamp, osThreadId, buffer, ref index),
 
                         AsyncEventID.RuntimeAsync_UnwindAsyncException or AsyncEventID.TaskAsync_UnwindAsyncException =>
-                            ParseUnwindEvent(eventId, baseTimestamp, osThreadId, currentTaskId, buffer, ref index),
+                            ParseUnwindEvent(eventId, baseTimestamp, osThreadId, currentDispatcherId, currentParentDispatcherId, buffer, ref index),
 
                         AsyncEventID.AsyncProfilerMetadata =>
-                            ParseMetadataEvent(baseTimestamp, osThreadId, currentTaskId, buffer, ref index),
+                            ParseMetadataEvent(baseTimestamp, osThreadId, currentDispatcherId, currentParentDispatcherId, buffer, ref index),
 
                         AsyncEventID.AsyncProfilerSyncClock =>
-                            ParseSyncClockEvent(baseTimestamp, osThreadId, currentTaskId, buffer, ref index),
+                            ParseSyncClockEvent(baseTimestamp, osThreadId, currentDispatcherId, currentParentDispatcherId, buffer, ref index),
 
-                        _ => ParseUnknownEvent(eventId, baseTimestamp, osThreadId, currentTaskId, buffer, ref index)
+                        _ => ParseUnknownEvent(eventId, baseTimestamp, osThreadId, currentDispatcherId, currentParentDispatcherId, buffer, ref index)
                     };
 
                     allEvents.Add(evt);
@@ -743,48 +862,82 @@ namespace System.Threading.Tasks.Tests
 
             return new ParsedEventStream(allEvents);
 
-            static ParsedEvent ParseContextEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
-                ReadOnlySpan<byte> buffer, ref int index, ref ulong currentTaskId, Stack<ulong> taskIdStack)
+            static ParsedEvent ParseCreateContextEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
+                ReadOnlySpan<byte> buffer, ref int index)
             {
-                ulong id = ReadCompressedUInt64(buffer, ref index);
-                bool isResume = eventId is AsyncEventID.RuntimeAsync_ResumeAsyncContext or AsyncEventID.TaskAsync_ResumeAsyncContext;
-                if (isResume && id != currentTaskId)
+                ulong parentDispatcherId = ReadCompressedUInt64(buffer, ref index);
+                ulong dispatcherId = ReadCompressedUInt64(buffer, ref index);
+                return new ParsedEvent
                 {
-                    taskIdStack.Push(currentTaskId);
+                    EventId = eventId,
+                    Timestamp = timestamp,
+                    OsThreadId = osThreadId,
+                    ParentDispatcherId = parentDispatcherId,
+                    DispatcherId = dispatcherId,
+                };
+            }
+
+            static ParsedEvent ParseResumeContextEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
+                ReadOnlySpan<byte> buffer, ref int index,
+                ref ulong currentDispatcherId, ref ulong currentParentDispatcherId,
+                Stack<(ulong DispatcherId, ulong ParentDispatcherId)> dispatcherStack)
+            {
+                ulong dispatcherId = ReadCompressedUInt64(buffer, ref index);
+
+                dispatcherStack.Push((currentDispatcherId, currentParentDispatcherId));
+                currentDispatcherId = dispatcherId;
+                currentParentDispatcherId = 0;
+
+                return new ParsedEvent
+                {
+                    EventId = eventId,
+                    Timestamp = timestamp,
+                    OsThreadId = osThreadId,
+                    ParentDispatcherId = 0,
+                    DispatcherId = dispatcherId,
+                };
+            }
+
+            static ParsedEvent ParseEndContextEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
+                ref ulong currentDispatcherId, ref ulong currentParentDispatcherId,
+                Stack<(ulong DispatcherId, ulong ParentDispatcherId)> dispatcherStack)
+            {
+                ulong endingDispatcherId = currentDispatcherId;
+                ulong endingParentDispatcherId = currentParentDispatcherId;
+
+                if (dispatcherStack.Count > 0)
+                {
+                    var top = dispatcherStack.Pop();
+                    currentDispatcherId = top.DispatcherId;
+                    currentParentDispatcherId = top.ParentDispatcherId;
+                }
+                else
+                {
+                    currentDispatcherId = 0;
+                    currentParentDispatcherId = 0;
                 }
 
-                currentTaskId = id;
-
                 return new ParsedEvent
                 {
                     EventId = eventId,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
-                    TaskId = id
+                    ParentDispatcherId = endingParentDispatcherId,
+                    DispatcherId = endingDispatcherId,
                 };
             }
 
-            static ParsedEvent ParseCompleteContextEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
-                ref ulong currentTaskId, Stack<ulong> taskIdStack)
+            static ParsedEvent ParseResetEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
+                ref ulong currentDispatcherId, ref ulong currentParentDispatcherId,
+                Stack<(ulong DispatcherId, ulong ParentDispatcherId)> dispatcherStack)
             {
-                ulong completedTaskId = currentTaskId;
-                currentTaskId = taskIdStack.Count > 0 ? taskIdStack.Pop() : 0;
-
-                return new ParsedEvent
-                {
-                    EventId = eventId,
-                    Timestamp = timestamp,
-                    OsThreadId = osThreadId,
-                    TaskId = completedTaskId
-                };
-            }
-
-            static ParsedEvent ParseResetEvent(AsyncEventID eventId, long timestamp, ulong osThreadId, ref ulong currentTaskId)
-            {
-                ulong prevTaskId = currentTaskId;
+                ulong prevDispatcherId = currentDispatcherId;
+                ulong prevParentDispatcherId = currentParentDispatcherId;
                 if (eventId == AsyncEventID.ResetAsyncThreadContext)
                 {
-                    currentTaskId = 0;
+                    dispatcherStack.Clear();
+                    currentDispatcherId = 0;
+                    currentParentDispatcherId = 0;
                 }
 
                 return new ParsedEvent
@@ -792,27 +945,24 @@ namespace System.Threading.Tasks.Tests
                     EventId = eventId,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
-                    TaskId = prevTaskId
+                    ParentDispatcherId = prevParentDispatcherId,
+                    DispatcherId = prevDispatcherId,
                 };
             }
 
             static ParsedEvent ParseCallstackEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
-                ReadOnlySpan<byte> buffer, ref int index, ref ulong currentTaskId, Stack<ulong> taskIdStack)
+                ReadOnlySpan<byte> buffer, ref int index)
             {
                 AsyncCallstackType callstackType = CallstackTypeFromEventId(eventId);
-                ReadCallstackPayload(buffer, ref index, callstackType, out ulong taskId, out byte continuationIndex, out byte frameCount, out var frames);
-                if (taskId != currentTaskId)
-                {
-                    taskIdStack.Push(currentTaskId);
-                    currentTaskId = taskId;
-                }
+                ReadCallstackPayload(buffer, ref index, eventId, callstackType, out ulong parentDispatcherId, out ulong dispatcherId, out byte continuationIndex, out byte frameCount, out var frames);
 
                 return new ParsedEvent
                 {
                     EventId = eventId,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
-                    TaskId = taskId,
+                    ParentDispatcherId = parentDispatcherId,
+                    DispatcherId = dispatcherId,
                     CallstackType = callstackType,
                     ContinuationIndex = continuationIndex,
                     FrameCount = frameCount,
@@ -820,7 +970,8 @@ namespace System.Threading.Tasks.Tests
                 };
             }
 
-            static ParsedEvent ParseUnwindEvent(AsyncEventID eventId, long timestamp, ulong osThreadId, ulong currentTaskId,
+            static ParsedEvent ParseUnwindEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
+                ulong currentDispatcherId, ulong currentParentDispatcherId,
                 ReadOnlySpan<byte> buffer, ref int index)
             {
                 uint unwindCount = ReadCompressedUInt32(buffer, ref index);
@@ -830,12 +981,14 @@ namespace System.Threading.Tasks.Tests
                     EventId = eventId,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
-                    TaskId = currentTaskId,
+                    ParentDispatcherId = currentParentDispatcherId,
+                    DispatcherId = currentDispatcherId,
                     UnwindFrameCount = unwindCount
                 };
             }
 
-            static ParsedEvent ParseMetadataEvent(long timestamp, ulong osThreadId, ulong currentTaskId,
+            static ParsedEvent ParseMetadataEvent(long timestamp, ulong osThreadId,
+                ulong currentDispatcherId, ulong currentParentDispatcherId,
                 ReadOnlySpan<byte> buffer, ref int index)
             {
                 ReadMetadataPayload(buffer, ref index, out ulong freq, out ulong qpcSync, out ulong utcSync, out uint bufSize, out byte wrapperCount);
@@ -845,12 +998,14 @@ namespace System.Threading.Tasks.Tests
                     EventId = AsyncEventID.AsyncProfilerMetadata,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
-                    TaskId = currentTaskId,
+                    ParentDispatcherId = currentParentDispatcherId,
+                    DispatcherId = currentDispatcherId,
                     Metadata = new MetadataFromBuffer(freq, qpcSync, utcSync, bufSize, wrapperCount)
                 };
             }
 
-            static ParsedEvent ParseSyncClockEvent(long timestamp, ulong osThreadId, ulong currentTaskId,
+            static ParsedEvent ParseSyncClockEvent(long timestamp, ulong osThreadId,
+                ulong currentDispatcherId, ulong currentParentDispatcherId,
                 ReadOnlySpan<byte> buffer, ref int index)
             {
                 ulong qpcSync = ReadCompressedUInt64(buffer, ref index);
@@ -861,14 +1016,16 @@ namespace System.Threading.Tasks.Tests
                     EventId = AsyncEventID.AsyncProfilerSyncClock,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
-                    TaskId = currentTaskId,
+                    ParentDispatcherId = currentParentDispatcherId,
+                    DispatcherId = currentDispatcherId,
                     SyncClockQpc = qpcSync,
                     SyncClockUtc = utcSync
                 };
             }
 
             static ParsedEvent ParseUnknownEvent(AsyncEventID eventId, long timestamp, ulong osThreadId,
-                ulong currentTaskId, ReadOnlySpan<byte> buffer, ref int index)
+                ulong currentDispatcherId, ulong currentParentDispatcherId,
+                ReadOnlySpan<byte> buffer, ref int index)
             {
                 SkipEventPayload(eventId, buffer, ref index);
 
@@ -877,7 +1034,8 @@ namespace System.Threading.Tasks.Tests
                     EventId = eventId,
                     Timestamp = timestamp,
                     OsThreadId = osThreadId,
-                    TaskId = currentTaskId
+                    ParentDispatcherId = currentParentDispatcherId,
+                    DispatcherId = currentDispatcherId,
                 };
             }
         }
@@ -1053,9 +1211,9 @@ namespace System.Threading.Tasks.Tests
             }
             Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{markerMethodName}'");
 
-            ulong taskId = resumeStacks[0].TaskId;
+            ulong dispatcherId = resumeStacks[0].DispatcherId;
 
-            var sequence = stream.ForTask(taskId);
+            var sequence = stream.ChainEventsFromDispatcher(dispatcherId);
             int stackDepth = 0;
 
             foreach (var evt in sequence)
@@ -1090,25 +1248,25 @@ namespace System.Threading.Tasks.Tests
             Assert.Equal(0, stackDepth);
         }
 
-        private static void AssertExactlyOneCreateAndComplete(ParsedEventStream stream, ulong taskId, string chainName)
+        private static void AssertExactlyOneCreateAndComplete(ParsedEventStream stream, ulong dispatcherId, string chainName)
         {
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
             int creates = ids.Count(id => id is AsyncEventID.RuntimeAsync_CreateAsyncContext or AsyncEventID.TaskAsync_CreateAsyncContext);
             int completes = ids.Count(id => id is AsyncEventID.RuntimeAsync_CompleteAsyncContext or AsyncEventID.TaskAsync_CompleteAsyncContext);
-            Assert.True(creates == 1, $"Expected exactly 1 CreateAsyncContext for {chainName} (TaskId {taskId}), got {creates}");
-            Assert.True(completes == 1, $"Expected exactly 1 CompleteAsyncContext for {chainName} (TaskId {taskId}), got {completes}");
+            Assert.True(creates == 1, $"Expected exactly 1 CreateAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
+            Assert.True(completes == 1, $"Expected exactly 1 CompleteAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {completes}");
         }
 
         // V1-friendly variant: V1's per-MoveNext dispatcher model emits one Create per await
-        // suspension, so a method with N awaits produces N dispatchers / N Creates on the same
-        // TaskId. The invariant we can still assert is creates == completes (both >= 1).
-        private static void AssertCreateEqualsCompleteForTask(ParsedEventStream stream, ulong taskId, string chainName)
+        // suspension, so a method with N awaits produces N dispatchers / N Creates within the
+        // same dispatcher tree. The invariant we can still assert is creates == completes (both >= 1).
+        private static void AssertCreateEqualsCompleteInChain(ParsedEventStream stream, ulong dispatcherId, string chainName)
         {
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
             int creates = ids.Count(id => id == AsyncEventID.TaskAsync_CreateAsyncContext);
             int completes = ids.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
-            Assert.True(creates >= 1, $"Expected at least 1 TaskAsync_CreateAsyncContext for {chainName} (TaskId {taskId}), got {creates}");
-            Assert.True(creates == completes, $"Expected TaskAsync_CreateAsyncContext count == TaskAsync_CompleteAsyncContext count for {chainName} (TaskId {taskId}), got {creates} creates and {completes} completes");
+            Assert.True(creates >= 1, $"Expected at least 1 TaskAsync_CreateAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
+            Assert.True(creates == completes, $"Expected TaskAsync_CreateAsyncContext count == TaskAsync_CompleteAsyncContext count for {chainName} (DispatcherId {dispatcherId}), got {creates} creates and {completes} completes");
         }
 
         private sealed class InlinePostSynchronizationContext : SynchronizationContext
@@ -1246,14 +1404,14 @@ namespace System.Threading.Tasks.Tests
                 }
 
                 Deserializer.ReadUInt32(buffer, ref index, out uint totalSize);
-                Deserializer.ReadUInt32(buffer, ref index, out uint contextId);
+                Deserializer.ReadUInt32(buffer, ref index, out uint asyncThreadContextId);
                 Deserializer.ReadUInt64(buffer, ref index, out ulong osThreadId);
                 Deserializer.ReadUInt32(buffer, ref index, out uint totalEventCount);
                 Deserializer.ReadUInt64(buffer, ref index, out ulong startTimestamp);
                 Deserializer.ReadUInt64(buffer, ref index, out ulong endTimestamp);
 
                 Console.WriteLine($"TotalSize: {totalSize}");
-                Console.WriteLine($"AsyncThreadContextId: {contextId}");
+                Console.WriteLine($"AsyncThreadContextId: {asyncThreadContextId}");
                 Console.WriteLine($"OSThreadId: {osThreadId}");
                 Console.WriteLine($"TotalEventCount: {totalEventCount}");
                 Console.WriteLine($"StartTimestamp: 0x{startTimestamp:X16}");
@@ -1351,16 +1509,18 @@ namespace System.Threading.Tasks.Tests
             private static int OutputCreateAsyncContextEvent(ReadOnlySpan<byte> buffer)
             {
                 int index = 0;
-                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong id);
-                Console.WriteLine($"  ID: {id}");
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong parentDispatcherId);
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong dispatcherId);
+                Console.WriteLine($"  ParentDispatcherId: {parentDispatcherId}");
+                Console.WriteLine($"  DispatcherId: {dispatcherId}");
                 return index;
             }
 
             private static int OutputResumeAsyncContextEvent(ReadOnlySpan<byte> buffer)
             {
                 int index = 0;
-                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong id);
-                Console.WriteLine($"  ID: {id}");
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out ulong dispatcherId);
+                Console.WriteLine($"  DispatcherId: {dispatcherId}");
                 return index;
             }
 
@@ -1448,7 +1608,8 @@ namespace System.Threading.Tasks.Tests
 
             private static int OutputAsyncCallstackEvent(AsyncEventID eventId, ReadOnlySpan<byte> buffer)
             {
-                ulong id;
+                ulong parentDispatcherId = 0;
+                ulong dispatcherId;
                 byte callstackId;
                 byte continuationIndex;
                 byte asyncCallstackLength;
@@ -1461,9 +1622,17 @@ namespace System.Threading.Tasks.Tests
                 callstackId = buffer[index++];
                 continuationIndex = buffer[index++];
                 asyncCallstackLength = buffer[index++];
-                Deserializer.ReadCompressedUInt64(buffer, ref index, out id);
+                if (eventId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack)
+                {
+                    Deserializer.ReadCompressedUInt64(buffer, ref index, out parentDispatcherId);
+                }
+                Deserializer.ReadCompressedUInt64(buffer, ref index, out dispatcherId);
 
-                Console.WriteLine($"  ID: {id}");
+                if (eventId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack)
+                {
+                    Console.WriteLine($"  ParentDispatcherId: {parentDispatcherId}");
+                }
+                Console.WriteLine($"  DispatcherId: {dispatcherId}");
                 Console.WriteLine($"  CallstackId: {callstackId}");
                 Console.WriteLine($"  ContinuationIndex: {continuationIndex}");
                 Console.WriteLine($"  Length: {asyncCallstackLength}");

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -184,6 +184,11 @@ namespace System.Threading.Tasks.Tests
 
             int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, resumeIdx + 1);
             AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteStateMachineAsyncContext after Resume");
+
+            // A single-await method completes on its only resume, so its dispatcher must report
+            // Complete and never Suspend (validates the complete side of the IsCompleted classification).
+            int suspendCount = ids.Count(id => id == AsyncEventID.SuspendStateMachineAsyncContext);
+            AssertEqual(stream, 0, suspendCount);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -222,8 +227,25 @@ namespace System.Threading.Tasks.Tests
             int completeCount = ids.Count(id => id == AsyncEventID.CompleteStateMachineAsyncContext);
             AssertTrue(stream, completeCount >= 1, "Expected at least one CompleteStateMachineAsyncContext");
 
-            // Expected ResumeStateMachineAsyncContext and CompleteStateMachineAsyncContext counts to match.
-            AssertEqual(stream, resumeCount, completeCount);
+            int suspendCount = ids.Count(id => id == AsyncEventID.SuspendStateMachineAsyncContext);
+
+            // The 3-await marker yields before completing, so at least one Suspend must be emitted.
+            AssertTrue(stream, suspendCount >= 1, "Expected at least one SuspendStateMachineAsyncContext");
+
+            // Each resume ends in exactly one suspend (yielded) or one complete (finished).
+            AssertEqual(stream, resumeCount, completeCount + suspendCount);
+
+            // A suspension must sit between a resume and a later resume (Resume -> Suspend -> Resume),
+            // and the chain must end in Complete (terminal) after the final resume.
+            int firstResumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext);
+            int firstSuspendIdx = ids.IndexOf(AsyncEventID.SuspendStateMachineAsyncContext, firstResumeIdx + 1);
+            AssertTrue(stream, firstSuspendIdx > firstResumeIdx, "Expected SuspendStateMachineAsyncContext after a Resume");
+
+            int resumeAfterSuspendIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, firstSuspendIdx + 1);
+            AssertTrue(stream, resumeAfterSuspendIdx > firstSuspendIdx, "Expected a ResumeStateMachineAsyncContext after a Suspend");
+
+            int completeIdx = ids.LastIndexOf(AsyncEventID.CompleteStateMachineAsyncContext);
+            AssertTrue(stream, completeIdx > firstSuspendIdx, "Expected the terminal CompleteStateMachineAsyncContext after suspensions");
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
@@ -885,6 +907,7 @@ namespace System.Threading.Tasks.Tests
         {
             yield return new object[] { (long)CreateStateMachineAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CreateStateMachineAsyncContext } };
             yield return new object[] { (long)ResumeStateMachineAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeStateMachineAsyncContext } };
+            yield return new object[] { (long)SuspendStateMachineAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.SuspendStateMachineAsyncContext } };
             yield return new object[] { (long)CompleteStateMachineAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteStateMachineAsyncContext } };
             yield return new object[] { (long)UnwindStateMachineAsyncExceptionKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.UnwindStateMachineAsyncException } };
             yield return new object[] { (long)ResumeStateMachineAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeStateMachineAsyncCallstack, AsyncEventID.AppendStateMachineAsyncCallstack } };
@@ -1065,7 +1088,7 @@ namespace System.Threading.Tasks.Tests
             AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Fast_Marker));
             AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow1_Marker));
             AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow2_Marker));
-            AssertCreateEqualsCompleteInChain(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Marker));
+            AssertCreateBalancesSuspendAndCompleteInChain(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Marker));
 
             // The outer marker's chain: exactly one Create, at least two Resumes (one after
             // WhenAny, one after WhenAll on the slow branches), then Complete.
@@ -1240,13 +1263,15 @@ namespace System.Threading.Tasks.Tests
             int createCount = taskEvents.Count(e => e.EventId == AsyncEventID.CreateStateMachineAsyncContext);
             int completeCount = taskEvents.Count(e => e.EventId == AsyncEventID.CompleteStateMachineAsyncContext);
             int resumeCount = taskEvents.Count(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncContext);
+            int suspendCount = taskEvents.Count(e => e.EventId == AsyncEventID.SuspendStateMachineAsyncContext);
 
             // At least one root Create event.
             AssertTrue(stream, createCount >= 1,
                 $"Expected at least one CreateStateMachineAsyncContext event, got {createCount}");
 
-            AssertEqual(stream, createCount, completeCount);
-            AssertEqual(stream, resumeCount, completeCount);
+            // Each created dispatcher and each resume ends in exactly one suspend or one complete.
+            AssertEqual(stream, createCount, completeCount + suspendCount);
+            AssertEqual(stream, resumeCount, completeCount + suspendCount);
 
             AssertTrue(stream, createCount >= 3,
                 $"Expected fan-out chain to produce at least 3 CreateStateMachineAsyncContext events (root + 2 child wraps), got {createCount}");

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -174,8 +174,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_EventSequenceOrder_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -211,8 +211,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_SuspendResumeCompleteEvents_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -269,8 +269,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -313,8 +313,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -360,8 +360,8 @@ namespace System.Threading.Tasks.Tests
 
             Assert.Equal(ExpectedChainDepth, markerCallstacks[0].Frames.Count);
 
-            ulong chainTaskId = markerCallstacks[0].TaskId;
-            var chainEvents = stream.ForTask(chainTaskId);
+            ulong leafDispatcherId = markerCallstacks[0].DispatcherId;
+            var chainEvents = stream.ChainEventsFromDispatcher(leafDispatcherId);
 
             int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncMethod);
             Assert.Equal(ExpectedChainDepth, resumeCount);
@@ -393,8 +393,8 @@ namespace System.Threading.Tasks.Tests
 
             Assert.NotEmpty(markerCallstacks);
 
-            ulong chainTaskId = markerCallstacks[0].TaskId;
-            var chainEvents = stream.ForTask(chainTaskId);
+            ulong leafDispatcherId = markerCallstacks[0].DispatcherId;
+            var chainEvents = stream.ChainEventsFromDispatcher(leafDispatcherId);
 
             var sequence = chainEvents
                 .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncMethod
@@ -403,7 +403,7 @@ namespace System.Threading.Tasks.Tests
                 .Select(e => e.EventId)
                 .ToList();
 
-            // Exactly one Unwind expected on the chain's context (InnerThrows throws once).
+            // Exactly one Unwind expected on the chain (InnerThrows throws once).
             Assert.Equal(1, sequence.Count(id => id == AsyncEventID.TaskAsync_UnwindAsyncException));
 
             // Around the Unwind: the throwing method's Resume precedes it, and the catching
@@ -445,8 +445,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong chainTaskId = markerCallstacks[0].TaskId;
-            var chainEvents = stream.ForTask(chainTaskId);
+            ulong leafDispatcherId = markerCallstacks[0].DispatcherId;
+            var chainEvents = stream.ChainEventsFromDispatcher(leafDispatcherId);
 
             var sequence = chainEvents
                 .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncMethod
@@ -730,9 +730,9 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // No Append events should fire on this context -- the chain was complete at Resume time.
-            ulong chainTaskId = markerCallstacks[0].TaskId;
-            var appendEvents = stream.ForTask(chainTaskId)
+            // No Append events should fire on this chain -- the chain was complete at Resume time.
+            ulong chainDispatcherId = markerCallstacks[0].DispatcherId;
+            var appendEvents = stream.ChainEventsFromDispatcher(chainDispatcherId)
                 .Where(e => e.EventId == AsyncEventID.TaskAsync_AppendAsyncCallstack)
                 .ToList();
             Assert.Empty(appendEvents);
@@ -785,9 +785,9 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // Verify the standard Create -> Resume -> Complete sequence fired for our context.
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            // Verify the standard Create -> Resume -> Complete sequence fired for our chain.
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the custom SyncContext scenario");
@@ -839,9 +839,9 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // Verify standard Create -> Resume -> Complete sequence for our context.
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            // Verify standard Create -> Resume -> Complete sequence for our chain.
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the custom TaskScheduler scenario");
@@ -978,15 +978,15 @@ namespace System.Threading.Tasks.Tests
             Assert.NotEmpty(branchBCallstacks);
             Assert.NotEmpty(branchCCallstacks);
 
-            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own TaskId.
-            AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].TaskId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
-            AssertExactlyOneCreateAndComplete(stream, branchBCallstacks[0].TaskId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker));
-            AssertExactlyOneCreateAndComplete(stream, branchCCallstacks[0].TaskId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker));
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_WhenAll_TracksAllBranches_Marker));
+            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete in its own dispatcher tree.
+            AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].DispatcherId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchBCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchCCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAll_TracksAllBranches_Marker));
 
-            // The outer marker's chain should fire the standard Create -> Resume -> Complete sequence on its own TaskId, in that order.
-            ulong markerTaskId = markerCallstacks[0].TaskId;
-            var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
+            // The outer marker's chain should fire the standard Create -> Resume -> Complete sequence in its own dispatcher tree, in that order.
+            ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
+            var markerIds = stream.ChainEventsFromDispatcher(markerDispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the WhenAll outer marker");
@@ -1060,16 +1060,16 @@ namespace System.Threading.Tasks.Tests
             Assert.NotEmpty(slow1Callstacks);
             Assert.NotEmpty(slow2Callstacks);
 
-            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own TaskId.
-            AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].TaskId, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
-            AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].TaskId, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker));
-            AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].TaskId, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker));
-            AssertCreateEqualsCompleteForTask(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_WhenAny_TracksAllBranches_Marker));
+            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete in its own dispatcher tree.
+            AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].DispatcherId, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].DispatcherId, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            AssertCreateEqualsCompleteInChain(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAny_TracksAllBranches_Marker));
 
             // The outer marker's chain: exactly one Create, at least two Resumes (one after
             // WhenAny, one after WhenAll on the slow branches), then Complete.
-            ulong markerTaskId = markerCallstacks[0].TaskId;
-            var markerEvents = stream.ForTask(markerTaskId);
+            ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
+            var markerEvents = stream.ChainEventsFromDispatcher(markerDispatcherId);
             var markerIds = markerEvents.Select(e => e.EventId).ToList();
 
             int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncContext);
@@ -1118,8 +1118,8 @@ namespace System.Threading.Tasks.Tests
                 $"Expected merged frame count >= {requestedDepth}, got {deepest.Frames.Count}");
 
             // Each individual event clamps its own FrameCount at byte.MaxValue (wire format limit).
-            ulong chainTaskId = deepest.TaskId;
-            var perEventCallstacks = stream.ForTask(chainTaskId)
+            ulong chainDispatcherId = deepest.DispatcherId;
+            var perEventCallstacks = stream.ChainEventsFromDispatcher(chainDispatcherId)
                 .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncCallstack or AsyncEventID.TaskAsync_AppendAsyncCallstack)
                 .ToList();
             Assert.NotEmpty(perEventCallstacks);
@@ -1223,19 +1223,19 @@ namespace System.Threading.Tasks.Tests
                 RunScenarioAndFlush(() => TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker());
             });
 
-            DumpAllEvents(events);
+            // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            // Locate the marker's logical TaskId so the balance check is scoped to this scenario's
+            // Locate the marker's logical dispatcher so the balance check is scoped to this scenario's
             // chain and not polluted by unrelated dispatcher activity from other threads (e.g. the
             // xunit runner's RunAsync state machine being replayed by ResetAsyncThreadContext and
             // completing while this test's listener is still active).
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
-            ulong markerTaskId = markerCallstacks[0].TaskId;
+            ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
 
-            var taskEvents = stream.ForTask(markerTaskId);
+            var taskEvents = stream.ChainEventsFromDispatcher(markerDispatcherId);
             int createCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_CreateAsyncContext);
             int completeCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncContext);
             int resumeCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext);
@@ -1301,8 +1301,8 @@ namespace System.Threading.Tasks.Tests
             Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalse_Marker), frameNames);
 
             // ConfigureAwait(false) on a sequential await chain collapses Leaf -> Mid -> Marker into one
-            // continuation chain, so exactly one Create / one Complete is expected on the marker's TaskId.
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
+            // continuation chain, so exactly one Create / one Complete is expected in the marker's dispatcher tree.
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1349,15 +1349,15 @@ namespace System.Threading.Tasks.Tests
             int completeCount = stream.OfType(AsyncEventID.TaskAsync_CompleteAsyncContext).Count();
             Assert.Equal(createCount, completeCount);
 
-            // Both inner (faulting) and outer marker chains must see exactly one Create and one Complete on their own TaskId.
-            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].TaskId, nameof(TaskAsync_FaultedTask_Inner_Marker));
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_FaultedTask_Marker));
+            // Both inner (faulting) and outer marker chains must see exactly one Create and one Complete in their own dispatcher tree.
+            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(TaskAsync_FaultedTask_Inner_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_FaultedTask_Marker));
 
             // The unwind must be attributed to the inner faulting chain.
-            ulong innerTaskId = innerCallstacks[0].TaskId;
-            int unwindCountForInner = stream.ForTask(innerTaskId).Count(e => e.EventId == AsyncEventID.TaskAsync_UnwindAsyncException);
+            ulong innerDispatcherId = innerCallstacks[0].DispatcherId;
+            int unwindCountForInner = stream.ChainEventsFromDispatcher(innerDispatcherId).Count(e => e.EventId == AsyncEventID.TaskAsync_UnwindAsyncException);
             Assert.True(unwindCountForInner >= 1,
-                $"Expected at least one UnwindAsyncException on the faulted inner chain (TaskId {innerTaskId}), got {unwindCountForInner}");
+                $"Expected at least one UnwindAsyncException on the faulted inner chain (DispatcherId {innerDispatcherId}), got {unwindCountForInner}");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1401,9 +1401,9 @@ namespace System.Threading.Tasks.Tests
             var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Inner_Marker));
             Assert.NotEmpty(innerCallstacks);
 
-            // Inner cancelled task + outer marker must each see exactly one Create and one Complete on their own TaskId.
-            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].TaskId, nameof(TaskAsync_TaskCancellation_Inner_Marker));
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_TaskCancellation_Marker));
+            // Inner cancelled task + outer marker must each see exactly one Create and one Complete in their own dispatcher tree.
+            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(TaskAsync_TaskCancellation_Inner_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_TaskCancellation_Marker));
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1428,8 +1428,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_EventSequenceOrder_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -1569,8 +1569,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -1629,8 +1629,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -1716,12 +1716,12 @@ namespace System.Threading.Tasks.Tests
                     continue;
                 }
 
-                var replayTaskIds = postResetMarkerCallstacks.Select(c => c.TaskId).ToHashSet();
+                var replayDispatcherIds = postResetMarkerCallstacks.Select(c => c.DispatcherId).ToHashSet();
                 var postResetResumeContext = stream.All
                     .Where(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext
                                 && e.OsThreadId == threadId
                                 && e.Timestamp >= lastResetTimestamp
-                                && replayTaskIds.Contains(e.TaskId))
+                                && replayDispatcherIds.Contains(e.DispatcherId))
                     .ToList();
                 if (postResetResumeContext.Count == 0)
                 {

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1147,7 +1147,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_CallstackStressWithVaryingDepths()
         {
-            const int iterations = 50;
+            const int iterations = 100;
             int[] depths = new int[iterations];
             var rng = new Random(42);
             for (int i = 0; i < iterations; i++)
@@ -1223,7 +1223,7 @@ namespace System.Threading.Tasks.Tests
                 RunScenarioAndFlush(() => TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker());
             });
 
-            // DumpAllEvents(events);
+            DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -102,6 +102,18 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_RecursiveChainGated(int depth, Task gate)
+        {
+            if (depth <= 1)
+            {
+                await gate;
+                return;
+            }
+            await StateMachineAsync_RecursiveChainGated(depth - 1, gate);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static async ValueTask ValueStateMachineAsync_Level1()
         {
             await ValueStateMachineAsync_Level2();
@@ -1353,6 +1365,49 @@ namespace System.Threading.Tasks.Tests
                 AssertTrue(stream, methodId != 0, "Frame has zero MethodId");
                 var method = GetMethodNameFromMethodId(deepest.CallstackType, methodId);
                 AssertTrue(stream, method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CallstackOverflow_PreservesFullDepth()
+        {
+            const int Depth = 200;
+            const int Iterations = 500;
+
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    for (int i = 0; i < Iterations; i++)
+                    {
+                        var gate = new TaskCompletionSource();
+                        Task chain = StateMachineAsync_RecursiveChainGated(Depth, gate.Task);
+                        gate.SetResult();
+                        await chain;
+                    }
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The deep chains overflow the per-thread buffer many times over (Iterations deep callstacks far
+            // exceed one buffer's capacity), so the rent/overflow path is exercised. The regression check:
+            // every chain resume must carry its full frame count. Scope to our recursive chains by method
+            // rather than by frame count -- a callstack truncated by the overflow bug has fewer frames but
+            // still consists of the recursive method, so it stays in scope and is caught.
+            var chainCallstacks = stream.OfType(AsyncEventID.ResumeStateMachineAsyncCallstack)
+                .Where(cs => cs.Frames.Any(f => GetMethodNameFromMethodId(cs.CallstackType, f.MethodId) == nameof(StateMachineAsync_RecursiveChainGated)))
+                .ToList();
+            AssertNotEmpty(stream, chainCallstacks);
+
+            int leafDepth = chainCallstacks.Max(cs => (int)cs.FrameCount);
+            AssertTrue(stream, leafDepth >= Depth, $"Expected captured depth >= {Depth}, got {leafDepth}");
+            foreach (var cs in chainCallstacks)
+            {
+                AssertEqual(stream, leafDepth, (int)cs.FrameCount);
+                AssertEqual(stream, (int)cs.FrameCount, cs.Frames.Count);
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1644,6 +1644,208 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ResetContext_ReplaysPendingV1Chain_Inner_Marker()
+        {
+            using var dummy = new TestEventListener();
+            dummy.AddSource(AsyncProfilerEventSourceName, EventLevel.Informational, EventKeywords.None);
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ResetContext_ReplaysPendingV1Chain_Mid_Marker()
+        {
+            await TaskAsync_ResetContext_ReplaysPendingV1Chain_Inner_Marker();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ResetContext_ReplaysPendingV1Chain_Outer_Marker()
+        {
+            await TaskAsync_ResetContext_ReplaysPendingV1Chain_Mid_Marker();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_ResetContext_ReplaysPendingV1Chain()
+        {
+            var events = CollectEvents(AllKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_ResetContext_ReplaysPendingV1Chain_Outer_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Locate the V1 dispatcher driving the marker chain via its ResumeAsyncCallstack
+            // events (which carry the marker frames in their callstack).
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysPendingV1Chain");
+            Assert.NotEmpty(markerCallstacks);
+
+            // Thread-scoped replay assertion: at least one OS thread must have seen two
+            // ResetAsyncThreadContext events AND show a marker ResumeAsyncCallstack plus
+            // matching ResumeAsyncContext after its most recent reset. Multiple threads
+            // in the trace can accumulate two resets (e.g. the test thread re-enables on
+            // its initial event then again later), so we have to look at each candidate
+            // thread, not just the first one. The thread that actually drove the replay
+            // is the one the V1 continuation resumed onto.
+            var resetsByThread = stream.All
+                .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
+                .GroupBy(e => e.OsThreadId)
+                .Where(g => g.Count() >= 2)
+                .ToList();
+            Assert.NotEmpty(resetsByThread);
+
+            bool found = false;
+            foreach (var threadResets in resetsByThread)
+            {
+                ulong threadId = threadResets.Key;
+                long lastResetTimestamp = threadResets.Max(e => e.Timestamp);
+
+                var postResetMarkerCallstacks = markerCallstacks
+                    .Where(c => c.OsThreadId == threadId && c.Timestamp >= lastResetTimestamp)
+                    .ToList();
+                if (postResetMarkerCallstacks.Count == 0)
+                {
+                    continue;
+                }
+
+                var replayTaskIds = postResetMarkerCallstacks.Select(c => c.TaskId).ToHashSet();
+                var postResetResumeContext = stream.All
+                    .Where(e => e.EventId == AsyncEventID.ResumeAsyncContext
+                                && e.OsThreadId == threadId
+                                && e.Timestamp >= lastResetTimestamp
+                                && replayTaskIds.Contains(e.TaskId))
+                    .ToList();
+                if (postResetResumeContext.Count == 0)
+                {
+                    continue;
+                }
+
+                found = true;
+                break;
+            }
+
+            Assert.True(found,
+                "Expected at least one OS thread with >= 2 ResetAsyncThreadContext events followed by a marker ResumeAsyncCallstack and matching ResumeAsyncContext.");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ResetContext_ReplaysMultipleDispatchers_Inner_Marker(
+            Task gate,
+            ManualResetEventSlim block,
+            Action onBlocked,
+            TaskCompletionSource innerDone)
+        {
+            await gate;
+            onBlocked();
+            block.Wait();
+            innerDone.SetResult();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ResetContext_ReplaysMultipleDispatchers_Outer_Marker(TaskCompletionSource innerDone)
+        {
+            await innerDone.Task;
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_ResetContext_ReplaysMultipleDispatchers()
+        {
+            var events = CollectEvents(AllKeywords, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var block = new ManualResetEventSlim(false);
+                    var blocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var innerDone = new TaskCompletionSource();
+
+                    Task inner = TaskAsync_ResetContext_ReplaysMultipleDispatchers_Inner_Marker(gate.Task, block, () => blocked.SetResult(), innerDone);
+                    Task outer = TaskAsync_ResetContext_ReplaysMultipleDispatchers_Outer_Marker(innerDone);
+
+                    _ = Task.Run(() => gate.SetResult());
+
+                    await blocked.Task;
+
+                    var dummy = new TestEventListener();
+                    try
+                    {
+                        dummy.AddSource(AsyncProfilerEventSourceName, EventLevel.Informational, EventKeywords.None);
+
+                        block.Set();
+
+                        await outer;
+                        await inner;
+                    }
+                    finally
+                    {
+                        dummy.Dispose();
+                    }
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The replay must emit at least one ResumeAsyncCallstack carrying the V1 marker chain.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysMultipleDispatchers");
+            Assert.NotEmpty(markerCallstacks);
+
+            // The decisive proof: find an OS thread where a single ResetAsyncThreadContext
+            // event is followed by >= 2 ResumeAsyncContext events before the next reset
+            // (or end of trace). A normal dispatcher resume can only emit one Resume
+            // per MoveNext invocation; observing >= 2 in a single reset window proves
+            // the walker traversed multiple nested dispatchers from a single ResetContext.
+            var resetsByThread = stream.All
+                .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
+                .GroupBy(e => e.OsThreadId)
+                .ToList();
+            Assert.NotEmpty(resetsByThread);
+
+            bool found = false;
+            foreach (var threadResets in resetsByThread)
+            {
+                ulong threadId = threadResets.Key;
+                var orderedResets = threadResets.OrderBy(e => e.Timestamp).ToList();
+
+                for (int i = 0; i < orderedResets.Count; i++)
+                {
+                    long windowStart = orderedResets[i].Timestamp;
+                    long windowEnd = (i + 1 < orderedResets.Count)
+                        ? orderedResets[i + 1].Timestamp
+                        : long.MaxValue;
+
+                    int resumeContextCount = stream.All
+                        .Count(e => e.EventId == AsyncEventID.ResumeAsyncContext
+                                    && e.OsThreadId == threadId
+                                    && e.Timestamp >= windowStart
+                                    && e.Timestamp < windowEnd);
+
+                    if (resumeContextCount >= 2)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found)
+                {
+                    break;
+                }
+            }
+
+            Assert.True(found,
+                "Expected at least one OS thread with a ResetAsyncThreadContext event " +
+                "followed by >= 2 ResumeAsyncContext events in the same reset window, " +
+                "proving the reset-replay walker traversed multiple nested dispatchers.");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static async Task TaskAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker(Task gate)
         {
             await gate;

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -57,15 +57,6 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_MultiYield()
-        {
-            await Task.Yield();
-            await Task.Yield();
-            await Task.Yield();
-        }
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         static async Task TaskAsync_ExceptionHandled()
         {
             try
@@ -100,47 +91,6 @@ namespace System.Threading.Tasks.Tests
             throw new InvalidOperationException("v1 unhandled inner");
         }
 
-        private static ulong AssertCompleteContextChain(ParsedEventStream stream, params AsyncEventID[] expectedSequence)
-        {
-            var byTask = stream.ByTaskId();
-            var candidates = new List<string>();
-
-            foreach (var (taskId, events) in byTask)
-            {
-                var contextEvents = events
-                    .Where(e => e.EventId is AsyncEventID.CreateAsyncContext
-                        or AsyncEventID.ResumeAsyncContext
-                        or AsyncEventID.SuspendAsyncContext
-                        or AsyncEventID.CompleteAsyncContext
-                        or AsyncEventID.UnwindAsyncException)
-                    .Select(e => e.EventId)
-                    .ToList();
-
-                candidates.Add($"  TaskId={taskId}: [{string.Join(", ", contextEvents)}]");
-
-                if (contextEvents.Count != expectedSequence.Length)
-                    continue;
-
-                bool match = true;
-                for (int i = 0; i < expectedSequence.Length; i++)
-                {
-                    if (contextEvents[i] != expectedSequence[i])
-                    {
-                        match = false;
-                        break;
-                    }
-                }
-
-                if (match)
-                    return taskId;
-            }
-
-            string expected = string.Join(", ", expectedSequence);
-            string found = string.Join(Environment.NewLine, candidates);
-            Assert.Fail($"No context found with expected chain [{expected}].\nContexts found:\n{found}");
-            return 0; // unreachable
-        }
-
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_EventsEmitted()
         {
@@ -171,51 +121,94 @@ namespace System.Threading.Tasks.Tests
             Assert.True(creates.Count >= 1, $"Expected at least 1 CreateAsyncContext, got {creates.Count}");
         }
 
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_EventSequenceOrderMarker()
+        {
+            // Use Task.Delay (not Task.Yield) so the dispatcher has predictable scheduling latency.
+            // The marker is the leaf await, so there is no parent-registration race to worry about.
+            await Task.Delay(100);
+        }
+
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_EventSequenceOrder()
         {
-            var events = CollectEvents(CoreKeywords, () =>
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_SingleYield());
+                RunScenarioAndFlush(() => TaskAsync_EventSequenceOrderMarker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            AssertCompleteContextChain(stream,
-                AsyncEventID.CreateAsyncContext,
-                AsyncEventID.ResumeAsyncContext,
-                AsyncEventID.CompleteAsyncContext);
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_EventSequenceOrderMarker));
+            Assert.True(markerCallstacks.Count > 0, $"Expected at least one merged resume callstack with {nameof(TaskAsync_EventSequenceOrderMarker)}");
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_SuspendResumeCompleteEventsMarker()
+        {
+            // Three sequential Delays produce three Suspend/Resume cycles on the same context
+            // (Create reuses the active dispatcher's context id and emits Suspend on each subsequent yield).
+            // Using Task.Delay (not Task.Yield) avoids the dispatcher-vs-registration race; the marker
+            // is the inner box, so it is reliably present in the Resume callstack at walk time.
+            await Task.Delay(100);
+            await Task.Delay(100);
+            await Task.Delay(100);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_SuspendResumeCompleteEvents()
         {
-            var events = CollectEvents(CoreKeywords, () =>
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_MultiYield());
+                RunScenarioAndFlush(() => TaskAsync_SuspendResumeCompleteEventsMarker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            ulong taskId = AssertCompleteContextChain(stream,
-                AsyncEventID.CreateAsyncContext,
-                AsyncEventID.ResumeAsyncContext,
-                AsyncEventID.SuspendAsyncContext,
-                AsyncEventID.ResumeAsyncContext,
-                AsyncEventID.SuspendAsyncContext,
-                AsyncEventID.ResumeAsyncContext,
-                AsyncEventID.CompleteAsyncContext);
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_SuspendResumeCompleteEventsMarker));
+            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(TaskAsync_SuspendResumeCompleteEventsMarker)}");
 
-            var taskEvents = stream.ForTask(taskId);
-            foreach (var evt in taskEvents)
-            {
-                if (evt.EventId is AsyncEventID.ResumeAsyncContext or AsyncEventID.CreateAsyncContext)
-                    Assert.Equal(taskId, evt.TaskId);
-            }
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx1 = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx1 > createIdx, "Expected first ResumeAsyncContext after Create");
+
+            int suspendIdx1 = ids.IndexOf(AsyncEventID.SuspendAsyncContext, resumeIdx1 + 1);
+            Assert.True(suspendIdx1 > resumeIdx1, "Expected first SuspendAsyncContext after first Resume");
+
+            int resumeIdx2 = ids.IndexOf(AsyncEventID.ResumeAsyncContext, suspendIdx1 + 1);
+            Assert.True(resumeIdx2 > suspendIdx1, "Expected second ResumeAsyncContext after first Suspend");
+
+            int suspendIdx2 = ids.IndexOf(AsyncEventID.SuspendAsyncContext, resumeIdx2 + 1);
+            Assert.True(suspendIdx2 > resumeIdx2, "Expected second SuspendAsyncContext after second Resume");
+
+            int resumeIdx3 = ids.IndexOf(AsyncEventID.ResumeAsyncContext, suspendIdx2 + 1);
+            Assert.True(resumeIdx3 > suspendIdx2, "Expected third ResumeAsyncContext after second Suspend");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx3 + 1);
+            Assert.True(completeIdx > resumeIdx3, "Expected CompleteAsyncContext after third Resume");
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -235,50 +228,89 @@ namespace System.Threading.Tasks.Tests
             Assert.Contains(AsyncEventID.CompleteAsyncMethod, ids);
         }
 
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_HandledException_EmitsUnwindAndCompleteMarker()
+        {
+            await TaskAsync_ExceptionHandled();
+        }
+
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_HandledException_EmitsUnwindAndComplete()
         {
-            var events = CollectEvents(CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_ExceptionHandled());
+                RunScenarioAndFlush(() => TaskAsync_HandledException_EmitsUnwindAndCompleteMarker());
             });
 
-            DumpAllEvents(events);
+            //DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            AssertCompleteContextChain(stream,
-                AsyncEventID.CreateAsyncContext,
-                AsyncEventID.ResumeAsyncContext,
-                AsyncEventID.UnwindAsyncException,
-                AsyncEventID.CompleteAsyncContext);
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_HandledException_EmitsUnwindAndCompleteMarker));
+            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(TaskAsync_HandledException_EmitsUnwindAndCompleteMarker)}");
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx + 1);
+            Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker()
+        {
+            await TaskAsync_UnhandledExceptionOuter();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_UnhandledException_EmitsUnwindAndComplete()
         {
-            var events = CollectEvents(CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
             {
                 try
                 {
-                    RunScenario(() => TaskAsync_UnhandledExceptionOuter());
+                    RunScenarioAndFlush(() => TaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker());
                 }
                 catch (InvalidOperationException)
                 {
                 }
-                SendFlushCommand();
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            AssertCompleteContextChain(stream,
-                AsyncEventID.CreateAsyncContext,
-                AsyncEventID.ResumeAsyncContext,
-                AsyncEventID.UnwindAsyncException,
-                AsyncEventID.UnwindAsyncException,
-                AsyncEventID.CompleteAsyncContext);
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker));
+            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(TaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker)}");
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int unwindIdx1 = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            Assert.True(unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
+
+            int unwindIdx2 = ids.IndexOf(AsyncEventID.UnwindAsyncException, unwindIdx1 + 1);
+            Assert.True(unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx2 + 1);
+            Assert.True(completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -355,12 +387,11 @@ namespace System.Threading.Tasks.Tests
             {
                 try
                 {
-                    RunScenario(() => TaskAsync_UnhandledExceptionOuter());
+                    RunScenarioAndFlush(() => TaskAsync_UnhandledExceptionOuter());
                 }
                 catch (InvalidOperationException)
                 {
                 }
-                SendFlushCommand();
             });
 
             // DumpAllEvents(events);
@@ -385,6 +416,1324 @@ namespace System.Threading.Tasks.Tests
             Assert.Equal(AsyncEventID.UnwindAsyncException, tail[1]);
             Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[2]);
             Assert.Equal(AsyncEventID.UnwindAsyncException, tail[3]);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_ResumeAsyncCallstackEmitted()
+        {
+            //System.Diagnostics.Debugger.Launch();
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_DeepChain());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var callstacks = stream.All
+                .Where(e => e.EventId == AsyncEventID.ResumeAsyncCallstack)
+                .ToList();
+
+            Assert.NotEmpty(callstacks);
+            Assert.All(callstacks, cs =>
+            {
+                Assert.True(cs.FrameCount > 0, "Expected at least one frame in resume callstack");
+                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero methodId in first frame");
+            });
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_CallstackDepthMarker()
+        {
+            await TaskAsync_Level1();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CallstackDepthMatchesChainDepth()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_CallstackDepthMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_CallstackDepthMarker));
+            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with TaskAsync_CallstackDepthMarker");
+
+            // TaskAsync_CallstackDepthMarker → Level1 → Level2 → Level3: deepest callstack should have exactly 4 frames
+            Assert.Equal(4, markerCallstacks[0].FrameCount);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_DistinctMethodIdsMarker()
+        {
+            await TaskAsync_Level1();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CallstackFramesHaveDistinctMethodIds()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_DistinctMethodIdsMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_DistinctMethodIdsMarker));
+            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with TaskAsync_DistinctMethodIdsMarker");
+
+            // Frames in the same callstack should have distinct methodIds (different async methods)
+            var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
+            Assert.Equal(methodIds.Count, methodIds.Distinct().Count());
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_StateRoot()
+        {
+            await Task.Yield();
+            await TaskAsync_StateMiddle();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_StateMiddle()
+        {
+            await Task.Yield();
+            await Task.Yield();
+            await TaskAsync_StateLeaf();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_StateLeaf()
+        {
+            await Task.Delay(100);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_CallstackStatesMarker()
+        {
+            await TaskAsync_StateRoot();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CallstackFramesHaveDistinctStates()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_CallstackStatesMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_CallstackStatesMarker));
+            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with marker");
+
+            // The deepest callstack (on the final Delay resume) should have 4 frames:
+            // Leaf (state=3), Middle (state=2), Root (state=1), Marker (state=0)
+            var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
+            Assert.Equal(4, deepest.FrameCount);
+
+            // Each frame should have a different state reflecting its suspend point
+            var states = deepest.Frames.Select(f => f.State).ToList();
+            Assert.Equal(0, states[0]); // Leaf: suspended at 1st await (state=0)
+            Assert.Equal(2, states[1]); // Middle: suspended at 3rd await (state=2)
+            Assert.Equal(1, states[2]); // Root: suspended at 2nd await (state=1)
+            Assert.Equal(0, states[3]); // Marker: suspended at 1st await (state=0)
+        }
+
+        // --- Yield at each level scenario ---
+        // Each frame yields after calling its child, causing separate resume events
+        // with progressively shrinking callstacks as outer frames complete.
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_YieldEachLevel_Marker()
+        {
+            await TaskAsync_YieldEachLevel_Level1();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_YieldEachLevel_Level1()
+        {
+            await TaskAsync_YieldEachLevel_Level2();
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_YieldEachLevel_Level2()
+        {
+            await TaskAsync_YieldEachLevel_Level3();
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_YieldEachLevel_Level3()
+        {
+            await Task.Delay(100);
+            await Task.Yield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_YieldAtEachLevel_CallstackShrinks()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_YieldEachLevel_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_YieldEachLevel_Marker));
+
+            // After Task.Delay resumes: full chain (Level3, Level2, Level1, Marker) = 4 frames
+            // After Level3's yield resumes: Level3 completes, chain is (Level2, Level1, Marker) = 3 frames
+            // After Level2's yield resumes: Level2 completes, chain is (Level1, Marker) = 2 frames
+            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 4);
+            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 3);
+            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 2);
+        }
+
+        // --- Append callstack race scenario ---
+        // Forces the chain-growth race where the parent registers as a continuation
+        // AFTER the child's dispatcher has already walked the callstack but BEFORE
+        // the dispatcher hits its next suspend/complete point. This is the exact
+        // window the AppendAsyncCallstack mechanism is designed to fill in.
+        //
+        // Uses a SemaphoreSlim to deterministically order events independent of TP
+        // scheduling latency (a pure Thread.Sleep approach is unreliable because the
+        // TP dispatch latency for D1 can exceed the parent's sleep window).
+        //
+        // Order of events:
+        //   1. Parent calls Child; Child suspends at first Yield; D1 is created and queued.
+        //   2. Parent calls s_appendRace_proceed.Wait() — blocks.
+        //   3. D1 picked up by TP. D1.Resume walks chain → 1 frame (Child), because
+        //      Parent hasn't done `await t` yet (it's still in Wait()).
+        //   4. D1 calls Child.MoveNext; Child resumes past the await and calls Release().
+        //   5. Parent unblocks, does `await t` — registers Parent on Child.Task.
+        //   6. Meanwhile Child does Thread.Sleep(200) holding D1 alive.
+        //   7. Child hits second Yield → SuspendAsyncContext on D1 → Append check sees
+        //      Parent now registered → emits AppendAsyncCallstack with Parent's frame.
+
+        private static SemaphoreSlim s_appendRace_proceed;
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_AppendRace_Child()
+        {
+            await Task.Yield();
+            // Inside D1.MoveNext now; Resume callstack walk already happened.
+            s_appendRace_proceed.Release();
+            Thread.Sleep(200);
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_AppendRace_Parent()
+        {
+            Task t = TaskAsync_AppendRace_Child();
+            s_appendRace_proceed.Wait();
+            await t;
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_AppendCallstack_FiresOnLateParentRegistration()
+        {
+            // System.Diagnostics.Debugger.Launch();
+            s_appendRace_proceed = new SemaphoreSlim(0, 1);
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_AppendRace_Parent());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The initial Resume on the TP thread should walk only Child (race: Parent not registered yet).
+            var childOnlyResumes = stream
+                .OfType(AsyncEventID.ResumeAsyncCallstack)
+                .Where(e => e.FrameCount == 1 && e.HasMarkerFrame(nameof(TaskAsync_AppendRace_Child)))
+                .ToList();
+            Assert.NotEmpty(childOnlyResumes);
+
+            // After Parent registers and Child hits its next suspend/complete hook,
+            // an AppendAsyncCallstack should fire with the Parent frame.
+            var appendsWithParent = stream
+                .OfType(AsyncEventID.AppendAsyncCallstack)
+                .Where(e => e.HasMarkerFrame(nameof(TaskAsync_AppendRace_Parent)))
+                .ToList();
+            Assert.NotEmpty(appendsWithParent);
+        }
+
+        // --- Negative: Append should NOT fire when the chain is already complete at Resume time ---
+        // The deep-chain marker awaits Level1→Level2→Level3, where Level3 awaits Task.Delay(100).
+        // The 100ms delay gives all parent continuations ample time to register before the
+        // dispatcher walks the chain. The walker should terminate at a non-box (Task.Run wrapper)
+        // and set LastContinuation = null, so subsequent ResumeAsyncMethod/Suspend/Complete hooks
+        // for the inline cascade short-circuit and emit no Append events.
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_CompleteChain_NoAppendMarker()
+        {
+            await TaskAsync_DeepChain();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CompleteChain_DoesNotEmitAppendEvents()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_CompleteChain_NoAppendMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Sanity: the marker frame must appear in the initial Resume callstack (full chain captured).
+            var markerCallstacks = stream
+                .OfType(AsyncEventID.ResumeAsyncCallstack)
+                .Where(e => e.HasMarkerFrame(nameof(TaskAsync_CompleteChain_NoAppendMarker)))
+                .ToList();
+            Assert.True(markerCallstacks.Count > 0,
+                $"Expected initial Resume callstack to contain {nameof(TaskAsync_CompleteChain_NoAppendMarker)} (full chain at walk time)");
+
+            // No Append events should fire — the chain was complete at Resume time.
+            var appendEvents = stream
+                .OfType(AsyncEventID.AppendAsyncCallstack)
+                .ToList();
+            Assert.True(appendEvents.Count == 0,
+                $"Expected zero AppendAsyncCallstack events for a complete-chain scenario, got {appendEvents.Count}");
+        }
+
+        // --- Custom SynchronizationContext scenario ---
+        // Validates that when a non-default SynchronizationContext is active during an await,
+        // the dispatcher wrapping path is taken (TaskAwaiter.UnsafeOnCompletedInternal wraps the box)
+        // and the continuation flows through the custom context's Post back into the dispatcher's
+        // MoveNext. Standard Resume/Suspend/Complete events should fire normally; the marker frame
+        // must be visible in the Resume callstack.
+
+        private sealed class InlinePostSynchronizationContext : SynchronizationContext
+        {
+            private int _postCount;
+            public int PostCount => _postCount;
+
+            public override void Post(SendOrPostCallback d, object? state)
+            {
+                Interlocked.Increment(ref _postCount);
+                d(state);
+            }
+        }
+
+        private static InlinePostSynchronizationContext? s_taskAsyncSyncContextCtx;
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_SyncContextMarker()
+        {
+            // Install a non-default SynchronizationContext on this thread so the await captures it.
+            // The await's continuation will be routed via SynchronizationContextAwaitTaskContinuation,
+            // which wraps the box in an AsyncTaskDispatcher and posts back to the context.
+            //
+            // Note: the await may resume on a different thread (the SyncContext's Post may run on
+            // the timer thread or another worker). Only restore the previous context if we resumed
+            // on the same thread, to avoid polluting an unrelated thread's SynchronizationContext.
+            int callerThreadId = Environment.CurrentManagedThreadId;
+            SynchronizationContext? prev = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(s_taskAsyncSyncContextCtx);
+            try
+            {
+                await Task.Delay(100);
+            }
+            finally
+            {
+                if (Environment.CurrentManagedThreadId == callerThreadId)
+                {
+                    SynchronizationContext.SetSynchronizationContext(prev);
+                }
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack()
+        {
+            s_taskAsyncSyncContextCtx = new InlinePostSynchronizationContext();
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_SyncContextMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            // The custom SyncContext should have received at least one Post for the await continuation.
+            Assert.True(s_taskAsyncSyncContextCtx.PostCount > 0,
+                $"Expected custom SynchronizationContext to receive at least one Post, got {s_taskAsyncSyncContextCtx.PostCount}");
+
+            var stream = ParseAllEvents(events);
+
+            // The marker frame should appear in the Resume callstack (or via Append if the chain raced).
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_SyncContextMarker));
+            Assert.True(markerCallstacks.Count > 0,
+                $"Expected merged Resume callstack containing {nameof(TaskAsync_SyncContextMarker)}");
+
+            // Verify the standard Create → Resume → Complete sequence fired for our context.
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the custom SyncContext scenario");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+        }
+
+        // --- Custom TaskScheduler scenario ---
+        // Validates that when a non-default TaskScheduler is active (the marker runs on a custom
+        // scheduler via Task.Factory.StartNew(..., scheduler)), the dispatcher wrapping path is taken
+        // and the continuation flows through the custom scheduler's QueueTask back into the dispatcher's
+        // MoveNext via TaskSchedulerAwaitTaskContinuation. Standard Resume/Suspend/Complete events
+        // should fire normally.
+
+        private sealed class InlineRunTaskScheduler : TaskScheduler
+        {
+            private int _queuedCount;
+            public int QueuedCount => _queuedCount;
+
+            protected override void QueueTask(Task task)
+            {
+                Interlocked.Increment(ref _queuedCount);
+                TryExecuteTask(task);
+            }
+
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+            protected override IEnumerable<Task>? GetScheduledTasks() => null;
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_TaskSchedulerMarker()
+        {
+            // We rely on the caller having scheduled this method on a custom TaskScheduler via
+            // Task.Factory.StartNew, so TaskScheduler.InternalCurrent is the custom scheduler at
+            // the moment of await. The await's continuation gets routed through that scheduler.
+            await Task.Delay(100);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack()
+        {
+            var scheduler = new InlineRunTaskScheduler();
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                // Schedule the marker on our custom scheduler so TaskScheduler.InternalCurrent
+                // is the custom scheduler when its first await is registered. Unwrap+GetResult
+                // blocks until the async chain completes, then RunScenarioAndFlush's pattern is
+                // inlined here (we can't reuse RunScenarioAndFlush because it uses Task.Run).
+                try
+                {
+                    Task.Factory.StartNew(
+                        () => TaskAsync_TaskSchedulerMarker(),
+                        CancellationToken.None,
+                        TaskCreationOptions.None,
+                        scheduler).Unwrap().GetAwaiter().GetResult();
+                }
+                finally
+                {
+                    Thread.Sleep(50);
+                    SendFlushCommand();
+                }
+            });
+
+            // DumpAllEvents(events);
+
+            // The custom scheduler must have received at least one QueueTask call (for the outer
+            // task). The continuation may or may not also be queued depending on whether the runtime
+            // inlines it on the timer thread; what matters for this test is that the dispatcher's
+            // events fired for the async context.
+            Assert.True(scheduler.QueuedCount >= 1,
+                $"Expected custom TaskScheduler to receive at least one QueueTask call, got {scheduler.QueuedCount}");
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_TaskSchedulerMarker));
+            Assert.True(markerCallstacks.Count > 0,
+                $"Expected merged Resume callstack containing {nameof(TaskAsync_TaskSchedulerMarker)}");
+
+            // Verify standard Create → Resume → Complete sequence for our context.
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the custom TaskScheduler scenario");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+        }
+
+        // --- ValueTask scenario methods ---
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_Level1()
+        {
+            await ValueTaskAsync_Level2();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_Level2()
+        {
+            await ValueTaskAsync_Level3();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_Level3()
+        {
+            await Task.Delay(100);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_Marker()
+        {
+            await ValueTaskAsync_Level1();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_EventSequenceOrderMarker()
+        {
+            await ValueTaskAsync_Marker();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void ValueTaskAsync_EventSequenceOrder()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => ValueTaskAsync_EventSequenceOrderMarker().AsTask());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_EventSequenceOrderMarker));
+            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(ValueTaskAsync_EventSequenceOrderMarker)}");
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void ValueTaskAsync_MethodEventsEmitted()
+        {
+            var events = CollectEvents(MethodKeywords | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => ValueTaskAsync_Marker().AsTask());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // ValueTask chain of 4 methods: Marker → Level1 → Level2 → Level3
+            var methodEvents = stream.All
+                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod or AsyncEventID.CompleteAsyncMethod)
+                .Select(e => e.EventId)
+                .ToList();
+
+            int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeAsyncMethod);
+            int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteAsyncMethod);
+
+            Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
+            Assert.True(completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events for ValueTask chain, got {completeCount}");
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void ValueTaskAsync_CallstackDepthMatchesChainDepth()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => ValueTaskAsync_Marker().AsTask());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_Marker));
+            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with ValueTaskAsync_Marker");
+
+            // ValueTaskAsync_Marker → Level1 → Level2 → Level3: deepest should have 4 frames
+            Assert.Equal(4, markerCallstacks[0].FrameCount);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void ValueTaskAsync_CallstackFramesHaveDistinctMethodIds()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => ValueTaskAsync_Marker().AsTask());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_Marker));
+            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with ValueTaskAsync_Marker");
+
+            var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
+            Assert.Equal(methodIds.Count, methodIds.Distinct().Count());
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_InnerThrows()
+        {
+            await Task.Delay(100);
+            throw new InvalidOperationException("valuetask inner throw");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_ExceptionHandled()
+        {
+            try
+            {
+                await ValueTaskAsync_InnerThrows();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_HandledException_EmitsUnwindAndCompleteMarker()
+        {
+            await ValueTaskAsync_ExceptionHandled();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void ValueTaskAsync_HandledException_EmitsUnwindAndComplete()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            {
+                RunScenarioAndFlush(() => ValueTaskAsync_HandledException_EmitsUnwindAndCompleteMarker().AsTask());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_HandledException_EmitsUnwindAndCompleteMarker));
+            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(ValueTaskAsync_HandledException_EmitsUnwindAndCompleteMarker)}");
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx + 1);
+            Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_UnhandledOuter()
+        {
+            await ValueTaskAsync_UnhandledInner();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_UnhandledInner()
+        {
+            await Task.Delay(100);
+            throw new InvalidOperationException("valuetask unhandled inner");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask ValueTaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker()
+        {
+            await ValueTaskAsync_UnhandledOuter();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            {
+                try
+                {
+                    RunScenarioAndFlush(() => ValueTaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker().AsTask());
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker));
+            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker)}");
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int unwindIdx1 = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            Assert.True(unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
+
+            int unwindIdx2 = ids.IndexOf(AsyncEventID.UnwindAsyncException, unwindIdx1 + 1);
+            Assert.True(unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx2 + 1);
+            Assert.True(completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
+        }
+
+        // --- Negative: no events when profiler is disabled ---
+        // Validates that the InstrumentCheckPoint + AsyncProfiler flag short-circuit kicks in
+        // before the listener is attached, so async work done with no listener leaves no
+        // context-level events behind. After attachment, only background metadata events should
+        // be present (no Create/Resume/Suspend/Complete from prior or current work).
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_NoEventsWhenDisabledScenario()
+        {
+            await Task.Delay(50);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_NoEventsWhenDisabled()
+        {
+            // Run async work WITHOUT a listener attached. No keywords enabled → no events emitted.
+            for (int i = 0; i < 50; i++)
+            {
+                RunScenario(() => TaskAsync_NoEventsWhenDisabledScenario());
+            }
+
+            // Now attach a listener but don't perform any V1 async work — verify no stale events
+            // from the previous work leaked through.
+            var events = CollectEvents(CoreKeywords, () => { /* no-op */ });
+
+            var ids = ParseAllEvents(events).EventIds;
+            int contextEvents = ids.Count(id =>
+                id == AsyncEventID.CreateAsyncContext ||
+                id == AsyncEventID.ResumeAsyncContext ||
+                id == AsyncEventID.SuspendAsyncContext ||
+                id == AsyncEventID.CompleteAsyncContext);
+
+            Assert.Equal(0, contextEvents);
+        }
+
+        // --- Keyword gatekeeping ---
+        // Validates that each individual keyword only enables its corresponding event type.
+        // Auto-emitted infrastructure events (ResetAsyncThreadContext, AsyncProfilerMetadata)
+        // are always allowed. ResumeAsyncCallstackKeyword controls both ResumeAsyncCallstack
+        // AND AppendAsyncCallstack (V1 emits Append events under the same keyword as Resume).
+
+        public static IEnumerable<object[]> TaskAsyncKeywordGatekeepingData()
+        {
+            yield return new object[] { (long)CreateAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CreateAsyncContext } };
+            yield return new object[] { (long)ResumeAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncContext } };
+            yield return new object[] { (long)SuspendAsyncContextKeyword,   new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.SuspendAsyncContext } };
+            yield return new object[] { (long)CompleteAsyncContextKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteAsyncContext } };
+            yield return new object[] { (long)UnwindAsyncExceptionKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.UnwindAsyncException } };
+            yield return new object[] { (long)ResumeAsyncCallstackKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncCallstack, AsyncEventID.AppendAsyncCallstack } };
+            yield return new object[] { (long)ResumeAsyncMethodKeyword,     new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncMethod } };
+            yield return new object[] { (long)CompleteAsyncMethodKeyword,   new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteAsyncMethod } };
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_KeywordGatekeepingMarker()
+        {
+            // Exercise multiple event types: exception unwind, multiple suspends, method invocations.
+            try
+            {
+                await TaskAsync_InnerThrows();
+            }
+            catch (InvalidOperationException) { }
+            await Task.Delay(50);
+        }
+
+        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [MemberData(nameof(TaskAsyncKeywordGatekeepingData))]
+        public void TaskAsync_KeywordGatekeeping(long keywordValue, AsyncEventID[] allowedEventIds)
+        {
+            EventKeywords kw = (EventKeywords)keywordValue;
+            var allowed = new HashSet<AsyncEventID>(allowedEventIds);
+
+            var events = CollectEvents(kw, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_KeywordGatekeepingMarker());
+            });
+
+            var stream = ParseAllEvents(events);
+            var unexpected = stream.EventIds.Where(id => !allowed.Contains(id)).ToList();
+
+            Assert.True(unexpected.Count == 0,
+                $"Keyword 0x{(long)kw:X}: unexpected event IDs [{string.Join(", ", unexpected)}], allowed [{string.Join(", ", allowed)}]");
+        }
+
+        // --- Fork/join (WhenAll) test ---
+        // Validates V1 dispatcher behavior under a fork-join pattern: a single outer task awaits
+        // multiple parallel branches via Task.WhenAll. Each branch is its own async chain that
+        // completes on a (potentially) different ThreadPool thread. The outer resumes only after
+        // all branches have completed. This exercises:
+        //   1. Multi-branch chain tracking — each branch produces its own Create/Resume/Complete.
+        //   2. Concurrent Append safety — branches may complete on different threads simultaneously.
+        //   3. Outer resume after fan-in — the marker's Resume callstack reconstructs correctly
+        //      after WhenAll's join releases the outer continuation.
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_WhenAllBranchA() => await Task.Delay(100);
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_WhenAllBranchB() => await Task.Delay(120);
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_WhenAllBranchC() => await Task.Delay(140);
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_WhenAllMarker()
+        {
+            await Task.WhenAll(
+                TaskAsync_WhenAllBranchA(),
+                TaskAsync_WhenAllBranchB(),
+                TaskAsync_WhenAllBranchC());
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_WhenAll_TracksAllBranchesAndJoin()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_WhenAllMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The outer marker must resume after WhenAll's join releases it. Its callstack
+            // should contain the marker frame (proves the outer dispatcher was tracked and
+            // the resume callstack reconstruction works through the WhenAll join point).
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAllMarker));
+            Assert.True(markerCallstacks.Count > 0,
+                $"Expected at least one Resume callstack containing {nameof(TaskAsync_WhenAllMarker)} after WhenAll join");
+
+            // Each branch is its own async chain; its inner await of Task.Delay produces a
+            // Resume callstack containing the branch frame.
+            var branchACallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAllBranchA));
+            var branchBCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAllBranchB));
+            var branchCCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAllBranchC));
+            Assert.True(branchACallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchA)}");
+            Assert.True(branchBCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchB)}");
+            Assert.True(branchCCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchC)}");
+
+            // Every Create must be balanced by a Complete — fork-join must not leak dispatcher
+            // contexts, and concurrent branch completion must not double-Create.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            // We expect at least 4 Create events: 3 branches + 1 outer marker (the outer's
+            // await of WhenAll wraps its box). More is fine — internal infrastructure tasks
+            // (WhenAll's join task, Task.Delay continuations) may also wrap depending on
+            // SyncContext/Scheduler state. The lower bound proves all our user-visible chains
+            // were tracked.
+            Assert.True(createCount >= 4,
+                $"Expected at least 4 CreateAsyncContext events (3 branches + outer), got {createCount}");
+
+            // The outer marker's chain should fire the standard Create → Resume → Complete
+            // sequence on its own TaskId, in that order.
+            ulong markerTaskId = markerCallstacks[0].TaskId;
+            var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
+
+            int createIdx = markerIds.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the WhenAll outer marker");
+
+            int resumeIdx = markerIds.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
+
+            int completeIdx = markerIds.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
+
+            // The outer should be created exactly once (no double-wrap regression).
+            int createCountForMarker = markerIds.Count(id => id == AsyncEventID.CreateAsyncContext);
+            Assert.Equal(1, createCountForMarker);
+        }
+
+        // --- Fork/join (WhenAny) test ---
+        // Validates V1 dispatcher behavior under WhenAny: outer resumes when the FIRST branch
+        // completes; the remaining branches continue running in the background. This is
+        // structurally different from WhenAll because:
+        //   1. Outer is resumed mid-fan-in, while sibling branches are still alive.
+        //   2. The outer dispatcher may be resumed MORE THAN ONCE (here: once after WhenAny,
+        //      then again after WhenAll on the slow branches), exercising the resume-of-same-
+        //      context cycle without re-Creating the dispatcher.
+        //   3. Branch dispatcher lifetimes are independent of the outer's WhenAny return —
+        //      we still observe their Create/Resume/Complete events when they finish later.
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_WhenAnyFast() => await Task.Delay(50);
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_WhenAnySlow1() => await Task.Delay(400);
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_WhenAnySlow2() => await Task.Delay(600);
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_WhenAnyMarker()
+        {
+            Task fast = TaskAsync_WhenAnyFast();
+            Task slow1 = TaskAsync_WhenAnySlow1();
+            Task slow2 = TaskAsync_WhenAnySlow2();
+
+            await Task.WhenAny(fast, slow1, slow2);
+
+            // Ensure the slow branches actually complete before the scenario ends so their
+            // Create/Resume/Complete events are observable in the trace. This also forces a
+            // second suspend/resume cycle on the outer marker.
+            await Task.WhenAll(slow1, slow2);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_WhenAnyMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The outer marker is resumed at least once (after WhenAny releases it). Its
+            // callstack must contain the marker frame.
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAnyMarker));
+            Assert.True(markerCallstacks.Count > 0,
+                $"Expected at least one Resume callstack containing {nameof(TaskAsync_WhenAnyMarker)} after WhenAny");
+
+            // All branches — including the slow ones whose completion the outer is no longer
+            // strictly waiting on after WhenAny returned — must produce their own Resume
+            // callstacks. This proves their dispatcher lifetimes are tracked independently.
+            var fastCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAnyFast));
+            var slow1Callstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAnySlow1));
+            var slow2Callstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAnySlow2));
+            Assert.True(fastCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnyFast)}");
+            Assert.True(slow1Callstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnySlow1)}");
+            Assert.True(slow2Callstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnySlow2)}");
+
+            // Every Create must be balanced by a Complete — concurrent fan-in with independent
+            // sibling lifetimes must not leak or double-count dispatcher contexts.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            // At least 4 Creates: 3 branches + 1 outer marker.
+            Assert.True(createCount >= 4,
+                $"Expected at least 4 CreateAsyncContext events (3 branches + outer), got {createCount}");
+
+            // The outer marker's chain: exactly one Create, at least two Resumes (one after
+            // WhenAny, one after WhenAll on the slow branches), then Complete. This validates
+            // resume-of-same-context cycles without re-Creating the dispatcher (no double-wrap).
+            ulong markerTaskId = markerCallstacks[0].TaskId;
+            var markerEvents = stream.ForTask(markerTaskId);
+            var markerIds = markerEvents.Select(e => e.EventId).ToList();
+
+            int createCountForMarker = markerIds.Count(id => id == AsyncEventID.CreateAsyncContext);
+            Assert.Equal(1, createCountForMarker);
+
+            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.ResumeAsyncContext);
+            // Resume count is timing-sensitive: ideally the outer suspends/resumes twice (after
+            // WhenAny, then after the subsequent WhenAll on the slow branches). But under load,
+            // by the time WhenAny returns and we reach the WhenAll, the slow tasks may have
+            // already completed — in which case WhenAll returns synchronously without a second
+            // suspend/resume. Either shape is correct runtime behavior; we only require >=1
+            // (proves the outer was resumed at all).
+            Assert.True(resumeCountForMarker >= 1,
+                $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
+
+            // Note: We don't assert an exact count of CompleteAsyncContext for the marker. V1's
+            // Suspend/Complete events don't carry an explicit TaskId in the wire format; the parser
+            // recovers it from the active context. The parser pops on Complete but NOT on Suspend,
+            // so when the marker suspends (awaiting WhenAll on the slow branches) and a sibling
+            // branch's Complete then fires, the parser misattributes that Complete to the still-
+            // active marker context. So the parsed Complete count for the marker may be >1 even
+            // though the runtime emitted exactly one Complete for it. The overall Create==Complete
+            // balance check above already covers the no-leak guarantee.
+            int completeCountForMarker = markerIds.Count(id => id == AsyncEventID.CompleteAsyncContext);
+            Assert.True(completeCountForMarker >= 1, "Expected at least one CompleteAsyncContext for the outer marker");
+
+            // First event for the marker is its Create; last is a Complete.
+            Assert.Equal(AsyncEventID.CreateAsyncContext, markerIds[0]);
+            Assert.Equal(AsyncEventID.CompleteAsyncContext, markerIds[^1]);
+        }
+
+        // --- Callstack cap / overflow / stress tests ---
+        // Mirrors the V2 versions but uses V1 (Task-based) recursive chains. The walker shares
+        // the same buffer/cap infrastructure (byte FrameCount, rent-on-overflow fallback) so these
+        // tests guard the same code paths from the V1 entry point.
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_RecursiveChain(int depth)
+        {
+            if (depth <= 1)
+            {
+                await Task.Delay(100);
+                return;
+            }
+            await TaskAsync_RecursiveChain(depth - 1);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_RecursiveChainMarker(int depth)
+        {
+            await TaskAsync_RecursiveChain(depth);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CallstackDepthCappedAtMaxFrames()
+        {
+            // Build a chain deeper than the 255-frame cap (byte FrameCount). The deepest
+            // ResumeAsyncCallstack should clamp at byte.MaxValue without crashing.
+            const int requestedDepth = 300;
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_RecursiveChainMarker(requestedDepth));
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var callstacks = stream.OfType(AsyncEventID.ResumeAsyncCallstack).ToList();
+            Assert.True(callstacks.Count >= 1, "Expected at least one callstack");
+
+            // Walker caps frames at byte.MaxValue. Requested depth is 300, capped to 255.
+            var deepest = callstacks.MaxBy(cs => cs.FrameCount);
+            Assert.Equal(byte.MaxValue, deepest!.FrameCount);
+            Assert.Equal((int)deepest.FrameCount, deepest.Frames.Count);
+
+            // Every captured frame should resolve to a managed method.
+            foreach (var (methodId, _) in deepest.Frames)
+            {
+                Assert.True(methodId != 0, "Frame has zero MethodId");
+                var method = GetMethodNameFromMethodId(deepest.CallstackType, methodId);
+                Assert.True(method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CallstackStressWithVaryingDepths()
+        {
+            // Stress test: many V1 async invocations with varying chain depths. Varying sizes
+            // place some callstacks at buffer boundaries, naturally exercising the overflow/rewind
+            // path in the shared callstack emission code.
+            const int iterations = 50;
+            int[] depths = new int[iterations];
+            var rng = new Random(42);
+            for (int i = 0; i < iterations; i++)
+                depths[i] = rng.Next(1, 60);
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    for (int i = 0; i < iterations; i++)
+                        await TaskAsync_RecursiveChainMarker(depths[i]);
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var callstacks = stream
+                .OfType(AsyncEventID.ResumeAsyncCallstack)
+                .Where(e => e.HasMarkerFrame(nameof(TaskAsync_RecursiveChainMarker)))
+                .ToList();
+
+            // Every emitted callstack must have valid frame data.
+            foreach (var cs in callstacks)
+            {
+                Assert.True(cs.FrameCount > 0, "Callstack has 0 frames");
+                Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
+                for (int f = 0; f < cs.Frames.Count; f++)
+                {
+                    var (methodId, _) = cs.Frames[f];
+                    Assert.True(methodId != 0, $"Frame {f} has zero MethodId");
+                    var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
+                    Assert.True(method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
+                }
+            }
+
+            // We expect at least one marker callstack per iteration (some may not be the deepest
+            // due to mid-chain dispatcher walks). Use >= as the strict count varies with timing.
+            Assert.True(callstacks.Count >= iterations,
+                $"Expected at least {iterations} callstacks with marker, got {callstacks.Count}");
+
+            // Verify multiple buffer flushes occurred — proves the buffer machinery is exercised.
+            int bufferCount = 0;
+            ForEachEventBufferPayload(events, _ => bufferCount++);
+            Assert.True(bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
+        }
+
+        // --- ConfigureAwait(false) chain test ---
+        // Validates that ConfigureAwait(false) at every level of a chain does NOT break the
+        // dispatcher cascade or cause the box to be wrapped more than once. ConfigureAwait(false)
+        // routes through ConfiguredTaskAwaitable instead of TaskAwaiter, which has its own
+        // UnsafeOnCompletedInternal path. A regression here would either drop chain frames or
+        // emit multiple Create events per logical async method.
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_ConfigureAwaitFalseLeaf()
+        {
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_ConfigureAwaitFalseMid()
+        {
+            await TaskAsync_ConfigureAwaitFalseLeaf().ConfigureAwait(false);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_ConfigureAwaitFalseMarker()
+        {
+            await TaskAsync_ConfigureAwaitFalseMid().ConfigureAwait(false);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_ConfigureAwaitFalse_DoesNotBreakCascadeOrDoubleWrap()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_ConfigureAwaitFalseMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The full chain (Leaf -> Mid -> Marker) must appear in the Resume callstack.
+            // For ConfigureAwait(false) box-to-box chains with no SyncContext/Scheduler, the
+            // runtime takes the inline-cascade optimization: a single dispatcher walks the
+            // entire chain instead of wrapping each level. This is the OPTIMAL trace shape —
+            // minimum dispatcher overhead, full chain visibility via the callstack.
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_ConfigureAwaitFalseMarker));
+            Assert.True(markerCallstacks.Count > 0,
+                $"Expected at least one Resume callstack containing {nameof(TaskAsync_ConfigureAwaitFalseMarker)} (cascade not broken)");
+
+            // The deepest callstack should include all 3 chain frames — proves the chain walk
+            // crossed every ConfigureAwait(false) level without dropping any.
+            var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
+            var frameNames = deepest.Frames
+                .Select(f => GetMethodNameFromMethodId(deepest.CallstackType, f.MethodId))
+                .Where(n => n is not null)
+                .ToList();
+            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseLeaf), frameNames);
+            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseMid), frameNames);
+            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseMarker), frameNames);
+
+            // Every Create must be balanced by a Complete — no leaks.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            // Strongest no-double-wrap check: the cascade optimization should produce exactly
+            // 1 dispatcher for the entire chain (the leaf's non-box Task.Delay wrapping). A
+            // regression that re-introduced per-level wrapping would push this to 3+.
+            Assert.Equal(1, createCount);
+        }
+
+        // --- Faulted task test ---
+        // Validates that an async method that throws (and whose exception is caught upstream)
+        // still produces a clean trace: balanced Create/Complete events, an UnwindAsyncException
+        // event reflecting the unwound frames, and the marker's Resume callstack present.
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_FaultedInner()
+        {
+            await Task.Delay(50);
+            throw new InvalidOperationException("test fault");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_FaultedMarker()
+        {
+            try
+            {
+                await TaskAsync_FaultedInner();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_FaultedTask_BalancedEventsAndUnwindEmitted()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_FaultedMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The marker must still resume and complete — exception propagation does not orphan
+            // the dispatcher.
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_FaultedMarker));
+            Assert.True(markerCallstacks.Count > 0,
+                $"Expected at least one Resume callstack containing {nameof(TaskAsync_FaultedMarker)}");
+
+            // No leak: every dispatcher that was Created must Complete, even on the fault path.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            // The runtime emits UnwindAsyncException when an async method completes with an
+            // exception (AsyncTaskMethodBuilder<T>.SetException path).
+            int unwindCount = stream.OfType(AsyncEventID.UnwindAsyncException).Count();
+            Assert.True(unwindCount > 0,
+                "Expected at least one UnwindAsyncException event for the faulted inner task");
+        }
+
+        // --- Cancellation test ---
+        // Validates that cancellation (OperationCanceledException flowing through the chain)
+        // produces a well-formed trace with balanced events and the cancelled chain's marker
+        // visible in a Resume callstack.
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_CancelledInner(CancellationToken ct)
+        {
+            await Task.Delay(5000, ct);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_CancelledMarker()
+        {
+            using var cts = new CancellationTokenSource();
+            Task inner = TaskAsync_CancelledInner(cts.Token);
+            cts.CancelAfter(50);
+            try
+            {
+                await inner;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_Cancellation_BalancedEvents()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_CancelledMarker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The marker must resume and produce a callstack — cancellation propagation does
+            // not orphan the dispatcher chain.
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_CancelledMarker));
+            Assert.True(markerCallstacks.Count > 0,
+                $"Expected at least one Resume callstack containing {nameof(TaskAsync_CancelledMarker)}");
+
+            // No leak: every Create must be balanced by a Complete on the cancellation path.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            // At least 2 Creates: inner cancelled task + outer marker. Both must Complete.
+            Assert.True(createCount >= 2,
+                $"Expected at least 2 CreateAsyncContext events (inner + marker), got {createCount}");
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -133,7 +133,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_EventsEmitted()
         {
             var events = CollectEvents(StateMachineAsyncCoreKeywords, () =>
@@ -147,7 +147,7 @@ namespace System.Threading.Tasks.Tests
             AssertContains(events, events.Events, e => e.EventId == AsyncEventsId);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CreateAsyncContextEmittedOnFirstAwait()
         {
             var events = CollectEvents(StateMachineAsyncCoreKeywords, () =>
@@ -170,7 +170,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_EventSequenceOrder()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -212,7 +212,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_SuspendResumeCompleteEvents()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -268,7 +268,7 @@ namespace System.Threading.Tasks.Tests
             resumedThreadId.Value = Environment.CurrentManagedThreadId;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_InlineResume_CompletesWithoutSuspend()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -328,7 +328,7 @@ namespace System.Threading.Tasks.Tests
             await gate2;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_InlineResume_ReSuspends()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -400,7 +400,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_PoolResume_ReSuspends()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -455,7 +455,7 @@ namespace System.Threading.Tasks.Tests
             AssertEqual(stream, resumeEvt.OsThreadId, suspendEvt.OsThreadId);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_ResumeCompleteMethodEvents()
         {
             var events = CollectEvents(StateMachineAsyncMethodKeywords, () =>
@@ -479,7 +479,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_ExceptionHandled();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_HandledException_EmitsUnwindAndComplete()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
@@ -517,7 +517,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_UnhandledExceptionOuter();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_UnhandledException_EmitsUnwindAndComplete()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
@@ -565,7 +565,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_DeepChain();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_MethodEventCountMatchesChainDepth()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncMethodKeywords | StateMachineAsyncCoreKeywords, () =>
@@ -602,7 +602,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_ExceptionHandled();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_HandledException_MethodEventsWithUnwind()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncMethodKeywords | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
@@ -646,7 +646,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_UnhandledExceptionOuter();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_UnhandledException_MethodEventsWithUnwind()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncMethodKeywords | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
@@ -700,7 +700,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_DeepChain();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_ResumeAsyncCallstackEmitted()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -729,7 +729,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CallstackDepthMatchesChainDepth()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -755,7 +755,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CallstackFramesHaveDistinctMethodIds()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -806,7 +806,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_CallstackFramesHaveDistinctStates_Root_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CallstackFramesHaveDistinctStates()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -865,7 +865,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Level1_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_YieldAtEachLevel_CallstackShrinks()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -908,7 +908,7 @@ namespace System.Threading.Tasks.Tests
             await t;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_AppendCallstack_FiresOnLateParentRegistration()
         {
             s_appendRace_proceed = new SemaphoreSlim(0, 1);
@@ -939,7 +939,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_DeepChain();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CompleteChain_DoesNotEmitAppendEvents()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -993,7 +993,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CustomSyncContext_EmitsContextEventsAndCallstack()
         {
             s_stateMachineAsyncSyncContextCtx = new InlinePostSynchronizationContext();
@@ -1036,7 +1036,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack()
         {
             var scheduler = new InlineRunTaskScheduler();
@@ -1090,7 +1090,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(50);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_NoEventsWhenDisabled()
         {
             for (int i = 0; i < 50; i++)
@@ -1136,7 +1136,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(50);
         }
 
-        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         [MemberData(nameof(StateMachineAsyncKeywordGatekeepingData))]
         public void StateMachineAsync_KeywordGatekeeping(long keywordValue, AsyncEventID[] allowedEventIds)
         {
@@ -1186,7 +1186,7 @@ namespace System.Threading.Tasks.Tests
                 StateMachineAsync_WhenAll_TracksAllBranches_BranchC_Marker());
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_WhenAll_TracksAllBranches()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -1266,7 +1266,7 @@ namespace System.Threading.Tasks.Tests
             await Task.WhenAll(slow1, slow2);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_WhenAny_TracksAllBranches()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -1318,7 +1318,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_RecursiveChain(depth);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CallstackDepthCappedAtMaxFrames()
         {
             // Build a chain deeper than the 255-frame cap (byte FrameCount). The deepest
@@ -1368,7 +1368,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CallstackOverflow_PreservesFullDepth()
         {
             const int Depth = 200;
@@ -1418,7 +1418,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_RecursiveChain(depth);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CallstackStressWithVaryingDepths()
         {
             const int iterations = 100;
@@ -1489,7 +1489,7 @@ namespace System.Threading.Tasks.Tests
             await Task.WhenAll(b1, b2);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_WaitThenYield_BalancesResumeAndComplete()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -1548,7 +1548,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_ConfigureAwaitFalse_Mid_Marker().ConfigureAwait(false);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_ConfigureAwaitFalse()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -1598,7 +1598,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_FaultedTask()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | UnwindStateMachineAsyncExceptionKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -1653,7 +1653,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_TaskCancellation()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | UnwindStateMachineAsyncExceptionKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -1683,7 +1683,7 @@ namespace System.Threading.Tasks.Tests
             await ValueStateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void ValueStateMachineAsync_EventSequenceOrder()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -1718,7 +1718,7 @@ namespace System.Threading.Tasks.Tests
             await ValueStateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void ValueStateMachineAsync_MethodEventsEmitted()
         {
             var events = CollectEvents(StateMachineAsyncMethodKeywords | StateMachineAsyncCoreKeywords, () =>
@@ -1751,7 +1751,7 @@ namespace System.Threading.Tasks.Tests
             await ValueStateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void ValueStateMachineAsync_CallstackDepthMatchesChainDepth()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -1777,7 +1777,7 @@ namespace System.Threading.Tasks.Tests
             await ValueStateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void ValueStateMachineAsync_CallstackFramesHaveDistinctMethodIds()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
@@ -1824,7 +1824,7 @@ namespace System.Threading.Tasks.Tests
             await ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete_Handled_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
@@ -1878,7 +1878,7 @@ namespace System.Threading.Tasks.Tests
             await ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledOuter_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete()
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
@@ -1941,7 +1941,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_ResetContext_ReplaysPendingV1Chain_Mid_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_ResetContext_ReplaysPendingV1Chain()
         {
             var events = CollectEvents(AllStateMachineAsyncKeywords, () =>
@@ -2027,7 +2027,7 @@ namespace System.Threading.Tasks.Tests
             await innerDone.Task;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_ResetContext_ReplaysMultipleDispatchers()
         {
             var events = CollectEvents(AllStateMachineAsyncKeywords, () =>
@@ -2143,7 +2143,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_ResetContext_ReplayResumeCompleteBalance_Mid_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_ResetContext_ReplayResumeCompleteBalance()
         {
             var events = CollectEvents(AllStateMachineAsyncKeywords, () =>
@@ -2201,7 +2201,7 @@ namespace System.Threading.Tasks.Tests
             await StateMachineAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker(gate);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncSupported))]
         public async Task StateMachineAsync_SingleThread_ChainEventsAndCallstack()
         {
             var events = await CollectEventsAsync(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | StateMachineAsyncMethodKeywords, async () =>

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1371,8 +1371,9 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
         public void StateMachineAsync_CallstackOverflow_PreservesFullDepth()
         {
-            const int Depth = 200;
-            const int Iterations = 500;
+            const int Depth = 300;
+            const int MaxFrames = byte.MaxValue;
+            const int Iterations = 128;
 
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword, () =>
             {
@@ -1392,18 +1393,18 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            // The deep chains overflow the per-thread buffer many times over (Iterations deep callstacks far
-            // exceed one buffer's capacity), so the rent/overflow path is exercised. The regression check:
-            // every chain resume must carry its full frame count. Scope to our recursive chains by method
-            // rather than by frame count -- a callstack truncated by the overflow bug has fewer frames but
-            // still consists of the recursive method, so it stays in scope and is caught.
+            // The deep chains overflow the per-thread buffer many times over, so the rent/overflow path is
+            // exercised. The regression check: every chain resume must carry the full (capped) frame count.
+            // Scope to our recursive chains by method rather than by frame count -- a callstack truncated by
+            // the overflow bug has fewer frames but still consists of the recursive method, so it stays in
+            // scope and is caught.
             var chainCallstacks = stream.OfType(AsyncEventID.ResumeStateMachineAsyncCallstack)
                 .Where(cs => cs.Frames.Any(f => GetMethodNameFromMethodId(cs.CallstackType, f.MethodId) == nameof(StateMachineAsync_RecursiveChainGated)))
                 .ToList();
             AssertNotEmpty(stream, chainCallstacks);
 
             int leafDepth = chainCallstacks.Max(cs => (int)cs.FrameCount);
-            AssertTrue(stream, leafDepth >= Depth, $"Expected captured depth >= {Depth}, got {leafDepth}");
+            AssertEqual(stream, MaxFrames, leafDepth);
             foreach (var cs in chainCallstacks)
             {
                 AssertEqual(stream, leafDepth, (int)cs.FrameCount);

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1223,7 +1223,7 @@ namespace System.Threading.Tasks.Tests
                 RunScenarioAndFlush(() => TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker());
             });
 
-            // DumpAllEvents(events);
+            DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -132,8 +132,8 @@ namespace System.Threading.Tasks.Tests
 
             // DumpAllEvents(events);
 
-            Assert.True(events.Events.Count > 0, "Expected at least one AsyncEvents event to be emitted");
-            Assert.Contains(events.Events, e => e.EventId == AsyncEventsId);
+            AssertTrue(events, events.Events.Count > 0, "Expected at least one AsyncEvents event to be emitted");
+            AssertContains(events, events.Events, e => e.EventId == AsyncEventsId);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
@@ -149,7 +149,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var creates = stream.OfType(AsyncEventID.TaskAsync_CreateAsyncContext).ToList();
-            Assert.True(creates.Count >= 1, $"Expected at least 1 CreateAsyncContext, got {creates.Count}");
+            AssertTrue(stream, creates.Count >= 1, $"Expected at least 1 CreateAsyncContext, got {creates.Count}");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -172,19 +172,19 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_EventSequenceOrder_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -209,25 +209,25 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_SuspendResumeCompleteEvents_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeCount = ids.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncContext);
-            Assert.True(resumeCount >= 1, "Expected at least one ResumeAsyncContext");
+            AssertTrue(stream, resumeCount >= 1, "Expected at least one ResumeAsyncContext");
 
             int completeCount = ids.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
-            Assert.True(completeCount >= 1, "Expected at least one CompleteAsyncContext");
+            AssertTrue(stream, completeCount >= 1, "Expected at least one CompleteAsyncContext");
 
             // Expected ResumeAsyncContext and CompleteAsyncContext counts to match.
-            Assert.Equal(resumeCount, completeCount);
+            AssertEqual(stream, resumeCount, completeCount);
 
             // Expected no SuspendAsyncContext events.
-            Assert.DoesNotContain(AsyncEventID.TaskAsync_SuspendAsyncContext, ids);
+            AssertDoesNotContain(stream, AsyncEventID.TaskAsync_SuspendAsyncContext, ids);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
@@ -243,8 +243,8 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             var ids = stream.EventIds;
 
-            Assert.Contains(AsyncEventID.TaskAsync_ResumeAsyncMethod, ids);
-            Assert.Contains(AsyncEventID.TaskAsync_CompleteAsyncMethod, ids);
+            AssertContains(stream, AsyncEventID.TaskAsync_ResumeAsyncMethod, ids);
+            AssertContains(stream, AsyncEventID.TaskAsync_CompleteAsyncMethod, ids);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -267,22 +267,22 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int unwindIdx = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
-            Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+            AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
             int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx + 1);
-            Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
+            AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -311,25 +311,25 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int unwindIdx1 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
-            Assert.True(unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
+            AssertTrue(stream, unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
 
             int unwindIdx2 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, unwindIdx1 + 1);
-            Assert.True(unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
+            AssertTrue(stream, unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
 
             int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx2 + 1);
-            Assert.True(completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
+            AssertTrue(stream, completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
         }
 
 
@@ -356,18 +356,18 @@ namespace System.Threading.Tasks.Tests
             const int ExpectedChainDepth = 5;
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_MethodEventCountMatchesChainDepth_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
-            Assert.Equal(ExpectedChainDepth, markerCallstacks[0].Frames.Count);
+            AssertEqual(stream, ExpectedChainDepth, markerCallstacks[0].Frames.Count);
 
             ulong leafDispatcherId = markerCallstacks[0].DispatcherId;
             var chainEvents = stream.ChainEventsFromDispatcher(leafDispatcherId);
 
             int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncMethod);
-            Assert.Equal(ExpectedChainDepth, resumeCount);
+            AssertEqual(stream, ExpectedChainDepth, resumeCount);
 
             int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncMethod);
-            Assert.Equal(ExpectedChainDepth, completeCount);
+            AssertEqual(stream, ExpectedChainDepth, completeCount);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -391,7 +391,7 @@ namespace System.Threading.Tasks.Tests
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_HandledException_MethodEventsWithUnwind_Marker));
 
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong leafDispatcherId = markerCallstacks[0].DispatcherId;
             var chainEvents = stream.ChainEventsFromDispatcher(leafDispatcherId);
@@ -404,14 +404,14 @@ namespace System.Threading.Tasks.Tests
                 .ToList();
 
             // Exactly one Unwind expected on the chain (InnerThrows throws once).
-            Assert.Equal(1, sequence.Count(id => id == AsyncEventID.TaskAsync_UnwindAsyncException));
+            AssertEqual(stream, 1, sequence.Count(id => id == AsyncEventID.TaskAsync_UnwindAsyncException));
 
             // Around the Unwind: the throwing method's Resume precedes it, and the catching
             // method's Resume -> Complete pair follows.
             int unwindIdx = sequence.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException);
-            Assert.Equal(AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[unwindIdx - 1]);
-            Assert.Equal(AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[unwindIdx + 1]);
-            Assert.Equal(AsyncEventID.TaskAsync_CompleteAsyncMethod, sequence[unwindIdx + 2]);
+            AssertEqual(stream, AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[unwindIdx - 1]);
+            AssertEqual(stream, AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[unwindIdx + 1]);
+            AssertEqual(stream, AsyncEventID.TaskAsync_CompleteAsyncMethod, sequence[unwindIdx + 2]);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -443,7 +443,7 @@ namespace System.Threading.Tasks.Tests
             const int ExpectedChainDepth = 3;
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong leafDispatcherId = markerCallstacks[0].DispatcherId;
             var chainEvents = stream.ChainEventsFromDispatcher(leafDispatcherId);
@@ -456,15 +456,15 @@ namespace System.Threading.Tasks.Tests
                 .ToList();
 
             // Every method in the chain unwinds (no catch); no CompleteAsyncMethod expected.
-            Assert.Equal(ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncMethod));
-            Assert.Equal(ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.TaskAsync_UnwindAsyncException));
-            Assert.Equal(0, sequence.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncMethod));
+            AssertEqual(stream, ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncMethod));
+            AssertEqual(stream, ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.TaskAsync_UnwindAsyncException));
+            AssertEqual(stream, 0, sequence.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncMethod));
 
             // Per-method ordering: each Resume is immediately followed by its Unwind.
             for (int i = 0; i < sequence.Count; i += 2)
             {
-                Assert.Equal(AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[i]);
-                Assert.Equal(AsyncEventID.TaskAsync_UnwindAsyncException, sequence[i + 1]);
+                AssertEqual(stream, AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[i]);
+                AssertEqual(stream, AsyncEventID.TaskAsync_UnwindAsyncException, sequence[i + 1]);
             }
         }
 
@@ -488,9 +488,9 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_ResumeAsyncCallstackEmitted_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
-            Assert.All(markerCallstacks, cs =>
+            AssertAll(stream, markerCallstacks, cs =>
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in resume callstack");
                 Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero methodId in first frame");
@@ -517,10 +517,10 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackDepthMatchesChainDepth_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // TaskAsync_CallstackDepthMarker -> Level1 -> Level2 -> Level3: deepest callstack should have exactly 4 frames
-            Assert.Equal(4, markerCallstacks[0].FrameCount);
+            AssertEqual(stream, 4, markerCallstacks[0].FrameCount);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -543,11 +543,11 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Frames in the same callstack should have distinct methodIds (different async methods)
             var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
-            Assert.Equal(methodIds.Count, methodIds.Distinct().Count());
+            AssertEqual(stream, methodIds.Count, methodIds.Distinct().Count());
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -594,19 +594,19 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctStates_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // The deepest callstack (on the final Delay resume) should have 4 frames:
             // Leaf (state=0), Middle (state=2), Root (state=1), Marker (state=0)
             var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
-            Assert.Equal(4, deepest.FrameCount);
+            AssertEqual(stream, 4, deepest.FrameCount);
 
             // Each frame's state should reflect its suspend point (values may repeat across frames).
             var states = deepest.Frames.Select(f => f.State).ToList();
-            Assert.Equal(0, states[0]); // Leaf: suspended at 1st await (state=0)
-            Assert.Equal(2, states[1]); // Middle: suspended at 3rd await (state=2)
-            Assert.Equal(1, states[2]); // Root: suspended at 2nd await (state=1)
-            Assert.Equal(0, states[3]); // Marker: suspended at 1st await (state=0)
+            AssertEqual(stream, 0, states[0]); // Leaf: suspended at 1st await (state=0)
+            AssertEqual(stream, 2, states[1]); // Middle: suspended at 3rd await (state=2)
+            AssertEqual(stream, 1, states[2]); // Root: suspended at 2nd await (state=1)
+            AssertEqual(stream, 0, states[3]); // Marker: suspended at 1st await (state=0)
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -657,9 +657,9 @@ namespace System.Threading.Tasks.Tests
             // After Task.Delay resumes: full chain (Level3, Level2, Level1, Marker) = 4 frames
             // After Level3's yield resumes: Level3 completes, chain is (Level2, Level1, Marker) = 3 frames
             // After Level2's yield resumes: Level2 completes, chain is (Level1, Marker) = 2 frames
-            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 4);
-            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 3);
-            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 2);
+            AssertContains(stream, markerCallstacks, cs => cs.FrameCount == 4);
+            AssertContains(stream, markerCallstacks, cs => cs.FrameCount == 3);
+            AssertContains(stream, markerCallstacks, cs => cs.FrameCount == 2);
         }
 
         private static SemaphoreSlim s_appendRace_proceed;
@@ -699,12 +699,12 @@ namespace System.Threading.Tasks.Tests
 
             // The initial Resume should only include TaskAsync_AppendRace_Child (race: Parent not registered yet).
             var childOnlyResumes = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker));
-            Assert.NotEmpty(childOnlyResumes);
+            AssertNotEmpty(stream, childOnlyResumes);
 
             // After Parent registers and Child hits its next complete hook,
             // an AppendAsyncCallstack should fire with the Parent frame.
             var appendsWithParent = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_AppendAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker));
-            Assert.NotEmpty(appendsWithParent);
+            AssertNotEmpty(stream, appendsWithParent);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -728,14 +728,14 @@ namespace System.Threading.Tasks.Tests
 
             // Sanity: the marker frame must appear in the initial Resume callstack (full chain captured).
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // No Append events should fire on this chain -- the chain was complete at Resume time.
             ulong chainDispatcherId = markerCallstacks[0].DispatcherId;
             var appendEvents = stream.ChainEventsFromDispatcher(chainDispatcherId)
                 .Where(e => e.EventId == AsyncEventID.TaskAsync_AppendAsyncCallstack)
                 .ToList();
-            Assert.Empty(appendEvents);
+            AssertEmpty(stream, appendEvents);
         }
 
         private static InlinePostSynchronizationContext? s_taskAsyncSyncContextCtx;
@@ -776,27 +776,27 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             // The custom SyncContext should have received at least one Post for the await continuation.
-            Assert.True(s_taskAsyncSyncContextCtx.PostCount > 0,
+            AssertTrue(events, s_taskAsyncSyncContextCtx.PostCount > 0,
                 $"Expected custom SynchronizationContext to receive at least one Post, got {s_taskAsyncSyncContextCtx.PostCount}");
 
             var stream = ParseAllEvents(events);
 
             // The marker frame should appear in the Resume callstack.
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Verify the standard Create -> Resume -> Complete sequence fired for our chain.
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the custom SyncContext scenario");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext for the custom SyncContext scenario");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -831,26 +831,26 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             // The custom scheduler must have received at least one QueueTask call.
-            Assert.True(scheduler.QueuedCount >= 1,
+            AssertTrue(events, scheduler.QueuedCount >= 1,
                 $"Expected custom TaskScheduler to receive at least one QueueTask call, got {scheduler.QueuedCount}");
 
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Verify standard Create -> Resume -> Complete sequence for our chain.
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the custom TaskScheduler scenario");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext for the custom TaskScheduler scenario");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -878,7 +878,7 @@ namespace System.Threading.Tasks.Tests
                 id == AsyncEventID.TaskAsync_SuspendAsyncContext ||
                 id == AsyncEventID.TaskAsync_CompleteAsyncContext);
 
-            Assert.Equal(0, contextEvents);
+            AssertEqual(events, 0, contextEvents);
         }
 
         public static IEnumerable<object[]> TaskAsyncKeywordGatekeepingData()
@@ -920,7 +920,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             var unexpected = stream.EventIds.Where(id => !allowed.Contains(id)).ToList();
 
-            Assert.True(unexpected.Count == 0,
+            AssertTrue(stream, unexpected.Count == 0,
                 $"Keyword 0x{(long)kw:X}: unexpected event IDs [{string.Join(", ", unexpected)}], allowed [{string.Join(", ", allowed)}]");
         }
 
@@ -968,15 +968,15 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Each branch is its own async chain; its inner await of Task.Delay produces a Resume callstack containing the branch frame.
             var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
             var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker));
             var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker));
-            Assert.NotEmpty(branchACallstacks);
-            Assert.NotEmpty(branchBCallstacks);
-            Assert.NotEmpty(branchCCallstacks);
+            AssertNotEmpty(stream, branchACallstacks);
+            AssertNotEmpty(stream, branchBCallstacks);
+            AssertNotEmpty(stream, branchCCallstacks);
 
             // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete in its own dispatcher tree.
             AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].DispatcherId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
@@ -989,17 +989,17 @@ namespace System.Threading.Tasks.Tests
             var markerIds = stream.ChainEventsFromDispatcher(markerDispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the WhenAll outer marker");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext for the WhenAll outer marker");
 
             int resumeIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
 
             int completeIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
 
             // The outer should be created exactly once.
             int createCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.Equal(1, createCountForMarker);
+            AssertEqual(stream, 1, createCountForMarker);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1048,7 +1048,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // All branches - including the slow ones whose completion the outer is no longer
             // strictly waiting on after WhenAny returned -- must produce their own Resume
@@ -1056,9 +1056,9 @@ namespace System.Threading.Tasks.Tests
             var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
             var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker));
             var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker));
-            Assert.NotEmpty(fastCallstacks);
-            Assert.NotEmpty(slow1Callstacks);
-            Assert.NotEmpty(slow2Callstacks);
+            AssertNotEmpty(stream, fastCallstacks);
+            AssertNotEmpty(stream, slow1Callstacks);
+            AssertNotEmpty(stream, slow2Callstacks);
 
             // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete in its own dispatcher tree.
             AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
@@ -1073,11 +1073,11 @@ namespace System.Threading.Tasks.Tests
             var markerIds = markerEvents.Select(e => e.EventId).ToList();
 
             int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncContext);
-            Assert.True(resumeCountForMarker >= 1,
+            AssertTrue(stream, resumeCountForMarker >= 1,
                 $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
 
             int completeCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
-            Assert.True(completeCountForMarker >= 1, "Expected at least one CompleteAsyncContext for the outer marker");
+            AssertTrue(stream, completeCountForMarker >= 1, "Expected at least one CompleteAsyncContext for the outer marker");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1108,13 +1108,13 @@ namespace System.Threading.Tasks.Tests
             // in a subsequent AppendAsyncCallstack carrying the remaining frames. Use the merged
             // view to validate the chain as a whole.
             var mergedMarker = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_CallstackDepthCappedAtMaxFrames_Marker));
-            Assert.NotEmpty(mergedMarker);
+            AssertNotEmpty(stream, mergedMarker);
 
             var deepest = mergedMarker.MaxBy(cs => cs.Frames.Count);
-            Assert.NotNull(deepest);
+            AssertNotNull(stream, deepest);
 
             // Walker should have captured at least the full requested depth across Resume+Appends.
-            Assert.True(deepest.Frames.Count >= requestedDepth,
+            AssertTrue(stream, deepest.Frames.Count >= requestedDepth,
                 $"Expected merged frame count >= {requestedDepth}, got {deepest.Frames.Count}");
 
             // Each individual event clamps its own FrameCount at byte.MaxValue (wire format limit).
@@ -1122,18 +1122,18 @@ namespace System.Threading.Tasks.Tests
             var perEventCallstacks = stream.ChainEventsFromDispatcher(chainDispatcherId)
                 .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncCallstack or AsyncEventID.TaskAsync_AppendAsyncCallstack)
                 .ToList();
-            Assert.NotEmpty(perEventCallstacks);
-            Assert.All(perEventCallstacks, cs => Assert.True(cs.FrameCount <= byte.MaxValue));
+            AssertNotEmpty(stream, perEventCallstacks);
+            AssertAll(stream, perEventCallstacks, cs => Assert.True(cs.FrameCount <= byte.MaxValue));
 
             // At least one event must have hit the cap (otherwise the test isn't exercising it).
-            Assert.Contains(perEventCallstacks, cs => cs.FrameCount == byte.MaxValue);
+            AssertContains(stream, perEventCallstacks, cs => cs.FrameCount == byte.MaxValue);
 
             // Every captured frame should resolve to a managed method.
             foreach (var (methodId, _) in deepest.Frames)
             {
-                Assert.True(methodId != 0, "Frame has zero MethodId");
+                AssertTrue(stream, methodId != 0, "Frame has zero MethodId");
                 var method = GetMethodNameFromMethodId(deepest.CallstackType, methodId);
-                Assert.True(method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
+                AssertTrue(stream, method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
             }
         }
 
@@ -1166,30 +1166,30 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackStressWithVaryingDepths_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Every emitted callstack must have valid frame data.
             foreach (var cs in markerCallstacks)
             {
-                Assert.True(cs.FrameCount > 0, "Callstack has 0 frames");
-                Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
+                AssertTrue(stream, cs.FrameCount > 0, "Callstack has 0 frames");
+                AssertEqual(stream, (int)cs.FrameCount, cs.Frames.Count);
                 for (int f = 0; f < cs.Frames.Count; f++)
                 {
                     var (methodId, _) = cs.Frames[f];
-                    Assert.True(methodId != 0, $"Frame {f} has zero MethodId");
+                    AssertTrue(stream, methodId != 0, $"Frame {f} has zero MethodId");
                     var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
-                    Assert.True(method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
+                    AssertTrue(stream, method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
                 }
             }
 
             // We expect at least one marker callstack per iteration.
-            Assert.True(markerCallstacks.Count >= iterations,
+            AssertTrue(stream, markerCallstacks.Count >= iterations,
                 $"Expected at least {iterations} callstacks with marker, got {markerCallstacks.Count}");
 
             // Verify multiple buffer flushes occurred -- proves the buffer machinery is exercised.
             int bufferCount = 0;
             ForEachEventBufferPayload(events, _ => bufferCount++);
-            Assert.True(bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
+            AssertTrue(stream, bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1232,7 +1232,7 @@ namespace System.Threading.Tasks.Tests
             // xunit runner's RunAsync state machine being replayed by ResetAsyncThreadContext and
             // completing while this test's listener is still active).
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
             ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
 
             var taskEvents = stream.ChainEventsFromDispatcher(markerDispatcherId);
@@ -1242,16 +1242,16 @@ namespace System.Threading.Tasks.Tests
             int suspendCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_SuspendAsyncContext);
 
             // At least one root Create event.
-            Assert.True(createCount >= 1,
+            AssertTrue(stream, createCount >= 1,
                 $"Expected at least one CreateAsyncContext event, got {createCount}");
 
-            Assert.Equal(createCount, completeCount);
-            Assert.Equal(resumeCount, completeCount);
+            AssertEqual(stream, createCount, completeCount);
+            AssertEqual(stream, resumeCount, completeCount);
 
             // Does not emit Suspend events.
-            Assert.Equal(0, suspendCount);
+            AssertEqual(stream, 0, suspendCount);
 
-            Assert.True(createCount >= 3,
+            AssertTrue(stream, createCount >= 3,
                 $"Expected fan-out chain to produce at least 3 CreateAsyncContext events (root + 2 child wraps), got {createCount}");
         }
 
@@ -1289,16 +1289,16 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             var frameNames = markerCallstacks[0].Frames
                 .Select(f => GetMethodNameFromMethodId(markerCallstacks[0].CallstackType, f.MethodId))
                 .Where(n => n is not null)
                 .ToList();
 
-            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalse_Leaf_Marker), frameNames);
-            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalse_Mid_Marker), frameNames);
-            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalse_Marker), frameNames);
+            AssertContains(stream, nameof(TaskAsync_ConfigureAwaitFalse_Leaf_Marker), frameNames);
+            AssertContains(stream, nameof(TaskAsync_ConfigureAwaitFalse_Mid_Marker), frameNames);
+            AssertContains(stream, nameof(TaskAsync_ConfigureAwaitFalse_Marker), frameNames);
 
             // ConfigureAwait(false) on a sequential await chain collapses Leaf -> Mid -> Marker into one
             // continuation chain, so exactly one Create / one Complete is expected in the marker's dispatcher tree.
@@ -1339,24 +1339,22 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Inner_Marker));
-            Assert.NotEmpty(innerCallstacks);
-
-            // Every dispatcher that was Created must Complete, even on the fault path.
-            int createCount = stream.OfType(AsyncEventID.TaskAsync_CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.TaskAsync_CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
+            AssertNotEmpty(stream, innerCallstacks);
 
             // Both inner (faulting) and outer marker chains must see exactly one Create and one Complete in their own dispatcher tree.
+            // (Scoped to each chain's dispatcher; a whole-stream Create/Complete balance would be polluted by unrelated dispatcher
+            // activity from other threads -- e.g. the xunit runner's state machine completing while this test's listener is active --
+            // and by Completes that can fall outside the captured window when a resume is scheduled rather than inlined.)
             AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(TaskAsync_FaultedTask_Inner_Marker));
             AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_FaultedTask_Marker));
 
             // The unwind must be attributed to the inner faulting chain.
             ulong innerDispatcherId = innerCallstacks[0].DispatcherId;
             int unwindCountForInner = stream.ChainEventsFromDispatcher(innerDispatcherId).Count(e => e.EventId == AsyncEventID.TaskAsync_UnwindAsyncException);
-            Assert.True(unwindCountForInner >= 1,
+            AssertTrue(stream, unwindCountForInner >= 1,
                 $"Expected at least one UnwindAsyncException on the faulted inner chain (DispatcherId {innerDispatcherId}), got {unwindCountForInner}");
         }
 
@@ -1396,10 +1394,10 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Inner_Marker));
-            Assert.NotEmpty(innerCallstacks);
+            AssertNotEmpty(stream, innerCallstacks);
 
             // Inner cancelled task + outer marker must each see exactly one Create and one Complete in their own dispatcher tree.
             AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(TaskAsync_TaskCancellation_Inner_Marker));
@@ -1426,19 +1424,19 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_EventSequenceOrder_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1469,8 +1467,8 @@ namespace System.Threading.Tasks.Tests
             int completeCount = methodEvents.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncMethod);
 
             // Marker -> Level1 -> Level2 -> Level3
-            Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
-            Assert.True(completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events for ValueTask chain, got {completeCount}");
+            AssertTrue(stream, resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
+            AssertTrue(stream, completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events for ValueTask chain, got {completeCount}");
         }
 
 
@@ -1494,10 +1492,10 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Marker -> Level1 -> Level2 -> Level3
-            Assert.Equal(4, markerCallstacks[0].FrameCount);
+            AssertEqual(stream, 4, markerCallstacks[0].FrameCount);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1520,10 +1518,10 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
-            Assert.Equal(methodIds.Count, methodIds.Distinct().Count());
+            AssertEqual(stream, methodIds.Count, methodIds.Distinct().Count());
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1567,22 +1565,22 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int unwindIdx = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
-            Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+            AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
             int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx + 1);
-            Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
+            AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
 
@@ -1627,25 +1625,25 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int unwindIdx1 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
-            Assert.True(unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
+            AssertTrue(stream, unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
 
             int unwindIdx2 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, unwindIdx1 + 1);
-            Assert.True(unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
+            AssertTrue(stream, unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
 
             int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx2 + 1);
-            Assert.True(completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
+            AssertTrue(stream, completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1686,7 +1684,7 @@ namespace System.Threading.Tasks.Tests
             // Locate the V1 dispatcher driving the marker chain via its ResumeAsyncCallstack
             // events (which carry the marker frames in their callstack).
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysPendingV1Chain");
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Thread-scoped replay assertion: at least one OS thread must have seen two
             // ResetAsyncThreadContext events AND show a marker ResumeAsyncCallstack plus
@@ -1700,7 +1698,7 @@ namespace System.Threading.Tasks.Tests
                 .GroupBy(e => e.OsThreadId)
                 .Where(g => g.Count() >= 2)
                 .ToList();
-            Assert.NotEmpty(resetsByThread);
+            AssertNotEmpty(stream, resetsByThread);
 
             bool found = false;
             foreach (var threadResets in resetsByThread)
@@ -1732,7 +1730,7 @@ namespace System.Threading.Tasks.Tests
                 break;
             }
 
-            Assert.True(found,
+            AssertTrue(stream, found,
                 "Expected at least one OS thread with >= 2 ResetAsyncThreadContext events followed by a marker ResumeAsyncCallstack and matching ResumeAsyncContext.");
         }
 
@@ -1799,7 +1797,7 @@ namespace System.Threading.Tasks.Tests
 
             // The replay must emit at least one ResumeAsyncCallstack carrying the V1 marker chain.
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysMultipleDispatchers");
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // The decisive proof: find an OS thread where a single ResetAsyncThreadContext
             // event is followed by >= 2 ResumeAsyncContext events before the next reset
@@ -1810,7 +1808,7 @@ namespace System.Threading.Tasks.Tests
                 .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
                 .GroupBy(e => e.OsThreadId)
                 .ToList();
-            Assert.NotEmpty(resetsByThread);
+            AssertNotEmpty(stream, resetsByThread);
 
             bool found = false;
             foreach (var threadResets in resetsByThread)
@@ -1844,7 +1842,7 @@ namespace System.Threading.Tasks.Tests
                 }
             }
 
-            Assert.True(found,
+            AssertTrue(stream, found,
                 "Expected at least one OS thread with a ResetAsyncThreadContext event " +
                 "followed by >= 2 ResumeAsyncContext events in the same reset window, " +
                 "proving the reset-replay walker traversed multiple nested dispatchers.");
@@ -1890,7 +1888,7 @@ namespace System.Threading.Tasks.Tests
             // callstack carrying the marker frames.
             var markerCallstacks = stream.CallstacksWithMarker(
                 AsyncEventID.TaskAsync_ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplayResumeCompleteBalance");
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Resume/Complete balance across the replay boundary. V1 uses a per-MoveNext dispatcher
             // model, so the marker chain spans a dispatcher tree whose deepest replayed callstack
@@ -1905,7 +1903,7 @@ namespace System.Threading.Tasks.Tests
             int completeMethodCount = stream.ChainEventsFromDispatcher(leafDispatcherId)
                 .Count(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncMethod);
 
-            Assert.True(completeMethodCount >= deepest.FrameCount,
+            AssertTrue(stream, completeMethodCount >= deepest.FrameCount,
                 $"Expected at least {deepest.FrameCount} TaskAsync_CompleteAsyncMethod events across the " +
                 $"trace for marker dispatcher chain {leafDispatcherId} to balance the replayed callstack of " +
                 $"depth {deepest.FrameCount}, but found {completeMethodCount}.");
@@ -1948,35 +1946,52 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // The marker frame must appear in a Resume callstack -- proves the chain was walkable.
+            // This is the deterministic, scheduling-independent core of the test: when the chain
+            // first resumes (gate set), V1 emits a ResumeAsyncCallstack carrying the remaining chain,
+            // which at first resume is all three frames.
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
             var frameNames = deepest.Frames
                 .Select(f => GetMethodNameFromMethodId(deepest.CallstackType, f.MethodId))
                 .Where(n => n is not null)
                 .ToList();
-            Assert.Contains(nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker), frameNames);
-            Assert.Contains(nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker), frameNames);
-            Assert.Contains(nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker), frameNames);
+            AssertContains(stream, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker), frameNames);
+            AssertContains(stream, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker), frameNames);
+            AssertContains(stream, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker), frameNames);
 
-            // Create balanced by Complete on the synchronous cascade path.
-            int createCount = stream.OfType(AsyncEventID.TaskAsync_CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.TaskAsync_CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
+            // Lifecycle ORDERING (not counting). We deliberately do not assert global Create/Complete
+            // balance or an exact dispatcher count: depending on whether the resume cascade inlines,
+            // the chain may collapse into one dispatcher or split into several across scheduling
+            // boundaries, and a scheduled/nested resume can push a dispatcher's CompleteAsyncContext
+            // (or its method-complete events) outside the captured trace window. Those counts are
+            // therefore not invariants. What IS invariant is the per-dispatcher ordering of whatever
+            // events were captured: a dispatcher is created before it resumes, and completes (if its
+            // Complete is in-window) after it resumes.
+            foreach (ulong dispatcherId in markerCallstacks.Select(c => c.DispatcherId).Distinct())
+            {
+                var dispatcherEvents = stream.All
+                    .Where(e => e.DispatcherId == dispatcherId)
+                    .OrderBy(e => e.Timestamp)
+                    .ToList();
 
-            // Inline-cascade optimization: exactly 1 Create for the entire chain.
-            Assert.Equal(1, createCount);
+                ParsedEvent? createEvt = dispatcherEvents.FirstOrDefault(e => e.EventId == AsyncEventID.TaskAsync_CreateAsyncContext);
+                ParsedEvent? resumeEvt = dispatcherEvents.FirstOrDefault(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext);
+                ParsedEvent? completeEvt = dispatcherEvents.FirstOrDefault(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncContext);
 
-            int methodResumeCount = stream.OfType(AsyncEventID.TaskAsync_ResumeAsyncMethod).Count();
-            int methodCompleteCount = stream.OfType(AsyncEventID.TaskAsync_CompleteAsyncMethod).Count();
+                if (createEvt is not null && resumeEvt is not null)
+                {
+                    AssertTrue(stream, createEvt.Timestamp <= resumeEvt.Timestamp,
+                        $"Dispatcher {dispatcherId}: CreateAsyncContext must precede ResumeAsyncContext.");
+                }
 
-            // Method-level events should be balanced.
-            Assert.Equal(methodResumeCount, methodCompleteCount);
-
-            // No AppendAsyncCallstack events should be emitted in this scenario.
-            int appendCount = stream.OfType(AsyncEventID.TaskAsync_AppendAsyncCallstack).Count();
-            Assert.Equal(0, appendCount);
+                if (resumeEvt is not null && completeEvt is not null)
+                {
+                    AssertTrue(stream, resumeEvt.Timestamp <= completeEvt.Timestamp,
+                        $"Dispatcher {dispatcherId}: CompleteAsyncContext must follow ResumeAsyncContext.");
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -148,7 +148,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var creates = stream.OfType(AsyncEventID.CreateAsyncContext).ToList();
+            var creates = stream.OfType(AsyncEventID.TaskAsync_CreateAsyncContext).ToList();
             Assert.True(creates.Count >= 1, $"Expected at least 1 CreateAsyncContext, got {creates.Count}");
         }
 
@@ -171,19 +171,19 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_EventSequenceOrder_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_EventSequenceOrder_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -208,26 +208,26 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_SuspendResumeCompleteEvents_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_SuspendResumeCompleteEvents_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeCount = ids.Count(id => id == AsyncEventID.ResumeAsyncContext);
+            int resumeCount = ids.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncContext);
             Assert.True(resumeCount >= 1, "Expected at least one ResumeAsyncContext");
 
-            int completeCount = ids.Count(id => id == AsyncEventID.CompleteAsyncContext);
+            int completeCount = ids.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
             Assert.True(completeCount >= 1, "Expected at least one CompleteAsyncContext");
 
             // Expected ResumeAsyncContext and CompleteAsyncContext counts to match.
             Assert.Equal(resumeCount, completeCount);
 
             // Expected no SuspendAsyncContext events.
-            Assert.DoesNotContain(AsyncEventID.SuspendAsyncContext, ids);
+            Assert.DoesNotContain(AsyncEventID.TaskAsync_SuspendAsyncContext, ids);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -243,8 +243,8 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             var ids = stream.EventIds;
 
-            Assert.Contains(AsyncEventID.ResumeAsyncMethod, ids);
-            Assert.Contains(AsyncEventID.CompleteAsyncMethod, ids);
+            Assert.Contains(AsyncEventID.TaskAsync_ResumeAsyncMethod, ids);
+            Assert.Contains(AsyncEventID.TaskAsync_CompleteAsyncMethod, ids);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -266,22 +266,22 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            int unwindIdx = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
             Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx + 1);
             Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
@@ -310,25 +310,25 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int unwindIdx1 = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            int unwindIdx1 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
             Assert.True(unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
 
-            int unwindIdx2 = ids.IndexOf(AsyncEventID.UnwindAsyncException, unwindIdx1 + 1);
+            int unwindIdx2 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, unwindIdx1 + 1);
             Assert.True(unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx2 + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx2 + 1);
             Assert.True(completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
         }
 
@@ -355,7 +355,7 @@ namespace System.Threading.Tasks.Tests
             // Marker -> DeepChain -> Level1 -> Level2 -> Level3
             const int ExpectedChainDepth = 5;
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_MethodEventCountMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_MethodEventCountMatchesChainDepth_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             Assert.Equal(ExpectedChainDepth, markerCallstacks[0].Frames.Count);
@@ -363,10 +363,10 @@ namespace System.Threading.Tasks.Tests
             ulong chainTaskId = markerCallstacks[0].TaskId;
             var chainEvents = stream.ForTask(chainTaskId);
 
-            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.ResumeAsyncMethod);
+            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncMethod);
             Assert.Equal(ExpectedChainDepth, resumeCount);
 
-            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.CompleteAsyncMethod);
+            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncMethod);
             Assert.Equal(ExpectedChainDepth, completeCount);
         }
 
@@ -389,7 +389,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_HandledException_MethodEventsWithUnwind_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_HandledException_MethodEventsWithUnwind_Marker));
 
             Assert.NotEmpty(markerCallstacks);
 
@@ -397,21 +397,21 @@ namespace System.Threading.Tasks.Tests
             var chainEvents = stream.ForTask(chainTaskId);
 
             var sequence = chainEvents
-                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod
-                    or AsyncEventID.CompleteAsyncMethod
-                    or AsyncEventID.UnwindAsyncException)
+                .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncMethod
+                    or AsyncEventID.TaskAsync_CompleteAsyncMethod
+                    or AsyncEventID.TaskAsync_UnwindAsyncException)
                 .Select(e => e.EventId)
                 .ToList();
 
             // Exactly one Unwind expected on the chain's context (InnerThrows throws once).
-            Assert.Equal(1, sequence.Count(id => id == AsyncEventID.UnwindAsyncException));
+            Assert.Equal(1, sequence.Count(id => id == AsyncEventID.TaskAsync_UnwindAsyncException));
 
             // Around the Unwind: the throwing method's Resume precedes it, and the catching
             // method's Resume -> Complete pair follows.
-            int unwindIdx = sequence.IndexOf(AsyncEventID.UnwindAsyncException);
-            Assert.Equal(AsyncEventID.ResumeAsyncMethod, sequence[unwindIdx - 1]);
-            Assert.Equal(AsyncEventID.ResumeAsyncMethod, sequence[unwindIdx + 1]);
-            Assert.Equal(AsyncEventID.CompleteAsyncMethod, sequence[unwindIdx + 2]);
+            int unwindIdx = sequence.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException);
+            Assert.Equal(AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[unwindIdx - 1]);
+            Assert.Equal(AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[unwindIdx + 1]);
+            Assert.Equal(AsyncEventID.TaskAsync_CompleteAsyncMethod, sequence[unwindIdx + 2]);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -442,29 +442,29 @@ namespace System.Threading.Tasks.Tests
             // Marker -> UnhandledExceptionOuter -> UnhandledExceptionInner
             const int ExpectedChainDepth = 3;
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong chainTaskId = markerCallstacks[0].TaskId;
             var chainEvents = stream.ForTask(chainTaskId);
 
             var sequence = chainEvents
-                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod
-                    or AsyncEventID.CompleteAsyncMethod
-                    or AsyncEventID.UnwindAsyncException)
+                .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncMethod
+                    or AsyncEventID.TaskAsync_CompleteAsyncMethod
+                    or AsyncEventID.TaskAsync_UnwindAsyncException)
                 .Select(e => e.EventId)
                 .ToList();
 
             // Every method in the chain unwinds (no catch); no CompleteAsyncMethod expected.
-            Assert.Equal(ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.ResumeAsyncMethod));
-            Assert.Equal(ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.UnwindAsyncException));
-            Assert.Equal(0, sequence.Count(id => id == AsyncEventID.CompleteAsyncMethod));
+            Assert.Equal(ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncMethod));
+            Assert.Equal(ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.TaskAsync_UnwindAsyncException));
+            Assert.Equal(0, sequence.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncMethod));
 
             // Per-method ordering: each Resume is immediately followed by its Unwind.
             for (int i = 0; i < sequence.Count; i += 2)
             {
-                Assert.Equal(AsyncEventID.ResumeAsyncMethod, sequence[i]);
-                Assert.Equal(AsyncEventID.UnwindAsyncException, sequence[i + 1]);
+                Assert.Equal(AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[i]);
+                Assert.Equal(AsyncEventID.TaskAsync_UnwindAsyncException, sequence[i + 1]);
             }
         }
 
@@ -487,7 +487,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_ResumeAsyncCallstackEmitted_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_ResumeAsyncCallstackEmitted_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             Assert.All(markerCallstacks, cs =>
@@ -516,7 +516,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CallstackDepthMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackDepthMatchesChainDepth_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // TaskAsync_CallstackDepthMarker -> Level1 -> Level2 -> Level3: deepest callstack should have exactly 4 frames
@@ -542,7 +542,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Frames in the same callstack should have distinct methodIds (different async methods)
@@ -593,7 +593,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctStates_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctStates_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // The deepest callstack (on the final Delay resume) should have 4 frames:
@@ -652,7 +652,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_YieldAtEachLevel_CallstackShrinks_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_YieldAtEachLevel_CallstackShrinks_Marker));
 
             // After Task.Delay resumes: full chain (Level3, Level2, Level1, Marker) = 4 frames
             // After Level3's yield resumes: Level3 completes, chain is (Level2, Level1, Marker) = 3 frames
@@ -698,12 +698,12 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // The initial Resume should only include TaskAsync_AppendRace_Child (race: Parent not registered yet).
-            var childOnlyResumes = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker));
+            var childOnlyResumes = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker));
             Assert.NotEmpty(childOnlyResumes);
 
             // After Parent registers and Child hits its next complete hook,
             // an AppendAsyncCallstack should fire with the Parent frame.
-            var appendsWithParent = stream.CallstacksWithMarker(AsyncEventID.AppendAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker));
+            var appendsWithParent = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_AppendAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker));
             Assert.NotEmpty(appendsWithParent);
         }
 
@@ -727,13 +727,13 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // Sanity: the marker frame must appear in the initial Resume callstack (full chain captured).
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // No Append events should fire on this context -- the chain was complete at Resume time.
             ulong chainTaskId = markerCallstacks[0].TaskId;
             var appendEvents = stream.ForTask(chainTaskId)
-                .Where(e => e.EventId == AsyncEventID.AppendAsyncCallstack)
+                .Where(e => e.EventId == AsyncEventID.TaskAsync_AppendAsyncCallstack)
                 .ToList();
             Assert.Empty(appendEvents);
         }
@@ -782,20 +782,20 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // The marker frame should appear in the Resume callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Verify the standard Create -> Resume -> Complete sequence fired for our context.
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the custom SyncContext scenario");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -836,20 +836,20 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Verify standard Create -> Resume -> Complete sequence for our context.
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the custom TaskScheduler scenario");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -873,23 +873,23 @@ namespace System.Threading.Tasks.Tests
 
             var ids = ParseAllEvents(events).EventIds;
             int contextEvents = ids.Count(id =>
-                id == AsyncEventID.CreateAsyncContext ||
-                id == AsyncEventID.ResumeAsyncContext ||
-                id == AsyncEventID.SuspendAsyncContext ||
-                id == AsyncEventID.CompleteAsyncContext);
+                id == AsyncEventID.TaskAsync_CreateAsyncContext ||
+                id == AsyncEventID.TaskAsync_ResumeAsyncContext ||
+                id == AsyncEventID.TaskAsync_SuspendAsyncContext ||
+                id == AsyncEventID.TaskAsync_CompleteAsyncContext);
 
             Assert.Equal(0, contextEvents);
         }
 
         public static IEnumerable<object[]> TaskAsyncKeywordGatekeepingData()
         {
-            yield return new object[] { (long)CreateAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CreateAsyncContext } };
-            yield return new object[] { (long)ResumeAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncContext } };
-            yield return new object[] { (long)CompleteAsyncContextKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteAsyncContext } };
-            yield return new object[] { (long)UnwindAsyncExceptionKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.UnwindAsyncException } };
-            yield return new object[] { (long)ResumeAsyncCallstackKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncCallstack, AsyncEventID.AppendAsyncCallstack } };
-            yield return new object[] { (long)ResumeAsyncMethodKeyword,     new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncMethod } };
-            yield return new object[] { (long)CompleteAsyncMethodKeyword,   new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteAsyncMethod } };
+            yield return new object[] { (long)CreateAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_CreateAsyncContext } };
+            yield return new object[] { (long)ResumeAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_ResumeAsyncContext } };
+            yield return new object[] { (long)CompleteAsyncContextKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_CompleteAsyncContext } };
+            yield return new object[] { (long)UnwindAsyncExceptionKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_UnwindAsyncException } };
+            yield return new object[] { (long)ResumeAsyncCallstackKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_ResumeAsyncCallstack, AsyncEventID.TaskAsync_AppendAsyncCallstack } };
+            yield return new object[] { (long)ResumeAsyncMethodKeyword,     new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_ResumeAsyncMethod } };
+            yield return new object[] { (long)CompleteAsyncMethodKeyword,   new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_CompleteAsyncMethod } };
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -967,13 +967,13 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Each branch is its own async chain; its inner await of Task.Delay produces a Resume callstack containing the branch frame.
-            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
-            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker));
-            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker));
             Assert.NotEmpty(branchACallstacks);
             Assert.NotEmpty(branchBCallstacks);
             Assert.NotEmpty(branchCCallstacks);
@@ -988,17 +988,17 @@ namespace System.Threading.Tasks.Tests
             ulong markerTaskId = markerCallstacks[0].TaskId;
             var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
 
-            int createIdx = markerIds.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the WhenAll outer marker");
 
-            int resumeIdx = markerIds.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
 
-            int completeIdx = markerIds.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
 
             // The outer should be created exactly once.
-            int createCountForMarker = markerIds.Count(id => id == AsyncEventID.CreateAsyncContext);
+            int createCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.Equal(1, createCountForMarker);
         }
 
@@ -1047,15 +1047,15 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // All branches - including the slow ones whose completion the outer is no longer
             // strictly waiting on after WhenAny returned -- must produce their own Resume
             // callstacks. This proves their dispatcher lifetimes are tracked independently.
-            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
-            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker));
-            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker));
             Assert.NotEmpty(fastCallstacks);
             Assert.NotEmpty(slow1Callstacks);
             Assert.NotEmpty(slow2Callstacks);
@@ -1072,11 +1072,11 @@ namespace System.Threading.Tasks.Tests
             var markerEvents = stream.ForTask(markerTaskId);
             var markerIds = markerEvents.Select(e => e.EventId).ToList();
 
-            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.ResumeAsyncContext);
+            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncContext);
             Assert.True(resumeCountForMarker >= 1,
                 $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
 
-            int completeCountForMarker = markerIds.Count(id => id == AsyncEventID.CompleteAsyncContext);
+            int completeCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
             Assert.True(completeCountForMarker >= 1, "Expected at least one CompleteAsyncContext for the outer marker");
         }
 
@@ -1120,7 +1120,7 @@ namespace System.Threading.Tasks.Tests
             // Each individual event clamps its own FrameCount at byte.MaxValue (wire format limit).
             ulong chainTaskId = deepest.TaskId;
             var perEventCallstacks = stream.ForTask(chainTaskId)
-                .Where(e => e.EventId is AsyncEventID.ResumeAsyncCallstack or AsyncEventID.AppendAsyncCallstack)
+                .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncCallstack or AsyncEventID.TaskAsync_AppendAsyncCallstack)
                 .ToList();
             Assert.NotEmpty(perEventCallstacks);
             Assert.All(perEventCallstacks, cs => Assert.True(cs.FrameCount <= byte.MaxValue));
@@ -1165,7 +1165,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CallstackStressWithVaryingDepths_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackStressWithVaryingDepths_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Every emitted callstack must have valid frame data.
@@ -1231,15 +1231,15 @@ namespace System.Threading.Tasks.Tests
             // chain and not polluted by unrelated dispatcher activity from other threads (e.g. the
             // xunit runner's RunAsync state machine being replayed by ResetAsyncThreadContext and
             // completing while this test's listener is still active).
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
             ulong markerTaskId = markerCallstacks[0].TaskId;
 
             var taskEvents = stream.ForTask(markerTaskId);
-            int createCount = taskEvents.Count(e => e.EventId == AsyncEventID.CreateAsyncContext);
-            int completeCount = taskEvents.Count(e => e.EventId == AsyncEventID.CompleteAsyncContext);
-            int resumeCount = taskEvents.Count(e => e.EventId == AsyncEventID.ResumeAsyncContext);
-            int suspendCount = taskEvents.Count(e => e.EventId == AsyncEventID.SuspendAsyncContext);
+            int createCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_CreateAsyncContext);
+            int completeCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncContext);
+            int resumeCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext);
+            int suspendCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_SuspendAsyncContext);
 
             // At least one root Create event.
             Assert.True(createCount >= 1,
@@ -1288,7 +1288,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             var frameNames = markerCallstacks[0].Frames
@@ -1338,15 +1338,15 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Inner_Marker));
+            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Inner_Marker));
             Assert.NotEmpty(innerCallstacks);
 
             // Every dispatcher that was Created must Complete, even on the fault path.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            int createCount = stream.OfType(AsyncEventID.TaskAsync_CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.TaskAsync_CompleteAsyncContext).Count();
             Assert.Equal(createCount, completeCount);
 
             // Both inner (faulting) and outer marker chains must see exactly one Create and one Complete on their own TaskId.
@@ -1355,7 +1355,7 @@ namespace System.Threading.Tasks.Tests
 
             // The unwind must be attributed to the inner faulting chain.
             ulong innerTaskId = innerCallstacks[0].TaskId;
-            int unwindCountForInner = stream.ForTask(innerTaskId).Count(e => e.EventId == AsyncEventID.UnwindAsyncException);
+            int unwindCountForInner = stream.ForTask(innerTaskId).Count(e => e.EventId == AsyncEventID.TaskAsync_UnwindAsyncException);
             Assert.True(unwindCountForInner >= 1,
                 $"Expected at least one UnwindAsyncException on the faulted inner chain (TaskId {innerTaskId}), got {unwindCountForInner}");
         }
@@ -1395,10 +1395,10 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Inner_Marker));
+            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Inner_Marker));
             Assert.NotEmpty(innerCallstacks);
 
             // Inner cancelled task + outer marker must each see exactly one Create and one Complete on their own TaskId.
@@ -1425,19 +1425,19 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_EventSequenceOrder_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_EventSequenceOrder_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -1461,12 +1461,12 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var methodEvents = stream.All
-                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod or AsyncEventID.CompleteAsyncMethod)
+                .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncMethod or AsyncEventID.TaskAsync_CompleteAsyncMethod)
                 .Select(e => e.EventId)
                 .ToList();
 
-            int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeAsyncMethod);
-            int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteAsyncMethod);
+            int resumeCount = methodEvents.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncMethod);
+            int completeCount = methodEvents.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncMethod);
 
             // Marker -> Level1 -> Level2 -> Level3
             Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
@@ -1493,7 +1493,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Marker -> Level1 -> Level2 -> Level3
@@ -1519,7 +1519,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
@@ -1566,22 +1566,22 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            int unwindIdx = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
             Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx + 1);
             Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
@@ -1626,25 +1626,25 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int unwindIdx1 = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            int unwindIdx1 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
             Assert.True(unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
 
-            int unwindIdx2 = ids.IndexOf(AsyncEventID.UnwindAsyncException, unwindIdx1 + 1);
+            int unwindIdx2 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, unwindIdx1 + 1);
             Assert.True(unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx2 + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx2 + 1);
             Assert.True(completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
         }
 
@@ -1685,7 +1685,7 @@ namespace System.Threading.Tasks.Tests
 
             // Locate the V1 dispatcher driving the marker chain via its ResumeAsyncCallstack
             // events (which carry the marker frames in their callstack).
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysPendingV1Chain");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysPendingV1Chain");
             Assert.NotEmpty(markerCallstacks);
 
             // Thread-scoped replay assertion: at least one OS thread must have seen two
@@ -1718,7 +1718,7 @@ namespace System.Threading.Tasks.Tests
 
                 var replayTaskIds = postResetMarkerCallstacks.Select(c => c.TaskId).ToHashSet();
                 var postResetResumeContext = stream.All
-                    .Where(e => e.EventId == AsyncEventID.ResumeAsyncContext
+                    .Where(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext
                                 && e.OsThreadId == threadId
                                 && e.Timestamp >= lastResetTimestamp
                                 && replayTaskIds.Contains(e.TaskId))
@@ -1798,7 +1798,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // The replay must emit at least one ResumeAsyncCallstack carrying the V1 marker chain.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysMultipleDispatchers");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysMultipleDispatchers");
             Assert.NotEmpty(markerCallstacks);
 
             // The decisive proof: find an OS thread where a single ResetAsyncThreadContext
@@ -1826,7 +1826,7 @@ namespace System.Threading.Tasks.Tests
                         : long.MaxValue;
 
                     int resumeContextCount = stream.All
-                        .Count(e => e.EventId == AsyncEventID.ResumeAsyncContext
+                        .Count(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext
                                     && e.OsThreadId == threadId
                                     && e.Timestamp >= windowStart
                                     && e.Timestamp < windowEnd);
@@ -1887,7 +1887,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // The marker frame must appear in a Resume callstack -- proves the chain was walkable.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
@@ -1900,21 +1900,21 @@ namespace System.Threading.Tasks.Tests
             Assert.Contains(nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker), frameNames);
 
             // Create balanced by Complete on the synchronous cascade path.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            int createCount = stream.OfType(AsyncEventID.TaskAsync_CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.TaskAsync_CompleteAsyncContext).Count();
             Assert.Equal(createCount, completeCount);
 
             // Inline-cascade optimization: exactly 1 Create for the entire chain.
             Assert.Equal(1, createCount);
 
-            int methodResumeCount = stream.OfType(AsyncEventID.ResumeAsyncMethod).Count();
-            int methodCompleteCount = stream.OfType(AsyncEventID.CompleteAsyncMethod).Count();
+            int methodResumeCount = stream.OfType(AsyncEventID.TaskAsync_ResumeAsyncMethod).Count();
+            int methodCompleteCount = stream.OfType(AsyncEventID.TaskAsync_CompleteAsyncMethod).Count();
 
             // Method-level events should be balanced.
             Assert.Equal(methodResumeCount, methodCompleteCount);
 
             // No AppendAsyncCallstack events should be emitted in this scenario.
-            int appendCount = stream.OfType(AsyncEventID.AppendAsyncCallstack).Count();
+            int appendCount = stream.OfType(AsyncEventID.TaskAsync_AppendAsyncCallstack).Count();
             Assert.Equal(0, appendCount);
         }
     }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -122,7 +122,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_EventsEmitted()
         {
             var events = CollectEvents(CoreKeywords, () =>
@@ -136,7 +136,7 @@ namespace System.Threading.Tasks.Tests
             Assert.Contains(events.Events, e => e.EventId == AsyncEventsId);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_CreateAsyncContextEmittedOnFirstAwait()
         {
             var events = CollectEvents(CoreKeywords, () =>
@@ -159,7 +159,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_EventSequenceOrder()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -196,7 +196,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_SuspendResumeCompleteEvents()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -230,7 +230,7 @@ namespace System.Threading.Tasks.Tests
             Assert.DoesNotContain(AsyncEventID.TaskAsync_SuspendAsyncContext, ids);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_ResumeCompleteMethodEvents()
         {
             var events = CollectEvents(MethodKeywords, () =>
@@ -254,7 +254,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_ExceptionHandled();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_HandledException_EmitsUnwindAndComplete()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
@@ -292,7 +292,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_UnhandledExceptionOuter();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_UnhandledException_EmitsUnwindAndComplete()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
@@ -340,7 +340,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_DeepChain();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_MethodEventCountMatchesChainDepth()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | MethodKeywords | CoreKeywords, () =>
@@ -377,7 +377,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_ExceptionHandled();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_HandledException_MethodEventsWithUnwind()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
@@ -421,7 +421,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_UnhandledExceptionOuter();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_UnhandledException_MethodEventsWithUnwind()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
@@ -475,7 +475,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_DeepChain();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_ResumeAsyncCallstackEmitted()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -504,7 +504,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_CallstackDepthMatchesChainDepth()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -530,7 +530,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_CallstackFramesHaveDistinctMethodIds()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -581,7 +581,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_CallstackFramesHaveDistinctStates_Root_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_CallstackFramesHaveDistinctStates()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -640,7 +640,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_YieldAtEachLevel_CallstackShrinks_Level1_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_YieldAtEachLevel_CallstackShrinks()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -683,7 +683,7 @@ namespace System.Threading.Tasks.Tests
             await t;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_AppendCallstack_FiresOnLateParentRegistration()
         {
             s_appendRace_proceed = new SemaphoreSlim(0, 1);
@@ -714,7 +714,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_DeepChain();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_CompleteChain_DoesNotEmitAppendEvents()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -763,7 +763,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack()
         {
             s_taskAsyncSyncContextCtx = new InlinePostSynchronizationContext();
@@ -806,7 +806,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack()
         {
             var scheduler = new InlineRunTaskScheduler();
@@ -860,7 +860,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(50);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_NoEventsWhenDisabled()
         {
             for (int i = 0; i < 50; i++)
@@ -905,7 +905,7 @@ namespace System.Threading.Tasks.Tests
             await Task.Delay(50);
         }
 
-        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         [MemberData(nameof(TaskAsyncKeywordGatekeepingData))]
         public void TaskAsync_KeywordGatekeeping(long keywordValue, AsyncEventID[] allowedEventIds)
         {
@@ -955,7 +955,7 @@ namespace System.Threading.Tasks.Tests
                 TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker());
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_WhenAll_TracksAllBranches()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -1035,7 +1035,7 @@ namespace System.Threading.Tasks.Tests
             await Task.WhenAll(slow1, slow2);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_WhenAny_TracksAllBranches()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -1087,7 +1087,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_RecursiveChain(depth);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_CallstackDepthCappedAtMaxFrames()
         {
             // Build a chain deeper than the 255-frame cap (byte FrameCount). The deepest
@@ -1144,7 +1144,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_RecursiveChain(depth);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_CallstackStressWithVaryingDepths()
         {
             const int iterations = 100;
@@ -1215,7 +1215,7 @@ namespace System.Threading.Tasks.Tests
             await Task.WhenAll(b1, b2);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_WaitThenYield_BalancesResumeAndComplete()
         {
             var events = CollectEvents(CoreKeywords | ResumeAsyncCallstackKeyword, () =>
@@ -1276,7 +1276,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_ConfigureAwaitFalse_Mid_Marker().ConfigureAwait(false);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_ConfigureAwaitFalse()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -1326,7 +1326,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_FaultedTask()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
@@ -1383,7 +1383,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_TaskCancellation()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
@@ -1413,7 +1413,7 @@ namespace System.Threading.Tasks.Tests
             await ValueTaskAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void ValueTaskAsync_EventSequenceOrder()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -1448,7 +1448,7 @@ namespace System.Threading.Tasks.Tests
             await ValueTaskAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void ValueTaskAsync_MethodEventsEmitted()
         {
             var events = CollectEvents(MethodKeywords | CoreKeywords, () =>
@@ -1481,7 +1481,7 @@ namespace System.Threading.Tasks.Tests
             await ValueTaskAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void ValueTaskAsync_CallstackDepthMatchesChainDepth()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -1507,7 +1507,7 @@ namespace System.Threading.Tasks.Tests
             await ValueTaskAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void ValueTaskAsync_CallstackFramesHaveDistinctMethodIds()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
@@ -1554,7 +1554,7 @@ namespace System.Threading.Tasks.Tests
             await ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Handled_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void ValueTaskAsync_HandledException_EmitsUnwindAndComplete()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
@@ -1608,7 +1608,7 @@ namespace System.Threading.Tasks.Tests
             await ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledOuter_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
@@ -1671,7 +1671,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_ResetContext_ReplaysPendingV1Chain_Mid_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_ResetContext_ReplaysPendingV1Chain()
         {
             var events = CollectEvents(AllKeywords, () =>
@@ -1757,7 +1757,7 @@ namespace System.Threading.Tasks.Tests
             await innerDone.Task;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
         public void TaskAsync_ResetContext_ReplaysMultipleDispatchers()
         {
             var events = CollectEvents(AllKeywords, () =>
@@ -1871,7 +1871,7 @@ namespace System.Threading.Tasks.Tests
             await TaskAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker(gate);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationSupported))]
         public async Task TaskAsync_SingleThread_ChainEventsAndCallstack()
         {
             var events = await CollectEventsAsync(ResumeAsyncCallstackKeyword | CoreKeywords | MethodKeywords, async () =>

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -5,61 +5,60 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Threading.Tasks.Tests
 {
-    // Tests for V1 (Task-based AsyncStateMachineBox) async profiler event emission.
+    // Tests for StateMachine (Task-based AsyncStateMachineBox) async profiler event emission.
     // All scenario methods use [RuntimeAsyncMethodGeneration(false)] to ensure they
     // exercise the legacy Task-based async path even if the default changes in the future.
-    // Most tests use sync CollectEvents with RunScenarioAndFlush to isolate the V1 chain
+    // Most tests use sync CollectEvents with RunScenarioAndFlush to isolate the StateMachine chain
     // on a threadpool thread, ensuring dispatcher finally blocks complete before flush.
     // Requires threading support.
     public partial class AsyncProfilerTests
     {
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_SingleYield()
+        private static async Task StateMachineAsync_SingleYield()
         {
             await Task.Yield();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_DeepChain()
+        private static async Task StateMachineAsync_DeepChain()
         {
-            await TaskAsync_Level1();
+            await StateMachineAsync_Level1();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_Level1()
+        private static async Task StateMachineAsync_Level1()
         {
-            await TaskAsync_Level2();
+            await StateMachineAsync_Level2();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_Level2()
+        private static async Task StateMachineAsync_Level2()
         {
-            await TaskAsync_Level3();
+            await StateMachineAsync_Level3();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_Level3()
+        private static async Task StateMachineAsync_Level3()
         {
             await Task.Delay(100);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ExceptionHandled()
+        private static async Task StateMachineAsync_ExceptionHandled()
         {
             try
             {
-                await TaskAsync_InnerThrows();
+                await StateMachineAsync_InnerThrows();
             }
             catch (InvalidOperationException)
             {
@@ -68,7 +67,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_InnerThrows()
+        private static async Task StateMachineAsync_InnerThrows()
         {
             await Task.Delay(100);
             throw new InvalidOperationException("inner");
@@ -76,14 +75,14 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_UnhandledExceptionOuter()
+        private static async Task StateMachineAsync_UnhandledExceptionOuter()
         {
-            await TaskAsync_UnhandledExceptionInner();
+            await StateMachineAsync_UnhandledExceptionInner();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_UnhandledExceptionInner()
+        private static async Task StateMachineAsync_UnhandledExceptionInner()
         {
             await Task.Delay(100);
             throw new InvalidOperationException("unhandled inner");
@@ -91,43 +90,43 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_RecursiveChain(int depth)
+        private static async Task StateMachineAsync_RecursiveChain(int depth)
         {
             if (depth <= 1)
             {
                 await Task.Delay(100);
                 return;
             }
-            await TaskAsync_RecursiveChain(depth - 1);
+            await StateMachineAsync_RecursiveChain(depth - 1);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_Level1()
+        private static async ValueTask ValueStateMachineAsync_Level1()
         {
-            await ValueTaskAsync_Level2();
+            await ValueStateMachineAsync_Level2();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_Level2()
+        private static async ValueTask ValueStateMachineAsync_Level2()
         {
-            await ValueTaskAsync_Level3();
+            await ValueStateMachineAsync_Level3();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_Level3()
+        private static async ValueTask ValueStateMachineAsync_Level3()
         {
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_EventsEmitted()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_EventsEmitted()
         {
-            var events = CollectEvents(CoreKeywords, () =>
+            var events = CollectEvents(StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_SingleYield());
+                RunScenarioAndFlush(() => StateMachineAsync_SingleYield());
             });
 
             // DumpAllEvents(events);
@@ -136,106 +135,103 @@ namespace System.Threading.Tasks.Tests
             AssertContains(events, events.Events, e => e.EventId == AsyncEventsId);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_CreateAsyncContextEmittedOnFirstAwait()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CreateAsyncContextEmittedOnFirstAwait()
         {
-            var events = CollectEvents(CoreKeywords, () =>
+            var events = CollectEvents(StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_SingleYield());
+                RunScenarioAndFlush(() => StateMachineAsync_SingleYield());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var creates = stream.OfType(AsyncEventID.TaskAsync_CreateAsyncContext).ToList();
-            AssertTrue(stream, creates.Count >= 1, $"Expected at least 1 CreateAsyncContext, got {creates.Count}");
+            var creates = stream.OfType(AsyncEventID.CreateStateMachineAsyncContext).ToList();
+            AssertTrue(stream, creates.Count >= 1, $"Expected at least 1 CreateStateMachineAsyncContextKeyword, got {creates.Count}");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_EventSequenceOrder_Marker()
+        private static async Task StateMachineAsync_EventSequenceOrder_Marker()
         {
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_EventSequenceOrder()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_EventSequenceOrder()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_EventSequenceOrder_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_EventSequenceOrder_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_EventSequenceOrder_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_EventSequenceOrder_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, resumeIdx + 1);
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteStateMachineAsyncContext after Resume");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_SuspendResumeCompleteEvents_Marker()
+        private static async Task StateMachineAsync_SuspendResumeCompleteEvents_Marker()
         {
             await Task.Delay(100);
             await Task.Delay(100);
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_SuspendResumeCompleteEvents()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_SuspendResumeCompleteEvents()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_SuspendResumeCompleteEvents_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_SuspendResumeCompleteEvents_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_SuspendResumeCompleteEvents_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_SuspendResumeCompleteEvents_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext");
 
-            int resumeCount = ids.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncContext);
-            AssertTrue(stream, resumeCount >= 1, "Expected at least one ResumeAsyncContext");
+            int resumeCount = ids.Count(id => id == AsyncEventID.ResumeStateMachineAsyncContext);
+            AssertTrue(stream, resumeCount >= 1, "Expected at least one ResumeStateMachineAsyncContext");
 
-            int completeCount = ids.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
-            AssertTrue(stream, completeCount >= 1, "Expected at least one CompleteAsyncContext");
+            int completeCount = ids.Count(id => id == AsyncEventID.CompleteStateMachineAsyncContext);
+            AssertTrue(stream, completeCount >= 1, "Expected at least one CompleteStateMachineAsyncContext");
 
-            // Expected ResumeAsyncContext and CompleteAsyncContext counts to match.
+            // Expected ResumeStateMachineAsyncContext and CompleteStateMachineAsyncContext counts to match.
             AssertEqual(stream, resumeCount, completeCount);
-
-            // Expected no SuspendAsyncContext events.
-            AssertDoesNotContain(stream, AsyncEventID.TaskAsync_SuspendAsyncContext, ids);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_ResumeCompleteMethodEvents()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_ResumeCompleteMethodEvents()
         {
-            var events = CollectEvents(MethodKeywords, () =>
+            var events = CollectEvents(StateMachineAsyncMethodKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_SingleYield());
+                RunScenarioAndFlush(() => StateMachineAsync_SingleYield());
             });
 
             // DumpAllEvents(events);
@@ -243,63 +239,63 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             var ids = stream.EventIds;
 
-            AssertContains(stream, AsyncEventID.TaskAsync_ResumeAsyncMethod, ids);
-            AssertContains(stream, AsyncEventID.TaskAsync_CompleteAsyncMethod, ids);
+            AssertContains(stream, AsyncEventID.ResumeStateMachineAsyncMethod, ids);
+            AssertContains(stream, AsyncEventID.CompleteStateMachineAsyncMethod, ids);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_HandledException_EmitsUnwindAndComplete_Marker()
+        private static async Task StateMachineAsync_HandledException_EmitsUnwindAndComplete_Marker()
         {
-            await TaskAsync_ExceptionHandled();
+            await StateMachineAsync_ExceptionHandled();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_HandledException_EmitsUnwindAndComplete()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_HandledException_EmitsUnwindAndComplete()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_HandledException_EmitsUnwindAndComplete_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_HandledException_EmitsUnwindAndComplete_Marker());
             });
 
             //DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_HandledException_EmitsUnwindAndComplete_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
 
-            int unwindIdx = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
-            AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindStateMachineAsyncException, resumeIdx + 1);
+            AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindStateMachineAsyncException after Resume");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx + 1);
-            AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, unwindIdx + 1);
+            AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteStateMachineAsyncContext after Unwind");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker()
+        private static async Task StateMachineAsync_UnhandledException_EmitsUnwindAndComplete_Marker()
         {
-            await TaskAsync_UnhandledExceptionOuter();
+            await StateMachineAsync_UnhandledExceptionOuter();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_UnhandledException_EmitsUnwindAndComplete()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_UnhandledException_EmitsUnwindAndComplete()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
             {
                 try
                 {
-                    RunScenarioAndFlush(() => TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker());
+                    RunScenarioAndFlush(() => StateMachineAsync_UnhandledException_EmitsUnwindAndComplete_Marker());
                 }
                 catch (InvalidOperationException)
                 {
@@ -310,42 +306,42 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
 
-            int unwindIdx1 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
-            AssertTrue(stream, unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
+            int unwindIdx1 = ids.IndexOf(AsyncEventID.UnwindStateMachineAsyncException, resumeIdx + 1);
+            AssertTrue(stream, unwindIdx1 > resumeIdx, "Expected first UnwindStateMachineAsyncException after Resume");
 
-            int unwindIdx2 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, unwindIdx1 + 1);
-            AssertTrue(stream, unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
+            int unwindIdx2 = ids.IndexOf(AsyncEventID.UnwindStateMachineAsyncException, unwindIdx1 + 1);
+            AssertTrue(stream, unwindIdx2 > unwindIdx1, "Expected second UnwindStateMachineAsyncException after first Unwind");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx2 + 1);
-            AssertTrue(stream, completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, unwindIdx2 + 1);
+            AssertTrue(stream, completeIdx > unwindIdx2, "Expected CompleteStateMachineAsyncContext after second Unwind");
         }
 
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_MethodEventCountMatchesChainDepth_Marker()
+        private static async Task StateMachineAsync_MethodEventCountMatchesChainDepth_Marker()
         {
-            await TaskAsync_DeepChain();
+            await StateMachineAsync_DeepChain();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_MethodEventCountMatchesChainDepth()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_MethodEventCountMatchesChainDepth()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | MethodKeywords | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncMethodKeywords | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_MethodEventCountMatchesChainDepth_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_MethodEventCountMatchesChainDepth_Marker());
             });
 
             // DumpAllEvents(events);
@@ -355,7 +351,7 @@ namespace System.Threading.Tasks.Tests
             // Marker -> DeepChain -> Level1 -> Level2 -> Level3
             const int ExpectedChainDepth = 5;
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_MethodEventCountMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_MethodEventCountMatchesChainDepth_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             AssertEqual(stream, ExpectedChainDepth, markerCallstacks[0].Frames.Count);
@@ -363,33 +359,33 @@ namespace System.Threading.Tasks.Tests
             ulong leafDispatcherId = markerCallstacks[0].DispatcherId;
             var chainEvents = stream.ChainEventsFromDispatcher(leafDispatcherId);
 
-            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncMethod);
+            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncMethod);
             AssertEqual(stream, ExpectedChainDepth, resumeCount);
 
-            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncMethod);
+            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.CompleteStateMachineAsyncMethod);
             AssertEqual(stream, ExpectedChainDepth, completeCount);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_HandledException_MethodEventsWithUnwind_Marker()
+        private static async Task StateMachineAsync_HandledException_MethodEventsWithUnwind_Marker()
         {
-            await TaskAsync_ExceptionHandled();
+            await StateMachineAsync_ExceptionHandled();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_HandledException_MethodEventsWithUnwind()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_HandledException_MethodEventsWithUnwind()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncMethodKeywords | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_HandledException_MethodEventsWithUnwind_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_HandledException_MethodEventsWithUnwind_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_HandledException_MethodEventsWithUnwind_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_HandledException_MethodEventsWithUnwind_Marker));
 
             AssertNotEmpty(stream, markerCallstacks);
 
@@ -397,38 +393,38 @@ namespace System.Threading.Tasks.Tests
             var chainEvents = stream.ChainEventsFromDispatcher(leafDispatcherId);
 
             var sequence = chainEvents
-                .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncMethod
-                    or AsyncEventID.TaskAsync_CompleteAsyncMethod
-                    or AsyncEventID.TaskAsync_UnwindAsyncException)
+                .Where(e => e.EventId is AsyncEventID.ResumeStateMachineAsyncMethod
+                    or AsyncEventID.CompleteStateMachineAsyncMethod
+                    or AsyncEventID.UnwindStateMachineAsyncException)
                 .Select(e => e.EventId)
                 .ToList();
 
             // Exactly one Unwind expected on the chain (InnerThrows throws once).
-            AssertEqual(stream, 1, sequence.Count(id => id == AsyncEventID.TaskAsync_UnwindAsyncException));
+            AssertEqual(stream, 1, sequence.Count(id => id == AsyncEventID.UnwindStateMachineAsyncException ));
 
             // Around the Unwind: the throwing method's Resume precedes it, and the catching
             // method's Resume -> Complete pair follows.
-            int unwindIdx = sequence.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException);
-            AssertEqual(stream, AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[unwindIdx - 1]);
-            AssertEqual(stream, AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[unwindIdx + 1]);
-            AssertEqual(stream, AsyncEventID.TaskAsync_CompleteAsyncMethod, sequence[unwindIdx + 2]);
+            int unwindIdx = sequence.IndexOf(AsyncEventID.UnwindStateMachineAsyncException);
+            AssertEqual(stream, AsyncEventID.ResumeStateMachineAsyncMethod, sequence[unwindIdx - 1]);
+            AssertEqual(stream, AsyncEventID.ResumeStateMachineAsyncMethod, sequence[unwindIdx + 1]);
+            AssertEqual(stream, AsyncEventID.CompleteStateMachineAsyncMethod, sequence[unwindIdx + 2]);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker()
+        private static async Task StateMachineAsync_UnhandledException_MethodEventsWithUnwind_Marker()
         {
-            await TaskAsync_UnhandledExceptionOuter();
+            await StateMachineAsync_UnhandledExceptionOuter();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_UnhandledException_MethodEventsWithUnwind()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_UnhandledException_MethodEventsWithUnwind()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncMethodKeywords | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
             {
                 try
                 {
-                    RunScenarioAndFlush(() => TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker());
+                    RunScenarioAndFlush(() => StateMachineAsync_UnhandledException_MethodEventsWithUnwind_Marker());
                 }
                 catch (InvalidOperationException)
                 {
@@ -442,52 +438,52 @@ namespace System.Threading.Tasks.Tests
             // Marker -> UnhandledExceptionOuter -> UnhandledExceptionInner
             const int ExpectedChainDepth = 3;
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_UnhandledException_MethodEventsWithUnwind_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong leafDispatcherId = markerCallstacks[0].DispatcherId;
             var chainEvents = stream.ChainEventsFromDispatcher(leafDispatcherId);
 
             var sequence = chainEvents
-                .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncMethod
-                    or AsyncEventID.TaskAsync_CompleteAsyncMethod
-                    or AsyncEventID.TaskAsync_UnwindAsyncException)
+                .Where(e => e.EventId is AsyncEventID.ResumeStateMachineAsyncMethod
+                    or AsyncEventID.CompleteStateMachineAsyncMethod
+                    or AsyncEventID.UnwindStateMachineAsyncException)
                 .Select(e => e.EventId)
                 .ToList();
 
             // Every method in the chain unwinds (no catch); no CompleteAsyncMethod expected.
-            AssertEqual(stream, ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncMethod));
-            AssertEqual(stream, ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.TaskAsync_UnwindAsyncException));
-            AssertEqual(stream, 0, sequence.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncMethod));
+            AssertEqual(stream, ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.ResumeStateMachineAsyncMethod));
+            AssertEqual(stream, ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.UnwindStateMachineAsyncException));
+            AssertEqual(stream, 0, sequence.Count(id => id == AsyncEventID.CompleteStateMachineAsyncMethod));
 
             // Per-method ordering: each Resume is immediately followed by its Unwind.
             for (int i = 0; i < sequence.Count; i += 2)
             {
-                AssertEqual(stream, AsyncEventID.TaskAsync_ResumeAsyncMethod, sequence[i]);
-                AssertEqual(stream, AsyncEventID.TaskAsync_UnwindAsyncException, sequence[i + 1]);
+                AssertEqual(stream, AsyncEventID.ResumeStateMachineAsyncMethod, sequence[i]);
+                AssertEqual(stream, AsyncEventID.UnwindStateMachineAsyncException, sequence[i + 1]);
             }
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ResumeAsyncCallstackEmitted_Marker()
+        private static async Task StateMachineAsync_ResumeAsyncCallstackEmitted_Marker()
         {
-            await TaskAsync_DeepChain();
+            await StateMachineAsync_DeepChain();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_ResumeAsyncCallstackEmitted()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_ResumeAsyncCallstackEmitted()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_ResumeAsyncCallstackEmitted_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_ResumeAsyncCallstackEmitted_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_ResumeAsyncCallstackEmitted_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_ResumeAsyncCallstackEmitted_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             AssertAll(stream, markerCallstacks, cs =>
@@ -499,50 +495,50 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CallstackDepthMatchesChainDepth_Marker()
+        private static async Task StateMachineAsync_CallstackDepthMatchesChainDepth_Marker()
         {
-            await TaskAsync_Level1();
+            await StateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_CallstackDepthMatchesChainDepth()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CallstackDepthMatchesChainDepth()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_CallstackDepthMatchesChainDepth_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_CallstackDepthMatchesChainDepth_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackDepthMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_CallstackDepthMatchesChainDepth_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
-            // TaskAsync_CallstackDepthMarker -> Level1 -> Level2 -> Level3: deepest callstack should have exactly 4 frames
+            // StateMachineAsync_CallstackDepthMarker -> Level1 -> Level2 -> Level3: deepest callstack should have exactly 4 frames
             AssertEqual(stream, 4, markerCallstacks[0].FrameCount);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CallstackFramesHaveDistinctMethodIds_Marker()
+        private static async Task StateMachineAsync_CallstackFramesHaveDistinctMethodIds_Marker()
         {
-            await TaskAsync_Level1();
+            await StateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_CallstackFramesHaveDistinctMethodIds()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CallstackFramesHaveDistinctMethodIds()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_CallstackFramesHaveDistinctMethodIds_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_CallstackFramesHaveDistinctMethodIds_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_CallstackFramesHaveDistinctMethodIds_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // Frames in the same callstack should have distinct methodIds (different async methods)
@@ -552,48 +548,48 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CallstackFramesHaveDistinctStates_Root_Marker()
+        private static async Task StateMachineAsync_CallstackFramesHaveDistinctStates_Root_Marker()
         {
             await Task.Yield();
-            await TaskAsync_CallstackFramesHaveDistinctStates_Middle_Marker();
+            await StateMachineAsync_CallstackFramesHaveDistinctStates_Middle_Marker();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CallstackFramesHaveDistinctStates_Middle_Marker()
+        private static async Task StateMachineAsync_CallstackFramesHaveDistinctStates_Middle_Marker()
         {
             await Task.Yield();
             await Task.Yield();
-            await TaskAsync_CallstackFramesHaveDistinctStates_Leaf_Marker();
+            await StateMachineAsync_CallstackFramesHaveDistinctStates_Leaf_Marker();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CallstackFramesHaveDistinctStates_Leaf_Marker()
+        private static async Task StateMachineAsync_CallstackFramesHaveDistinctStates_Leaf_Marker()
         {
             await Task.Delay(100);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CallstackFramesHaveDistinctStates_Marker()
+        private static async Task StateMachineAsync_CallstackFramesHaveDistinctStates_Marker()
         {
-            await TaskAsync_CallstackFramesHaveDistinctStates_Root_Marker();
+            await StateMachineAsync_CallstackFramesHaveDistinctStates_Root_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_CallstackFramesHaveDistinctStates()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CallstackFramesHaveDistinctStates()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_CallstackFramesHaveDistinctStates_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_CallstackFramesHaveDistinctStates_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctStates_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_CallstackFramesHaveDistinctStates_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // The deepest callstack (on the final Delay resume) should have 4 frames:
@@ -611,23 +607,23 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_YieldAtEachLevel_CallstackShrinks_Level1_Marker()
+        private static async Task StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Level1_Marker()
         {
-            await TaskAsync_YieldAtEachLevel_CallstackShrinks_Level2_Marker();
+            await StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Level2_Marker();
             await Task.Yield();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_YieldAtEachLevel_CallstackShrinks_Level2_Marker()
+        private static async Task StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Level2_Marker()
         {
-            await TaskAsync_YieldAtEachLevel_CallstackShrinks_Level3_Marker();
+            await StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Level3_Marker();
             await Task.Yield();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_YieldAtEachLevel_CallstackShrinks_Level3_Marker()
+        private static async Task StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Level3_Marker()
         {
             await Task.Delay(100);
             await Task.Yield();
@@ -635,24 +631,24 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_YieldAtEachLevel_CallstackShrinks_Marker()
+        private static async Task StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Marker()
         {
-            await TaskAsync_YieldAtEachLevel_CallstackShrinks_Level1_Marker();
+            await StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Level1_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_YieldAtEachLevel_CallstackShrinks()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_YieldAtEachLevel_CallstackShrinks()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_YieldAtEachLevel_CallstackShrinks_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_YieldAtEachLevel_CallstackShrinks_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_YieldAtEachLevel_CallstackShrinks_Marker));
 
             // After Task.Delay resumes: full chain (Level3, Level2, Level1, Marker) = 4 frames
             // After Level3's yield resumes: Level3 completes, chain is (Level2, Level1, Marker) = 3 frames
@@ -666,7 +662,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker()
+        private static async Task StateMachineAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker()
         {
             await Task.Yield();
             s_appendRace_proceed.Release();
@@ -676,50 +672,50 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker()
+        private static async Task StateMachineAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker()
         {
-            Task t = TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker();
+            Task t = StateMachineAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker();
             Assert.True(s_appendRace_proceed.Wait(TimeSpan.FromSeconds(20)), "Timed out waiting for child to reach append-race checkpoint");
             await t;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_AppendCallstack_FiresOnLateParentRegistration()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_AppendCallstack_FiresOnLateParentRegistration()
         {
             s_appendRace_proceed = new SemaphoreSlim(0, 1);
 
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            // The initial Resume should only include TaskAsync_AppendRace_Child (race: Parent not registered yet).
-            var childOnlyResumes = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker));
+            // The initial Resume should only include StateMachineAsync_AppendRace_Child (race: Parent not registered yet).
+            var childOnlyResumes = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker));
             AssertNotEmpty(stream, childOnlyResumes);
 
             // After Parent registers and Child hits its next complete hook,
             // an AppendAsyncCallstack should fire with the Parent frame.
-            var appendsWithParent = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_AppendAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker));
+            var appendsWithParent = stream.CallstacksWithMarker(AsyncEventID.AppendStateMachineAsyncCallstack, nameof(StateMachineAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker));
             AssertNotEmpty(stream, appendsWithParent);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker()
+        private static async Task StateMachineAsync_CompleteChain_DoesNotEmitAppendEvents_Marker()
         {
-            await TaskAsync_DeepChain();
+            await StateMachineAsync_DeepChain();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_CompleteChain_DoesNotEmitAppendEvents()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CompleteChain_DoesNotEmitAppendEvents()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_CompleteChain_DoesNotEmitAppendEvents_Marker());
             });
 
             // DumpAllEvents(events);
@@ -727,29 +723,29 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // Sanity: the marker frame must appear in the initial Resume callstack (full chain captured).
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_CompleteChain_DoesNotEmitAppendEvents_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // No Append events should fire on this chain -- the chain was complete at Resume time.
             ulong chainDispatcherId = markerCallstacks[0].DispatcherId;
             var appendEvents = stream.ChainEventsFromDispatcher(chainDispatcherId)
-                .Where(e => e.EventId == AsyncEventID.TaskAsync_AppendAsyncCallstack)
+                .Where(e => e.EventId == AsyncEventID.AppendStateMachineAsyncCallstack)
                 .ToList();
             AssertEmpty(stream, appendEvents);
         }
 
-        private static InlinePostSynchronizationContext? s_taskAsyncSyncContextCtx;
+        private static InlinePostSynchronizationContext? s_stateMachineAsyncSyncContextCtx;
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker()
+        private static async Task StateMachineAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker()
         {
             // Install a non-default SynchronizationContext on this thread so the await captures it.
             // The await's continuation will be routed via SynchronizationContextAwaitTaskContinuation,
-            // which wraps the box in an AsyncTaskDispatcher and posts back to the context.
+            // which wraps the box in an AsyncStateMachineDispatcher and posts back to the context.
             int callerThreadId = Environment.CurrentManagedThreadId;
             SynchronizationContext? prev = SynchronizationContext.Current;
-            SynchronizationContext.SetSynchronizationContext(s_taskAsyncSyncContextCtx);
+            SynchronizationContext.SetSynchronizationContext(s_stateMachineAsyncSyncContextCtx);
             try
             {
                 await Task.Delay(100);
@@ -768,60 +764,60 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CustomSyncContext_EmitsContextEventsAndCallstack()
         {
-            s_taskAsyncSyncContextCtx = new InlinePostSynchronizationContext();
+            s_stateMachineAsyncSyncContextCtx = new InlinePostSynchronizationContext();
 
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => RunIsolatedScenarioAsync(TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+                RunScenarioAndFlush(() => RunIsolatedScenarioAsync(StateMachineAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
             });
 
             // DumpAllEvents(events);
 
             // The custom SyncContext should have received at least one Post for the await continuation.
-            AssertTrue(events, s_taskAsyncSyncContextCtx.PostCount > 0,
-                $"Expected custom SynchronizationContext to receive at least one Post, got {s_taskAsyncSyncContextCtx.PostCount}");
+            AssertTrue(events, s_stateMachineAsyncSyncContextCtx.PostCount > 0,
+                $"Expected custom SynchronizationContext to receive at least one Post, got {s_stateMachineAsyncSyncContextCtx.PostCount}");
 
             var stream = ParseAllEvents(events);
 
             // The marker frame should appear in the Resume callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // Verify the standard Create -> Resume -> Complete sequence fired for our chain.
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext for the custom SyncContext scenario");
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext for the custom SyncContext scenario");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, resumeIdx + 1);
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteStateMachineAsyncContext after Resume");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker()
+        private static async Task StateMachineAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker()
         {
             await Task.Delay(100);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack()
         {
             var scheduler = new InlineRunTaskScheduler();
 
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
                 try
                 {
                     Task.Factory.StartNew(
-                        () => TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker(),
+                        () => StateMachineAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker(),
                         CancellationToken.None,
                         TaskCreationOptions.None,
                         scheduler).Unwrap().GetAwaiter().GetResult();
@@ -841,85 +837,85 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // Verify standard Create -> Resume -> Complete sequence for our chain.
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext for the custom TaskScheduler scenario");
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext for the custom TaskScheduler scenario");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, resumeIdx + 1);
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteStateMachineAsyncContext after Resume");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_NoEventsWhenDisabled_Marker()
+        private static async Task StateMachineAsync_NoEventsWhenDisabled_Marker()
         {
             await Task.Delay(50);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_NoEventsWhenDisabled()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_NoEventsWhenDisabled()
         {
             for (int i = 0; i < 50; i++)
             {
-                RunScenario(() => TaskAsync_NoEventsWhenDisabled_Marker());
+                RunScenario(() => StateMachineAsync_NoEventsWhenDisabled_Marker());
             }
 
-            // Now attach a listener but don't perform any V1 async work.
-            var events = CollectEvents(CoreKeywords, () => { });
+            // Now attach a listener but don't perform any StateMachine async work.
+            var events = CollectEvents(StateMachineAsyncCoreKeywords, () => { });
 
             var ids = ParseAllEvents(events).EventIds;
             int contextEvents = ids.Count(id =>
-                id == AsyncEventID.TaskAsync_CreateAsyncContext ||
-                id == AsyncEventID.TaskAsync_ResumeAsyncContext ||
-                id == AsyncEventID.TaskAsync_SuspendAsyncContext ||
-                id == AsyncEventID.TaskAsync_CompleteAsyncContext);
+                id == AsyncEventID.CreateStateMachineAsyncContext ||
+                id == AsyncEventID.ResumeStateMachineAsyncContext ||
+                id == AsyncEventID.CompleteStateMachineAsyncContext);
 
             AssertEqual(events, 0, contextEvents);
         }
 
-        public static IEnumerable<object[]> TaskAsyncKeywordGatekeepingData()
+        public static IEnumerable<object[]> StateMachineAsyncKeywordGatekeepingData()
         {
-            yield return new object[] { (long)CreateAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_CreateAsyncContext } };
-            yield return new object[] { (long)ResumeAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_ResumeAsyncContext } };
-            yield return new object[] { (long)CompleteAsyncContextKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_CompleteAsyncContext } };
-            yield return new object[] { (long)UnwindAsyncExceptionKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_UnwindAsyncException } };
-            yield return new object[] { (long)ResumeAsyncCallstackKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_ResumeAsyncCallstack, AsyncEventID.TaskAsync_AppendAsyncCallstack } };
-            yield return new object[] { (long)ResumeAsyncMethodKeyword,     new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_ResumeAsyncMethod } };
-            yield return new object[] { (long)CompleteAsyncMethodKeyword,   new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.TaskAsync_CompleteAsyncMethod } };
+            yield return new object[] { (long)CreateStateMachineAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CreateStateMachineAsyncContext } };
+            yield return new object[] { (long)ResumeStateMachineAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeStateMachineAsyncContext } };
+            yield return new object[] { (long)CompleteStateMachineAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteStateMachineAsyncContext } };
+            yield return new object[] { (long)UnwindStateMachineAsyncExceptionKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.UnwindStateMachineAsyncException } };
+            yield return new object[] { (long)ResumeStateMachineAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeStateMachineAsyncCallstack, AsyncEventID.AppendStateMachineAsyncCallstack } };
+            yield return new object[] { (long)ResumeStateMachineAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeStateMachineAsyncMethod } };
+            yield return new object[] { (long)CompleteStateMachineAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteStateMachineAsyncMethod } };
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_KeywordGatekeeping_Marker()
+        private static async Task StateMachineAsync_KeywordGatekeeping_Marker()
         {
             // Exercise multiple event types: exception unwind, multiple completes, method invocations.
             try
             {
-                await TaskAsync_InnerThrows();
+                await StateMachineAsync_InnerThrows();
             }
             catch (InvalidOperationException) { }
+            await RuntimeAsync_SingleYield();
             await Task.Delay(50);
         }
 
-        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        [MemberData(nameof(TaskAsyncKeywordGatekeepingData))]
-        public void TaskAsync_KeywordGatekeeping(long keywordValue, AsyncEventID[] allowedEventIds)
+        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        [MemberData(nameof(StateMachineAsyncKeywordGatekeepingData))]
+        public void StateMachineAsync_KeywordGatekeeping(long keywordValue, AsyncEventID[] allowedEventIds)
         {
             EventKeywords kw = (EventKeywords)keywordValue;
             var allowed = new HashSet<AsyncEventID>(allowedEventIds);
 
             var events = CollectEvents(kw, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_KeywordGatekeeping_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_KeywordGatekeeping_Marker());
             });
 
             var stream = ParseAllEvents(events);
@@ -931,145 +927,145 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker()
+        private static async Task StateMachineAsync_WhenAll_TracksAllBranches_BranchA_Marker()
         {
             await Task.Delay(100);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker()
+        private static async Task StateMachineAsync_WhenAll_TracksAllBranches_BranchB_Marker()
         {
             await Task.Delay(120);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker()
+        private static async Task StateMachineAsync_WhenAll_TracksAllBranches_BranchC_Marker()
         {
             await Task.Delay(140);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAll_TracksAllBranches_Marker()
+        private static async Task StateMachineAsync_WhenAll_TracksAllBranches_Marker()
         {
             await Task.WhenAll(
-                TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker(),
-                TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker(),
-                TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker());
+                StateMachineAsync_WhenAll_TracksAllBranches_BranchA_Marker(),
+                StateMachineAsync_WhenAll_TracksAllBranches_BranchB_Marker(),
+                StateMachineAsync_WhenAll_TracksAllBranches_BranchC_Marker());
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_WhenAll_TracksAllBranches()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_WhenAll_TracksAllBranches()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_WhenAll_TracksAllBranches_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_WhenAll_TracksAllBranches_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_WhenAll_TracksAllBranches_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // Each branch is its own async chain; its inner await of Task.Delay produces a Resume callstack containing the branch frame.
-            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
-            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker));
-            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchC_Marker));
             AssertNotEmpty(stream, branchACallstacks);
             AssertNotEmpty(stream, branchBCallstacks);
             AssertNotEmpty(stream, branchCCallstacks);
 
             // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete in its own dispatcher tree.
-            AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].DispatcherId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
-            AssertExactlyOneCreateAndComplete(stream, branchBCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker));
-            AssertExactlyOneCreateAndComplete(stream, branchCCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker));
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAll_TracksAllBranches_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchBCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchCCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAll_TracksAllBranches_Marker));
 
             // The outer marker's chain should fire the standard Create -> Resume -> Complete sequence in its own dispatcher tree, in that order.
             ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
             var markerIds = stream.ChainEventsFromDispatcher(markerDispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext for the WhenAll outer marker");
+            int createIdx = markerIds.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext for the WhenAll outer marker");
 
-            int resumeIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
+            int resumeIdx = markerIds.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create on the outer marker");
 
-            int completeIdx = markerIds.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
+            int completeIdx = markerIds.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, resumeIdx + 1);
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteStateMachineAsyncContext after Resume on the outer marker");
 
             // The outer should be created exactly once.
-            int createCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_CreateAsyncContext);
+            int createCountForMarker = markerIds.Count(id => id == AsyncEventID.CreateStateMachineAsyncContext);
             AssertEqual(stream, 1, createCountForMarker);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAny_TracksAllBranches_Fast_Marker()
+        private static async Task StateMachineAsync_WhenAny_TracksAllBranches_Fast_Marker()
         {
             await Task.Delay(50);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker()
+        private static async Task StateMachineAsync_WhenAny_TracksAllBranches_Slow1_Marker()
         {
             await Task.Delay(400);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker()
+        private static async Task StateMachineAsync_WhenAny_TracksAllBranches_Slow2_Marker()
         {
             await Task.Delay(600);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAny_TracksAllBranches_Marker()
+        private static async Task StateMachineAsync_WhenAny_TracksAllBranches_Marker()
         {
-            Task fast = TaskAsync_WhenAny_TracksAllBranches_Fast_Marker();
-            Task slow1 = TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker();
-            Task slow2 = TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker();
+            Task fast = StateMachineAsync_WhenAny_TracksAllBranches_Fast_Marker();
+            Task slow1 = StateMachineAsync_WhenAny_TracksAllBranches_Slow1_Marker();
+            Task slow2 = StateMachineAsync_WhenAny_TracksAllBranches_Slow2_Marker();
 
             await Task.WhenAny(fast, slow1, slow2);
             await Task.WhenAll(slow1, slow2);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_WhenAny_TracksAllBranches()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_WhenAny_TracksAllBranches()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_WhenAny_TracksAllBranches_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_WhenAny_TracksAllBranches_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // All branches - including the slow ones whose completion the outer is no longer
             // strictly waiting on after WhenAny returned -- must produce their own Resume
             // callstacks. This proves their dispatcher lifetimes are tracked independently.
-            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
-            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker));
-            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow2_Marker));
             AssertNotEmpty(stream, fastCallstacks);
             AssertNotEmpty(stream, slow1Callstacks);
             AssertNotEmpty(stream, slow2Callstacks);
 
             // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete in its own dispatcher tree.
-            AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
-            AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].DispatcherId, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker));
-            AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].DispatcherId, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker));
-            AssertCreateEqualsCompleteInChain(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_WhenAny_TracksAllBranches_Marker));
+            AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            AssertCreateEqualsCompleteInChain(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Marker));
 
             // The outer marker's chain: exactly one Create, at least two Resumes (one after
             // WhenAny, one after WhenAll on the slow branches), then Complete.
@@ -1077,31 +1073,31 @@ namespace System.Threading.Tasks.Tests
             var markerEvents = stream.ChainEventsFromDispatcher(markerDispatcherId);
             var markerIds = markerEvents.Select(e => e.EventId).ToList();
 
-            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncContext);
+            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.ResumeStateMachineAsyncCallstack);
             AssertTrue(stream, resumeCountForMarker >= 1,
                 $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
 
-            int completeCountForMarker = markerIds.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncContext);
-            AssertTrue(stream, completeCountForMarker >= 1, "Expected at least one CompleteAsyncContext for the outer marker");
+            int completeCountForMarker = markerIds.Count(id => id == AsyncEventID.CompleteStateMachineAsyncContext);
+            AssertTrue(stream, completeCountForMarker >= 1, "Expected at least one CompleteStateMachineAsyncContext for the outer marker");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CallstackDepthCappedAtMaxFrames_Marker(int depth)
+        private static async Task StateMachineAsync_CallstackDepthCappedAtMaxFrames_Marker(int depth)
         {
-            await TaskAsync_RecursiveChain(depth);
+            await StateMachineAsync_RecursiveChain(depth);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_CallstackDepthCappedAtMaxFrames()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CallstackDepthCappedAtMaxFrames()
         {
             // Build a chain deeper than the 255-frame cap (byte FrameCount). The deepest
             // ResumeAsyncCallstack should clamp at byte.MaxValue without crashing.
             const int requestedDepth = 300;
 
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_CallstackDepthCappedAtMaxFrames_Marker(requestedDepth));
+                RunScenarioAndFlush(() => StateMachineAsync_CallstackDepthCappedAtMaxFrames_Marker(requestedDepth));
             });
 
             // DumpAllEvents(events);
@@ -1112,7 +1108,7 @@ namespace System.Threading.Tasks.Tests
             // the leaf. The marker sits at the top of the chain (deeper than 255), so it appears
             // in a subsequent AppendAsyncCallstack carrying the remaining frames. Use the merged
             // view to validate the chain as a whole.
-            var mergedMarker = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_CallstackDepthCappedAtMaxFrames_Marker));
+            var mergedMarker = stream.MergedResumeCallstacksWithMarker(nameof(StateMachineAsync_CallstackDepthCappedAtMaxFrames_Marker));
             AssertNotEmpty(stream, mergedMarker);
 
             var deepest = mergedMarker.MaxBy(cs => cs.Frames.Count);
@@ -1125,7 +1121,7 @@ namespace System.Threading.Tasks.Tests
             // Each individual event clamps its own FrameCount at byte.MaxValue (wire format limit).
             ulong chainDispatcherId = deepest.DispatcherId;
             var perEventCallstacks = stream.ChainEventsFromDispatcher(chainDispatcherId)
-                .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncCallstack or AsyncEventID.TaskAsync_AppendAsyncCallstack)
+                .Where(e => e.EventId is AsyncEventID.ResumeStateMachineAsyncCallstack or AsyncEventID.AppendStateMachineAsyncCallstack)
                 .ToList();
             AssertNotEmpty(stream, perEventCallstacks);
             AssertAll(stream, perEventCallstacks, cs => Assert.True(cs.FrameCount <= byte.MaxValue));
@@ -1144,13 +1140,13 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CallstackStressWithVaryingDepths_Marker(int depth)
+        private static async Task StateMachineAsync_CallstackStressWithVaryingDepths_Marker(int depth)
         {
-            await TaskAsync_RecursiveChain(depth);
+            await StateMachineAsync_RecursiveChain(depth);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_CallstackStressWithVaryingDepths()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_CallstackStressWithVaryingDepths()
         {
             const int iterations = 100;
             int[] depths = new int[iterations];
@@ -1158,19 +1154,19 @@ namespace System.Threading.Tasks.Tests
             for (int i = 0; i < iterations; i++)
                 depths[i] = rng.Next(1, 60);
 
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
                 RunScenarioAndFlush(async () =>
                 {
                     for (int i = 0; i < iterations; i++)
-                        await TaskAsync_CallstackStressWithVaryingDepths_Marker(depths[i]);
+                        await StateMachineAsync_CallstackStressWithVaryingDepths_Marker(depths[i]);
                 });
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_CallstackStressWithVaryingDepths_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_CallstackStressWithVaryingDepths_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // Every emitted callstack must have valid frame data.
@@ -1199,7 +1195,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WaitThenYield_BalancesResumeAndComplete_WaitYield_Marker(Task gate)
+        private static async Task StateMachineAsync_WaitThenYield_BalancesResumeAndComplete_WaitYield_Marker(Task gate)
         {
             await gate;
             await Task.Yield();
@@ -1207,25 +1203,25 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker()
+        private static async Task StateMachineAsync_WaitThenYield_BalancesResumeAndComplete_Marker()
         {
             await Task.Yield();
 
             var tcs = new TaskCompletionSource();
-            Task b1 = TaskAsync_WaitThenYield_BalancesResumeAndComplete_WaitYield_Marker(tcs.Task);
-            Task b2 = TaskAsync_WaitThenYield_BalancesResumeAndComplete_WaitYield_Marker(tcs.Task);
+            Task b1 = StateMachineAsync_WaitThenYield_BalancesResumeAndComplete_WaitYield_Marker(tcs.Task);
+            Task b2 = StateMachineAsync_WaitThenYield_BalancesResumeAndComplete_WaitYield_Marker(tcs.Task);
 
             tcs.SetResult();
 
             await Task.WhenAll(b1, b2);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_WaitThenYield_BalancesResumeAndComplete()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_WaitThenYield_BalancesResumeAndComplete()
         {
-            var events = CollectEvents(CoreKeywords | ResumeAsyncCallstackKeyword, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_WaitThenYield_BalancesResumeAndComplete_Marker());
             });
 
             // DumpAllEvents(events);
@@ -1236,64 +1232,60 @@ namespace System.Threading.Tasks.Tests
             // chain and not polluted by unrelated dispatcher activity from other threads (e.g. the
             // xunit runner's RunAsync state machine being replayed by ResetAsyncThreadContext and
             // completing while this test's listener is still active).
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_WaitThenYield_BalancesResumeAndComplete_Marker));
             AssertNotEmpty(stream, markerCallstacks);
             ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
 
             var taskEvents = stream.ChainEventsFromDispatcher(markerDispatcherId);
-            int createCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_CreateAsyncContext);
-            int completeCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncContext);
-            int resumeCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext);
-            int suspendCount = taskEvents.Count(e => e.EventId == AsyncEventID.TaskAsync_SuspendAsyncContext);
+            int createCount = taskEvents.Count(e => e.EventId == AsyncEventID.CreateStateMachineAsyncContext);
+            int completeCount = taskEvents.Count(e => e.EventId == AsyncEventID.CompleteStateMachineAsyncContext);
+            int resumeCount = taskEvents.Count(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncContext);
 
             // At least one root Create event.
             AssertTrue(stream, createCount >= 1,
-                $"Expected at least one CreateAsyncContext event, got {createCount}");
+                $"Expected at least one CreateStateMachineAsyncContext event, got {createCount}");
 
             AssertEqual(stream, createCount, completeCount);
             AssertEqual(stream, resumeCount, completeCount);
 
-            // Does not emit Suspend events.
-            AssertEqual(stream, 0, suspendCount);
-
             AssertTrue(stream, createCount >= 3,
-                $"Expected fan-out chain to produce at least 3 CreateAsyncContext events (root + 2 child wraps), got {createCount}");
+                $"Expected fan-out chain to produce at least 3 CreateStateMachineAsyncContext events (root + 2 child wraps), got {createCount}");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ConfigureAwaitFalse_Leaf_Marker()
+        private static async Task StateMachineAsync_ConfigureAwaitFalse_Leaf_Marker()
         {
             await Task.Delay(100).ConfigureAwait(false);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ConfigureAwaitFalse_Mid_Marker()
+        private static async Task StateMachineAsync_ConfigureAwaitFalse_Mid_Marker()
         {
-            await TaskAsync_ConfigureAwaitFalse_Leaf_Marker().ConfigureAwait(false);
+            await StateMachineAsync_ConfigureAwaitFalse_Leaf_Marker().ConfigureAwait(false);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ConfigureAwaitFalse_Marker()
+        private static async Task StateMachineAsync_ConfigureAwaitFalse_Marker()
         {
-            await TaskAsync_ConfigureAwaitFalse_Mid_Marker().ConfigureAwait(false);
+            await StateMachineAsync_ConfigureAwaitFalse_Mid_Marker().ConfigureAwait(false);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_ConfigureAwaitFalse()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_ConfigureAwaitFalse()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_ConfigureAwaitFalse_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_ConfigureAwaitFalse_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_ConfigureAwaitFalse_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             var frameNames = markerCallstacks[0].Frames
@@ -1301,18 +1293,18 @@ namespace System.Threading.Tasks.Tests
                 .Where(n => n is not null)
                 .ToList();
 
-            AssertContains(stream, nameof(TaskAsync_ConfigureAwaitFalse_Leaf_Marker), frameNames);
-            AssertContains(stream, nameof(TaskAsync_ConfigureAwaitFalse_Mid_Marker), frameNames);
-            AssertContains(stream, nameof(TaskAsync_ConfigureAwaitFalse_Marker), frameNames);
+            AssertContains(stream, nameof(StateMachineAsync_ConfigureAwaitFalse_Leaf_Marker), frameNames);
+            AssertContains(stream, nameof(StateMachineAsync_ConfigureAwaitFalse_Mid_Marker), frameNames);
+            AssertContains(stream, nameof(StateMachineAsync_ConfigureAwaitFalse_Marker), frameNames);
 
             // ConfigureAwait(false) on a sequential await chain collapses Leaf -> Mid -> Marker into one
             // continuation chain, so exactly one Create / one Complete is expected in the marker's dispatcher tree.
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_ConfigureAwaitFalse_Marker));
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_FaultedTask_Inner_Marker()
+        private static async Task StateMachineAsync_FaultedTask_Inner_Marker()
         {
             await Task.Delay(50);
             throw new InvalidOperationException("test fault");
@@ -1320,62 +1312,62 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_FaultedTask_Marker()
+        private static async Task StateMachineAsync_FaultedTask_Marker()
         {
             try
             {
-                await TaskAsync_FaultedTask_Inner_Marker();
+                await StateMachineAsync_FaultedTask_Inner_Marker();
             }
             catch (InvalidOperationException)
             {
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_FaultedTask()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_FaultedTask()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | UnwindStateMachineAsyncExceptionKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_FaultedTask_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_FaultedTask_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_FaultedTask_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
-            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Inner_Marker));
+            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_FaultedTask_Inner_Marker));
             AssertNotEmpty(stream, innerCallstacks);
 
             // Both inner (faulting) and outer marker chains must see exactly one Create and one Complete in their own dispatcher tree.
             // (Scoped to each chain's dispatcher; a whole-stream Create/Complete balance would be polluted by unrelated dispatcher
             // activity from other threads -- e.g. the xunit runner's state machine completing while this test's listener is active --
             // and by Completes that can fall outside the captured window when a resume is scheduled rather than inlined.)
-            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(TaskAsync_FaultedTask_Inner_Marker));
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_FaultedTask_Marker));
+            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(StateMachineAsync_FaultedTask_Inner_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_FaultedTask_Marker));
 
             // The unwind must be attributed to the inner faulting chain.
             ulong innerDispatcherId = innerCallstacks[0].DispatcherId;
-            int unwindCountForInner = stream.ChainEventsFromDispatcher(innerDispatcherId).Count(e => e.EventId == AsyncEventID.TaskAsync_UnwindAsyncException);
+            int unwindCountForInner = stream.ChainEventsFromDispatcher(innerDispatcherId).Count(e => e.EventId == AsyncEventID.UnwindStateMachineAsyncException);
             AssertTrue(stream, unwindCountForInner >= 1,
                 $"Expected at least one UnwindAsyncException on the faulted inner chain (DispatcherId {innerDispatcherId}), got {unwindCountForInner}");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_TaskCancellation_Inner_Marker(CancellationToken ct)
+        private static async Task StateMachineAsync_TaskCancellation_Inner_Marker(CancellationToken ct)
         {
             await Task.Delay(5000, ct);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_TaskCancellation_Marker()
+        private static async Task StateMachineAsync_TaskCancellation_Marker()
         {
             using var cts = new CancellationTokenSource();
-            Task inner = TaskAsync_TaskCancellation_Inner_Marker(cts.Token);
+            Task inner = StateMachineAsync_TaskCancellation_Inner_Marker(cts.Token);
             cts.CancelAfter(50);
             try
             {
@@ -1386,77 +1378,77 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_TaskCancellation()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_TaskCancellation()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | UnwindStateMachineAsyncExceptionKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_TaskCancellation_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_TaskCancellation_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_TaskCancellation_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
-            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Inner_Marker));
+            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_TaskCancellation_Inner_Marker));
             AssertNotEmpty(stream, innerCallstacks);
 
             // Inner cancelled task + outer marker must each see exactly one Create and one Complete in their own dispatcher tree.
-            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(TaskAsync_TaskCancellation_Inner_Marker));
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(TaskAsync_TaskCancellation_Marker));
+            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(StateMachineAsync_TaskCancellation_Inner_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_TaskCancellation_Marker));
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_EventSequenceOrder_Marker()
+        private static async ValueTask ValueStateMachineAsync_EventSequenceOrder_Marker()
         {
-            await ValueTaskAsync_Level1();
+            await ValueStateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void ValueTaskAsync_EventSequenceOrder()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void ValueStateMachineAsync_EventSequenceOrder()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_EventSequenceOrder_Marker().AsTask());
+                RunScenarioAndFlush(() => ValueStateMachineAsync_EventSequenceOrder_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_EventSequenceOrder_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(ValueStateMachineAsync_EventSequenceOrder_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, resumeIdx + 1);
-            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, resumeIdx + 1);
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteStateMachineAsyncContext after Resume");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_MethodEventsEmitted_Marker()
+        private static async ValueTask ValueStateMachineAsync_MethodEventsEmitted_Marker()
         {
-            await ValueTaskAsync_Level1();
+            await ValueStateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void ValueTaskAsync_MethodEventsEmitted()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void ValueStateMachineAsync_MethodEventsEmitted()
         {
-            var events = CollectEvents(MethodKeywords | CoreKeywords, () =>
+            var events = CollectEvents(StateMachineAsyncMethodKeywords | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_MethodEventsEmitted_Marker().AsTask());
+                RunScenarioAndFlush(() => ValueStateMachineAsync_MethodEventsEmitted_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
@@ -1464,39 +1456,39 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var methodEvents = stream.All
-                .Where(e => e.EventId is AsyncEventID.TaskAsync_ResumeAsyncMethod or AsyncEventID.TaskAsync_CompleteAsyncMethod)
+                .Where(e => e.EventId is AsyncEventID.ResumeStateMachineAsyncMethod or AsyncEventID.CompleteStateMachineAsyncMethod)
                 .Select(e => e.EventId)
                 .ToList();
 
-            int resumeCount = methodEvents.Count(id => id == AsyncEventID.TaskAsync_ResumeAsyncMethod);
-            int completeCount = methodEvents.Count(id => id == AsyncEventID.TaskAsync_CompleteAsyncMethod);
+            int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeStateMachineAsyncMethod);
+            int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteStateMachineAsyncMethod);
 
             // Marker -> Level1 -> Level2 -> Level3
-            AssertTrue(stream, resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
-            AssertTrue(stream, completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events for ValueTask chain, got {completeCount}");
+            AssertTrue(stream, resumeCount >= 4, $"Expected at least 4 ResumeStateMachineAsyncMethod events for ValueTask chain, got {resumeCount}");
+            AssertTrue(stream, completeCount >= 4, $"Expected at least 4 CompleteStateMachineAsyncMethod events for ValueTask chain, got {completeCount}");
         }
 
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker()
+        private static async ValueTask ValueStateMachineAsync_CallstackDepthMatchesChainDepth_Marker()
         {
-            await ValueTaskAsync_Level1();
+            await ValueStateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void ValueTaskAsync_CallstackDepthMatchesChainDepth()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void ValueStateMachineAsync_CallstackDepthMatchesChainDepth()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker().AsTask());
+                RunScenarioAndFlush(() => ValueStateMachineAsync_CallstackDepthMatchesChainDepth_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(ValueStateMachineAsync_CallstackDepthMatchesChainDepth_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // Marker -> Level1 -> Level2 -> Level3
@@ -1505,24 +1497,24 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_CallstackFramesHaveDistinctMethodIds_Marker()
+        private static async ValueTask ValueStateMachineAsync_CallstackFramesHaveDistinctMethodIds_Marker()
         {
-            await ValueTaskAsync_Level1();
+            await ValueStateMachineAsync_Level1();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void ValueTaskAsync_CallstackFramesHaveDistinctMethodIds()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void ValueStateMachineAsync_CallstackFramesHaveDistinctMethodIds()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_CallstackFramesHaveDistinctMethodIds_Marker().AsTask());
+                RunScenarioAndFlush(() => ValueStateMachineAsync_CallstackFramesHaveDistinctMethodIds_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(ValueStateMachineAsync_CallstackFramesHaveDistinctMethodIds_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
@@ -1531,7 +1523,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_HandledException_EmitsUnwindAndComplete_InnerThrows_Marker()
+        private static async ValueTask ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete_InnerThrows_Marker()
         {
             await Task.Delay(100);
             throw new InvalidOperationException("valuetask inner throw");
@@ -1539,11 +1531,11 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Handled_Marker()
+        private static async ValueTask ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete_Handled_Marker()
         {
             try
             {
-                await ValueTaskAsync_HandledException_EmitsUnwindAndComplete_InnerThrows_Marker();
+                await ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete_InnerThrows_Marker();
             }
             catch (InvalidOperationException)
             {
@@ -1552,53 +1544,53 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker()
+        private static async ValueTask ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete_Marker()
         {
-            await ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Handled_Marker();
+            await ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete_Handled_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void ValueTaskAsync_HandledException_EmitsUnwindAndComplete()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker().AsTask());
+                RunScenarioAndFlush(() => ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(ValueStateMachineAsync_HandledException_EmitsUnwindAndComplete_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
 
-            int unwindIdx = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
-            AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindStateMachineAsyncException, resumeIdx + 1);
+            AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindStateMachineAsyncException after Resume");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx + 1);
-            AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, unwindIdx + 1);
+            AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteStateMachineAsyncContext after Unwind");
         }
 
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledOuter_Marker()
+        private static async ValueTask ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledOuter_Marker()
         {
-            await ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledInner_Marker();
+            await ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledInner_Marker();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledInner_Marker()
+        private static async ValueTask ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledInner_Marker()
         {
             await Task.Delay(100);
             throw new InvalidOperationException("valuetask unhandled inner");
@@ -1606,19 +1598,19 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async ValueTask ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker()
+        private static async ValueTask ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete_Marker()
         {
-            await ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledOuter_Marker();
+            await ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledOuter_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete()
         {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | UnwindStateMachineAsyncExceptionKeyword, () =>
             {
                 try
                 {
-                    RunScenarioAndFlush(() => ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker().AsTask());
+                    RunScenarioAndFlush(() => ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete_Marker().AsTask());
                 }
                 catch (InvalidOperationException)
                 {
@@ -1629,31 +1621,31 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(ValueStateMachineAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.TaskAsync_CreateAsyncContext);
-            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.TaskAsync_ResumeAsyncContext, createIdx + 1);
-            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
 
-            int unwindIdx1 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, resumeIdx + 1);
-            AssertTrue(stream, unwindIdx1 > resumeIdx, "Expected first UnwindAsyncException after Resume");
+            int unwindIdx1 = ids.IndexOf(AsyncEventID.UnwindStateMachineAsyncException, resumeIdx + 1);
+            AssertTrue(stream, unwindIdx1 > resumeIdx, "Expected first UnwindStateMachineAsyncException after Resume");
 
-            int unwindIdx2 = ids.IndexOf(AsyncEventID.TaskAsync_UnwindAsyncException, unwindIdx1 + 1);
-            AssertTrue(stream, unwindIdx2 > unwindIdx1, "Expected second UnwindAsyncException after first Unwind");
+            int unwindIdx2 = ids.IndexOf(AsyncEventID.UnwindStateMachineAsyncException, unwindIdx1 + 1);
+            AssertTrue(stream, unwindIdx2 > unwindIdx1, "Expected second UnwindStateMachineAsyncException after first Unwind");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.TaskAsync_CompleteAsyncContext, unwindIdx2 + 1);
-            AssertTrue(stream, completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, unwindIdx2 + 1);
+            AssertTrue(stream, completeIdx > unwindIdx2, "Expected CompleteStateMachineAsyncContext after second Unwind");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ResetContext_ReplaysPendingV1Chain_Inner_Marker()
+        private static async Task StateMachineAsync_ResetContext_ReplaysPendingV1Chain_Inner_Marker()
         {
             using var dummy = new TestEventListener();
             dummy.AddSource(AsyncProfilerEventSourceName, EventLevel.Informational, EventKeywords.None);
@@ -1662,42 +1654,42 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ResetContext_ReplaysPendingV1Chain_Mid_Marker()
+        private static async Task StateMachineAsync_ResetContext_ReplaysPendingV1Chain_Mid_Marker()
         {
-            await TaskAsync_ResetContext_ReplaysPendingV1Chain_Inner_Marker();
+            await StateMachineAsync_ResetContext_ReplaysPendingV1Chain_Inner_Marker();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ResetContext_ReplaysPendingV1Chain_Outer_Marker()
+        private static async Task StateMachineAsync_ResetContext_ReplaysPendingV1Chain_Outer_Marker()
         {
-            await TaskAsync_ResetContext_ReplaysPendingV1Chain_Mid_Marker();
+            await StateMachineAsync_ResetContext_ReplaysPendingV1Chain_Mid_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_ResetContext_ReplaysPendingV1Chain()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_ResetContext_ReplaysPendingV1Chain()
         {
-            var events = CollectEvents(AllKeywords, () =>
+            var events = CollectEvents(AllStateMachineAsyncKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_ResetContext_ReplaysPendingV1Chain_Outer_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_ResetContext_ReplaysPendingV1Chain_Outer_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            // Locate the V1 dispatcher driving the marker chain via its ResumeAsyncCallstack
+            // Locate the StateMachine dispatcher driving the marker chain via its ResumeStateMachineAsyncCallstack
             // events (which carry the marker frames in their callstack).
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysPendingV1Chain");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, "StateMachineAsync_ResetContext_ReplaysPendingV1Chain");
             AssertNotEmpty(stream, markerCallstacks);
 
             // Thread-scoped replay assertion: at least one OS thread must have seen two
-            // ResetAsyncThreadContext events AND show a marker ResumeAsyncCallstack plus
-            // matching ResumeAsyncContext after its most recent reset. Multiple threads
+            // ResetAsyncThreadContext events AND show a marker ResumeStateMachineAsyncCallstack plus
+            // matching ResumeStateMachineAsyncContext after its most recent reset. Multiple threads
             // in the trace can accumulate two resets (e.g. the test thread re-enables on
             // its initial event then again later), so we have to look at each candidate
             // thread, not just the first one. The thread that actually drove the replay
-            // is the one the V1 continuation resumed onto.
+            // is the one the StateMachine continuation resumed onto.
             var resetsByThread = stream.All
                 .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
                 .GroupBy(e => e.OsThreadId)
@@ -1721,7 +1713,7 @@ namespace System.Threading.Tasks.Tests
 
                 var replayDispatcherIds = postResetMarkerCallstacks.Select(c => c.DispatcherId).ToHashSet();
                 var postResetResumeContext = stream.All
-                    .Where(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext
+                    .Where(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncContext
                                 && e.OsThreadId == threadId
                                 && e.Timestamp >= lastResetTimestamp
                                 && replayDispatcherIds.Contains(e.DispatcherId))
@@ -1741,7 +1733,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ResetContext_ReplaysMultipleDispatchers_Inner_Marker(
+        private static async Task StateMachineAsync_ResetContext_ReplaysMultipleDispatchers_Inner_Marker(
             Task gate,
             ManualResetEventSlim block,
             Action onBlocked,
@@ -1755,15 +1747,15 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ResetContext_ReplaysMultipleDispatchers_Outer_Marker(TaskCompletionSource innerDone)
+        private static async Task StateMachineAsync_ResetContext_ReplaysMultipleDispatchers_Outer_Marker(TaskCompletionSource innerDone)
         {
             await innerDone.Task;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_ResetContext_ReplaysMultipleDispatchers()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_ResetContext_ReplaysMultipleDispatchers()
         {
-            var events = CollectEvents(AllKeywords, () =>
+            var events = CollectEvents(AllStateMachineAsyncKeywords, () =>
             {
                 RunScenarioAndFlush(async () =>
                 {
@@ -1772,8 +1764,8 @@ namespace System.Threading.Tasks.Tests
                     var blocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     var innerDone = new TaskCompletionSource();
 
-                    Task inner = TaskAsync_ResetContext_ReplaysMultipleDispatchers_Inner_Marker(gate.Task, block, () => blocked.SetResult(), innerDone);
-                    Task outer = TaskAsync_ResetContext_ReplaysMultipleDispatchers_Outer_Marker(innerDone);
+                    Task inner = StateMachineAsync_ResetContext_ReplaysMultipleDispatchers_Inner_Marker(gate.Task, block, () => blocked.SetResult(), innerDone);
+                    Task outer = StateMachineAsync_ResetContext_ReplaysMultipleDispatchers_Outer_Marker(innerDone);
 
                     _ = Task.Run(() => gate.SetResult());
 
@@ -1800,8 +1792,8 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            // The replay must emit at least one ResumeAsyncCallstack carrying the V1 marker chain.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplaysMultipleDispatchers");
+            // The replay must emit at least one ResumeAsyncCallstack carrying the StateMachine marker chain.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, "StateMachineAsync_ResetContext_ReplaysMultipleDispatchers");
             AssertNotEmpty(stream, markerCallstacks);
 
             // The decisive proof: find an OS thread where a single ResetAsyncThreadContext
@@ -1829,7 +1821,7 @@ namespace System.Threading.Tasks.Tests
                         : long.MaxValue;
 
                     int resumeContextCount = stream.All
-                        .Count(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext
+                        .Count(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncCallstack
                                     && e.OsThreadId == threadId
                                     && e.Timestamp >= windowStart
                                     && e.Timestamp < windowEnd);
@@ -1855,7 +1847,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ResetContext_ReplayResumeCompleteBalance_Inner_Marker()
+        private static async Task StateMachineAsync_ResetContext_ReplayResumeCompleteBalance_Inner_Marker()
         {
             using var dummy = new TestEventListener();
             dummy.AddSource(AsyncProfilerEventSourceName, EventLevel.Informational, EventKeywords.None);
@@ -1864,24 +1856,24 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ResetContext_ReplayResumeCompleteBalance_Mid_Marker()
+        private static async Task StateMachineAsync_ResetContext_ReplayResumeCompleteBalance_Mid_Marker()
         {
-            await TaskAsync_ResetContext_ReplayResumeCompleteBalance_Inner_Marker();
+            await StateMachineAsync_ResetContext_ReplayResumeCompleteBalance_Inner_Marker();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker()
+        private static async Task StateMachineAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker()
         {
-            await TaskAsync_ResetContext_ReplayResumeCompleteBalance_Mid_Marker();
+            await StateMachineAsync_ResetContext_ReplayResumeCompleteBalance_Mid_Marker();
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
-        public void TaskAsync_ResetContext_ReplayResumeCompleteBalance()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_ResetContext_ReplayResumeCompleteBalance()
         {
-            var events = CollectEvents(AllKeywords, () =>
+            var events = CollectEvents(AllStateMachineAsyncKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker());
+                RunScenarioAndFlush(() => StateMachineAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker());
             });
 
             // DumpAllEvents(events);
@@ -1889,13 +1881,12 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // Locate the replayed marker ResumeAsyncCallstack: the reset (triggered by the dummy
-            // listener inside the inner marker) replays the suspended V1 chain, producing a
+            // listener inside the inner marker) replays the suspended StateMachine chain, producing a
             // callstack carrying the marker frames.
-            var markerCallstacks = stream.CallstacksWithMarker(
-                AsyncEventID.TaskAsync_ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplayResumeCompleteBalance");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, "StateMachineAsync_ResetContext_ReplayResumeCompleteBalance");
             AssertNotEmpty(stream, markerCallstacks);
 
-            // Resume/Complete balance across the replay boundary. V1 uses a per-MoveNext dispatcher
+            // Resume/Complete balance across the replay boundary. StateMachine uses a per-MoveNext dispatcher
             // model, so the marker chain spans a dispatcher tree whose deepest replayed callstack
             // has N frames; each of those N resumed async methods must eventually complete. Balance
             // is NOT preserved per reset epoch by design (a Resume can land in one epoch and its
@@ -1906,42 +1897,42 @@ namespace System.Threading.Tasks.Tests
             ulong leafDispatcherId = deepest.DispatcherId;
 
             int completeMethodCount = stream.ChainEventsFromDispatcher(leafDispatcherId)
-                .Count(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncMethod);
+                .Count(e => e.EventId == AsyncEventID.CompleteStateMachineAsyncMethod);
 
             AssertTrue(stream, completeMethodCount >= deepest.FrameCount,
-                $"Expected at least {deepest.FrameCount} TaskAsync_CompleteAsyncMethod events across the " +
+                $"Expected at least {deepest.FrameCount} CompleteStateMachineAsyncMethod events across the " +
                 $"trace for marker dispatcher chain {leafDispatcherId} to balance the replayed callstack of " +
                 $"depth {deepest.FrameCount}, but found {completeMethodCount}.");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker(Task gate)
+        private static async Task StateMachineAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker(Task gate)
         {
             await gate;
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker(Task gate)
+        private static async Task StateMachineAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker(Task gate)
         {
-            await TaskAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker(gate);
+            await StateMachineAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker(gate);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_SingleThread_ChainEventsAndCallstack_Marker(Task gate)
+        private static async Task StateMachineAsync_SingleThread_ChainEventsAndCallstack_Marker(Task gate)
         {
-            await TaskAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker(gate);
+            await StateMachineAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker(gate);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationSupported))]
-        public async Task TaskAsync_SingleThread_ChainEventsAndCallstack()
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationSupported))]
+        public async Task StateMachineAsync_SingleThread_ChainEventsAndCallstack()
         {
-            var events = await CollectEventsAsync(ResumeAsyncCallstackKeyword | CoreKeywords | MethodKeywords, async () =>
+            var events = await CollectEventsAsync(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords | StateMachineAsyncMethodKeywords, async () =>
             {
                 var tcs = new TaskCompletionSource();
-                Task chain = TaskAsync_SingleThread_ChainEventsAndCallstack_Marker(tcs.Task);
+                Task chain = StateMachineAsync_SingleThread_ChainEventsAndCallstack_Marker(tcs.Task);
                 tcs.SetResult();
                 await chain;
             });
@@ -1952,9 +1943,9 @@ namespace System.Threading.Tasks.Tests
 
             // The marker frame must appear in a Resume callstack -- proves the chain was walkable.
             // This is the deterministic, scheduling-independent core of the test: when the chain
-            // first resumes (gate set), V1 emits a ResumeAsyncCallstack carrying the remaining chain,
+            // first resumes (gate set), StateMachine emits a ResumeAsyncCallstack carrying the remaining chain,
             // which at first resume is all three frames.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.TaskAsync_ResumeAsyncCallstack, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_SingleThread_ChainEventsAndCallstack_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
@@ -1962,9 +1953,9 @@ namespace System.Threading.Tasks.Tests
                 .Select(f => GetMethodNameFromMethodId(deepest.CallstackType, f.MethodId))
                 .Where(n => n is not null)
                 .ToList();
-            AssertContains(stream, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker), frameNames);
-            AssertContains(stream, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker), frameNames);
-            AssertContains(stream, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker), frameNames);
+            AssertContains(stream, nameof(StateMachineAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker), frameNames);
+            AssertContains(stream, nameof(StateMachineAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker), frameNames);
+            AssertContains(stream, nameof(StateMachineAsync_SingleThread_ChainEventsAndCallstack_Marker), frameNames);
 
             // Lifecycle ORDERING (not counting). We deliberately do not assert global Create/Complete
             // balance or an exact dispatcher count: depending on whether the resume cascade inlines,
@@ -1981,20 +1972,20 @@ namespace System.Threading.Tasks.Tests
                     .OrderBy(e => e.Timestamp)
                     .ToList();
 
-                ParsedEvent? createEvt = dispatcherEvents.FirstOrDefault(e => e.EventId == AsyncEventID.TaskAsync_CreateAsyncContext);
-                ParsedEvent? resumeEvt = dispatcherEvents.FirstOrDefault(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext);
-                ParsedEvent? completeEvt = dispatcherEvents.FirstOrDefault(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncContext);
+                ParsedEvent? createEvt = dispatcherEvents.FirstOrDefault(e => e.EventId == AsyncEventID.CreateStateMachineAsyncContext);
+                ParsedEvent? resumeEvt = dispatcherEvents.FirstOrDefault(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncContext);
+                ParsedEvent? completeEvt = dispatcherEvents.FirstOrDefault(e => e.EventId == AsyncEventID.CompleteStateMachineAsyncContext);
 
                 if (createEvt is not null && resumeEvt is not null)
                 {
                     AssertTrue(stream, createEvt.Timestamp <= resumeEvt.Timestamp,
-                        $"Dispatcher {dispatcherId}: CreateAsyncContext must precede ResumeAsyncContext.");
+                        $"Dispatcher {dispatcherId}: CreateStateMachineAsyncContext must precede ResumeStateMachineAsyncContext.");
                 }
 
                 if (resumeEvt is not null && completeEvt is not null)
                 {
                     AssertTrue(stream, resumeEvt.Timestamp <= completeEvt.Timestamp,
-                        $"Dispatcher {dispatcherId}: CompleteAsyncContext must follow ResumeAsyncContext.");
+                        $"Dispatcher {dispatcherId}: CompleteStateMachineAsyncContext must follow ResumeStateMachineAsyncContext.");
                 }
             }
         }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1223,14 +1223,23 @@ namespace System.Threading.Tasks.Tests
                 RunScenarioAndFlush(() => TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker());
             });
 
-            DumpAllEvents(events);
+            // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            int resumeCount = stream.OfType(AsyncEventID.ResumeAsyncContext).Count();
-            int suspendCount = stream.OfType(AsyncEventID.SuspendAsyncContext).Count();
+            // Locate the marker's logical TaskId so the balance check is scoped to this scenario's
+            // chain and not polluted by unrelated dispatcher activity from other threads (e.g. the
+            // xunit runner's RunAsync state machine being replayed by ResetAsyncThreadContext and
+            // completing while this test's listener is still active).
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker));
+            Assert.NotEmpty(markerCallstacks);
+            ulong markerTaskId = markerCallstacks[0].TaskId;
+
+            var taskEvents = stream.ForTask(markerTaskId);
+            int createCount = taskEvents.Count(e => e.EventId == AsyncEventID.CreateAsyncContext);
+            int completeCount = taskEvents.Count(e => e.EventId == AsyncEventID.CompleteAsyncContext);
+            int resumeCount = taskEvents.Count(e => e.EventId == AsyncEventID.ResumeAsyncContext);
+            int suspendCount = taskEvents.Count(e => e.EventId == AsyncEventID.SuspendAsyncContext);
 
             // At least one root Create event.
             Assert.True(createCount >= 1,
@@ -1244,9 +1253,6 @@ namespace System.Threading.Tasks.Tests
 
             Assert.True(createCount >= 3,
                 $"Expected fan-out chain to produce at least 3 CreateAsyncContext events (root + 2 child wraps), got {createCount}");
-
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker));
-            Assert.NotEmpty(markerCallstacks);
         }
 
         [RuntimeAsyncMethodGeneration(false)]

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -91,6 +91,18 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_RecursiveChain(int depth)
+        {
+            if (depth <= 1)
+            {
+                await Task.Delay(100);
+                return;
+            }
+            await TaskAsync_RecursiveChain(depth - 1);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static async ValueTask ValueTaskAsync_Level1()
         {
             await ValueTaskAsync_Level2();
@@ -395,7 +407,7 @@ namespace System.Threading.Tasks.Tests
             Assert.Equal(1, sequence.Count(id => id == AsyncEventID.UnwindAsyncException));
 
             // Around the Unwind: the throwing method's Resume precedes it, and the catching
-            // method's Resume â†’ Complete pair follows.
+            // method's Resume -> Complete pair follows.
             int unwindIdx = sequence.IndexOf(AsyncEventID.UnwindAsyncException);
             Assert.Equal(AsyncEventID.ResumeAsyncMethod, sequence[unwindIdx - 1]);
             Assert.Equal(AsyncEventID.ResumeAsyncMethod, sequence[unwindIdx + 1]);
@@ -507,7 +519,7 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CallstackDepthMatchesChainDepth_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // TaskAsync_CallstackDepthMarker â†’ Level1 â†’ Level2 â†’ Level3: deepest callstack should have exactly 4 frames
+            // TaskAsync_CallstackDepthMarker -> Level1 -> Level2 -> Level3: deepest callstack should have exactly 4 frames
             Assert.Equal(4, markerCallstacks[0].FrameCount);
         }
 
@@ -718,24 +730,12 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // No Append events should fire on this context â€” the chain was complete at Resume time.
+            // No Append events should fire on this context -- the chain was complete at Resume time.
             ulong chainTaskId = markerCallstacks[0].TaskId;
             var appendEvents = stream.ForTask(chainTaskId)
                 .Where(e => e.EventId == AsyncEventID.AppendAsyncCallstack)
                 .ToList();
             Assert.Empty(appendEvents);
-        }
-
-        private sealed class InlinePostSynchronizationContext : SynchronizationContext
-        {
-            private int _postCount;
-            public int PostCount => _postCount;
-
-            public override void Post(SendOrPostCallback d, object? state)
-            {
-                Interlocked.Increment(ref _postCount);
-                d(state);
-            }
         }
 
         private static InlinePostSynchronizationContext? s_taskAsyncSyncContextCtx;
@@ -785,7 +785,7 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // Verify the standard Create â†’ Resume â†’ Complete sequence fired for our context.
+            // Verify the standard Create -> Resume -> Complete sequence fired for our context.
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
@@ -797,22 +797,6 @@ namespace System.Threading.Tasks.Tests
 
             int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
-        }
-
-        private sealed class InlineRunTaskScheduler : TaskScheduler
-        {
-            private int _queuedCount;
-            public int QueuedCount => _queuedCount;
-
-            protected override void QueueTask(Task task)
-            {
-                Interlocked.Increment(ref _queuedCount);
-                TryExecuteTask(task);
-            }
-
-            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
-
-            protected override IEnumerable<Task>? GetScheduledTasks() => null;
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -855,7 +839,7 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // Verify standard Create â†’ Resume â†’ Complete sequence for our context.
+            // Verify standard Create -> Resume -> Complete sequence for our context.
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
@@ -942,64 +926,65 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAllBranchA()
+        private static async Task TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker()
         {
             await Task.Delay(100);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAllBranchB()
+        private static async Task TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker()
         {
             await Task.Delay(120);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAllBranchC()
+        private static async Task TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker()
         {
             await Task.Delay(140);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAll_TracksAllBranchesAndJoin_Marker()
+        private static async Task TaskAsync_WhenAll_TracksAllBranches_Marker()
         {
-            await Task.WhenAll(TaskAsync_WhenAllBranchA(), TaskAsync_WhenAllBranchB(), TaskAsync_WhenAllBranchC());
+            await Task.WhenAll(
+                TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker(),
+                TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker(),
+                TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker());
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_WhenAll_TracksAllBranchesAndJoin()
+        public void TaskAsync_WhenAll_TracksAllBranches()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_WhenAll_TracksAllBranchesAndJoin_Marker());
+                RunScenarioAndFlush(() => TaskAsync_WhenAll_TracksAllBranches_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranchesAndJoin_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Each branch is its own async chain; its inner await of Task.Delay produces a Resume callstack containing the branch frame.
-            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAllBranchA));
-            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAllBranchB));
-            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAllBranchC));
-            Assert.True(branchACallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchA)}");
-            Assert.True(branchBCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchB)}");
-            Assert.True(branchCCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchC)}");
+            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            Assert.NotEmpty(branchACallstacks);
+            Assert.NotEmpty(branchBCallstacks);
+            Assert.NotEmpty(branchCCallstacks);
 
-            // Every Create must be balanced by a Complete.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
+            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own TaskId.
+            AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].TaskId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchBCallstacks[0].TaskId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchCCallstacks[0].TaskId, nameof(TaskAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_WhenAll_TracksAllBranches_Marker));
 
-            Assert.True(createCount >= 4,
-                $"Expected at least 4 CreateAsyncContext events (3 branches + outer), got {createCount}");
-
-            // The outer marker's chain should fire the standard Create â†’ Resume â†’ Complete sequence on its own TaskId, in that order.
+            // The outer marker's chain should fire the standard Create -> Resume -> Complete sequence on its own TaskId, in that order.
             ulong markerTaskId = markerCallstacks[0].TaskId;
             var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
 
@@ -1019,69 +1004,67 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAnyFast()
+        private static async Task TaskAsync_WhenAny_TracksAllBranches_Fast_Marker()
         {
             await Task.Delay(50);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAnySlow1()
+        private static async Task TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker()
         {
             await Task.Delay(400);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAnySlow2()
+        private static async Task TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker()
         {
             await Task.Delay(600);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes_Marker()
+        private static async Task TaskAsync_WhenAny_TracksAllBranches_Marker()
         {
-            Task fast = TaskAsync_WhenAnyFast();
-            Task slow1 = TaskAsync_WhenAnySlow1();
-            Task slow2 = TaskAsync_WhenAnySlow2();
+            Task fast = TaskAsync_WhenAny_TracksAllBranches_Fast_Marker();
+            Task slow1 = TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker();
+            Task slow2 = TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker();
 
             await Task.WhenAny(fast, slow1, slow2);
             await Task.WhenAll(slow1, slow2);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes()
+        public void TaskAsync_WhenAny_TracksAllBranches()
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes_Marker());
+                RunScenarioAndFlush(() => TaskAsync_WhenAny_TracksAllBranches_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // All branches â€” including the slow ones whose completion the outer is no longer
-            // strictly waiting on after WhenAny returned â€” must produce their own Resume
+            // All branches - including the slow ones whose completion the outer is no longer
+            // strictly waiting on after WhenAny returned -- must produce their own Resume
             // callstacks. This proves their dispatcher lifetimes are tracked independently.
-            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAnyFast));
-            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAnySlow1));
-            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAnySlow2));
-            Assert.True(fastCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnyFast)}");
-            Assert.True(slow1Callstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnySlow1)}");
-            Assert.True(slow2Callstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnySlow2)}");
+            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            Assert.NotEmpty(fastCallstacks);
+            Assert.NotEmpty(slow1Callstacks);
+            Assert.NotEmpty(slow2Callstacks);
 
-            // Every Create must be balanced by a Complete.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
-
-            Assert.True(createCount >= 4,
-                $"Expected at least 4 CreateAsyncContext events (3 branches + outer), got {createCount}");
+            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own TaskId.
+            AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].TaskId, nameof(TaskAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].TaskId, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].TaskId, nameof(TaskAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            AssertCreateEqualsCompleteForTask(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_WhenAny_TracksAllBranches_Marker));
 
             // The outer marker's chain: exactly one Create, at least two Resumes (one after
             // WhenAny, one after WhenAll on the slow branches), then Complete.
@@ -1095,22 +1078,6 @@ namespace System.Threading.Tasks.Tests
 
             int completeCountForMarker = markerIds.Count(id => id == AsyncEventID.CompleteAsyncContext);
             Assert.True(completeCountForMarker >= 1, "Expected at least one CompleteAsyncContext for the outer marker");
-
-            // First event for the marker is its Create; last is a Complete.
-            Assert.Equal(AsyncEventID.CreateAsyncContext, markerIds[0]);
-            Assert.Equal(AsyncEventID.CompleteAsyncContext, markerIds[^1]);
-        }
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_RecursiveChain(int depth)
-        {
-            if (depth <= 1)
-            {
-                await Task.Delay(100);
-                return;
-            }
-            await TaskAsync_RecursiveChain(depth - 1);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1219,7 +1186,7 @@ namespace System.Threading.Tasks.Tests
             Assert.True(markerCallstacks.Count >= iterations,
                 $"Expected at least {iterations} callstacks with marker, got {markerCallstacks.Count}");
 
-            // Verify multiple buffer flushes occurred â€” proves the buffer machinery is exercised.
+            // Verify multiple buffer flushes occurred -- proves the buffer machinery is exercised.
             int bufferCount = 0;
             ForEachEventBufferPayload(events, _ => bufferCount++);
             Assert.True(bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
@@ -1227,7 +1194,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_WaitThenYield(Task gate)
+        private static async Task TaskAsync_WaitThenYield_BalancesResumeAndComplete_WaitYield_Marker(Task gate)
         {
             await gate;
             await Task.Yield();
@@ -1235,13 +1202,13 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_DoubleSuspendInOneMoveNext_BalancesResumeAndComplete_Marker()
+        private static async Task TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker()
         {
             await Task.Yield();
 
             var tcs = new TaskCompletionSource();
-            Task b1 = TaskAsync_WaitThenYield(tcs.Task);
-            Task b2 = TaskAsync_WaitThenYield(tcs.Task);
+            Task b1 = TaskAsync_WaitThenYield_BalancesResumeAndComplete_WaitYield_Marker(tcs.Task);
+            Task b2 = TaskAsync_WaitThenYield_BalancesResumeAndComplete_WaitYield_Marker(tcs.Task);
 
             tcs.SetResult();
 
@@ -1249,11 +1216,11 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_DoubleSuspendInOneMoveNext_BalancesResumeAndComplete()
+        public void TaskAsync_WaitThenYield_BalancesResumeAndComplete()
         {
             var events = CollectEvents(CoreKeywords | ResumeAsyncCallstackKeyword, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_DoubleSuspendInOneMoveNext_BalancesResumeAndComplete_Marker());
+                RunScenarioAndFlush(() => TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker());
             });
 
             // DumpAllEvents(events);
@@ -1278,29 +1245,29 @@ namespace System.Threading.Tasks.Tests
             Assert.True(createCount >= 3,
                 $"Expected fan-out chain to produce at least 3 CreateAsyncContext events (root + 2 child wraps), got {createCount}");
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_DoubleSuspendInOneMoveNext_BalancesResumeAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WaitThenYield_BalancesResumeAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ConfigureAwaitFalseLeaf()
+        private static async Task TaskAsync_ConfigureAwaitFalse_Leaf_Marker()
         {
             await Task.Delay(100).ConfigureAwait(false);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_ConfigureAwaitFalseMid()
+        private static async Task TaskAsync_ConfigureAwaitFalse_Mid_Marker()
         {
-            await TaskAsync_ConfigureAwaitFalseLeaf().ConfigureAwait(false);
+            await TaskAsync_ConfigureAwaitFalse_Leaf_Marker().ConfigureAwait(false);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static async Task TaskAsync_ConfigureAwaitFalse_Marker()
         {
-            await TaskAsync_ConfigureAwaitFalseMid().ConfigureAwait(false);
+            await TaskAsync_ConfigureAwaitFalse_Mid_Marker().ConfigureAwait(false);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -1318,25 +1285,23 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // The deepest callstack should include all 3 chain frames.
-            var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
-            var frameNames = deepest.Frames
-                .Select(f => GetMethodNameFromMethodId(deepest.CallstackType, f.MethodId))
+            var frameNames = markerCallstacks[0].Frames
+                .Select(f => GetMethodNameFromMethodId(markerCallstacks[0].CallstackType, f.MethodId))
                 .Where(n => n is not null)
                 .ToList();
-            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseLeaf), frameNames);
-            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseMid), frameNames);
+
+            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalse_Leaf_Marker), frameNames);
+            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalse_Mid_Marker), frameNames);
             Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalse_Marker), frameNames);
 
-            // Every Create must be balanced by a Complete.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
+            // ConfigureAwait(false) on a sequential await chain collapses Leaf -> Mid -> Marker into one
+            // continuation chain, so exactly one Create / one Complete is expected on the marker's TaskId.
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_FaultedInner()
+        private static async Task TaskAsync_FaultedTask_Inner_Marker()
         {
             await Task.Delay(50);
             throw new InvalidOperationException("test fault");
@@ -1348,7 +1313,7 @@ namespace System.Threading.Tasks.Tests
         {
             try
             {
-                await TaskAsync_FaultedInner();
+                await TaskAsync_FaultedTask_Inner_Marker();
             }
             catch (InvalidOperationException)
             {
@@ -1370,19 +1335,28 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Marker));
             Assert.NotEmpty(markerCallstacks);
 
+            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Inner_Marker));
+            Assert.NotEmpty(innerCallstacks);
+
             // Every dispatcher that was Created must Complete, even on the fault path.
             int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
             int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
             Assert.Equal(createCount, completeCount);
 
-            int unwindCount = stream.OfType(AsyncEventID.UnwindAsyncException).Count();
-            Assert.True(unwindCount > 0,
-                "Expected at least one UnwindAsyncException event for the faulted inner task");
+            // Both inner (faulting) and outer marker chains must see exactly one Create and one Complete on their own TaskId.
+            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].TaskId, nameof(TaskAsync_FaultedTask_Inner_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_FaultedTask_Marker));
+
+            // The unwind must be attributed to the inner faulting chain.
+            ulong innerTaskId = innerCallstacks[0].TaskId;
+            int unwindCountForInner = stream.ForTask(innerTaskId).Count(e => e.EventId == AsyncEventID.UnwindAsyncException);
+            Assert.True(unwindCountForInner >= 1,
+                $"Expected at least one UnwindAsyncException on the faulted inner chain (TaskId {innerTaskId}), got {unwindCountForInner}");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task TaskAsync_CancelledInner(CancellationToken ct)
+        private static async Task TaskAsync_TaskCancellation_Inner_Marker(CancellationToken ct)
         {
             await Task.Delay(5000, ct);
         }
@@ -1392,7 +1366,7 @@ namespace System.Threading.Tasks.Tests
         private static async Task TaskAsync_TaskCancellation_Marker()
         {
             using var cts = new CancellationTokenSource();
-            Task inner = TaskAsync_CancelledInner(cts.Token);
+            Task inner = TaskAsync_TaskCancellation_Inner_Marker(cts.Token);
             cts.CancelAfter(50);
             try
             {
@@ -1418,14 +1392,12 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // Every Create must be balanced by a Complete on the cancellation path.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
+            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Inner_Marker));
+            Assert.NotEmpty(innerCallstacks);
 
-            // At least 2 Creates: inner cancelled task + outer marker. Both must Complete.
-            Assert.True(createCount >= 2,
-                $"Expected at least 2 CreateAsyncContext events (inner + marker), got {createCount}");
+            // Inner cancelled task + outer marker must each see exactly one Create and one Complete on their own TaskId.
+            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].TaskId, nameof(TaskAsync_TaskCancellation_Inner_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(TaskAsync_TaskCancellation_Marker));
         }
 
         [RuntimeAsyncMethodGeneration(false)]
@@ -1490,7 +1462,7 @@ namespace System.Threading.Tasks.Tests
             int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeAsyncMethod);
             int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteAsyncMethod);
 
-            // Marker â†’ Level1 â†’ Level2 â†’ Level3
+            // Marker -> Level1 -> Level2 -> Level3
             Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
             Assert.True(completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events for ValueTask chain, got {completeCount}");
         }
@@ -1518,7 +1490,7 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // Marker â†’ Level1 â†’ Level2 â†’ Level3
+            // Marker -> Level1 -> Level2 -> Level3
             Assert.Equal(4, markerCallstacks[0].FrameCount);
         }
 
@@ -1706,7 +1678,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            // The marker frame must appear in a Resume callstack â€” proves the chain was walkable.
+            // The marker frame must appear in a Resume callstack -- proves the chain was walkable.
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -679,7 +679,7 @@ namespace System.Threading.Tasks.Tests
         private static async Task TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker()
         {
             Task t = TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker();
-            s_appendRace_proceed.Wait();
+            Assert.True(s_appendRace_proceed.Wait(TimeSpan.FromSeconds(20)), "Timed out waiting for child to reach append-race checkpoint");
             await t;
         }
 
@@ -914,7 +914,7 @@ namespace System.Threading.Tasks.Tests
 
             var events = CollectEvents(kw, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_NoEventsWhenDisabled_Marker());
+                RunScenarioAndFlush(() => TaskAsync_KeywordGatekeeping_Marker());
             });
 
             var stream = ParseAllEvents(events);

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -10,54 +10,52 @@ using Xunit;
 
 namespace System.Threading.Tasks.Tests
 {
-    /// <summary>
-    /// Tests for V1 (Task-based AsyncStateMachineBox) async profiler event emission.
-    /// All scenario methods use [RuntimeAsyncMethodGeneration(false)] to ensure they
-    /// exercise the legacy Task-based async path even if the default changes in the future.
-    /// Tests use sync CollectEvents with RunScenarioAndFlush to isolate the V1 chain
-    /// on a threadpool thread, ensuring dispatcher finally blocks complete before flush.
-    /// Requires threading support.
-    /// </summary>
+    // Tests for V1 (Task-based AsyncStateMachineBox) async profiler event emission.
+    // All scenario methods use [RuntimeAsyncMethodGeneration(false)] to ensure they
+    // exercise the legacy Task-based async path even if the default changes in the future.
+    // Most tests use sync CollectEvents with RunScenarioAndFlush to isolate the V1 chain
+    // on a threadpool thread, ensuring dispatcher finally blocks complete before flush.
+    // Requires threading support.
     public partial class AsyncProfilerTests
     {
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_SingleYield()
+        private static async Task TaskAsync_SingleYield()
         {
             await Task.Yield();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_DeepChain()
+        private static async Task TaskAsync_DeepChain()
         {
             await TaskAsync_Level1();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_Level1()
+        private static async Task TaskAsync_Level1()
         {
             await TaskAsync_Level2();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_Level2()
+        private static async Task TaskAsync_Level2()
         {
             await TaskAsync_Level3();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_Level3()
+        private static async Task TaskAsync_Level3()
         {
             await Task.Delay(100);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_ExceptionHandled()
+        private static async Task TaskAsync_ExceptionHandled()
         {
             try
             {
@@ -70,25 +68,46 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_InnerThrows()
+        private static async Task TaskAsync_InnerThrows()
         {
             await Task.Delay(100);
-            throw new InvalidOperationException("v1 inner");
+            throw new InvalidOperationException("inner");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_UnhandledExceptionOuter()
+        private static async Task TaskAsync_UnhandledExceptionOuter()
         {
             await TaskAsync_UnhandledExceptionInner();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_UnhandledExceptionInner()
+        private static async Task TaskAsync_UnhandledExceptionInner()
         {
             await Task.Delay(100);
-            throw new InvalidOperationException("v1 unhandled inner");
+            throw new InvalidOperationException("unhandled inner");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async ValueTask ValueTaskAsync_Level1()
+        {
+            await ValueTaskAsync_Level2();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async ValueTask ValueTaskAsync_Level2()
+        {
+            await ValueTaskAsync_Level3();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async ValueTask ValueTaskAsync_Level3()
+        {
+            await Task.Delay(100);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -123,10 +142,8 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_EventSequenceOrderMarker()
+        private static async Task TaskAsync_EventSequenceOrder_Marker()
         {
-            // Use Task.Delay (not Task.Yield) so the dispatcher has predictable scheduling latency.
-            // The marker is the leaf await, so there is no parent-registration race to worry about.
             await Task.Delay(100);
         }
 
@@ -135,15 +152,15 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_EventSequenceOrderMarker());
+                RunScenarioAndFlush(() => TaskAsync_EventSequenceOrder_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_EventSequenceOrderMarker));
-            Assert.True(markerCallstacks.Count > 0, $"Expected at least one merged resume callstack with {nameof(TaskAsync_EventSequenceOrderMarker)}");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_EventSequenceOrder_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
@@ -160,12 +177,8 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_SuspendResumeCompleteEventsMarker()
+        private static async Task TaskAsync_SuspendResumeCompleteEvents_Marker()
         {
-            // Three sequential Delays produce three Suspend/Resume cycles on the same context
-            // (Create reuses the active dispatcher's context id and emits Suspend on each subsequent yield).
-            // Using Task.Delay (not Task.Yield) avoids the dispatcher-vs-registration race; the marker
-            // is the inner box, so it is reliably present in the Resume callstack at walk time.
             await Task.Delay(100);
             await Task.Delay(100);
             await Task.Delay(100);
@@ -176,15 +189,15 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_SuspendResumeCompleteEventsMarker());
+                RunScenarioAndFlush(() => TaskAsync_SuspendResumeCompleteEvents_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_SuspendResumeCompleteEventsMarker));
-            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(TaskAsync_SuspendResumeCompleteEventsMarker)}");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_SuspendResumeCompleteEvents_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
@@ -192,23 +205,17 @@ namespace System.Threading.Tasks.Tests
             int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx1 = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx1 > createIdx, "Expected first ResumeAsyncContext after Create");
+            int resumeCount = ids.Count(id => id == AsyncEventID.ResumeAsyncContext);
+            Assert.True(resumeCount >= 1, "Expected at least one ResumeAsyncContext");
 
-            int suspendIdx1 = ids.IndexOf(AsyncEventID.SuspendAsyncContext, resumeIdx1 + 1);
-            Assert.True(suspendIdx1 > resumeIdx1, "Expected first SuspendAsyncContext after first Resume");
+            int completeCount = ids.Count(id => id == AsyncEventID.CompleteAsyncContext);
+            Assert.True(completeCount >= 1, "Expected at least one CompleteAsyncContext");
 
-            int resumeIdx2 = ids.IndexOf(AsyncEventID.ResumeAsyncContext, suspendIdx1 + 1);
-            Assert.True(resumeIdx2 > suspendIdx1, "Expected second ResumeAsyncContext after first Suspend");
+            // Expected ResumeAsyncContext and CompleteAsyncContext counts to match.
+            Assert.Equal(resumeCount, completeCount);
 
-            int suspendIdx2 = ids.IndexOf(AsyncEventID.SuspendAsyncContext, resumeIdx2 + 1);
-            Assert.True(suspendIdx2 > resumeIdx2, "Expected second SuspendAsyncContext after second Resume");
-
-            int resumeIdx3 = ids.IndexOf(AsyncEventID.ResumeAsyncContext, suspendIdx2 + 1);
-            Assert.True(resumeIdx3 > suspendIdx2, "Expected third ResumeAsyncContext after second Suspend");
-
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx3 + 1);
-            Assert.True(completeIdx > resumeIdx3, "Expected CompleteAsyncContext after third Resume");
+            // Expected no SuspendAsyncContext events.
+            Assert.DoesNotContain(AsyncEventID.SuspendAsyncContext, ids);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -230,7 +237,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_HandledException_EmitsUnwindAndCompleteMarker()
+        private static async Task TaskAsync_HandledException_EmitsUnwindAndComplete_Marker()
         {
             await TaskAsync_ExceptionHandled();
         }
@@ -240,15 +247,15 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_HandledException_EmitsUnwindAndCompleteMarker());
+                RunScenarioAndFlush(() => TaskAsync_HandledException_EmitsUnwindAndComplete_Marker());
             });
 
             //DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_HandledException_EmitsUnwindAndCompleteMarker));
-            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(TaskAsync_HandledException_EmitsUnwindAndCompleteMarker)}");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
@@ -268,7 +275,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker()
+        private static async Task TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker()
         {
             await TaskAsync_UnhandledExceptionOuter();
         }
@@ -280,7 +287,7 @@ namespace System.Threading.Tasks.Tests
             {
                 try
                 {
-                    RunScenarioAndFlush(() => TaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker());
+                    RunScenarioAndFlush(() => TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker());
                 }
                 catch (InvalidOperationException)
                 {
@@ -291,8 +298,8 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker));
-            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(TaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker)}");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
@@ -313,81 +320,103 @@ namespace System.Threading.Tasks.Tests
             Assert.True(completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
         }
 
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_MethodEventCountMatchesChainDepth_Marker()
+        {
+            await TaskAsync_DeepChain();
+        }
+
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_MethodEventCountMatchesChainDepth()
         {
-            var events = CollectEvents(MethodKeywords | CoreKeywords, () =>
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | MethodKeywords | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_DeepChain());
+                RunScenarioAndFlush(() => TaskAsync_MethodEventCountMatchesChainDepth_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            // DeepChain → Level1 → Level2 → Level3 = 4 methods
-            // Level3 uses Task.Delay to ensure full chain is built before resume.
-            // On resume: Level3, Level2, Level1, DeepChain each resume and complete = 4 pairs.
-            var methodEvents = stream.All
-                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod or AsyncEventID.CompleteAsyncMethod)
-                .Select(e => e.EventId)
-                .ToList();
+            // Marker -> DeepChain -> Level1 -> Level2 -> Level3
+            const int ExpectedChainDepth = 5;
 
-            int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeAsyncMethod);
-            int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteAsyncMethod);
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_MethodEventCountMatchesChainDepth_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
-            Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events, got {resumeCount}");
-            Assert.True(completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events, got {completeCount}");
+            Assert.Equal(ExpectedChainDepth, markerCallstacks[0].Frames.Count);
 
-            // Verify interleaved ordering: each Resume is followed by its matching Complete
-            // Check the last 8 events (4 Resume/Complete pairs from the inner chain)
-            var tail = methodEvents.Skip(methodEvents.Count - 8).ToList();
-            for (int i = 0; i < tail.Count; i += 2)
-            {
-                Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[i]);
-                Assert.Equal(AsyncEventID.CompleteAsyncMethod, tail[i + 1]);
-            }
+            ulong chainTaskId = markerCallstacks[0].TaskId;
+            var chainEvents = stream.ForTask(chainTaskId);
+
+            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.ResumeAsyncMethod);
+            Assert.Equal(ExpectedChainDepth, resumeCount);
+
+            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.CompleteAsyncMethod);
+            Assert.Equal(ExpectedChainDepth, completeCount);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_HandledException_MethodEventsWithUnwind_Marker()
+        {
+            await TaskAsync_ExceptionHandled();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_HandledException_MethodEventsWithUnwind()
         {
-            var events = CollectEvents(MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_ExceptionHandled());
+                RunScenarioAndFlush(() => TaskAsync_HandledException_MethodEventsWithUnwind_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            // ExceptionHandled → InnerThrows (2 methods)
-            // InnerThrows resumes, throws → Unwind
-            // ExceptionHandled resumes (catches), completes
-            // Expected method events: Resume, Unwind, Resume, Complete
-            var methodEvents = stream.All
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_HandledException_MethodEventsWithUnwind_Marker));
+
+            Assert.NotEmpty(markerCallstacks);
+
+            ulong chainTaskId = markerCallstacks[0].TaskId;
+            var chainEvents = stream.ForTask(chainTaskId);
+
+            var sequence = chainEvents
                 .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod
                     or AsyncEventID.CompleteAsyncMethod
                     or AsyncEventID.UnwindAsyncException)
                 .Select(e => e.EventId)
                 .ToList();
 
-            var tail = methodEvents.Skip(methodEvents.Count - 4).ToList();
-            Assert.Equal(4, tail.Count);
-            Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[0]);
-            Assert.Equal(AsyncEventID.UnwindAsyncException, tail[1]);
-            Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[2]);
-            Assert.Equal(AsyncEventID.CompleteAsyncMethod, tail[3]);
+            // Exactly one Unwind expected on the chain's context (InnerThrows throws once).
+            Assert.Equal(1, sequence.Count(id => id == AsyncEventID.UnwindAsyncException));
+
+            // Around the Unwind: the throwing method's Resume precedes it, and the catching
+            // method's Resume â†’ Complete pair follows.
+            int unwindIdx = sequence.IndexOf(AsyncEventID.UnwindAsyncException);
+            Assert.Equal(AsyncEventID.ResumeAsyncMethod, sequence[unwindIdx - 1]);
+            Assert.Equal(AsyncEventID.ResumeAsyncMethod, sequence[unwindIdx + 1]);
+            Assert.Equal(AsyncEventID.CompleteAsyncMethod, sequence[unwindIdx + 2]);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker()
+        {
+            await TaskAsync_UnhandledExceptionOuter();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_UnhandledException_MethodEventsWithUnwind()
         {
-            var events = CollectEvents(MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
             {
                 try
                 {
-                    RunScenarioAndFlush(() => TaskAsync_UnhandledExceptionOuter());
+                    RunScenarioAndFlush(() => TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker());
                 }
                 catch (InvalidOperationException)
                 {
@@ -398,46 +427,58 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            // UnhandledExceptionOuter → UnhandledExceptionInner (2 methods, neither catches)
-            // Inner resumes, throws → Unwind
-            // Outer resumes (continuation), propagates → Unwind
-            // No CompleteAsyncMethod for either — both unwind
-            // Expected method events: Resume, Unwind, Resume, Unwind
-            var methodEvents = stream.All
+            // Marker -> UnhandledExceptionOuter -> UnhandledExceptionInner
+            const int ExpectedChainDepth = 3;
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_UnhandledException_MethodEventsWithUnwind_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            ulong chainTaskId = markerCallstacks[0].TaskId;
+            var chainEvents = stream.ForTask(chainTaskId);
+
+            var sequence = chainEvents
                 .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod
                     or AsyncEventID.CompleteAsyncMethod
                     or AsyncEventID.UnwindAsyncException)
                 .Select(e => e.EventId)
                 .ToList();
 
-            var tail = methodEvents.Skip(methodEvents.Count - 4).ToList();
-            Assert.Equal(4, tail.Count);
-            Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[0]);
-            Assert.Equal(AsyncEventID.UnwindAsyncException, tail[1]);
-            Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[2]);
-            Assert.Equal(AsyncEventID.UnwindAsyncException, tail[3]);
+            // Every method in the chain unwinds (no catch); no CompleteAsyncMethod expected.
+            Assert.Equal(ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.ResumeAsyncMethod));
+            Assert.Equal(ExpectedChainDepth, sequence.Count(id => id == AsyncEventID.UnwindAsyncException));
+            Assert.Equal(0, sequence.Count(id => id == AsyncEventID.CompleteAsyncMethod));
+
+            // Per-method ordering: each Resume is immediately followed by its Unwind.
+            for (int i = 0; i < sequence.Count; i += 2)
+            {
+                Assert.Equal(AsyncEventID.ResumeAsyncMethod, sequence[i]);
+                Assert.Equal(AsyncEventID.UnwindAsyncException, sequence[i + 1]);
+            }
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ResumeAsyncCallstackEmitted_Marker()
+        {
+            await TaskAsync_DeepChain();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_ResumeAsyncCallstackEmitted()
         {
-            //System.Diagnostics.Debugger.Launch();
-
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_DeepChain());
+                RunScenarioAndFlush(() => TaskAsync_ResumeAsyncCallstackEmitted_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var callstacks = stream.All
-                .Where(e => e.EventId == AsyncEventID.ResumeAsyncCallstack)
-                .ToList();
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_ResumeAsyncCallstackEmitted_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
-            Assert.NotEmpty(callstacks);
-            Assert.All(callstacks, cs =>
+            Assert.All(markerCallstacks, cs =>
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in resume callstack");
                 Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero methodId in first frame");
@@ -446,7 +487,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_CallstackDepthMarker()
+        private static async Task TaskAsync_CallstackDepthMatchesChainDepth_Marker()
         {
             await TaskAsync_Level1();
         }
@@ -456,23 +497,23 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_CallstackDepthMarker());
+                RunScenarioAndFlush(() => TaskAsync_CallstackDepthMatchesChainDepth_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_CallstackDepthMarker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with TaskAsync_CallstackDepthMarker");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CallstackDepthMatchesChainDepth_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
-            // TaskAsync_CallstackDepthMarker → Level1 → Level2 → Level3: deepest callstack should have exactly 4 frames
+            // TaskAsync_CallstackDepthMarker â†’ Level1 â†’ Level2 â†’ Level3: deepest callstack should have exactly 4 frames
             Assert.Equal(4, markerCallstacks[0].FrameCount);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_DistinctMethodIdsMarker()
+        private static async Task TaskAsync_CallstackFramesHaveDistinctMethodIds_Marker()
         {
             await TaskAsync_Level1();
         }
@@ -482,15 +523,15 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_DistinctMethodIdsMarker());
+                RunScenarioAndFlush(() => TaskAsync_CallstackFramesHaveDistinctMethodIds_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_DistinctMethodIdsMarker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with TaskAsync_DistinctMethodIdsMarker");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             // Frames in the same callstack should have distinct methodIds (different async methods)
             var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
@@ -499,33 +540,33 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_StateRoot()
+        private static async Task TaskAsync_CallstackFramesHaveDistinctStates_Root_Marker()
         {
             await Task.Yield();
-            await TaskAsync_StateMiddle();
+            await TaskAsync_CallstackFramesHaveDistinctStates_Middle_Marker();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_StateMiddle()
+        private static async Task TaskAsync_CallstackFramesHaveDistinctStates_Middle_Marker()
         {
             await Task.Yield();
             await Task.Yield();
-            await TaskAsync_StateLeaf();
+            await TaskAsync_CallstackFramesHaveDistinctStates_Leaf_Marker();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_StateLeaf()
+        private static async Task TaskAsync_CallstackFramesHaveDistinctStates_Leaf_Marker()
         {
             await Task.Delay(100);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_CallstackStatesMarker()
+        private static async Task TaskAsync_CallstackFramesHaveDistinctStates_Marker()
         {
-            await TaskAsync_StateRoot();
+            await TaskAsync_CallstackFramesHaveDistinctStates_Root_Marker();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -533,15 +574,15 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_CallstackStatesMarker());
+                RunScenarioAndFlush(() => TaskAsync_CallstackFramesHaveDistinctStates_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_CallstackStatesMarker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with marker");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CallstackFramesHaveDistinctStates_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             // The deepest callstack (on the final Delay resume) should have 4 frames:
             // Leaf (state=3), Middle (state=2), Root (state=1), Marker (state=0)
@@ -556,39 +597,35 @@ namespace System.Threading.Tasks.Tests
             Assert.Equal(0, states[3]); // Marker: suspended at 1st await (state=0)
         }
 
-        // --- Yield at each level scenario ---
-        // Each frame yields after calling its child, causing separate resume events
-        // with progressively shrinking callstacks as outer frames complete.
-
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_YieldEachLevel_Marker()
+        private static async Task TaskAsync_YieldAtEachLevel_CallstackShrinks_Level1_Marker()
         {
-            await TaskAsync_YieldEachLevel_Level1();
-        }
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_YieldEachLevel_Level1()
-        {
-            await TaskAsync_YieldEachLevel_Level2();
+            await TaskAsync_YieldAtEachLevel_CallstackShrinks_Level2_Marker();
             await Task.Yield();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_YieldEachLevel_Level2()
+        private static async Task TaskAsync_YieldAtEachLevel_CallstackShrinks_Level2_Marker()
         {
-            await TaskAsync_YieldEachLevel_Level3();
+            await TaskAsync_YieldAtEachLevel_CallstackShrinks_Level3_Marker();
             await Task.Yield();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_YieldEachLevel_Level3()
+        private static async Task TaskAsync_YieldAtEachLevel_CallstackShrinks_Level3_Marker()
         {
             await Task.Delay(100);
             await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_YieldAtEachLevel_CallstackShrinks_Marker()
+        {
+            await TaskAsync_YieldAtEachLevel_CallstackShrinks_Level1_Marker();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -596,14 +633,14 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_YieldEachLevel_Marker());
+                RunScenarioAndFlush(() => TaskAsync_YieldAtEachLevel_CallstackShrinks_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_YieldEachLevel_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_YieldAtEachLevel_CallstackShrinks_Marker));
 
             // After Task.Delay resumes: full chain (Level3, Level2, Level1, Marker) = 4 frames
             // After Level3's yield resumes: Level3 completes, chain is (Level2, Level1, Marker) = 3 frames
@@ -613,35 +650,13 @@ namespace System.Threading.Tasks.Tests
             Assert.Contains(markerCallstacks, cs => cs.FrameCount == 2);
         }
 
-        // --- Append callstack race scenario ---
-        // Forces the chain-growth race where the parent registers as a continuation
-        // AFTER the child's dispatcher has already walked the callstack but BEFORE
-        // the dispatcher hits its next suspend/complete point. This is the exact
-        // window the AppendAsyncCallstack mechanism is designed to fill in.
-        //
-        // Uses a SemaphoreSlim to deterministically order events independent of TP
-        // scheduling latency (a pure Thread.Sleep approach is unreliable because the
-        // TP dispatch latency for D1 can exceed the parent's sleep window).
-        //
-        // Order of events:
-        //   1. Parent calls Child; Child suspends at first Yield; D1 is created and queued.
-        //   2. Parent calls s_appendRace_proceed.Wait() — blocks.
-        //   3. D1 picked up by TP. D1.Resume walks chain → 1 frame (Child), because
-        //      Parent hasn't done `await t` yet (it's still in Wait()).
-        //   4. D1 calls Child.MoveNext; Child resumes past the await and calls Release().
-        //   5. Parent unblocks, does `await t` — registers Parent on Child.Task.
-        //   6. Meanwhile Child does Thread.Sleep(200) holding D1 alive.
-        //   7. Child hits second Yield → SuspendAsyncContext on D1 → Append check sees
-        //      Parent now registered → emits AppendAsyncCallstack with Parent's frame.
-
         private static SemaphoreSlim s_appendRace_proceed;
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_AppendRace_Child()
+        private static async Task TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker()
         {
             await Task.Yield();
-            // Inside D1.MoveNext now; Resume callstack walk already happened.
             s_appendRace_proceed.Release();
             Thread.Sleep(200);
             await Task.Yield();
@@ -649,9 +664,9 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_AppendRace_Parent()
+        private static async Task TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker()
         {
-            Task t = TaskAsync_AppendRace_Child();
+            Task t = TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker();
             s_appendRace_proceed.Wait();
             await t;
         }
@@ -659,44 +674,30 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void TaskAsync_AppendCallstack_FiresOnLateParentRegistration()
         {
-            // System.Diagnostics.Debugger.Launch();
             s_appendRace_proceed = new SemaphoreSlim(0, 1);
 
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_AppendRace_Parent());
+                RunScenarioAndFlush(() => TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            // The initial Resume on the TP thread should walk only Child (race: Parent not registered yet).
-            var childOnlyResumes = stream
-                .OfType(AsyncEventID.ResumeAsyncCallstack)
-                .Where(e => e.FrameCount == 1 && e.HasMarkerFrame(nameof(TaskAsync_AppendRace_Child)))
-                .ToList();
+            // The initial Resume should only include TaskAsync_AppendRace_Child (race: Parent not registered yet).
+            var childOnlyResumes = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Child_Marker));
             Assert.NotEmpty(childOnlyResumes);
 
-            // After Parent registers and Child hits its next suspend/complete hook,
+            // After Parent registers and Child hits its next complete hook,
             // an AppendAsyncCallstack should fire with the Parent frame.
-            var appendsWithParent = stream
-                .OfType(AsyncEventID.AppendAsyncCallstack)
-                .Where(e => e.HasMarkerFrame(nameof(TaskAsync_AppendRace_Parent)))
-                .ToList();
+            var appendsWithParent = stream.CallstacksWithMarker(AsyncEventID.AppendAsyncCallstack, nameof(TaskAsync_AppendCallstack_FiresOnLateParentRegistration_Parent_Marker));
             Assert.NotEmpty(appendsWithParent);
         }
 
-        // --- Negative: Append should NOT fire when the chain is already complete at Resume time ---
-        // The deep-chain marker awaits Level1→Level2→Level3, where Level3 awaits Task.Delay(100).
-        // The 100ms delay gives all parent continuations ample time to register before the
-        // dispatcher walks the chain. The walker should terminate at a non-box (Task.Run wrapper)
-        // and set LastContinuation = null, so subsequent ResumeAsyncMethod/Suspend/Complete hooks
-        // for the inline cascade short-circuit and emit no Append events.
-
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_CompleteChain_NoAppendMarker()
+        private static async Task TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker()
         {
             await TaskAsync_DeepChain();
         }
@@ -706,7 +707,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_CompleteChain_NoAppendMarker());
+                RunScenarioAndFlush(() => TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker());
             });
 
             // DumpAllEvents(events);
@@ -714,27 +715,16 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // Sanity: the marker frame must appear in the initial Resume callstack (full chain captured).
-            var markerCallstacks = stream
-                .OfType(AsyncEventID.ResumeAsyncCallstack)
-                .Where(e => e.HasMarkerFrame(nameof(TaskAsync_CompleteChain_NoAppendMarker)))
-                .ToList();
-            Assert.True(markerCallstacks.Count > 0,
-                $"Expected initial Resume callstack to contain {nameof(TaskAsync_CompleteChain_NoAppendMarker)} (full chain at walk time)");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CompleteChain_DoesNotEmitAppendEvents_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
-            // No Append events should fire — the chain was complete at Resume time.
-            var appendEvents = stream
-                .OfType(AsyncEventID.AppendAsyncCallstack)
+            // No Append events should fire on this context â€” the chain was complete at Resume time.
+            ulong chainTaskId = markerCallstacks[0].TaskId;
+            var appendEvents = stream.ForTask(chainTaskId)
+                .Where(e => e.EventId == AsyncEventID.AppendAsyncCallstack)
                 .ToList();
-            Assert.True(appendEvents.Count == 0,
-                $"Expected zero AppendAsyncCallstack events for a complete-chain scenario, got {appendEvents.Count}");
+            Assert.Empty(appendEvents);
         }
-
-        // --- Custom SynchronizationContext scenario ---
-        // Validates that when a non-default SynchronizationContext is active during an await,
-        // the dispatcher wrapping path is taken (TaskAwaiter.UnsafeOnCompletedInternal wraps the box)
-        // and the continuation flows through the custom context's Post back into the dispatcher's
-        // MoveNext. Standard Resume/Suspend/Complete events should fire normally; the marker frame
-        // must be visible in the Resume callstack.
 
         private sealed class InlinePostSynchronizationContext : SynchronizationContext
         {
@@ -752,15 +742,11 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_SyncContextMarker()
+        private static async Task TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker()
         {
             // Install a non-default SynchronizationContext on this thread so the await captures it.
             // The await's continuation will be routed via SynchronizationContextAwaitTaskContinuation,
             // which wraps the box in an AsyncTaskDispatcher and posts back to the context.
-            //
-            // Note: the await may resume on a different thread (the SyncContext's Post may run on
-            // the timer thread or another worker). Only restore the previous context if we resumed
-            // on the same thread, to avoid polluting an unrelated thread's SynchronizationContext.
             int callerThreadId = Environment.CurrentManagedThreadId;
             SynchronizationContext? prev = SynchronizationContext.Current;
             SynchronizationContext.SetSynchronizationContext(s_taskAsyncSyncContextCtx);
@@ -784,7 +770,7 @@ namespace System.Threading.Tasks.Tests
 
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_SyncContextMarker());
+                RunScenarioAndFlush(() => TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker());
             });
 
             // DumpAllEvents(events);
@@ -795,12 +781,11 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            // The marker frame should appear in the Resume callstack (or via Append if the chain raced).
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_SyncContextMarker));
-            Assert.True(markerCallstacks.Count > 0,
-                $"Expected merged Resume callstack containing {nameof(TaskAsync_SyncContextMarker)}");
+            // The marker frame should appear in the Resume callstack.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
-            // Verify the standard Create → Resume → Complete sequence fired for our context.
+            // Verify the standard Create â†’ Resume â†’ Complete sequence fired for our context.
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
@@ -813,13 +798,6 @@ namespace System.Threading.Tasks.Tests
             int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
-
-        // --- Custom TaskScheduler scenario ---
-        // Validates that when a non-default TaskScheduler is active (the marker runs on a custom
-        // scheduler via Task.Factory.StartNew(..., scheduler)), the dispatcher wrapping path is taken
-        // and the continuation flows through the custom scheduler's QueueTask back into the dispatcher's
-        // MoveNext via TaskSchedulerAwaitTaskContinuation. Standard Resume/Suspend/Complete events
-        // should fire normally.
 
         private sealed class InlineRunTaskScheduler : TaskScheduler
         {
@@ -839,11 +817,8 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_TaskSchedulerMarker()
+        private static async Task TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker()
         {
-            // We rely on the caller having scheduled this method on a custom TaskScheduler via
-            // Task.Factory.StartNew, so TaskScheduler.InternalCurrent is the custom scheduler at
-            // the moment of await. The await's continuation gets routed through that scheduler.
             await Task.Delay(100);
         }
 
@@ -854,14 +829,10 @@ namespace System.Threading.Tasks.Tests
 
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                // Schedule the marker on our custom scheduler so TaskScheduler.InternalCurrent
-                // is the custom scheduler when its first await is registered. Unwrap+GetResult
-                // blocks until the async chain completes, then RunScenarioAndFlush's pattern is
-                // inlined here (we can't reuse RunScenarioAndFlush because it uses Task.Run).
                 try
                 {
                     Task.Factory.StartNew(
-                        () => TaskAsync_TaskSchedulerMarker(),
+                        () => TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker(),
                         CancellationToken.None,
                         TaskCreationOptions.None,
                         scheduler).Unwrap().GetAwaiter().GetResult();
@@ -875,20 +846,16 @@ namespace System.Threading.Tasks.Tests
 
             // DumpAllEvents(events);
 
-            // The custom scheduler must have received at least one QueueTask call (for the outer
-            // task). The continuation may or may not also be queued depending on whether the runtime
-            // inlines it on the timer thread; what matters for this test is that the dispatcher's
-            // events fired for the async context.
+            // The custom scheduler must have received at least one QueueTask call.
             Assert.True(scheduler.QueuedCount >= 1,
                 $"Expected custom TaskScheduler to receive at least one QueueTask call, got {scheduler.QueuedCount}");
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_TaskSchedulerMarker));
-            Assert.True(markerCallstacks.Count > 0,
-                $"Expected merged Resume callstack containing {nameof(TaskAsync_TaskSchedulerMarker)}");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
-            // Verify standard Create → Resume → Complete sequence for our context.
+            // Verify standard Create â†’ Resume â†’ Complete sequence for our context.
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
@@ -902,41 +869,570 @@ namespace System.Threading.Tasks.Tests
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
-        // --- ValueTask scenario methods ---
-
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_Level1()
+        private static async Task TaskAsync_NoEventsWhenDisabled_Marker()
         {
-            await ValueTaskAsync_Level2();
+            await Task.Delay(50);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_NoEventsWhenDisabled()
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                RunScenario(() => TaskAsync_NoEventsWhenDisabled_Marker());
+            }
+
+            // Now attach a listener but don't perform any V1 async work.
+            var events = CollectEvents(CoreKeywords, () => { });
+
+            var ids = ParseAllEvents(events).EventIds;
+            int contextEvents = ids.Count(id =>
+                id == AsyncEventID.CreateAsyncContext ||
+                id == AsyncEventID.ResumeAsyncContext ||
+                id == AsyncEventID.SuspendAsyncContext ||
+                id == AsyncEventID.CompleteAsyncContext);
+
+            Assert.Equal(0, contextEvents);
+        }
+
+        public static IEnumerable<object[]> TaskAsyncKeywordGatekeepingData()
+        {
+            yield return new object[] { (long)CreateAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CreateAsyncContext } };
+            yield return new object[] { (long)ResumeAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncContext } };
+            yield return new object[] { (long)CompleteAsyncContextKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteAsyncContext } };
+            yield return new object[] { (long)UnwindAsyncExceptionKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.UnwindAsyncException } };
+            yield return new object[] { (long)ResumeAsyncCallstackKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncCallstack, AsyncEventID.AppendAsyncCallstack } };
+            yield return new object[] { (long)ResumeAsyncMethodKeyword,     new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncMethod } };
+            yield return new object[] { (long)CompleteAsyncMethodKeyword,   new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteAsyncMethod } };
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_Level2()
+        private static async Task TaskAsync_KeywordGatekeeping_Marker()
         {
-            await ValueTaskAsync_Level3();
+            // Exercise multiple event types: exception unwind, multiple completes, method invocations.
+            try
+            {
+                await TaskAsync_InnerThrows();
+            }
+            catch (InvalidOperationException) { }
+            await Task.Delay(50);
+        }
+
+        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [MemberData(nameof(TaskAsyncKeywordGatekeepingData))]
+        public void TaskAsync_KeywordGatekeeping(long keywordValue, AsyncEventID[] allowedEventIds)
+        {
+            EventKeywords kw = (EventKeywords)keywordValue;
+            var allowed = new HashSet<AsyncEventID>(allowedEventIds);
+
+            var events = CollectEvents(kw, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_NoEventsWhenDisabled_Marker());
+            });
+
+            var stream = ParseAllEvents(events);
+            var unexpected = stream.EventIds.Where(id => !allowed.Contains(id)).ToList();
+
+            Assert.True(unexpected.Count == 0,
+                $"Keyword 0x{(long)kw:X}: unexpected event IDs [{string.Join(", ", unexpected)}], allowed [{string.Join(", ", allowed)}]");
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_Level3()
+        private static async Task TaskAsync_WhenAllBranchA()
         {
             await Task.Delay(100);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_Marker()
+        private static async Task TaskAsync_WhenAllBranchB()
         {
-            await ValueTaskAsync_Level1();
+            await Task.Delay(120);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_EventSequenceOrderMarker()
+        private static async Task TaskAsync_WhenAllBranchC()
         {
-            await ValueTaskAsync_Marker();
+            await Task.Delay(140);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_WhenAll_TracksAllBranchesAndJoin_Marker()
+        {
+            await Task.WhenAll(TaskAsync_WhenAllBranchA(), TaskAsync_WhenAllBranchB(), TaskAsync_WhenAllBranchC());
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_WhenAll_TracksAllBranchesAndJoin()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_WhenAll_TracksAllBranchesAndJoin_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAll_TracksAllBranchesAndJoin_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // Each branch is its own async chain; its inner await of Task.Delay produces a Resume callstack containing the branch frame.
+            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAllBranchA));
+            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAllBranchB));
+            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAllBranchC));
+            Assert.True(branchACallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchA)}");
+            Assert.True(branchBCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchB)}");
+            Assert.True(branchCCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchC)}");
+
+            // Every Create must be balanced by a Complete.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            Assert.True(createCount >= 4,
+                $"Expected at least 4 CreateAsyncContext events (3 branches + outer), got {createCount}");
+
+            // The outer marker's chain should fire the standard Create â†’ Resume â†’ Complete sequence on its own TaskId, in that order.
+            ulong markerTaskId = markerCallstacks[0].TaskId;
+            var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
+
+            int createIdx = markerIds.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the WhenAll outer marker");
+
+            int resumeIdx = markerIds.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
+
+            int completeIdx = markerIds.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
+
+            // The outer should be created exactly once.
+            int createCountForMarker = markerIds.Count(id => id == AsyncEventID.CreateAsyncContext);
+            Assert.Equal(1, createCountForMarker);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_WhenAnyFast()
+        {
+            await Task.Delay(50);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_WhenAnySlow1()
+        {
+            await Task.Delay(400);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_WhenAnySlow2()
+        {
+            await Task.Delay(600);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes_Marker()
+        {
+            Task fast = TaskAsync_WhenAnyFast();
+            Task slow1 = TaskAsync_WhenAnySlow1();
+            Task slow2 = TaskAsync_WhenAnySlow2();
+
+            await Task.WhenAny(fast, slow1, slow2);
+            await Task.WhenAll(slow1, slow2);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // All branches â€” including the slow ones whose completion the outer is no longer
+            // strictly waiting on after WhenAny returned â€” must produce their own Resume
+            // callstacks. This proves their dispatcher lifetimes are tracked independently.
+            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAnyFast));
+            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAnySlow1));
+            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_WhenAnySlow2));
+            Assert.True(fastCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnyFast)}");
+            Assert.True(slow1Callstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnySlow1)}");
+            Assert.True(slow2Callstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnySlow2)}");
+
+            // Every Create must be balanced by a Complete.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            Assert.True(createCount >= 4,
+                $"Expected at least 4 CreateAsyncContext events (3 branches + outer), got {createCount}");
+
+            // The outer marker's chain: exactly one Create, at least two Resumes (one after
+            // WhenAny, one after WhenAll on the slow branches), then Complete.
+            ulong markerTaskId = markerCallstacks[0].TaskId;
+            var markerEvents = stream.ForTask(markerTaskId);
+            var markerIds = markerEvents.Select(e => e.EventId).ToList();
+
+            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.ResumeAsyncContext);
+            Assert.True(resumeCountForMarker >= 1,
+                $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
+
+            int completeCountForMarker = markerIds.Count(id => id == AsyncEventID.CompleteAsyncContext);
+            Assert.True(completeCountForMarker >= 1, "Expected at least one CompleteAsyncContext for the outer marker");
+
+            // First event for the marker is its Create; last is a Complete.
+            Assert.Equal(AsyncEventID.CreateAsyncContext, markerIds[0]);
+            Assert.Equal(AsyncEventID.CompleteAsyncContext, markerIds[^1]);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_RecursiveChain(int depth)
+        {
+            if (depth <= 1)
+            {
+                await Task.Delay(100);
+                return;
+            }
+            await TaskAsync_RecursiveChain(depth - 1);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_CallstackDepthCappedAtMaxFrames_Marker(int depth)
+        {
+            await TaskAsync_RecursiveChain(depth);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CallstackDepthCappedAtMaxFrames()
+        {
+            // Build a chain deeper than the 255-frame cap (byte FrameCount). The deepest
+            // ResumeAsyncCallstack should clamp at byte.MaxValue without crashing.
+            const int requestedDepth = 300;
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_CallstackDepthCappedAtMaxFrames_Marker(requestedDepth));
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // With the cap at byte.MaxValue, the initial Resume walks the first 255 frames from
+            // the leaf. The marker sits at the top of the chain (deeper than 255), so it appears
+            // in a subsequent AppendAsyncCallstack carrying the remaining frames. Use the merged
+            // view to validate the chain as a whole.
+            var mergedMarker = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_CallstackDepthCappedAtMaxFrames_Marker));
+            Assert.NotEmpty(mergedMarker);
+
+            var deepest = mergedMarker.MaxBy(cs => cs.Frames.Count);
+            Assert.NotNull(deepest);
+
+            // Walker should have captured at least the full requested depth across Resume+Appends.
+            Assert.True(deepest.Frames.Count >= requestedDepth,
+                $"Expected merged frame count >= {requestedDepth}, got {deepest.Frames.Count}");
+
+            // Each individual event clamps its own FrameCount at byte.MaxValue (wire format limit).
+            ulong chainTaskId = deepest.TaskId;
+            var perEventCallstacks = stream.ForTask(chainTaskId)
+                .Where(e => e.EventId is AsyncEventID.ResumeAsyncCallstack or AsyncEventID.AppendAsyncCallstack)
+                .ToList();
+            Assert.NotEmpty(perEventCallstacks);
+            Assert.All(perEventCallstacks, cs => Assert.True(cs.FrameCount <= byte.MaxValue));
+
+            // At least one event must have hit the cap (otherwise the test isn't exercising it).
+            Assert.Contains(perEventCallstacks, cs => cs.FrameCount == byte.MaxValue);
+
+            // Every captured frame should resolve to a managed method.
+            foreach (var (methodId, _) in deepest.Frames)
+            {
+                Assert.True(methodId != 0, "Frame has zero MethodId");
+                var method = GetMethodNameFromMethodId(deepest.CallstackType, methodId);
+                Assert.True(method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
+            }
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_CallstackStressWithVaryingDepths_Marker(int depth)
+        {
+            await TaskAsync_RecursiveChain(depth);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CallstackStressWithVaryingDepths()
+        {
+            const int iterations = 50;
+            int[] depths = new int[iterations];
+            var rng = new Random(42);
+            for (int i = 0; i < iterations; i++)
+                depths[i] = rng.Next(1, 60);
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    for (int i = 0; i < iterations; i++)
+                        await TaskAsync_CallstackStressWithVaryingDepths_Marker(depths[i]);
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_CallstackStressWithVaryingDepths_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // Every emitted callstack must have valid frame data.
+            foreach (var cs in markerCallstacks)
+            {
+                Assert.True(cs.FrameCount > 0, "Callstack has 0 frames");
+                Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
+                for (int f = 0; f < cs.Frames.Count; f++)
+                {
+                    var (methodId, _) = cs.Frames[f];
+                    Assert.True(methodId != 0, $"Frame {f} has zero MethodId");
+                    var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
+                    Assert.True(method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
+                }
+            }
+
+            // We expect at least one marker callstack per iteration.
+            Assert.True(markerCallstacks.Count >= iterations,
+                $"Expected at least {iterations} callstacks with marker, got {markerCallstacks.Count}");
+
+            // Verify multiple buffer flushes occurred â€” proves the buffer machinery is exercised.
+            int bufferCount = 0;
+            ForEachEventBufferPayload(events, _ => bufferCount++);
+            Assert.True(bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_WaitThenYield(Task gate)
+        {
+            await gate;
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_DoubleSuspendInOneMoveNext_BalancesResumeAndComplete_Marker()
+        {
+            await Task.Yield();
+
+            var tcs = new TaskCompletionSource();
+            Task b1 = TaskAsync_WaitThenYield(tcs.Task);
+            Task b2 = TaskAsync_WaitThenYield(tcs.Task);
+
+            tcs.SetResult();
+
+            await Task.WhenAll(b1, b2);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_DoubleSuspendInOneMoveNext_BalancesResumeAndComplete()
+        {
+            var events = CollectEvents(CoreKeywords | ResumeAsyncCallstackKeyword, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_DoubleSuspendInOneMoveNext_BalancesResumeAndComplete_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            int resumeCount = stream.OfType(AsyncEventID.ResumeAsyncContext).Count();
+            int suspendCount = stream.OfType(AsyncEventID.SuspendAsyncContext).Count();
+
+            // At least one root Create event.
+            Assert.True(createCount >= 1,
+                $"Expected at least one CreateAsyncContext event, got {createCount}");
+
+            Assert.Equal(createCount, completeCount);
+            Assert.Equal(resumeCount, completeCount);
+
+            // Does not emit Suspend events.
+            Assert.Equal(0, suspendCount);
+
+            Assert.True(createCount >= 3,
+                $"Expected fan-out chain to produce at least 3 CreateAsyncContext events (root + 2 child wraps), got {createCount}");
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_DoubleSuspendInOneMoveNext_BalancesResumeAndComplete_Marker));
+            Assert.NotEmpty(markerCallstacks);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ConfigureAwaitFalseLeaf()
+        {
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ConfigureAwaitFalseMid()
+        {
+            await TaskAsync_ConfigureAwaitFalseLeaf().ConfigureAwait(false);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ConfigureAwaitFalse_Marker()
+        {
+            await TaskAsync_ConfigureAwaitFalseMid().ConfigureAwait(false);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_ConfigureAwaitFalse()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_ConfigureAwaitFalse_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_ConfigureAwaitFalse_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // The deepest callstack should include all 3 chain frames.
+            var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
+            var frameNames = deepest.Frames
+                .Select(f => GetMethodNameFromMethodId(deepest.CallstackType, f.MethodId))
+                .Where(n => n is not null)
+                .ToList();
+            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseLeaf), frameNames);
+            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseMid), frameNames);
+            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalse_Marker), frameNames);
+
+            // Every Create must be balanced by a Complete.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_FaultedInner()
+        {
+            await Task.Delay(50);
+            throw new InvalidOperationException("test fault");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_FaultedTask_Marker()
+        {
+            try
+            {
+                await TaskAsync_FaultedInner();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_FaultedTask()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_FaultedTask_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_FaultedTask_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // Every dispatcher that was Created must Complete, even on the fault path.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            int unwindCount = stream.OfType(AsyncEventID.UnwindAsyncException).Count();
+            Assert.True(unwindCount > 0,
+                "Expected at least one UnwindAsyncException event for the faulted inner task");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_CancelledInner(CancellationToken ct)
+        {
+            await Task.Delay(5000, ct);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_TaskCancellation_Marker()
+        {
+            using var cts = new CancellationTokenSource();
+            Task inner = TaskAsync_CancelledInner(cts.Token);
+            cts.CancelAfter(50);
+            try
+            {
+                await inner;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_TaskCancellation()
+        {
+            var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_TaskCancellation_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_TaskCancellation_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // Every Create must be balanced by a Complete on the cancellation path.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            // At least 2 Creates: inner cancelled task + outer marker. Both must Complete.
+            Assert.True(createCount >= 2,
+                $"Expected at least 2 CreateAsyncContext events (inner + marker), got {createCount}");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async ValueTask ValueTaskAsync_EventSequenceOrder_Marker()
+        {
+            await ValueTaskAsync_Level1();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -944,15 +1440,15 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_EventSequenceOrderMarker().AsTask());
+                RunScenarioAndFlush(() => ValueTaskAsync_EventSequenceOrder_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_EventSequenceOrderMarker));
-            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(ValueTaskAsync_EventSequenceOrderMarker)}");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_EventSequenceOrder_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
@@ -967,19 +1463,25 @@ namespace System.Threading.Tasks.Tests
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async ValueTask ValueTaskAsync_MethodEventsEmitted_Marker()
+        {
+            await ValueTaskAsync_Level1();
+        }
+
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void ValueTaskAsync_MethodEventsEmitted()
         {
             var events = CollectEvents(MethodKeywords | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_Marker().AsTask());
+                RunScenarioAndFlush(() => ValueTaskAsync_MethodEventsEmitted_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            // ValueTask chain of 4 methods: Marker → Level1 → Level2 → Level3
             var methodEvents = stream.All
                 .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod or AsyncEventID.CompleteAsyncMethod)
                 .Select(e => e.EventId)
@@ -988,8 +1490,17 @@ namespace System.Threading.Tasks.Tests
             int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeAsyncMethod);
             int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteAsyncMethod);
 
+            // Marker â†’ Level1 â†’ Level2 â†’ Level3
             Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
             Assert.True(completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events for ValueTask chain, got {completeCount}");
+        }
+
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async ValueTask ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker()
+        {
+            await ValueTaskAsync_Level1();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -997,18 +1508,25 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_Marker().AsTask());
+                RunScenarioAndFlush(() => ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_Marker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with ValueTaskAsync_Marker");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackDepthMatchesChainDepth_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
-            // ValueTaskAsync_Marker → Level1 → Level2 → Level3: deepest should have 4 frames
+            // Marker â†’ Level1 â†’ Level2 â†’ Level3
             Assert.Equal(4, markerCallstacks[0].FrameCount);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async ValueTask ValueTaskAsync_CallstackFramesHaveDistinctMethodIds_Marker()
+        {
+            await ValueTaskAsync_Level1();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -1016,15 +1534,15 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_Marker().AsTask());
+                RunScenarioAndFlush(() => ValueTaskAsync_CallstackFramesHaveDistinctMethodIds_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_Marker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with ValueTaskAsync_Marker");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_CallstackFramesHaveDistinctMethodIds_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
             Assert.Equal(methodIds.Count, methodIds.Distinct().Count());
@@ -1032,7 +1550,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_InnerThrows()
+        private static async ValueTask ValueTaskAsync_HandledException_EmitsUnwindAndComplete_InnerThrows_Marker()
         {
             await Task.Delay(100);
             throw new InvalidOperationException("valuetask inner throw");
@@ -1040,11 +1558,11 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_ExceptionHandled()
+        private static async ValueTask ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Handled_Marker()
         {
             try
             {
-                await ValueTaskAsync_InnerThrows();
+                await ValueTaskAsync_HandledException_EmitsUnwindAndComplete_InnerThrows_Marker();
             }
             catch (InvalidOperationException)
             {
@@ -1053,9 +1571,9 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_HandledException_EmitsUnwindAndCompleteMarker()
+        private static async ValueTask ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker()
         {
-            await ValueTaskAsync_ExceptionHandled();
+            await ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Handled_Marker();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -1063,15 +1581,15 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
             {
-                RunScenarioAndFlush(() => ValueTaskAsync_HandledException_EmitsUnwindAndCompleteMarker().AsTask());
+                RunScenarioAndFlush(() => ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker().AsTask());
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_HandledException_EmitsUnwindAndCompleteMarker));
-            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(ValueTaskAsync_HandledException_EmitsUnwindAndCompleteMarker)}");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_HandledException_EmitsUnwindAndComplete_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
@@ -1089,16 +1607,17 @@ namespace System.Threading.Tasks.Tests
             Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
+
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_UnhandledOuter()
+        private static async ValueTask ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledOuter_Marker()
         {
-            await ValueTaskAsync_UnhandledInner();
+            await ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledInner_Marker();
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_UnhandledInner()
+        private static async ValueTask ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledInner_Marker()
         {
             await Task.Delay(100);
             throw new InvalidOperationException("valuetask unhandled inner");
@@ -1106,9 +1625,9 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask ValueTaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker()
+        private static async ValueTask ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker()
         {
-            await ValueTaskAsync_UnhandledOuter();
+            await ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_UnhandledOuter_Marker();
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
@@ -1118,7 +1637,7 @@ namespace System.Threading.Tasks.Tests
             {
                 try
                 {
-                    RunScenarioAndFlush(() => ValueTaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker().AsTask());
+                    RunScenarioAndFlush(() => ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker().AsTask());
                 }
                 catch (InvalidOperationException)
                 {
@@ -1129,8 +1648,8 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker));
-            Assert.True(markerCallstacks.Count > 0, $"Expected at least one callstack with {nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndCompleteMarker)}");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ValueTaskAsync_UnhandledException_EmitsUnwindAndComplete_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
@@ -1151,456 +1670,34 @@ namespace System.Threading.Tasks.Tests
             Assert.True(completeIdx > unwindIdx2, "Expected CompleteAsyncContext after second Unwind");
         }
 
-        // --- Negative: no events when profiler is disabled ---
-        // Validates that the InstrumentCheckPoint + AsyncProfiler flag short-circuit kicks in
-        // before the listener is attached, so async work done with no listener leaves no
-        // context-level events behind. After attachment, only background metadata events should
-        // be present (no Create/Resume/Suspend/Complete from prior or current work).
-
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_NoEventsWhenDisabledScenario()
-        {
-            await Task.Delay(50);
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_NoEventsWhenDisabled()
-        {
-            // Run async work WITHOUT a listener attached. No keywords enabled → no events emitted.
-            for (int i = 0; i < 50; i++)
-            {
-                RunScenario(() => TaskAsync_NoEventsWhenDisabledScenario());
-            }
-
-            // Now attach a listener but don't perform any V1 async work — verify no stale events
-            // from the previous work leaked through.
-            var events = CollectEvents(CoreKeywords, () => { /* no-op */ });
-
-            var ids = ParseAllEvents(events).EventIds;
-            int contextEvents = ids.Count(id =>
-                id == AsyncEventID.CreateAsyncContext ||
-                id == AsyncEventID.ResumeAsyncContext ||
-                id == AsyncEventID.SuspendAsyncContext ||
-                id == AsyncEventID.CompleteAsyncContext);
-
-            Assert.Equal(0, contextEvents);
-        }
-
-        // --- Keyword gatekeeping ---
-        // Validates that each individual keyword only enables its corresponding event type.
-        // Auto-emitted infrastructure events (ResetAsyncThreadContext, AsyncProfilerMetadata)
-        // are always allowed. ResumeAsyncCallstackKeyword controls both ResumeAsyncCallstack
-        // AND AppendAsyncCallstack (V1 emits Append events under the same keyword as Resume).
-
-        public static IEnumerable<object[]> TaskAsyncKeywordGatekeepingData()
-        {
-            yield return new object[] { (long)CreateAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CreateAsyncContext } };
-            yield return new object[] { (long)ResumeAsyncContextKeyword,    new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncContext } };
-            yield return new object[] { (long)SuspendAsyncContextKeyword,   new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.SuspendAsyncContext } };
-            yield return new object[] { (long)CompleteAsyncContextKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteAsyncContext } };
-            yield return new object[] { (long)UnwindAsyncExceptionKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.UnwindAsyncException } };
-            yield return new object[] { (long)ResumeAsyncCallstackKeyword,  new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncCallstack, AsyncEventID.AppendAsyncCallstack } };
-            yield return new object[] { (long)ResumeAsyncMethodKeyword,     new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.ResumeAsyncMethod } };
-            yield return new object[] { (long)CompleteAsyncMethodKeyword,   new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.AsyncProfilerMetadata, AsyncEventID.CompleteAsyncMethod } };
-        }
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_KeywordGatekeepingMarker()
-        {
-            // Exercise multiple event types: exception unwind, multiple suspends, method invocations.
-            try
-            {
-                await TaskAsync_InnerThrows();
-            }
-            catch (InvalidOperationException) { }
-            await Task.Delay(50);
-        }
-
-        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        [MemberData(nameof(TaskAsyncKeywordGatekeepingData))]
-        public void TaskAsync_KeywordGatekeeping(long keywordValue, AsyncEventID[] allowedEventIds)
-        {
-            EventKeywords kw = (EventKeywords)keywordValue;
-            var allowed = new HashSet<AsyncEventID>(allowedEventIds);
-
-            var events = CollectEvents(kw, () =>
-            {
-                RunScenarioAndFlush(() => TaskAsync_KeywordGatekeepingMarker());
-            });
-
-            var stream = ParseAllEvents(events);
-            var unexpected = stream.EventIds.Where(id => !allowed.Contains(id)).ToList();
-
-            Assert.True(unexpected.Count == 0,
-                $"Keyword 0x{(long)kw:X}: unexpected event IDs [{string.Join(", ", unexpected)}], allowed [{string.Join(", ", allowed)}]");
-        }
-
-        // --- Fork/join (WhenAll) test ---
-        // Validates V1 dispatcher behavior under a fork-join pattern: a single outer task awaits
-        // multiple parallel branches via Task.WhenAll. Each branch is its own async chain that
-        // completes on a (potentially) different ThreadPool thread. The outer resumes only after
-        // all branches have completed. This exercises:
-        //   1. Multi-branch chain tracking — each branch produces its own Create/Resume/Complete.
-        //   2. Concurrent Append safety — branches may complete on different threads simultaneously.
-        //   3. Outer resume after fan-in — the marker's Resume callstack reconstructs correctly
-        //      after WhenAll's join releases the outer continuation.
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_WhenAllBranchA() => await Task.Delay(100);
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_WhenAllBranchB() => await Task.Delay(120);
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_WhenAllBranchC() => await Task.Delay(140);
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_WhenAllMarker()
-        {
-            await Task.WhenAll(
-                TaskAsync_WhenAllBranchA(),
-                TaskAsync_WhenAllBranchB(),
-                TaskAsync_WhenAllBranchC());
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_WhenAll_TracksAllBranchesAndJoin()
-        {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
-            {
-                RunScenarioAndFlush(() => TaskAsync_WhenAllMarker());
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // The outer marker must resume after WhenAll's join releases it. Its callstack
-            // should contain the marker frame (proves the outer dispatcher was tracked and
-            // the resume callstack reconstruction works through the WhenAll join point).
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAllMarker));
-            Assert.True(markerCallstacks.Count > 0,
-                $"Expected at least one Resume callstack containing {nameof(TaskAsync_WhenAllMarker)} after WhenAll join");
-
-            // Each branch is its own async chain; its inner await of Task.Delay produces a
-            // Resume callstack containing the branch frame.
-            var branchACallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAllBranchA));
-            var branchBCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAllBranchB));
-            var branchCCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAllBranchC));
-            Assert.True(branchACallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchA)}");
-            Assert.True(branchBCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchB)}");
-            Assert.True(branchCCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAllBranchC)}");
-
-            // Every Create must be balanced by a Complete — fork-join must not leak dispatcher
-            // contexts, and concurrent branch completion must not double-Create.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
-
-            // We expect at least 4 Create events: 3 branches + 1 outer marker (the outer's
-            // await of WhenAll wraps its box). More is fine — internal infrastructure tasks
-            // (WhenAll's join task, Task.Delay continuations) may also wrap depending on
-            // SyncContext/Scheduler state. The lower bound proves all our user-visible chains
-            // were tracked.
-            Assert.True(createCount >= 4,
-                $"Expected at least 4 CreateAsyncContext events (3 branches + outer), got {createCount}");
-
-            // The outer marker's chain should fire the standard Create → Resume → Complete
-            // sequence on its own TaskId, in that order.
-            ulong markerTaskId = markerCallstacks[0].TaskId;
-            var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
-
-            int createIdx = markerIds.IndexOf(AsyncEventID.CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext for the WhenAll outer marker");
-
-            int resumeIdx = markerIds.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
-
-            int completeIdx = markerIds.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
-
-            // The outer should be created exactly once (no double-wrap regression).
-            int createCountForMarker = markerIds.Count(id => id == AsyncEventID.CreateAsyncContext);
-            Assert.Equal(1, createCountForMarker);
-        }
-
-        // --- Fork/join (WhenAny) test ---
-        // Validates V1 dispatcher behavior under WhenAny: outer resumes when the FIRST branch
-        // completes; the remaining branches continue running in the background. This is
-        // structurally different from WhenAll because:
-        //   1. Outer is resumed mid-fan-in, while sibling branches are still alive.
-        //   2. The outer dispatcher may be resumed MORE THAN ONCE (here: once after WhenAny,
-        //      then again after WhenAll on the slow branches), exercising the resume-of-same-
-        //      context cycle without re-Creating the dispatcher.
-        //   3. Branch dispatcher lifetimes are independent of the outer's WhenAny return —
-        //      we still observe their Create/Resume/Complete events when they finish later.
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_WhenAnyFast() => await Task.Delay(50);
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_WhenAnySlow1() => await Task.Delay(400);
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_WhenAnySlow2() => await Task.Delay(600);
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_WhenAnyMarker()
-        {
-            Task fast = TaskAsync_WhenAnyFast();
-            Task slow1 = TaskAsync_WhenAnySlow1();
-            Task slow2 = TaskAsync_WhenAnySlow2();
-
-            await Task.WhenAny(fast, slow1, slow2);
-
-            // Ensure the slow branches actually complete before the scenario ends so their
-            // Create/Resume/Complete events are observable in the trace. This also forces a
-            // second suspend/resume cycle on the outer marker.
-            await Task.WhenAll(slow1, slow2);
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_WhenAny_TracksAllBranchesWithIndependentLifetimes()
-        {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
-            {
-                RunScenarioAndFlush(() => TaskAsync_WhenAnyMarker());
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // The outer marker is resumed at least once (after WhenAny releases it). Its
-            // callstack must contain the marker frame.
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAnyMarker));
-            Assert.True(markerCallstacks.Count > 0,
-                $"Expected at least one Resume callstack containing {nameof(TaskAsync_WhenAnyMarker)} after WhenAny");
-
-            // All branches — including the slow ones whose completion the outer is no longer
-            // strictly waiting on after WhenAny returned — must produce their own Resume
-            // callstacks. This proves their dispatcher lifetimes are tracked independently.
-            var fastCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAnyFast));
-            var slow1Callstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAnySlow1));
-            var slow2Callstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_WhenAnySlow2));
-            Assert.True(fastCallstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnyFast)}");
-            Assert.True(slow1Callstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnySlow1)}");
-            Assert.True(slow2Callstacks.Count > 0, $"Expected Resume callstack for {nameof(TaskAsync_WhenAnySlow2)}");
-
-            // Every Create must be balanced by a Complete — concurrent fan-in with independent
-            // sibling lifetimes must not leak or double-count dispatcher contexts.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
-
-            // At least 4 Creates: 3 branches + 1 outer marker.
-            Assert.True(createCount >= 4,
-                $"Expected at least 4 CreateAsyncContext events (3 branches + outer), got {createCount}");
-
-            // The outer marker's chain: exactly one Create, at least two Resumes (one after
-            // WhenAny, one after WhenAll on the slow branches), then Complete. This validates
-            // resume-of-same-context cycles without re-Creating the dispatcher (no double-wrap).
-            ulong markerTaskId = markerCallstacks[0].TaskId;
-            var markerEvents = stream.ForTask(markerTaskId);
-            var markerIds = markerEvents.Select(e => e.EventId).ToList();
-
-            int createCountForMarker = markerIds.Count(id => id == AsyncEventID.CreateAsyncContext);
-            Assert.Equal(1, createCountForMarker);
-
-            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.ResumeAsyncContext);
-            // Resume count is timing-sensitive: ideally the outer suspends/resumes twice (after
-            // WhenAny, then after the subsequent WhenAll on the slow branches). But under load,
-            // by the time WhenAny returns and we reach the WhenAll, the slow tasks may have
-            // already completed — in which case WhenAll returns synchronously without a second
-            // suspend/resume. Either shape is correct runtime behavior; we only require >=1
-            // (proves the outer was resumed at all).
-            Assert.True(resumeCountForMarker >= 1,
-                $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
-
-            // Note: We don't assert an exact count of CompleteAsyncContext for the marker. V1's
-            // Suspend/Complete events don't carry an explicit TaskId in the wire format; the parser
-            // recovers it from the active context. The parser pops on Complete but NOT on Suspend,
-            // so when the marker suspends (awaiting WhenAll on the slow branches) and a sibling
-            // branch's Complete then fires, the parser misattributes that Complete to the still-
-            // active marker context. So the parsed Complete count for the marker may be >1 even
-            // though the runtime emitted exactly one Complete for it. The overall Create==Complete
-            // balance check above already covers the no-leak guarantee.
-            int completeCountForMarker = markerIds.Count(id => id == AsyncEventID.CompleteAsyncContext);
-            Assert.True(completeCountForMarker >= 1, "Expected at least one CompleteAsyncContext for the outer marker");
-
-            // First event for the marker is its Create; last is a Complete.
-            Assert.Equal(AsyncEventID.CreateAsyncContext, markerIds[0]);
-            Assert.Equal(AsyncEventID.CompleteAsyncContext, markerIds[^1]);
-        }
-
-        // --- Callstack cap / overflow / stress tests ---
-        // Mirrors the V2 versions but uses V1 (Task-based) recursive chains. The walker shares
-        // the same buffer/cap infrastructure (byte FrameCount, rent-on-overflow fallback) so these
-        // tests guard the same code paths from the V1 entry point.
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_RecursiveChain(int depth)
-        {
-            if (depth <= 1)
-            {
-                await Task.Delay(100);
-                return;
-            }
-            await TaskAsync_RecursiveChain(depth - 1);
-        }
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_RecursiveChainMarker(int depth)
-        {
-            await TaskAsync_RecursiveChain(depth);
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_CallstackDepthCappedAtMaxFrames()
-        {
-            // Build a chain deeper than the 255-frame cap (byte FrameCount). The deepest
-            // ResumeAsyncCallstack should clamp at byte.MaxValue without crashing.
-            const int requestedDepth = 300;
-
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
-            {
-                RunScenarioAndFlush(() => TaskAsync_RecursiveChainMarker(requestedDepth));
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var callstacks = stream.OfType(AsyncEventID.ResumeAsyncCallstack).ToList();
-            Assert.True(callstacks.Count >= 1, "Expected at least one callstack");
-
-            // Walker caps frames at byte.MaxValue. Requested depth is 300, capped to 255.
-            var deepest = callstacks.MaxBy(cs => cs.FrameCount);
-            Assert.Equal(byte.MaxValue, deepest!.FrameCount);
-            Assert.Equal((int)deepest.FrameCount, deepest.Frames.Count);
-
-            // Every captured frame should resolve to a managed method.
-            foreach (var (methodId, _) in deepest.Frames)
-            {
-                Assert.True(methodId != 0, "Frame has zero MethodId");
-                var method = GetMethodNameFromMethodId(deepest.CallstackType, methodId);
-                Assert.True(method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
-            }
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_CallstackStressWithVaryingDepths()
-        {
-            // Stress test: many V1 async invocations with varying chain depths. Varying sizes
-            // place some callstacks at buffer boundaries, naturally exercising the overflow/rewind
-            // path in the shared callstack emission code.
-            const int iterations = 50;
-            int[] depths = new int[iterations];
-            var rng = new Random(42);
-            for (int i = 0; i < iterations; i++)
-                depths[i] = rng.Next(1, 60);
-
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
-            {
-                RunScenarioAndFlush(async () =>
-                {
-                    for (int i = 0; i < iterations; i++)
-                        await TaskAsync_RecursiveChainMarker(depths[i]);
-                });
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-            var callstacks = stream
-                .OfType(AsyncEventID.ResumeAsyncCallstack)
-                .Where(e => e.HasMarkerFrame(nameof(TaskAsync_RecursiveChainMarker)))
-                .ToList();
-
-            // Every emitted callstack must have valid frame data.
-            foreach (var cs in callstacks)
-            {
-                Assert.True(cs.FrameCount > 0, "Callstack has 0 frames");
-                Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
-                for (int f = 0; f < cs.Frames.Count; f++)
-                {
-                    var (methodId, _) = cs.Frames[f];
-                    Assert.True(methodId != 0, $"Frame {f} has zero MethodId");
-                    var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
-                    Assert.True(method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
-                }
-            }
-
-            // We expect at least one marker callstack per iteration (some may not be the deepest
-            // due to mid-chain dispatcher walks). Use >= as the strict count varies with timing.
-            Assert.True(callstacks.Count >= iterations,
-                $"Expected at least {iterations} callstacks with marker, got {callstacks.Count}");
-
-            // Verify multiple buffer flushes occurred — proves the buffer machinery is exercised.
-            int bufferCount = 0;
-            ForEachEventBufferPayload(events, _ => bufferCount++);
-            Assert.True(bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
-        }
-
-        // --- Single-threaded compatible test ---
-        // Validates that V1 dispatcher events fire correctly on platforms without threading
-        // support (single-threaded WASM). Uses TaskCompletionSource as a deterministic
-        // suspension/resume primitive instead of Task.Delay / Task.Run, so the test runs
-        // cleanly on the single-threaded runtime.
-        //
-        // The chain suspends on `await gate`; SetResult drives synchronous resumption that
-        // unwinds the entire chain in-order on the calling thread. This exercises the V1
-        // inline-cascade code path (1 Create for the whole chain, full callstack reconstruction).
-        //
-        // Coverage in one test: Create/Resume/Complete events fire, callstack reconstruction
-        // works across all chain levels, marker frame visibility, no double-wrap, balanced
-        // Create/Complete (no leaks). The IsRuntimeAsyncSupported gate (looser than the
-        // IsRuntimeAsyncAndThreadingSupported gate used by the rest of the V1 suite) lets this
-        // test run on single-threaded WASM.
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_SingleThreadInner(Task gate)
+        private static async Task TaskAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker(Task gate)
         {
             await gate;
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_SingleThreadMid(Task gate)
+        private static async Task TaskAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker(Task gate)
         {
-            await TaskAsync_SingleThreadInner(gate);
+            await TaskAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker(gate);
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_SingleThreadMarker(Task gate)
+        private static async Task TaskAsync_SingleThread_ChainEventsAndCallstack_Marker(Task gate)
         {
-            await TaskAsync_SingleThreadMid(gate);
+            await TaskAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker(gate);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
-        public async Task TaskAsync_SingleThreadCompatible_ChainEventsAndCallstack()
+        public async Task TaskAsync_SingleThread_ChainEventsAndCallstack()
         {
             var events = await CollectEventsAsync(ResumeAsyncCallstackKeyword | CoreKeywords | MethodKeywords, async () =>
             {
                 var tcs = new TaskCompletionSource();
-                Task chain = TaskAsync_SingleThreadMarker(tcs.Task);
-                // chain is now suspended: Inner awaits gate, Mid awaits Inner, Marker awaits Mid.
-                // SetResult (default, NOT RunContinuationsAsynchronously which requires ThreadPool)
-                // runs continuations synchronously inline on this thread, driving the entire chain
-                // to completion in-order without involving any timer or worker thread.
+                Task chain = TaskAsync_SingleThread_ChainEventsAndCallstack_Marker(tcs.Task);
                 tcs.SetResult();
                 await chain;
             });
@@ -1609,239 +1706,36 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            // The marker frame must appear in a Resume callstack — proves the chain was walkable.
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_SingleThreadMarker));
-            Assert.True(markerCallstacks.Count > 0,
-                $"Expected at least one Resume callstack containing {nameof(TaskAsync_SingleThreadMarker)}");
+            // The marker frame must appear in a Resume callstack â€” proves the chain was walkable.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
-            // All 3 chain frames must be reconstructable in the deepest callstack — proves the
-            // inline-cascade walker crosses every level without dropping any.
             var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
             var frameNames = deepest.Frames
                 .Select(f => GetMethodNameFromMethodId(deepest.CallstackType, f.MethodId))
                 .Where(n => n is not null)
                 .ToList();
-            Assert.Contains(nameof(TaskAsync_SingleThreadInner), frameNames);
-            Assert.Contains(nameof(TaskAsync_SingleThreadMid), frameNames);
-            Assert.Contains(nameof(TaskAsync_SingleThreadMarker), frameNames);
+            Assert.Contains(nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Inner_Marker), frameNames);
+            Assert.Contains(nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Mid_Marker), frameNames);
+            Assert.Contains(nameof(TaskAsync_SingleThread_ChainEventsAndCallstack_Marker), frameNames);
 
-            // No dispatcher leak: every Create balanced by a Complete on the synchronous cascade path.
+            // Create balanced by Complete on the synchronous cascade path.
             int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
             int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
             Assert.Equal(createCount, completeCount);
 
-            // Inline-cascade optimization: exactly 1 Create for the entire chain (the leaf's
-            // non-box TCS wrapping). A regression that re-introduced per-level wrapping would
-            // push this higher. This is the same strong invariant as the ConfigureAwait(false)
-            // test, validated here on the single-threaded code path.
+            // Inline-cascade optimization: exactly 1 Create for the entire chain.
             Assert.Equal(1, createCount);
 
-            // Method-level instrumentation: each async method's MoveNext invocation emits a
-            // Resume/Complete pair (distinct from the dispatcher-level Resume/Complete events
-            // above). For our 3-method chain, every method must fire at least one Resume and
-            // at least one Complete.
             int methodResumeCount = stream.OfType(AsyncEventID.ResumeAsyncMethod).Count();
             int methodCompleteCount = stream.OfType(AsyncEventID.CompleteAsyncMethod).Count();
-            Assert.True(methodResumeCount >= 3,
-                $"Expected at least 3 ResumeAsyncMethod events (one per chain level), got {methodResumeCount}");
-            Assert.True(methodCompleteCount >= 3,
-                $"Expected at least 3 CompleteAsyncMethod events (one per chain level), got {methodCompleteCount}");
 
-            // Method-level events should be balanced: every method resume must have a matching
-            // complete on this synchronous, exception-free path.
+            // Method-level events should be balanced.
             Assert.Equal(methodResumeCount, methodCompleteCount);
 
-            // No AppendAsyncCallstack events should be emitted in this scenario. The original
-            // Resume callstack already contained the full 3-frame chain (Inner -> Mid -> Marker),
-            // and Marker's parent chain never grew during the synchronous cascade (the test never
-            // awaits Marker's task before the cascade completes). Any Append here would be a
-            // regression of the duplicate-emission bug where the entering-box overload of
-            // Append re-emitted the LastContinuation box that was already in the trace.
+            // No AppendAsyncCallstack events should be emitted in this scenario.
             int appendCount = stream.OfType(AsyncEventID.AppendAsyncCallstack).Count();
             Assert.Equal(0, appendCount);
-        }
-
-        // --- ConfigureAwait(false) chain test ---
-        // Validates that ConfigureAwait(false) at every level of a chain does NOT break the
-        // dispatcher cascade or cause the box to be wrapped more than once. ConfigureAwait(false)
-        // routes through ConfiguredTaskAwaitable instead of TaskAwaiter, which has its own
-        // UnsafeOnCompletedInternal path. A regression here would either drop chain frames or
-        // emit multiple Create events per logical async method.
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_ConfigureAwaitFalseLeaf()
-        {
-            await Task.Delay(100).ConfigureAwait(false);
-        }
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_ConfigureAwaitFalseMid()
-        {
-            await TaskAsync_ConfigureAwaitFalseLeaf().ConfigureAwait(false);
-        }
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_ConfigureAwaitFalseMarker()
-        {
-            await TaskAsync_ConfigureAwaitFalseMid().ConfigureAwait(false);
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_ConfigureAwaitFalse_DoesNotBreakCascadeOrDoubleWrap()
-        {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
-            {
-                RunScenarioAndFlush(() => TaskAsync_ConfigureAwaitFalseMarker());
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // The full chain (Leaf -> Mid -> Marker) must appear in the Resume callstack.
-            // For ConfigureAwait(false) box-to-box chains with no SyncContext/Scheduler, the
-            // runtime takes the inline-cascade optimization: a single dispatcher walks the
-            // entire chain instead of wrapping each level. This is the OPTIMAL trace shape —
-            // minimum dispatcher overhead, full chain visibility via the callstack.
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_ConfigureAwaitFalseMarker));
-            Assert.True(markerCallstacks.Count > 0,
-                $"Expected at least one Resume callstack containing {nameof(TaskAsync_ConfigureAwaitFalseMarker)} (cascade not broken)");
-
-            // The deepest callstack should include all 3 chain frames — proves the chain walk
-            // crossed every ConfigureAwait(false) level without dropping any.
-            var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
-            var frameNames = deepest.Frames
-                .Select(f => GetMethodNameFromMethodId(deepest.CallstackType, f.MethodId))
-                .Where(n => n is not null)
-                .ToList();
-            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseLeaf), frameNames);
-            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseMid), frameNames);
-            Assert.Contains(nameof(TaskAsync_ConfigureAwaitFalseMarker), frameNames);
-
-            // Every Create must be balanced by a Complete — no leaks.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
-
-            // Strongest no-double-wrap check: the cascade optimization should produce exactly
-            // 1 dispatcher for the entire chain (the leaf's non-box Task.Delay wrapping). A
-            // regression that re-introduced per-level wrapping would push this to 3+.
-            Assert.Equal(1, createCount);
-        }
-
-        // --- Faulted task test ---
-        // Validates that an async method that throws (and whose exception is caught upstream)
-        // still produces a clean trace: balanced Create/Complete events, an UnwindAsyncException
-        // event reflecting the unwound frames, and the marker's Resume callstack present.
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_FaultedInner()
-        {
-            await Task.Delay(50);
-            throw new InvalidOperationException("test fault");
-        }
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_FaultedMarker()
-        {
-            try
-            {
-                await TaskAsync_FaultedInner();
-            }
-            catch (InvalidOperationException)
-            {
-            }
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_FaultedTask_BalancedEventsAndUnwindEmitted()
-        {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
-            {
-                RunScenarioAndFlush(() => TaskAsync_FaultedMarker());
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // The marker must still resume and complete — exception propagation does not orphan
-            // the dispatcher.
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_FaultedMarker));
-            Assert.True(markerCallstacks.Count > 0,
-                $"Expected at least one Resume callstack containing {nameof(TaskAsync_FaultedMarker)}");
-
-            // No leak: every dispatcher that was Created must Complete, even on the fault path.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
-
-            // The runtime emits UnwindAsyncException when an async method completes with an
-            // exception (AsyncTaskMethodBuilder<T>.SetException path).
-            int unwindCount = stream.OfType(AsyncEventID.UnwindAsyncException).Count();
-            Assert.True(unwindCount > 0,
-                "Expected at least one UnwindAsyncException event for the faulted inner task");
-        }
-
-        // --- Cancellation test ---
-        // Validates that cancellation (OperationCanceledException flowing through the chain)
-        // produces a well-formed trace with balanced events and the cancelled chain's marker
-        // visible in a Resume callstack.
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_CancelledInner(CancellationToken ct)
-        {
-            await Task.Delay(5000, ct);
-        }
-
-        [RuntimeAsyncMethodGeneration(false)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task TaskAsync_CancelledMarker()
-        {
-            using var cts = new CancellationTokenSource();
-            Task inner = TaskAsync_CancelledInner(cts.Token);
-            cts.CancelAfter(50);
-            try
-            {
-                await inner;
-            }
-            catch (OperationCanceledException)
-            {
-            }
-        }
-
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void TaskAsync_Cancellation_BalancedEvents()
-        {
-            var events = CollectEvents(ResumeAsyncCallstackKeyword | UnwindAsyncExceptionKeyword | CoreKeywords, () =>
-            {
-                RunScenarioAndFlush(() => TaskAsync_CancelledMarker());
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // The marker must resume and produce a callstack — cancellation propagation does
-            // not orphan the dispatcher chain.
-            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_CancelledMarker));
-            Assert.True(markerCallstacks.Count > 0,
-                $"Expected at least one Resume callstack containing {nameof(TaskAsync_CancelledMarker)}");
-
-            // No leak: every Create must be balanced by a Complete on the cancellation path.
-            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
-            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
-            Assert.Equal(createCount, completeCount);
-
-            // At least 2 Creates: inner cancelled task + outer marker. Both must Complete.
-            Assert.True(createCount >= 2,
-                $"Expected at least 2 CreateAsyncContext events (inner + marker), got {createCount}");
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1,0 +1,390 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.DotNet.XUnitExtensions;
+using Xunit;
+
+namespace System.Threading.Tasks.Tests
+{
+    /// <summary>
+    /// Tests for V1 (Task-based AsyncStateMachineBox) async profiler event emission.
+    /// All scenario methods use [RuntimeAsyncMethodGeneration(false)] to ensure they
+    /// exercise the legacy Task-based async path even if the default changes in the future.
+    /// Tests use sync CollectEvents with RunScenarioAndFlush to isolate the V1 chain
+    /// on a threadpool thread, ensuring dispatcher finally blocks complete before flush.
+    /// Requires threading support.
+    /// </summary>
+    public partial class AsyncProfilerTests
+    {
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_SingleYield()
+        {
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_DeepChain()
+        {
+            await TaskAsync_Level1();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_Level1()
+        {
+            await TaskAsync_Level2();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_Level2()
+        {
+            await TaskAsync_Level3();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_Level3()
+        {
+            await Task.Delay(100);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_MultiYield()
+        {
+            await Task.Yield();
+            await Task.Yield();
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_ExceptionHandled()
+        {
+            try
+            {
+                await TaskAsync_InnerThrows();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_InnerThrows()
+        {
+            await Task.Delay(100);
+            throw new InvalidOperationException("v1 inner");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_UnhandledExceptionOuter()
+        {
+            await TaskAsync_UnhandledExceptionInner();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_UnhandledExceptionInner()
+        {
+            await Task.Delay(100);
+            throw new InvalidOperationException("v1 unhandled inner");
+        }
+
+        private static ulong AssertCompleteContextChain(ParsedEventStream stream, params AsyncEventID[] expectedSequence)
+        {
+            var byTask = stream.ByTaskId();
+            var candidates = new List<string>();
+
+            foreach (var (taskId, events) in byTask)
+            {
+                var contextEvents = events
+                    .Where(e => e.EventId is AsyncEventID.CreateAsyncContext
+                        or AsyncEventID.ResumeAsyncContext
+                        or AsyncEventID.SuspendAsyncContext
+                        or AsyncEventID.CompleteAsyncContext
+                        or AsyncEventID.UnwindAsyncException)
+                    .Select(e => e.EventId)
+                    .ToList();
+
+                candidates.Add($"  TaskId={taskId}: [{string.Join(", ", contextEvents)}]");
+
+                if (contextEvents.Count != expectedSequence.Length)
+                    continue;
+
+                bool match = true;
+                for (int i = 0; i < expectedSequence.Length; i++)
+                {
+                    if (contextEvents[i] != expectedSequence[i])
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+
+                if (match)
+                    return taskId;
+            }
+
+            string expected = string.Join(", ", expectedSequence);
+            string found = string.Join(Environment.NewLine, candidates);
+            Assert.Fail($"No context found with expected chain [{expected}].\nContexts found:\n{found}");
+            return 0; // unreachable
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_EventsEmitted()
+        {
+            var events = CollectEvents(CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_SingleYield());
+            });
+
+            // DumpAllEvents(events);
+
+            Assert.True(events.Events.Count > 0, "Expected at least one AsyncEvents event to be emitted");
+            Assert.Contains(events.Events, e => e.EventId == AsyncEventsId);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_CreateAsyncContextEmittedOnFirstAwait()
+        {
+            var events = CollectEvents(CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_SingleYield());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var creates = stream.OfType(AsyncEventID.CreateAsyncContext).ToList();
+            Assert.True(creates.Count >= 1, $"Expected at least 1 CreateAsyncContext, got {creates.Count}");
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_EventSequenceOrder()
+        {
+            var events = CollectEvents(CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_SingleYield());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            AssertCompleteContextChain(stream,
+                AsyncEventID.CreateAsyncContext,
+                AsyncEventID.ResumeAsyncContext,
+                AsyncEventID.CompleteAsyncContext);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_SuspendResumeCompleteEvents()
+        {
+            var events = CollectEvents(CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_MultiYield());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            ulong taskId = AssertCompleteContextChain(stream,
+                AsyncEventID.CreateAsyncContext,
+                AsyncEventID.ResumeAsyncContext,
+                AsyncEventID.SuspendAsyncContext,
+                AsyncEventID.ResumeAsyncContext,
+                AsyncEventID.SuspendAsyncContext,
+                AsyncEventID.ResumeAsyncContext,
+                AsyncEventID.CompleteAsyncContext);
+
+            var taskEvents = stream.ForTask(taskId);
+            foreach (var evt in taskEvents)
+            {
+                if (evt.EventId is AsyncEventID.ResumeAsyncContext or AsyncEventID.CreateAsyncContext)
+                    Assert.Equal(taskId, evt.TaskId);
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_ResumeCompleteMethodEvents()
+        {
+            var events = CollectEvents(MethodKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_SingleYield());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var ids = stream.EventIds;
+
+            Assert.Contains(AsyncEventID.ResumeAsyncMethod, ids);
+            Assert.Contains(AsyncEventID.CompleteAsyncMethod, ids);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_HandledException_EmitsUnwindAndComplete()
+        {
+            var events = CollectEvents(CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_ExceptionHandled());
+            });
+
+            DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            AssertCompleteContextChain(stream,
+                AsyncEventID.CreateAsyncContext,
+                AsyncEventID.ResumeAsyncContext,
+                AsyncEventID.UnwindAsyncException,
+                AsyncEventID.CompleteAsyncContext);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_UnhandledException_EmitsUnwindAndComplete()
+        {
+            var events = CollectEvents(CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            {
+                try
+                {
+                    RunScenario(() => TaskAsync_UnhandledExceptionOuter());
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                SendFlushCommand();
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            AssertCompleteContextChain(stream,
+                AsyncEventID.CreateAsyncContext,
+                AsyncEventID.ResumeAsyncContext,
+                AsyncEventID.UnwindAsyncException,
+                AsyncEventID.UnwindAsyncException,
+                AsyncEventID.CompleteAsyncContext);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_MethodEventCountMatchesChainDepth()
+        {
+            var events = CollectEvents(MethodKeywords | CoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_DeepChain());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // DeepChain → Level1 → Level2 → Level3 = 4 methods
+            // Level3 uses Task.Delay to ensure full chain is built before resume.
+            // On resume: Level3, Level2, Level1, DeepChain each resume and complete = 4 pairs.
+            var methodEvents = stream.All
+                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod or AsyncEventID.CompleteAsyncMethod)
+                .Select(e => e.EventId)
+                .ToList();
+
+            int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeAsyncMethod);
+            int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteAsyncMethod);
+
+            Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events, got {resumeCount}");
+            Assert.True(completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events, got {completeCount}");
+
+            // Verify interleaved ordering: each Resume is followed by its matching Complete
+            // Check the last 8 events (4 Resume/Complete pairs from the inner chain)
+            var tail = methodEvents.Skip(methodEvents.Count - 8).ToList();
+            for (int i = 0; i < tail.Count; i += 2)
+            {
+                Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[i]);
+                Assert.Equal(AsyncEventID.CompleteAsyncMethod, tail[i + 1]);
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_HandledException_MethodEventsWithUnwind()
+        {
+            var events = CollectEvents(MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_ExceptionHandled());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // ExceptionHandled → InnerThrows (2 methods)
+            // InnerThrows resumes, throws → Unwind
+            // ExceptionHandled resumes (catches), completes
+            // Expected method events: Resume, Unwind, Resume, Complete
+            var methodEvents = stream.All
+                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod
+                    or AsyncEventID.CompleteAsyncMethod
+                    or AsyncEventID.UnwindAsyncException)
+                .Select(e => e.EventId)
+                .ToList();
+
+            var tail = methodEvents.Skip(methodEvents.Count - 4).ToList();
+            Assert.Equal(4, tail.Count);
+            Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[0]);
+            Assert.Equal(AsyncEventID.UnwindAsyncException, tail[1]);
+            Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[2]);
+            Assert.Equal(AsyncEventID.CompleteAsyncMethod, tail[3]);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void TaskAsync_UnhandledException_MethodEventsWithUnwind()
+        {
+            var events = CollectEvents(MethodKeywords | CoreKeywords | UnwindAsyncExceptionKeyword, () =>
+            {
+                try
+                {
+                    RunScenario(() => TaskAsync_UnhandledExceptionOuter());
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                SendFlushCommand();
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // UnhandledExceptionOuter → UnhandledExceptionInner (2 methods, neither catches)
+            // Inner resumes, throws → Unwind
+            // Outer resumes (continuation), propagates → Unwind
+            // No CompleteAsyncMethod for either — both unwind
+            // Expected method events: Resume, Unwind, Resume, Unwind
+            var methodEvents = stream.All
+                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod
+                    or AsyncEventID.CompleteAsyncMethod
+                    or AsyncEventID.UnwindAsyncException)
+                .Select(e => e.EventId)
+                .ToList();
+
+            var tail = methodEvents.Skip(methodEvents.Count - 4).ToList();
+            Assert.Equal(4, tail.Count);
+            Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[0]);
+            Assert.Equal(AsyncEventID.UnwindAsyncException, tail[1]);
+            Assert.Equal(AsyncEventID.ResumeAsyncMethod, tail[2]);
+            Assert.Equal(AsyncEventID.UnwindAsyncException, tail[3]);
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1334,30 +1334,25 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            // With the cap at byte.MaxValue, the initial Resume walks the first 255 frames from
-            // the leaf. The marker sits at the top of the chain (deeper than 255), so it appears
-            // in a subsequent AppendAsyncCallstack carrying the remaining frames. Use the merged
-            // view to validate the chain as a whole.
-            var mergedMarker = stream.MergedResumeCallstacksWithMarker(nameof(StateMachineAsync_CallstackDepthCappedAtMaxFrames_Marker));
-            AssertNotEmpty(stream, mergedMarker);
-
-            var deepest = mergedMarker.MaxBy(cs => cs.Frames.Count);
-            AssertNotNull(stream, deepest);
-
-            // Walker should have captured at least the full requested depth across Resume+Appends.
-            AssertTrue(stream, deepest.Frames.Count >= requestedDepth,
-                $"Expected merged frame count >= {requestedDepth}, got {deepest.Frames.Count}");
-
-            // Each individual event clamps its own FrameCount at byte.MaxValue (wire format limit).
-            ulong chainDispatcherId = deepest.DispatcherId;
-            var perEventCallstacks = stream.ChainEventsFromDispatcher(chainDispatcherId)
-                .Where(e => e.EventId is AsyncEventID.ResumeStateMachineAsyncCallstack or AsyncEventID.AppendStateMachineAsyncCallstack)
+            // The chain is deeper than the 255-frame cap, so the initial Resume clamps at byte.MaxValue and
+            // the dropped frames are NOT backfilled by a later Append: the cap is a hard limit. The marker
+            // sits at the top of the chain (deeper than 255) and is therefore truncated away, so scope to the
+            // recursive method instead.
+            var mergedChain = stream.MergedResumeCallstacks()
+                .Where(cs => cs.Frames.Any(f => GetMethodNameFromMethodId(cs.CallstackType, f.MethodId) == nameof(StateMachineAsync_RecursiveChain)))
                 .ToList();
-            AssertNotEmpty(stream, perEventCallstacks);
-            AssertAll(stream, perEventCallstacks, cs => Assert.True(cs.FrameCount <= byte.MaxValue));
+            AssertNotEmpty(stream, mergedChain);
 
-            // At least one event must have hit the cap (otherwise the test isn't exercising it).
-            AssertContains(stream, perEventCallstacks, cs => cs.FrameCount == byte.MaxValue);
+            // Hard cap: no merged Resume+Append chain may exceed the cap. If Append backfilled the truncated
+            // frames, the merged count would climb back toward the requested depth.
+            AssertAll(stream, mergedChain, cs => Assert.True(cs.Frames.Count <= byte.MaxValue,
+                $"Merged frame count {cs.Frames.Count} exceeds the {byte.MaxValue}-frame cap"));
+
+            // The deepest chain must actually reach the cap (otherwise the test isn't exercising truncation).
+            var deepest = mergedChain.MaxBy(cs => cs.Frames.Count);
+            AssertNotNull(stream, deepest);
+            AssertEqual(stream, (int)byte.MaxValue, deepest!.Frames.Count);
+            AssertEqual(stream, (int)deepest.FrameCount, deepest.Frames.Count);
 
             // Every captured frame should resolve to a managed method.
             foreach (var (methodId, _) in deepest.Frames)

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -248,6 +248,201 @@ namespace System.Threading.Tasks.Tests
             AssertTrue(stream, completeIdx > firstSuspendIdx, "Expected the terminal CompleteStateMachineAsyncContext after suspensions");
         }
 
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_InlineResume_CompletesWithoutSuspend_Marker(Task gate, StrongBox<int> resumedThreadId)
+        {
+            await gate;
+            resumedThreadId.Value = Environment.CurrentManagedThreadId;
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_InlineResume_CompletesWithoutSuspend()
+        {
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    var resumedThreadId = new StrongBox<int>();
+                    var gate = new TaskCompletionSource();
+                    Task marker = StateMachineAsync_InlineResume_CompletesWithoutSuspend_Marker(gate.Task, resumedThreadId);
+
+                    int setResultThreadId = Environment.CurrentManagedThreadId;
+                    gate.SetResult();
+
+                    Assert.True(resumedThreadId.Value == setResultThreadId,
+                        $"Expected inline resume on the SetResult thread {setResultThreadId}, but the marker resumed on thread {resumedThreadId.Value} (0 = did not resume synchronously)");
+
+                    await marker;
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_InlineResume_CompletesWithoutSuspend_Marker));
+            AssertNotEmpty(stream, markerCallstacks);
+
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var chain = stream.ChainEventsFromDispatcher(dispatcherId);
+            var ids = chain.Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, resumeIdx + 1);
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteStateMachineAsyncContext after Resume");
+
+            // Completing inline on the only resume must not emit a Suspend.
+            int suspendCount = ids.Count(id => id == AsyncEventID.SuspendStateMachineAsyncContext);
+            AssertEqual(stream, 0, suspendCount);
+
+            ParsedEvent resumeEvt = chain.First(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncContext);
+            ParsedEvent completeEvt = chain.First(e => e.EventId == AsyncEventID.CompleteStateMachineAsyncContext);
+            AssertTrue(stream, resumeEvt.OsThreadId != 0, "Expected a valid OS thread id on the Resume event");
+            AssertEqual(stream, resumeEvt.OsThreadId, completeEvt.OsThreadId);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_InlineResume_ReSuspends_Marker(Task gate1, StrongBox<int> resumedThreadId, Task gate2)
+        {
+            await gate1;
+            resumedThreadId.Value = Environment.CurrentManagedThreadId;
+            await gate2;
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_InlineResume_ReSuspends()
+        {
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    var resumedThreadId = new StrongBox<int>();
+                    var gate1 = new TaskCompletionSource();
+                    var gate2 = new TaskCompletionSource();
+                    Task marker = StateMachineAsync_InlineResume_ReSuspends_Marker(gate1.Task, resumedThreadId, gate2.Task);
+
+                    int setResultThreadId = Environment.CurrentManagedThreadId;
+                    gate1.SetResult();
+
+                    Assert.True(resumedThreadId.Value == setResultThreadId,
+                        $"Expected inline resume on the gate1.SetResult thread {setResultThreadId}, but the marker resumed on thread {resumedThreadId.Value} (0 = did not resume synchronously)");
+
+                    gate2.SetResult();
+                    await marker;
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_InlineResume_ReSuspends_Marker));
+            AssertNotEmpty(stream, markerCallstacks);
+
+            // The marker resumes under two dispatchers (one per gate). The first one re-suspends, so identify
+            // it as the marker dispatcher whose own events contain a Suspend.
+            var markerDispatcherIds = markerCallstacks.Select(c => c.DispatcherId).Distinct().ToList();
+
+            List<ParsedEvent>? suspendingEvents = null;
+            foreach (ulong id in markerDispatcherIds)
+            {
+                var own = stream.All.Where(e => e.DispatcherId == id).OrderBy(e => e.Timestamp).ToList();
+                if (own.Any(e => e.EventId == AsyncEventID.SuspendStateMachineAsyncContext))
+                {
+                    suspendingEvents = own;
+                    break;
+                }
+            }
+
+            AssertTrue(stream, suspendingEvents != null, "Expected a marker dispatcher that re-suspended inline");
+
+            var d1Ids = suspendingEvents!.Select(e => e.EventId).ToList();
+
+            int createIdx = d1Ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext on the re-suspending dispatcher");
+
+            int resumeIdx = d1Ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
+
+            int suspendIdx = d1Ids.IndexOf(AsyncEventID.SuspendStateMachineAsyncContext, resumeIdx + 1);
+            AssertTrue(stream, suspendIdx > resumeIdx, "Expected SuspendStateMachineAsyncContext after Resume (inline re-suspension)");
+
+            ParsedEvent resumeEvt = suspendingEvents!.First(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncContext);
+            ParsedEvent suspendEvt = suspendingEvents!.First(e => e.EventId == AsyncEventID.SuspendStateMachineAsyncContext);
+            AssertTrue(stream, resumeEvt.OsThreadId != 0, "Expected a valid OS thread id on the Resume event");
+            AssertEqual(stream, resumeEvt.OsThreadId, suspendEvt.OsThreadId);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_PoolResume_ReSuspends_Marker(Task gate)
+        {
+            await gate;
+            await Task.Delay(100);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
+        public void StateMachineAsync_PoolResume_ReSuspends()
+        {
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    Task marker = StateMachineAsync_PoolResume_ReSuspends_Marker(gate.Task);
+                    gate.SetResult();
+                    await marker;
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_PoolResume_ReSuspends_Marker));
+            AssertNotEmpty(stream, markerCallstacks);
+
+            // The marker resumes under two dispatchers (the gate hop and the Task.Delay hop). The first one
+            // re-suspends, so identify it as the marker dispatcher whose own events contain a Suspend.
+            var markerDispatcherIds = markerCallstacks.Select(c => c.DispatcherId).Distinct().ToList();
+
+            List<ParsedEvent>? suspendingEvents = null;
+            foreach (ulong id in markerDispatcherIds)
+            {
+                var own = stream.All.Where(e => e.DispatcherId == id).OrderBy(e => e.Timestamp).ToList();
+                if (own.Any(e => e.EventId == AsyncEventID.SuspendStateMachineAsyncContext))
+                {
+                    suspendingEvents = own;
+                    break;
+                }
+            }
+
+            AssertTrue(stream, suspendingEvents != null, "Expected a marker dispatcher that re-suspended on the pool");
+
+            var ids = suspendingEvents!.Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateStateMachineAsyncContext);
+            AssertTrue(stream, createIdx >= 0, "Expected CreateStateMachineAsyncContext on the re-suspending dispatcher");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeStateMachineAsyncContext, createIdx + 1);
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeStateMachineAsyncContext after Create");
+
+            int suspendIdx = ids.IndexOf(AsyncEventID.SuspendStateMachineAsyncContext, resumeIdx + 1);
+            AssertTrue(stream, suspendIdx > resumeIdx, "Expected SuspendStateMachineAsyncContext after Resume (pool re-suspension)");
+
+            ParsedEvent resumeEvt = suspendingEvents!.First(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncContext);
+            ParsedEvent suspendEvt = suspendingEvents!.First(e => e.EventId == AsyncEventID.SuspendStateMachineAsyncContext);
+            AssertTrue(stream, resumeEvt.OsThreadId != 0, "Expected a valid OS thread id on the Resume event");
+            AssertEqual(stream, resumeEvt.OsThreadId, suspendEvt.OsThreadId);
+        }
+
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncInstrumentationAndThreadingSupported))]
         public void StateMachineAsync_ResumeCompleteMethodEvents()
         {

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1553,6 +1553,114 @@ namespace System.Threading.Tasks.Tests
             Assert.True(bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
         }
 
+        // --- Single-threaded compatible test ---
+        // Validates that V1 dispatcher events fire correctly on platforms without threading
+        // support (single-threaded WASM). Uses TaskCompletionSource as a deterministic
+        // suspension/resume primitive instead of Task.Delay / Task.Run, so the test runs
+        // cleanly on the single-threaded runtime.
+        //
+        // The chain suspends on `await gate`; SetResult drives synchronous resumption that
+        // unwinds the entire chain in-order on the calling thread. This exercises the V1
+        // inline-cascade code path (1 Create for the whole chain, full callstack reconstruction).
+        //
+        // Coverage in one test: Create/Resume/Complete events fire, callstack reconstruction
+        // works across all chain levels, marker frame visibility, no double-wrap, balanced
+        // Create/Complete (no leaks). The IsRuntimeAsyncSupported gate (looser than the
+        // IsRuntimeAsyncAndThreadingSupported gate used by the rest of the V1 suite) lets this
+        // test run on single-threaded WASM.
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_SingleThreadInner(Task gate)
+        {
+            await gate;
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_SingleThreadMid(Task gate)
+        {
+            await TaskAsync_SingleThreadInner(gate);
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task TaskAsync_SingleThreadMarker(Task gate)
+        {
+            await TaskAsync_SingleThreadMid(gate);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task TaskAsync_SingleThreadCompatible_ChainEventsAndCallstack()
+        {
+            var events = await CollectEventsAsync(ResumeAsyncCallstackKeyword | CoreKeywords | MethodKeywords, async () =>
+            {
+                var tcs = new TaskCompletionSource();
+                Task chain = TaskAsync_SingleThreadMarker(tcs.Task);
+                // chain is now suspended: Inner awaits gate, Mid awaits Inner, Marker awaits Mid.
+                // SetResult (default, NOT RunContinuationsAsynchronously which requires ThreadPool)
+                // runs continuations synchronously inline on this thread, driving the entire chain
+                // to completion in-order without involving any timer or worker thread.
+                tcs.SetResult();
+                await chain;
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The marker frame must appear in a Resume callstack — proves the chain was walkable.
+            var markerCallstacks = stream.MergedResumeCallstacksWithMarker(nameof(TaskAsync_SingleThreadMarker));
+            Assert.True(markerCallstacks.Count > 0,
+                $"Expected at least one Resume callstack containing {nameof(TaskAsync_SingleThreadMarker)}");
+
+            // All 3 chain frames must be reconstructable in the deepest callstack — proves the
+            // inline-cascade walker crosses every level without dropping any.
+            var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
+            var frameNames = deepest.Frames
+                .Select(f => GetMethodNameFromMethodId(deepest.CallstackType, f.MethodId))
+                .Where(n => n is not null)
+                .ToList();
+            Assert.Contains(nameof(TaskAsync_SingleThreadInner), frameNames);
+            Assert.Contains(nameof(TaskAsync_SingleThreadMid), frameNames);
+            Assert.Contains(nameof(TaskAsync_SingleThreadMarker), frameNames);
+
+            // No dispatcher leak: every Create balanced by a Complete on the synchronous cascade path.
+            int createCount = stream.OfType(AsyncEventID.CreateAsyncContext).Count();
+            int completeCount = stream.OfType(AsyncEventID.CompleteAsyncContext).Count();
+            Assert.Equal(createCount, completeCount);
+
+            // Inline-cascade optimization: exactly 1 Create for the entire chain (the leaf's
+            // non-box TCS wrapping). A regression that re-introduced per-level wrapping would
+            // push this higher. This is the same strong invariant as the ConfigureAwait(false)
+            // test, validated here on the single-threaded code path.
+            Assert.Equal(1, createCount);
+
+            // Method-level instrumentation: each async method's MoveNext invocation emits a
+            // Resume/Complete pair (distinct from the dispatcher-level Resume/Complete events
+            // above). For our 3-method chain, every method must fire at least one Resume and
+            // at least one Complete.
+            int methodResumeCount = stream.OfType(AsyncEventID.ResumeAsyncMethod).Count();
+            int methodCompleteCount = stream.OfType(AsyncEventID.CompleteAsyncMethod).Count();
+            Assert.True(methodResumeCount >= 3,
+                $"Expected at least 3 ResumeAsyncMethod events (one per chain level), got {methodResumeCount}");
+            Assert.True(methodCompleteCount >= 3,
+                $"Expected at least 3 CompleteAsyncMethod events (one per chain level), got {methodCompleteCount}");
+
+            // Method-level events should be balanced: every method resume must have a matching
+            // complete on this synchronous, exception-free path.
+            Assert.Equal(methodResumeCount, methodCompleteCount);
+
+            // No AppendAsyncCallstack events should be emitted in this scenario. The original
+            // Resume callstack already contained the full 3-frame chain (Inner -> Mid -> Marker),
+            // and Marker's parent chain never grew during the synchronous cascade (the test never
+            // awaits Marker's task before the cascade completes). Any Append here would be a
+            // regression of the duplicate-emission bug where the entering-box overload of
+            // Append re-emitted the LastContinuation box that was already in the trace.
+            int appendCount = stream.OfType(AsyncEventID.AppendAsyncCallstack).Count();
+            Assert.Equal(0, appendCount);
+        }
+
         // --- ConfigureAwait(false) chain test ---
         // Validates that ConfigureAwait(false) at every level of a chain does NOT break the
         // dispatcher cascade or cause the box to be wrapped more than once. ConfigureAwait(false)

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -597,11 +597,11 @@ namespace System.Threading.Tasks.Tests
             Assert.NotEmpty(markerCallstacks);
 
             // The deepest callstack (on the final Delay resume) should have 4 frames:
-            // Leaf (state=3), Middle (state=2), Root (state=1), Marker (state=0)
+            // Leaf (state=0), Middle (state=2), Root (state=1), Marker (state=0)
             var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
             Assert.Equal(4, deepest.FrameCount);
 
-            // Each frame should have a different state reflecting its suspend point
+            // Each frame's state should reflect its suspend point (values may repeat across frames).
             var states = deepest.Frames.Select(f => f.State).ToList();
             Assert.Equal(0, states[0]); // Leaf: suspended at 1st await (state=0)
             Assert.Equal(2, states[1]); // Middle: suspended at 3rd await (state=2)
@@ -1848,6 +1848,67 @@ namespace System.Threading.Tasks.Tests
                 "Expected at least one OS thread with a ResetAsyncThreadContext event " +
                 "followed by >= 2 ResumeAsyncContext events in the same reset window, " +
                 "proving the reset-replay walker traversed multiple nested dispatchers.");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ResetContext_ReplayResumeCompleteBalance_Inner_Marker()
+        {
+            using var dummy = new TestEventListener();
+            dummy.AddSource(AsyncProfilerEventSourceName, EventLevel.Informational, EventKeywords.None);
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ResetContext_ReplayResumeCompleteBalance_Mid_Marker()
+        {
+            await TaskAsync_ResetContext_ReplayResumeCompleteBalance_Inner_Marker();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task TaskAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker()
+        {
+            await TaskAsync_ResetContext_ReplayResumeCompleteBalance_Mid_Marker();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsTaskAsyncInstrumentationAndThreadingSupported))]
+        public void TaskAsync_ResetContext_ReplayResumeCompleteBalance()
+        {
+            var events = CollectEvents(AllKeywords, () =>
+            {
+                RunScenarioAndFlush(() => TaskAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Locate the replayed marker ResumeAsyncCallstack: the reset (triggered by the dummy
+            // listener inside the inner marker) replays the suspended V1 chain, producing a
+            // callstack carrying the marker frames.
+            var markerCallstacks = stream.CallstacksWithMarker(
+                AsyncEventID.TaskAsync_ResumeAsyncCallstack, "TaskAsync_ResetContext_ReplayResumeCompleteBalance");
+            Assert.NotEmpty(markerCallstacks);
+
+            // Resume/Complete balance across the replay boundary. V1 uses a per-MoveNext dispatcher
+            // model, so the marker chain spans a dispatcher tree whose deepest replayed callstack
+            // has N frames; each of those N resumed async methods must eventually complete. Balance
+            // is NOT preserved per reset epoch by design (a Resume can land in one epoch and its
+            // Complete in a later epoch once a config change bumps the revision mid-chain), so the
+            // count is reconstructed over the whole trace, scoped to the marker dispatcher's chain.
+            // Using >= keeps the assertion robust against additional method events from the harness.
+            var deepest = markerCallstacks.OrderByDescending(c => c.FrameCount).First();
+            ulong leafDispatcherId = deepest.DispatcherId;
+
+            int completeMethodCount = stream.ChainEventsFromDispatcher(leafDispatcherId)
+                .Count(e => e.EventId == AsyncEventID.TaskAsync_CompleteAsyncMethod);
+
+            Assert.True(completeMethodCount >= deepest.FrameCount,
+                $"Expected at least {deepest.FrameCount} TaskAsync_CompleteAsyncMethod events across the " +
+                $"trace for marker dispatcher chain {leafDispatcherId} to balance the replayed callstack of " +
+                $"depth {deepest.FrameCount}, but found {completeMethodCount}.");
         }
 
         [RuntimeAsyncMethodGeneration(false)]

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -756,6 +756,11 @@ namespace System.Threading.Tasks.Tests
             }
             finally
             {
+                // The await may resume on a different thread; only restore on the original (install)
+                // thread. On multi-threaded platforms this method runs on a dedicated throwaway
+                // thread (see RunIsolatedScenarioAsync), so a skipped restore can't leak the context
+                // onto a shared thread-pool thread. On single-threaded platforms the resume is on
+                // this same thread, so the restore always runs here.
                 if (Environment.CurrentManagedThreadId == callerThreadId)
                 {
                     SynchronizationContext.SetSynchronizationContext(prev);
@@ -770,7 +775,7 @@ namespace System.Threading.Tasks.Tests
 
             var events = CollectEvents(ResumeAsyncCallstackKeyword | CoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker());
+                RunScenarioAndFlush(() => RunIsolatedScenarioAsync(TaskAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
             });
 
             // DumpAllEvents(events);

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -814,7 +814,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackSimulation_HandledException_Marker);
 
-            DumpAllEvents(events);
+            // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
             AssertCallstackSimulationReachesZero(stream, nameof(RuntimeAsync_CallstackSimulation_HandledException_Marker));
@@ -1861,7 +1861,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_ConfigureAwaitFalse_Marker);
 
-            DumpAllEvents(events);
+            // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
@@ -2450,6 +2450,175 @@ namespace System.Threading.Tasks.Tests
                 "Expected at least one OS thread with a ResetAsyncThreadContext event " +
                 "followed by >= 2 ResumeAsyncContext events in the same reset window, " +
                 "proving the reset-replay walker traversed multiple stacked V2 dispatcher infos.");
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplayResumeCompleteBalance_Inner_Marker()
+        {
+            using var dummy = new TestEventListener();
+            dummy.AddSource(AsyncProfilerEventSourceName, EventLevel.Informational, EventKeywords.None);
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplayResumeCompleteBalance_Mid_Marker()
+        {
+            await RuntimeAsync_ResetContext_ReplayResumeCompleteBalance_Inner_Marker();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker()
+        {
+            await RuntimeAsync_ResetContext_ReplayResumeCompleteBalance_Mid_Marker();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ResetContext_ReplayResumeCompleteBalance()
+        {
+            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Locate the replayed marker ResumeAsyncCallstack (the reset replays the suspended
+            // Outer->Mid->Inner chain, producing a callstack carrying the marker frames).
+            var markerCallstacks = stream.CallstacksWithMarker(
+                AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplayResumeCompleteBalance");
+            Assert.NotEmpty(markerCallstacks);
+
+            // Resume/Complete balance across the replay boundary: the whole Outer->Mid->Inner chain
+            // is a single V2 dispatcher whose deepest replayed callstack has N frames, so N async
+            // methods must each eventually complete. Balance is NOT preserved per reset epoch by
+            // design (a Resume can land in one epoch and its Complete in a later epoch once a config
+            // change bumps the revision mid-chain), so the count must be reconstructed over the whole
+            // trace, scoped to the dispatcher rather than to a single epoch. Assert the marker
+            // dispatcher emits at least N CompleteAsyncMethod events across the entire trace. Using
+            // >= keeps the assertion robust against additional method events from the harness.
+            var deepest = markerCallstacks.OrderByDescending(c => c.FrameCount).First();
+            ulong markerDispatcherId = deepest.DispatcherId;
+
+            int completeMethodCount = stream.ChainEventsFromDispatcher(markerDispatcherId)
+                .Count(e => e.EventId == AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
+
+            Assert.True(completeMethodCount >= deepest.FrameCount,
+                $"Expected at least {deepest.FrameCount} RuntimeAsync_CompleteAsyncMethod events across the " +
+                $"trace for marker dispatcher {markerDispatcherId} to balance the replayed callstack of depth " +
+                $"{deepest.FrameCount}, but found {completeMethodCount}.");
+        }
+
+        // Regular async (V1, Task-based) inner. When it calls innerDone.SetResult() it inline-resumes
+        // the V2 outer while this V1 dispatcher's AsyncTaskDispatcherInfo is still on t_current,
+        // co-stacking a V1 and a V2 dispatcher info at the moment the reset replay walker runs.
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplaysMixedV1V2ChainInAddressOrder_V1Inner_Marker(
+            Task gate,
+            ManualResetEventSlim block,
+            Action onBlocked,
+            TaskCompletionSource innerDone)
+        {
+            await gate;
+            onBlocked();
+            block.Wait();
+            innerDone.SetResult();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplaysMixedV1V2ChainInAddressOrder_V2Outer_Marker(TaskCompletionSource innerDone)
+        {
+            await innerDone.Task;
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public async Task RuntimeAsync_ResetContext_ReplaysMixedV1V2ChainInAddressOrder()
+        {
+            var events = await CollectEventsAsync(AllKeywords, async () =>
+            {
+                var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var block = new ManualResetEventSlim(false);
+                var blocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                // No RunContinuationsAsynchronously: innerDone.SetResult() inline-resumes the V2
+                // outer while the V1 inner dispatcher is still on t_current, producing a mixed
+                // V1+V2 chain for the reset replay walker to merge.
+                var innerDone = new TaskCompletionSource();
+
+                Task inner = RuntimeAsync_ResetContext_ReplaysMixedV1V2ChainInAddressOrder_V1Inner_Marker(gate.Task, block, () => blocked.SetResult(), innerDone);
+                Task outer = RuntimeAsync_ResetContext_ReplaysMixedV1V2ChainInAddressOrder_V2Outer_Marker(innerDone);
+
+                _ = Task.Run(() => gate.SetResult());
+
+                await blocked.Task;
+
+                var dummy = new TestEventListener();
+                try
+                {
+                    dummy.AddSource(AsyncProfilerEventSourceName, EventLevel.Informational, EventKeywords.None);
+
+                    block.Set();
+
+                    await outer;
+                    await inner;
+                }
+                finally
+                {
+                    dummy.Dispose();
+                }
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The merge walker traverses both the V1 (AsyncTaskDispatcherInfo) and V2
+            // (AsyncDispatcherInfo) t_current chains, recursing on the smaller-address node first
+            // to emit oldest-first. Decisive proof that both branches of the merge ran: within a
+            // single reset window on one thread, both a TaskAsync_ResumeAsyncContext (V1) and a
+            // RuntimeAsync_ResumeAsyncContext (V2) are replayed.
+            var resetsByThread = stream.All
+                .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
+                .GroupBy(e => e.OsThreadId)
+                .ToList();
+            Assert.NotEmpty(resetsByThread);
+
+            bool found = false;
+            foreach (var threadResets in resetsByThread)
+            {
+                ulong threadId = threadResets.Key;
+                var orderedResets = threadResets.OrderBy(e => e.Timestamp).ToList();
+
+                for (int i = 0; i < orderedResets.Count && !found; i++)
+                {
+                    long windowStart = orderedResets[i].Timestamp;
+                    long windowEnd = (i + 1 < orderedResets.Count)
+                        ? orderedResets[i + 1].Timestamp
+                        : long.MaxValue;
+
+                    bool hasV1Resume = stream.All.Any(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext
+                        && e.OsThreadId == threadId && e.Timestamp >= windowStart && e.Timestamp < windowEnd);
+                    bool hasV2Resume = stream.All.Any(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncContext
+                        && e.OsThreadId == threadId && e.Timestamp >= windowStart && e.Timestamp < windowEnd);
+
+                    if (hasV1Resume && hasV2Resume)
+                    {
+                        found = true;
+                    }
+                }
+
+                if (found)
+                {
+                    break;
+                }
+            }
+
+            Assert.True(found,
+                "Expected a single ResetAsyncThreadContext window containing both a TaskAsync_ResumeAsyncContext " +
+                "(V1) and a RuntimeAsync_ResumeAsyncContext (V2), proving the reset-replay merge walker traversed " +
+                "a mixed V1+V2 chain and exercised both branches of its address-ordered recursion.");
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -265,8 +265,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendResumeCompleteEvents_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var taskEvts = stream.ForTask(taskId);
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
             Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncContext, ids);
@@ -296,10 +296,10 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ContextEventIdLifecycle_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            Assert.True(taskId > 0, "Context ID should be non-zero");
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            Assert.True(dispatcherId > 0, "DispatcherId should be non-zero");
 
-            var taskEvts = stream.ForTask(taskId);
+            var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
@@ -342,8 +342,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_EventSequenceOrder_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var taskEvts = stream.ForTask(taskId);
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
             // Verify the expected lifecycle sequence exists in order.
@@ -392,7 +392,7 @@ namespace System.Threading.Tasks.Tests
             Assert.All(createCallstacks, cs =>
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in create callstack");
-                Assert.True(cs.TaskId != 0, "Expected non-zero task ID in create callstack");
+                Assert.True(cs.DispatcherId != 0, "Expected non-zero dispatcher ID in create callstack");
                 Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
             });
         }
@@ -446,7 +446,7 @@ namespace System.Threading.Tasks.Tests
             Assert.All(suspendCallstacks, cs =>
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in suspend callstack");
-                Assert.True(cs.TaskId != 0, "Expected non-zero task ID in suspend callstack");
+                Assert.True(cs.DispatcherId != 0, "Expected non-zero dispatcher ID in suspend callstack");
                 Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
             });
         }
@@ -499,10 +499,10 @@ namespace System.Threading.Tasks.Tests
             var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackPrecedesComplete_Marker));
             Assert.NotEmpty(suspendStacks);
 
-            ulong taskId = suspendStacks[0].TaskId;
-            Assert.True(taskId > 0, "Expected non-zero context ID");
+            ulong dispatcherId = suspendStacks[0].DispatcherId;
+            Assert.True(dispatcherId > 0, "Expected non-zero dispatcher ID");
 
-            var taskEvts = stream.ForTask(taskId);
+            var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
             int suspendIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack);
@@ -568,12 +568,12 @@ namespace System.Threading.Tasks.Tests
             int matchedPairs = 0;
             foreach (var create in createStacks)
             {
-                var matchingResume = resumeStacks.FirstOrDefault(r => r.TaskId == create.TaskId);
+                var matchingResume = resumeStacks.FirstOrDefault(r => r.DispatcherId == create.DispatcherId);
                 if (matchingResume is null)
                     continue;
 
                 matchedPairs++;
-                Assert.True(create.Timestamp <= matchingResume.Timestamp, $"For task {create.TaskId}: CreateAsyncCallstack (ts {create.Timestamp}) should precede ResumeAsyncCallstack (ts {matchingResume.Timestamp})");
+                Assert.True(create.Timestamp <= matchingResume.Timestamp, $"For dispatcher {create.DispatcherId}: CreateAsyncCallstack (ts {create.Timestamp}) should precede ResumeAsyncCallstack (ts {matchingResume.Timestamp})");
             }
 
             Assert.True(matchedPairs >= 1, $"Expected at least one matching Create/Resume callstack pair, but found {matchedPairs}");
@@ -601,11 +601,11 @@ namespace System.Threading.Tasks.Tests
             Assert.NotEmpty(createStacks);
             Assert.NotEmpty(resumeStacks);
 
-            // For each create callstack, find the first resume with the same task ID and verify frames match.
+            // For each create callstack, find the first resume with the same dispatcher ID and verify frames match.
             int matchedPairs = 0;
             foreach (var create in createStacks)
             {
-                var matchingResume = resumeStacks.FirstOrDefault(r => r.TaskId == create.TaskId);
+                var matchingResume = resumeStacks.FirstOrDefault(r => r.DispatcherId == create.DispatcherId);
                 if (matchingResume is null)
                     continue;
 
@@ -642,7 +642,7 @@ namespace System.Threading.Tasks.Tests
             Assert.All(callstacks, cs =>
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in callstack");
-                Assert.True(cs.TaskId != 0, "Expected non-zero task ID in resume callstack");
+                Assert.True(cs.DispatcherId != 0, "Expected non-zero dispatcher ID in resume callstack");
                 Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
             });
         }
@@ -698,8 +698,8 @@ namespace System.Threading.Tasks.Tests
 
             Assert.Equal(ExpectedChainDepth, markerCallstacks[0].Frames.Count);
 
-            ulong chainTaskId = markerCallstacks[0].TaskId;
-            var chainEvents = stream.ForTask(chainTaskId);
+            ulong chainDispatcherId = markerCallstacks[0].DispatcherId;
+            var chainEvents = stream.ChainEventsFromDispatcher(chainDispatcherId);
 
             int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncMethod);
             Assert.Equal(ExpectedChainDepth, resumeCount);
@@ -882,9 +882,9 @@ namespace System.Threading.Tasks.Tests
             var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_UnhandledExceptionUnwind_Marker));
             Assert.NotEmpty(resumeStacks);
 
-            ulong taskId = resumeStacks[0].TaskId;
+            ulong dispatcherId = resumeStacks[0].DispatcherId;
 
-            var taskEvts = stream.ForTask(taskId);
+            var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var eventIds = taskEvts.Select(e => e.EventId).ToList();
 
             Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
@@ -916,9 +916,9 @@ namespace System.Threading.Tasks.Tests
             var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_HandledExceptionUnwind_Marker));
             Assert.NotEmpty(resumeStacks);
 
-            ulong taskId = resumeStacks[0].TaskId;
+            ulong dispatcherId = resumeStacks[0].DispatcherId;
 
-            var taskEvts = stream.ForTask(taskId);
+            var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var eventIds = taskEvts.Select(e => e.EventId).ToList();
 
             Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
@@ -1533,7 +1533,7 @@ namespace System.Threading.Tasks.Tests
                     if (header is null)
                         return;
 
-                    uint contextId = header.Value.AsyncThreadContextId;
+                    uint threadContextId = header.Value.AsyncThreadContextId;
 
                     // Parse the first event in this buffer.
                     int index = HeaderSize;
@@ -1549,17 +1549,17 @@ namespace System.Threading.Tasks.Tests
                         firstId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack ||
                         firstId == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack)
                     {
-                        // Callstack payload: callstackId(1) + continuationIndex(1) + frameCount(1) + compressed taskId + frames...
+                        // Callstack payload: callstackId(1) + continuationIndex(1) + frameCount(1) + compressed parentDispatcherId + compressed dispatcherId + frames...
                         index++; // callstack ID (reserved)
                         index++; // continuation index
                         if (index < buffer.Length)
                             frameCount = buffer[index];
                     }
 
-                    if (!buffersByContext.TryGetValue(contextId, out var list))
+                    if (!buffersByContext.TryGetValue(threadContextId, out var list))
                     {
                         list = new List<(int, AsyncEventID, byte)>();
-                        buffersByContext[contextId] = list;
+                        buffersByContext[threadContextId] = list;
                     }
                     list.Add((buffer.Length, firstId, frameCount));
                 });
@@ -1733,7 +1733,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_WhenAll_TracksAllBranches_Marker);
 
-            DumpAllEvents(events);
+            // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
@@ -1748,15 +1748,15 @@ namespace System.Threading.Tasks.Tests
             Assert.NotEmpty(branchBCallstacks);
             Assert.NotEmpty(branchCCallstacks);
 
-            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own TaskId.
-            AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].TaskId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
-            AssertExactlyOneCreateAndComplete(stream, branchBCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
-            AssertExactlyOneCreateAndComplete(stream, branchCCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
+            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own DispatcherId.
+            AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchBCallstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchCCallstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
 
             // The outer marker's chain should fire Create -> Resume -> Complete in that order.
-            ulong markerTaskId = markerCallstacks[0].TaskId;
-            var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
+            ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
+            var markerIds = stream.ChainEventsFromDispatcher(markerDispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             int resumeIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
@@ -1820,15 +1820,15 @@ namespace System.Threading.Tasks.Tests
             Assert.NotEmpty(slow1Callstacks);
             Assert.NotEmpty(slow2Callstacks);
 
-            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own TaskId.
-            AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
-            AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].TaskId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker));
-            AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].TaskId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker));
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Marker));
+            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own DispatcherId.
+            AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Marker));
 
             // The outer marker should also be resumed at least once.
-            ulong markerTaskId = markerCallstacks[0].TaskId;
-            var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
+            ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
+            var markerIds = stream.ChainEventsFromDispatcher(markerDispatcherId).Select(e => e.EventId).ToList();
             int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.RuntimeAsync_ResumeAsyncContext);
             Assert.True(resumeCountForMarker >= 1, $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
         }
@@ -1859,7 +1859,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_ConfigureAwaitFalse_Marker);
 
-            DumpAllEvents(events);
+            // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
@@ -1878,8 +1878,8 @@ namespace System.Threading.Tasks.Tests
             Assert.Contains(nameof(RuntimeAsync_ConfigureAwaitFalse_Marker), frameNames);
 
             // ConfigureAwait(false) on a sequential await chain collapses Leaf -> Mid -> Marker into one
-            // continuation chain, so exactly one Create / one Complete is expected on the marker's TaskId.
-            AssertExactlyOneCreateAndComplete(stream, deepest.TaskId, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
+            // continuation chain, so exactly one Create / one Complete is expected on the marker's DispatcherId.
+            AssertExactlyOneCreateAndComplete(stream, deepest.DispatcherId, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -1920,9 +1920,9 @@ namespace System.Threading.Tasks.Tests
             var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
             Assert.NotEmpty(innerCallstacks);
 
-            // Inner cancelled task + outer marker must each see exactly one Create and one Complete on their own TaskId.
-            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].TaskId, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_TaskCancellation_Marker));
+            // Inner cancelled task + outer marker must each see exactly one Create and one Complete on their own DispatcherId.
+            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(RuntimeAsync_TaskCancellation_Marker));
         }
 
         private static InlinePostSynchronizationContext? s_runtimeAsyncSyncContextCtx;
@@ -1969,12 +1969,12 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // The marker's chain should see exactly one Create and one Complete on its own TaskId.
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+            // The marker's chain should see exactly one Create and one Complete on its own DispatcherId.
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
 
             // Verify the standard Create -> Resume -> Complete sequence fired in order for our context.
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
@@ -2017,12 +2017,12 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // The marker's chain should see exactly one Create and one Complete on its own TaskId.
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
+            // The marker's chain should see exactly one Create and one Complete on its own DispatcherId.
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
 
             // Verify the standard Create -> Resume -> Complete sequence fired in order for our context.
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
@@ -2051,8 +2051,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_EventSequenceOrder_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -2179,8 +2179,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -2238,8 +2238,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            ulong taskId = markerCallstacks[0].TaskId;
-            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+            ulong dispatcherId = markerCallstacks[0].DispatcherId;
+            var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
@@ -2319,12 +2319,12 @@ namespace System.Threading.Tasks.Tests
                     continue;
                 }
 
-                var replayTaskIds = postResetMarkerCallstacks.Select(c => c.TaskId).ToHashSet();
+                var replayDispatcherIds = postResetMarkerCallstacks.Select(c => c.DispatcherId).ToHashSet();
                 var postResetResumeContext = stream.All
                     .Where(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncContext
                                 && e.OsThreadId == threadId
                                 && e.Timestamp >= lastResetTimestamp
-                                && replayTaskIds.Contains(e.TaskId))
+                                && replayDispatcherIds.Contains(e.DispatcherId))
                     .ToList();
                 if (postResetResumeContext.Count == 0)
                 {

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -2,20 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Threading.Tasks.Tests
 {
-    // Tests for V2 (runtime-async) async profiler event emission. All scenario methods use
+    // Tests for Runtime (runtime-async) async profiler event emission. All scenario methods use
     // [RuntimeAsyncMethodGeneration(true)] to ensure they exercise the runtime-async path.
-    // V2 emits Create/Resume/Suspend/Complete callstacks natively from the runtime dispatch
-    // loop, unlike V1 which uses the AsyncStateMachineBox dispatcher wrapper.
+    // Runtime emits Create/Resume/Suspend/Complete callstacks natively from the runtime dispatch
+    // loop, unlike StateMachine which uses the AsyncStateMachineBox dispatcher wrapper.
     public partial class AsyncProfilerTests
     {
         [RuntimeAsyncMethodGeneration(true)]
@@ -199,7 +196,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_EventBufferHeaderFormat()
         {
-            var events = await CollectEventsAsync(CoreKeywords, RuntimeAsync_SingleYield);
+            var events = await CollectEventsAsync(RuntimeAsyncCoreKeywords, RuntimeAsync_SingleYield);
 
             // DumpAllEvents(events);
 
@@ -236,7 +233,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_EventsEmitted()
         {
-            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_SingleYield);
+            var events = await CollectEventsAsync(AllRuntimeAsyncKeywords, RuntimeAsync_SingleYield);
 
             // DumpAllEvents(events);
 
@@ -255,23 +252,23 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendResumeCompleteEvents()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendResumeCompleteEvents_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_SuspendResumeCompleteEvents_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
             // Find our context via marker callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendResumeCompleteEvents_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_SuspendResumeCompleteEvents_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
-            AssertContains(stream, AsyncEventID.RuntimeAsync_ResumeAsyncContext, ids);
-            AssertContains(stream, AsyncEventID.RuntimeAsync_SuspendAsyncContext, ids);
-            AssertContains(stream, AsyncEventID.RuntimeAsync_CompleteAsyncContext, ids);
+            AssertContains(stream, AsyncEventID.ResumeRuntimeAsyncContext, ids);
+            AssertContains(stream, AsyncEventID.SuspendRuntimeAsyncContext, ids);
+            AssertContains(stream, AsyncEventID.CompleteRuntimeAsyncContext, ids);
         }
 
 
@@ -286,14 +283,14 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ContextEventIdLifecycle()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_ContextEventIdLifecycle_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_ContextEventIdLifecycle_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
             // Find events in the context that contains our marker method.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ContextEventIdLifecycle_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_ContextEventIdLifecycle_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
@@ -302,8 +299,8 @@ namespace System.Threading.Tasks.Tests
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
-            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.CreateRuntimeAsyncContext);
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeRuntimeAsyncContext);
             AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext in context events");
             AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after CreateAsyncContext");
         }
@@ -311,14 +308,14 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ResumeCompleteMethodEvents()
         {
-            var events = await CollectEventsAsync(MethodKeywords, RuntimeAsync_ChainedYield);
+            var events = await CollectEventsAsync(RuntimeAsyncMethodKeywords, RuntimeAsync_ChainedYield);
 
             // DumpAllEvents(events);
 
             var ids = ParseAllEvents(events).EventIds;
 
-            AssertContains(events, AsyncEventID.RuntimeAsync_ResumeAsyncMethod, ids);
-            AssertContains(events, AsyncEventID.RuntimeAsync_CompleteAsyncMethod, ids);
+            AssertContains(events, AsyncEventID.ResumeRuntimeAsyncMethod, ids);
+            AssertContains(events, AsyncEventID.CompleteRuntimeAsyncMethod, ids);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -332,14 +329,14 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_EventSequenceOrder()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_EventSequenceOrder_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_EventSequenceOrder_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
             // Find our context via marker callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_EventSequenceOrder_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_EventSequenceOrder_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
@@ -347,28 +344,28 @@ namespace System.Threading.Tasks.Tests
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
             // Verify the expected lifecycle sequence exists in order.
-            int resumeIdx1 = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext);
+            int resumeIdx1 = ids.IndexOf(AsyncEventID.ResumeRuntimeAsyncContext);
             AssertTrue(stream, resumeIdx1 >= 0, "Expected first ResumeAsyncContext");
 
-            int suspendIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_SuspendAsyncContext, resumeIdx1 + 1);
+            int suspendIdx = ids.IndexOf(AsyncEventID.SuspendRuntimeAsyncContext, resumeIdx1 + 1);
             AssertTrue(stream, suspendIdx > resumeIdx1, "Expected SuspendAsyncContext after first Resume");
 
-            int resumeIdx2 = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, suspendIdx + 1);
+            int resumeIdx2 = ids.IndexOf(AsyncEventID.ResumeRuntimeAsyncContext, suspendIdx + 1);
             AssertTrue(stream, resumeIdx2 > suspendIdx, "Expected second ResumeAsyncContext after Suspend");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx2 + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteRuntimeAsyncContext, resumeIdx2 + 1);
             AssertTrue(stream, completeIdx > resumeIdx2, "Expected CompleteAsyncContext after second Resume");
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CreateAsyncContextEmittedOnFirstAwait()
         {
-            var events = await CollectEventsAsync(CreateAsyncContextKeyword | CompleteAsyncContextKeyword, RuntimeAsync_SingleYield);
+            var events = await CollectEventsAsync(CreateRuntimeAsyncContextKeyword | CompleteRuntimeAsyncContextKeyword, RuntimeAsync_SingleYield);
 
             // DumpAllEvents(events);
 
             var ids = ParseAllEvents(events).EventIds;
-            AssertContains(events, AsyncEventID.RuntimeAsync_CreateAsyncContext, ids);
+            AssertContains(events, AsyncEventID.CreateRuntimeAsyncContext, ids);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -381,12 +378,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker));
+            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateRuntimeAsyncCallstack, nameof(RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker));
 
             AssertNotEmpty(stream, createCallstacks);
             AssertAll(stream, createCallstacks, cs =>
@@ -408,12 +405,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CreateCallstackDepthMatchesChain()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CreateCallstackDepthMatchesChain_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CreateCallstackDepthMatchesChain_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateCallstackDepthMatchesChain_Marker));
+            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateRuntimeAsyncCallstack, nameof(RuntimeAsync_CreateCallstackDepthMatchesChain_Marker));
 
             // The expected [NoInlining] frames in order (innermost first):
             // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> RuntimeAsync_CreateCallstackDepthMatchesChain_Marker
@@ -436,12 +433,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker));
+            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendRuntimeAsyncCallstack, nameof(RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker));
 
             AssertNotEmpty(stream, suspendCallstacks);
             AssertAll(stream, suspendCallstacks, cs =>
@@ -463,12 +460,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendCallstackDepthMatchesChain()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker));
+            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendRuntimeAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker));
 
             // The expected [NoInlining] frames in order (innermost first):
             // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker
@@ -491,14 +488,14 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendCallstackPrecedesComplete()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendCallstackPrecedesComplete_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_SuspendCallstackPrecedesComplete_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
             // Find the suspend callstack via marker to get the context ID
-            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackPrecedesComplete_Marker));
+            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendRuntimeAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackPrecedesComplete_Marker));
             AssertNotEmpty(stream, suspendStacks);
 
             ulong dispatcherId = suspendStacks[0].DispatcherId;
@@ -507,8 +504,8 @@ namespace System.Threading.Tasks.Tests
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
-            int suspendIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack);
-            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext);
+            int suspendIdx = ids.IndexOf(AsyncEventID.SuspendRuntimeAsyncCallstack);
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteRuntimeAsyncContext);
 
             AssertTrue(stream, suspendIdx >= 0, "Expected SuspendAsyncCallstack in context events");
             AssertTrue(stream, completeIdx >= 0, "Expected CompleteAsyncContext in context events");
@@ -526,13 +523,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendCallstackDeeperThanInitialResume()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
-            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
+            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendRuntimeAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
 
             AssertNotEmpty(stream, resumeStacks);
             AssertNotEmpty(stream, suspendStacks);
@@ -555,13 +552,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CreateCallstackPrecedesResumeCallstack()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
+            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateRuntimeAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
 
             AssertNotEmpty(stream, createStacks);
             AssertNotEmpty(stream, resumeStacks);
@@ -592,13 +589,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CreateAndFirstResumeCallstacksMatch()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
+            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateRuntimeAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
 
             AssertNotEmpty(stream, createStacks);
             AssertNotEmpty(stream, resumeStacks);
@@ -633,12 +630,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackEmittedOnResume()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackEmittedOnResume_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CallstackEmittedOnResume_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackEmittedOnResume_Marker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_CallstackEmittedOnResume_Marker));
 
             AssertNotEmpty(stream, callstacks);
             AssertAll(stream, callstacks, cs =>
@@ -660,12 +657,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackDepthMatchesChain()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackDepthMatchesChain_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CallstackDepthMatchesChain_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackDepthMatchesChain_Marker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_CallstackDepthMatchesChain_Marker));
 
             // The expected [NoInlining] frames in order (innermost first):
             // RuntimeAsync_InnerYield -> RuntimeAsync_CallstackDepthMatchesChain_Marker
@@ -687,7 +684,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_MethodEventCountMatchesChainDepth()
         {
-            var events = await CollectEventsAsync(CallstackKeywords | MethodKeywords, RuntimeAsync_MethodEventCountMatchesChainDepth_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords | RuntimeAsyncMethodKeywords, RuntimeAsync_MethodEventCountMatchesChainDepth_Marker);
 
             // DumpAllEvents(events);
 
@@ -696,7 +693,7 @@ namespace System.Threading.Tasks.Tests
             // Marker -> DeepChain -> Level1 -> Level2 -> Level3
             const int ExpectedChainDepth = 5;
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_MethodEventCountMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_MethodEventCountMatchesChainDepth_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             AssertEqual(stream, ExpectedChainDepth, markerCallstacks[0].Frames.Count);
@@ -704,10 +701,10 @@ namespace System.Threading.Tasks.Tests
             ulong chainDispatcherId = markerCallstacks[0].DispatcherId;
             var chainEvents = stream.ChainEventsFromDispatcher(chainDispatcherId);
 
-            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncMethod);
+            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.ResumeRuntimeAsyncMethod);
             AssertEqual(stream, ExpectedChainDepth, resumeCount);
 
-            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
+            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.CompleteRuntimeAsyncMethod);
             AssertEqual(stream, ExpectedChainDepth, completeCount);
         }
 
@@ -721,13 +718,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackFramesHaveDistinctMethodIds()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // Frames in the same callstack should have distinct methodIds (one per async method in the chain).
@@ -770,13 +767,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_YieldAtEachLevel_CallstackShrinks()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Marker));
 
             // After Task.Delay resumes: full chain (Level3, Level2, Level1, Marker) = 4 frames
             // After Level3's yield resumes: Level3 completes, chain is (Level2, Level1, Marker) = 3 frames
@@ -797,7 +794,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackSimulation_NormalCompletion()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackSimulation_NormalCompletion_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CallstackSimulation_NormalCompletion_Marker);
 
             // DumpAllEvents(events);
 
@@ -815,7 +812,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackSimulation_HandledException()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackSimulation_HandledException_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CallstackSimulation_HandledException_Marker);
 
             // DumpAllEvents(events);
 
@@ -846,7 +843,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackSimulation_UnhandledException()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackSimulation_UnhandledException_Catcher_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CallstackSimulation_UnhandledException_Catcher_Marker);
 
             // DumpAllEvents(events);
 
@@ -877,12 +874,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_UnhandledExceptionUnwind()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_UnhandledExceptionUnwind_Catcher_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_UnhandledExceptionUnwind_Catcher_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_UnhandledExceptionUnwind_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_UnhandledExceptionUnwind_Marker));
             AssertNotEmpty(stream, resumeStacks);
 
             ulong dispatcherId = resumeStacks[0].DispatcherId;
@@ -890,13 +887,13 @@ namespace System.Threading.Tasks.Tests
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var eventIds = taskEvts.Select(e => e.EventId).ToList();
 
-            AssertContains(stream, AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
-            AssertContains(stream, AsyncEventID.RuntimeAsync_UnwindAsyncException, eventIds);
-            AssertContains(stream, AsyncEventID.RuntimeAsync_CompleteAsyncContext, eventIds);
+            AssertContains(stream, AsyncEventID.ResumeRuntimeAsyncContext, eventIds);
+            AssertContains(stream, AsyncEventID.UnwindRuntimeAsyncException, eventIds);
+            AssertContains(stream, AsyncEventID.CompleteRuntimeAsyncContext, eventIds);
 
             // Verify unwind frame count for this task
             // Marker -> RuntimeAsync_DeepUnhandledOuter -> RuntimeAsync_DeepUnhandledMiddle -> RuntimeAsync_DeepUnhandledInnerThrows, 4 frames deep after the initial resume.
-            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.RuntimeAsync_UnwindAsyncException).ToList();
+            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.UnwindRuntimeAsyncException).ToList();
             AssertNotEmpty(stream, unwindEvents);
             AssertAll(stream, unwindEvents, e => Assert.Equal(4u, e.UnwindFrameCount));
         }
@@ -911,12 +908,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_HandledExceptionUnwind()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_HandledExceptionUnwind_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_HandledExceptionUnwind_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_HandledExceptionUnwind_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_HandledExceptionUnwind_Marker));
             AssertNotEmpty(stream, resumeStacks);
 
             ulong dispatcherId = resumeStacks[0].DispatcherId;
@@ -924,13 +921,13 @@ namespace System.Threading.Tasks.Tests
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var eventIds = taskEvts.Select(e => e.EventId).ToList();
 
-            AssertContains(stream, AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
-            AssertContains(stream, AsyncEventID.RuntimeAsync_UnwindAsyncException, eventIds);
-            AssertContains(stream, AsyncEventID.RuntimeAsync_CompleteAsyncContext, eventIds);
+            AssertContains(stream, AsyncEventID.ResumeRuntimeAsyncContext, eventIds);
+            AssertContains(stream, AsyncEventID.UnwindRuntimeAsyncException, eventIds);
+            AssertContains(stream, AsyncEventID.CompleteRuntimeAsyncContext, eventIds);
 
             // Verify unwind frame count for this task
             // RuntimeAsync_DeepMiddle -> RuntimeAsync_DeepInnerThrows, 2 frames deep after the initial resume.
-            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.RuntimeAsync_UnwindAsyncException).ToList();
+            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.UnwindRuntimeAsyncException).ToList();
             AssertNotEmpty(stream, unwindEvents);
             AssertAll(stream, unwindEvents, e => Assert.Equal(2u, e.UnwindFrameCount));
         }
@@ -947,7 +944,7 @@ namespace System.Threading.Tasks.Tests
         {
             var captures = new List<(string MethodName, int WrapperSlot)>();
 
-            var events = CollectEvents(ResumeAsyncCallstackKeyword, () =>
+            var events = CollectEvents(ResumeRuntimeAsyncCallstackKeyword, () =>
             {
                 RunScenarioAndFlush(async () =>
                 {
@@ -974,7 +971,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void RuntimeAsync_WrapperIndexResetEmitted()
         {
-            var events = CollectEvents(AllKeywords, () =>
+            var events = CollectEvents(AllRuntimeAsyncKeywords, () =>
             {
                 // Recursive chain 34 levels deep crosses the 32-slot boundary,
                 // triggering at least one ResetAsyncContinuationWrapperIndex event.
@@ -996,7 +993,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public void RuntimeAsync_WrapperIndexNoResetUnder32()
         {
-            var events = CollectEvents(AllKeywords, () =>
+            var events = CollectEvents(AllRuntimeAsyncKeywords, () =>
             {
                 // A shallow chain stays within the first 32 slots --
                 // no reset event should be emitted.
@@ -1020,12 +1017,12 @@ namespace System.Threading.Tasks.Tests
         public void RuntimeAsync_PeriodicTimerFlush()
         {
             static bool IsRequestedEvent(AsyncEventID id) =>
-                id == AsyncEventID.RuntimeAsync_CreateAsyncContext ||
-                id == AsyncEventID.RuntimeAsync_ResumeAsyncContext ||
-                id == AsyncEventID.RuntimeAsync_SuspendAsyncContext ||
-                id == AsyncEventID.RuntimeAsync_CompleteAsyncContext;
+                id == AsyncEventID.CreateRuntimeAsyncContext ||
+                id == AsyncEventID.ResumeRuntimeAsyncContext ||
+                id == AsyncEventID.SuspendRuntimeAsyncContext ||
+                id == AsyncEventID.CompleteRuntimeAsyncContext;
 
-            var events = CollectEvents(CoreKeywords, (collectedEvents, _) =>
+            var events = CollectEvents(RuntimeAsyncCoreKeywords, (collectedEvents, _) =>
             {
                 // Run scenario - do NOT flush explicitly afterwards.
                 RunScenario(async () =>
@@ -1074,7 +1071,7 @@ namespace System.Threading.Tasks.Tests
             var firstFlushSeen = new ManualResetEventSlim(false);
             var events = new CollectedEvents();
 
-            using (var listener = CreateListener(CoreKeywords))
+            using (var listener = CreateListener(RuntimeAsyncCoreKeywords))
             {
                 listener.RunWithCallback(e =>
                 {
@@ -1153,7 +1150,7 @@ namespace System.Threading.Tasks.Tests
             // There must be at least 2 such buffers (one per RuntimeAsync_SingleYield() call), and ALL of them must
             // have the worker's OsThreadId - proving the timer flush didn't corrupt the header.
             var stream = ParseAllEvents(events);
-            var createEvents = stream.OfType(AsyncEventID.RuntimeAsync_CreateAsyncContext).ToList();
+            var createEvents = stream.OfType(AsyncEventID.CreateRuntimeAsyncContext).ToList();
             AssertTrue(stream, createEvents.Count >= 2, $"Expected at least 2 CreateAsyncContext events from the worker thread, got {createEvents.Count}");
             AssertAll(stream, createEvents, e => Assert.Equal(workerOsThreadId, e.OsThreadId));
         }
@@ -1165,12 +1162,12 @@ namespace System.Threading.Tasks.Tests
         public void RuntimeAsync_DeadThreadFlush()
         {
             static bool IsRequestedEvent(AsyncEventID id) =>
-                id == AsyncEventID.RuntimeAsync_CreateAsyncContext ||
-                id == AsyncEventID.RuntimeAsync_ResumeAsyncContext ||
-                id == AsyncEventID.RuntimeAsync_SuspendAsyncContext ||
-                id == AsyncEventID.RuntimeAsync_CompleteAsyncContext;
+                id == AsyncEventID.CreateRuntimeAsyncContext ||
+                id == AsyncEventID.ResumeRuntimeAsyncContext ||
+                id == AsyncEventID.SuspendRuntimeAsyncContext ||
+                id == AsyncEventID.CompleteRuntimeAsyncContext;
 
-            var events = CollectEvents(CoreKeywords, (collectedEvents, _) =>
+            var events = CollectEvents(RuntimeAsyncCoreKeywords, (collectedEvents, _) =>
             {
                 // Spawn a dedicated thread that runs async work then exits.
                 // Its thread-local buffer becomes orphaned when the thread dies.
@@ -1215,7 +1212,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_NoSyncClockEventBeforeInterval()
         {
-            var events = await CollectEventsAsync(CoreKeywords, RuntimeAsync_SingleYield);
+            var events = await CollectEventsAsync(RuntimeAsyncCoreKeywords, RuntimeAsync_SingleYield);
 
             var ids = ParseAllEvents(events).EventIds;
 
@@ -1237,28 +1234,28 @@ namespace System.Threading.Tasks.Tests
 
             // Now attach listener but don't run any RuntimeAsync work inside --
             // just call a synchronous no-op. Verify no stale events from above leak through.
-            var events = await CollectEventsAsync(CoreKeywords, () => Task.CompletedTask);
+            var events = await CollectEventsAsync(RuntimeAsyncCoreKeywords, () => Task.CompletedTask);
 
             // There may be meta data related events, but there should be no suspend/resume/complete events from the earlier work.
             var ids = ParseAllEvents(events).EventIds;
 
-            int contextEvents = ids.Count(id => id == AsyncEventID.RuntimeAsync_ResumeAsyncContext || id == AsyncEventID.RuntimeAsync_SuspendAsyncContext || id == AsyncEventID.RuntimeAsync_CompleteAsyncContext);
+            int contextEvents = ids.Count(id => id == AsyncEventID.ResumeRuntimeAsyncContext || id == AsyncEventID.SuspendRuntimeAsyncContext || id == AsyncEventID.CompleteRuntimeAsyncContext);
 
             AssertEqual(events, 0, contextEvents);
         }
 
         public static IEnumerable<object[]> KeywordGatekeepingData()
         {
-            yield return new object[] { (long)CreateAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_CreateAsyncContext, AsyncEventID.TaskAsync_CreateAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)ResumeAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_ResumeAsyncContext, AsyncEventID.TaskAsync_ResumeAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)SuspendAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_SuspendAsyncContext, AsyncEventID.TaskAsync_SuspendAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)CompleteAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_CompleteAsyncContext, AsyncEventID.TaskAsync_CompleteAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)UnwindAsyncExceptionKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_UnwindAsyncException, AsyncEventID.TaskAsync_UnwindAsyncException, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)CreateAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_CreateAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)ResumeAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, AsyncEventID.TaskAsync_ResumeAsyncCallstack, AsyncEventID.TaskAsync_AppendAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)SuspendAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)ResumeAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_ResumeAsyncMethod, AsyncEventID.TaskAsync_ResumeAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)CompleteAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_CompleteAsyncMethod, AsyncEventID.TaskAsync_CompleteAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CreateRuntimeAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CreateRuntimeAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)ResumeRuntimeAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeRuntimeAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)SuspendRuntimeAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.SuspendRuntimeAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CompleteRuntimeAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CompleteRuntimeAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)UnwindRuntimeAsyncExceptionKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.UnwindRuntimeAsyncException, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CreateRuntimeAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CreateRuntimeAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)ResumeRuntimeAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeRuntimeAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)SuspendRuntimeAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.SuspendRuntimeAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)ResumeRuntimeAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeRuntimeAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CompleteRuntimeAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CompleteRuntimeAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -1267,6 +1264,7 @@ namespace System.Threading.Tasks.Tests
         {
             await RuntimeAsync_OuterCatches();
             await RuntimeAsync_ChainedYield();
+            await StateMachineAsync_SingleYield();
         }
 
         // This test is sensitive to event noise - it asserts that ONLY the expected event
@@ -1296,7 +1294,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ResetAsyncThreadContextEvent()
         {
-            var events = await CollectEventsAsync(CoreKeywords, RuntimeAsync_SingleYield);
+            var events = await CollectEventsAsync(RuntimeAsyncCoreKeywords, RuntimeAsync_SingleYield);
 
             // DumpAllEvents(events);
 
@@ -1308,7 +1306,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_MetadataEventEmittedOnEnable()
         {
-            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_SingleYield);
+            var events = await CollectEventsAsync(AllRuntimeAsyncKeywords, RuntimeAsync_SingleYield);
 
             // DumpAllEvents(events);
 
@@ -1332,7 +1330,7 @@ namespace System.Threading.Tasks.Tests
         {
             const int threadCount = 8;
 
-            var events = CollectEvents(AllKeywords, () =>
+            var events = CollectEvents(AllRuntimeAsyncKeywords, () =>
             {
                 using var barrier = new Barrier(threadCount);
                 var tasks = new Task[threadCount];
@@ -1372,10 +1370,10 @@ namespace System.Threading.Tasks.Tests
             // methods at different JIT-assigned addresses, the deltas between consecutive
             // NativeIPs will naturally span both directions. This exercises the full
             // zigzag + LEB128 encode/decode path through the production serializer.
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker));
             AssertNotEmpty(stream, callstacks);
 
             // Find callstacks with 3+ frames -- enough depth for meaningful deltas.
@@ -1438,7 +1436,7 @@ namespace System.Threading.Tasks.Tests
             for (int i = 0; i < iterations; i++)
                 depths[i] = rng.Next(1, 120);
 
-            var events = CollectEvents(CallstackKeywords, () =>
+            var events = CollectEvents(RuntimeAsyncCallstackKeywords, () =>
             {
                 RunScenarioAndFlush(async () =>
                 {
@@ -1450,7 +1448,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackStressWithVaryingDepths_Marker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_CallstackStressWithVaryingDepths_Marker));
 
             // Verify all callstacks have valid frame data that resolves to managed methods.
             foreach (var cs in callstacks)
@@ -1511,7 +1509,7 @@ namespace System.Threading.Tasks.Tests
                 for (int i = 0; i < iterations; i++)
                     depths[i] = rng.Next(50, 250);
 
-                var events = CollectEvents(AllKeywords, () =>
+                var events = CollectEvents(AllRuntimeAsyncKeywords, () =>
                 {
                     RunScenarioAndFlush(async () =>
                     {
@@ -1550,9 +1548,9 @@ namespace System.Threading.Tasks.Tests
                     _ = ReadPayloadLengthPrefix(buffer, firstId, ref index);
 
                     byte frameCount = 0;
-                    if (firstId == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack ||
-                        firstId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack ||
-                        firstId == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack)
+                    if (firstId == AsyncEventID.ResumeRuntimeAsyncCallstack ||
+                        firstId == AsyncEventID.CreateRuntimeAsyncCallstack ||
+                        firstId == AsyncEventID.SuspendRuntimeAsyncCallstack)
                     {
                         // Callstack payload: callstackId(1) + continuationIndex(1) + frameCount(1) + compressed parentDispatcherId + compressed dispatcherId + frames...
                         index++; // callstack ID (reserved)
@@ -1583,9 +1581,9 @@ namespace System.Threading.Tasks.Tests
                         uint remaining = bufferCapacity - (uint)current.UsedSize;
                         bool currentNotFull = remaining > 0;
                         bool nextStartsWithLargeCallstack =
-                            (next.FirstEventId == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack ||
-                             next.FirstEventId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack ||
-                             next.FirstEventId == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack) &&
+                            (next.FirstEventId == AsyncEventID.ResumeRuntimeAsyncCallstack ||
+                             next.FirstEventId == AsyncEventID.CreateRuntimeAsyncCallstack ||
+                             next.FirstEventId == AsyncEventID.SuspendRuntimeAsyncCallstack) &&
                             next.FirstFrameCount > 30;
 
                         if (currentNotFull && nextStartsWithLargeCallstack)
@@ -1602,7 +1600,7 @@ namespace System.Threading.Tasks.Tests
                 // Validate all large callstacks in the stream have correct frames.
                 if (overflowDetected)
                 {
-                    var largeCallstacks = stream.OfType(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack)
+                    var largeCallstacks = stream.OfType(AsyncEventID.ResumeRuntimeAsyncCallstack)
                         .Where(e => e.FrameCount > 30)
                         .ToList();
 
@@ -1636,7 +1634,7 @@ namespace System.Threading.Tasks.Tests
             // RuntimeAsync_RecursiveChain(300) produces a 300-deep chain + 1 lambda = 301 frames.
             const int requestedDepth = 300;
 
-            var events = CollectEvents(ResumeAsyncCallstackKeyword, () =>
+            var events = CollectEvents(ResumeRuntimeAsyncCallstackKeyword, () =>
             {
                 RunScenarioAndFlush(async () =>
                 {
@@ -1647,7 +1645,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.OfType(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack).ToList();
+            var callstacks = stream.OfType(AsyncEventID.ResumeRuntimeAsyncCallstack).ToList();
             AssertTrue(stream, callstacks.Count >= 1, "Expected at least one callstack");
 
             // Find the callstack from our deep RuntimeAsync_RecursiveChain call.
@@ -1670,7 +1668,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_MetadataMatchesWrapperMethods()
         {
-            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_SingleYield);
+            var events = await CollectEventsAsync(AllRuntimeAsyncKeywords, RuntimeAsync_SingleYield);
 
             var stream = ParseAllEvents(events);
             var metadataList = stream.MetadataEvents;
@@ -1736,7 +1734,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_WhenAll_TracksAllBranches()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_WhenAll_TracksAllBranches_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_WhenAll_TracksAllBranches_Marker);
 
             // DumpAllEvents(events);
 
@@ -1744,16 +1742,16 @@ namespace System.Threading.Tasks.Tests
 
             // Each branch awaits a (staggered) Task.Delay, so it always suspends and produces its own
             // tracked chain with a Resume callstack containing the branch frame.
-            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
-            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
-            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
             AssertNotEmpty(stream, branchACallstacks);
             AssertNotEmpty(stream, branchBCallstacks);
             AssertNotEmpty(stream, branchCCallstacks);
 
             // Because every branch suspends on a pending Task.Delay, Task.WhenAll is always pending when
             // the outer marker awaits it, so the marker also suspends and gets its own tracked chain.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own DispatcherId.
@@ -1766,11 +1764,11 @@ namespace System.Threading.Tasks.Tests
             ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
             var markerIds = stream.ChainEventsFromDispatcher(markerDispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
-            int resumeIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
+            int createIdx = markerIds.IndexOf(AsyncEventID.CreateRuntimeAsyncContext);
+            int resumeIdx = markerIds.IndexOf(AsyncEventID.ResumeRuntimeAsyncContext, createIdx + 1);
             AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
 
-            int completeIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = markerIds.IndexOf(AsyncEventID.CompleteRuntimeAsyncContext, resumeIdx + 1);
             AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
         }
 
@@ -1810,20 +1808,20 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_WhenAny_TracksAllBranches()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_WhenAny_TracksAllBranches_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_WhenAny_TracksAllBranches_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // All branches - including the slow ones whose completion the outer is no longer
             // strictly waiting on after WhenAny returned - must produce their own Resume callstacks.
-            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
-            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker));
-            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker));
             AssertNotEmpty(stream, fastCallstacks);
             AssertNotEmpty(stream, slow1Callstacks);
             AssertNotEmpty(stream, slow2Callstacks);
@@ -1837,7 +1835,7 @@ namespace System.Threading.Tasks.Tests
             // The outer marker should also be resumed at least once.
             ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
             var markerIds = stream.ChainEventsFromDispatcher(markerDispatcherId).Select(e => e.EventId).ToList();
-            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.RuntimeAsync_ResumeAsyncContext);
+            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.ResumeRuntimeAsyncContext);
             AssertTrue(stream, resumeCountForMarker >= 1, $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
         }
 
@@ -1865,13 +1863,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public async Task RuntimeAsync_ConfigureAwaitFalse()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_ConfigureAwaitFalse_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_ConfigureAwaitFalse_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             var deepest = markerCallstacks.OrderByDescending(cs => cs.FrameCount).First();
@@ -1916,16 +1914,16 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_TaskCancellation()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_TaskCancellation_Marker);
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_TaskCancellation_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
-            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
+            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
             AssertNotEmpty(stream, innerCallstacks);
 
             // Inner cancelled task + outer marker must each see exactly one Create and one Complete on their own DispatcherId.
@@ -1941,7 +1939,7 @@ namespace System.Threading.Tasks.Tests
         {
             // Install a non-default SynchronizationContext on this thread so the await captures it.
             // The await's continuation will be routed via SynchronizationContextAwaitTaskContinuation,
-            // which the V2 runtime-async dispatch loop should honor when resuming the chain.
+            // which the Runtime runtime-async dispatch loop should honor when resuming the chain.
             int callerThreadId = Environment.CurrentManagedThreadId;
             SynchronizationContext? prev = SynchronizationContext.Current;
             SynchronizationContext.SetSynchronizationContext(s_runtimeAsyncSyncContextCtx);
@@ -1968,7 +1966,7 @@ namespace System.Threading.Tasks.Tests
         {
             s_runtimeAsyncSyncContextCtx = new InlinePostSynchronizationContext();
 
-            var events = await CollectEventsAsync(CallstackKeywords, () => RunIsolatedScenarioAsync(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, () => RunIsolatedScenarioAsync(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
 
             // DumpAllEvents(events);
 
@@ -1979,7 +1977,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // The marker frame should appear in the Resume callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // The marker's chain should see exactly one Create and one Complete on its own DispatcherId.
@@ -1989,11 +1987,11 @@ namespace System.Threading.Tasks.Tests
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
-            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
+            int createIdx = ids.IndexOf(AsyncEventID.CreateRuntimeAsyncContext);
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeRuntimeAsyncContext, createIdx + 1);
             AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteRuntimeAsyncContext, resumeIdx + 1);
             AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -2009,7 +2007,7 @@ namespace System.Threading.Tasks.Tests
         {
             var scheduler = new InlineRunTaskScheduler();
 
-            var events = await CollectEventsAsync(CallstackKeywords, async () =>
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, async () =>
             {
                 // Start the marker on the custom scheduler so the resulting Task is queued through it.
                 await Task.Factory.StartNew(
@@ -2027,7 +2025,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // The marker's chain should see exactly one Create and one Complete on its own DispatcherId.
@@ -2037,11 +2035,11 @@ namespace System.Threading.Tasks.Tests
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
-            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
+            int createIdx = ids.IndexOf(AsyncEventID.CreateRuntimeAsyncContext);
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeRuntimeAsyncContext, createIdx + 1);
             AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteRuntimeAsyncContext, resumeIdx + 1);
             AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -2055,25 +2053,25 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ValueTask_EventSequenceOrder()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, async () => await RuntimeAsync_ValueTask_EventSequenceOrder_Marker());
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, async () => await RuntimeAsync_ValueTask_EventSequenceOrder_Marker());
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_EventSequenceOrder_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_ValueTask_EventSequenceOrder_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.CreateRuntimeAsyncContext);
             AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeRuntimeAsyncContext, createIdx + 1);
             AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteRuntimeAsyncContext, resumeIdx + 1);
             AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -2087,19 +2085,19 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ValueTask_MethodEventsEmitted()
         {
-            var events = await CollectEventsAsync(MethodKeywords | CoreKeywords, async () => await RuntimeAsync_ValueTask_MethodEventsEmitted_Marker());
+            var events = await CollectEventsAsync(RuntimeAsyncMethodKeywords | RuntimeAsyncCoreKeywords, async () => await RuntimeAsync_ValueTask_MethodEventsEmitted_Marker());
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
             var methodEvents = stream.All
-                .Where(e => e.EventId is AsyncEventID.RuntimeAsync_ResumeAsyncMethod or AsyncEventID.RuntimeAsync_CompleteAsyncMethod)
+                .Where(e => e.EventId is AsyncEventID.ResumeRuntimeAsyncMethod or AsyncEventID.CompleteRuntimeAsyncMethod)
                 .Select(e => e.EventId)
                 .ToList();
 
-            int resumeCount = methodEvents.Count(id => id == AsyncEventID.RuntimeAsync_ResumeAsyncMethod);
-            int completeCount = methodEvents.Count(id => id == AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
+            int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeRuntimeAsyncMethod);
+            int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteRuntimeAsyncMethod);
 
             // Marker -> Level1 -> Level2 -> Level3
             AssertTrue(stream, resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
@@ -2116,13 +2114,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth()
         {
-            var events = await CollectValueTaskEventsAsync(CallstackKeywords, RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker);
+            var events = await CollectValueTaskEventsAsync(RuntimeAsyncCallstackKeywords, RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             // Marker -> Level1 -> Level2 -> Level3.
@@ -2139,13 +2137,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, async () => await RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker());
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords, async () => await RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker());
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
@@ -2183,28 +2181,28 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete()
         {
-            var events = await CollectEventsAsync(CallstackKeywords | UnwindAsyncExceptionKeyword, async () => await RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker());
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords | UnwindRuntimeAsyncExceptionKeyword, async () => await RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker());
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.CreateRuntimeAsyncContext);
             AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeRuntimeAsyncContext, createIdx + 1);
             AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int unwindIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_UnwindAsyncException, resumeIdx + 1);
+            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindRuntimeAsyncException, resumeIdx + 1);
             AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, unwindIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteRuntimeAsyncContext, unwindIdx + 1);
             AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
@@ -2233,7 +2231,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete()
         {
-            var events = await CollectEventsAsync(CallstackKeywords | UnwindAsyncExceptionKeyword, async () =>
+            var events = await CollectEventsAsync(RuntimeAsyncCallstackKeywords | UnwindRuntimeAsyncExceptionKeyword, async () =>
             {
                 try
                 {
@@ -2248,22 +2246,22 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, nameof(RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.CreateRuntimeAsyncContext);
             AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeRuntimeAsyncContext, createIdx + 1);
             AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int unwindIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_UnwindAsyncException, resumeIdx + 1);
+            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindRuntimeAsyncException, resumeIdx + 1);
             AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, unwindIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteRuntimeAsyncContext, unwindIdx + 1);
             AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
@@ -2293,15 +2291,15 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ResetContext_ReplaysPendingV2Chain()
         {
-            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_ResetContext_ReplaysPendingV2Chain_Outer_Marker);
+            var events = await CollectEventsAsync(AllRuntimeAsyncKeywords, RuntimeAsync_ResetContext_ReplaysPendingV2Chain_Outer_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
-            // Locate the V2 dispatcher driving the marker chain via its ResumeAsyncCallstack
+            // Locate the Runtime dispatcher driving the marker chain via its ResumeAsyncCallstack
             // events (which carry the marker frames in their callstack).
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysPendingV2Chain");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysPendingV2Chain");
             AssertNotEmpty(stream, markerCallstacks);
 
             // Thread-scoped replay assertion: at least one OS thread must have seen two
@@ -2310,7 +2308,7 @@ namespace System.Threading.Tasks.Tests
             // in the trace can accumulate two resets (e.g. the test thread re-enables on
             // its initial event then again later), so we have to look at each candidate
             // thread, not just the first one. The thread that actually drove the replay
-            // is the one the V2 continuation resumed onto.
+            // is the one the Runtime continuation resumed onto.
             var resetsByThread = stream.All
                 .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
                 .GroupBy(e => e.OsThreadId)
@@ -2334,7 +2332,7 @@ namespace System.Threading.Tasks.Tests
 
                 var replayDispatcherIds = postResetMarkerCallstacks.Select(c => c.DispatcherId).ToHashSet();
                 var postResetResumeContext = stream.All
-                    .Where(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncContext
+                    .Where(e => e.EventId == AsyncEventID.ResumeRuntimeAsyncContext
                                 && e.OsThreadId == threadId
                                 && e.Timestamp >= lastResetTimestamp
                                 && replayDispatcherIds.Contains(e.DispatcherId))
@@ -2376,7 +2374,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public async Task RuntimeAsync_ResetContext_ReplaysMultipleDispatchers()
         {
-            var events = await CollectEventsAsync(AllKeywords, async () =>
+            var events = await CollectEventsAsync(AllRuntimeAsyncKeywords, async () =>
             {
                 var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 var block = new ManualResetEventSlim(false);
@@ -2410,12 +2408,12 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            // The replay must emit at least one ResumeAsyncCallstack carrying a V2 marker chain.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysMultipleDispatchers");
+            // The replay must emit at least one ResumeAsyncCallstack carrying a Runtime marker chain.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeRuntimeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysMultipleDispatchers");
             AssertNotEmpty(stream, markerCallstacks);
 
             // Decisive proof: find an OS thread where a single ResetAsyncThreadContext is
-            // followed by >= 2 ResumeAsyncContext events before the next reset. A normal V2
+            // followed by >= 2 ResumeAsyncContext events before the next reset. A normal Runtime
             // dispatch loop emits only one ResumeAsyncContext per dispatcher entry, so two
             // in one reset window can only come from the walker traversing two stacked
             // asyncDispatcherInfo entries on t_current.
@@ -2439,7 +2437,7 @@ namespace System.Threading.Tasks.Tests
                         : long.MaxValue;
 
                     int resumeContextCount = stream.All
-                        .Count(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncContext
+                        .Count(e => e.EventId == AsyncEventID.ResumeRuntimeAsyncContext
                                     && e.OsThreadId == threadId
                                     && e.Timestamp >= windowStart
                                     && e.Timestamp < windowEnd);
@@ -2460,7 +2458,7 @@ namespace System.Threading.Tasks.Tests
             AssertTrue(stream, found,
                 "Expected at least one OS thread with a ResetAsyncThreadContext event " +
                 "followed by >= 2 ResumeAsyncContext events in the same reset window, " +
-                "proving the reset-replay walker traversed multiple stacked V2 dispatcher infos.");
+                "proving the reset-replay walker traversed multiple stacked Runtime dispatcher infos.");
         }
 
         [RuntimeAsyncMethodGeneration(true)]
@@ -2489,7 +2487,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ResetContext_ReplayResumeCompleteBalance()
         {
-            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker);
+            var events = await CollectEventsAsync(AllRuntimeAsyncKeywords, RuntimeAsync_ResetContext_ReplayResumeCompleteBalance_Outer_Marker);
 
             // DumpAllEvents(events);
 
@@ -2498,11 +2496,11 @@ namespace System.Threading.Tasks.Tests
             // Locate the replayed marker ResumeAsyncCallstack (the reset replays the suspended
             // Outer->Mid->Inner chain, producing a callstack carrying the marker frames).
             var markerCallstacks = stream.CallstacksWithMarker(
-                AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplayResumeCompleteBalance");
+                AsyncEventID.ResumeRuntimeAsyncCallstack, "RuntimeAsync_ResetContext_ReplayResumeCompleteBalance");
             AssertNotEmpty(stream, markerCallstacks);
 
             // Resume/Complete balance across the replay boundary: the whole Outer->Mid->Inner chain
-            // is a single V2 dispatcher whose deepest replayed callstack has N frames, so N async
+            // is a single Runtime dispatcher whose deepest replayed callstack has N frames, so N async
             // methods must each eventually complete. Balance is NOT preserved per reset epoch by
             // design (a Resume can land in one epoch and its Complete in a later epoch once a config
             // change bumps the revision mid-chain), so the count must be reconstructed over the whole
@@ -2513,17 +2511,17 @@ namespace System.Threading.Tasks.Tests
             ulong markerDispatcherId = deepest.DispatcherId;
 
             int completeMethodCount = stream.ChainEventsFromDispatcher(markerDispatcherId)
-                .Count(e => e.EventId == AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
+                .Count(e => e.EventId == AsyncEventID.CompleteRuntimeAsyncMethod);
 
             AssertTrue(stream, completeMethodCount >= deepest.FrameCount,
-                $"Expected at least {deepest.FrameCount} RuntimeAsync_CompleteAsyncMethod events across the " +
+                $"Expected at least {deepest.FrameCount} CompleteRuntimeAsyncMethod events across the " +
                 $"trace for marker dispatcher {markerDispatcherId} to balance the replayed callstack of depth " +
                 $"{deepest.FrameCount}, but found {completeMethodCount}.");
         }
 
-        // Regular async (V1, Task-based) inner. When it calls innerDone.SetResult() it inline-resumes
-        // the V2 outer while this V1 dispatcher's AsyncTaskDispatcherInfo is still on t_current,
-        // co-stacking a V1 and a V2 dispatcher info at the moment the reset replay walker runs.
+        // StateMachine async inner. When it calls innerDone.SetResult() it inline-resumes
+        // the Runtime outer while this StateMachine dispatcher's AsyncStateMachineDispatcherInfo is still on t_current,
+        // co-stacking a StateMachine and a Runtime dispatcher info at the moment the reset replay walker runs.
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static async Task RuntimeAsync_ResetContext_ReplaysMixedV1V2ChainInAddressOrder_V1Inner_Marker(
@@ -2553,9 +2551,9 @@ namespace System.Threading.Tasks.Tests
                 var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 var block = new ManualResetEventSlim(false);
                 var blocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                // No RunContinuationsAsynchronously: innerDone.SetResult() inline-resumes the V2
-                // outer while the V1 inner dispatcher is still on t_current, producing a mixed
-                // V1+V2 chain for the reset replay walker to merge.
+                // No RunContinuationsAsynchronously: innerDone.SetResult() inline-resumes the Runtime
+                // outer while the StateMachine inner dispatcher is still on t_current, producing a mixed
+                // StateMachine+Runtime chain for the reset replay walker to merge.
                 var innerDone = new TaskCompletionSource();
 
                 Task inner = RuntimeAsync_ResetContext_ReplaysMixedV1V2ChainInAddressOrder_V1Inner_Marker(gate.Task, block, () => blocked.SetResult(), innerDone);
@@ -2585,11 +2583,11 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            // The merge walker traverses both the V1 (AsyncTaskDispatcherInfo) and V2
+            // The merge walker traverses both the StateMachine (AsyncStateMachineDispatcherInfo) and Runtime
             // (AsyncDispatcherInfo) t_current chains, recursing on the smaller-address node first
             // to emit oldest-first. Decisive proof that both branches of the merge ran: within a
-            // single reset window on one thread, both a TaskAsync_ResumeAsyncContext (V1) and a
-            // RuntimeAsync_ResumeAsyncContext (V2) are replayed.
+            // single reset window on one thread, both a ResumeStateMachineAsyncContextKeyword (StateMachine) and a
+            // ResumeRuntimeAsyncContext (Runtime) are replayed.
             var resetsByThread = stream.All
                 .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
                 .GroupBy(e => e.OsThreadId)
@@ -2609,9 +2607,9 @@ namespace System.Threading.Tasks.Tests
                         ? orderedResets[i + 1].Timestamp
                         : long.MaxValue;
 
-                    bool hasV1Resume = stream.All.Any(e => e.EventId == AsyncEventID.TaskAsync_ResumeAsyncContext
+                    bool hasV1Resume = stream.All.Any(e => e.EventId == AsyncEventID.ResumeStateMachineAsyncContext
                         && e.OsThreadId == threadId && e.Timestamp >= windowStart && e.Timestamp < windowEnd);
-                    bool hasV2Resume = stream.All.Any(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncContext
+                    bool hasV2Resume = stream.All.Any(e => e.EventId == AsyncEventID.ResumeRuntimeAsyncContext
                         && e.OsThreadId == threadId && e.Timestamp >= windowStart && e.Timestamp < windowEnd);
 
                     if (hasV1Resume && hasV2Resume)
@@ -2627,9 +2625,9 @@ namespace System.Threading.Tasks.Tests
             }
 
             AssertTrue(stream, found,
-                "Expected a single ResetAsyncThreadContext window containing both a TaskAsync_ResumeAsyncContext " +
-                "(V1) and a RuntimeAsync_ResumeAsyncContext (V2), proving the reset-replay merge walker traversed " +
-                "a mixed V1+V2 chain and exercised both branches of its address-ordered recursion.");
+                "Expected a single ResetAsyncThreadContext window containing both a ResumeStateMachineAsyncContextKeyword " +
+                "(StateMachine) and a ResumeRuntimeAsyncContext (Runtime), proving the reset-replay merge walker traversed " +
+                "a mixed StateMachine+Runtime chain and exercised both branches of its address-ordered recursion.");
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -1543,6 +1543,8 @@ namespace System.Threading.Tasks.Tests
                     AsyncEventID firstId = (AsyncEventID)buffer[index++];
                     // Skip timestamp delta
                     ReadCompressedUInt64(buffer, ref index);
+                    // Skip the payload-length prefix (UShort for callstack events).
+                    _ = ReadPayloadLengthPrefix(buffer, firstId, ref index);
 
                     byte frameCount = 0;
                     if (firstId == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack ||

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -41,6 +41,34 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_DeepChain_Level3()
+        {
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_DeepChain_Level2()
+        {
+            await RuntimeAsync_DeepChain_Level3();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_DeepChain_Level1()
+        {
+            await RuntimeAsync_DeepChain_Level2();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_DeepChain()
+        {
+            await RuntimeAsync_DeepChain_Level1();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static async Task RuntimeAsync_OuterCatches()
         {
             try
@@ -646,6 +674,115 @@ namespace System.Threading.Tasks.Tests
                 $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
         }
 
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_MethodEventCountMatchesChainDepth_Marker()
+        {
+            await RuntimeAsync_DeepChain();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_MethodEventCountMatchesChainDepth()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords | MethodKeywords, RuntimeAsync_MethodEventCountMatchesChainDepth_Marker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Marker -> DeepChain -> Level1 -> Level2 -> Level3
+            const int ExpectedChainDepth = 5;
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_MethodEventCountMatchesChainDepth_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            Assert.Equal(ExpectedChainDepth, markerCallstacks[0].Frames.Count);
+
+            ulong chainTaskId = markerCallstacks[0].TaskId;
+            var chainEvents = stream.ForTask(chainTaskId);
+
+            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.ResumeAsyncMethod);
+            Assert.Equal(ExpectedChainDepth, resumeCount);
+
+            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.CompleteAsyncMethod);
+            Assert.Equal(ExpectedChainDepth, completeCount);
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker()
+        {
+            await RuntimeAsync_DeepChain();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CallstackFramesHaveDistinctMethodIds()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // Frames in the same callstack should have distinct methodIds (one per async method in the chain).
+            var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
+            var methodIds = deepest.Frames.Select(f => f.MethodId).ToList();
+            Assert.Equal(methodIds.Count, methodIds.Distinct().Count());
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Level3()
+        {
+            await Task.Delay(100);
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Level2()
+        {
+            await RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Level3();
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Level1()
+        {
+            await RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Level2();
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Marker()
+        {
+            await RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Level1();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_YieldAtEachLevel_CallstackShrinks()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Marker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Marker));
+
+            // After Task.Delay resumes: full chain (Level3, Level2, Level1, Marker) = 4 frames
+            // After Level3's yield resumes: Level3 completes, chain is (Level2, Level1, Marker) = 3 frames
+            // After Level2's yield resumes: Level2 completes, chain is (Level1, Marker) = 2 frames
+            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 4);
+            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 3);
+            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 2);
+        }
+
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static async Task RuntimeAsync_CallstackSimulation_NormalCompletion_Marker()
@@ -858,7 +995,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(AllKeywords, () =>
             {
-                // A shallow chain stays within the first 32 slots —
+                // A shallow chain stays within the first 32 slots --
                 // no reset event should be emitted.
                 RunScenarioAndFlush(async () =>
                 {
@@ -1095,7 +1232,7 @@ namespace System.Threading.Tasks.Tests
                 await RuntimeAsync_SingleYield();
             }
 
-            // Now attach listener but don't run any RuntimeAsync work inside —
+            // Now attach listener but don't run any RuntimeAsync work inside --
             // just call a synchronous no-op. Verify no stale events from above leak through.
             var events = await CollectEventsAsync(CoreKeywords, () => Task.CompletedTask);
 
@@ -1238,7 +1375,7 @@ namespace System.Threading.Tasks.Tests
             var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker));
             Assert.NotEmpty(callstacks);
 
-            // Find callstacks with 3+ frames — enough depth for meaningful deltas.
+            // Find callstacks with 3+ frames -- enough depth for meaningful deltas.
             var deepCallstacks = callstacks.Where(cs => cs.FrameCount >= 3).ToList();
 
             Assert.True(deepCallstacks.Count > 0, "Expected at least one callstack with 3+ frames for delta verification");
@@ -1354,7 +1491,7 @@ namespace System.Threading.Tasks.Tests
             // Targeted test: run random-depth callstacks until we detect the overflow
             // path was exercised, then validate the affected callstack.
             // The overflow path fires when a large callstack doesn't fit inline in the
-            // remaining buffer space — the code rewinds, flushes the partial buffer,
+            // remaining buffer space -- the code rewinds, flushes the partial buffer,
             // and re-writes the callstack as the first event in a fresh buffer.
             //
             // To prove overflow occurred we check consecutive buffer pairs:
@@ -1479,7 +1616,7 @@ namespace System.Threading.Tasks.Tests
                 }
             }
 
-            Assert.True(overflowDetected, "Failed to trigger callstack buffer overflow after 10 attempts — " +
+            Assert.True(overflowDetected, "Failed to trigger callstack buffer overflow after 10 attempts -- " +
                 "no consecutive buffer pair found where buffer N has remaining capacity and buffer N+1 starts with a large callstack");
         }
 
@@ -1559,6 +1696,339 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker()
+        {
+            await Task.Yield();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker()
+        {
+            await Task.Yield();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker()
+        {
+            await Task.Yield();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_WhenAll_TracksAllBranches_Marker()
+        {
+            await Task.WhenAll(
+                RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker(),
+                RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker(),
+                RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker());
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_WhenAll_TracksAllBranches()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_WhenAll_TracksAllBranches_Marker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // Each branch is its own async chain; its inner await of Task.Yield produces a Resume callstack containing the branch frame.
+            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            Assert.NotEmpty(branchACallstacks);
+            Assert.NotEmpty(branchBCallstacks);
+            Assert.NotEmpty(branchCCallstacks);
+
+            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own TaskId.
+            AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].TaskId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchBCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            AssertExactlyOneCreateAndComplete(stream, branchCCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
+
+            // The outer marker's chain should fire Create -> Resume -> Complete in that order.
+            ulong markerTaskId = markerCallstacks[0].TaskId;
+            var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
+
+            int createIdx = markerIds.IndexOf(AsyncEventID.CreateAsyncContext);
+            int resumeIdx = markerIds.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
+
+            int completeIdx = markerIds.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker()
+        {
+            await Task.Yield();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker()
+        {
+            await Task.Delay(200);
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker()
+        {
+            await Task.Delay(300);
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_WhenAny_TracksAllBranches_Marker()
+        {
+            Task fast = RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker();
+            Task slow1 = RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker();
+            Task slow2 = RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker();
+
+            await Task.WhenAny(fast, slow1, slow2);
+            await Task.WhenAll(slow1, slow2);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_WhenAny_TracksAllBranches()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_WhenAny_TracksAllBranches_Marker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // All branches - including the slow ones whose completion the outer is no longer
+            // strictly waiting on after WhenAny returned - must produce their own Resume callstacks.
+            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            Assert.NotEmpty(fastCallstacks);
+            Assert.NotEmpty(slow1Callstacks);
+            Assert.NotEmpty(slow2Callstacks);
+
+            // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own TaskId.
+            AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].TaskId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].TaskId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Marker));
+
+            // The outer marker should also be resumed at least once.
+            ulong markerTaskId = markerCallstacks[0].TaskId;
+            var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
+            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.ResumeAsyncContext);
+            Assert.True(resumeCountForMarker >= 1, $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ConfigureAwaitFalse_Leaf_Marker()
+        {
+            await Task.Yield();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ConfigureAwaitFalse_Mid_Marker()
+        {
+            await RuntimeAsync_ConfigureAwaitFalse_Leaf_Marker().ConfigureAwait(false);
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ConfigureAwaitFalse_Marker()
+        {
+            await RuntimeAsync_ConfigureAwaitFalse_Mid_Marker().ConfigureAwait(false);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ConfigureAwaitFalse()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_ConfigureAwaitFalse_Marker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            var frameNames = markerCallstacks[0].Frames
+                .Select(f => GetMethodNameFromMethodId(markerCallstacks[0].CallstackType, f.MethodId))
+                .Where(n => n is not null)
+                .ToList();
+
+            Assert.Contains(nameof(RuntimeAsync_ConfigureAwaitFalse_Leaf_Marker), frameNames);
+            Assert.Contains(nameof(RuntimeAsync_ConfigureAwaitFalse_Mid_Marker), frameNames);
+            Assert.Contains(nameof(RuntimeAsync_ConfigureAwaitFalse_Marker), frameNames);
+
+            // ConfigureAwait(false) on a sequential await chain collapses Leaf -> Mid -> Marker into one
+            // continuation chain, so exactly one Create / one Complete is expected on the marker's TaskId.
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_TaskCancellation_Inner_Marker(CancellationToken ct)
+        {
+            await Task.Delay(5000, ct);
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_TaskCancellation_Marker()
+        {
+            using var cts = new CancellationTokenSource();
+            Task inner = RuntimeAsync_TaskCancellation_Inner_Marker(cts.Token);
+            cts.CancelAfter(50);
+            try
+            {
+                await inner;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_TaskCancellation()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_TaskCancellation_Marker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
+            Assert.NotEmpty(innerCallstacks);
+
+            // Inner cancelled task + outer marker must each see exactly one Create and one Complete on their own TaskId.
+            AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].TaskId, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_TaskCancellation_Marker));
+        }
+
+        private static InlinePostSynchronizationContext? s_runtimeAsyncSyncContextCtx;
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker()
+        {
+            // Install a non-default SynchronizationContext on this thread so the await captures it.
+            // The await's continuation will be routed via SynchronizationContextAwaitTaskContinuation,
+            // which the V2 runtime-async dispatch loop should honor when resuming the chain.
+            int callerThreadId = Environment.CurrentManagedThreadId;
+            SynchronizationContext? prev = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(s_runtimeAsyncSyncContextCtx);
+            try
+            {
+                await Task.Delay(100);
+            }
+            finally
+            {
+                if (Environment.CurrentManagedThreadId == callerThreadId)
+                {
+                    SynchronizationContext.SetSynchronizationContext(prev);
+                }
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack()
+        {
+            s_runtimeAsyncSyncContextCtx = new InlinePostSynchronizationContext();
+
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker);
+
+            // DumpAllEvents(events);
+
+            // The custom SyncContext should have received at least one Post for the await continuation.
+            Assert.True(s_runtimeAsyncSyncContextCtx.PostCount > 0,
+                $"Expected custom SynchronizationContext to receive at least one Post, got {s_runtimeAsyncSyncContextCtx.PostCount}");
+
+            var stream = ParseAllEvents(events);
+
+            // The marker frame should appear in the Resume callstack.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // The marker's chain should see exactly one Create and one Complete on its own TaskId.
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+
+            // Verify the standard Create -> Resume -> Complete sequence fired in order for our context.
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker()
+        {
+            await Task.Delay(100);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack()
+        {
+            var scheduler = new InlineRunTaskScheduler();
+
+            var events = await CollectEventsAsync(CallstackKeywords, async () =>
+            {
+                // Start the marker on the custom scheduler so the resulting Task is queued through it.
+                await Task.Factory.StartNew(
+                    () => RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker(),
+                    CancellationToken.None,
+                    TaskCreationOptions.None,
+                    scheduler).Unwrap();
+            });
+
+            // DumpAllEvents(events);
+
+            // The custom scheduler must have received at least one QueueTask call.
+            Assert.True(scheduler.QueuedCount >= 1,
+                $"Expected custom TaskScheduler to receive at least one QueueTask call, got {scheduler.QueuedCount}");
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // The marker's chain should see exactly one Create and one Complete on its own TaskId.
+            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
+
+            // Verify the standard Create -> Resume -> Complete sequence fired in order for our context.
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+        }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -1623,42 +1623,6 @@ namespace System.Threading.Tasks.Tests
                 "no consecutive buffer pair found where buffer N has remaining capacity and buffer N+1 starts with a large callstack");
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
-        public void RuntimeAsync_CallstackOverflow_PreservesFullDepth()
-        {
-            const int Depth = 200;
-            const int Iterations = 500;
-
-            var events = CollectEvents(ResumeRuntimeAsyncCallstackKeyword, () =>
-            {
-                RunScenarioAndFlush(async () =>
-                {
-                    for (int i = 0; i < Iterations; i++)
-                        await RuntimeAsync_RecursiveChain(Depth);
-                });
-            });
-
-            // DumpAllEvents(events);
-
-            var stream = ParseAllEvents(events);
-
-            // Scope to our recursive chains by method rather than by frame count -- a callstack truncated by
-            // the overflow bug has fewer frames but still consists of the recursive method, so it stays in
-            // scope and is caught.
-            var chainCallstacks = stream.OfType(AsyncEventID.ResumeRuntimeAsyncCallstack)
-                .Where(cs => cs.Frames.Any(f => GetMethodNameFromMethodId(cs.CallstackType, f.MethodId) == nameof(RuntimeAsync_RecursiveChain)))
-                .ToList();
-            AssertNotEmpty(stream, chainCallstacks);
-
-            int leafDepth = chainCallstacks.Max(cs => (int)cs.FrameCount);
-            AssertTrue(stream, leafDepth >= Depth, $"Expected captured depth >= {Depth}, got {leafDepth}");
-            foreach (var cs in chainCallstacks)
-            {
-                AssertEqual(stream, leafDepth, (int)cs.FrameCount);
-                AssertEqual(stream, (int)cs.FrameCount, cs.Frames.Count);
-            }
-        }
-
         // Requires threading:
         // Deep recursive chains must execute in a single dispatch
         // loop (no sync context) to produce chains exceeding the 255-frame cap.

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -12,43 +12,36 @@ using Xunit;
 
 namespace System.Threading.Tasks.Tests
 {
-    /// <summary>
-    /// Tests for V2 (runtime-async) async profiler event emission. All scenario methods use
-    /// [RuntimeAsyncMethodGeneration(true)] to ensure they exercise the runtime-async path.
-    /// V2 emits Create/Resume/Suspend/Complete callstacks natively from the runtime dispatch
-    /// loop, unlike V1 which uses the AsyncStateMachineBox dispatcher wrapper.
-    /// </summary>
+    // Tests for V2 (runtime-async) async profiler event emission. All scenario methods use
+    // [RuntimeAsyncMethodGeneration(true)] to ensure they exercise the runtime-async path.
+    // V2 emits Create/Resume/Suspend/Complete callstacks natively from the runtime dispatch
+    // loop, unlike V1 which uses the AsyncStateMachineBox dispatcher wrapper.
     public partial class AsyncProfilerTests
     {
-        // --- V2 (runtime-async) scenario helpers ---
-        // Named with RuntimeAsync_* prefix to mirror the V1 TaskAsync_* convention and the
-        // RuntimeAsync_* test method prefix. All use RuntimeAsyncMethodGeneration(true) to
-        // force the runtime-async code path.
-
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_SingleYield()
+        private static async Task RuntimeAsync_SingleYield()
         {
             await Task.Yield();
         }
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_ChainedYield()
+        private static async Task RuntimeAsync_ChainedYield()
         {
             await RuntimeAsync_InnerYield();
         }
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_InnerYield()
+        private static async Task RuntimeAsync_InnerYield()
         {
             await Task.Yield();
         }
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_OuterCatches()
+        private static async Task RuntimeAsync_OuterCatches()
         {
             try
             {
@@ -62,7 +55,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_InnerThrows()
+        private static async Task RuntimeAsync_InnerThrows()
         {
             await Task.Yield();
             throw new InvalidOperationException("inner");
@@ -70,7 +63,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_DeepOuterCatches()
+        private static async Task RuntimeAsync_DeepOuterCatches()
         {
             try
             {
@@ -83,14 +76,14 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_DeepMiddle()
+        private static async Task RuntimeAsync_DeepMiddle()
         {
             await RuntimeAsync_DeepInnerThrows();
         }
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_DeepInnerThrows()
+        private static async Task RuntimeAsync_DeepInnerThrows()
         {
             await Task.Yield();
             throw new InvalidOperationException("deep inner");
@@ -98,21 +91,21 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_DeepUnhandledOuter()
+        private static async Task RuntimeAsync_DeepUnhandledOuter()
         {
             await RuntimeAsync_DeepUnhandledMiddle();
         }
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_DeepUnhandledMiddle()
+        private static async Task RuntimeAsync_DeepUnhandledMiddle()
         {
             await RuntimeAsync_DeepUnhandledInnerThrows();
         }
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_DeepUnhandledInnerThrows()
+        private static async Task RuntimeAsync_DeepUnhandledInnerThrows()
         {
             await Task.Yield();
             throw new InvalidOperationException("deep unhandled");
@@ -120,7 +113,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_RecursiveChain(int depth)
+        private static async Task RuntimeAsync_RecursiveChain(int depth)
         {
             if (depth <= 1)
             {
@@ -132,7 +125,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_WrapperTestA(List<(string MethodName, int WrapperSlot)> captures)
+        private static async Task RuntimeAsync_WrapperTestA(List<(string MethodName, int WrapperSlot)> captures)
         {
             await RuntimeAsync_WrapperTestB(captures);
             captures.Add((nameof(RuntimeAsync_WrapperTestA), GetCurrentWrapperSlot(nameof(RuntimeAsync_WrapperTestA))));
@@ -140,7 +133,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_WrapperTestB(List<(string MethodName, int WrapperSlot)> captures)
+        private static async Task RuntimeAsync_WrapperTestB(List<(string MethodName, int WrapperSlot)> captures)
         {
             await RuntimeAsync_WrapperTestC(captures);
             captures.Add((nameof(RuntimeAsync_WrapperTestB), GetCurrentWrapperSlot(nameof(RuntimeAsync_WrapperTestB))));
@@ -148,7 +141,7 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(true)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task RuntimeAsync_WrapperTestC(List<(string MethodName, int WrapperSlot)> captures)
+        private static async Task RuntimeAsync_WrapperTestC(List<(string MethodName, int WrapperSlot)> captures)
         {
             await Task.Yield();
             captures.Add((nameof(RuntimeAsync_WrapperTestC), GetCurrentWrapperSlot(nameof(RuntimeAsync_WrapperTestC))));
@@ -204,7 +197,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendResumeCompleteMarker()
+        private static async Task RuntimeAsync_SuspendResumeCompleteEvents_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_SingleYield();
@@ -213,15 +206,15 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendResumeCompleteEvents()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendResumeCompleteMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendResumeCompleteEvents_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
             // Find our context via marker callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(SuspendResumeCompleteMarker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with SuspendResumeCompleteMarker");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendResumeCompleteEvents_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var taskEvts = stream.ForTask(taskId);
@@ -235,7 +228,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task ContextLifecycleMarker()
+        private static async Task RuntimeAsync_ContextEventIdLifecycle_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_SingleYield();
@@ -244,15 +237,15 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ContextEventIdLifecycle()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, ContextLifecycleMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_ContextEventIdLifecycle_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
             // Find events in the context that contains our marker method.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ContextLifecycleMarker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with ContextLifecycleMarker");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ContextEventIdLifecycle_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             Assert.True(taskId > 0, "Context ID should be non-zero");
@@ -281,7 +274,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task EventSequenceOrderMarker()
+        private static async Task RuntimeAsync_EventSequenceOrder_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_SingleYield();
@@ -290,15 +283,15 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_EventSequenceOrder()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, EventSequenceOrderMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_EventSequenceOrder_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
             // Find our context via marker callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(EventSequenceOrderMarker));
-            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with EventSequenceOrderMarker");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_EventSequenceOrder_Marker));
+            Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var taskEvts = stream.ForTask(taskId);
@@ -331,7 +324,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CreateCallstackMarker()
+        private static async Task RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker()
         {
             await RuntimeAsync_SingleYield();
         }
@@ -339,12 +332,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, CreateCallstackMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreateCallstackMarker));
+            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker));
 
             Assert.NotEmpty(createCallstacks);
             Assert.All(createCallstacks, cs =>
@@ -358,7 +351,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CreateCallstackDepthMarker()
+        private static async Task RuntimeAsync_CreateCallstackDepthMatchesChain_Marker()
         {
             await RuntimeAsync_ChainedYield();
         }
@@ -366,17 +359,17 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CreateCallstackDepthMatchesChain()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, CreateCallstackDepthMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CreateCallstackDepthMatchesChain_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreateCallstackDepthMarker));
+            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(RuntimeAsync_CreateCallstackDepthMatchesChain_Marker));
 
             // The expected [NoInlining] frames in order (innermost first):
-            // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> CreateCallstackDepthMarker
+            // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> RuntimeAsync_CreateCallstackDepthMatchesChain_Marker
             Assert.NotEmpty(createCallstacks);
-            string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_ChainedYield), nameof(CreateCallstackDepthMarker)];
+            string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_ChainedYield), nameof(RuntimeAsync_CreateCallstackDepthMatchesChain_Marker)];
             Assert.True(
                 HasCallstackWithExpectedFrames(createCallstacks, expectedFrames),
                 $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
@@ -384,7 +377,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendCallstackMarker()
+        private static async Task RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_SingleYield();
@@ -393,12 +386,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendCallstackMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendCallstackMarker));
+            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker));
 
             Assert.NotEmpty(suspendCallstacks);
             Assert.All(suspendCallstacks, cs =>
@@ -411,7 +404,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendDepthMarker()
+        private static async Task RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_ChainedYield();
@@ -420,17 +413,17 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendCallstackDepthMatchesChain()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendDepthMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendDepthMarker));
+            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker));
 
             // The expected [NoInlining] frames in order (innermost first):
-            // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> SuspendDepthMarker
+            // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker
             Assert.NotEmpty(suspendCallstacks);
-            string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_ChainedYield), nameof(SuspendDepthMarker)];
+            string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_ChainedYield), nameof(RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker)];
             Assert.True(
                 HasCallstackWithExpectedFrames(suspendCallstacks, expectedFrames),
                 $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
@@ -438,7 +431,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendPrecedesCompleteMarker()
+        private static async Task RuntimeAsync_SuspendCallstackPrecedesComplete_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_InnerYield();
@@ -447,15 +440,15 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendCallstackPrecedesComplete()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendPrecedesCompleteMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendCallstackPrecedesComplete_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
             // Find the suspend callstack via marker to get the context ID
-            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendPrecedesCompleteMarker));
-            Assert.True(suspendStacks.Count >= 1, $"Expected at least one suspend callstack with marker, got {suspendStacks.Count}");
+            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackPrecedesComplete_Marker));
+            Assert.NotEmpty(suspendStacks);
 
             ulong taskId = suspendStacks[0].TaskId;
             Assert.True(taskId > 0, "Expected non-zero context ID");
@@ -473,7 +466,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SuspendDeeperMarker()
+        private static async Task RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_InnerYield();
@@ -482,16 +475,16 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_SuspendCallstackDeeperThanInitialResume()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, SuspendDeeperMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(SuspendDeeperMarker));
-            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendDeeperMarker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
+            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
 
-            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker, got {resumeStacks.Count}");
-            Assert.True(suspendStacks.Count >= 1, $"Expected at least one suspend callstack with marker, got {suspendStacks.Count}");
+            Assert.NotEmpty(resumeStacks);
+            Assert.NotEmpty(suspendStacks);
 
             // First resume (after initial Yield) should be shallow, first suspend (RuntimeAsync_InnerYield's Yield) should be deeper
             var firstResume = resumeStacks[0];
@@ -502,7 +495,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CreatePrecedesResumeMarker()
+        private static async Task RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_InnerYield();
@@ -511,13 +504,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CreateCallstackPrecedesResumeCallstack()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, CreatePrecedesResumeMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreatePrecedesResumeMarker));
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CreatePrecedesResumeMarker));
+            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
 
             Assert.NotEmpty(createStacks);
             Assert.NotEmpty(resumeStacks);
@@ -539,7 +532,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CreateResumeMatchMarker()
+        private static async Task RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_InnerYield();
@@ -548,13 +541,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CreateAndFirstResumeCallstacksMatch()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, CreateResumeMatchMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreateResumeMatchMarker));
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CreateResumeMatchMarker));
+            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
 
             Assert.NotEmpty(createStacks);
             Assert.NotEmpty(resumeStacks);
@@ -580,7 +573,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CallstackOnResumeMarker()
+        private static async Task RuntimeAsync_CallstackEmittedOnResume_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_InnerYield();
@@ -589,12 +582,12 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackEmittedOnResume()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, CallstackOnResumeMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackEmittedOnResume_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CallstackOnResumeMarker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackEmittedOnResume_Marker));
 
             Assert.NotEmpty(callstacks);
             Assert.All(callstacks, cs =>
@@ -607,7 +600,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CallstackDepthMarker()
+        private static async Task RuntimeAsync_CallstackDepthMatchesChain_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_InnerYield();
@@ -616,17 +609,17 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackDepthMatchesChain()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, CallstackDepthMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackDepthMatchesChain_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CallstackDepthMarker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackDepthMatchesChain_Marker));
 
             // The expected [NoInlining] frames in order (innermost first):
-            // RuntimeAsync_InnerYield -> CallstackDepthMarker
+            // RuntimeAsync_InnerYield -> RuntimeAsync_CallstackDepthMatchesChain_Marker
             Assert.NotEmpty(callstacks);
-            string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(CallstackDepthMarker)];
+            string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_CallstackDepthMatchesChain_Marker)];
             Assert.True(
                 HasCallstackWithExpectedFrames(callstacks, expectedFrames),
                 $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
@@ -634,7 +627,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SimulationNormalMarker()
+        private static async Task RuntimeAsync_CallstackSimulation_NormalCompletion_Marker()
         {
             await Task.Yield();
             await RuntimeAsync_InnerYield();
@@ -643,17 +636,17 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackSimulation_NormalCompletion()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, SimulationNormalMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackSimulation_NormalCompletion_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            AssertCallstackSimulationReachesZero(stream, nameof(SimulationNormalMarker));
+            AssertCallstackSimulationReachesZero(stream, nameof(RuntimeAsync_CallstackSimulation_NormalCompletion_Marker));
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SimulationHandledMarker()
+        private static async Task RuntimeAsync_CallstackSimulation_HandledException_Marker()
         {
             await RuntimeAsync_DeepOuterCatches();
         }
@@ -661,28 +654,28 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackSimulation_HandledException()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, SimulationHandledMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackSimulation_HandledException_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            AssertCallstackSimulationReachesZero(stream, nameof(SimulationHandledMarker));
+            AssertCallstackSimulationReachesZero(stream, nameof(RuntimeAsync_CallstackSimulation_HandledException_Marker));
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SimulationUnhandledMarker()
+        private static async Task RuntimeAsync_CallstackSimulation_UnhandledException_Marker()
         {
             await RuntimeAsync_DeepUnhandledOuter();
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(false)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task SimulationUnhandledMarkerCatcher()
+        private static async Task RuntimeAsync_CallstackSimulation_UnhandledException_Catcher_Marker()
         {
             try
             {
-                await SimulationUnhandledMarker();
+                await RuntimeAsync_CallstackSimulation_UnhandledException_Marker();
             }
             catch (InvalidOperationException)
             {
@@ -692,28 +685,28 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_CallstackSimulation_UnhandledException()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, SimulationUnhandledMarkerCatcher);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackSimulation_UnhandledException_Catcher_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            AssertCallstackSimulationReachesZero(stream, nameof(SimulationUnhandledMarker));
+            AssertCallstackSimulationReachesZero(stream, nameof(RuntimeAsync_CallstackSimulation_UnhandledException_Marker));
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task UnhandledUnwindMarker()
+        private static async Task RuntimeAsync_UnhandledExceptionUnwind_Marker()
         {
             await RuntimeAsync_DeepUnhandledOuter();
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(false)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task UnhandledUnwindCatcher()
+        private static async Task RuntimeAsync_UnhandledExceptionUnwind_Catcher_Marker()
         {
             try
             {
-                await UnhandledUnwindMarker();
+                await RuntimeAsync_UnhandledExceptionUnwind_Marker();
             }
             catch (InvalidOperationException)
             {
@@ -723,13 +716,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_UnhandledExceptionUnwind()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, UnhandledUnwindCatcher);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_UnhandledExceptionUnwind_Catcher_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(UnhandledUnwindMarker));
-            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{nameof(UnhandledUnwindMarker)}'");
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_UnhandledExceptionUnwind_Marker));
+            Assert.NotEmpty(resumeStacks);
 
             ulong taskId = resumeStacks[0].TaskId;
 
@@ -741,7 +734,7 @@ namespace System.Threading.Tasks.Tests
             Assert.Contains(AsyncEventID.CompleteAsyncContext, eventIds);
 
             // Verify unwind frame count for this task
-            // UnhandledUnwindMarker -> RuntimeAsync_DeepUnhandledOuter -> RuntimeAsync_DeepUnhandledMiddle -> RuntimeAsync_DeepUnhandledInnerThrows, 4 frames deep after the initial resume.
+            // Marker -> RuntimeAsync_DeepUnhandledOuter -> RuntimeAsync_DeepUnhandledMiddle -> RuntimeAsync_DeepUnhandledInnerThrows, 4 frames deep after the initial resume.
             var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.UnwindAsyncException).ToList();
             Assert.NotEmpty(unwindEvents);
             Assert.All(unwindEvents, e => Assert.Equal(4u, e.UnwindFrameCount));
@@ -749,7 +742,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task HandledUnwindMarker()
+        private static async Task RuntimeAsync_HandledExceptionUnwind_Marker()
         {
             await RuntimeAsync_DeepOuterCatches();
         }
@@ -757,13 +750,13 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_HandledExceptionUnwind()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, HandledUnwindMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_HandledExceptionUnwind_Marker);
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(HandledUnwindMarker));
-            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{nameof(HandledUnwindMarker)}'");
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_HandledExceptionUnwind_Marker));
+            Assert.NotEmpty(resumeStacks);
 
             ulong taskId = resumeStacks[0].TaskId;
 
@@ -925,14 +918,25 @@ namespace System.Threading.Tasks.Tests
                 listener.RunWithCallback(e =>
                 {
                     if (!workerIdReady.IsSet)
+                    {
                         return;
+                    }
+
                     if (e.EventId != AsyncEventsId || e.Payload is null || e.Payload.Count == 0)
+                    {
                         return;
+                    }
+
                     if (e.Payload[0] is not byte[] payload)
+                    {
                         return;
+                    }
+
                     EventBufferHeader? header = ParseEventBufferHeader(payload);
                     if (header is not null && header.Value.OsThreadId == workerOsThreadId)
+                    {
                         events.Events.Enqueue(e);
+                    }
                 }, () =>
                 {
                     SendFlushCommand();
@@ -1098,7 +1102,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task KeywordGatekeepingMarker()
+        private static async Task RuntimeAsync_KeywordGatekeeping_Marker()
         {
             await RuntimeAsync_OuterCatches();
             await RuntimeAsync_ChainedYield();
@@ -1118,7 +1122,7 @@ namespace System.Threading.Tasks.Tests
             // Run a scenario that exercises all event types: resume, suspend,
             // complete, method events, callstacks, and exception unwinds.
             // Only the events matching the enabled keyword should be emitted.
-            var events = await CollectEventsAsync(kw, KeywordGatekeepingMarker);
+            var events = await CollectEventsAsync(kw, RuntimeAsync_KeywordGatekeeping_Marker);
 
             // DumpAllEvents(events);
 
@@ -1192,7 +1196,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task NativeIPDeltaRoundtripMarker()
+        private static async Task RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker()
         {
             await RuntimeAsync_ChainedYield();
             await RuntimeAsync_DeepOuterCatches();
@@ -1207,10 +1211,10 @@ namespace System.Threading.Tasks.Tests
             // methods at different JIT-assigned addresses, the deltas between consecutive
             // NativeIPs will naturally span both directions. This exercises the full
             // zigzag + LEB128 encode/decode path through the production serializer.
-            var events = await CollectEventsAsync(CallstackKeywords, NativeIPDeltaRoundtripMarker);
+            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(NativeIPDeltaRoundtripMarker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker));
             Assert.NotEmpty(callstacks);
 
             // Find callstacks with 3+ frames — enough depth for meaningful deltas.
@@ -1251,7 +1255,7 @@ namespace System.Threading.Tasks.Tests
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        static async Task CallstackStressMarker(int depth)
+        private static async Task RuntimeAsync_CallstackStressWithVaryingDepths_Marker(int depth)
         {
             await RuntimeAsync_RecursiveChain(depth);
         }
@@ -1266,7 +1270,7 @@ namespace System.Threading.Tasks.Tests
             // Stress test: run many async calls with varying callstack depths.
             // Varying sizes mean some callstacks will land at buffer boundaries,
             // naturally exercising the overflow/rewind path in callstack emission.
-            // lambda -> CallstackStressMarker(d) -> RuntimeAsync_RecursiveChain(d) produces d + 2 frames.
+            // lambda -> Marker(d) -> RuntimeAsync_RecursiveChain(d) produces d + 2 frames.
             const int iterations = 200;
             int[] depths = new int[iterations];
             var rng = new Random(42);
@@ -1278,14 +1282,14 @@ namespace System.Threading.Tasks.Tests
                 RunScenarioAndFlush(async () =>
                 {
                     for (int i = 0; i < iterations; i++)
-                        await CallstackStressMarker(depths[i]);
+                        await RuntimeAsync_CallstackStressWithVaryingDepths_Marker(depths[i]);
                 });
             });
 
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CallstackStressMarker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackStressWithVaryingDepths_Marker));
 
             // Verify all callstacks have valid frame data that resolves to managed methods.
             foreach (var cs in callstacks)
@@ -1303,15 +1307,15 @@ namespace System.Threading.Tasks.Tests
             }
 
             // One resume callstack per iteration (marker filters out noise).
-            // lambda -> CallstackStressMarker -> RuntimeAsync_RecursiveChain(d) produces d + 2 frames.
+            // lambda -> Marker -> RuntimeAsync_RecursiveChain(d) produces d + 2 frames.
             Assert.True(callstacks.Count >= iterations, $"Expected at least {iterations} callstacks with marker, got {callstacks.Count}");
 
             for (int i = 0; i < iterations; i++)
             {
-                // lambda + CallstackStressMarker + RuntimeAsync_RecursiveChain(d) = d + 2
+                // lambda + Marker + RuntimeAsync_RecursiveChain(d) = d + 2
                 int expected = depths[i] + 2;
                 int actual = callstacks[i].FrameCount;
-                Assert.True(actual == expected, $"Iteration {i}: expected depth {expected} (lambda -> CallstackStressMarker -> RuntimeAsync_RecursiveChain({depths[i]})), got {actual}");
+                Assert.True(actual == expected, $"Iteration {i}: expected depth {expected} (lambda -> Marker -> RuntimeAsync_RecursiveChain({depths[i]})), got {actual}");
             }
 
             // Verify multiple buffer flushes occurred.

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -147,6 +147,27 @@ namespace System.Threading.Tasks.Tests
             captures.Add((nameof(RuntimeAsync_WrapperTestC), GetCurrentWrapperSlot(nameof(RuntimeAsync_WrapperTestC))));
         }
 
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_Level1()
+        {
+            await RuntimeAsync_ValueTask_Level2();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_Level2()
+        {
+            await RuntimeAsync_ValueTask_Level3();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_Level3()
+        {
+            await Task.Yield();
+        }
+
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_EventBufferHeaderFormat()
         {
@@ -1536,6 +1557,229 @@ namespace System.Threading.Tasks.Tests
                     .Count(m => m.Name.StartsWith(WrapperNamePrefix, StringComparison.Ordinal));
                 Assert.Equal(meta.WrapperCount, actualCount);
             }
+        }
+
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_EventSequenceOrder_Marker()
+        {
+            await RuntimeAsync_ValueTask_Level1();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ValueTask_EventSequenceOrder()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, async () => await RuntimeAsync_ValueTask_EventSequenceOrder_Marker());
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_EventSequenceOrder_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_MethodEventsEmitted_Marker()
+        {
+            await RuntimeAsync_ValueTask_Level1();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ValueTask_MethodEventsEmitted()
+        {
+            var events = await CollectEventsAsync(MethodKeywords | CoreKeywords, async () => await RuntimeAsync_ValueTask_MethodEventsEmitted_Marker());
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var methodEvents = stream.All
+                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod or AsyncEventID.CompleteAsyncMethod)
+                .Select(e => e.EventId)
+                .ToList();
+
+            int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeAsyncMethod);
+            int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteAsyncMethod);
+
+            // Marker -> Level1 -> Level2 -> Level3
+            Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
+            Assert.True(completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events for ValueTask chain, got {completeCount}");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker()
+        {
+            await RuntimeAsync_ValueTask_Level1();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, async () => await RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker());
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            // Async lambda -> Marker -> Level1 -> Level2 -> Level3.
+            Assert.Equal(5, markerCallstacks[0].FrameCount);
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker()
+        {
+            await RuntimeAsync_ValueTask_Level1();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, async () => await RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker());
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
+            Assert.Equal(methodIds.Count, methodIds.Distinct().Count());
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_HandledException_InnerThrows_Marker()
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("valuetask inner throw");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_HandledException_Handled_Marker()
+        {
+            try
+            {
+                await RuntimeAsync_ValueTask_HandledException_InnerThrows_Marker();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker()
+        {
+            await RuntimeAsync_ValueTask_HandledException_Handled_Marker();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords | UnwindAsyncExceptionKeyword, async () => await RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker());
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx + 1);
+            Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_UnhandledException_UnhandledOuter_Marker()
+        {
+            await RuntimeAsync_ValueTask_UnhandledException_UnhandledInner_Marker();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_UnhandledException_UnhandledInner_Marker()
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("valuetask unhandled inner");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static async ValueTask RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete_Marker()
+        {
+            await RuntimeAsync_ValueTask_UnhandledException_UnhandledOuter_Marker();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords | UnwindAsyncExceptionKeyword, async () =>
+            {
+                try
+                {
+                    await RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete_Marker();
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete_Marker));
+            Assert.NotEmpty(markerCallstacks);
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+
+            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx + 1);
+            Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -814,7 +814,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackSimulation_HandledException_Marker);
 
-            // DumpAllEvents(events);
+            DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
             AssertCallstackSimulationReachesZero(stream, nameof(RuntimeAsync_CallstackSimulation_HandledException_Marker));
@@ -1861,7 +1861,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_ConfigureAwaitFalse_Marker);
 
-            // DumpAllEvents(events);
+            DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -1734,7 +1734,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_WhenAll_TracksAllBranches_Marker);
 
-            // DumpAllEvents(events);
+            DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 
@@ -1860,7 +1860,7 @@ namespace System.Threading.Tasks.Tests
         {
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_ConfigureAwaitFalse_Marker);
 
-            // DumpAllEvents(events);
+            DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -1,0 +1,1537 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.DotNet.XUnitExtensions;
+using Xunit;
+
+namespace System.Threading.Tasks.Tests
+{
+    /// <summary>
+    /// Tests for V2 (runtime-async) async profiler event emission. All scenario methods use
+    /// [RuntimeAsyncMethodGeneration(true)] to ensure they exercise the runtime-async path.
+    /// V2 emits Create/Resume/Suspend/Complete callstacks natively from the runtime dispatch
+    /// loop, unlike V1 which uses the AsyncStateMachineBox dispatcher wrapper.
+    /// </summary>
+    public partial class AsyncProfilerTests
+    {
+        // --- V2 (runtime-async) scenario helpers ---
+        // Named with RuntimeAsync_* prefix to mirror the V1 TaskAsync_* convention and the
+        // RuntimeAsync_* test method prefix. All use RuntimeAsyncMethodGeneration(true) to
+        // force the runtime-async code path.
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_SingleYield()
+        {
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_ChainedYield()
+        {
+            await RuntimeAsync_InnerYield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_InnerYield()
+        {
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_OuterCatches()
+        {
+            try
+            {
+                await RuntimeAsync_InnerThrows();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_InnerThrows()
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("inner");
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_DeepOuterCatches()
+        {
+            try
+            {
+                await RuntimeAsync_DeepMiddle();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_DeepMiddle()
+        {
+            await RuntimeAsync_DeepInnerThrows();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_DeepInnerThrows()
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("deep inner");
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_DeepUnhandledOuter()
+        {
+            await RuntimeAsync_DeepUnhandledMiddle();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_DeepUnhandledMiddle()
+        {
+            await RuntimeAsync_DeepUnhandledInnerThrows();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_DeepUnhandledInnerThrows()
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("deep unhandled");
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_RecursiveChain(int depth)
+        {
+            if (depth <= 1)
+            {
+                await Task.Yield();
+                return;
+            }
+            await RuntimeAsync_RecursiveChain(depth - 1);
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_WrapperTestA(List<(string MethodName, int WrapperSlot)> captures)
+        {
+            await RuntimeAsync_WrapperTestB(captures);
+            captures.Add((nameof(RuntimeAsync_WrapperTestA), GetCurrentWrapperSlot(nameof(RuntimeAsync_WrapperTestA))));
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_WrapperTestB(List<(string MethodName, int WrapperSlot)> captures)
+        {
+            await RuntimeAsync_WrapperTestC(captures);
+            captures.Add((nameof(RuntimeAsync_WrapperTestB), GetCurrentWrapperSlot(nameof(RuntimeAsync_WrapperTestB))));
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async Task RuntimeAsync_WrapperTestC(List<(string MethodName, int WrapperSlot)> captures)
+        {
+            await Task.Yield();
+            captures.Add((nameof(RuntimeAsync_WrapperTestC), GetCurrentWrapperSlot(nameof(RuntimeAsync_WrapperTestC))));
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_EventBufferHeaderFormat()
+        {
+            var events = await CollectEventsAsync(CoreKeywords, RuntimeAsync_SingleYield);
+
+            // DumpAllEvents(events);
+
+            int buffersChecked = 0;
+            ForEachEventBufferPayload(events, buffer =>
+            {
+                EventBufferHeader? parsed = ParseEventBufferHeader(buffer);
+                Assert.NotNull(parsed);
+                EventBufferHeader header = parsed.Value;
+
+                Assert.Equal(1, header.Version);
+                Assert.Equal((uint)buffer.Length, header.TotalSize);
+                Assert.True(header.AsyncThreadContextId > 0, "Async thread context ID should be positive");
+                Assert.True(header.OsThreadId != 0, "OS thread ID should be non-zero");
+                Assert.True(header.StartTimestamp > 0, "Start timestamp should be positive");
+                Assert.True(header.EndTimestamp >= header.StartTimestamp, $"End timestamp ({header.EndTimestamp}) should be >= start timestamp ({header.StartTimestamp})");
+
+                int eventCount = 0;
+                ParseEventBuffer(buffer, (AsyncEventID eventId, ReadOnlySpan<byte> buf, ref int idx) =>
+                {
+                    eventCount++;
+                    return SkipEventPayload(eventId, buf, ref idx);
+                });
+
+                Assert.Equal(header.EventCount, (uint)eventCount);
+                Assert.True(header.EventCount > 0, "Expected at least one event in buffer");
+
+                buffersChecked++;
+            });
+
+            Assert.True(buffersChecked > 0, "Expected at least one buffer");
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_EventsEmitted()
+        {
+            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_SingleYield);
+
+            // DumpAllEvents(events);
+
+            Assert.True(events.Events.Count > 0, "Expected at least one AsyncEvents event to be emitted");
+            Assert.Contains(events.Events, e => e.EventId == AsyncEventsId);
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task SuspendResumeCompleteMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_SingleYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_SuspendResumeCompleteEvents()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, SuspendResumeCompleteMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Find our context via marker callstack.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(SuspendResumeCompleteMarker));
+            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with SuspendResumeCompleteMarker");
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var taskEvts = stream.ForTask(taskId);
+            var ids = taskEvts.Select(e => e.EventId).ToList();
+
+            Assert.Contains(AsyncEventID.ResumeAsyncContext, ids);
+            Assert.Contains(AsyncEventID.SuspendAsyncContext, ids);
+            Assert.Contains(AsyncEventID.CompleteAsyncContext, ids);
+        }
+
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task ContextLifecycleMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_SingleYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ContextEventIdLifecycle()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, ContextLifecycleMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Find events in the context that contains our marker method.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(ContextLifecycleMarker));
+            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with ContextLifecycleMarker");
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            Assert.True(taskId > 0, "Context ID should be non-zero");
+
+            var taskEvts = stream.ForTask(taskId);
+            var ids = taskEvts.Select(e => e.EventId).ToList();
+
+            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext);
+            Assert.True(createIdx >= 0, "Expected CreateAsyncContext in context events");
+            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after CreateAsyncContext");
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ResumeCompleteMethodEvents()
+        {
+            var events = await CollectEventsAsync(MethodKeywords, RuntimeAsync_ChainedYield);
+
+            // DumpAllEvents(events);
+
+            var ids = ParseAllEvents(events).EventIds;
+
+            Assert.Contains(AsyncEventID.ResumeAsyncMethod, ids);
+            Assert.Contains(AsyncEventID.CompleteAsyncMethod, ids);
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task EventSequenceOrderMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_SingleYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_EventSequenceOrder()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, EventSequenceOrderMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Find our context via marker callstack.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(EventSequenceOrderMarker));
+            Assert.True(markerCallstacks.Count > 0, "Expected at least one callstack with EventSequenceOrderMarker");
+
+            ulong taskId = markerCallstacks[0].TaskId;
+            var taskEvts = stream.ForTask(taskId);
+            var ids = taskEvts.Select(e => e.EventId).ToList();
+
+            // Verify the expected lifecycle sequence exists in order.
+            int resumeIdx1 = ids.IndexOf(AsyncEventID.ResumeAsyncContext);
+            Assert.True(resumeIdx1 >= 0, "Expected first ResumeAsyncContext");
+
+            int suspendIdx = ids.IndexOf(AsyncEventID.SuspendAsyncContext, resumeIdx1 + 1);
+            Assert.True(suspendIdx > resumeIdx1, "Expected SuspendAsyncContext after first Resume");
+
+            int resumeIdx2 = ids.IndexOf(AsyncEventID.ResumeAsyncContext, suspendIdx + 1);
+            Assert.True(resumeIdx2 > suspendIdx, "Expected second ResumeAsyncContext after Suspend");
+
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx2 + 1);
+            Assert.True(completeIdx > resumeIdx2, "Expected CompleteAsyncContext after second Resume");
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CreateAsyncContextEmittedOnFirstAwait()
+        {
+            var events = await CollectEventsAsync(CreateAsyncContextKeyword | CompleteAsyncContextKeyword, RuntimeAsync_SingleYield);
+
+            // DumpAllEvents(events);
+
+            var ids = ParseAllEvents(events).EventIds;
+            Assert.Contains(AsyncEventID.CreateAsyncContext, ids);
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task CreateCallstackMarker()
+        {
+            await RuntimeAsync_SingleYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, CreateCallstackMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreateCallstackMarker));
+
+            Assert.NotEmpty(createCallstacks);
+            Assert.All(createCallstacks, cs =>
+            {
+                Assert.True(cs.FrameCount > 0, "Expected at least one frame in create callstack");
+                Assert.True(cs.TaskId != 0, "Expected non-zero task ID in create callstack");
+                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
+            });
+        }
+
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task CreateCallstackDepthMarker()
+        {
+            await RuntimeAsync_ChainedYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CreateCallstackDepthMatchesChain()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, CreateCallstackDepthMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreateCallstackDepthMarker));
+
+            // The expected [NoInlining] frames in order (innermost first):
+            // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> CreateCallstackDepthMarker
+            Assert.NotEmpty(createCallstacks);
+            string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_ChainedYield), nameof(CreateCallstackDepthMarker)];
+            Assert.True(
+                HasCallstackWithExpectedFrames(createCallstacks, expectedFrames),
+                $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task SuspendCallstackMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_SingleYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, SuspendCallstackMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendCallstackMarker));
+
+            Assert.NotEmpty(suspendCallstacks);
+            Assert.All(suspendCallstacks, cs =>
+            {
+                Assert.True(cs.FrameCount > 0, "Expected at least one frame in suspend callstack");
+                Assert.True(cs.TaskId != 0, "Expected non-zero task ID in suspend callstack");
+                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
+            });
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task SuspendDepthMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_ChainedYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_SuspendCallstackDepthMatchesChain()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, SuspendDepthMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendDepthMarker));
+
+            // The expected [NoInlining] frames in order (innermost first):
+            // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> SuspendDepthMarker
+            Assert.NotEmpty(suspendCallstacks);
+            string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_ChainedYield), nameof(SuspendDepthMarker)];
+            Assert.True(
+                HasCallstackWithExpectedFrames(suspendCallstacks, expectedFrames),
+                $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task SuspendPrecedesCompleteMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_InnerYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_SuspendCallstackPrecedesComplete()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, SuspendPrecedesCompleteMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Find the suspend callstack via marker to get the context ID
+            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendPrecedesCompleteMarker));
+            Assert.True(suspendStacks.Count >= 1, $"Expected at least one suspend callstack with marker, got {suspendStacks.Count}");
+
+            ulong taskId = suspendStacks[0].TaskId;
+            Assert.True(taskId > 0, "Expected non-zero context ID");
+
+            var taskEvts = stream.ForTask(taskId);
+            var ids = taskEvts.Select(e => e.EventId).ToList();
+
+            int suspendIdx = ids.IndexOf(AsyncEventID.SuspendAsyncCallstack);
+            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext);
+
+            Assert.True(suspendIdx >= 0, "Expected SuspendAsyncCallstack in context events");
+            Assert.True(completeIdx >= 0, "Expected CompleteAsyncContext in context events");
+            Assert.True(suspendIdx < completeIdx, $"SuspendAsyncCallstack (index {suspendIdx}) should precede CompleteAsyncContext (index {completeIdx})");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task SuspendDeeperMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_InnerYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_SuspendCallstackDeeperThanInitialResume()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, SuspendDeeperMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(SuspendDeeperMarker));
+            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(SuspendDeeperMarker));
+
+            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker, got {resumeStacks.Count}");
+            Assert.True(suspendStacks.Count >= 1, $"Expected at least one suspend callstack with marker, got {suspendStacks.Count}");
+
+            // First resume (after initial Yield) should be shallow, first suspend (RuntimeAsync_InnerYield's Yield) should be deeper
+            var firstResume = resumeStacks[0];
+            var firstSuspend = suspendStacks[0];
+
+            Assert.True(firstSuspend.FrameCount > firstResume.FrameCount, $"First suspend callstack depth ({firstSuspend.FrameCount}) should be deeper than first resume callstack depth ({firstResume.FrameCount})");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task CreatePrecedesResumeMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_InnerYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CreateCallstackPrecedesResumeCallstack()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, CreatePrecedesResumeMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreatePrecedesResumeMarker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CreatePrecedesResumeMarker));
+
+            Assert.NotEmpty(createStacks);
+            Assert.NotEmpty(resumeStacks);
+
+            // For each task that has both Create and Resume callstacks, verify Create timestamp precedes Resume.
+            int matchedPairs = 0;
+            foreach (var create in createStacks)
+            {
+                var matchingResume = resumeStacks.FirstOrDefault(r => r.TaskId == create.TaskId);
+                if (matchingResume is null)
+                    continue;
+
+                matchedPairs++;
+                Assert.True(create.Timestamp <= matchingResume.Timestamp, $"For task {create.TaskId}: CreateAsyncCallstack (ts {create.Timestamp}) should precede ResumeAsyncCallstack (ts {matchingResume.Timestamp})");
+            }
+
+            Assert.True(matchedPairs >= 1, $"Expected at least one matching Create/Resume callstack pair, but found {matchedPairs}");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task CreateResumeMatchMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_InnerYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CreateAndFirstResumeCallstacksMatch()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, CreateResumeMatchMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(CreateResumeMatchMarker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CreateResumeMatchMarker));
+
+            Assert.NotEmpty(createStacks);
+            Assert.NotEmpty(resumeStacks);
+
+            // For each create callstack, find the first resume with the same task ID and verify frames match.
+            int matchedPairs = 0;
+            foreach (var create in createStacks)
+            {
+                var matchingResume = resumeStacks.FirstOrDefault(r => r.TaskId == create.TaskId);
+                if (matchingResume is null)
+                    continue;
+
+                matchedPairs++;
+                Assert.Equal(create.Frames.Count, matchingResume.Frames.Count);
+                for (int i = 0; i < create.Frames.Count; i++)
+                {
+                    Assert.Equal(create.Frames[i].MethodId, matchingResume.Frames[i].MethodId);
+                }
+            }
+
+            Assert.True(matchedPairs >= 1, $"Expected at least one matching Create/Resume callstack pair, but found {matchedPairs}");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task CallstackOnResumeMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_InnerYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CallstackEmittedOnResume()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, CallstackOnResumeMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CallstackOnResumeMarker));
+
+            Assert.NotEmpty(callstacks);
+            Assert.All(callstacks, cs =>
+            {
+                Assert.True(cs.FrameCount > 0, "Expected at least one frame in callstack");
+                Assert.True(cs.TaskId != 0, "Expected non-zero task ID in resume callstack");
+                Assert.True(cs.Frames[0].MethodId != 0, "Expected non-zero MethodId in first frame");
+            });
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task CallstackDepthMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_InnerYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CallstackDepthMatchesChain()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, CallstackDepthMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CallstackDepthMarker));
+
+            // The expected [NoInlining] frames in order (innermost first):
+            // RuntimeAsync_InnerYield -> CallstackDepthMarker
+            Assert.NotEmpty(callstacks);
+            string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(CallstackDepthMarker)];
+            Assert.True(
+                HasCallstackWithExpectedFrames(callstacks, expectedFrames),
+                $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task SimulationNormalMarker()
+        {
+            await Task.Yield();
+            await RuntimeAsync_InnerYield();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CallstackSimulation_NormalCompletion()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, SimulationNormalMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            AssertCallstackSimulationReachesZero(stream, nameof(SimulationNormalMarker));
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task SimulationHandledMarker()
+        {
+            await RuntimeAsync_DeepOuterCatches();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CallstackSimulation_HandledException()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, SimulationHandledMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            AssertCallstackSimulationReachesZero(stream, nameof(SimulationHandledMarker));
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task SimulationUnhandledMarker()
+        {
+            await RuntimeAsync_DeepUnhandledOuter();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(false)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task SimulationUnhandledMarkerCatcher()
+        {
+            try
+            {
+                await SimulationUnhandledMarker();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CallstackSimulation_UnhandledException()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, SimulationUnhandledMarkerCatcher);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            AssertCallstackSimulationReachesZero(stream, nameof(SimulationUnhandledMarker));
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task UnhandledUnwindMarker()
+        {
+            await RuntimeAsync_DeepUnhandledOuter();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(false)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task UnhandledUnwindCatcher()
+        {
+            try
+            {
+                await UnhandledUnwindMarker();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_UnhandledExceptionUnwind()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, UnhandledUnwindCatcher);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(UnhandledUnwindMarker));
+            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{nameof(UnhandledUnwindMarker)}'");
+
+            ulong taskId = resumeStacks[0].TaskId;
+
+            var taskEvts = stream.ForTask(taskId);
+            var eventIds = taskEvts.Select(e => e.EventId).ToList();
+
+            Assert.Contains(AsyncEventID.ResumeAsyncContext, eventIds);
+            Assert.Contains(AsyncEventID.UnwindAsyncException, eventIds);
+            Assert.Contains(AsyncEventID.CompleteAsyncContext, eventIds);
+
+            // Verify unwind frame count for this task
+            // UnhandledUnwindMarker -> RuntimeAsync_DeepUnhandledOuter -> RuntimeAsync_DeepUnhandledMiddle -> RuntimeAsync_DeepUnhandledInnerThrows, 4 frames deep after the initial resume.
+            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.UnwindAsyncException).ToList();
+            Assert.NotEmpty(unwindEvents);
+            Assert.All(unwindEvents, e => Assert.Equal(4u, e.UnwindFrameCount));
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task HandledUnwindMarker()
+        {
+            await RuntimeAsync_DeepOuterCatches();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_HandledExceptionUnwind()
+        {
+            var events = await CollectEventsAsync(CallstackKeywords, HandledUnwindMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(HandledUnwindMarker));
+            Assert.True(resumeStacks.Count >= 1, $"Expected at least one resume callstack with marker '{nameof(HandledUnwindMarker)}'");
+
+            ulong taskId = resumeStacks[0].TaskId;
+
+            var taskEvts = stream.ForTask(taskId);
+            var eventIds = taskEvts.Select(e => e.EventId).ToList();
+
+            Assert.Contains(AsyncEventID.ResumeAsyncContext, eventIds);
+            Assert.Contains(AsyncEventID.UnwindAsyncException, eventIds);
+            Assert.Contains(AsyncEventID.CompleteAsyncContext, eventIds);
+
+            // Verify unwind frame count for this task
+            // RuntimeAsync_DeepMiddle -> RuntimeAsync_DeepInnerThrows, 2 frames deep after the initial resume.
+            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.UnwindAsyncException).ToList();
+            Assert.NotEmpty(unwindEvents);
+            Assert.All(unwindEvents, e => Assert.Equal(2u, e.UnwindFrameCount));
+        }
+
+        // Requires threading:
+        // Wrapper index tests use RunScenarioAndFlush (Task.Run) to escape xunit's
+        // AsyncTestSyncContext. With a SynchronizationContext present, each level in the
+        // async chain re-dispatches through the sync context, creating a separate
+        // DispatchContinuations call that resets the wrapper index to 0. Task.Run ensures
+        // the entire continuation chain executes in a single dispatch loop where the
+        // wrapper index increments sequentially across resumptions.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_WrapperIndexMatchesCallstack()
+        {
+            var captures = new List<(string MethodName, int WrapperSlot)>();
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    await RuntimeAsync_WrapperTestA(captures);
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            Assert.True(captures.Count == 3, $"Expected 3 wrapper captures, got {captures.Count}");
+
+            Assert.All(captures, c => Assert.True(c.WrapperSlot >= 0, $"{c.MethodName} did not find wrapper frame on stack (slot={c.WrapperSlot})"));
+
+            int slotC = captures.First(c => c.MethodName == nameof(RuntimeAsync_WrapperTestC)).WrapperSlot;
+            int slotB = captures.First(c => c.MethodName == nameof(RuntimeAsync_WrapperTestB)).WrapperSlot;
+            int slotA = captures.First(c => c.MethodName == nameof(RuntimeAsync_WrapperTestA)).WrapperSlot;
+
+            Assert.Equal(slotC + 1, slotB);
+            Assert.Equal(slotB + 1, slotA);
+        }
+
+        // Requires threading:
+        // Same comment as RuntimeAsync_WrapperIndexMatchesCallstack regarding Task.Run and wrapper index behavior.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_WrapperIndexResetEmitted()
+        {
+            var events = CollectEvents(AllKeywords, () =>
+            {
+                // Recursive chain 34 levels deep crosses the 32-slot boundary,
+                // triggering at least one ResetAsyncContinuationWrapperIndex event.
+                RunScenarioAndFlush(async () =>
+                {
+                    await RuntimeAsync_RecursiveChain(34);
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var ids = ParseAllEvents(events).EventIds;
+
+            Assert.Contains(AsyncEventID.ResetAsyncContinuationWrapperIndex, ids);
+        }
+
+        // Requires threading:
+        // Same comment as RuntimeAsync_WrapperIndexMatchesCallstack regarding Task.Run and wrapper index behavior.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_WrapperIndexNoResetUnder32()
+        {
+            var events = CollectEvents(AllKeywords, () =>
+            {
+                // A shallow chain stays within the first 32 slots —
+                // no reset event should be emitted.
+                RunScenarioAndFlush(async () =>
+                {
+                    await RuntimeAsync_RecursiveChain(2);
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var ids = ParseAllEvents(events).EventIds;
+
+            Assert.DoesNotContain(AsyncEventID.ResetAsyncContinuationWrapperIndex, ids);
+        }
+
+        // Requires threading:
+        // The periodic flush timer runs on a background thread.
+        // On single-threaded runtimes there is no background thread to fire the timer.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_PeriodicTimerFlush()
+        {
+            static bool IsRequestedEvent(AsyncEventID id) =>
+                id == AsyncEventID.CreateAsyncContext ||
+                id == AsyncEventID.ResumeAsyncContext ||
+                id == AsyncEventID.SuspendAsyncContext ||
+                id == AsyncEventID.CompleteAsyncContext;
+
+            var events = CollectEvents(CoreKeywords, (collectedEvents, _) =>
+            {
+                // Run scenario - do NOT flush explicitly afterwards.
+                RunScenario(async () =>
+                {
+                    await RuntimeAsync_SingleYield();
+                });
+
+                // Wait for the periodic flush timer (1s interval) to detect the idle buffer and flush it automatically.
+                Thread.Sleep(1000);
+
+                // Poll to make sure the expected buffer got flush.
+                bool flushed = SpinWait.SpinUntil(() =>
+                {
+                    var stream = ParseAllEvents(collectedEvents);
+                    return stream.EventIds.Any(id => IsRequestedEvent(id));
+                }, TimeSpan.FromSeconds(20));
+
+                Assert.True(flushed, "Expected periodic timer to flush buffer with core lifecycle events within timeout");
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            int coreEventCount = stream.EventIds.Count(id => IsRequestedEvent(id));
+
+            Assert.True(coreEventCount > 0, "Expected periodic timer to flush buffer with core lifecycle events");
+        }
+
+        // Requires threading:
+        // Verifies the background flush timer preserves the owning thread's OS thread ID,
+        // which needs both a dedicated worker thread and the timer thread.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_PeriodicTimerFlush_PreservesOwnerThreadId()
+        {
+            // This test verifies that when the background flush timer flushes a thread's buffer,
+            // the new header written afterwards preserves the owning thread's OS thread ID
+            // (not the timer thread's ID).
+            //
+            // Strategy: run async work on a dedicated thread so its profiler context gets events.
+            // Between two batches of work, wait for the flush timer to fire. Both buffer flushes
+            // from the dedicated thread should carry the same OsThreadId.
+
+            ulong workerOsThreadId = 0;
+            var workerIdReady = new ManualResetEventSlim(false);
+            var firstBatchDone = new ManualResetEventSlim(false);
+            var firstFlushSeen = new ManualResetEventSlim(false);
+            var events = new CollectedEvents();
+
+            using (var listener = CreateListener(CoreKeywords))
+            {
+                listener.RunWithCallback(e =>
+                {
+                    if (!workerIdReady.IsSet)
+                        return;
+                    if (e.EventId != AsyncEventsId || e.Payload is null || e.Payload.Count == 0)
+                        return;
+                    if (e.Payload[0] is not byte[] payload)
+                        return;
+                    EventBufferHeader? header = ParseEventBufferHeader(payload);
+                    if (header is not null && header.Value.OsThreadId == workerOsThreadId)
+                        events.Events.Enqueue(e);
+                }, () =>
+                {
+                    SendFlushCommand();
+
+                    var thread = new Thread(() =>
+                    {
+                        workerOsThreadId = GetCurrentOSThreadId();
+                        workerIdReady.Set();
+
+                        // First batch: generate events on this thread's profiler context.
+                        RuntimeAsync_SingleYield().GetAwaiter().GetResult();
+                        firstBatchDone.Set();
+
+                        // Wait for the flush to deliver our first buffer before generating more events.
+                        bool flushed = firstFlushSeen.Wait(TimeSpan.FromSeconds(20));
+                        Assert.True(flushed, "Expected first flush of core lifecycle events within timeout");
+
+                        // Second batch: generate more events on the same thread's context.
+                        RuntimeAsync_SingleYield().GetAwaiter().GetResult();
+                    });
+
+                    thread.IsBackground = true;
+                    thread.Start();
+
+                    // Wait for the worker to finish its first batch, then force flush.
+                    firstBatchDone.Wait(TimeSpan.FromSeconds(20));
+                    SendFlushCommand();
+
+                    // Poll for first buffer from our worker thread.
+                    bool firstFlush = SpinWait.SpinUntil(() => events.Events.Count >= 1, TimeSpan.FromSeconds(20));
+                    Assert.True(firstFlush, "Expected periodic timer to flush core lifecycle events within timeout");
+
+                    firstFlushSeen.Set();
+
+                    // Wait for the worker to finish its second batch.
+                    bool joined = thread.Join(TimeSpan.FromSeconds(20));
+                    Assert.True(joined, "Expected worker thread to terminate within timeout after second batch of work");
+
+                    // Force a flush to deliver the second batch.
+                    SendFlushCommand();
+
+                    // Poll for second buffer from our worker thread.
+                    bool secondFlush = SpinWait.SpinUntil(() => events.Events.Count >= 2, TimeSpan.FromSeconds(20));
+                    Assert.True(secondFlush, "Expected periodic timer to flush core lifecycle events within timeout");
+                });
+            }
+
+            // DumpAllEvents(events);
+
+            Assert.True(workerOsThreadId != 0, "Failed to capture worker OS thread ID");
+
+            // The key assertion: find buffers that contain CreateAsyncContext events (our work batches).
+            // There must be at least 2 such buffers (one per RuntimeAsync_SingleYield() call), and ALL of them must
+            // have the worker's OsThreadId - proving the timer flush didn't corrupt the header.
+            var stream = ParseAllEvents(events);
+            var createEvents = stream.OfType(AsyncEventID.CreateAsyncContext).ToList();
+            Assert.True(createEvents.Count >= 2, $"Expected at least 2 CreateAsyncContext events from the worker thread, got {createEvents.Count}");
+            Assert.All(createEvents, e => Assert.Equal(workerOsThreadId, e.OsThreadId));
+        }
+
+        // Requires threading:
+        // Spawns a dedicated thread that exits, then waits for the background flush timer
+        // to detect and flush the orphaned thread-local buffer.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_DeadThreadFlush()
+        {
+            static bool IsRequestedEvent(AsyncEventID id) =>
+                id == AsyncEventID.CreateAsyncContext ||
+                id == AsyncEventID.ResumeAsyncContext ||
+                id == AsyncEventID.SuspendAsyncContext ||
+                id == AsyncEventID.CompleteAsyncContext;
+
+            var events = CollectEvents(CoreKeywords, (collectedEvents, _) =>
+            {
+                // Spawn a dedicated thread that runs async work then exits.
+                // Its thread-local buffer becomes orphaned when the thread dies.
+                var thread = new Thread(() =>
+                {
+                    RunScenario(async () =>
+                    {
+                        await RuntimeAsync_SingleYield();
+                    });
+                });
+
+                thread.IsBackground = true;
+                thread.Start();
+                bool joined = thread.Join(TimeSpan.FromSeconds(20));
+                Assert.True(joined, "Expected worker thread to terminate within timeout before waiting for orphaned buffer flush");
+
+                // Do NOT send a flush command.
+                // Wait for the periodic flush timer to detect the dead thread and flush its orphaned buffer.
+                Thread.Sleep(1000);
+
+                // Poll to make sure the expected buffer got flush.
+                bool flushed = SpinWait.SpinUntil(() =>
+                {
+                    var stream = ParseAllEvents(collectedEvents);
+                    return stream.EventIds.Any(id => IsRequestedEvent(id));
+                }, TimeSpan.FromSeconds(20));
+
+                Assert.True(flushed, "Expected periodic timer to flush buffer with core lifecycle events within timeout");
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            int coreEventCount = stream.EventIds.Count(id => IsRequestedEvent(id));
+
+            Assert.True(coreEventCount > 0, "Expected periodic timer to flush dead thread's buffer");
+        }
+
+        // This test is sensitive to event noise - it asserts a specific clock event is absent.
+        // It cannot run in parallel with other async profiler scenarios that might produce
+        // clock events. Test parallelization is disabled via XunitAssemblyAttributes.cs.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_NoSyncClockEventBeforeInterval()
+        {
+            var events = await CollectEventsAsync(CoreKeywords, RuntimeAsync_SingleYield);
+
+            var ids = ParseAllEvents(events).EventIds;
+
+            Assert.DoesNotContain(AsyncEventID.AsyncProfilerSyncClock, ids);
+        }
+
+        // This test is sensitive to event noise - it asserts zero context events appear
+        // after enabling the listener. It cannot run in parallel with other async profiler
+        // scenarios that might produce events on the same thread context.
+        // Test parallelization is already disabled via XunitAssemblyAttributes.cs.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_NoEventsWhenDisabled()
+        {
+            // Run async work WITHOUT a listener attached
+            for (int i = 0; i < 50; i++)
+            {
+                await RuntimeAsync_SingleYield();
+            }
+
+            // Now attach listener but don't run any RuntimeAsync work inside —
+            // just call a synchronous no-op. Verify no stale events from above leak through.
+            var events = await CollectEventsAsync(CoreKeywords, () => Task.CompletedTask);
+
+            // There may be meta data related events, but there should be no suspend/resume/complete events from the earlier work.
+            var ids = ParseAllEvents(events).EventIds;
+
+            int contextEvents = ids.Count(id => id == AsyncEventID.ResumeAsyncContext || id == AsyncEventID.SuspendAsyncContext || id == AsyncEventID.CompleteAsyncContext);
+
+            Assert.Equal(0, contextEvents);
+        }
+
+        public static IEnumerable<object[]> KeywordGatekeepingData()
+        {
+            yield return new object[] { (long)CreateAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CreateAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)ResumeAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)SuspendAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.SuspendAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CompleteAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CompleteAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)UnwindAsyncExceptionKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.UnwindAsyncException, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CreateAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CreateAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)ResumeAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)SuspendAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.SuspendAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)ResumeAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CompleteAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CompleteAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task KeywordGatekeepingMarker()
+        {
+            await RuntimeAsync_OuterCatches();
+            await RuntimeAsync_ChainedYield();
+        }
+
+        // This test is sensitive to event noise - it asserts that ONLY the expected event
+        // types appear for a given keyword. It cannot run in parallel with other async
+        // profiler scenarios that might produce events on the same thread context.
+        // Test parallelization is already disabled via XunitAssemblyAttributes.cs.
+        [ConditionalTheory(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        [MemberData(nameof(KeywordGatekeepingData))]
+        public async Task RuntimeAsync_KeywordGatekeeping(long keywordValue, AsyncEventID[] allowedEventIds)
+        {
+            EventKeywords kw = (EventKeywords)keywordValue;
+            var allowed = new HashSet<AsyncEventID>(allowedEventIds);
+
+            // Run a scenario that exercises all event types: resume, suspend,
+            // complete, method events, callstacks, and exception unwinds.
+            // Only the events matching the enabled keyword should be emitted.
+            var events = await CollectEventsAsync(kw, KeywordGatekeepingMarker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var unexpected = stream.EventIds.Where(id => !allowed.Contains(id)).ToList();
+
+            Assert.True(unexpected.Count == 0, $"Keyword 0x{(long)kw:X}: unexpected event IDs [{string.Join(", ", unexpected)}], " + $"allowed [{string.Join(", ", allowed)}]");
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ResetAsyncThreadContextEvent()
+        {
+            var events = await CollectEventsAsync(CoreKeywords, RuntimeAsync_SingleYield);
+
+            // DumpAllEvents(events);
+
+            var ids = ParseAllEvents(events).EventIds;
+
+            Assert.Contains(AsyncEventID.ResetAsyncThreadContext, ids);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_MetadataEventEmittedOnEnable()
+        {
+            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_SingleYield);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var metadataList = stream.MetadataEvents;
+            Assert.True(metadataList.Count >= 1, "Expected at least one metadata event in buffer");
+
+            MetadataFromBuffer meta = metadataList[0];
+            Assert.True(meta.QpcFrequency > 0, $"QPC frequency should be positive, got {meta.QpcFrequency}");
+            Assert.True(meta.QpcSync > 0, $"QPC sync timestamp should be positive, got {meta.QpcSync}");
+            Assert.True(meta.UtcSync > 0, $"UTC sync timestamp should be positive, got {meta.UtcSync}");
+            Assert.True(meta.EventBufferSize > 0, $"Event buffer size should be positive, got {meta.EventBufferSize}");
+            Assert.True(meta.WrapperCount > 0, "Wrapper count should be positive");
+        }
+
+        // Requires threading:
+        // Spawns 8 threads with a Barrier to verify metadata is
+        // emitted exactly once under concurrent enable pressure.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_MetadataEventEmittedOnceAcrossThreads()
+        {
+            const int threadCount = 8;
+
+            var events = CollectEvents(AllKeywords, () =>
+            {
+                using var barrier = new Barrier(threadCount);
+                var tasks = new Task[threadCount];
+                for (int i = 0; i < threadCount; i++)
+                {
+                    tasks[i] = Task.Factory.StartNew(() =>
+                    {
+                        barrier.SignalAndWait();
+                        RuntimeAsync_SingleYield().GetAwaiter().GetResult();
+                    }, TaskCreationOptions.LongRunning);
+                }
+                Task.WaitAll(tasks);
+                SendFlushCommand();
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var metadataList = stream.MetadataEvents;
+            Assert.True(metadataList.Count == 1, $"Expected exactly 1 metadata event across {threadCount} threads, got {metadataList.Count}");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task NativeIPDeltaRoundtripMarker()
+        {
+            await RuntimeAsync_ChainedYield();
+            await RuntimeAsync_DeepOuterCatches();
+            await RuntimeAsync_RecursiveChain(10);
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_CallstackNativeIPDeltaRoundtrip()
+        {
+            // Verify that delta-encoded NativeIPs in callstacks roundtrip correctly,
+            // including both positive and negative deltas. With multiple distinct async
+            // methods at different JIT-assigned addresses, the deltas between consecutive
+            // NativeIPs will naturally span both directions. This exercises the full
+            // zigzag + LEB128 encode/decode path through the production serializer.
+            var events = await CollectEventsAsync(CallstackKeywords, NativeIPDeltaRoundtripMarker);
+
+            var stream = ParseAllEvents(events);
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(NativeIPDeltaRoundtripMarker));
+            Assert.NotEmpty(callstacks);
+
+            // Find callstacks with 3+ frames — enough depth for meaningful deltas.
+            var deepCallstacks = callstacks.Where(cs => cs.FrameCount >= 3).ToList();
+
+            Assert.True(deepCallstacks.Count > 0, "Expected at least one callstack with 3+ frames for delta verification");
+
+            bool hasPositiveDelta = false;
+            bool hasNegativeDelta = false;
+
+            foreach (var cs in deepCallstacks)
+            {
+                for (int i = 0; i < cs.Frames.Count; i++)
+                {
+                    var (methodId, _) = cs.Frames[i];
+                    Assert.True(methodId != 0, $"Frame {i} has zero MethodId");
+
+                    var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
+                    Assert.True(method is not null, $"Frame {i}: MethodId 0x{methodId:X} does not resolve to a managed method");
+
+                    if (i > 0)
+                    {
+                        long delta = (long)(cs.Frames[i].MethodId - cs.Frames[i - 1].MethodId);
+                        if (delta > 0)
+                            hasPositiveDelta = true;
+                        else if (delta < 0)
+                            hasNegativeDelta = true;
+                    }
+                }
+            }
+
+            // With multiple distinct async methods at different addresses, we expect
+            // both positive and negative deltas. If the JIT happens to lay out all
+            // methods monotonically (extremely unlikely), at minimum we must see
+            // non-zero deltas proving the encoding works.
+            Assert.True(hasPositiveDelta || hasNegativeDelta, "Expected at least one non-zero NativeIP delta across all callstack frames");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static async Task CallstackStressMarker(int depth)
+        {
+            await RuntimeAsync_RecursiveChain(depth);
+        }
+
+        // Requires threading:
+        // The recursive async chain must execute in a single dispatch
+        // loop (no sync context) to produce full-depth callstacks. Under xunit's
+        // AsyncTestSyncContext, each await re-dispatches, fragmenting the chain.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_CallstackStressWithVaryingDepths()
+        {
+            // Stress test: run many async calls with varying callstack depths.
+            // Varying sizes mean some callstacks will land at buffer boundaries,
+            // naturally exercising the overflow/rewind path in callstack emission.
+            // lambda -> CallstackStressMarker(d) -> RuntimeAsync_RecursiveChain(d) produces d + 2 frames.
+            const int iterations = 200;
+            int[] depths = new int[iterations];
+            var rng = new Random(42);
+            for (int i = 0; i < iterations; i++)
+                depths[i] = rng.Next(1, 120);
+
+            var events = CollectEvents(CallstackKeywords, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    for (int i = 0; i < iterations; i++)
+                        await CallstackStressMarker(depths[i]);
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(CallstackStressMarker));
+
+            // Verify all callstacks have valid frame data that resolves to managed methods.
+            foreach (var cs in callstacks)
+            {
+                Assert.True(cs.FrameCount > 0, "Callstack has 0 frames");
+                Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
+                for (int f = 0; f < cs.Frames.Count; f++)
+                {
+                    var (methodId, _) = cs.Frames[f];
+                    Assert.True(methodId != 0, $"Frame {f} has zero MethodId");
+
+                    var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
+                    Assert.True(method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
+                }
+            }
+
+            // One resume callstack per iteration (marker filters out noise).
+            // lambda -> CallstackStressMarker -> RuntimeAsync_RecursiveChain(d) produces d + 2 frames.
+            Assert.True(callstacks.Count >= iterations, $"Expected at least {iterations} callstacks with marker, got {callstacks.Count}");
+
+            for (int i = 0; i < iterations; i++)
+            {
+                // lambda + CallstackStressMarker + RuntimeAsync_RecursiveChain(d) = d + 2
+                int expected = depths[i] + 2;
+                int actual = callstacks[i].FrameCount;
+                Assert.True(actual == expected, $"Iteration {i}: expected depth {expected} (lambda -> CallstackStressMarker -> RuntimeAsync_RecursiveChain({depths[i]})), got {actual}");
+            }
+
+            // Verify multiple buffer flushes occurred.
+            int bufferCount = 0;
+            ForEachEventBufferPayload(events, _ => bufferCount++);
+            Assert.True(bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
+        }
+
+        // Requires threading:
+        // Deep recursive chains must execute in a single dispatch loop (no sync context)
+        // to produce full-depth callstacks that trigger overflow.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_CallstackOverflowPathProducesValidFrames()
+        {
+            // Targeted test: run random-depth callstacks until we detect the overflow
+            // path was exercised, then validate the affected callstack.
+            // The overflow path fires when a large callstack doesn't fit inline in the
+            // remaining buffer space — the code rewinds, flushes the partial buffer,
+            // and re-writes the callstack as the first event in a fresh buffer.
+            //
+            // To prove overflow occurred we check consecutive buffer pairs:
+            //   Buffer N: not full (has remaining capacity, but not enough for the next callstack)
+            //   Buffer N+1: first event is a large callstack
+            // This proves the runtime detected insufficient space, rewound, and flushed.
+            bool overflowDetected = false;
+            var rng = new Random(42);
+
+            for (int attempt = 0; attempt < 10 && !overflowDetected; attempt++)
+            {
+                int iterations = 500;
+                int[] depths = new int[iterations];
+                for (int i = 0; i < iterations; i++)
+                    depths[i] = rng.Next(50, 250);
+
+                var events = CollectEvents(AllKeywords, () =>
+                {
+                    RunScenarioAndFlush(async () =>
+                    {
+                        for (int i = 0; i < iterations; i++)
+                            await RuntimeAsync_RecursiveChain(depths[i]);
+                    });
+                });
+
+                // Get buffer capacity from metadata.
+                var stream = ParseAllEvents(events);
+                var metadataList = stream.MetadataEvents;
+                if (metadataList.Count == 0)
+                    continue;
+                uint bufferCapacity = metadataList[0].EventBufferSize;
+
+                // Collect per-buffer info grouped by async thread context.
+                // Consecutive buffers from the same context represent the overflow sequence.
+                var buffersByContext = new Dictionary<uint, List<(int UsedSize, AsyncEventID FirstEventId, byte FirstFrameCount)>>();
+                ForEachEventBufferPayload(events, buffer =>
+                {
+                    EventBufferHeader? header = ParseEventBufferHeader(buffer);
+                    if (header is null)
+                        return;
+
+                    uint contextId = header.Value.AsyncThreadContextId;
+
+                    // Parse the first event in this buffer.
+                    int index = HeaderSize;
+                    if (index >= buffer.Length)
+                        return;
+
+                    AsyncEventID firstId = (AsyncEventID)buffer[index++];
+                    // Skip timestamp delta
+                    ReadCompressedUInt64(buffer, ref index);
+
+                    byte frameCount = 0;
+                    if (firstId == AsyncEventID.ResumeAsyncCallstack ||
+                        firstId == AsyncEventID.CreateAsyncCallstack ||
+                        firstId == AsyncEventID.SuspendAsyncCallstack)
+                    {
+                        // Callstack payload: type(1) + callstackId(1) + frameCount(1) + compressed taskId + frames...
+                        index++; // type byte
+                        index++; // callstack ID (reserved)
+                        if (index < buffer.Length)
+                            frameCount = buffer[index];
+                    }
+
+                    if (!buffersByContext.TryGetValue(contextId, out var list))
+                    {
+                        list = new List<(int, AsyncEventID, byte)>();
+                        buffersByContext[contextId] = list;
+                    }
+                    list.Add((buffer.Length, firstId, frameCount));
+                });
+
+                // Look for overflow evidence within the same thread context:
+                // buffer N not full, buffer N+1 starts with large callstack.
+                foreach (var bufferInfos in buffersByContext.Values)
+                {
+                    for (int i = 0; i < bufferInfos.Count - 1; i++)
+                    {
+                        var current = bufferInfos[i];
+                        var next = bufferInfos[i + 1];
+
+                        Assert.True((uint)current.UsedSize <= bufferCapacity, $"Buffer used size {current.UsedSize} exceeds capacity {bufferCapacity}.");
+
+                        uint remaining = bufferCapacity - (uint)current.UsedSize;
+                        bool currentNotFull = remaining > 0;
+                        bool nextStartsWithLargeCallstack =
+                            (next.FirstEventId == AsyncEventID.ResumeAsyncCallstack ||
+                             next.FirstEventId == AsyncEventID.CreateAsyncCallstack ||
+                             next.FirstEventId == AsyncEventID.SuspendAsyncCallstack) &&
+                            next.FirstFrameCount > 30;
+
+                        if (currentNotFull && nextStartsWithLargeCallstack)
+                        {
+                            overflowDetected = true;
+                            break;
+                        }
+                    }
+
+                    if (overflowDetected)
+                        break;
+                }
+
+                // Validate all large callstacks in the stream have correct frames.
+                if (overflowDetected)
+                {
+                    var largeCallstacks = stream.OfType(AsyncEventID.ResumeAsyncCallstack)
+                        .Where(e => e.FrameCount > 30)
+                        .ToList();
+
+                    foreach (var cs in largeCallstacks)
+                    {
+                        Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
+                        for (int f = 0; f < cs.Frames.Count; f++)
+                        {
+                            var (methodId, _) = cs.Frames[f];
+                            Assert.True(methodId != 0, $"Overflow callstack frame {f} has zero MethodId");
+
+                            var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
+                            Assert.True(method is not null, $"Overflow callstack frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
+                        }
+                    }
+                }
+            }
+
+            Assert.True(overflowDetected, "Failed to trigger callstack buffer overflow after 10 attempts — " +
+                "no consecutive buffer pair found where buffer N has remaining capacity and buffer N+1 starts with a large callstack");
+        }
+
+        // Requires threading:
+        // Deep recursive chains must execute in a single dispatch
+        // loop (no sync context) to produce chains exceeding the 255-frame cap.
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_CallstackDepthCappedAtMaxFrames()
+        {
+            // Verify that callstack depth is capped when the continuation chain
+            // exceeds the maximum frame count (255, limited by byte storage).
+            // RuntimeAsync_RecursiveChain(300) produces a 300-deep chain + 1 lambda = 301 frames.
+            const int requestedDepth = 300;
+
+            var events = CollectEvents(ResumeAsyncCallstackKeyword, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    await RuntimeAsync_RecursiveChain(requestedDepth);
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+            var callstacks = stream.OfType(AsyncEventID.ResumeAsyncCallstack).ToList();
+            Assert.True(callstacks.Count >= 1, "Expected at least one callstack");
+
+            // Find the callstack from our deep RuntimeAsync_RecursiveChain call.
+            // The max frame count is capped at 255 (byte.MaxValue) since the
+            // CaptureRuntimeAsyncCallstackState.Count is a byte.
+            // RuntimeAsync_RecursiveChain(300) + 1 lambda = 301 frames, capped to 255.
+            var deepest = callstacks.MaxBy(cs => cs.FrameCount);
+            Assert.Equal(255, (int)deepest!.FrameCount);
+            Assert.Equal((int)deepest.FrameCount, deepest.Frames.Count);
+
+            // Verify all frames are valid.
+            foreach (var (methodId, _) in deepest.Frames)
+            {
+                Assert.True(methodId != 0, "Frame has zero MethodId");
+                var method = GetMethodNameFromMethodId(deepest.CallstackType, methodId);
+                Assert.True(method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
+            }
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_MetadataMatchesWrapperMethods()
+        {
+            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_SingleYield);
+
+            var stream = ParseAllEvents(events);
+            var metadataList = stream.MetadataEvents;
+            Assert.True(metadataList.Count >= 1, "Expected at least one metadata event in buffer");
+
+            MetadataFromBuffer meta = metadataList[0];
+            Assert.True(meta.WrapperCount > 0, "Expected positive wrapper count in metadata");
+
+            // On CoreCLR, verify via reflection that the contract-defined template produces names matching real methods.
+            // This catches accidental renames of wrapper methods without updating the contract.
+            if (PlatformDetection.IsCoreCLR)
+            {
+                Type? wrapperType = typeof(System.Runtime.CompilerServices.AsyncTaskMethodBuilder)
+                    .Assembly.GetType("System.Runtime.CompilerServices.AsyncProfiler+ContinuationWrapper");
+                Assert.NotNull(wrapperType);
+                for (int i = 0; i < meta.WrapperCount; i++)
+                {
+                    string expectedName = string.Format(WrapperNameTemplate, i);
+                    var method = wrapperType.GetMethod(expectedName,
+                        System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+                    Assert.True(method is not null, $"Expected method '{expectedName}' not found on ContinuationWrapper type");
+                }
+
+                // Verify that the wrapper count matches the actual number of wrapper methods on the type.
+                int actualCount = wrapperType.GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public)
+                    .Count(m => m.Name.StartsWith(WrapperNamePrefix, StringComparison.Ordinal));
+                Assert.Equal(meta.WrapperCount, actualCount);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -1549,9 +1549,10 @@ namespace System.Threading.Tasks.Tests
                         firstId == AsyncEventID.CreateAsyncCallstack ||
                         firstId == AsyncEventID.SuspendAsyncCallstack)
                     {
-                        // Callstack payload: type(1) + callstackId(1) + frameCount(1) + compressed taskId + frames...
+                        // Callstack payload: type(1) + callstackId(1) + continuationIndex(1) + frameCount(1) + compressed taskId + frames...
                         index++; // type byte
                         index++; // callstack ID (reserved)
+                        index++; // continuation index
                         if (index < buffer.Length)
                             frameCount = buffer[index];
                     }
@@ -1866,8 +1867,10 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            var frameNames = markerCallstacks[0].Frames
-                .Select(f => GetMethodNameFromMethodId(markerCallstacks[0].CallstackType, f.MethodId))
+            var deepest = markerCallstacks.OrderByDescending(cs => cs.FrameCount).First();
+
+            var frameNames = deepest.Frames
+                .Select(f => GetMethodNameFromMethodId(deepest.CallstackType, f.MethodId))
                 .Where(n => n is not null)
                 .ToList();
 
@@ -1877,7 +1880,7 @@ namespace System.Threading.Tasks.Tests
 
             // ConfigureAwait(false) on a sequential await chain collapses Leaf -> Mid -> Marker into one
             // continuation chain, so exactly one Create / one Complete is expected on the marker's TaskId.
-            AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].TaskId, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
+            AssertExactlyOneCreateAndComplete(stream, deepest.TaskId, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -2101,7 +2104,7 @@ namespace System.Threading.Tasks.Tests
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
         public async Task RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth()
         {
-            var events = await CollectEventsAsync(CallstackKeywords, async () => await RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker());
+            var events = await CollectValueTaskEventsAsync(CallstackKeywords, RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker);
 
             // DumpAllEvents(events);
 
@@ -2110,8 +2113,8 @@ namespace System.Threading.Tasks.Tests
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            // Async lambda -> Marker -> Level1 -> Level2 -> Level3.
-            Assert.Equal(5, markerCallstacks[0].FrameCount);
+            // Marker -> Level1 -> Level2 -> Level3.
+            Assert.Equal(4, markerCallstacks[0].FrameCount);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -1856,7 +1856,7 @@ namespace System.Threading.Tasks.Tests
             await RuntimeAsync_ConfigureAwaitFalse_Mid_Marker().ConfigureAwait(false);
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public async Task RuntimeAsync_ConfigureAwaitFalse()
         {
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_ConfigureAwaitFalse_Marker);

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -1706,21 +1706,21 @@ namespace System.Threading.Tasks.Tests
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static async Task RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker()
         {
-            await Task.Yield();
+            await Task.Delay(100);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static async Task RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker()
         {
-            await Task.Yield();
+            await Task.Delay(120);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static async Task RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker()
         {
-            await Task.Yield();
+            await Task.Delay(140);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -1742,16 +1742,19 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
-            AssertNotEmpty(stream, markerCallstacks);
-
-            // Each branch is its own async chain; its inner await of Task.Yield produces a Resume callstack containing the branch frame.
+            // Each branch awaits a (staggered) Task.Delay, so it always suspends and produces its own
+            // tracked chain with a Resume callstack containing the branch frame.
             var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
             var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
             var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
             AssertNotEmpty(stream, branchACallstacks);
             AssertNotEmpty(stream, branchBCallstacks);
             AssertNotEmpty(stream, branchCCallstacks);
+
+            // Because every branch suspends on a pending Task.Delay, Task.WhenAll is always pending when
+            // the outer marker awaits it, so the marker also suspends and gets its own tracked chain.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own DispatcherId.
             AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
@@ -1948,6 +1951,11 @@ namespace System.Threading.Tasks.Tests
             }
             finally
             {
+                // The await may resume on a different thread; only restore on the original (install)
+                // thread. On multi-threaded platforms this method runs on a dedicated throwaway
+                // thread (see RunIsolatedScenarioAsync), so a skipped restore can't leak the context
+                // onto a shared thread-pool thread. On single-threaded platforms the resume is on
+                // this same thread, so the restore always runs here.
                 if (Environment.CurrentManagedThreadId == callerThreadId)
                 {
                     SynchronizationContext.SetSynchronizationContext(prev);
@@ -1960,7 +1968,7 @@ namespace System.Threading.Tasks.Tests
         {
             s_runtimeAsyncSyncContextCtx = new InlinePostSynchronizationContext();
 
-            var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker);
+            var events = await CollectEventsAsync(CallstackKeywords, () => RunIsolatedScenarioAsync(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
 
             // DumpAllEvents(events);
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -262,16 +262,16 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // Find our context via marker callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendResumeCompleteEvents_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendResumeCompleteEvents_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var taskEvts = stream.ForTask(taskId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
-            Assert.Contains(AsyncEventID.ResumeAsyncContext, ids);
-            Assert.Contains(AsyncEventID.SuspendAsyncContext, ids);
-            Assert.Contains(AsyncEventID.CompleteAsyncContext, ids);
+            Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncContext, ids);
+            Assert.Contains(AsyncEventID.RuntimeAsync_SuspendAsyncContext, ids);
+            Assert.Contains(AsyncEventID.RuntimeAsync_CompleteAsyncContext, ids);
         }
 
 
@@ -293,7 +293,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // Find events in the context that contains our marker method.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ContextEventIdLifecycle_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ContextEventIdLifecycle_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
@@ -302,8 +302,8 @@ namespace System.Threading.Tasks.Tests
             var taskEvts = stream.ForTask(taskId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
+            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext in context events");
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after CreateAsyncContext");
         }
@@ -317,8 +317,8 @@ namespace System.Threading.Tasks.Tests
 
             var ids = ParseAllEvents(events).EventIds;
 
-            Assert.Contains(AsyncEventID.ResumeAsyncMethod, ids);
-            Assert.Contains(AsyncEventID.CompleteAsyncMethod, ids);
+            Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncMethod, ids);
+            Assert.Contains(AsyncEventID.RuntimeAsync_CompleteAsyncMethod, ids);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -339,7 +339,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // Find our context via marker callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_EventSequenceOrder_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_EventSequenceOrder_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
@@ -347,16 +347,16 @@ namespace System.Threading.Tasks.Tests
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
             // Verify the expected lifecycle sequence exists in order.
-            int resumeIdx1 = ids.IndexOf(AsyncEventID.ResumeAsyncContext);
+            int resumeIdx1 = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext);
             Assert.True(resumeIdx1 >= 0, "Expected first ResumeAsyncContext");
 
-            int suspendIdx = ids.IndexOf(AsyncEventID.SuspendAsyncContext, resumeIdx1 + 1);
+            int suspendIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_SuspendAsyncContext, resumeIdx1 + 1);
             Assert.True(suspendIdx > resumeIdx1, "Expected SuspendAsyncContext after first Resume");
 
-            int resumeIdx2 = ids.IndexOf(AsyncEventID.ResumeAsyncContext, suspendIdx + 1);
+            int resumeIdx2 = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, suspendIdx + 1);
             Assert.True(resumeIdx2 > suspendIdx, "Expected second ResumeAsyncContext after Suspend");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx2 + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx2 + 1);
             Assert.True(completeIdx > resumeIdx2, "Expected CompleteAsyncContext after second Resume");
         }
 
@@ -368,7 +368,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var ids = ParseAllEvents(events).EventIds;
-            Assert.Contains(AsyncEventID.CreateAsyncContext, ids);
+            Assert.Contains(AsyncEventID.RuntimeAsync_CreateAsyncContext, ids);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -386,7 +386,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker));
+            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker));
 
             Assert.NotEmpty(createCallstacks);
             Assert.All(createCallstacks, cs =>
@@ -413,7 +413,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(RuntimeAsync_CreateCallstackDepthMatchesChain_Marker));
+            var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateCallstackDepthMatchesChain_Marker));
 
             // The expected [NoInlining] frames in order (innermost first):
             // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> RuntimeAsync_CreateCallstackDepthMatchesChain_Marker
@@ -440,7 +440,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker));
+            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker));
 
             Assert.NotEmpty(suspendCallstacks);
             Assert.All(suspendCallstacks, cs =>
@@ -467,7 +467,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker));
+            var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker));
 
             // The expected [NoInlining] frames in order (innermost first):
             // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker
@@ -496,7 +496,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // Find the suspend callstack via marker to get the context ID
-            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackPrecedesComplete_Marker));
+            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackPrecedesComplete_Marker));
             Assert.NotEmpty(suspendStacks);
 
             ulong taskId = suspendStacks[0].TaskId;
@@ -505,8 +505,8 @@ namespace System.Threading.Tasks.Tests
             var taskEvts = stream.ForTask(taskId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
-            int suspendIdx = ids.IndexOf(AsyncEventID.SuspendAsyncCallstack);
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext);
+            int suspendIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack);
+            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext);
 
             Assert.True(suspendIdx >= 0, "Expected SuspendAsyncCallstack in context events");
             Assert.True(completeIdx >= 0, "Expected CompleteAsyncContext in context events");
@@ -529,8 +529,8 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
-            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
+            var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
 
             Assert.NotEmpty(resumeStacks);
             Assert.NotEmpty(suspendStacks);
@@ -558,8 +558,8 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
+            var createStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
 
             Assert.NotEmpty(createStacks);
             Assert.NotEmpty(resumeStacks);
@@ -595,8 +595,8 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var createStacks = stream.CallstacksWithMarker(AsyncEventID.CreateAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
+            var createStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
 
             Assert.NotEmpty(createStacks);
             Assert.NotEmpty(resumeStacks);
@@ -636,7 +636,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackEmittedOnResume_Marker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackEmittedOnResume_Marker));
 
             Assert.NotEmpty(callstacks);
             Assert.All(callstacks, cs =>
@@ -663,7 +663,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackDepthMatchesChain_Marker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackDepthMatchesChain_Marker));
 
             // The expected [NoInlining] frames in order (innermost first):
             // RuntimeAsync_InnerYield -> RuntimeAsync_CallstackDepthMatchesChain_Marker
@@ -693,7 +693,7 @@ namespace System.Threading.Tasks.Tests
             // Marker -> DeepChain -> Level1 -> Level2 -> Level3
             const int ExpectedChainDepth = 5;
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_MethodEventCountMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_MethodEventCountMatchesChainDepth_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             Assert.Equal(ExpectedChainDepth, markerCallstacks[0].Frames.Count);
@@ -701,10 +701,10 @@ namespace System.Threading.Tasks.Tests
             ulong chainTaskId = markerCallstacks[0].TaskId;
             var chainEvents = stream.ForTask(chainTaskId);
 
-            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.ResumeAsyncMethod);
+            int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncMethod);
             Assert.Equal(ExpectedChainDepth, resumeCount);
 
-            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.CompleteAsyncMethod);
+            int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
             Assert.Equal(ExpectedChainDepth, completeCount);
         }
 
@@ -724,7 +724,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Frames in the same callstack should have distinct methodIds (one per async method in the chain).
@@ -773,7 +773,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_YieldAtEachLevel_CallstackShrinks_Marker));
 
             // After Task.Delay resumes: full chain (Level3, Level2, Level1, Marker) = 4 frames
             // After Level3's yield resumes: Level3 completes, chain is (Level2, Level1, Marker) = 3 frames
@@ -879,7 +879,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_UnhandledExceptionUnwind_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_UnhandledExceptionUnwind_Marker));
             Assert.NotEmpty(resumeStacks);
 
             ulong taskId = resumeStacks[0].TaskId;
@@ -887,13 +887,13 @@ namespace System.Threading.Tasks.Tests
             var taskEvts = stream.ForTask(taskId);
             var eventIds = taskEvts.Select(e => e.EventId).ToList();
 
-            Assert.Contains(AsyncEventID.ResumeAsyncContext, eventIds);
-            Assert.Contains(AsyncEventID.UnwindAsyncException, eventIds);
-            Assert.Contains(AsyncEventID.CompleteAsyncContext, eventIds);
+            Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
+            Assert.Contains(AsyncEventID.RuntimeAsync_UnwindAsyncException, eventIds);
+            Assert.Contains(AsyncEventID.RuntimeAsync_CompleteAsyncContext, eventIds);
 
             // Verify unwind frame count for this task
             // Marker -> RuntimeAsync_DeepUnhandledOuter -> RuntimeAsync_DeepUnhandledMiddle -> RuntimeAsync_DeepUnhandledInnerThrows, 4 frames deep after the initial resume.
-            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.UnwindAsyncException).ToList();
+            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.RuntimeAsync_UnwindAsyncException).ToList();
             Assert.NotEmpty(unwindEvents);
             Assert.All(unwindEvents, e => Assert.Equal(4u, e.UnwindFrameCount));
         }
@@ -913,7 +913,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_HandledExceptionUnwind_Marker));
+            var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_HandledExceptionUnwind_Marker));
             Assert.NotEmpty(resumeStacks);
 
             ulong taskId = resumeStacks[0].TaskId;
@@ -921,13 +921,13 @@ namespace System.Threading.Tasks.Tests
             var taskEvts = stream.ForTask(taskId);
             var eventIds = taskEvts.Select(e => e.EventId).ToList();
 
-            Assert.Contains(AsyncEventID.ResumeAsyncContext, eventIds);
-            Assert.Contains(AsyncEventID.UnwindAsyncException, eventIds);
-            Assert.Contains(AsyncEventID.CompleteAsyncContext, eventIds);
+            Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
+            Assert.Contains(AsyncEventID.RuntimeAsync_UnwindAsyncException, eventIds);
+            Assert.Contains(AsyncEventID.RuntimeAsync_CompleteAsyncContext, eventIds);
 
             // Verify unwind frame count for this task
             // RuntimeAsync_DeepMiddle -> RuntimeAsync_DeepInnerThrows, 2 frames deep after the initial resume.
-            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.UnwindAsyncException).ToList();
+            var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.RuntimeAsync_UnwindAsyncException).ToList();
             Assert.NotEmpty(unwindEvents);
             Assert.All(unwindEvents, e => Assert.Equal(2u, e.UnwindFrameCount));
         }
@@ -1017,10 +1017,10 @@ namespace System.Threading.Tasks.Tests
         public void RuntimeAsync_PeriodicTimerFlush()
         {
             static bool IsRequestedEvent(AsyncEventID id) =>
-                id == AsyncEventID.CreateAsyncContext ||
-                id == AsyncEventID.ResumeAsyncContext ||
-                id == AsyncEventID.SuspendAsyncContext ||
-                id == AsyncEventID.CompleteAsyncContext;
+                id == AsyncEventID.RuntimeAsync_CreateAsyncContext ||
+                id == AsyncEventID.RuntimeAsync_ResumeAsyncContext ||
+                id == AsyncEventID.RuntimeAsync_SuspendAsyncContext ||
+                id == AsyncEventID.RuntimeAsync_CompleteAsyncContext;
 
             var events = CollectEvents(CoreKeywords, (collectedEvents, _) =>
             {
@@ -1150,7 +1150,7 @@ namespace System.Threading.Tasks.Tests
             // There must be at least 2 such buffers (one per RuntimeAsync_SingleYield() call), and ALL of them must
             // have the worker's OsThreadId - proving the timer flush didn't corrupt the header.
             var stream = ParseAllEvents(events);
-            var createEvents = stream.OfType(AsyncEventID.CreateAsyncContext).ToList();
+            var createEvents = stream.OfType(AsyncEventID.RuntimeAsync_CreateAsyncContext).ToList();
             Assert.True(createEvents.Count >= 2, $"Expected at least 2 CreateAsyncContext events from the worker thread, got {createEvents.Count}");
             Assert.All(createEvents, e => Assert.Equal(workerOsThreadId, e.OsThreadId));
         }
@@ -1162,10 +1162,10 @@ namespace System.Threading.Tasks.Tests
         public void RuntimeAsync_DeadThreadFlush()
         {
             static bool IsRequestedEvent(AsyncEventID id) =>
-                id == AsyncEventID.CreateAsyncContext ||
-                id == AsyncEventID.ResumeAsyncContext ||
-                id == AsyncEventID.SuspendAsyncContext ||
-                id == AsyncEventID.CompleteAsyncContext;
+                id == AsyncEventID.RuntimeAsync_CreateAsyncContext ||
+                id == AsyncEventID.RuntimeAsync_ResumeAsyncContext ||
+                id == AsyncEventID.RuntimeAsync_SuspendAsyncContext ||
+                id == AsyncEventID.RuntimeAsync_CompleteAsyncContext;
 
             var events = CollectEvents(CoreKeywords, (collectedEvents, _) =>
             {
@@ -1239,23 +1239,23 @@ namespace System.Threading.Tasks.Tests
             // There may be meta data related events, but there should be no suspend/resume/complete events from the earlier work.
             var ids = ParseAllEvents(events).EventIds;
 
-            int contextEvents = ids.Count(id => id == AsyncEventID.ResumeAsyncContext || id == AsyncEventID.SuspendAsyncContext || id == AsyncEventID.CompleteAsyncContext);
+            int contextEvents = ids.Count(id => id == AsyncEventID.RuntimeAsync_ResumeAsyncContext || id == AsyncEventID.RuntimeAsync_SuspendAsyncContext || id == AsyncEventID.RuntimeAsync_CompleteAsyncContext);
 
             Assert.Equal(0, contextEvents);
         }
 
         public static IEnumerable<object[]> KeywordGatekeepingData()
         {
-            yield return new object[] { (long)CreateAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CreateAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)ResumeAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)SuspendAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.SuspendAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)CompleteAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CompleteAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)UnwindAsyncExceptionKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.UnwindAsyncException, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)CreateAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CreateAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)ResumeAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)SuspendAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.SuspendAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)ResumeAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.ResumeAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
-            yield return new object[] { (long)CompleteAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.CompleteAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CreateAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_CreateAsyncContext, AsyncEventID.TaskAsync_CreateAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)ResumeAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_ResumeAsyncContext, AsyncEventID.TaskAsync_ResumeAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)SuspendAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_SuspendAsyncContext, AsyncEventID.TaskAsync_SuspendAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CompleteAsyncContextKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_CompleteAsyncContext, AsyncEventID.TaskAsync_CompleteAsyncContext, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)UnwindAsyncExceptionKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_UnwindAsyncException, AsyncEventID.TaskAsync_UnwindAsyncException, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CreateAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_CreateAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)ResumeAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, AsyncEventID.TaskAsync_ResumeAsyncCallstack, AsyncEventID.TaskAsync_AppendAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)SuspendAsyncCallstackKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)ResumeAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_ResumeAsyncMethod, AsyncEventID.TaskAsync_ResumeAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
+            yield return new object[] { (long)CompleteAsyncMethodKeyword, new AsyncEventID[] { AsyncEventID.ResetAsyncThreadContext, AsyncEventID.RuntimeAsync_CompleteAsyncMethod, AsyncEventID.TaskAsync_CompleteAsyncMethod, AsyncEventID.AsyncProfilerMetadata } };
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -1372,7 +1372,7 @@ namespace System.Threading.Tasks.Tests
             var events = await CollectEventsAsync(CallstackKeywords, RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker));
             Assert.NotEmpty(callstacks);
 
             // Find callstacks with 3+ frames -- enough depth for meaningful deltas.
@@ -1447,7 +1447,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackStressWithVaryingDepths_Marker));
+            var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackStressWithVaryingDepths_Marker));
 
             // Verify all callstacks have valid frame data that resolves to managed methods.
             foreach (var cs in callstacks)
@@ -1545,12 +1545,11 @@ namespace System.Threading.Tasks.Tests
                     ReadCompressedUInt64(buffer, ref index);
 
                     byte frameCount = 0;
-                    if (firstId == AsyncEventID.ResumeAsyncCallstack ||
-                        firstId == AsyncEventID.CreateAsyncCallstack ||
-                        firstId == AsyncEventID.SuspendAsyncCallstack)
+                    if (firstId == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack ||
+                        firstId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack ||
+                        firstId == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack)
                     {
-                        // Callstack payload: type(1) + callstackId(1) + continuationIndex(1) + frameCount(1) + compressed taskId + frames...
-                        index++; // type byte
+                        // Callstack payload: callstackId(1) + continuationIndex(1) + frameCount(1) + compressed taskId + frames...
                         index++; // callstack ID (reserved)
                         index++; // continuation index
                         if (index < buffer.Length)
@@ -1579,9 +1578,9 @@ namespace System.Threading.Tasks.Tests
                         uint remaining = bufferCapacity - (uint)current.UsedSize;
                         bool currentNotFull = remaining > 0;
                         bool nextStartsWithLargeCallstack =
-                            (next.FirstEventId == AsyncEventID.ResumeAsyncCallstack ||
-                             next.FirstEventId == AsyncEventID.CreateAsyncCallstack ||
-                             next.FirstEventId == AsyncEventID.SuspendAsyncCallstack) &&
+                            (next.FirstEventId == AsyncEventID.RuntimeAsync_ResumeAsyncCallstack ||
+                             next.FirstEventId == AsyncEventID.RuntimeAsync_CreateAsyncCallstack ||
+                             next.FirstEventId == AsyncEventID.RuntimeAsync_SuspendAsyncCallstack) &&
                             next.FirstFrameCount > 30;
 
                         if (currentNotFull && nextStartsWithLargeCallstack)
@@ -1598,7 +1597,7 @@ namespace System.Threading.Tasks.Tests
                 // Validate all large callstacks in the stream have correct frames.
                 if (overflowDetected)
                 {
-                    var largeCallstacks = stream.OfType(AsyncEventID.ResumeAsyncCallstack)
+                    var largeCallstacks = stream.OfType(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack)
                         .Where(e => e.FrameCount > 30)
                         .ToList();
 
@@ -1643,7 +1642,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var stream = ParseAllEvents(events);
-            var callstacks = stream.OfType(AsyncEventID.ResumeAsyncCallstack).ToList();
+            var callstacks = stream.OfType(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack).ToList();
             Assert.True(callstacks.Count >= 1, "Expected at least one callstack");
 
             // Find the callstack from our deep RuntimeAsync_RecursiveChain call.
@@ -1738,13 +1737,13 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Each branch is its own async chain; its inner await of Task.Yield produces a Resume callstack containing the branch frame.
-            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
-            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
-            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
+            var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
+            var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
+            var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
             Assert.NotEmpty(branchACallstacks);
             Assert.NotEmpty(branchBCallstacks);
             Assert.NotEmpty(branchCCallstacks);
@@ -1759,11 +1758,11 @@ namespace System.Threading.Tasks.Tests
             ulong markerTaskId = markerCallstacks[0].TaskId;
             var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
 
-            int createIdx = markerIds.IndexOf(AsyncEventID.CreateAsyncContext);
-            int resumeIdx = markerIds.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int createIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
+            int resumeIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
 
-            int completeIdx = markerIds.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
         }
 
@@ -1809,14 +1808,14 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // All branches - including the slow ones whose completion the outer is no longer
             // strictly waiting on after WhenAny returned - must produce their own Resume callstacks.
-            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
-            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker));
-            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker));
+            var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
+            var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker));
+            var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker));
             Assert.NotEmpty(fastCallstacks);
             Assert.NotEmpty(slow1Callstacks);
             Assert.NotEmpty(slow2Callstacks);
@@ -1830,7 +1829,7 @@ namespace System.Threading.Tasks.Tests
             // The outer marker should also be resumed at least once.
             ulong markerTaskId = markerCallstacks[0].TaskId;
             var markerIds = stream.ForTask(markerTaskId).Select(e => e.EventId).ToList();
-            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.ResumeAsyncContext);
+            int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.RuntimeAsync_ResumeAsyncContext);
             Assert.True(resumeCountForMarker >= 1, $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
         }
 
@@ -1864,7 +1863,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             var deepest = markerCallstacks.OrderByDescending(cs => cs.FrameCount).First();
@@ -1915,10 +1914,10 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Marker));
             Assert.NotEmpty(markerCallstacks);
 
-            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
+            var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
             Assert.NotEmpty(innerCallstacks);
 
             // Inner cancelled task + outer marker must each see exactly one Create and one Complete on their own TaskId.
@@ -1967,7 +1966,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // The marker frame should appear in the Resume callstack.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // The marker's chain should see exactly one Create and one Complete on its own TaskId.
@@ -1977,11 +1976,11 @@ namespace System.Threading.Tasks.Tests
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
+            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -2015,7 +2014,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // The marker's chain should see exactly one Create and one Complete on its own TaskId.
@@ -2025,11 +2024,11 @@ namespace System.Threading.Tasks.Tests
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
+            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -2049,19 +2048,19 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_EventSequenceOrder_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_EventSequenceOrder_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, resumeIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
             Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
@@ -2082,12 +2081,12 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var methodEvents = stream.All
-                .Where(e => e.EventId is AsyncEventID.ResumeAsyncMethod or AsyncEventID.CompleteAsyncMethod)
+                .Where(e => e.EventId is AsyncEventID.RuntimeAsync_ResumeAsyncMethod or AsyncEventID.RuntimeAsync_CompleteAsyncMethod)
                 .Select(e => e.EventId)
                 .ToList();
 
-            int resumeCount = methodEvents.Count(id => id == AsyncEventID.ResumeAsyncMethod);
-            int completeCount = methodEvents.Count(id => id == AsyncEventID.CompleteAsyncMethod);
+            int resumeCount = methodEvents.Count(id => id == AsyncEventID.RuntimeAsync_ResumeAsyncMethod);
+            int completeCount = methodEvents.Count(id => id == AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
 
             // Marker -> Level1 -> Level2 -> Level3
             Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
@@ -2110,7 +2109,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             // Marker -> Level1 -> Level2 -> Level3.
@@ -2133,7 +2132,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
@@ -2177,22 +2176,22 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            int unwindIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_UnwindAsyncException, resumeIdx + 1);
             Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, unwindIdx + 1);
             Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
@@ -2236,22 +2235,22 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
 
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete_Marker));
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete_Marker));
             Assert.NotEmpty(markerCallstacks);
 
             ulong taskId = markerCallstacks[0].TaskId;
             var ids = stream.ForTask(taskId).Select(e => e.EventId).ToList();
 
-            int createIdx = ids.IndexOf(AsyncEventID.CreateAsyncContext);
+            int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
 
-            int resumeIdx = ids.IndexOf(AsyncEventID.ResumeAsyncContext, createIdx + 1);
+            int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
             Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
-            int unwindIdx = ids.IndexOf(AsyncEventID.UnwindAsyncException, resumeIdx + 1);
+            int unwindIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_UnwindAsyncException, resumeIdx + 1);
             Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
-            int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx + 1);
+            int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, unwindIdx + 1);
             Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
@@ -2289,7 +2288,7 @@ namespace System.Threading.Tasks.Tests
 
             // Locate the V2 dispatcher driving the marker chain via its ResumeAsyncCallstack
             // events (which carry the marker frames in their callstack).
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysPendingV2Chain");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysPendingV2Chain");
             Assert.NotEmpty(markerCallstacks);
 
             // Thread-scoped replay assertion: at least one OS thread must have seen two
@@ -2322,7 +2321,7 @@ namespace System.Threading.Tasks.Tests
 
                 var replayTaskIds = postResetMarkerCallstacks.Select(c => c.TaskId).ToHashSet();
                 var postResetResumeContext = stream.All
-                    .Where(e => e.EventId == AsyncEventID.ResumeAsyncContext
+                    .Where(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncContext
                                 && e.OsThreadId == threadId
                                 && e.Timestamp >= lastResetTimestamp
                                 && replayTaskIds.Contains(e.TaskId))
@@ -2399,7 +2398,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             // The replay must emit at least one ResumeAsyncCallstack carrying a V2 marker chain.
-            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysMultipleDispatchers");
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysMultipleDispatchers");
             Assert.NotEmpty(markerCallstacks);
 
             // Decisive proof: find an OS thread where a single ResetAsyncThreadContext is
@@ -2427,7 +2426,7 @@ namespace System.Threading.Tasks.Tests
                         : long.MaxValue;
 
                     int resumeContextCount = stream.All
-                        .Count(e => e.EventId == AsyncEventID.ResumeAsyncContext
+                        .Count(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncContext
                                     && e.OsThreadId == threadId
                                     && e.Timestamp >= windowStart
                                     && e.Timestamp < windowEnd);

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -1623,6 +1623,42 @@ namespace System.Threading.Tasks.Tests
                 "no consecutive buffer pair found where buffer N has remaining capacity and buffer N+1 starts with a large callstack");
         }
 
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_CallstackOverflow_PreservesFullDepth()
+        {
+            const int Depth = 200;
+            const int Iterations = 500;
+
+            var events = CollectEvents(ResumeRuntimeAsyncCallstackKeyword, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    for (int i = 0; i < Iterations; i++)
+                        await RuntimeAsync_RecursiveChain(Depth);
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Scope to our recursive chains by method rather than by frame count -- a callstack truncated by
+            // the overflow bug has fewer frames but still consists of the recursive method, so it stays in
+            // scope and is caught.
+            var chainCallstacks = stream.OfType(AsyncEventID.ResumeRuntimeAsyncCallstack)
+                .Where(cs => cs.Frames.Any(f => GetMethodNameFromMethodId(cs.CallstackType, f.MethodId) == nameof(RuntimeAsync_RecursiveChain)))
+                .ToList();
+            AssertNotEmpty(stream, chainCallstacks);
+
+            int leafDepth = chainCallstacks.Max(cs => (int)cs.FrameCount);
+            AssertTrue(stream, leafDepth >= Depth, $"Expected captured depth >= {Depth}, got {leafDepth}");
+            foreach (var cs in chainCallstacks)
+            {
+                AssertEqual(stream, leafDepth, (int)cs.FrameCount);
+                AssertEqual(stream, (int)cs.FrameCount, cs.Frames.Count);
+            }
+        }
+
         // Requires threading:
         // Deep recursive chains must execute in a single dispatch
         // loop (no sync context) to produce chains exceeding the 255-frame cap.

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -2361,7 +2361,7 @@ namespace System.Threading.Tasks.Tests
             await innerDone.Task;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
         public async Task RuntimeAsync_ResetContext_ReplaysMultipleDispatchers()
         {
             var events = await CollectEventsAsync(AllKeywords, async () =>

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -2251,5 +2251,201 @@ namespace System.Threading.Tasks.Tests
             int completeIdx = ids.IndexOf(AsyncEventID.CompleteAsyncContext, unwindIdx + 1);
             Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplaysPendingV2Chain_Inner_Marker()
+        {
+            using var dummy = new TestEventListener();
+            dummy.AddSource(AsyncProfilerEventSourceName, EventLevel.Informational, EventKeywords.None);
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplaysPendingV2Chain_Mid_Marker()
+        {
+            await RuntimeAsync_ResetContext_ReplaysPendingV2Chain_Inner_Marker();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplaysPendingV2Chain_Outer_Marker()
+        {
+            await RuntimeAsync_ResetContext_ReplaysPendingV2Chain_Mid_Marker();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ResetContext_ReplaysPendingV2Chain()
+        {
+            var events = await CollectEventsAsync(AllKeywords, RuntimeAsync_ResetContext_ReplaysPendingV2Chain_Outer_Marker);
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Locate the V2 dispatcher driving the marker chain via its ResumeAsyncCallstack
+            // events (which carry the marker frames in their callstack).
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysPendingV2Chain");
+            Assert.NotEmpty(markerCallstacks);
+
+            // Thread-scoped replay assertion: at least one OS thread must have seen two
+            // ResetAsyncThreadContext events AND show a marker ResumeAsyncCallstack plus
+            // matching ResumeAsyncContext after its most recent reset. Multiple threads
+            // in the trace can accumulate two resets (e.g. the test thread re-enables on
+            // its initial event then again later), so we have to look at each candidate
+            // thread, not just the first one. The thread that actually drove the replay
+            // is the one the V2 continuation resumed onto.
+            var resetsByThread = stream.All
+                .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
+                .GroupBy(e => e.OsThreadId)
+                .Where(g => g.Count() >= 2)
+                .ToList();
+            Assert.NotEmpty(resetsByThread);
+
+            bool found = false;
+            foreach (var threadResets in resetsByThread)
+            {
+                ulong threadId = threadResets.Key;
+                long lastResetTimestamp = threadResets.Max(e => e.Timestamp);
+
+                var postResetMarkerCallstacks = markerCallstacks
+                    .Where(c => c.OsThreadId == threadId && c.Timestamp >= lastResetTimestamp)
+                    .ToList();
+                if (postResetMarkerCallstacks.Count == 0)
+                {
+                    continue;
+                }
+
+                var replayTaskIds = postResetMarkerCallstacks.Select(c => c.TaskId).ToHashSet();
+                var postResetResumeContext = stream.All
+                    .Where(e => e.EventId == AsyncEventID.ResumeAsyncContext
+                                && e.OsThreadId == threadId
+                                && e.Timestamp >= lastResetTimestamp
+                                && replayTaskIds.Contains(e.TaskId))
+                    .ToList();
+                if (postResetResumeContext.Count == 0)
+                {
+                    continue;
+                }
+
+                found = true;
+                break;
+            }
+
+            Assert.True(found,
+                "Expected at least one OS thread with >= 2 ResetAsyncThreadContext events followed by a marker ResumeAsyncCallstack and matching ResumeAsyncContext.");
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplaysMultipleDispatchers_Inner_Marker(
+            Task gate,
+            ManualResetEventSlim block,
+            Action onBlocked,
+            TaskCompletionSource innerDone)
+        {
+            await gate;
+            onBlocked();
+            block.Wait();
+            innerDone.SetResult();
+        }
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResetContext_ReplaysMultipleDispatchers_Outer_Marker(TaskCompletionSource innerDone)
+        {
+            await innerDone.Task;
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
+        public async Task RuntimeAsync_ResetContext_ReplaysMultipleDispatchers()
+        {
+            var events = await CollectEventsAsync(AllKeywords, async () =>
+            {
+                var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var block = new ManualResetEventSlim(false);
+                var blocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var innerDone = new TaskCompletionSource();
+
+                Task inner = RuntimeAsync_ResetContext_ReplaysMultipleDispatchers_Inner_Marker(gate.Task, block, () => blocked.SetResult(), innerDone);
+                Task outer = RuntimeAsync_ResetContext_ReplaysMultipleDispatchers_Outer_Marker(innerDone);
+
+                _ = Task.Run(() => gate.SetResult());
+
+                await blocked.Task;
+
+                var dummy = new TestEventListener();
+                try
+                {
+                    dummy.AddSource(AsyncProfilerEventSourceName, EventLevel.Informational, EventKeywords.None);
+
+                    block.Set();
+
+                    await outer;
+                    await inner;
+                }
+                finally
+                {
+                    dummy.Dispose();
+                }
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // The replay must emit at least one ResumeAsyncCallstack carrying a V2 marker chain.
+            var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysMultipleDispatchers");
+            Assert.NotEmpty(markerCallstacks);
+
+            // Decisive proof: find an OS thread where a single ResetAsyncThreadContext is
+            // followed by >= 2 ResumeAsyncContext events before the next reset. A normal V2
+            // dispatch loop emits only one ResumeAsyncContext per dispatcher entry, so two
+            // in one reset window can only come from the walker traversing two stacked
+            // asyncDispatcherInfo entries on t_current.
+            var resetsByThread = stream.All
+                .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
+                .GroupBy(e => e.OsThreadId)
+                .ToList();
+            Assert.NotEmpty(resetsByThread);
+
+            bool found = false;
+            foreach (var threadResets in resetsByThread)
+            {
+                ulong threadId = threadResets.Key;
+                var orderedResets = threadResets.OrderBy(e => e.Timestamp).ToList();
+
+                for (int i = 0; i < orderedResets.Count; i++)
+                {
+                    long windowStart = orderedResets[i].Timestamp;
+                    long windowEnd = (i + 1 < orderedResets.Count)
+                        ? orderedResets[i + 1].Timestamp
+                        : long.MaxValue;
+
+                    int resumeContextCount = stream.All
+                        .Count(e => e.EventId == AsyncEventID.ResumeAsyncContext
+                                    && e.OsThreadId == threadId
+                                    && e.Timestamp >= windowStart
+                                    && e.Timestamp < windowEnd);
+
+                    if (resumeContextCount >= 2)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found)
+                {
+                    break;
+                }
+            }
+
+            Assert.True(found,
+                "Expected at least one OS thread with a ResetAsyncThreadContext event " +
+                "followed by >= 2 ResumeAsyncContext events in the same reset window, " +
+                "proving the reset-replay walker traversed multiple stacked V2 dispatcher infos.");
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -207,15 +207,15 @@ namespace System.Threading.Tasks.Tests
             ForEachEventBufferPayload(events, buffer =>
             {
                 EventBufferHeader? parsed = ParseEventBufferHeader(buffer);
-                Assert.NotNull(parsed);
+                AssertNotNull(events, parsed);
                 EventBufferHeader header = parsed.Value;
 
-                Assert.Equal(1, header.Version);
-                Assert.Equal((uint)buffer.Length, header.TotalSize);
-                Assert.True(header.AsyncThreadContextId > 0, "Async thread context ID should be positive");
-                Assert.True(header.OsThreadId != 0, "OS thread ID should be non-zero");
-                Assert.True(header.StartTimestamp > 0, "Start timestamp should be positive");
-                Assert.True(header.EndTimestamp >= header.StartTimestamp, $"End timestamp ({header.EndTimestamp}) should be >= start timestamp ({header.StartTimestamp})");
+                AssertEqual(events, 1, header.Version);
+                AssertEqual(events, (uint)buffer.Length, header.TotalSize);
+                AssertTrue(events, header.AsyncThreadContextId > 0, "Async thread context ID should be positive");
+                AssertTrue(events, header.OsThreadId != 0, "OS thread ID should be non-zero");
+                AssertTrue(events, header.StartTimestamp > 0, "Start timestamp should be positive");
+                AssertTrue(events, header.EndTimestamp >= header.StartTimestamp, $"End timestamp ({header.EndTimestamp}) should be >= start timestamp ({header.StartTimestamp})");
 
                 int eventCount = 0;
                 ParseEventBuffer(buffer, (AsyncEventID eventId, ReadOnlySpan<byte> buf, ref int idx) =>
@@ -224,13 +224,13 @@ namespace System.Threading.Tasks.Tests
                     return SkipEventPayload(eventId, buf, ref idx);
                 });
 
-                Assert.Equal(header.EventCount, (uint)eventCount);
-                Assert.True(header.EventCount > 0, "Expected at least one event in buffer");
+                AssertEqual(events, header.EventCount, (uint)eventCount);
+                AssertTrue(events, header.EventCount > 0, "Expected at least one event in buffer");
 
                 buffersChecked++;
             });
 
-            Assert.True(buffersChecked > 0, "Expected at least one buffer");
+            AssertTrue(events, buffersChecked > 0, "Expected at least one buffer");
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
@@ -240,8 +240,8 @@ namespace System.Threading.Tasks.Tests
 
             // DumpAllEvents(events);
 
-            Assert.True(events.Events.Count > 0, "Expected at least one AsyncEvents event to be emitted");
-            Assert.Contains(events.Events, e => e.EventId == AsyncEventsId);
+            AssertTrue(events, events.Events.Count > 0, "Expected at least one AsyncEvents event to be emitted");
+            AssertContains(events, events.Events, e => e.EventId == AsyncEventsId);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -263,15 +263,15 @@ namespace System.Threading.Tasks.Tests
 
             // Find our context via marker callstack.
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendResumeCompleteEvents_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
-            Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncContext, ids);
-            Assert.Contains(AsyncEventID.RuntimeAsync_SuspendAsyncContext, ids);
-            Assert.Contains(AsyncEventID.RuntimeAsync_CompleteAsyncContext, ids);
+            AssertContains(stream, AsyncEventID.RuntimeAsync_ResumeAsyncContext, ids);
+            AssertContains(stream, AsyncEventID.RuntimeAsync_SuspendAsyncContext, ids);
+            AssertContains(stream, AsyncEventID.RuntimeAsync_CompleteAsyncContext, ids);
         }
 
 
@@ -294,18 +294,18 @@ namespace System.Threading.Tasks.Tests
 
             // Find events in the context that contains our marker method.
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ContextEventIdLifecycle_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
-            Assert.True(dispatcherId > 0, "DispatcherId should be non-zero");
+            AssertTrue(stream, dispatcherId > 0, "DispatcherId should be non-zero");
 
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext in context events");
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext in context events");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after CreateAsyncContext");
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
@@ -317,8 +317,8 @@ namespace System.Threading.Tasks.Tests
 
             var ids = ParseAllEvents(events).EventIds;
 
-            Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncMethod, ids);
-            Assert.Contains(AsyncEventID.RuntimeAsync_CompleteAsyncMethod, ids);
+            AssertContains(events, AsyncEventID.RuntimeAsync_ResumeAsyncMethod, ids);
+            AssertContains(events, AsyncEventID.RuntimeAsync_CompleteAsyncMethod, ids);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -340,7 +340,7 @@ namespace System.Threading.Tasks.Tests
 
             // Find our context via marker callstack.
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_EventSequenceOrder_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
@@ -348,16 +348,16 @@ namespace System.Threading.Tasks.Tests
 
             // Verify the expected lifecycle sequence exists in order.
             int resumeIdx1 = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext);
-            Assert.True(resumeIdx1 >= 0, "Expected first ResumeAsyncContext");
+            AssertTrue(stream, resumeIdx1 >= 0, "Expected first ResumeAsyncContext");
 
             int suspendIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_SuspendAsyncContext, resumeIdx1 + 1);
-            Assert.True(suspendIdx > resumeIdx1, "Expected SuspendAsyncContext after first Resume");
+            AssertTrue(stream, suspendIdx > resumeIdx1, "Expected SuspendAsyncContext after first Resume");
 
             int resumeIdx2 = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, suspendIdx + 1);
-            Assert.True(resumeIdx2 > suspendIdx, "Expected second ResumeAsyncContext after Suspend");
+            AssertTrue(stream, resumeIdx2 > suspendIdx, "Expected second ResumeAsyncContext after Suspend");
 
             int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx2 + 1);
-            Assert.True(completeIdx > resumeIdx2, "Expected CompleteAsyncContext after second Resume");
+            AssertTrue(stream, completeIdx > resumeIdx2, "Expected CompleteAsyncContext after second Resume");
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
@@ -368,7 +368,7 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             var ids = ParseAllEvents(events).EventIds;
-            Assert.Contains(AsyncEventID.RuntimeAsync_CreateAsyncContext, ids);
+            AssertContains(events, AsyncEventID.RuntimeAsync_CreateAsyncContext, ids);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -388,8 +388,8 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             var createCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateAsyncCallstackEmittedOnFirstAwait_Marker));
 
-            Assert.NotEmpty(createCallstacks);
-            Assert.All(createCallstacks, cs =>
+            AssertNotEmpty(stream, createCallstacks);
+            AssertAll(stream, createCallstacks, cs =>
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in create callstack");
                 Assert.True(cs.DispatcherId != 0, "Expected non-zero dispatcher ID in create callstack");
@@ -417,9 +417,10 @@ namespace System.Threading.Tasks.Tests
 
             // The expected [NoInlining] frames in order (innermost first):
             // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> RuntimeAsync_CreateCallstackDepthMatchesChain_Marker
-            Assert.NotEmpty(createCallstacks);
+            AssertNotEmpty(stream, createCallstacks);
             string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_ChainedYield), nameof(RuntimeAsync_CreateCallstackDepthMatchesChain_Marker)];
-            Assert.True(
+            AssertTrue(
+                stream,
                 HasCallstackWithExpectedFrames(createCallstacks, expectedFrames),
                 $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
         }
@@ -442,8 +443,8 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             var suspendCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendAsyncCallstackEmittedOnAwait_Marker));
 
-            Assert.NotEmpty(suspendCallstacks);
-            Assert.All(suspendCallstacks, cs =>
+            AssertNotEmpty(stream, suspendCallstacks);
+            AssertAll(stream, suspendCallstacks, cs =>
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in suspend callstack");
                 Assert.True(cs.DispatcherId != 0, "Expected non-zero dispatcher ID in suspend callstack");
@@ -471,9 +472,10 @@ namespace System.Threading.Tasks.Tests
 
             // The expected [NoInlining] frames in order (innermost first):
             // RuntimeAsync_InnerYield -> RuntimeAsync_ChainedYield -> RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker
-            Assert.NotEmpty(suspendCallstacks);
+            AssertNotEmpty(stream, suspendCallstacks);
             string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_ChainedYield), nameof(RuntimeAsync_SuspendCallstackDepthMatchesChain_Marker)];
-            Assert.True(
+            AssertTrue(
+                stream,
                 HasCallstackWithExpectedFrames(suspendCallstacks, expectedFrames),
                 $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
         }
@@ -497,10 +499,10 @@ namespace System.Threading.Tasks.Tests
 
             // Find the suspend callstack via marker to get the context ID
             var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackPrecedesComplete_Marker));
-            Assert.NotEmpty(suspendStacks);
+            AssertNotEmpty(stream, suspendStacks);
 
             ulong dispatcherId = suspendStacks[0].DispatcherId;
-            Assert.True(dispatcherId > 0, "Expected non-zero dispatcher ID");
+            AssertTrue(stream, dispatcherId > 0, "Expected non-zero dispatcher ID");
 
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var ids = taskEvts.Select(e => e.EventId).ToList();
@@ -508,9 +510,9 @@ namespace System.Threading.Tasks.Tests
             int suspendIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack);
             int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext);
 
-            Assert.True(suspendIdx >= 0, "Expected SuspendAsyncCallstack in context events");
-            Assert.True(completeIdx >= 0, "Expected CompleteAsyncContext in context events");
-            Assert.True(suspendIdx < completeIdx, $"SuspendAsyncCallstack (index {suspendIdx}) should precede CompleteAsyncContext (index {completeIdx})");
+            AssertTrue(stream, suspendIdx >= 0, "Expected SuspendAsyncCallstack in context events");
+            AssertTrue(stream, completeIdx >= 0, "Expected CompleteAsyncContext in context events");
+            AssertTrue(stream, suspendIdx < completeIdx, $"SuspendAsyncCallstack (index {suspendIdx}) should precede CompleteAsyncContext (index {completeIdx})");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -532,14 +534,14 @@ namespace System.Threading.Tasks.Tests
             var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
             var suspendStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_SuspendAsyncCallstack, nameof(RuntimeAsync_SuspendCallstackDeeperThanInitialResume_Marker));
 
-            Assert.NotEmpty(resumeStacks);
-            Assert.NotEmpty(suspendStacks);
+            AssertNotEmpty(stream, resumeStacks);
+            AssertNotEmpty(stream, suspendStacks);
 
             // First resume (after initial Yield) should be shallow, first suspend (RuntimeAsync_InnerYield's Yield) should be deeper
             var firstResume = resumeStacks[0];
             var firstSuspend = suspendStacks[0];
 
-            Assert.True(firstSuspend.FrameCount > firstResume.FrameCount, $"First suspend callstack depth ({firstSuspend.FrameCount}) should be deeper than first resume callstack depth ({firstResume.FrameCount})");
+            AssertTrue(stream, firstSuspend.FrameCount > firstResume.FrameCount, $"First suspend callstack depth ({firstSuspend.FrameCount}) should be deeper than first resume callstack depth ({firstResume.FrameCount})");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -561,8 +563,8 @@ namespace System.Threading.Tasks.Tests
             var createStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
             var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CreateCallstackPrecedesResumeCallstack_Marker));
 
-            Assert.NotEmpty(createStacks);
-            Assert.NotEmpty(resumeStacks);
+            AssertNotEmpty(stream, createStacks);
+            AssertNotEmpty(stream, resumeStacks);
 
             // For each task that has both Create and Resume callstacks, verify Create timestamp precedes Resume.
             int matchedPairs = 0;
@@ -573,10 +575,10 @@ namespace System.Threading.Tasks.Tests
                     continue;
 
                 matchedPairs++;
-                Assert.True(create.Timestamp <= matchingResume.Timestamp, $"For dispatcher {create.DispatcherId}: CreateAsyncCallstack (ts {create.Timestamp}) should precede ResumeAsyncCallstack (ts {matchingResume.Timestamp})");
+                AssertTrue(stream, create.Timestamp <= matchingResume.Timestamp, $"For dispatcher {create.DispatcherId}: CreateAsyncCallstack (ts {create.Timestamp}) should precede ResumeAsyncCallstack (ts {matchingResume.Timestamp})");
             }
 
-            Assert.True(matchedPairs >= 1, $"Expected at least one matching Create/Resume callstack pair, but found {matchedPairs}");
+            AssertTrue(stream, matchedPairs >= 1, $"Expected at least one matching Create/Resume callstack pair, but found {matchedPairs}");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -598,8 +600,8 @@ namespace System.Threading.Tasks.Tests
             var createStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_CreateAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
             var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CreateAndFirstResumeCallstacksMatch_Marker));
 
-            Assert.NotEmpty(createStacks);
-            Assert.NotEmpty(resumeStacks);
+            AssertNotEmpty(stream, createStacks);
+            AssertNotEmpty(stream, resumeStacks);
 
             // For each create callstack, find the first resume with the same dispatcher ID and verify frames match.
             int matchedPairs = 0;
@@ -610,14 +612,14 @@ namespace System.Threading.Tasks.Tests
                     continue;
 
                 matchedPairs++;
-                Assert.Equal(create.Frames.Count, matchingResume.Frames.Count);
+                AssertEqual(stream, create.Frames.Count, matchingResume.Frames.Count);
                 for (int i = 0; i < create.Frames.Count; i++)
                 {
-                    Assert.Equal(create.Frames[i].MethodId, matchingResume.Frames[i].MethodId);
+                    AssertEqual(stream, create.Frames[i].MethodId, matchingResume.Frames[i].MethodId);
                 }
             }
 
-            Assert.True(matchedPairs >= 1, $"Expected at least one matching Create/Resume callstack pair, but found {matchedPairs}");
+            AssertTrue(stream, matchedPairs >= 1, $"Expected at least one matching Create/Resume callstack pair, but found {matchedPairs}");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -638,8 +640,8 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackEmittedOnResume_Marker));
 
-            Assert.NotEmpty(callstacks);
-            Assert.All(callstacks, cs =>
+            AssertNotEmpty(stream, callstacks);
+            AssertAll(stream, callstacks, cs =>
             {
                 Assert.True(cs.FrameCount > 0, "Expected at least one frame in callstack");
                 Assert.True(cs.DispatcherId != 0, "Expected non-zero dispatcher ID in resume callstack");
@@ -667,9 +669,10 @@ namespace System.Threading.Tasks.Tests
 
             // The expected [NoInlining] frames in order (innermost first):
             // RuntimeAsync_InnerYield -> RuntimeAsync_CallstackDepthMatchesChain_Marker
-            Assert.NotEmpty(callstacks);
+            AssertNotEmpty(stream, callstacks);
             string[] expectedFrames = [nameof(RuntimeAsync_InnerYield), nameof(RuntimeAsync_CallstackDepthMatchesChain_Marker)];
-            Assert.True(
+            AssertTrue(
+                stream,
                 HasCallstackWithExpectedFrames(callstacks, expectedFrames),
                 $"Expected callstack to contain frames [{string.Join(", ", expectedFrames)}] in order");
         }
@@ -694,18 +697,18 @@ namespace System.Threading.Tasks.Tests
             const int ExpectedChainDepth = 5;
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_MethodEventCountMatchesChainDepth_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
-            Assert.Equal(ExpectedChainDepth, markerCallstacks[0].Frames.Count);
+            AssertEqual(stream, ExpectedChainDepth, markerCallstacks[0].Frames.Count);
 
             ulong chainDispatcherId = markerCallstacks[0].DispatcherId;
             var chainEvents = stream.ChainEventsFromDispatcher(chainDispatcherId);
 
             int resumeCount = chainEvents.Count(e => e.EventId == AsyncEventID.RuntimeAsync_ResumeAsyncMethod);
-            Assert.Equal(ExpectedChainDepth, resumeCount);
+            AssertEqual(stream, ExpectedChainDepth, resumeCount);
 
             int completeCount = chainEvents.Count(e => e.EventId == AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
-            Assert.Equal(ExpectedChainDepth, completeCount);
+            AssertEqual(stream, ExpectedChainDepth, completeCount);
         }
 
         [RuntimeAsyncMethodGeneration(true)]
@@ -725,12 +728,12 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackFramesHaveDistinctMethodIds_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Frames in the same callstack should have distinct methodIds (one per async method in the chain).
             var deepest = markerCallstacks.MaxBy(cs => cs.FrameCount)!;
             var methodIds = deepest.Frames.Select(f => f.MethodId).ToList();
-            Assert.Equal(methodIds.Count, methodIds.Distinct().Count());
+            AssertEqual(stream, methodIds.Count, methodIds.Distinct().Count());
         }
 
         [RuntimeAsyncMethodGeneration(true)]
@@ -778,9 +781,9 @@ namespace System.Threading.Tasks.Tests
             // After Task.Delay resumes: full chain (Level3, Level2, Level1, Marker) = 4 frames
             // After Level3's yield resumes: Level3 completes, chain is (Level2, Level1, Marker) = 3 frames
             // After Level2's yield resumes: Level2 completes, chain is (Level1, Marker) = 2 frames
-            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 4);
-            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 3);
-            Assert.Contains(markerCallstacks, cs => cs.FrameCount == 2);
+            AssertContains(stream, markerCallstacks, cs => cs.FrameCount == 4);
+            AssertContains(stream, markerCallstacks, cs => cs.FrameCount == 3);
+            AssertContains(stream, markerCallstacks, cs => cs.FrameCount == 2);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -880,22 +883,22 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
             var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_UnhandledExceptionUnwind_Marker));
-            Assert.NotEmpty(resumeStacks);
+            AssertNotEmpty(stream, resumeStacks);
 
             ulong dispatcherId = resumeStacks[0].DispatcherId;
 
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var eventIds = taskEvts.Select(e => e.EventId).ToList();
 
-            Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
-            Assert.Contains(AsyncEventID.RuntimeAsync_UnwindAsyncException, eventIds);
-            Assert.Contains(AsyncEventID.RuntimeAsync_CompleteAsyncContext, eventIds);
+            AssertContains(stream, AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
+            AssertContains(stream, AsyncEventID.RuntimeAsync_UnwindAsyncException, eventIds);
+            AssertContains(stream, AsyncEventID.RuntimeAsync_CompleteAsyncContext, eventIds);
 
             // Verify unwind frame count for this task
             // Marker -> RuntimeAsync_DeepUnhandledOuter -> RuntimeAsync_DeepUnhandledMiddle -> RuntimeAsync_DeepUnhandledInnerThrows, 4 frames deep after the initial resume.
             var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.RuntimeAsync_UnwindAsyncException).ToList();
-            Assert.NotEmpty(unwindEvents);
-            Assert.All(unwindEvents, e => Assert.Equal(4u, e.UnwindFrameCount));
+            AssertNotEmpty(stream, unwindEvents);
+            AssertAll(stream, unwindEvents, e => Assert.Equal(4u, e.UnwindFrameCount));
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -914,22 +917,22 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
             var resumeStacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_HandledExceptionUnwind_Marker));
-            Assert.NotEmpty(resumeStacks);
+            AssertNotEmpty(stream, resumeStacks);
 
             ulong dispatcherId = resumeStacks[0].DispatcherId;
 
             var taskEvts = stream.ChainEventsFromDispatcher(dispatcherId);
             var eventIds = taskEvts.Select(e => e.EventId).ToList();
 
-            Assert.Contains(AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
-            Assert.Contains(AsyncEventID.RuntimeAsync_UnwindAsyncException, eventIds);
-            Assert.Contains(AsyncEventID.RuntimeAsync_CompleteAsyncContext, eventIds);
+            AssertContains(stream, AsyncEventID.RuntimeAsync_ResumeAsyncContext, eventIds);
+            AssertContains(stream, AsyncEventID.RuntimeAsync_UnwindAsyncException, eventIds);
+            AssertContains(stream, AsyncEventID.RuntimeAsync_CompleteAsyncContext, eventIds);
 
             // Verify unwind frame count for this task
             // RuntimeAsync_DeepMiddle -> RuntimeAsync_DeepInnerThrows, 2 frames deep after the initial resume.
             var unwindEvents = taskEvts.Where(e => e.EventId == AsyncEventID.RuntimeAsync_UnwindAsyncException).ToList();
-            Assert.NotEmpty(unwindEvents);
-            Assert.All(unwindEvents, e => Assert.Equal(2u, e.UnwindFrameCount));
+            AssertNotEmpty(stream, unwindEvents);
+            AssertAll(stream, unwindEvents, e => Assert.Equal(2u, e.UnwindFrameCount));
         }
 
         // Requires threading:
@@ -954,16 +957,16 @@ namespace System.Threading.Tasks.Tests
 
             // DumpAllEvents(events);
 
-            Assert.True(captures.Count == 3, $"Expected 3 wrapper captures, got {captures.Count}");
+            AssertTrue(events, captures.Count == 3, $"Expected 3 wrapper captures, got {captures.Count}");
 
-            Assert.All(captures, c => Assert.True(c.WrapperSlot >= 0, $"{c.MethodName} did not find wrapper frame on stack (slot={c.WrapperSlot})"));
+            AssertAll(events, captures, c => Assert.True(c.WrapperSlot >= 0, $"{c.MethodName} did not find wrapper frame on stack (slot={c.WrapperSlot})"));
 
             int slotC = captures.First(c => c.MethodName == nameof(RuntimeAsync_WrapperTestC)).WrapperSlot;
             int slotB = captures.First(c => c.MethodName == nameof(RuntimeAsync_WrapperTestB)).WrapperSlot;
             int slotA = captures.First(c => c.MethodName == nameof(RuntimeAsync_WrapperTestA)).WrapperSlot;
 
-            Assert.Equal(slotC + 1, slotB);
-            Assert.Equal(slotB + 1, slotA);
+            AssertEqual(events, slotC + 1, slotB);
+            AssertEqual(events, slotB + 1, slotA);
         }
 
         // Requires threading:
@@ -985,7 +988,7 @@ namespace System.Threading.Tasks.Tests
 
             var ids = ParseAllEvents(events).EventIds;
 
-            Assert.Contains(AsyncEventID.ResetAsyncContinuationWrapperIndex, ids);
+            AssertContains(events, AsyncEventID.ResetAsyncContinuationWrapperIndex, ids);
         }
 
         // Requires threading:
@@ -1007,7 +1010,7 @@ namespace System.Threading.Tasks.Tests
 
             var ids = ParseAllEvents(events).EventIds;
 
-            Assert.DoesNotContain(AsyncEventID.ResetAsyncContinuationWrapperIndex, ids);
+            AssertDoesNotContain(events, AsyncEventID.ResetAsyncContinuationWrapperIndex, ids);
         }
 
         // Requires threading:
@@ -1048,7 +1051,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             int coreEventCount = stream.EventIds.Count(id => IsRequestedEvent(id));
 
-            Assert.True(coreEventCount > 0, "Expected periodic timer to flush buffer with core lifecycle events");
+            AssertTrue(stream, coreEventCount > 0, "Expected periodic timer to flush buffer with core lifecycle events");
         }
 
         // Requires threading:
@@ -1144,15 +1147,15 @@ namespace System.Threading.Tasks.Tests
 
             // DumpAllEvents(events);
 
-            Assert.True(workerOsThreadId != 0, "Failed to capture worker OS thread ID");
+            AssertTrue(events, workerOsThreadId != 0, "Failed to capture worker OS thread ID");
 
             // The key assertion: find buffers that contain CreateAsyncContext events (our work batches).
             // There must be at least 2 such buffers (one per RuntimeAsync_SingleYield() call), and ALL of them must
             // have the worker's OsThreadId - proving the timer flush didn't corrupt the header.
             var stream = ParseAllEvents(events);
             var createEvents = stream.OfType(AsyncEventID.RuntimeAsync_CreateAsyncContext).ToList();
-            Assert.True(createEvents.Count >= 2, $"Expected at least 2 CreateAsyncContext events from the worker thread, got {createEvents.Count}");
-            Assert.All(createEvents, e => Assert.Equal(workerOsThreadId, e.OsThreadId));
+            AssertTrue(stream, createEvents.Count >= 2, $"Expected at least 2 CreateAsyncContext events from the worker thread, got {createEvents.Count}");
+            AssertAll(stream, createEvents, e => Assert.Equal(workerOsThreadId, e.OsThreadId));
         }
 
         // Requires threading:
@@ -1203,7 +1206,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             int coreEventCount = stream.EventIds.Count(id => IsRequestedEvent(id));
 
-            Assert.True(coreEventCount > 0, "Expected periodic timer to flush dead thread's buffer");
+            AssertTrue(stream, coreEventCount > 0, "Expected periodic timer to flush dead thread's buffer");
         }
 
         // This test is sensitive to event noise - it asserts a specific clock event is absent.
@@ -1216,7 +1219,7 @@ namespace System.Threading.Tasks.Tests
 
             var ids = ParseAllEvents(events).EventIds;
 
-            Assert.DoesNotContain(AsyncEventID.AsyncProfilerSyncClock, ids);
+            AssertDoesNotContain(events, AsyncEventID.AsyncProfilerSyncClock, ids);
         }
 
         // This test is sensitive to event noise - it asserts zero context events appear
@@ -1241,7 +1244,7 @@ namespace System.Threading.Tasks.Tests
 
             int contextEvents = ids.Count(id => id == AsyncEventID.RuntimeAsync_ResumeAsyncContext || id == AsyncEventID.RuntimeAsync_SuspendAsyncContext || id == AsyncEventID.RuntimeAsync_CompleteAsyncContext);
 
-            Assert.Equal(0, contextEvents);
+            AssertEqual(events, 0, contextEvents);
         }
 
         public static IEnumerable<object[]> KeywordGatekeepingData()
@@ -1287,7 +1290,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
             var unexpected = stream.EventIds.Where(id => !allowed.Contains(id)).ToList();
 
-            Assert.True(unexpected.Count == 0, $"Keyword 0x{(long)kw:X}: unexpected event IDs [{string.Join(", ", unexpected)}], " + $"allowed [{string.Join(", ", allowed)}]");
+            AssertTrue(stream, unexpected.Count == 0, $"Keyword 0x{(long)kw:X}: unexpected event IDs [{string.Join(", ", unexpected)}], " + $"allowed [{string.Join(", ", allowed)}]");
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
@@ -1299,7 +1302,7 @@ namespace System.Threading.Tasks.Tests
 
             var ids = ParseAllEvents(events).EventIds;
 
-            Assert.Contains(AsyncEventID.ResetAsyncThreadContext, ids);
+            AssertContains(events, AsyncEventID.ResetAsyncThreadContext, ids);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncSupported))]
@@ -1311,14 +1314,14 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
             var metadataList = stream.MetadataEvents;
-            Assert.True(metadataList.Count >= 1, "Expected at least one metadata event in buffer");
+            AssertTrue(stream, metadataList.Count >= 1, "Expected at least one metadata event in buffer");
 
             MetadataFromBuffer meta = metadataList[0];
-            Assert.True(meta.QpcFrequency > 0, $"QPC frequency should be positive, got {meta.QpcFrequency}");
-            Assert.True(meta.QpcSync > 0, $"QPC sync timestamp should be positive, got {meta.QpcSync}");
-            Assert.True(meta.UtcSync > 0, $"UTC sync timestamp should be positive, got {meta.UtcSync}");
-            Assert.True(meta.EventBufferSize > 0, $"Event buffer size should be positive, got {meta.EventBufferSize}");
-            Assert.True(meta.WrapperCount > 0, "Wrapper count should be positive");
+            AssertTrue(stream, meta.QpcFrequency > 0, $"QPC frequency should be positive, got {meta.QpcFrequency}");
+            AssertTrue(stream, meta.QpcSync > 0, $"QPC sync timestamp should be positive, got {meta.QpcSync}");
+            AssertTrue(stream, meta.UtcSync > 0, $"UTC sync timestamp should be positive, got {meta.UtcSync}");
+            AssertTrue(stream, meta.EventBufferSize > 0, $"Event buffer size should be positive, got {meta.EventBufferSize}");
+            AssertTrue(stream, meta.WrapperCount > 0, "Wrapper count should be positive");
         }
 
         // Requires threading:
@@ -1349,7 +1352,7 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
             var metadataList = stream.MetadataEvents;
-            Assert.True(metadataList.Count == 1, $"Expected exactly 1 metadata event across {threadCount} threads, got {metadataList.Count}");
+            AssertTrue(stream, metadataList.Count == 1, $"Expected exactly 1 metadata event across {threadCount} threads, got {metadataList.Count}");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -1373,12 +1376,12 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
             var callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CallstackNativeIPDeltaRoundtrip_Marker));
-            Assert.NotEmpty(callstacks);
+            AssertNotEmpty(stream, callstacks);
 
             // Find callstacks with 3+ frames -- enough depth for meaningful deltas.
             var deepCallstacks = callstacks.Where(cs => cs.FrameCount >= 3).ToList();
 
-            Assert.True(deepCallstacks.Count > 0, "Expected at least one callstack with 3+ frames for delta verification");
+            AssertTrue(stream, deepCallstacks.Count > 0, "Expected at least one callstack with 3+ frames for delta verification");
 
             bool hasPositiveDelta = false;
             bool hasNegativeDelta = false;
@@ -1388,10 +1391,10 @@ namespace System.Threading.Tasks.Tests
                 for (int i = 0; i < cs.Frames.Count; i++)
                 {
                     var (methodId, _) = cs.Frames[i];
-                    Assert.True(methodId != 0, $"Frame {i} has zero MethodId");
+                    AssertTrue(stream, methodId != 0, $"Frame {i} has zero MethodId");
 
                     var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
-                    Assert.True(method is not null, $"Frame {i}: MethodId 0x{methodId:X} does not resolve to a managed method");
+                    AssertTrue(stream, method is not null, $"Frame {i}: MethodId 0x{methodId:X} does not resolve to a managed method");
 
                     if (i > 0)
                     {
@@ -1408,7 +1411,7 @@ namespace System.Threading.Tasks.Tests
             // both positive and negative deltas. If the JIT happens to lay out all
             // methods monotonically (extremely unlikely), at minimum we must see
             // non-zero deltas proving the encoding works.
-            Assert.True(hasPositiveDelta || hasNegativeDelta, "Expected at least one non-zero NativeIP delta across all callstack frames");
+            AssertTrue(stream, hasPositiveDelta || hasNegativeDelta, "Expected at least one non-zero NativeIP delta across all callstack frames");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -1452,34 +1455,34 @@ namespace System.Threading.Tasks.Tests
             // Verify all callstacks have valid frame data that resolves to managed methods.
             foreach (var cs in callstacks)
             {
-                Assert.True(cs.FrameCount > 0, "Callstack has 0 frames");
-                Assert.Equal((int)cs.FrameCount, cs.Frames.Count);
+                AssertTrue(stream, cs.FrameCount > 0, "Callstack has 0 frames");
+                AssertEqual(stream, (int)cs.FrameCount, cs.Frames.Count);
                 for (int f = 0; f < cs.Frames.Count; f++)
                 {
                     var (methodId, _) = cs.Frames[f];
-                    Assert.True(methodId != 0, $"Frame {f} has zero MethodId");
+                    AssertTrue(stream, methodId != 0, $"Frame {f} has zero MethodId");
 
                     var method = GetMethodNameFromMethodId(cs.CallstackType, methodId);
-                    Assert.True(method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
+                    AssertTrue(stream, method is not null, $"Frame {f}: MethodId 0x{methodId:X} does not resolve to a managed method");
                 }
             }
 
             // One resume callstack per iteration (marker filters out noise).
             // lambda -> Marker -> RuntimeAsync_RecursiveChain(d) produces d + 2 frames.
-            Assert.True(callstacks.Count >= iterations, $"Expected at least {iterations} callstacks with marker, got {callstacks.Count}");
+            AssertTrue(stream, callstacks.Count >= iterations, $"Expected at least {iterations} callstacks with marker, got {callstacks.Count}");
 
             for (int i = 0; i < iterations; i++)
             {
                 // lambda + Marker + RuntimeAsync_RecursiveChain(d) = d + 2
                 int expected = depths[i] + 2;
                 int actual = callstacks[i].FrameCount;
-                Assert.True(actual == expected, $"Iteration {i}: expected depth {expected} (lambda -> Marker -> RuntimeAsync_RecursiveChain({depths[i]})), got {actual}");
+                AssertTrue(stream, actual == expected, $"Iteration {i}: expected depth {expected} (lambda -> Marker -> RuntimeAsync_RecursiveChain({depths[i]})), got {actual}");
             }
 
             // Verify multiple buffer flushes occurred.
             int bufferCount = 0;
             ForEachEventBufferPayload(events, _ => bufferCount++);
-            Assert.True(bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
+            AssertTrue(stream, bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
         }
 
         // Requires threading:
@@ -1645,22 +1648,22 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
             var callstacks = stream.OfType(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack).ToList();
-            Assert.True(callstacks.Count >= 1, "Expected at least one callstack");
+            AssertTrue(stream, callstacks.Count >= 1, "Expected at least one callstack");
 
             // Find the callstack from our deep RuntimeAsync_RecursiveChain call.
             // The max frame count is capped at 255 (byte.MaxValue) since the
             // CaptureRuntimeAsyncCallstackState.Count is a byte.
             // RuntimeAsync_RecursiveChain(300) + 1 lambda = 301 frames, capped to 255.
             var deepest = callstacks.MaxBy(cs => cs.FrameCount);
-            Assert.Equal(255, (int)deepest!.FrameCount);
-            Assert.Equal((int)deepest.FrameCount, deepest.Frames.Count);
+            AssertEqual(stream, 255, (int)deepest!.FrameCount);
+            AssertEqual(stream, (int)deepest.FrameCount, deepest.Frames.Count);
 
             // Verify all frames are valid.
             foreach (var (methodId, _) in deepest.Frames)
             {
-                Assert.True(methodId != 0, "Frame has zero MethodId");
+                AssertTrue(stream, methodId != 0, "Frame has zero MethodId");
                 var method = GetMethodNameFromMethodId(deepest.CallstackType, methodId);
-                Assert.True(method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
+                AssertTrue(stream, method is not null, $"MethodId 0x{methodId:X} does not resolve to a managed method");
             }
         }
 
@@ -1671,10 +1674,10 @@ namespace System.Threading.Tasks.Tests
 
             var stream = ParseAllEvents(events);
             var metadataList = stream.MetadataEvents;
-            Assert.True(metadataList.Count >= 1, "Expected at least one metadata event in buffer");
+            AssertTrue(stream, metadataList.Count >= 1, "Expected at least one metadata event in buffer");
 
             MetadataFromBuffer meta = metadataList[0];
-            Assert.True(meta.WrapperCount > 0, "Expected positive wrapper count in metadata");
+            AssertTrue(stream, meta.WrapperCount > 0, "Expected positive wrapper count in metadata");
 
             // On CoreCLR, verify via reflection that the contract-defined template produces names matching real methods.
             // This catches accidental renames of wrapper methods without updating the contract.
@@ -1682,19 +1685,19 @@ namespace System.Threading.Tasks.Tests
             {
                 Type? wrapperType = typeof(System.Runtime.CompilerServices.AsyncTaskMethodBuilder)
                     .Assembly.GetType("System.Runtime.CompilerServices.AsyncProfiler+ContinuationWrapper");
-                Assert.NotNull(wrapperType);
+                AssertNotNull(stream, wrapperType);
                 for (int i = 0; i < meta.WrapperCount; i++)
                 {
                     string expectedName = string.Format(WrapperNameTemplate, i);
                     var method = wrapperType.GetMethod(expectedName,
                         System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
-                    Assert.True(method is not null, $"Expected method '{expectedName}' not found on ContinuationWrapper type");
+                    AssertTrue(stream, method is not null, $"Expected method '{expectedName}' not found on ContinuationWrapper type");
                 }
 
                 // Verify that the wrapper count matches the actual number of wrapper methods on the type.
                 int actualCount = wrapperType.GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public)
                     .Count(m => m.Name.StartsWith(WrapperNamePrefix, StringComparison.Ordinal));
-                Assert.Equal(meta.WrapperCount, actualCount);
+                AssertEqual(stream, meta.WrapperCount, actualCount);
             }
         }
 
@@ -1740,15 +1743,15 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Each branch is its own async chain; its inner await of Task.Yield produces a Resume callstack containing the branch frame.
             var branchACallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
             var branchBCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchB_Marker));
             var branchCCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchC_Marker));
-            Assert.NotEmpty(branchACallstacks);
-            Assert.NotEmpty(branchBCallstacks);
-            Assert.NotEmpty(branchCCallstacks);
+            AssertNotEmpty(stream, branchACallstacks);
+            AssertNotEmpty(stream, branchBCallstacks);
+            AssertNotEmpty(stream, branchCCallstacks);
 
             // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own DispatcherId.
             AssertExactlyOneCreateAndComplete(stream, branchACallstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAll_TracksAllBranches_BranchA_Marker));
@@ -1762,10 +1765,10 @@ namespace System.Threading.Tasks.Tests
 
             int createIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             int resumeIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create on the outer marker");
 
             int completeIdx = markerIds.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume on the outer marker");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -1811,16 +1814,16 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // All branches - including the slow ones whose completion the outer is no longer
             // strictly waiting on after WhenAny returned - must produce their own Resume callstacks.
             var fastCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
             var slow1Callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow1_Marker));
             var slow2Callstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Slow2_Marker));
-            Assert.NotEmpty(fastCallstacks);
-            Assert.NotEmpty(slow1Callstacks);
-            Assert.NotEmpty(slow2Callstacks);
+            AssertNotEmpty(stream, fastCallstacks);
+            AssertNotEmpty(stream, slow1Callstacks);
+            AssertNotEmpty(stream, slow2Callstacks);
 
             // Each tracked chain (3 branches + outer marker) must see exactly one Create and one Complete on its own DispatcherId.
             AssertExactlyOneCreateAndComplete(stream, fastCallstacks[0].DispatcherId, nameof(RuntimeAsync_WhenAny_TracksAllBranches_Fast_Marker));
@@ -1832,7 +1835,7 @@ namespace System.Threading.Tasks.Tests
             ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
             var markerIds = stream.ChainEventsFromDispatcher(markerDispatcherId).Select(e => e.EventId).ToList();
             int resumeCountForMarker = markerIds.Count(id => id == AsyncEventID.RuntimeAsync_ResumeAsyncContext);
-            Assert.True(resumeCountForMarker >= 1, $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
+            AssertTrue(stream, resumeCountForMarker >= 1, $"Expected outer marker to be resumed at least once, got {resumeCountForMarker}");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -1866,7 +1869,7 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             var deepest = markerCallstacks.OrderByDescending(cs => cs.FrameCount).First();
 
@@ -1875,9 +1878,9 @@ namespace System.Threading.Tasks.Tests
                 .Where(n => n is not null)
                 .ToList();
 
-            Assert.Contains(nameof(RuntimeAsync_ConfigureAwaitFalse_Leaf_Marker), frameNames);
-            Assert.Contains(nameof(RuntimeAsync_ConfigureAwaitFalse_Mid_Marker), frameNames);
-            Assert.Contains(nameof(RuntimeAsync_ConfigureAwaitFalse_Marker), frameNames);
+            AssertContains(stream, nameof(RuntimeAsync_ConfigureAwaitFalse_Leaf_Marker), frameNames);
+            AssertContains(stream, nameof(RuntimeAsync_ConfigureAwaitFalse_Mid_Marker), frameNames);
+            AssertContains(stream, nameof(RuntimeAsync_ConfigureAwaitFalse_Marker), frameNames);
 
             // ConfigureAwait(false) on a sequential await chain collapses Leaf -> Mid -> Marker into one
             // continuation chain, so exactly one Create / one Complete is expected on the marker's DispatcherId.
@@ -1917,10 +1920,10 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             var innerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
-            Assert.NotEmpty(innerCallstacks);
+            AssertNotEmpty(stream, innerCallstacks);
 
             // Inner cancelled task + outer marker must each see exactly one Create and one Complete on their own DispatcherId.
             AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(RuntimeAsync_TaskCancellation_Inner_Marker));
@@ -1962,14 +1965,14 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             // The custom SyncContext should have received at least one Post for the await continuation.
-            Assert.True(s_runtimeAsyncSyncContextCtx.PostCount > 0,
+            AssertTrue(events, s_runtimeAsyncSyncContextCtx.PostCount > 0,
                 $"Expected custom SynchronizationContext to receive at least one Post, got {s_runtimeAsyncSyncContextCtx.PostCount}");
 
             var stream = ParseAllEvents(events);
 
             // The marker frame should appear in the Resume callstack.
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // The marker's chain should see exactly one Create and one Complete on its own DispatcherId.
             AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(RuntimeAsync_CustomSyncContext_EmitsContextEventsAndCallstack_Marker));
@@ -1980,10 +1983,10 @@ namespace System.Threading.Tasks.Tests
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
         [RuntimeAsyncMethodGeneration(true)]
@@ -2011,13 +2014,13 @@ namespace System.Threading.Tasks.Tests
             // DumpAllEvents(events);
 
             // The custom scheduler must have received at least one QueueTask call.
-            Assert.True(scheduler.QueuedCount >= 1,
+            AssertTrue(events, scheduler.QueuedCount >= 1,
                 $"Expected custom TaskScheduler to receive at least one QueueTask call, got {scheduler.QueuedCount}");
 
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // The marker's chain should see exactly one Create and one Complete on its own DispatcherId.
             AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(RuntimeAsync_CustomTaskScheduler_EmitsContextEventsAndCallstack_Marker));
@@ -2028,10 +2031,10 @@ namespace System.Threading.Tasks.Tests
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
             int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -2051,19 +2054,19 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_EventSequenceOrder_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, resumeIdx + 1);
-            Assert.True(completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
+            AssertTrue(stream, completeIdx > resumeIdx, "Expected CompleteAsyncContext after Resume");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -2091,8 +2094,8 @@ namespace System.Threading.Tasks.Tests
             int completeCount = methodEvents.Count(id => id == AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
 
             // Marker -> Level1 -> Level2 -> Level3
-            Assert.True(resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
-            Assert.True(completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events for ValueTask chain, got {completeCount}");
+            AssertTrue(stream, resumeCount >= 4, $"Expected at least 4 ResumeAsyncMethod events for ValueTask chain, got {resumeCount}");
+            AssertTrue(stream, completeCount >= 4, $"Expected at least 4 CompleteAsyncMethod events for ValueTask chain, got {completeCount}");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -2112,10 +2115,10 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackDepthMatchesChainDepth_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Marker -> Level1 -> Level2 -> Level3.
-            Assert.Equal(4, markerCallstacks[0].FrameCount);
+            AssertEqual(stream, 4, markerCallstacks[0].FrameCount);
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -2135,10 +2138,10 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_CallstackFramesHaveDistinctMethodIds_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             var methodIds = markerCallstacks[0].Frames.Select(f => f.MethodId).ToList();
-            Assert.Equal(methodIds.Count, methodIds.Distinct().Count());
+            AssertEqual(stream, methodIds.Count, methodIds.Distinct().Count());
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -2179,22 +2182,22 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_HandledException_EmitsUnwindAndComplete_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int unwindIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_UnwindAsyncException, resumeIdx + 1);
-            Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+            AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
             int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, unwindIdx + 1);
-            Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
+            AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
@@ -2238,22 +2241,22 @@ namespace System.Threading.Tasks.Tests
             var stream = ParseAllEvents(events);
 
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, nameof(RuntimeAsync_ValueTask_UnhandledException_EmitsUnwindAndComplete_Marker));
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             ulong dispatcherId = markerCallstacks[0].DispatcherId;
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
 
             int createIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CreateAsyncContext);
-            Assert.True(createIdx >= 0, "Expected CreateAsyncContext");
+            AssertTrue(stream, createIdx >= 0, "Expected CreateAsyncContext");
 
             int resumeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_ResumeAsyncContext, createIdx + 1);
-            Assert.True(resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
+            AssertTrue(stream, resumeIdx > createIdx, "Expected ResumeAsyncContext after Create");
 
             int unwindIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_UnwindAsyncException, resumeIdx + 1);
-            Assert.True(unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
+            AssertTrue(stream, unwindIdx > resumeIdx, "Expected UnwindAsyncException after Resume");
 
             int completeIdx = ids.IndexOf(AsyncEventID.RuntimeAsync_CompleteAsyncContext, unwindIdx + 1);
-            Assert.True(completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
+            AssertTrue(stream, completeIdx > unwindIdx, "Expected CompleteAsyncContext after Unwind");
         }
 
         [RuntimeAsyncMethodGeneration(true)]
@@ -2291,7 +2294,7 @@ namespace System.Threading.Tasks.Tests
             // Locate the V2 dispatcher driving the marker chain via its ResumeAsyncCallstack
             // events (which carry the marker frames in their callstack).
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysPendingV2Chain");
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Thread-scoped replay assertion: at least one OS thread must have seen two
             // ResetAsyncThreadContext events AND show a marker ResumeAsyncCallstack plus
@@ -2305,7 +2308,7 @@ namespace System.Threading.Tasks.Tests
                 .GroupBy(e => e.OsThreadId)
                 .Where(g => g.Count() >= 2)
                 .ToList();
-            Assert.NotEmpty(resetsByThread);
+            AssertNotEmpty(stream, resetsByThread);
 
             bool found = false;
             foreach (var threadResets in resetsByThread)
@@ -2337,7 +2340,7 @@ namespace System.Threading.Tasks.Tests
                 break;
             }
 
-            Assert.True(found,
+            AssertTrue(stream, found,
                 "Expected at least one OS thread with >= 2 ResetAsyncThreadContext events followed by a marker ResumeAsyncCallstack and matching ResumeAsyncContext.");
         }
 
@@ -2401,7 +2404,7 @@ namespace System.Threading.Tasks.Tests
 
             // The replay must emit at least one ResumeAsyncCallstack carrying a V2 marker chain.
             var markerCallstacks = stream.CallstacksWithMarker(AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplaysMultipleDispatchers");
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Decisive proof: find an OS thread where a single ResetAsyncThreadContext is
             // followed by >= 2 ResumeAsyncContext events before the next reset. A normal V2
@@ -2412,7 +2415,7 @@ namespace System.Threading.Tasks.Tests
                 .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
                 .GroupBy(e => e.OsThreadId)
                 .ToList();
-            Assert.NotEmpty(resetsByThread);
+            AssertNotEmpty(stream, resetsByThread);
 
             bool found = false;
             foreach (var threadResets in resetsByThread)
@@ -2446,7 +2449,7 @@ namespace System.Threading.Tasks.Tests
                 }
             }
 
-            Assert.True(found,
+            AssertTrue(stream, found,
                 "Expected at least one OS thread with a ResetAsyncThreadContext event " +
                 "followed by >= 2 ResumeAsyncContext events in the same reset window, " +
                 "proving the reset-replay walker traversed multiple stacked V2 dispatcher infos.");
@@ -2488,7 +2491,7 @@ namespace System.Threading.Tasks.Tests
             // Outer->Mid->Inner chain, producing a callstack carrying the marker frames).
             var markerCallstacks = stream.CallstacksWithMarker(
                 AsyncEventID.RuntimeAsync_ResumeAsyncCallstack, "RuntimeAsync_ResetContext_ReplayResumeCompleteBalance");
-            Assert.NotEmpty(markerCallstacks);
+            AssertNotEmpty(stream, markerCallstacks);
 
             // Resume/Complete balance across the replay boundary: the whole Outer->Mid->Inner chain
             // is a single V2 dispatcher whose deepest replayed callstack has N frames, so N async
@@ -2504,7 +2507,7 @@ namespace System.Threading.Tasks.Tests
             int completeMethodCount = stream.ChainEventsFromDispatcher(markerDispatcherId)
                 .Count(e => e.EventId == AsyncEventID.RuntimeAsync_CompleteAsyncMethod);
 
-            Assert.True(completeMethodCount >= deepest.FrameCount,
+            AssertTrue(stream, completeMethodCount >= deepest.FrameCount,
                 $"Expected at least {deepest.FrameCount} RuntimeAsync_CompleteAsyncMethod events across the " +
                 $"trace for marker dispatcher {markerDispatcherId} to balance the replayed callstack of depth " +
                 $"{deepest.FrameCount}, but found {completeMethodCount}.");
@@ -2583,7 +2586,7 @@ namespace System.Threading.Tasks.Tests
                 .Where(e => e.EventId == AsyncEventID.ResetAsyncThreadContext && e.OsThreadId != 0)
                 .GroupBy(e => e.OsThreadId)
                 .ToList();
-            Assert.NotEmpty(resetsByThread);
+            AssertNotEmpty(stream, resetsByThread);
 
             bool found = false;
             foreach (var threadResets in resetsByThread)
@@ -2615,7 +2618,7 @@ namespace System.Threading.Tasks.Tests
                 }
             }
 
-            Assert.True(found,
+            AssertTrue(stream, found,
                 "Expected a single ResetAsyncThreadContext window containing both a TaskAsync_ResumeAsyncContext " +
                 "(V1) and a RuntimeAsync_ResumeAsyncContext (V2), proving the reset-replay merge walker traversed " +
                 "a mixed V1+V2 chain and exercised both branches of its address-ordered recursion.");

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -2579,7 +2579,7 @@ namespace System.Threading.Tasks.Tests
             await innerDone.Task;
         }
 
-        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsRuntimeAsyncAndThreadingSupported))]
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndRuntimeAsyncAndThreadingSupported))]
         public async Task RuntimeAsync_ResetContext_ReplaysMixedV1V2ChainInAddressOrder()
         {
             var events = await CollectEventsAsync(AllKeywords, async () =>

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Threading.Tasks.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Threading.Tasks.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="System.Runtime.CompilerServices\RuntimeAsyncTests.cs" Condition="'$(RuntimeFlavor)' != 'mono'" />
     <Compile Include="System.Runtime.CompilerServices\AsyncProfilerTests.cs" Condition="'$(RuntimeFlavor)' != 'mono'" />
     <Compile Include="System.Runtime.CompilerServices\AsyncProfilerV1Tests.cs" Condition="'$(RuntimeFlavor)' != 'mono'" />
+    <Compile Include="System.Runtime.CompilerServices\AsyncProfilerV2Tests.cs" Condition="'$(RuntimeFlavor)' != 'mono'" />
     <Compile Include="System.Runtime.CompilerServices\ConfiguredAsyncDisposable.cs" />
     <Compile Include="System.Runtime.CompilerServices\ConfiguredCancelableAsyncEnumerableTests.cs" />
     <Compile Include="System.Runtime.CompilerServices\TaskAwaiterTests.cs" />

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Threading.Tasks.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Threading.Tasks.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="System.Runtime.CompilerServices\AsyncTaskMethodBuilderTests.cs" />
     <Compile Include="System.Runtime.CompilerServices\RuntimeAsyncTests.cs" Condition="'$(RuntimeFlavor)' != 'mono'" />
     <Compile Include="System.Runtime.CompilerServices\AsyncProfilerTests.cs" Condition="'$(RuntimeFlavor)' != 'mono'" />
+    <Compile Include="System.Runtime.CompilerServices\AsyncProfilerV1Tests.cs" Condition="'$(RuntimeFlavor)' != 'mono'" />
     <Compile Include="System.Runtime.CompilerServices\ConfiguredAsyncDisposable.cs" />
     <Compile Include="System.Runtime.CompilerServices\ConfiguredCancelableAsyncEnumerableTests.cs" />
     <Compile Include="System.Runtime.CompilerServices\TaskAwaiterTests.cs" />


### PR DESCRIPTION
### Summary

Enables the async profiler for the V1 TaskAsync (state-machine-based) async path. Both V1 (TaskAsync) and V2 (RuntimeAsync) now emit a uniform, well-defined event stream that downstream tools can consume without knowing which async model produced a given chain. There are smaller variations to what events V1 can support, but all-important events are supported on both async models. The callstack events are also typed, since their data will end up slightly different (Native IP only on V2 and Method Start native IP and state on V1).

PR includes extensive test suite covering both paths as well as refactoring.

### Motivation

V1 async (the C#-compiler-generated state-machine IAsyncStateMachineBox model) is the dominant async path in the wild. Until now the async profiler only instrumented the V2 (RuntimeAsync) path, so V1 chains were invisible to consumers. This PR extends the instrumentation to V1 while keeping the event stream identical in shape between the two models.

### What's in this PR

**Runtime V1 instrumentation**

 - AsyncStateMachineDispatcher — class deriving from Task<VoidTaskResult> that wraps the actual state-machine box, with per-invocation TLS-pushed state held in AsyncStateMachineDispatcherInfo (ref struct).
 - Per-dispatcher fields (LastContinuation, ReachedLastContinuation, InnerBox) track the cascade so we can emit accurate Resume, Suspend, Complete, and append events as chains grow.
 - Cooperative append mechanism: when a parent registers after a child has already started walking, the runtime emits AppendAsyncCallstack to backfill the visible chain. Three race outcomes are handled (parent-registers-before-child-completes, parent-registers-during-suspend, and the unrecoverable late-parent case which is a design limit).
 - StateMachineDiagnosticData / GetDiagnosticData plumbed through AsyncTaskMethodBuilderT, AsyncMethodBuilderCore, and IAsyncStateMachineBox to expose the walkable chain to the profiler. NativeAOT returns false from GetDiagnosticData due to lack of native method IP and state field access.
 - InstrumentCheckPoint guards at all V1 builder await-completion sites (TaskAwaiter, ValueTaskAwaiter, ConfiguredValueTaskAwaitable, YieldAwaitable, PoolingAsyncValueTaskMethodBuilderT), linked out when no event source support.

**Async profiler V1 event model**

The runtime emits Create + Resume + Suspend + Complete per dispatcher MoveNext.

Create/suspend callstacks is not emitted on V1. The continuation chain is built and finalized after emitting a create/suspend event. Create/Suspend callstacks can be calculated when parsing the whole trace since the next resume for that context will carry the callstack.

On V2, continuation chains are build and finalized before scheduled for execution. On V1 this happens in parallel and chains can end up truncated in case completion race between the thread yielding and the thread executing the resumed continuation chain. A continuation chain might also continue to build after a thread started to execute a continuation chain. To handle this a new event was added to async profiler, AppendAsyncCallstack, it can fire several times between a resume async context and its completion. This gives a parser the ability to recreate the full resumed async callstack at resume point, even if it didn't exist at that point during runtime.

**Tests**

Test files split by async model to keep each focused:

 - AsyncProfilerTests.cs — shared partial-class infrastructure: parsers, event listeners, scenario runners.
 - AsyncProfilerV1Tests.cs — tests under the TaskAsync_* prefix covering V1 scenarios.
 - AsyncProfilerV2Tests.cs — tests under the RuntimeAsync_* prefix covering V2 scenarios.

Total of 116 tests covering both V1 and V2 scenarios.

### Out of scope (follow-ups)

 - Using the AsyncInstrumentation opens up for folding existing TPL and debugger checks into the same guard. This will be handled in a follow-up PR and could offer performance improvements on existing TPL and debugger paths where async profiler co-exists.
 - Code currently uses a dispatcher box put at the head of continuation chain to push/pop needed async dispatcher info on tls. There are some code paths that are known (thread pool, default sync context and scheduler), we could optimize those paths if we knew they are always taken at create location, removing the allocation. Having that said, every continuation in the chain is allocated, so might not be a big deal in the end anyways.
 - AsyncV1 have a late attach issue, same applies to TPL. Unless we always create/enable the async dispatcher info for AsyncV1, there will be potential blind spots in the stack when doing late attach and profiler have not been enabled at startup.
 - PoolingAsyncValueTaskMethodBuilderT instrumentation, can be added later, if needed.
 - NativeAOT V1 callstack support. NativeAOT async support is already limited in tooling. Since lack of async callstacks will void the majority of scenarios, NAOT is currently not supported on V1. Could be added in future if needed
 - Run V1 tests on Mono. AsyncProfiler + V1 instrumentation builds on Mono, but currently no tests are executed. Can be revisited later.