### PR TITLE
Clarify MetadataLoadContext load wording

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/src/Resources/Strings.resx
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/Resources/Strings.resx
@@ -178,7 +178,7 @@
     <value>The assembly '{0}' has already loaded been loaded into this MetadataLoadContext.</value>
   </data>
   <data name="FileNotFoundAssembly" xml:space="preserve">
-    <value>Could not find assembly '{0}'. Either explicitly load this assembly using a method such as LoadFromAssemblyPath() or use a MetadataAssemblyResolver that returns a valid assembly.</value>
+    <value>Could not find assembly '{0}'. Use a MetadataAssemblyResolver that returns a valid assembly for this assembly name.</value>
   </data>
   <data name="FileNotFoundModule" xml:space="preserve">
     <value>Could not find the module file for '{0}'.</value>

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/MetadataLoadContext.Apis.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/MetadataLoadContext.Apis.cs
@@ -115,7 +115,7 @@ namespace System.Reflection
         }
 
         /// <summary>
-        /// Loads an assembly from a specific path on the disk and binds its assembly name to it in the MetadataLoadContext. If a prior
+        /// Loads an assembly from a specific path on the disk into the MetadataLoadContext. If a prior
         /// assembly with the same name was already loaded into the MetadataLoadContext, the prior assembly will be returned. If the
         /// two assemblies do not have the same Mvid, this method throws a FileLoadException.
         /// </summary>
@@ -129,7 +129,7 @@ namespace System.Reflection
         }
 
         /// <summary>
-        /// Loads an assembly from a byte array and binds its assembly name to it in the MetadataLoadContext. If a prior
+        /// Loads an assembly from a byte array into the MetadataLoadContext. If a prior
         /// assembly with the same name was already loaded into the MetadataLoadContext, the prior assembly will be returned. If the
         /// two assemblies do not have the same Mvid, this method throws a FileLoadException.
         /// </summary>
@@ -143,7 +143,7 @@ namespace System.Reflection
         }
 
         /// <summary>
-        /// Loads an assembly from a stream and binds its assembly name to it in the MetadataLoadContext. If a prior
+        /// Loads an assembly from a stream into the MetadataLoadContext. If a prior
         /// assembly with the same name was already loaded into the MetadataLoadContext, the prior assembly will be returned. If the
         /// two assemblies do not have the same Mvid, this method throws a FileLoadException.
         ///


### PR DESCRIPTION
Fixes #113353.

Updates MetadataLoadContext LoadFrom* XML comments and the FileNotFoundAssembly resource string so they no longer imply that directly loading an assembly path/stream/byte array binds that assembly name for later resolver lookups. The wording now points callers to MetadataAssemblyResolver for assembly-name resolution.

Validation:
- git diff --check
- Strings.resx parsed as XML
- static search confirmed the stale binding/preload wording was removed from the target source files

Not run: full runtime build/test; wording-only change in a sparse checkout.