### PR TITLE
Fix ZstandardStream truncating multi-frame zstd responses to the first frame

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
@@ -355,6 +355,22 @@ namespace System.IO.Compression
             _finished = false;
         }
 
+        /// <summary>
+        /// Clears the end-of-frame state so the decoder can continue decoding the next frame
+        /// in a stream that contains multiple concatenated Zstandard frames (valid per RFC 8878 §3).
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Interop.Zstd.ZSTD_decompressStream"/> returns 0 at the end of each frame, not at the
+        /// end of the stream, and the native context is automatically ready to begin the next frame on the
+        /// following call. Only the managed end-of-frame latch is cleared here; the native context is left
+        /// intact so window-size and dictionary settings carry over to the next frame. Must only be called
+        /// after <see cref="Decompress"/> reported <see cref="OperationStatus.Done"/>.
+        /// </remarks>
+        internal void PrepareForNextFrame()
+        {
+            _finished = false;
+        }
+
         /// <summary>References a prefix for the next decompression operation.</summary>
         /// <remarks>The prefix will be used only for the next decompression frame and will be removed when <see cref="Reset"/> is called. The referenced data must remain valid and unmodified for the duration of the decompression operation.</remarks>
         /// <exception cref="ObjectDisposedException">The decoder has been disposed.</exception>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
@@ -363,37 +363,6 @@ namespace System.IO.Compression
             _finished = false;
         }
 
-        /// <summary>
-        /// Determines whether <paramref name="framePrefix"/> starts a new Zstandard frame (versus trailing data)
-        /// by feeding it to the decoder: a valid frame magic yields <see cref="OperationStatus.NeedMoreData"/>,
-        /// anything else yields <see cref="OperationStatus.InvalidData"/>. The bytes are not consumed; on return
-        /// the session is reset, ready to decode the next frame (<see langword="true"/>) or to end the stream
-        /// (<see langword="false"/>).
-        /// </summary>
-        /// <param name="framePrefix">The four boundary bytes (a frame magic number, or trailing data).</param>
-        internal bool IsFrameStart(ReadOnlySpan<byte> framePrefix)
-        {
-            Debug.Assert(framePrefix.Length == 4);
-            EnsureNotDisposed();
-
-            // Clear the just-finished frame's latch so Decompress feeds the prefix; session-only reset keeps
-            // any dictionary and the window-size cap.
-            _context.Reset();
-            _finished = false;
-
-            Span<byte> scratch = stackalloc byte[1]; // a frame magic produces no output
-            OperationStatus status = Decompress(framePrefix, scratch, out _, out _);
-            Debug.Assert(status is OperationStatus.NeedMoreData or OperationStatus.InvalidData);
-
-            bool isFrame = status == OperationStatus.NeedMoreData;
-
-            // Reset again so the next frame decodes from a clean session; for trailing data this re-latches
-            // _finished so the stream ends without re-feeding the rejected bytes.
-            _context.Reset();
-            _finished = !isFrame;
-            return isFrame;
-        }
-
         /// <summary>References a prefix for the next decompression operation.</summary>
         /// <remarks>The prefix will be used only for the next decompression frame and will be removed when <see cref="Reset"/> is called. The referenced data must remain valid and unmodified for the duration of the decompression operation.</remarks>
         /// <exception cref="ObjectDisposedException">The decoder has been disposed.</exception>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
@@ -156,6 +156,14 @@ namespace System.IO.Compression
         /// <param name="bytesConsumed">When this method returns, contains the number of bytes consumed from the source.</param>
         /// <param name="bytesWritten">When this method returns, contains the number of bytes written to the destination.</param>
         /// <returns>An <see cref="OperationStatus"/> indicating the result of the operation.</returns>
+        /// <remarks>
+        /// <see cref="OperationStatus.Done"/> marks the end of a single Zstandard frame, which is not
+        /// necessarily the end of the input: a stream may be several frames concatenated back-to-back
+        /// (RFC 8878 section 3). It can be returned with <paramref name="bytesWritten"/> equal to zero (for example,
+        /// a frame whose content is empty), so a caller decoding a concatenated stream must not treat a
+        /// zero-length <see cref="OperationStatus.Done"/> as the end of the input while data remains. To
+        /// continue with the following frame, call <see cref="Reset"/> and then <see cref="Decompress"/> again.
+        /// </remarks>
         /// <exception cref="ObjectDisposedException">The decoder has been disposed.</exception>
         /// <exception cref="IOException">An error occurred during decompression.</exception>
         public OperationStatus Decompress(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
@@ -345,6 +353,13 @@ namespace System.IO.Compression
         }
 
         /// <summary>Resets the decoder session, allowing reuse for the next decompression operation.</summary>
+        /// <remarks>
+        /// This also readies the decoder for the next frame of a stream that contains multiple Zstandard
+        /// frames concatenated back-to-back (RFC 8878 section 3), after <see cref="Decompress"/> has reported
+        /// <see cref="OperationStatus.Done"/> for the previous frame. The reset is session-only: the window
+        /// size and any referenced dictionary are preserved, while a single-use prefix set via
+        /// <see cref="SetPrefix"/> is released.
+        /// </remarks>
         /// <exception cref="ObjectDisposedException">The decoder has been disposed.</exception>
         /// <exception cref="IOException">Failed to reset the decoder session.</exception>
         public void Reset()
@@ -352,22 +367,6 @@ namespace System.IO.Compression
             EnsureNotDisposed();
 
             _context.Reset();
-            _finished = false;
-        }
-
-        /// <summary>
-        /// Clears the end-of-frame state so the decoder can continue decoding the next frame
-        /// in a stream that contains multiple concatenated Zstandard frames (valid per RFC 8878 §3).
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Interop.Zstd.ZSTD_decompressStream"/> returns 0 at the end of each frame, not at the
-        /// end of the stream, and the native context is automatically ready to begin the next frame on the
-        /// following call. Only the managed end-of-frame latch is cleared here; the native context is left
-        /// intact so window-size and dictionary settings carry over to the next frame. Must only be called
-        /// after <see cref="Decompress"/> reported <see cref="OperationStatus.Done"/>.
-        /// </remarks>
-        internal void PrepareForNextFrame()
-        {
             _finished = false;
         }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
@@ -157,12 +157,12 @@ namespace System.IO.Compression
         /// <param name="bytesWritten">When this method returns, contains the number of bytes written to the destination.</param>
         /// <returns>An <see cref="OperationStatus"/> indicating the result of the operation.</returns>
         /// <remarks>
-        /// <see cref="OperationStatus.Done"/> marks the end of a single Zstandard frame, which is not
-        /// necessarily the end of the input: a stream may be several frames concatenated back-to-back
-        /// (RFC 8878 section 3). It can be returned with <paramref name="bytesWritten"/> equal to zero (for example,
-        /// a frame whose content is empty), so a caller decoding a concatenated stream must not treat a
-        /// zero-length <see cref="OperationStatus.Done"/> as the end of the input while data remains. To
-        /// continue with the following frame, call <see cref="Reset"/> and then <see cref="Decompress"/> again.
+        /// The method returns <see cref="OperationStatus.Done"/> after all
+        /// contents of a single Zstandard frame are decoded and returned. However,
+        /// Zstandard data streams may consist of multiple concatenated frames
+        /// (some of which may even be empty). To allow processing further
+        /// frames on the same <see cref="ZstandardDecoder" /> instance, call
+        /// <see cref="Reset" /> before calling <see cref="Decompress" /> on the rest of the data.
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The decoder has been disposed.</exception>
         /// <exception cref="IOException">An error occurred during decompression.</exception>
@@ -352,14 +352,7 @@ namespace System.IO.Compression
             }
         }
 
-        /// <summary>Resets the decoder session, allowing reuse for the next decompression operation.</summary>
-        /// <remarks>
-        /// This also readies the decoder for the next frame of a stream that contains multiple Zstandard
-        /// frames concatenated back-to-back (RFC 8878 section 3), after <see cref="Decompress"/> has reported
-        /// <see cref="OperationStatus.Done"/> for the previous frame. The reset is session-only: the window
-        /// size and any referenced dictionary are preserved, while a single-use prefix set via
-        /// <see cref="SetPrefix"/> is released.
-        /// </remarks>
+        /// <summary>Resets the decoder session, allowing reuse for decompressing the next Zstandard frame.</summary>
         /// <exception cref="ObjectDisposedException">The decoder has been disposed.</exception>
         /// <exception cref="IOException">Failed to reset the decoder session.</exception>
         public void Reset()

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDecoder.cs
@@ -363,6 +363,37 @@ namespace System.IO.Compression
             _finished = false;
         }
 
+        /// <summary>
+        /// Determines whether <paramref name="framePrefix"/> starts a new Zstandard frame (versus trailing data)
+        /// by feeding it to the decoder: a valid frame magic yields <see cref="OperationStatus.NeedMoreData"/>,
+        /// anything else yields <see cref="OperationStatus.InvalidData"/>. The bytes are not consumed; on return
+        /// the session is reset, ready to decode the next frame (<see langword="true"/>) or to end the stream
+        /// (<see langword="false"/>).
+        /// </summary>
+        /// <param name="framePrefix">The four boundary bytes (a frame magic number, or trailing data).</param>
+        internal bool IsFrameStart(ReadOnlySpan<byte> framePrefix)
+        {
+            Debug.Assert(framePrefix.Length == 4);
+            EnsureNotDisposed();
+
+            // Clear the just-finished frame's latch so Decompress feeds the prefix; session-only reset keeps
+            // any dictionary and the window-size cap.
+            _context.Reset();
+            _finished = false;
+
+            Span<byte> scratch = stackalloc byte[1]; // a frame magic produces no output
+            OperationStatus status = Decompress(framePrefix, scratch, out _, out _);
+            Debug.Assert(status is OperationStatus.NeedMoreData or OperationStatus.InvalidData);
+
+            bool isFrame = status == OperationStatus.NeedMoreData;
+
+            // Reset again so the next frame decodes from a clean session; for trailing data this re-latches
+            // _finished so the stream ends without re-feeding the rejected bytes.
+            _context.Reset();
+            _finished = !isFrame;
+            return isFrame;
+        }
+
         /// <summary>References a prefix for the next decompression operation.</summary>
         /// <remarks>The prefix will be used only for the next decompression frame and will be removed when <see cref="Reset"/> is called. The referenced data must remain valid and unmodified for the duration of the decompression operation.</remarks>
         /// <exception cref="ObjectDisposedException">The decoder has been disposed.</exception>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -15,14 +15,8 @@ namespace System.IO.Compression
         private ZstandardDecoder? _decoder;
         private bool _nonEmptyInput;
 
-        // Set when the decoder reports the end of a frame (OperationStatus.Done). A zstd stream may
-        // contain multiple frames concatenated back-to-back (RFC 8878 §3), so reaching the end of a
-        // frame is not necessarily the end of the stream. While at a frame boundary, a subsequent
-        // end-of-input from the underlying stream is a clean end rather than truncated data.
-        private bool _atFrameBoundary;
-
         // Length of a Zstandard frame magic number, in bytes.
-        private const int ZstdFrameMagicLength = sizeof(uint);
+        private const int ZstdFrameMagicLength = 4;
 
         /// <summary>Initializes a new instance of the <see cref="ZstandardStream" /> class by using the specified stream and decoder instance.</summary>
         /// <param name="stream">The stream from which data to decompress is read.</param>
@@ -59,111 +53,64 @@ namespace System.IO.Compression
             _decoder = new ZstandardDecoder(decompressionOptions);
         }
 
+        // Decompresses buffered input for the current frame only. Returns true when there is a result for
+        // the caller to act on (output was produced, the frame finished, or a zero-byte read should
+        // return), and false when more input is needed to make progress on the current frame. Crossing a
+        // frame boundary into the next concatenated frame is handled by Read/ReadAsync once this reports
+        // OperationStatus.Done.
         private bool TryDecompress(Span<byte> destination, out int bytesWritten, out OperationStatus lastResult)
         {
             Debug.Assert(_decoder != null);
 
-            bytesWritten = 0;
+            OperationStatus status = _decoder.Decompress(_buffer.ActiveSpan, destination, out int bytesConsumed, out bytesWritten);
+            _buffer.Discard(bytesConsumed);
+            lastResult = status;
 
-            while (true)
+            if (status == OperationStatus.InvalidData)
             {
-                // Decompress any data we may have in our buffer into the remaining destination.
-                OperationStatus status = _decoder.Decompress(_buffer.ActiveSpan, destination, out int bytesConsumed, out int written);
-                _buffer.Discard(bytesConsumed);
-                bytesWritten += written;
-                destination = destination.Slice(written);
-                lastResult = status;
+                throw new InvalidDataException(SR.ZstandardStream_Decompress_InvalidData);
+            }
 
-                if (status == OperationStatus.InvalidData)
+            if (status == OperationStatus.Done)
+            {
+                // Reached the end of a frame. ZSTD_decompressStream reports end-of-frame, not end-of-stream:
+                // a zstd stream may be frames concatenated back-to-back (RFC 8878 section 3), so Read/ReadAsync
+                // decide whether another frame follows. This may be a zero-output frame (bytesWritten == 0).
+                return true;
+            }
+
+            if (bytesWritten != 0)
+            {
+                return true;
+            }
+
+            if (destination.IsEmpty)
+            {
+                // The caller provided a zero-byte buffer.  This is typically done in order to avoid allocating/renting
+                // a buffer until data is known to be available.  We don't have perfect knowledge here, as _decoder.Decompress
+                // will return DestinationTooSmall whether or not more data is required.  As such, we assume that if there's
+                // any data in our input buffer, it would have been decompressible into at least one byte of output, and
+                // otherwise we need to do a read on the underlying stream.  This isn't perfect, because having input data
+                // doesn't necessarily mean it'll decompress into at least one byte of output, but it's a reasonable approximation
+                // for the 99% case.  If it's wrong, it just means that a caller using zero-byte reads as a way to delay
+                // getting a buffer to use for a subsequent call may end up getting one earlier than otherwise preferred.
+                Debug.Assert(status == OperationStatus.DestinationTooSmall);
+                if (_buffer.ActiveLength != 0)
                 {
-                    throw new InvalidDataException(SR.ZstandardStream_Decompress_InvalidData);
-                }
-
-                if (status == OperationStatus.Done)
-                {
-                    // The decoder finished a frame. A zstd stream may be a sequence of frames
-                    // concatenated back-to-back (RFC 8878 §3) — produced by many encoders/CDNs that
-                    // flush a frame per buffer — so the end of a frame is not necessarily the end of
-                    // the stream. We're now at a frame boundary; end-of-input here is a clean end.
-                    _atFrameBoundary = true;
-
-                    // If the next frame is already buffered, keep decoding it on the same native
-                    // context (no reset needed: ZSTD_decompressStream automatically begins the next
-                    // frame on the following call) into whatever destination space remains.
-                    if (_buffer.ActiveLength >= ZstdFrameMagicLength && StartsWithZstdFrame(_buffer.ActiveSpan))
-                    {
-                        _decoder.PrepareForNextFrame();
-                        _atFrameBoundary = false;
-
-                        if (destination.IsEmpty)
-                        {
-                            // No room left to decode the next frame in this call. Hand back what we
-                            // have; the stream is not finished, so this must not be reported as Done
-                            // (which would trigger end-of-stream handling such as rewinding a seekable
-                            // base stream).
-                            lastResult = OperationStatus.DestinationTooSmall;
-                            return true;
-                        }
-
-                        continue;
-                    }
-
-                    // Enough leftover input to rule out another frame: this is trailing data after the
-                    // final frame. The stream is complete; leave the trailing bytes untouched (a seekable
-                    // base stream is rewound to the end of the compressed data by the caller), mirroring
-                    // how DeflateStream handles data after the last gzip member.
-                    if (_buffer.ActiveLength >= ZstdFrameMagicLength)
-                    {
-                        // lastResult is already Done; the stream is complete.
-                        return true;
-                    }
-
-                    // Fewer than ZstdFrameMagicLength bytes remain: not enough to tell whether another
-                    // frame follows (its magic number may be split across reads) or this was the last
-                    // frame. Hand back any output now and resolve on the next call / underlying read.
-                    // Because we're at a frame boundary, end-of-input is treated as a clean end rather
-                    // than truncation (see _atFrameBoundary checks in Read/ReadAsync).
-                    lastResult = OperationStatus.NeedMoreData;
-                    return bytesWritten != 0;
-                }
-
-                // If we successfully decompressed any bytes, we're done for this call.
-                if (bytesWritten != 0)
-                {
-                    _atFrameBoundary = false;
                     return true;
                 }
-
-                if (destination.IsEmpty)
-                {
-                    // The caller provided a zero-byte buffer.  This is typically done in order to avoid allocating/renting
-                    // a buffer until data is known to be available.  We don't have perfect knowledge here, as _decoder.Decompress
-                    // will return DestinationTooSmall whether or not more data is required.  As such, we assume that if there's
-                    // any data in our input buffer, it would have been decompressible into at least one byte of output, and
-                    // otherwise we need to do a read on the underlying stream.  This isn't perfect, because having input data
-                    // doesn't necessarily mean it'll decompress into at least one byte of output, but it's a reasonable approximation
-                    // for the 99% case.  If it's wrong, it just means that a caller using zero-byte reads as a way to delay
-                    // getting a buffer to use for a subsequent call may end up getting one earlier than otherwise preferred.
-                    Debug.Assert(status == OperationStatus.DestinationTooSmall);
-                    if (_buffer.ActiveLength != 0)
-                    {
-                        Debug.Assert(bytesWritten == 0);
-                        return true;
-                    }
-                }
-
-                Debug.Assert(
-                    status == OperationStatus.NeedMoreData ||
-                    (status == OperationStatus.DestinationTooSmall && destination.IsEmpty && _buffer.ActiveLength == 0), $"{nameof(status)} == {status}, {nameof(destination.Length)} == {destination.Length}");
-
-                _atFrameBoundary = false;
-                return false;
             }
+
+            Debug.Assert(
+                status == OperationStatus.NeedMoreData ||
+                (status == OperationStatus.DestinationTooSmall && destination.IsEmpty && _buffer.ActiveLength == 0), $"{nameof(status)} == {status}, {nameof(destination.Length)} == {destination.Length}");
+
+            return false;
         }
 
         /// <summary>
-        /// Returns whether <paramref name="data"/> begins with a Zstandard frame magic number — a standard
-        /// frame (0xFD2FB528) or a skippable frame (0x184D2A50–0x184D2A5F) — which indicates that another
+        /// Returns whether <paramref name="data"/> begins with a Zstandard frame magic number: a standard
+        /// frame (0xFD2FB528) or a skippable frame (0x184D2A50-0x184D2A5F), which indicates that another
         /// concatenated frame follows. Used to distinguish a subsequent frame from trailing data after the
         /// final frame. Requires at least <see cref="ZstdFrameMagicLength"/> bytes.
         /// </summary>
@@ -219,48 +166,172 @@ namespace System.IO.Compression
 
             try
             {
-                int bytesWritten;
-                OperationStatus lastResult;
-                while (!TryDecompress(buffer, out bytesWritten, out lastResult))
+                while (true)
                 {
-                    _buffer.EnsureAvailableSpace(1);
-
-                    int bytesRead = _stream.Read(_buffer.AvailableSpan);
-                    if (bytesRead <= 0)
+                    int bytesWritten;
+                    OperationStatus lastResult;
+                    while (!TryDecompress(buffer, out bytesWritten, out lastResult))
                     {
-                        // Only treat end-of-input as truncation if we're in the middle of a frame.
-                        // If we're at a frame boundary (_atFrameBoundary), the stream ended cleanly
-                        // after the last of one or more concatenated frames; report Done so that any
-                        // unconsumed trailing bytes are rewound on a seekable base stream.
-                        if (_nonEmptyInput && !buffer.IsEmpty && !_atFrameBoundary)
-                            ThrowTruncatedInvalidData();
-                        if (_atFrameBoundary)
-                            lastResult = OperationStatus.Done;
-                        break;
+                        _buffer.EnsureAvailableSpace(1);
+
+                        int bytesRead = _stream.Read(_buffer.AvailableSpan);
+                        if (bytesRead <= 0)
+                        {
+                            // The underlying stream ended in the middle of a frame, so the data is truncated.
+                            // A clean end after a completed frame is reported as Done by TryDecompress and is
+                            // resolved by the frame-boundary logic below, not here.
+                            if (_nonEmptyInput && !buffer.IsEmpty)
+                            {
+                                ThrowTruncatedInvalidData();
+                            }
+
+                            return 0;
+                        }
+
+                        _nonEmptyInput = true;
+
+                        if (bytesRead > _buffer.AvailableLength)
+                        {
+                            ThrowInvalidStream();
+                        }
+
+                        _buffer.Commit(bytesRead);
                     }
 
-                    _nonEmptyInput = true;
-
-                    if (bytesRead > _buffer.AvailableLength)
+                    if (lastResult != OperationStatus.Done)
                     {
-                        ThrowInvalidStream();
+                        // Produced output, or a zero-byte read that should return to the caller.
+                        return bytesWritten;
                     }
 
-                    _buffer.Commit(bytesRead);
+                    // A frame finished. A zstd stream may be frames concatenated back-to-back (RFC 8878
+                    // section 3), so decide whether another frame follows before reporting end-of-stream.
+                    if (!AdvanceToNextFrame(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0))
+                    {
+                        return bytesWritten;
+                    }
                 }
-
-                // When decompression finishes, rewind the stream to the exact end of compressed data
-                if (lastResult == OperationStatus.Done && _stream.CanSeek)
-                {
-                    TryRewindStream(_stream);
-                }
-
-                return bytesWritten;
             }
             finally
             {
                 EndRWOperation();
             }
+        }
+
+        // Called after TryDecompress reports OperationStatus.Done (end of a frame). Decides whether another
+        // concatenated frame follows: returns true (after resetting the decoder) when the caller should loop
+        // to decode it, or false when the stream is complete and the caller should return. Uses only buffered
+        // bytes when there is pending output to hand back; otherwise reads up to a frame magic to tell a split
+        // next-frame magic from end-of-stream. The sync variant; ReadAsync uses AdvanceToNextFrameAsync.
+        private bool AdvanceToNextFrame(bool zeroByteRead, bool hasPendingOutput)
+        {
+            if (hasPendingOutput)
+            {
+                // There is output to hand back now. Resolve the boundary only from already-buffered bytes:
+                // if this was the final frame (trailing non-zstd data) rewind a seekable base stream now;
+                // otherwise defer crossing into the next frame to the next Read (the decoder stays finished),
+                // so we don't block on the next frame's header before returning data we already have.
+                if (_buffer.ActiveLength >= ZstdFrameMagicLength && !StartsWithZstdFrame(_buffer.ActiveSpan) && _stream.CanSeek)
+                {
+                    TryRewindStream(_stream);
+                }
+
+                return false;
+            }
+
+            if (zeroByteRead)
+            {
+                // Zero-byte read: don't block peeking the next frame; the next read resolves it.
+                return false;
+            }
+
+            if (_buffer.ActiveLength < ZstdFrameMagicLength)
+            {
+                // Not enough buffered to tell a split next-frame magic from end-of-stream; read more.
+                int needed = ZstdFrameMagicLength - _buffer.ActiveLength;
+                _buffer.EnsureAvailableSpace(needed);
+                int peeked = _stream.ReadAtLeast(_buffer.AvailableSpan, needed, throwOnEndOfStream: false);
+                if (peeked > 0)
+                {
+                    _nonEmptyInput = true;
+                    _buffer.Commit(peeked);
+                }
+            }
+
+            if (_buffer.ActiveLength >= ZstdFrameMagicLength && StartsWithZstdFrame(_buffer.ActiveSpan))
+            {
+                // Another frame follows. Reset readies the decoder for it (a session-only native reset that
+                // keeps the window size and any dictionary, and releases a single-use prefix).
+                Debug.Assert(_decoder != null);
+                _decoder.Reset();
+                return true;
+            }
+
+            // Trailing non-zstd data or end of input after the final frame: the stream is complete. Leave any
+            // trailing bytes on a seekable base stream by rewinding to the end of the compressed data,
+            // mirroring how DeflateStream handles data after the last gzip member.
+            if (_stream.CanSeek)
+            {
+                TryRewindStream(_stream);
+            }
+
+            return false;
+        }
+
+        // Asynchronous counterpart of AdvanceToNextFrame, used by ReadAsync.
+        private async ValueTask<bool> AdvanceToNextFrameAsync(bool zeroByteRead, bool hasPendingOutput, CancellationToken cancellationToken)
+        {
+            if (hasPendingOutput)
+            {
+                // There is output to hand back now. Resolve the boundary only from already-buffered bytes:
+                // if this was the final frame (trailing non-zstd data) rewind a seekable base stream now;
+                // otherwise defer crossing into the next frame to the next read (the decoder stays finished),
+                // so we don't block on the next frame's header before returning data we already have.
+                if (_buffer.ActiveLength >= ZstdFrameMagicLength && !StartsWithZstdFrame(_buffer.ActiveSpan) && _stream.CanSeek)
+                {
+                    TryRewindStream(_stream);
+                }
+
+                return false;
+            }
+
+            if (zeroByteRead)
+            {
+                // Zero-byte read: don't block peeking the next frame; the next read resolves it.
+                return false;
+            }
+
+            if (_buffer.ActiveLength < ZstdFrameMagicLength)
+            {
+                // Not enough buffered to tell a split next-frame magic from end-of-stream; read more.
+                int needed = ZstdFrameMagicLength - _buffer.ActiveLength;
+                _buffer.EnsureAvailableSpace(needed);
+                int peeked = await _stream.ReadAtLeastAsync(_buffer.AvailableMemory, needed, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
+                if (peeked > 0)
+                {
+                    _nonEmptyInput = true;
+                    _buffer.Commit(peeked);
+                }
+            }
+
+            if (_buffer.ActiveLength >= ZstdFrameMagicLength && StartsWithZstdFrame(_buffer.ActiveSpan))
+            {
+                // Another frame follows. Reset readies the decoder for it (a session-only native reset that
+                // keeps the window size and any dictionary, and releases a single-use prefix).
+                Debug.Assert(_decoder != null);
+                _decoder.Reset();
+                return true;
+            }
+
+            // Trailing non-zstd data or end of input after the final frame: the stream is complete. Leave any
+            // trailing bytes on a seekable base stream by rewinding to the end of the compressed data,
+            // mirroring how DeflateStream handles data after the last gzip member.
+            if (_stream.CanSeek)
+            {
+                TryRewindStream(_stream);
+            }
+
+            return false;
         }
 
         /// <summary>Asynchronously reads decompressed bytes from the underlying stream and places them in the specified array.</summary>
@@ -302,43 +373,51 @@ namespace System.IO.Compression
 
             try
             {
-                int bytesWritten;
-                OperationStatus lastResult;
-                while (!TryDecompress(buffer.Span, out bytesWritten, out lastResult))
+                while (true)
                 {
-                    _buffer.EnsureAvailableSpace(1);
-
-                    int bytesRead = await _stream.ReadAsync(_buffer.AvailableMemory, cancellationToken).ConfigureAwait(false);
-                    if (bytesRead <= 0)
+                    int bytesWritten;
+                    OperationStatus lastResult;
+                    while (!TryDecompress(buffer.Span, out bytesWritten, out lastResult))
                     {
-                        // Only treat end-of-input as truncation if we're in the middle of a frame.
-                        // If we're at a frame boundary (_atFrameBoundary), the stream ended cleanly
-                        // after the last of one or more concatenated frames; report Done so that any
-                        // unconsumed trailing bytes are rewound on a seekable base stream.
-                        if (_nonEmptyInput && !buffer.IsEmpty && !_atFrameBoundary)
-                            ThrowTruncatedInvalidData();
-                        if (_atFrameBoundary)
-                            lastResult = OperationStatus.Done;
-                        break;
+                        _buffer.EnsureAvailableSpace(1);
+
+                        int bytesRead = await _stream.ReadAsync(_buffer.AvailableMemory, cancellationToken).ConfigureAwait(false);
+                        if (bytesRead <= 0)
+                        {
+                            // The underlying stream ended in the middle of a frame, so the data is truncated.
+                            // A clean end after a completed frame is reported as Done by TryDecompress and is
+                            // resolved by the frame-boundary logic below, not here.
+                            if (_nonEmptyInput && !buffer.IsEmpty)
+                            {
+                                ThrowTruncatedInvalidData();
+                            }
+
+                            return 0;
+                        }
+
+                        _nonEmptyInput = true;
+
+                        if (bytesRead > _buffer.AvailableLength)
+                        {
+                            ThrowInvalidStream();
+                        }
+
+                        _buffer.Commit(bytesRead);
                     }
 
-                    _nonEmptyInput = true;
-
-                    if (bytesRead > _buffer.AvailableLength)
+                    if (lastResult != OperationStatus.Done)
                     {
-                        ThrowInvalidStream();
+                        // Produced output, or a zero-byte read that should return to the caller.
+                        return bytesWritten;
                     }
 
-                    _buffer.Commit(bytesRead);
+                    // A frame finished. A zstd stream may be frames concatenated back-to-back (RFC 8878
+                    // section 3), so decide whether another frame follows before reporting end-of-stream.
+                    if (!await AdvanceToNextFrameAsync(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, cancellationToken).ConfigureAwait(false))
+                    {
+                        return bytesWritten;
+                    }
                 }
-
-                // When decompression finishes, rewind the stream to the exact end of compressed data
-                if (lastResult == OperationStatus.Done && _stream.CanSeek)
-                {
-                    TryRewindStream(_stream);
-                }
-
-                return bytesWritten;
             }
             finally
             {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -206,7 +206,8 @@ namespace System.IO.Compression
 
                     // A frame finished. A zstd stream may be frames concatenated back-to-back (RFC 8878
                     // section 3), so decide whether another frame follows before reporting end-of-stream.
-                    if (!AdvanceToNextFrame(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0))
+                    // async: false completes synchronously (it only ever takes the synchronous read path).
+                    if (!AdvanceToNextFrame(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, async: false, cancellationToken: default).GetAwaiter().GetResult())
                     {
                         return bytesWritten;
                     }
@@ -222,8 +223,8 @@ namespace System.IO.Compression
         // concatenated frame follows: returns true (after resetting the decoder) when the caller should loop
         // to decode it, or false when the stream is complete and the caller should return. Uses only buffered
         // bytes when there is pending output to hand back; otherwise reads up to a frame magic to tell a split
-        // next-frame magic from end-of-stream. The sync variant; ReadAsync uses AdvanceToNextFrameAsync.
-        private bool AdvanceToNextFrame(bool zeroByteRead, bool hasPendingOutput)
+        // next-frame magic from end-of-stream. Shared by Read (async: false) and ReadAsync (async: true).
+        private async ValueTask<bool> AdvanceToNextFrame(bool zeroByteRead, bool hasPendingOutput, bool async, CancellationToken cancellationToken)
         {
             if (hasPendingOutput)
             {
@@ -259,72 +260,9 @@ namespace System.IO.Compression
                 // Not enough buffered to tell a split next-frame magic from end-of-stream; read more.
                 int needed = ZstdFrameMagicLength - _buffer.ActiveLength;
                 _buffer.EnsureAvailableSpace(needed);
-                int peeked = _stream.ReadAtLeast(_buffer.AvailableSpan, needed, throwOnEndOfStream: false);
-                if (peeked > 0)
-                {
-                    _nonEmptyInput = true;
-                    _buffer.Commit(peeked);
-                }
-            }
-
-            if (_buffer.ActiveLength >= ZstdFrameMagicLength && StartsWithZstdFrame(_buffer.ActiveSpan))
-            {
-                // Another frame follows. Reset readies the decoder for it (a session-only native reset that
-                // keeps the window size and any dictionary, and releases a single-use prefix).
-                Debug.Assert(_decoder != null);
-                _decoder.Reset();
-                return true;
-            }
-
-            // Trailing non-zstd data or end of input after the final frame: the stream is complete. Leave any
-            // trailing bytes on a seekable base stream by rewinding to the end of the compressed data,
-            // mirroring how DeflateStream handles data after the last gzip member.
-            if (_stream.CanSeek)
-            {
-                TryRewindStream(_stream);
-            }
-
-            return false;
-        }
-
-        // Asynchronous counterpart of AdvanceToNextFrame, used by ReadAsync.
-        private async ValueTask<bool> AdvanceToNextFrameAsync(bool zeroByteRead, bool hasPendingOutput, CancellationToken cancellationToken)
-        {
-            if (hasPendingOutput)
-            {
-                // There is output to hand back now. If the next frame's header is already buffered, ready the
-                // decoder for it now (no read needed) so the next read decodes it directly; if this was instead
-                // the final frame (trailing non-zstd data) rewind a seekable base stream. With fewer than
-                // ZstdFrameMagicLength bytes buffered we can't tell yet, so defer the decision to the next read
-                // rather than block on the next frame's header before returning data we already have.
-                if (_buffer.ActiveLength >= ZstdFrameMagicLength)
-                {
-                    if (StartsWithZstdFrame(_buffer.ActiveSpan))
-                    {
-                        Debug.Assert(_decoder != null);
-                        _decoder.Reset();
-                    }
-                    else if (_stream.CanSeek)
-                    {
-                        TryRewindStream(_stream);
-                    }
-                }
-
-                return false;
-            }
-
-            if (zeroByteRead)
-            {
-                // Zero-byte read: don't block peeking the next frame; the next read resolves it.
-                return false;
-            }
-
-            if (_buffer.ActiveLength < ZstdFrameMagicLength)
-            {
-                // Not enough buffered to tell a split next-frame magic from end-of-stream; read more.
-                int needed = ZstdFrameMagicLength - _buffer.ActiveLength;
-                _buffer.EnsureAvailableSpace(needed);
-                int peeked = await _stream.ReadAtLeastAsync(_buffer.AvailableMemory, needed, throwOnEndOfStream: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                int peeked = async
+                    ? await _stream.ReadAtLeastAsync(_buffer.AvailableMemory, needed, throwOnEndOfStream: false, cancellationToken: cancellationToken).ConfigureAwait(false)
+                    : _stream.ReadAtLeast(_buffer.AvailableSpan, needed, throwOnEndOfStream: false);
                 if (peeked > 0)
                 {
                     _nonEmptyInput = true;
@@ -431,7 +369,7 @@ namespace System.IO.Compression
 
                     // A frame finished. A zstd stream may be frames concatenated back-to-back (RFC 8878
                     // section 3), so decide whether another frame follows before reporting end-of-stream.
-                    if (!await AdvanceToNextFrameAsync(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, cancellationToken: cancellationToken).ConfigureAwait(false))
+                    if (!await AdvanceToNextFrame(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, async: true, cancellationToken: cancellationToken).ConfigureAwait(false))
                     {
                         return bytesWritten;
                     }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
@@ -13,6 +14,15 @@ namespace System.IO.Compression
     {
         private ZstandardDecoder? _decoder;
         private bool _nonEmptyInput;
+
+        // Set when the decoder reports the end of a frame (OperationStatus.Done). A zstd stream may
+        // contain multiple frames concatenated back-to-back (RFC 8878 §3), so reaching the end of a
+        // frame is not necessarily the end of the stream. While at a frame boundary, a subsequent
+        // end-of-input from the underlying stream is a clean end rather than truncated data.
+        private bool _atFrameBoundary;
+
+        // Length of a Zstandard frame magic number, in bytes.
+        private const int ZstdFrameMagicLength = sizeof(uint);
 
         /// <summary>Initializes a new instance of the <see cref="ZstandardStream" /> class by using the specified stream and decoder instance.</summary>
         /// <param name="stream">The stream from which data to decompress is read.</param>
@@ -53,44 +63,124 @@ namespace System.IO.Compression
         {
             Debug.Assert(_decoder != null);
 
-            // Decompress any data we may have in our buffer.
-            lastResult = _decoder.Decompress(_buffer.ActiveSpan, destination, out int bytesConsumed, out bytesWritten);
-            _buffer.Discard(bytesConsumed);
+            bytesWritten = 0;
+            lastResult = OperationStatus.Done;
 
-            if (lastResult == OperationStatus.InvalidData)
+            while (true)
             {
-                throw new InvalidDataException(SR.ZstandardStream_Decompress_InvalidData);
-            }
+                // Decompress any data we may have in our buffer into the remaining destination.
+                OperationStatus status = _decoder.Decompress(_buffer.ActiveSpan, destination, out int bytesConsumed, out int written);
+                _buffer.Discard(bytesConsumed);
+                bytesWritten += written;
+                destination = destination.Slice(written);
+                lastResult = status;
 
-            // If we successfully decompressed any bytes, or if we've reached the end of the decompression, we're done.
-            if (bytesWritten != 0 || lastResult == OperationStatus.Done)
-            {
-                return true;
-            }
-
-            if (destination.IsEmpty)
-            {
-                // The caller provided a zero-byte buffer.  This is typically done in order to avoid allocating/renting
-                // a buffer until data is known to be available.  We don't have perfect knowledge here, as _decoder.Decompress
-                // will return DestinationTooSmall whether or not more data is required.  As such, we assume that if there's
-                // any data in our input buffer, it would have been decompressible into at least one byte of output, and
-                // otherwise we need to do a read on the underlying stream.  This isn't perfect, because having input data
-                // doesn't necessarily mean it'll decompress into at least one byte of output, but it's a reasonable approximation
-                // for the 99% case.  If it's wrong, it just means that a caller using zero-byte reads as a way to delay
-                // getting a buffer to use for a subsequent call may end up getting one earlier than otherwise preferred.
-                Debug.Assert(lastResult == OperationStatus.DestinationTooSmall);
-                if (_buffer.ActiveLength != 0)
+                if (status == OperationStatus.InvalidData)
                 {
-                    Debug.Assert(bytesWritten == 0);
+                    throw new InvalidDataException(SR.ZstandardStream_Decompress_InvalidData);
+                }
+
+                if (status == OperationStatus.Done)
+                {
+                    // The decoder finished a frame. A zstd stream may be a sequence of frames
+                    // concatenated back-to-back (RFC 8878 §3) — produced by many encoders/CDNs that
+                    // flush a frame per buffer — so the end of a frame is not necessarily the end of
+                    // the stream. We're now at a frame boundary; end-of-input here is a clean end.
+                    _atFrameBoundary = true;
+
+                    // If the next frame is already buffered, keep decoding it on the same native
+                    // context (no reset needed: ZSTD_decompressStream automatically begins the next
+                    // frame on the following call) into whatever destination space remains.
+                    if (_buffer.ActiveLength >= ZstdFrameMagicLength && StartsWithZstdFrame(_buffer.ActiveSpan))
+                    {
+                        _decoder.PrepareForNextFrame();
+                        _atFrameBoundary = false;
+
+                        if (destination.IsEmpty)
+                        {
+                            // No room left to decode the next frame in this call. Hand back what we
+                            // have; the stream is not finished, so this must not be reported as Done
+                            // (which would trigger end-of-stream handling such as rewinding a seekable
+                            // base stream).
+                            lastResult = OperationStatus.DestinationTooSmall;
+                            return true;
+                        }
+
+                        continue;
+                    }
+
+                    // Enough leftover input to rule out another frame: this is trailing data after the
+                    // final frame. The stream is complete; leave the trailing bytes untouched (a seekable
+                    // base stream is rewound to the end of the compressed data by the caller), mirroring
+                    // how DeflateStream handles data after the last gzip member.
+                    if (_buffer.ActiveLength >= ZstdFrameMagicLength)
+                    {
+                        lastResult = OperationStatus.Done;
+                        return true;
+                    }
+
+                    // Fewer than ZstdFrameMagicLength bytes remain: not enough to tell whether another
+                    // frame follows (its magic number may be split across reads) or this was the last
+                    // frame. Hand back any output now and resolve on the next call / underlying read.
+                    // Because we're at a frame boundary, end-of-input is treated as a clean end rather
+                    // than truncation (see _atFrameBoundary checks in Read/ReadAsync).
+                    lastResult = OperationStatus.NeedMoreData;
+                    return bytesWritten != 0;
+                }
+
+                // If we successfully decompressed any bytes, we're done for this call.
+                if (bytesWritten != 0)
+                {
+                    _atFrameBoundary = false;
                     return true;
                 }
+
+                if (destination.IsEmpty)
+                {
+                    // The caller provided a zero-byte buffer.  This is typically done in order to avoid allocating/renting
+                    // a buffer until data is known to be available.  We don't have perfect knowledge here, as _decoder.Decompress
+                    // will return DestinationTooSmall whether or not more data is required.  As such, we assume that if there's
+                    // any data in our input buffer, it would have been decompressible into at least one byte of output, and
+                    // otherwise we need to do a read on the underlying stream.  This isn't perfect, because having input data
+                    // doesn't necessarily mean it'll decompress into at least one byte of output, but it's a reasonable approximation
+                    // for the 99% case.  If it's wrong, it just means that a caller using zero-byte reads as a way to delay
+                    // getting a buffer to use for a subsequent call may end up getting one earlier than otherwise preferred.
+                    Debug.Assert(status == OperationStatus.DestinationTooSmall);
+                    if (_buffer.ActiveLength != 0)
+                    {
+                        Debug.Assert(bytesWritten == 0);
+                        return true;
+                    }
+                }
+
+                Debug.Assert(
+                    status == OperationStatus.NeedMoreData ||
+                    (status == OperationStatus.DestinationTooSmall && destination.IsEmpty && _buffer.ActiveLength == 0), $"{nameof(status)} == {status}, {nameof(destination.Length)} == {destination.Length}");
+
+                _atFrameBoundary = false;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="data"/> begins with a Zstandard frame magic number — a standard
+        /// frame (0xFD2FB528) or a skippable frame (0x184D2A50–0x184D2A5F) — which indicates that another
+        /// concatenated frame follows. Used to distinguish a subsequent frame from trailing data after the
+        /// final frame. Requires at least <see cref="ZstdFrameMagicLength"/> bytes.
+        /// </summary>
+        private static bool StartsWithZstdFrame(ReadOnlySpan<byte> data)
+        {
+            if (data.Length < ZstdFrameMagicLength)
+            {
+                return false;
             }
 
-            Debug.Assert(
-                lastResult == OperationStatus.NeedMoreData ||
-                (lastResult == OperationStatus.DestinationTooSmall && destination.IsEmpty && _buffer.ActiveLength == 0), $"{nameof(lastResult)} == {lastResult}, {nameof(destination.Length)} == {destination.Length}");
+            const uint ZstdFrameMagic = 0xFD2FB528;
+            const uint SkippableFrameMagicMin = 0x184D2A50;
+            const uint SkippableFrameMagicMax = 0x184D2A5F;
 
-            return false;
+            uint magic = BinaryPrimitives.ReadUInt32LittleEndian(data);
+            return magic == ZstdFrameMagic || (magic >= SkippableFrameMagicMin && magic <= SkippableFrameMagicMax);
         }
 
         /// <summary>Reads decompressed bytes from the underlying stream and places them in the specified array.</summary>
@@ -139,7 +229,10 @@ namespace System.IO.Compression
                     int bytesRead = _stream.Read(_buffer.AvailableSpan);
                     if (bytesRead <= 0)
                     {
-                        if (_nonEmptyInput && !buffer.IsEmpty)
+                        // Only treat end-of-input as truncation if we're in the middle of a frame.
+                        // If we're at a frame boundary (_atFrameBoundary), the stream ended cleanly
+                        // after the last of one or more concatenated frames.
+                        if (_nonEmptyInput && !buffer.IsEmpty && !_atFrameBoundary)
                             ThrowTruncatedInvalidData();
                         break;
                     }
@@ -216,7 +309,10 @@ namespace System.IO.Compression
                     int bytesRead = await _stream.ReadAsync(_buffer.AvailableMemory, cancellationToken).ConfigureAwait(false);
                     if (bytesRead <= 0)
                     {
-                        if (_nonEmptyInput && !buffer.IsEmpty)
+                        // Only treat end-of-input as truncation if we're in the middle of a frame.
+                        // If we're at a frame boundary (_atFrameBoundary), the stream ended cleanly
+                        // after the last of one or more concatenated frames.
+                        if (_nonEmptyInput && !buffer.IsEmpty && !_atFrameBoundary)
                             ThrowTruncatedInvalidData();
                         break;
                     }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -13,6 +13,7 @@ namespace System.IO.Compression
     {
         private ZstandardDecoder? _decoder;
         private bool _nonEmptyInput;
+        private bool _endOfStream;
 
         // Length of a Zstandard frame magic number, in bytes.
         private const int ZstdFrameMagicLength = 4;
@@ -144,6 +145,14 @@ namespace System.IO.Compression
 
             try
             {
+                if (_endOfStream)
+                {
+                    // A previous read reached the end of the final frame (or rejected trailing data). The
+                    // boundary probe may have left the decoder non-resumable, so never re-enter the decode
+                    // loop; report end-of-stream to all subsequent reads.
+                    return 0;
+                }
+
                 while (true)
                 {
                     int bytesWritten;
@@ -201,10 +210,12 @@ namespace System.IO.Compression
         }
 
         // Called after TryDecompress reports OperationStatus.Done with no pending output (a finished frame).
-        // Decides whether another concatenated frame follows: reads up to a frame magic and asks the decoder
-        // (IsFrameStart) whether those bytes begin a frame. Returns true (decoder reset and ready) so the caller
-        // loops to decode it, or false (stream complete; a seekable base stream is rewound to the end of the
-        // compressed data) so the caller returns. Shared by Read (async: false) and ReadAsync (async: true).
+        // Decides whether another concatenated frame follows by reading up to a frame magic and feeding just
+        // those bytes to the decoder: a valid magic is accepted (NeedMoreData) so decoding continues, while
+        // bytes that are not a frame magic identify trailing data after the final frame. Returns true (decoder
+        // reset and ready) so the caller loops to decode the next frame, or false (stream complete; _endOfStream
+        // is set and a seekable base stream is rewound to the end of the compressed data) so the caller returns.
+        // Shared by Read (async: false) and ReadAsync (async: true).
         private async ValueTask<bool> AdvanceToNextFrame(bool async, CancellationToken cancellationToken)
         {
             Debug.Assert(_decoder != null);
@@ -228,18 +239,39 @@ namespace System.IO.Compression
                 }
             }
 
-            if (_buffer.ActiveLength >= ZstdFrameMagicLength &&
-                _decoder.IsFrameStart(_buffer.ActiveSpan.Slice(0, ZstdFrameMagicLength)))
+            if (_buffer.ActiveLength >= ZstdFrameMagicLength)
             {
-                // Another frame follows. IsFrameStart has reset the decoder (a session-only native reset that
-                // keeps the window size and any dictionary, and releases a single-use prefix) and left it ready
-                // to decode the next frame.
-                return true;
+                // Determine whether another concatenated frame follows by feeding the decoder exactly the next
+                // frame magic number. The decoder validates the magic against both standard and skippable
+                // frames: a valid magic leaves it asking for more input (NeedMoreData), so decoding continues,
+                // while bytes that are not a frame magic produce InvalidData, identifying trailing data after
+                // the final frame. Feeding only the magic (not the whole buffer) means a frame whose magic is
+                // valid but whose body is corrupt is not mistaken for trailing data here: the magic is accepted
+                // and the corrupt body is rejected by the subsequent decode in the Read/ReadAsync loop.
+                _decoder.Reset();
+
+                // The magic alone never decodes into output, so the decoder needs no real output space; a single
+                // scratch byte borrowed from the buffer's free region (which the decoder won't write to) satisfies
+                // the non-empty-destination requirement. A Span local / stackalloc can't be used here because this
+                // method is async.
+                _buffer.EnsureAvailableSpace(1);
+                if (_decoder.Decompress(_buffer.ActiveSpan.Slice(0, ZstdFrameMagicLength), _buffer.AvailableSpan.Slice(0, 1), out int bytesConsumed, out _) == OperationStatus.NeedMoreData)
+                {
+                    // A valid magic; the decoder has taken the magic bytes into its session to continue decoding
+                    // the rest of the frame. Drop them from the buffer and keep decoding.
+                    _buffer.Discard(bytesConsumed);
+                    return true;
+                }
+
+                // Not a frame: leave the magic bytes buffered so they are included in the trailing-data rewind
+                // below (on a non-seekable stream they simply remain unconsumed).
             }
 
-            // Trailing non-zstd data or end of input after the final frame: the stream is complete. Leave any
-            // trailing bytes on a seekable base stream by rewinding to the end of the compressed data,
-            // mirroring how DeflateStream handles data after the last gzip member.
+            // Trailing non-zstd data or end of input after the final frame: the stream is complete. Mark the
+            // stream ended so subsequent reads short-circuit to 0 without re-entering the (now non-resumable)
+            // decoder, and leave any trailing bytes on a seekable base stream by rewinding to the end of the
+            // compressed data, mirroring how DeflateStream handles data after the last gzip member.
+            _endOfStream = true;
             if (_stream.CanSeek)
             {
                 TryRewindStream(_stream);
@@ -287,6 +319,14 @@ namespace System.IO.Compression
 
             try
             {
+                if (_endOfStream)
+                {
+                    // A previous read reached the end of the final frame (or rejected trailing data). The
+                    // boundary probe may have left the decoder non-resumable, so never re-enter the decode
+                    // loop; report end-of-stream to all subsequent reads.
+                    return 0;
+                }
+
                 while (true)
                 {
                     int bytesWritten;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -227,13 +227,22 @@ namespace System.IO.Compression
         {
             if (hasPendingOutput)
             {
-                // There is output to hand back now. Resolve the boundary only from already-buffered bytes:
-                // if this was the final frame (trailing non-zstd data) rewind a seekable base stream now;
-                // otherwise defer crossing into the next frame to the next Read (the decoder stays finished),
-                // so we don't block on the next frame's header before returning data we already have.
-                if (_buffer.ActiveLength >= ZstdFrameMagicLength && !StartsWithZstdFrame(_buffer.ActiveSpan) && _stream.CanSeek)
+                // There is output to hand back now. If the next frame's header is already buffered, ready the
+                // decoder for it now (no read needed) so the next read decodes it directly; if this was instead
+                // the final frame (trailing non-zstd data) rewind a seekable base stream. With fewer than
+                // ZstdFrameMagicLength bytes buffered we can't tell yet, so defer the decision to the next read
+                // rather than block on the next frame's header before returning data we already have.
+                if (_buffer.ActiveLength >= ZstdFrameMagicLength)
                 {
-                    TryRewindStream(_stream);
+                    if (StartsWithZstdFrame(_buffer.ActiveSpan))
+                    {
+                        Debug.Assert(_decoder != null);
+                        _decoder.Reset();
+                    }
+                    else if (_stream.CanSeek)
+                    {
+                        TryRewindStream(_stream);
+                    }
                 }
 
                 return false;
@@ -283,13 +292,22 @@ namespace System.IO.Compression
         {
             if (hasPendingOutput)
             {
-                // There is output to hand back now. Resolve the boundary only from already-buffered bytes:
-                // if this was the final frame (trailing non-zstd data) rewind a seekable base stream now;
-                // otherwise defer crossing into the next frame to the next read (the decoder stays finished),
-                // so we don't block on the next frame's header before returning data we already have.
-                if (_buffer.ActiveLength >= ZstdFrameMagicLength && !StartsWithZstdFrame(_buffer.ActiveSpan) && _stream.CanSeek)
+                // There is output to hand back now. If the next frame's header is already buffered, ready the
+                // decoder for it now (no read needed) so the next read decodes it directly; if this was instead
+                // the final frame (trailing non-zstd data) rewind a seekable base stream. With fewer than
+                // ZstdFrameMagicLength bytes buffered we can't tell yet, so defer the decision to the next read
+                // rather than block on the next frame's header before returning data we already have.
+                if (_buffer.ActiveLength >= ZstdFrameMagicLength)
                 {
-                    TryRewindStream(_stream);
+                    if (StartsWithZstdFrame(_buffer.ActiveSpan))
+                    {
+                        Debug.Assert(_decoder != null);
+                        _decoder.Reset();
+                    }
+                    else if (_stream.CanSeek)
+                    {
+                        TryRewindStream(_stream);
+                    }
                 }
 
                 return false;
@@ -306,7 +324,7 @@ namespace System.IO.Compression
                 // Not enough buffered to tell a split next-frame magic from end-of-stream; read more.
                 int needed = ZstdFrameMagicLength - _buffer.ActiveLength;
                 _buffer.EnsureAvailableSpace(needed);
-                int peeked = await _stream.ReadAtLeastAsync(_buffer.AvailableMemory, needed, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
+                int peeked = await _stream.ReadAtLeastAsync(_buffer.AvailableMemory, needed, throwOnEndOfStream: false, cancellationToken: cancellationToken).ConfigureAwait(false);
                 if (peeked > 0)
                 {
                     _nonEmptyInput = true;
@@ -413,7 +431,7 @@ namespace System.IO.Compression
 
                     // A frame finished. A zstd stream may be frames concatenated back-to-back (RFC 8878
                     // section 3), so decide whether another frame follows before reporting end-of-stream.
-                    if (!await AdvanceToNextFrameAsync(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, cancellationToken).ConfigureAwait(false))
+                    if (!await AdvanceToNextFrameAsync(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, cancellationToken: cancellationToken).ConfigureAwait(false))
                     {
                         return bytesWritten;
                     }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -207,7 +207,9 @@ namespace System.IO.Compression
                     // A frame finished. A zstd stream may be frames concatenated back-to-back (RFC 8878
                     // section 3), so decide whether another frame follows before reporting end-of-stream.
                     // async: false completes synchronously (it only ever takes the synchronous read path).
-                    if (!AdvanceToNextFrame(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, async: false, cancellationToken: default).GetAwaiter().GetResult())
+                    ValueTask<bool> advanceTask = AdvanceToNextFrame(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, async: false, cancellationToken: default);
+                    Debug.Assert(advanceTask.IsCompleted, "AdvanceToNextFrame should complete synchronously when async: false");
+                    if (!advanceTask.GetAwaiter().GetResult())
                     {
                         return bytesWritten;
                     }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -257,12 +257,16 @@ namespace System.IO.Compression
 
             if (_buffer.ActiveLength < ZstdFrameMagicLength)
             {
-                // Not enough buffered to tell a split next-frame magic from end-of-stream; read more.
+                // Not enough buffered to tell a split next-frame magic from end-of-stream; read just enough
+                // to complete the magic. Limiting the read to exactly the missing bytes (rather than filling
+                // the available buffer) avoids consuming and hiding trailing bytes past the magic on a
+                // non-seekable stream, where they can't be rewound; any following frame's body is read by the
+                // Read/ReadAsync loop afterwards.
                 int needed = ZstdFrameMagicLength - _buffer.ActiveLength;
                 _buffer.EnsureAvailableSpace(needed);
                 int peeked = async
-                    ? await _stream.ReadAtLeastAsync(_buffer.AvailableMemory, needed, throwOnEndOfStream: false, cancellationToken: cancellationToken).ConfigureAwait(false)
-                    : _stream.ReadAtLeast(_buffer.AvailableSpan, needed, throwOnEndOfStream: false);
+                    ? await _stream.ReadAtLeastAsync(_buffer.AvailableMemory.Slice(0, needed), needed, throwOnEndOfStream: false, cancellationToken: cancellationToken).ConfigureAwait(false)
+                    : _stream.ReadAtLeast(_buffer.AvailableSpan.Slice(0, needed), needed, throwOnEndOfStream: false);
                 if (peeked > 0)
                 {
                     _nonEmptyInput = true;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -64,7 +64,6 @@ namespace System.IO.Compression
             Debug.Assert(_decoder != null);
 
             bytesWritten = 0;
-            lastResult = OperationStatus.Done;
 
             while (true)
             {
@@ -115,7 +114,7 @@ namespace System.IO.Compression
                     // how DeflateStream handles data after the last gzip member.
                     if (_buffer.ActiveLength >= ZstdFrameMagicLength)
                     {
-                        lastResult = OperationStatus.Done;
+                        // lastResult is already Done; the stream is complete.
                         return true;
                     }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -231,9 +231,12 @@ namespace System.IO.Compression
                     {
                         // Only treat end-of-input as truncation if we're in the middle of a frame.
                         // If we're at a frame boundary (_atFrameBoundary), the stream ended cleanly
-                        // after the last of one or more concatenated frames.
+                        // after the last of one or more concatenated frames; report Done so that any
+                        // unconsumed trailing bytes are rewound on a seekable base stream.
                         if (_nonEmptyInput && !buffer.IsEmpty && !_atFrameBoundary)
                             ThrowTruncatedInvalidData();
+                        if (_atFrameBoundary)
+                            lastResult = OperationStatus.Done;
                         break;
                     }
 
@@ -311,9 +314,12 @@ namespace System.IO.Compression
                     {
                         // Only treat end-of-input as truncation if we're in the middle of a frame.
                         // If we're at a frame boundary (_atFrameBoundary), the stream ended cleanly
-                        // after the last of one or more concatenated frames.
+                        // after the last of one or more concatenated frames; report Done so that any
+                        // unconsumed trailing bytes are rewound on a seekable base stream.
                         if (_nonEmptyInput && !buffer.IsEmpty && !_atFrameBoundary)
                             ThrowTruncatedInvalidData();
+                        if (_atFrameBoundary)
+                            lastResult = OperationStatus.Done;
                         break;
                     }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
@@ -108,27 +107,6 @@ namespace System.IO.Compression
             return false;
         }
 
-        /// <summary>
-        /// Returns whether <paramref name="data"/> begins with a Zstandard frame magic number: a standard
-        /// frame (0xFD2FB528) or a skippable frame (0x184D2A50-0x184D2A5F), which indicates that another
-        /// concatenated frame follows. Used to distinguish a subsequent frame from trailing data after the
-        /// final frame. Requires at least <see cref="ZstdFrameMagicLength"/> bytes.
-        /// </summary>
-        private static bool StartsWithZstdFrame(ReadOnlySpan<byte> data)
-        {
-            if (data.Length < ZstdFrameMagicLength)
-            {
-                return false;
-            }
-
-            const uint ZstdFrameMagic = 0xFD2FB528;
-            const uint SkippableFrameMagicMin = 0x184D2A50;
-            const uint SkippableFrameMagicMax = 0x184D2A5F;
-
-            uint magic = BinaryPrimitives.ReadUInt32LittleEndian(data);
-            return magic == ZstdFrameMagic || (magic >= SkippableFrameMagicMin && magic <= SkippableFrameMagicMax);
-        }
-
         /// <summary>Reads decompressed bytes from the underlying stream and places them in the specified array.</summary>
         /// <param name="buffer">The byte array to contain the decompressed bytes.</param>
         /// <param name="offset">The byte offset in <paramref name="buffer" /> at which the read bytes will be placed.</param>
@@ -198,16 +176,17 @@ namespace System.IO.Compression
                         _buffer.Commit(bytesRead);
                     }
 
-                    if (lastResult != OperationStatus.Done)
+                    if (lastResult != OperationStatus.Done || bytesWritten != 0)
                     {
-                        // Produced output, or a zero-byte read that should return to the caller.
+                        // Output to hand back, or not at a finished-frame boundary: return to the caller.
                         return bytesWritten;
                     }
 
-                    // A frame finished. A zstd stream may be frames concatenated back-to-back (RFC 8878
-                    // section 3), so decide whether another frame follows before reporting end-of-stream.
-                    // async: false completes synchronously (it only ever takes the synchronous read path).
-                    ValueTask<bool> advanceTask = AdvanceToNextFrame(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, async: false, cancellationToken: default);
+                    // A frame finished with no pending output. A zstd stream may be frames concatenated
+                    // back-to-back (RFC 8878 section 3), so decide whether another frame follows before
+                    // reporting end-of-stream. async: false completes synchronously (it only ever takes the
+                    // synchronous read path).
+                    ValueTask<bool> advanceTask = AdvanceToNextFrame(async: false, cancellationToken: default);
                     Debug.Assert(advanceTask.IsCompleted, "AdvanceToNextFrame should complete synchronously when async: false");
                     if (!advanceTask.GetAwaiter().GetResult())
                     {
@@ -221,41 +200,14 @@ namespace System.IO.Compression
             }
         }
 
-        // Called after TryDecompress reports OperationStatus.Done (end of a frame). Decides whether another
-        // concatenated frame follows: returns true (after resetting the decoder) when the caller should loop
-        // to decode it, or false when the stream is complete and the caller should return. Uses only buffered
-        // bytes when there is pending output to hand back; otherwise reads up to a frame magic to tell a split
-        // next-frame magic from end-of-stream. Shared by Read (async: false) and ReadAsync (async: true).
-        private async ValueTask<bool> AdvanceToNextFrame(bool zeroByteRead, bool hasPendingOutput, bool async, CancellationToken cancellationToken)
+        // Called after TryDecompress reports OperationStatus.Done with no pending output (a finished frame).
+        // Decides whether another concatenated frame follows: reads up to a frame magic and asks the decoder
+        // (IsFrameStart) whether those bytes begin a frame. Returns true (decoder reset and ready) so the caller
+        // loops to decode it, or false (stream complete; a seekable base stream is rewound to the end of the
+        // compressed data) so the caller returns. Shared by Read (async: false) and ReadAsync (async: true).
+        private async ValueTask<bool> AdvanceToNextFrame(bool async, CancellationToken cancellationToken)
         {
-            if (hasPendingOutput)
-            {
-                // There is output to hand back now. If the next frame's header is already buffered, ready the
-                // decoder for it now (no read needed) so the next read decodes it directly; if this was instead
-                // the final frame (trailing non-zstd data) rewind a seekable base stream. With fewer than
-                // ZstdFrameMagicLength bytes buffered we can't tell yet, so defer the decision to the next read
-                // rather than block on the next frame's header before returning data we already have.
-                if (_buffer.ActiveLength >= ZstdFrameMagicLength)
-                {
-                    if (StartsWithZstdFrame(_buffer.ActiveSpan))
-                    {
-                        Debug.Assert(_decoder != null);
-                        _decoder.Reset();
-                    }
-                    else if (_stream.CanSeek)
-                    {
-                        TryRewindStream(_stream);
-                    }
-                }
-
-                return false;
-            }
-
-            if (zeroByteRead)
-            {
-                // Zero-byte read: don't block peeking the next frame; the next read resolves it.
-                return false;
-            }
+            Debug.Assert(_decoder != null);
 
             if (_buffer.ActiveLength < ZstdFrameMagicLength)
             {
@@ -276,12 +228,12 @@ namespace System.IO.Compression
                 }
             }
 
-            if (_buffer.ActiveLength >= ZstdFrameMagicLength && StartsWithZstdFrame(_buffer.ActiveSpan))
+            if (_buffer.ActiveLength >= ZstdFrameMagicLength &&
+                _decoder.IsFrameStart(_buffer.ActiveSpan.Slice(0, ZstdFrameMagicLength)))
             {
-                // Another frame follows. Reset readies the decoder for it (a session-only native reset that
-                // keeps the window size and any dictionary, and releases a single-use prefix).
-                Debug.Assert(_decoder != null);
-                _decoder.Reset();
+                // Another frame follows. IsFrameStart has reset the decoder (a session-only native reset that
+                // keeps the window size and any dictionary, and releases a single-use prefix) and left it ready
+                // to decode the next frame.
                 return true;
             }
 
@@ -367,15 +319,16 @@ namespace System.IO.Compression
                         _buffer.Commit(bytesRead);
                     }
 
-                    if (lastResult != OperationStatus.Done)
+                    if (lastResult != OperationStatus.Done || bytesWritten != 0)
                     {
-                        // Produced output, or a zero-byte read that should return to the caller.
+                        // Output to hand back, or not at a finished-frame boundary: return to the caller.
                         return bytesWritten;
                     }
 
-                    // A frame finished. A zstd stream may be frames concatenated back-to-back (RFC 8878
-                    // section 3), so decide whether another frame follows before reporting end-of-stream.
-                    if (!await AdvanceToNextFrame(buffer.IsEmpty, hasPendingOutput: bytesWritten != 0, async: true, cancellationToken: cancellationToken).ConfigureAwait(false))
+                    // A frame finished with no pending output. A zstd stream may be frames concatenated
+                    // back-to-back (RFC 8878 section 3), so decide whether another frame follows before
+                    // reporting end-of-stream.
+                    if (!await AdvanceToNextFrame(async: true, cancellationToken: cancellationToken).ConfigureAwait(false))
                     {
                         return bytesWritten;
                     }

--- a/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
+++ b/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
@@ -369,19 +369,17 @@ namespace System.IO.Compression
             return buffer;
         }
 
-        // Regression test for https://github.com/dotnet/runtime/issues/129038.
-        // A Zstandard stream can be a sequence of frames concatenated back-to-back (RFC 8878 §3),
-        // which is exactly what HTTP responses with Content-Encoding: zstd produce for large bodies.
-        // Previously ZstandardStream stopped after the first frame, silently truncating the output;
-        // it must now decode every frame.
+        // A Zstandard stream may be a sequence of frames concatenated back-to-back (RFC 8878 section 3),
+        // as produced by Content-Encoding: zstd for large HTTP bodies; decoding must cover every frame,
+        // not just the first.
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task ZstandardStream_ConcatenatedFrames_DecompressesAllFrames(bool async)
+        public async Task ZstandardStream_ConcatenatedFrames_FirstFrameExceeds64KBuffer(bool async)
         {
-            // Use payloads large enough to span the 64 KB internal buffer so the bug (truncation at
-            // the first frame boundary) would manifest, and different sizes so the total length alone
-            // proves that both frames were decoded.
+            // The first frame is larger than the 64 KB internal read buffer so its end lands across an
+            // underlying read of the base stream, the condition that triggered the dropped-tail behavior.
+            // The two sizes differ so the summed output length alone proves both frames were decoded.
             byte[] first = ZstandardTestUtils.CreateTestData(120_000);
             byte[] second = ZstandardTestUtils.CreateTestData(90_000);
             byte[] expected = [.. first, .. second];
@@ -406,14 +404,14 @@ namespace System.IO.Compression
             Assert.Equal(expected, output.ToArray());
         }
 
-        // The next frame's magic number can be split across underlying reads. A stream that yields a
-        // single byte per read forces every frame boundary to be discovered across multiple reads, and
-        // also exercises the non-seekable path (no rewind), as used by HttpClient automatic decompression.
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ZstandardStream_ConcatenatedFrames_AcrossReads_DecompressesAllFrames(bool async)
         {
+            // The next frame's magic number can be split across underlying reads. A stream that yields a
+            // single byte per read forces every frame boundary to be discovered across multiple reads, and
+            // also exercises the non-seekable path (no rewind), as used by HttpClient automatic decompression.
             byte[] first = ZstandardTestUtils.CreateTestData(8_000);
             byte[] second = ZstandardTestUtils.CreateTestData(5_000);
             byte[] expected = [.. first, .. second];
@@ -437,18 +435,29 @@ namespace System.IO.Compression
             Assert.Equal(expected, output.ToArray());
         }
 
-        // Trailing data that is not a Zstandard frame after the final frame must be left untouched (the
-        // stream is complete), mirroring how DeflateStream handles data after the last gzip member.
+        // A Zstandard frame can decode to zero bytes (for example, a frame whose content is empty). The
+        // decoder reports end-of-frame for it the same as any other frame, so a zero-output frame must be
+        // skipped rather than mistaken for the end of the stream, whether it is the leading, an
+        // intermediate, or the trailing frame.
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task ZstandardStream_FrameFollowedByTrailingData_StopsAtEndOfFrame(bool async)
+        public async Task ZstandardStream_EmptyFramesAmongFrames_DecompressesAllFrames(bool async)
         {
-            byte[] payload = ZstandardTestUtils.CreateTestData(10_000);
-            byte[] frame = CompressToSingleFrame(payload);
-            byte[] trailing = Enumerable.Range(0, 64).Select(i => (byte)(i + 1)).ToArray();
+            byte[] first = ZstandardTestUtils.CreateTestData(5_000);
+            byte[] second = ZstandardTestUtils.CreateTestData(7_000);
+            byte[] expected = [.. first, .. second];
 
-            using MemoryStream input = new([.. frame, .. trailing]);
+            byte[] body =
+            [
+                .. CompressToSingleFrame([]),
+                .. CompressToSingleFrame(first),
+                .. CompressToSingleFrame([]),
+                .. CompressToSingleFrame(second),
+                .. CompressToSingleFrame([]),
+            ];
+
+            using MemoryStream input = new(body);
             using MemoryStream output = new();
             using (ZstandardStream decompressor = new(input, CompressionMode.Decompress, leaveOpen: true))
             {
@@ -462,20 +471,14 @@ namespace System.IO.Compression
                 }
             }
 
-            Assert.Equal(payload, output.ToArray());
-
-            // The base stream (seekable) is rewound to the exact end of the compressed frame, so the
-            // trailing bytes remain available to the caller.
-            byte[] remainder = new byte[trailing.Length];
-            int read = input.Read(remainder, 0, remainder.Length);
-            Assert.Equal(trailing.Length, read);
-            Assert.Equal(trailing, remainder);
+            Assert.Equal(expected, output.ToArray());
         }
 
-        // Same as above, but with trailing data shorter than a frame magic number (1-3 bytes). This is
-        // the boundary case where the decoder cannot immediately tell a split next-frame magic from
-        // trailing data; the stream must still end cleanly and leave the trailing bytes on the (seekable)
-        // base stream, consistent with the >= 4 byte case.
+        // Trailing data shorter than a frame magic number (1-3 bytes) after the final frame. This is the
+        // boundary case where the decoder cannot immediately tell a split next-frame magic from trailing
+        // data; the stream must still end cleanly and leave the trailing bytes on the (seekable) base
+        // stream. The 4-or-more-byte trailing-data case is covered by the inherited
+        // AutomaticStreamRewinds_WhenDecompressionFinishes test (CompressionStreamUnitTestBase).
         [Theory]
         [InlineData(false, 1)]
         [InlineData(true, 1)]

--- a/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
+++ b/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit.Sdk;
@@ -359,5 +360,155 @@ namespace System.IO.Compression
             Assert.Throws<ObjectDisposedException>(() => decompressionStream.Read(new byte[1], 0, 1));
         }
 
+        // Compresses data into a single Zstandard frame.
+        private static byte[] CompressToSingleFrame(byte[] data)
+        {
+            byte[] buffer = new byte[ZstandardEncoder.GetMaxCompressedLength(data.Length)];
+            Assert.True(ZstandardEncoder.TryCompress(data, buffer, out int compressedLength));
+            Array.Resize(ref buffer, compressedLength);
+            return buffer;
+        }
+
+        // Regression test for https://github.com/dotnet/runtime/issues/129038.
+        // A Zstandard stream can be a sequence of frames concatenated back-to-back (RFC 8878 §3),
+        // which is exactly what HTTP responses with Content-Encoding: zstd produce for large bodies.
+        // Previously ZstandardStream stopped after the first frame, silently truncating the output;
+        // it must now decode every frame.
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ZstandardStream_ConcatenatedFrames_DecompressesAllFrames(bool async)
+        {
+            // Use payloads large enough to span the 64 KB internal buffer so the bug (truncation at
+            // the first frame boundary) would manifest, and different sizes so the total length alone
+            // proves that both frames were decoded.
+            byte[] first = ZstandardTestUtils.CreateTestData(120_000);
+            byte[] second = ZstandardTestUtils.CreateTestData(90_000);
+            byte[] expected = [.. first, .. second];
+
+            byte[] body = [.. CompressToSingleFrame(first), .. CompressToSingleFrame(second)];
+
+            using MemoryStream input = new(body);
+            using MemoryStream output = new();
+            using (ZstandardStream decompressor = new(input, CompressionMode.Decompress, leaveOpen: true))
+            {
+                if (async)
+                {
+                    await decompressor.CopyToAsync(output);
+                }
+                else
+                {
+                    decompressor.CopyTo(output);
+                }
+            }
+
+            Assert.Equal(expected.Length, output.Length);
+            Assert.Equal(expected, output.ToArray());
+        }
+
+        // The next frame's magic number can be split across underlying reads. A stream that yields a
+        // single byte per read forces every frame boundary to be discovered across multiple reads, and
+        // also exercises the non-seekable path (no rewind), as used by HttpClient automatic decompression.
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ZstandardStream_ConcatenatedFrames_AcrossReads_DecompressesAllFrames(bool async)
+        {
+            byte[] first = ZstandardTestUtils.CreateTestData(8_000);
+            byte[] second = ZstandardTestUtils.CreateTestData(5_000);
+            byte[] expected = [.. first, .. second];
+
+            byte[] body = [.. CompressToSingleFrame(first), .. CompressToSingleFrame(second)];
+
+            using Stream input = new SingleByteReadStream(body);
+            using MemoryStream output = new();
+            using (ZstandardStream decompressor = new(input, CompressionMode.Decompress, leaveOpen: true))
+            {
+                if (async)
+                {
+                    await decompressor.CopyToAsync(output);
+                }
+                else
+                {
+                    decompressor.CopyTo(output);
+                }
+            }
+
+            Assert.Equal(expected, output.ToArray());
+        }
+
+        // Trailing data that is not a Zstandard frame after the final frame must be left untouched (the
+        // stream is complete), mirroring how DeflateStream handles data after the last gzip member.
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ZstandardStream_FrameFollowedByTrailingData_StopsAtEndOfFrame(bool async)
+        {
+            byte[] payload = ZstandardTestUtils.CreateTestData(10_000);
+            byte[] frame = CompressToSingleFrame(payload);
+            byte[] trailing = Enumerable.Range(0, 64).Select(i => (byte)(i + 1)).ToArray();
+
+            using MemoryStream input = new([.. frame, .. trailing]);
+            using MemoryStream output = new();
+            using (ZstandardStream decompressor = new(input, CompressionMode.Decompress, leaveOpen: true))
+            {
+                if (async)
+                {
+                    await decompressor.CopyToAsync(output);
+                }
+                else
+                {
+                    decompressor.CopyTo(output);
+                }
+            }
+
+            Assert.Equal(payload, output.ToArray());
+
+            // The base stream (seekable) is rewound to the exact end of the compressed frame, so the
+            // trailing bytes remain available to the caller.
+            byte[] remainder = new byte[trailing.Length];
+            int read = input.Read(remainder, 0, remainder.Length);
+            Assert.Equal(trailing.Length, read);
+            Assert.Equal(trailing, remainder);
+        }
+
+        // A non-seekable, read-only stream that returns at most one byte per read.
+        private sealed class SingleByteReadStream : Stream
+        {
+            private readonly byte[] _data;
+            private int _position;
+
+            public SingleByteReadStream(byte[] data) => _data = data;
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+            public override int Read(Span<byte> buffer)
+            {
+                if (buffer.IsEmpty || _position >= _data.Length)
+                {
+                    return 0;
+                }
+
+                buffer[0] = _data[_position++];
+                return 1;
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+                Task.FromResult(Read(buffer.AsSpan(offset, count)));
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+                new ValueTask<int>(Read(buffer.Span));
+
+            public override void Flush() { }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
     }
 }

--- a/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
+++ b/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
@@ -472,6 +472,45 @@ namespace System.IO.Compression
             Assert.Equal(trailing, remainder);
         }
 
+        // Same as above, but with trailing data shorter than a frame magic number (1-3 bytes). This is
+        // the boundary case where the decoder cannot immediately tell a split next-frame magic from
+        // trailing data; the stream must still end cleanly and leave the trailing bytes on the (seekable)
+        // base stream, consistent with the >= 4 byte case.
+        [Theory]
+        [InlineData(false, 1)]
+        [InlineData(true, 1)]
+        [InlineData(false, 2)]
+        [InlineData(true, 2)]
+        [InlineData(false, 3)]
+        [InlineData(true, 3)]
+        public async Task ZstandardStream_FrameFollowedByShortTrailingData_StopsAtEndOfFrame(bool async, int trailingLength)
+        {
+            byte[] payload = ZstandardTestUtils.CreateTestData(10_000);
+            byte[] frame = CompressToSingleFrame(payload);
+            byte[] trailing = Enumerable.Range(1, trailingLength).Select(i => (byte)i).ToArray();
+
+            using MemoryStream input = new([.. frame, .. trailing]);
+            using MemoryStream output = new();
+            using (ZstandardStream decompressor = new(input, CompressionMode.Decompress, leaveOpen: true))
+            {
+                if (async)
+                {
+                    await decompressor.CopyToAsync(output);
+                }
+                else
+                {
+                    decompressor.CopyTo(output);
+                }
+            }
+
+            Assert.Equal(payload, output.ToArray());
+
+            byte[] remainder = new byte[trailing.Length];
+            int read = input.Read(remainder, 0, remainder.Length);
+            Assert.Equal(trailing.Length, read);
+            Assert.Equal(trailing, remainder);
+        }
+
         // A non-seekable, read-only stream that returns at most one byte per read.
         private sealed class SingleByteReadStream : Stream
         {
@@ -499,11 +538,25 @@ namespace System.IO.Compression
                 return 1;
             }
 
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
-                Task.FromResult(Read(buffer.AsSpan(offset, count)));
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return Task.FromCanceled<int>(cancellationToken);
+                }
 
-            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
-                new ValueTask<int>(Read(buffer.Span));
+                return Task.FromResult(Read(buffer.AsSpan(offset, count)));
+            }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return ValueTask.FromCanceled<int>(cancellationToken);
+                }
+
+                return new ValueTask<int>(Read(buffer.Span));
+            }
 
             public override void Flush() { }
             public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();

--- a/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
+++ b/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
@@ -517,10 +517,8 @@ namespace System.IO.Compression
         [InlineData(true)]
         public async Task ZstandardStream_FrameFollowedByCorruptFrame_Throws(bool async)
         {
-            // A continuation chunk that begins with a valid frame magic but is not a decodable frame is
-            // corrupt input, the same as a corrupt first frame, so it must throw rather than be silently
-            // dropped as trailing data. This is the case that distinguishes checking the frame magic from
-            // treating a first-call InvalidData as "not a frame".
+            // A continuation chunk that begins with a valid frame magic but a corrupt header is corrupt input,
+            // the same as a corrupt first frame, so it must throw rather than be silently dropped as trailing data.
             byte[] first = ZstandardTestUtils.CreateTestData(4_000);
             byte[] corruptFrame = CompressToSingleFrame(ZstandardTestUtils.CreateTestData(4_000));
 
@@ -543,6 +541,40 @@ namespace System.IO.Compression
             {
                 Assert.Throws<InvalidDataException>(() => decompressor.CopyTo(output));
             }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ZstandardStream_SkippableFrameBetweenFrames_DecompressesAllFrames(bool async)
+        {
+            // A skippable frame may appear between data frames and must not prevent subsequent
+            // frames from being decoded (RFC 8878 section 3.1.2).
+            byte[] first = ZstandardTestUtils.CreateTestData(4_000);
+            byte[] second = ZstandardTestUtils.CreateTestData(6_000);
+            byte[] expected = [.. first, .. second];
+
+            // A minimal skippable frame: magic 0x184D2A50, a 4-byte little-endian content size of 4, then 4
+            // bytes of (ignored) user data.
+            byte[] skippable = [0x50, 0x2A, 0x4D, 0x18, 0x04, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04];
+
+            byte[] body = [.. CompressToSingleFrame(first), .. skippable, .. CompressToSingleFrame(second)];
+
+            using MemoryStream input = new(body);
+            using MemoryStream output = new();
+            using (ZstandardStream decompressor = new(input, CompressionMode.Decompress, leaveOpen: true))
+            {
+                if (async)
+                {
+                    await decompressor.CopyToAsync(output);
+                }
+                else
+                {
+                    decompressor.CopyTo(output);
+                }
+            }
+
+            Assert.Equal(expected, output.ToArray());
         }
 
         // A non-seekable, read-only stream that returns at most one byte per read.

--- a/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
+++ b/src/libraries/System.IO.Compression/tests/Zstandard/CompressionStreamUnitTests.Zstandard.cs
@@ -369,19 +369,17 @@ namespace System.IO.Compression
             return buffer;
         }
 
-        // A Zstandard stream may be a sequence of frames concatenated back-to-back (RFC 8878 section 3),
-        // as produced by Content-Encoding: zstd for large HTTP bodies; decoding must cover every frame,
-        // not just the first.
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task ZstandardStream_ConcatenatedFrames_FirstFrameExceeds64KBuffer(bool async)
+        public async Task ZstandardStream_ConcatenatedFrames_DecompressesAllFrames(bool async)
         {
-            // The first frame is larger than the 64 KB internal read buffer so its end lands across an
-            // underlying read of the base stream, the condition that triggered the dropped-tail behavior.
-            // The two sizes differ so the summed output length alone proves both frames were decoded.
-            byte[] first = ZstandardTestUtils.CreateTestData(120_000);
-            byte[] second = ZstandardTestUtils.CreateTestData(90_000);
+            // A Zstandard stream may be a sequence of frames concatenated back-to-back (RFC 8878 section 3),
+            // as produced by Content-Encoding: zstd for large HTTP bodies; decoding must cover every frame,
+            // not just the first. Two differently sized frames so the summed output length alone proves both
+            // were decoded.
+            byte[] first = ZstandardTestUtils.CreateTestData(300);
+            byte[] second = ZstandardTestUtils.CreateTestData(200);
             byte[] expected = [.. first, .. second];
 
             byte[] body = [.. CompressToSingleFrame(first), .. CompressToSingleFrame(second)];
@@ -435,15 +433,15 @@ namespace System.IO.Compression
             Assert.Equal(expected, output.ToArray());
         }
 
-        // A Zstandard frame can decode to zero bytes (for example, a frame whose content is empty). The
-        // decoder reports end-of-frame for it the same as any other frame, so a zero-output frame must be
-        // skipped rather than mistaken for the end of the stream, whether it is the leading, an
-        // intermediate, or the trailing frame.
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ZstandardStream_EmptyFramesAmongFrames_DecompressesAllFrames(bool async)
         {
+            // A Zstandard frame can decode to zero bytes (for example, a frame whose content is empty). The
+            // decoder reports end-of-frame for it the same as any other frame, so a zero-output frame must be
+            // skipped rather than mistaken for the end of the stream, whether it is the leading, an
+            // intermediate, or the trailing frame.
             byte[] first = ZstandardTestUtils.CreateTestData(5_000);
             byte[] second = ZstandardTestUtils.CreateTestData(7_000);
             byte[] expected = [.. first, .. second];
@@ -474,11 +472,6 @@ namespace System.IO.Compression
             Assert.Equal(expected, output.ToArray());
         }
 
-        // Trailing data shorter than a frame magic number (1-3 bytes) after the final frame. This is the
-        // boundary case where the decoder cannot immediately tell a split next-frame magic from trailing
-        // data; the stream must still end cleanly and leave the trailing bytes on the (seekable) base
-        // stream. The 4-or-more-byte trailing-data case is covered by the inherited
-        // AutomaticStreamRewinds_WhenDecompressionFinishes test (CompressionStreamUnitTestBase).
         [Theory]
         [InlineData(false, 1)]
         [InlineData(true, 1)]
@@ -488,6 +481,11 @@ namespace System.IO.Compression
         [InlineData(true, 3)]
         public async Task ZstandardStream_FrameFollowedByShortTrailingData_StopsAtEndOfFrame(bool async, int trailingLength)
         {
+            // Trailing data shorter than a frame magic number (1-3 bytes) after the final frame. This is the
+            // boundary case where the decoder cannot immediately tell a split next-frame magic from trailing
+            // data; the stream must still end cleanly and leave the trailing bytes on the (seekable) base
+            // stream. The 4-or-more-byte trailing-data case is covered by the inherited
+            // AutomaticStreamRewinds_WhenDecompressionFinishes test (CompressionStreamUnitTestBase).
             byte[] payload = ZstandardTestUtils.CreateTestData(10_000);
             byte[] frame = CompressToSingleFrame(payload);
             byte[] trailing = Enumerable.Range(1, trailingLength).Select(i => (byte)i).ToArray();
@@ -512,6 +510,39 @@ namespace System.IO.Compression
             int read = input.Read(remainder, 0, remainder.Length);
             Assert.Equal(trailing.Length, read);
             Assert.Equal(trailing, remainder);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ZstandardStream_FrameFollowedByCorruptFrame_Throws(bool async)
+        {
+            // A continuation chunk that begins with a valid frame magic but is not a decodable frame is
+            // corrupt input, the same as a corrupt first frame, so it must throw rather than be silently
+            // dropped as trailing data. This is the case that distinguishes checking the frame magic from
+            // treating a first-call InvalidData as "not a frame".
+            byte[] first = ZstandardTestUtils.CreateTestData(4_000);
+            byte[] corruptFrame = CompressToSingleFrame(ZstandardTestUtils.CreateTestData(4_000));
+
+            // Keep the 4-byte magic intact (so it is recognized as a following frame) but set the reserved
+            // bit in the frame header descriptor (the byte right after the magic), which a compliant decoder
+            // must reject.
+            corruptFrame[4] |= 0x08;
+
+            byte[] body = [.. CompressToSingleFrame(first), .. corruptFrame];
+
+            using MemoryStream input = new(body);
+            using MemoryStream output = new();
+            using ZstandardStream decompressor = new(input, CompressionMode.Decompress, leaveOpen: true);
+
+            if (async)
+            {
+                await Assert.ThrowsAsync<InvalidDataException>(() => decompressor.CopyToAsync(output));
+            }
+            else
+            {
+                Assert.Throws<InvalidDataException>(() => decompressor.CopyTo(output));
+            }
         }
 
         // A non-seekable, read-only stream that returns at most one byte per read.


### PR DESCRIPTION
Fixes #129038.

## Problem

A zstd stream can be several frames concatenated back to back (RFC 8878 §3). Many encoders and CDNs emit one frame per buffer, so a large `Content-Encoding: zstd` response often arrives as multiple frames. `ZstandardStream` only decoded the first frame and dropped the rest, which surfaced downstream as truncated data. In the linked issue, `System.Text.Json` fails at exactly `BytePositionInLine: 65536`.

The cause is in `ZstandardDecoder.Decompress`:

```csharp
if (result == 0) { _finished = true; return OperationStatus.Done; }
```

A `0` return from `ZSTD_decompressStream` means the current frame is done, not that the whole stream is done (`lib/zstd.h`: "0 when a frame is completely decoded and fully flushed"). Because `_finished` is a one-way latch and `Decompress` returns early once it is set, finishing the first frame permanently stops decoding and every later frame is discarded.

## Fix

`ZstandardStream` now continues into the next frame instead of stopping at the first. This follows the pattern `GZipStream` and `DeflateStream` already use for concatenated members, adapted to zstd.

- `TryDecompress` decodes a single frame and returns when the decoder reports `Done`. The frame-to-frame loop now lives in `Read` and `ReadAsync`, with a single `AdvanceToNextFrame(bool async, ...)` helper handling the boundary for both.
- At a frame boundary, `AdvanceToNextFrame` reads up to the next 4-byte frame magic and feeds exactly those bytes to the decoder through the public `ZstandardDecoder.Decompress` (after a session-only `Reset()`). A valid magic comes back as `NeedMoreData`, so the stream discards the magic from its buffer and keeps decoding; anything else is trailing data after the final frame. Feeding only the magic (not the whole buffer) means a frame whose magic is valid but whose body is corrupt is not mistaken for trailing data: the magic is accepted and the corrupt body is rejected by the following decode.
- When the boundary check decides the stream is finished it sets `_endOfStream`, so later reads return 0 without re-entering the decoder (which may have been left in an error state by feeding it non-magic bytes). On a seekable stream the position is rewound so trailing data is still readable by the caller.
- `Reset()` is `ZSTD_DCtx_reset` in session-only mode, so window size and any referenced dictionary carry over to the next frame. It also releases the single-use prefix, which is only valid for one frame anyway.
- An empty frame (one that produces no output) is no longer mistaken for end of stream, so an empty leading or middle frame doesn't cut decoding short.
- End of input counts as a clean end only when the last frame finished on a frame boundary, so the existing truncation check still fires for a genuinely truncated frame.

The one-shot helpers were already correct across frames (`ZstandardDecoder.TryDecompress` calls `ZSTD_decompress` and `TryGetMaxDecompressedLength` calls `ZSTD_decompressBound`, both multi-frame aware), so they are unchanged.

## Tests

Added to `CompressionStreamUnitTests.Zstandard.cs`, each run sync and async:

- `ZstandardStream_ConcatenatedFrames_DecompressesAllFrames`: two concatenated frames, asserts the whole payload comes back (only the first frame decoded before the fix).
- `ZstandardStream_ConcatenatedFrames_AcrossReads_DecompressesAllFrames`: a non-seekable stream that returns one byte per read, so a frame magic can land split across reads. Covers the HttpClient style path with no rewind.
- `ZstandardStream_EmptyFramesAmongFrames_DecompressesAllFrames`: empty frames mixed in with real ones, to confirm an empty frame isn't read as end of stream.
- `ZstandardStream_FrameFollowedByShortTrailingData_StopsAtEndOfFrame`: a frame followed by 1 to 3 trailing bytes (shorter than the magic), checks the stream ends cleanly and the trailing bytes stay available on the base stream.
- `ZstandardStream_FrameFollowedByCorruptFrame_Throws`: a frame followed by a second frame with a valid magic but a corrupt body, asserts `InvalidDataException` so a corrupt continuation isn't swallowed as trailing data.
- `ZstandardStream_SkippableFrameBetweenFrames_DecompressesAllFrames`: a skippable frame between two real frames, asserts both real frames decode.

Existing tests, including `StreamTruncation_IsDetected`, still pass.

## Notes

Next-frame detection feeds the 4 boundary bytes straight to the decoder rather than recognizing the magic in managed code: a valid frame magic (standard or skippable) comes back as `OperationStatus.NeedMoreData`, anything else as `InvalidData`. This keeps the managed side out of knowing the frame-format magics, and a corrupt frame body is still surfaced as `InvalidDataException` by the subsequent decode rather than being swallowed as trailing data.

Repro: https://github.com/christosk92/zstd-net11-repro
