### PR TITLE
Add OpenBSD support in CPalThread

### DIFF
--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -2316,7 +2316,7 @@ CPalThread::GetStackBase()
 #ifdef TARGET_APPLE
     // This is a Mac specific method
     stackBase = pthread_get_stackaddr_np(pthread_self());
-#elif TARGET_OPENBSD
+#elif defined(TARGET_OPENBSD)
     stack_t stack;
     int status = pthread_stackseg_np(pthread_self(), &stack);
     _ASSERT_MSG(status == 0, "pthread_stackseg_np call failed");

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1423,7 +1423,7 @@ CPalThread::ThreadEntry(
                     // vendor-modified Android kernels with strict SELinux policy) block
                     // sched_setaffinity even when passed a mask extracted via sched_getaffinity.
                     // Treat this as non-fatal — the thread will continue running on any
-                    // available CPU rather than the originally affinitized one. 
+                    // available CPU rather than the originally affinitized one.
                     WARN("sched_setaffinity failed with EPERM/EACCES, ignoring\n");
                 }
                 else
@@ -2316,6 +2316,12 @@ CPalThread::GetStackBase()
 #ifdef TARGET_APPLE
     // This is a Mac specific method
     stackBase = pthread_get_stackaddr_np(pthread_self());
+#elif TARGET_OPENBSD
+    stack_t stack;
+    int status = pthread_stackseg_np(pthread_self(), &stack);
+    _ASSERT_MSG(status == 0, "pthread_stackseg_np call failed");
+
+    stackBase = stack.ss_sp;
 #else
     pthread_attr_t attr;
     void* stackAddr;
@@ -2361,6 +2367,12 @@ CPalThread::GetStackLimit()
     // This is a Mac specific method
     stackLimit = ((BYTE *)pthread_get_stackaddr_np(pthread_self()) -
                    pthread_get_stacksize_np(pthread_self()));
+#elif TARGET_OPENBSD
+    stack_t stack;
+    int status = pthread_stackseg_np(pthread_self(), &stack);
+    _ASSERT_MSG(status == 0, "pthread_stackseg_np call failed");
+
+    stackLimit = (void*)stack.ss_size;
 #else
     pthread_attr_t attr;
     size_t stackSize;

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -2367,7 +2367,7 @@ CPalThread::GetStackLimit()
     // This is a Mac specific method
     stackLimit = ((BYTE *)pthread_get_stackaddr_np(pthread_self()) -
                    pthread_get_stacksize_np(pthread_self()));
-#elif TARGET_OPENBSD
+#elif defined(TARGET_OPENBSD)
     stack_t stack;
     int status = pthread_stackseg_np(pthread_self(), &stack);
     _ASSERT_MSG(status == 0, "pthread_stackseg_np call failed");


### PR DESCRIPTION
Add OpenBSD support for `CPalThread::GetStackBase()` and `CPalThread::GetStackLimit()`.

OpenBSD does not have `pthread_attr_get_np` or `pthread_getattr_np` to get the current thread's stack attributes.

Instead there is a standalone function [pthread_stackseg_np](https://man.openbsd.org/pthread_stackseg_np.3) that does the same via [stack_t](https://man.openbsd.org/sigaltstack.2). Since we do not actually need a standard pthread attr in this case I put this case inside a `TARGET_OPENBSD` check similar to macOS.

I know that the preferred means of upstreaming the rest of OpenBSD support is to do it all at once but I'm fairly stuck now and you can see my most recent comments [here](https://github.com/dotnet/runtime/issues/124911#issuecomment-4635872759).

So I decided to send this PR for now while I try to figure out next steps for the port.

Contributes to #124911

