### PR TITLE
JIT: Fix for IV opt to preserve updates to a counter that is live into an EH handler

### DIFF
--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1328,13 +1328,6 @@ bool Compiler::optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loo
         return true;
     }
 
-    if (varDsc->lvDoNotEnregister)
-    {
-        // We cannot reason precisely about uses of locals that are not
-        // enregisterable, so be conservative.
-        return true;
-    }
-
     if (!varDsc->lvTracked && !varDsc->lvInSsa)
     {
         // We do not have liveness we can use for this untracked local.
@@ -1367,6 +1360,26 @@ bool Compiler::optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loo
         // (and whether it doesn't extend their lifetimes too much).
         return true;
     }
+
+#ifdef DEBUG
+    // We currently do not expect to ever widen IVs that are live into
+    // exceptional exits. Such IVs are not currently register candidates (EH
+    // write-thru is only for single def locals) which makes it unprofitable.
+    // If this ever changes we need some more expansive handling here.
+    loop->VisitLoopBlocks([=](BasicBlock* block) {
+        block->VisitAllSuccs(this, [=](BasicBlock* succ) {
+            if (!loop->ContainsBlock(succ) && bbIsHandlerBeg(succ))
+            {
+                assert(!optLocalIsLiveIntoBlock(lclNum, succ) &&
+                       "Candidate IV for widening is live into exceptional exit");
+            }
+
+            return BasicBlockVisit::Continue;
+        });
+
+        return BasicBlockVisit::Continue;
+    });
+#endif
 
     return false;
 }

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1362,16 +1362,15 @@ bool Compiler::optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loo
     }
 
 #ifdef DEBUG
-    // We currently do not expect to ever widen IVs that are live into
-    // exceptional exits. Such IVs are not currently register candidates (EH
-    // write-thru is only for single def locals) which makes it unprofitable.
-    // If this ever changes we need some more expansive handling here.
+    // We currently do not expect to optimize locals that are live into exceptional
+    // exits. Such IVs are not currently register candidates (EH write-thru is
+    // only for single def locals) which makes it unprofitable. If this ever
+    // changes we need some more expansive handling here.
     loop->VisitLoopBlocks([=](BasicBlock* block) {
         block->VisitAllSuccs(this, [=](BasicBlock* succ) {
             if (!loop->ContainsBlock(succ) && bbIsHandlerBeg(succ))
             {
-                assert(!optLocalIsLiveIntoBlock(lclNum, succ) &&
-                       "Candidate IV for widening is live into exceptional exit");
+                assert(!optLocalIsLiveIntoBlock(lclNum, succ) && "Candidate local is live into exceptional exit");
             }
 
             return BasicBlockVisit::Continue;

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -433,8 +433,8 @@ void PerLoopInfo::Invalidate(FlowGraphNaturalLoop* loop)
 //   sense that all their predecessors must come from inside the loop. Loop
 //   exit canonicalization guarantees this for regular exit blocks. It is not
 //   guaranteed for exceptional exits, but we do not expect to widen IVs that
-//   are live into exceptional exits since those are marked DNER which makes it
-//   unprofitable anyway.
+//   are live into exceptional exits since those are not register candidates
+//   (see optWidenPrimaryIV) which makes it unprofitable anyway.
 //
 //   Note that there may be natural loops that have not had their regular exits
 //   canonicalized at the time when IV opts run, in particular if RBO/assertion
@@ -1330,13 +1330,24 @@ bool Compiler::optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loo
 
     if (varDsc->lvDoNotEnregister)
     {
-        // This filters out locals that may be live into exceptional exits.
+        // We cannot reason precisely about uses of locals that are not
+        // enregisterable, so be conservative.
         return true;
     }
 
     if (!varDsc->lvTracked && !varDsc->lvInSsa)
     {
         // We do not have liveness we can use for this untracked local.
+        return true;
+    }
+
+    if (varDsc->lvTracked && varDsc->IsLiveInOutOfHandler())
+    {
+        // The local is live into an EH handler (an exceptional exit). The
+        // regular exit blocks visited below do not include handlers, and
+        // EH-live locals are no longer necessarily marked DNER at this point
+        // (that now happens during LSRA/lowering), so we must check for
+        // handler liveness explicitly here.
         return true;
     }
 

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1344,10 +1344,9 @@ bool Compiler::optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loo
     if (varDsc->lvTracked && varDsc->IsLiveInOutOfHandler())
     {
         // The local is live into an EH handler (an exceptional exit). The
-        // regular exit blocks visited below do not include handlers, and
-        // EH-live locals are no longer necessarily marked DNER at this point
-        // (that now happens during LSRA/lowering), so we must check for
-        // handler liveness explicitly here.
+        // regular exit blocks visited below do not include handlers, and we
+        // use this as a cheap alternative to checking all EH successors
+        // of all blocks in the loop.
         return true;
     }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_128392/Runtime_128392.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_128392/Runtime_128392.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Runtime_128392;
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Runtime_128392
+{
+    private static long s_sink;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Process(int x)
+    {
+        if (x < 0)
+        {
+            throw new Exception("boom");
+        }
+
+        s_sink += x;
+    }
+
+    // The loop counter 'i' is updated inside the try and read in the catch handler.
+    // Induction-variable optimization must not drop the in-loop update of 'i', since
+    // it is live into the EH handler; otherwise the handler observes a stale value.
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static int CountProcessedBeforeThrow(int[] values)
+    {
+        int i = 0;
+        try
+        {
+            for (; i < values.Length; i++)
+            {
+                Process(values[i]);
+            }
+        }
+        catch (Exception)
+        {
+            return i;
+        }
+
+        return -1;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        int[] values = { 0, 1, 2, -1, 4 };
+        Assert.Equal(3, CountProcessedBeforeThrow(values));
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -98,6 +98,7 @@
     <Compile Include="JitBlue\Runtime_126060\Runtime_126060.cs" />
     <Compile Include="JitBlue\Runtime_127260\Runtime_127260.cs" />
     <Compile Include="JitBlue\Runtime_127446\Runtime_127446.cs" />
+    <Compile Include="JitBlue\Runtime_128392\Runtime_128392.cs" />
     <Compile Include="JitBlue\Runtime_128631\Runtime_128631.cs" />
     <Compile Include="JitBlue\Runtime_128801\Runtime_128801.cs" />
   </ItemGroup>


### PR DESCRIPTION
`optLocalHasNonLoopUses` relied on `lvDoNotEnregister` to detect locals live into exceptional exits. PR #127932 decoupled DNER from liveness (DNER is now set during LSRA/lowering, after `optInductionVariables` runs), so an induction variable live into a catch handler was no longer detected and its in-loop self-update was removed by `optRemoveUnusedIVs`, producing wrong results under full-opt codegen (crossgen2, jitstress, AggressiveOptimization).

Add an explicit `lvTracked && IsLiveInOutOfHandler()` check, since `VisitRegularExitBlocks` deliberately excludes handler blocks. 

Fixes #128392.