### PR TITLE
[wasi] Enable PackedSimd intrinsics and ILLink substitutions

### DIFF
--- a/src/mono/mono/mini/interp/interp-nosimd.c
+++ b/src/mono/mono/mini/interp/interp-nosimd.c
@@ -6,7 +6,7 @@
 
 gboolean interp_simd_enabled = FALSE;
 
-#ifdef HOST_BROWSER
+#if HOST_BROWSER || HOST_WASI
 
 int interp_simd_p_p_wasm_opcode_table [] = {
 };
@@ -17,7 +17,7 @@ int interp_simd_p_pp_wasm_opcode_table [] = {
 int interp_simd_p_ppp_wasm_opcode_table [] = {
 };
 
-#endif // HOST_BROWSER
+#endif // HOST_BROWSER || HOST_WASI
 
 PP_SIMD_Method interp_simd_p_p_table [] = {
 };

--- a/src/mono/mono/mini/interp/interp-simd.c
+++ b/src/mono/mono/mini/interp/interp-simd.c
@@ -2,7 +2,7 @@
 #include "interp-internals.h"
 #include "interp-simd.h"
 
-#if HOST_BROWSER
+#if HOST_BROWSER || HOST_WASI
 #include <wasm_simd128.h>
 #endif
 
@@ -611,6 +611,12 @@ interp_v128_i8_shuffle (gpointer res, gpointer v1, gpointer v2)
 // https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/wasm_simd128.h
 // In this context V means Vector128 and P means void* pointer.
 #ifdef HOST_BROWSER
+#define HOST_WASM_SIMD 1
+#elif defined(HOST_WASI)
+#define HOST_WASM_SIMD 1
+#endif
+
+#if HOST_WASM_SIMD
 
 static v128_t
 _interp_wasm_simd_assert_not_reached (v128_t lhs, v128_t rhs) {
@@ -931,7 +937,7 @@ int interp_simd_p_ppp_wasm_opcode_table [] = {
 #undef INTERP_SIMD_INTRINSIC_P_PPP
 #define INTERP_SIMD_INTRINSIC_P_PPP(a,b,c)
 
-#endif // HOST_BROWSER
+#endif // HOST_WASM_SIMD
 
 #undef INTERP_SIMD_INTRINSIC_P_P
 #define INTERP_SIMD_INTRINSIC_P_P(a,b,c) b,

--- a/src/mono/mono/mini/interp/interp-simd.h
+++ b/src/mono/mono/mini/interp/interp-simd.h
@@ -13,7 +13,7 @@ extern PP_SIMD_Method interp_simd_p_p_table [];
 extern PPP_SIMD_Method interp_simd_p_pp_table [];
 extern PPPP_SIMD_Method interp_simd_p_ppp_table [];
 
-#if HOST_BROWSER
+#if HOST_BROWSER || HOST_WASI
 extern int interp_simd_p_p_wasm_opcode_table [];
 extern int interp_simd_p_pp_wasm_opcode_table [];
 extern int interp_simd_p_ppp_wasm_opcode_table [];

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -517,7 +517,7 @@ emit_sri_vector128 (TransformData *td, MonoMethod *cmethod, MonoMethodSignature 
 	if (csignature->hasthis)
 		return FALSE;
 
-#ifdef HOST_BROWSER
+#if defined(HOST_BROWSER) || defined(HOST_WASI)
 	if (emit_sri_packedsimd (td, cmethod, csignature))
 		return TRUE;
 #endif
@@ -731,7 +731,7 @@ opcode_added:
 static gboolean
 emit_sri_vector128_t (TransformData *td, MonoMethod *cmethod, MonoMethodSignature *csignature)
 {
-#ifdef HOST_BROWSER
+#if defined(HOST_BROWSER) || defined(HOST_WASI)
 	if (emit_sri_packedsimd (td, cmethod, csignature))
 		return TRUE;
 #endif
@@ -775,7 +775,7 @@ opcode_added:
 static gboolean
 emit_sn_vector_t (TransformData *td, MonoMethod *cmethod, MonoMethodSignature *csignature, gboolean newobj)
 {
-#ifdef HOST_BROWSER
+#if defined(HOST_BROWSER) || defined(HOST_WASI)
 	if (emit_sri_packedsimd (td, cmethod, csignature))
 		return TRUE;
 #endif
@@ -876,7 +876,7 @@ opcode_added:
 	return TRUE;
 }
 
-#if HOST_BROWSER
+#if defined(HOST_BROWSER) || defined(HOST_WASI)
 
 #define PSIMD_ARGTYPE_I1 MONO_TYPE_I1
 #define PSIMD_ARGTYPE_I2 MONO_TYPE_I2
@@ -1122,7 +1122,7 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 			// We don't want to emit the IsSupported or IsHardwareAccelerated methods for Vector* here
 			return FALSE;
 		}
-#if HOST_BROWSER
+#if defined(HOST_BROWSER) || defined(HOST_WASI)
 		interp_add_ins (td, MINT_LDC_I4_1);
 #else
 		interp_add_ins (td, MINT_LDC_I4_0);
@@ -1133,7 +1133,7 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 	if (!get_common_simd_info (vector_klass, csignature, &atype, &vector_size, &arg_size, &scalar_arg))
 		return FALSE;
 
-#if HOST_BROWSER
+#if defined(HOST_BROWSER) || defined(HOST_WASI)
 	if (!is_packedsimd) {
 		// transform the method name from the Vector(128|) name to the packed simd name
 		// FIXME: This is a hack, but it works for now.
@@ -1311,9 +1311,9 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 
 	interp_add_ins (td, simd_opcode);
 	td->last_ins->data [0] = simd_intrins;
-#else // HOST_BROWSER
+#else // defined(HOST_BROWSER) || defined(HOST_WASI)
 	return FALSE;
-#endif // HOST_BROWSER
+#endif // defined(HOST_BROWSER) || defined(HOST_WASI)
 
 opcode_added:
 	emit_common_simd_epilogue (td, vector_klass, csignature, vector_size, TRUE);

--- a/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk.pkgproj
@@ -15,6 +15,9 @@
     <PackageFile Include="$(WasiProjectRoot)build\WasiApp.props" TargetPath="Sdk" />
     <PackageFile Include="$(WasiProjectRoot)build\WasiApp.targets" TargetPath="Sdk" />
 
+    <PackageFile Include="$(BrowserProjectRoot)build\ILLink.Substitutions.WasmIntrinsics.xml" TargetPath="Sdk" />
+    <PackageFile Include="$(BrowserProjectRoot)build\ILLink.Substitutions.NoWasmIntrinsics.xml" TargetPath="Sdk" />
+
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.props" TargetPath="Sdk" />
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.targets" TargetPath="Sdk" />
 

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -46,6 +46,9 @@
     <WasmEmitSymbolMap Condition="'$(WasmEmitSymbolMap)' == '' and '$(RunAOTCompilation)' != 'true'">false</WasmEmitSymbolMap>
     <TrimMode Condition="'$(TrimMode)' == ''">full</TrimMode>
 
+    <_ExtraTrimmerArgs Condition="'$(WasmEnableSIMD)' != 'false'">$(_ExtraTrimmerArgs) --substitutions "$(MSBuildThisFileDirectory)ILLink.Substitutions.WasmIntrinsics.xml"</_ExtraTrimmerArgs>
+    <_ExtraTrimmerArgs Condition="'$(WasmEnableSIMD)' == 'false'">$(_ExtraTrimmerArgs) --substitutions "$(MSBuildThisFileDirectory)ILLink.Substitutions.NoWasmIntrinsics.xml"</_ExtraTrimmerArgs>
+
     <WasmRunWasmOpt Condition="'$(WasmRunWasmOpt)' == ''">false</WasmRunWasmOpt>
 
     <!--<WasiBundleAssemblies Condition="'$(WasiBundleAssemblies)' == ''">true</WasiBundleAssemblies>-->
@@ -245,7 +248,7 @@
       <_WasiClangCommonFlags Include="-v"                                Condition="'$(WasiClangVerbose)' != 'false'" />
       <!--<_WasiClangCommonFlags Include="-s DISABLE_EXCEPTION_CATCHING=0"   Condition="'$(WasmEnableExceptionHandling)' == 'false'" />-->
       <!--<_WasiClangCommonFlags Include="-fwasm-exceptions"                 Condition="'$(WasmEnableExceptionHandling)' == 'true'" />-->
-      <!--<_WasiClangCommonFlags Include="-msimd128"                         Condition="'$(WasmEnableSIMD)' == 'true'" />-->
+      <_WasiClangCommonFlags Include="-msimd128"                         Condition="'$(WasmEnableSIMD)' == 'true'" />
 
       <_WasmCommonCFlags Include="-DGEN_PINVOKE=1" />
       <_WasmCommonCFlags Condition="'$(_WasmShouldAOT)' == 'true'"         Include="-DENABLE_AOT=1" />


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI-generated with GitHub Copilot.

## Problem

Calling `System.Runtime.Intrinsics.Wasm.PackedSimd.ConvertNarrowingSaturateUnsigned` (and other PackedSimd intrinsics) in a WASI app crashes with a stack overflow, because the C# fallback for each intrinsic recursively calls itself when the runtime fails to substitute it.

Two separate things contribute:

1. **Mono interpreter (WASI, SIMD enabled).** \`src/mono/mono/mini/interp/transform-simd.c\` only emits the interpreter's wasm packed-simd opcodes when \`HOST_BROWSER\` is defined. On WASI \`emit_sri_packedsimd\` always returns \`FALSE\`, so the C# body runs and recurses.
2. **WASI SDK / MSBuild (any SIMD setting).** \`WasiApp.targets\` does not inject the ILLink \`WasmIntrinsics.xml\` / \`NoWasmIntrinsics.xml\` substitutions that \`BrowserWasmApp.targets\` uses to fold \`PackedSimd.IsSupported\` to a constant. Without that, \`WasmEnableSIMD=false\` apps still keep the simd call sites alive and trip the same recursion.

## Changes

**Interpreter (b):** Extend the \`HOST_BROWSER\` gates to also cover \`HOST_WASI\` so the interpreter substitutes PackedSimd intrinsics on WASI. The \`mono-wasm-simd\` static library is already built with \`-msimd128\` for both hosts (\`src/mono/mono/mini/CMakeLists.txt\` line 484).

- \`src/mono/mono/mini/interp/interp-simd.h\` — extern table declarations.
- \`src/mono/mono/mini/interp/interp-simd.c\` — \`<wasm_simd128.h>\` include and the wasm intrinsic block (now under a \`HOST_WASM_SIMD\` helper macro).
- \`src/mono/mono/mini/interp/interp-nosimd.c\` — empty fallback tables provided for WASI too.
- \`src/mono/mono/mini/interp/transform-simd.c\` — every \`HOST_BROWSER\` gate around \`emit_sri_packedsimd\` switched to \`defined(HOST_BROWSER) || defined(HOST_WASI)\`.

**MSBuild / SDK (a, c):**

- \`src/mono/wasi/build/WasiApp.targets\` — add \`_ExtraTrimmerArgs\` for the two substitution XMLs (mirrors \`BrowserWasmApp.targets:33-34\`), and uncomment \`-msimd128\` for \`WasmEnableSIMD=true\`.
- \`src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk.pkgproj\` — ship the two \`ILLink.Substitutions.*.xml\` files (reused from \`\$(BrowserProjectRoot)\`) next to \`WasiApp.targets\` in the WASI SDK pack so \`\$(MSBuildThisFileDirectory)\` resolves at app build time.

## Verification

- WASI mono native built cleanly with \`WasmEnableSIMD=true\`: \`libmono-wasm-simd.a\`, \`libmono-wasm-nosimd.a\`, \`transform.c.obj\` (includes \`transform-simd.c\`), and \`interp-simd.c.obj\` all built with \`HOST_WASI\` defined.
- An unrelated pre-existing wasi-sysroot link failure (\`undefined symbol: gethostname\` in \`libSystem.Native.a\`) blocks the final \`dotnet.wasm\` link; reproduced on \`main\`, not affected by these changes.

## Draft

Marked draft for review and to confirm there are no other WASI-only PackedSimd test gaps before un-drafting.