### PR TITLE
Make scheduled outerloop builds succeed when only Helix tests fail

### DIFF
--- a/eng/pipelines/libraries/helix.yml
+++ b/eng/pipelines/libraries/helix.yml
@@ -13,6 +13,11 @@ parameters:
   extraHelixArguments: ''
   shouldContinueOnError: false
   scenarios: ''
+  # When false, Helix work item and test failures do not fail the build, so the "Send to Helix"
+  # step still succeeds. Unlike shouldContinueOnError (which only marks the build as
+  # partiallySucceeded), this produces a fully successful build. Scheduled builds with
+  # always:false set this so that flaky tests don't cause AzDO to re-queue the same commit daily.
+  failOnTestFailures: true
 
 steps:
   - script: $(_msbuildCommand) $(_warnAsErrorParamHelixOverride) -restore
@@ -26,6 +31,8 @@ steps:
             /p:TestScope=${{ parameters.testScope }}
             /p:TestRunNamePrefixSuffix=${{ parameters.testRunNamePrefixSuffix }}
             /p:HelixBuild=$(Build.BuildNumber)
+            /p:FailOnWorkItemFailure=${{ parameters.failOnTestFailures }}
+            /p:FailOnTestFailure=${{ parameters.failOnTestFailures }}
             ${{ parameters.extraHelixArguments }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: Send to Helix

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -23,10 +23,6 @@ extends:
           parameters:
             jobTemplate: /eng/pipelines/common/global-build-job.yml
             helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-            # Don't fail scheduled builds on Helix work item failures. Otherwise a perpetually
-            # failing scheduled build (flaky outerloop tests) causes AzDO to re-queue the same
-            # commit every day, wasting Helix resources. See always:false on the schedule above.
-            shouldContinueOnError: ${{ eq(variables['Build.Reason'], 'Schedule') }}
             buildConfig: Release
             platforms:
             - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
@@ -56,14 +52,17 @@ extends:
                     testScope: outerloop
                     creator: dotnet-bot
                     testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+                    # On scheduled runs (always:false) don't fail the build on Helix work item or
+                    # test failures, so flaky outerloop tests don't keep AzDO re-queueing the same
+                    # commit. The Send to Helix step fully succeeds (not partiallySucceeded).
+                    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+                      failOnTestFailures: false
 
         - ${{ if eq(variables['isRollingBuild'], false) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
             parameters:
               jobTemplate: /eng/pipelines/common/global-build-job.yml
               helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-              # Don't fail scheduled builds on Helix work item failures (see comment above).
-              shouldContinueOnError: ${{ eq(variables['Build.Reason'], 'Schedule') }}
               buildConfig: Debug
               platforms:
               - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
@@ -87,14 +86,15 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+                      # Don't fail scheduled builds on Helix work item/test failures (see above).
+                      ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+                        failOnTestFailures: false
 
         - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
             parameters:
               jobTemplate: /eng/pipelines/common/global-build-job.yml
               helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-              # Don't fail scheduled builds on Helix work item failures (see comment above).
-              shouldContinueOnError: ${{ eq(variables['Build.Reason'], 'Schedule') }}
               buildConfig: Release
               platforms:
               - windows_x86
@@ -114,3 +114,6 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       extraHelixArguments: /p:BuildTargetFramework=net48
+                      # Don't fail scheduled builds on Helix work item/test failures (see above).
+                      ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+                        failOnTestFailures: false

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -55,7 +55,7 @@ extends:
                     # On scheduled runs (always:false) don't fail the build on Helix work item or
                     # test failures, so flaky outerloop tests don't keep AzDO re-queueing the same
                     # commit. The Send to Helix step fully succeeds (not partiallySucceeded).
-                    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+                    ${{ if in(variables['Build.Reason'], 'Schedule', 'Manual') }}:
                       failOnTestFailures: false
 
         - ${{ if eq(variables['isRollingBuild'], false) }}:
@@ -87,7 +87,7 @@ extends:
                       creator: dotnet-bot
                       testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
                       # Don't fail scheduled builds on Helix work item/test failures (see above).
-                      ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+                      ${{ if in(variables['Build.Reason'], 'Schedule', 'Manual') }}:
                         failOnTestFailures: false
 
         - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
@@ -115,5 +115,5 @@ extends:
                       creator: dotnet-bot
                       extraHelixArguments: /p:BuildTargetFramework=net48
                       # Don't fail scheduled builds on Helix work item/test failures (see above).
-                      ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+                      ${{ if in(variables['Build.Reason'], 'Schedule', 'Manual') }}:
                         failOnTestFailures: false

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -23,6 +23,10 @@ extends:
           parameters:
             jobTemplate: /eng/pipelines/common/global-build-job.yml
             helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+            # Don't fail scheduled builds on Helix work item failures. Otherwise a perpetually
+            # failing scheduled build (flaky outerloop tests) causes AzDO to re-queue the same
+            # commit every day, wasting Helix resources. See always:false on the schedule above.
+            shouldContinueOnError: ${{ eq(variables['Build.Reason'], 'Schedule') }}
             buildConfig: Release
             platforms:
             - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
@@ -58,6 +62,8 @@ extends:
             parameters:
               jobTemplate: /eng/pipelines/common/global-build-job.yml
               helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+              # Don't fail scheduled builds on Helix work item failures (see comment above).
+              shouldContinueOnError: ${{ eq(variables['Build.Reason'], 'Schedule') }}
               buildConfig: Debug
               platforms:
               - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
@@ -87,6 +93,8 @@ extends:
             parameters:
               jobTemplate: /eng/pipelines/common/global-build-job.yml
               helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+              # Don't fail scheduled builds on Helix work item failures (see comment above).
+              shouldContinueOnError: ${{ eq(variables['Build.Reason'], 'Schedule') }}
               buildConfig: Release
               platforms:
               - windows_x86

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -55,7 +55,7 @@ extends:
                     # On scheduled runs (always:false) don't fail the build on Helix work item or
                     # test failures, so flaky outerloop tests don't keep AzDO re-queueing the same
                     # commit. The Send to Helix step fully succeeds (not partiallySucceeded).
-                    ${{ if in(variables['Build.Reason'], 'Schedule', 'Manual') }}:
+                    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
                       failOnTestFailures: false
 
         - ${{ if eq(variables['isRollingBuild'], false) }}:
@@ -87,7 +87,7 @@ extends:
                       creator: dotnet-bot
                       testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
                       # Don't fail scheduled builds on Helix work item/test failures (see above).
-                      ${{ if in(variables['Build.Reason'], 'Schedule', 'Manual') }}:
+                      ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
                         failOnTestFailures: false
 
         - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
@@ -115,5 +115,5 @@ extends:
                       creator: dotnet-bot
                       extraHelixArguments: /p:BuildTargetFramework=net48
                       # Don't fail scheduled builds on Helix work item/test failures (see above).
-                      ${{ if in(variables['Build.Reason'], 'Schedule', 'Manual') }}:
+                      ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
                         failOnTestFailures: false


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.

## Problem

Several scheduled outerloop pipelines (the `outerloop.yml` family: `runtime-libraries-coreclr outerloop` and its `-windows`/`-linux`/`-osx` variants) use an `always: false` scheduled trigger. With `always: false`, AzDO only starts a new scheduled run if the source changed **since the last _successful_ scheduled run**.

Because the repo has many flaky outerloop tests, the Helix test work items virtually always have at least one failure, which fails the "Send to Helix" step and therefore the whole build. The build never reaches a `succeeded` state, so AzDO re-queues **the same, unchanged commit** day after day, submitting more and more Helix work for no benefit. (Empirically confirmed: a single commit was re-run and failed for 19 consecutive days; once a sibling definition produced a genuinely successful run, the same-SHA re-queue stopped.)

## Why `continueOnError` is not enough

`continueOnError: true` only downgrades the build to `partiallySucceeded`, which AzDO's `always: false` scheduler still does **not** treat as successful — so the same commit keeps getting re-queued. The Helix step must end **fully successful** (exit 0).

## Fix

Make the "Send to Helix" step actually succeed on scheduled runs by disabling the two Arcade `Microsoft.DotNet.Helix.Sdk` properties that fail the build (both default to `true`):

- **`FailOnWorkItemFailure`** — `CheckHelixJobStatus` errors when a work item exits non-zero.
- **`FailOnTestFailure`** — `CheckAzurePipelinesTestResults` errors when any published test failed.

Setting both to `false` lets the msbuild step exit 0, producing a fully `succeeded` build. Failed tests are still published and visible in the test results tab; AzDO does not auto-degrade a build to `partiallySucceeded` just because a published test run contains failures — only a failing task would.

### Changes

- **`eng/pipelines/libraries/helix.yml`**: Added a `failOnTestFailures` parameter (default `true`, preserving today's behavior) wired to `/p:FailOnWorkItemFailure` and `/p:FailOnTestFailure` on the Send to Helix msbuild invocation.
- **`eng/pipelines/libraries/outerloop.yml`**: Passes `failOnTestFailures: false` **only on scheduled runs** (`Build.Reason == 'Schedule'`) for all three matrix legs (Release, Debug, NET48).

## Behavior preservation

The new parameter defaults to `true`, so all other `helix.yml` callers are unaffected (none set `WaitForWorkItemCompletion` or these properties on this path, so they already resolve to `true`). Only scheduled outerloop runs change behavior. PR / rolling / manual outerloop runs continue to fail on Helix failures exactly as before. Build/compile breaks still fail scheduled runs (this only affects the Helix step).

## Tradeoff

On scheduled runs, `FailOnWorkItemFailure=false` also masks work-item crashes/timeouts/infra failures, not just test-assertion failures. This is an accepted tradeoff for the goal of stopping the wasteful daily re-queue of unchanged commits; results remain visible in the Helix/test reporting.
