### PR TITLE
[Wasm / RyuJit]: don't mark CORINFO_HELP_GETREFANY pure on wasm

### DIFF
--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -1596,9 +1596,12 @@ void HelperCallProperties::init()
                 break;
 
             // GETREFANY is pure up to the value of the struct argument. We
-            // only support that when it is not an implicit byref.
+            // only support that when it is not an implicit byref. The
+            // TypedReference struct (two pointers) is passed by implicit
+            // byref on win-x64 and on wasm (the wasm ABI passes any struct
+            // without a single scalar lowering by reference).
             case CORINFO_HELP_GETREFANY:
-#ifndef WINDOWS_AMD64_ABI
+#if !defined(WINDOWS_AMD64_ABI) && !defined(TARGET_WASM)
                 isPure = true;
 #endif
                 break;


### PR DESCRIPTION
The wasm ABI passes TypedReference as implicit byref. So CORINFO_HELP_GETREFANY  cannot be considered pure (just like on windows x64).

Affects refanyval users JIT/Methodical/refany/array2_{d,r} and array3_{d,r}.

See https://github.com/dotnet/runtime/issues/128234#issuecomment-4636089896 
