### PR TITLE
[Wasm / RyuJit]: implement CKFINITE

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -868,6 +868,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             genCatchArg(treeNode);
             break;
 
+        case GT_CKFINITE:
+            genCkfinite(treeNode);
+            break;
+
         default:
 #ifdef DEBUG
             if (JitConfig.JitWasmNyiToR2RUnsupported())
@@ -1843,6 +1847,70 @@ void CodeGen::genCodeForBitCast(GenTreeOp* tree)
 
     GetEmitter()->emitIns(ins);
     WasmProduceReg(tree);
+}
+
+//------------------------------------------------------------------------
+// genCkfinite: Generate code for ckfinite opcode.
+//
+// Arguments:
+//    treeNode - The GT_CKFINITE node
+//
+// Notes:
+//    The operand is expected to be marked MultiplyUsed so that codegen can
+//    re-use its value (via "local.get") after the check.
+//
+void CodeGen::genCkfinite(GenTree* treeNode)
+{
+    assert(treeNode->OperIs(GT_CKFINITE));
+
+    GenTree*  op1        = treeNode->AsOp()->gtOp1;
+    var_types targetType = treeNode->TypeGet();
+    assert(varTypeIsFloating(targetType));
+
+    // Push the operand value on the wasm stack. Because op1 was flagged as
+    // MultiplyUsed during lowering, "WasmProduceReg" will tee it into a
+    // temporary local so we can re-read it for the exponent check.
+    //
+    genConsumeOperands(treeNode->AsOp());
+
+    // Re-read the operand to feed the finiteness check.
+    //
+    regNumber op1Reg = GetMultiUseOperandReg(op1);
+    emitter*  emit   = GetEmitter();
+
+    // Compute "!(|x| < +Inf)". This is true for NaN and +/-Inf, false for
+    // every finite value. We rely on wasm's IEEE-754 comparison semantics
+    // where any comparison involving a NaN (other than "ne") returns 0.
+    //
+    // Note: IF_F32/IF_F64 both expect the +Inf constant as a double bit
+    // pattern (IF_F32 reinterprets and truncates to float during emission).
+    //
+    const int64_t infBits = 0x7FF0000000000000LL;
+    if (targetType == TYP_FLOAT)
+    {
+        emit->emitIns_I(INS_local_get, EA_4BYTE, WasmRegToIndex(op1Reg));
+        emit->emitIns(INS_f32_abs);
+        emit->emitIns_I(INS_f32_const, EA_4BYTE, infBits);
+        emit->emitIns(INS_f32_lt);
+    }
+    else
+    {
+        assert(targetType == TYP_DOUBLE);
+        emit->emitIns_I(INS_local_get, EA_8BYTE, WasmRegToIndex(op1Reg));
+        emit->emitIns(INS_f64_abs);
+        emit->emitIns_I(INS_f64_const, EA_8BYTE, infBits);
+        emit->emitIns(INS_f64_lt);
+    }
+    emit->emitIns(INS_i32_eqz);
+
+    // If "!(|x| < +Inf)", the value is NaN or +/-Inf; throw.
+    //
+    genJumpToThrowHlpBlk(SCK_ARITH_EXCPN);
+
+    // The operand value is still on the wasm stack from genConsumeOperands;
+    // produce it as the result of the GT_CKFINITE node.
+    //
+    WasmProduceReg(treeNode);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1856,8 +1856,9 @@ void CodeGen::genCodeForBitCast(GenTreeOp* tree)
 //    treeNode - The GT_CKFINITE node
 //
 // Notes:
-//    The operand is expected to be marked MultiplyUsed so that codegen can
-//    re-use its value (via "local.get") after the check.
+//    op1 is expected to be marked MultiplyUsed so that its producer tees
+//    its value into a temporary local. That lets us re-read the value
+//    after the finiteness check by emitting a "local.get".
 //
 void CodeGen::genCkfinite(GenTree* treeNode)
 {
@@ -1867,13 +1868,13 @@ void CodeGen::genCkfinite(GenTree* treeNode)
     var_types targetType = treeNode->TypeGet();
     assert(varTypeIsFloating(targetType));
 
-    // Push the operand value on the wasm stack. Because op1 was flagged as
-    // MultiplyUsed during lowering, "WasmProduceReg" will tee it into a
-    // temporary local so we can re-read it for the exponent check.
-    //
     genConsumeOperands(treeNode->AsOp());
 
-    // Re-read the operand to feed the finiteness check.
+    // op1's producer emitted "local.tee" via "WasmProduceReg" (because
+    // op1 was flagged as MultiplyUsed during lowering), leaving its
+    // value both on the wasm operand stack and in a temporary local.
+    // We re-read the local below to feed the finiteness check; the
+    // value on the stack will flow through as the result of GT_CKFINITE.
     //
     regNumber op1Reg = GetMultiUseOperandReg(op1);
     emitter*  emit   = GetEmitter();
@@ -1903,12 +1904,14 @@ void CodeGen::genCkfinite(GenTree* treeNode)
     }
     emit->emitIns(INS_i32_eqz);
 
-    // If "!(|x| < +Inf)", the value is NaN or +/-Inf; throw.
+    // If "!(|x| < +Inf)", the value is NaN or +/-Inf; throw. The wasm
+    // stack underneath the predicate (including op1's value) is preserved
+    // on the fall-through path.
     //
     genJumpToThrowHlpBlk(SCK_ARITH_EXCPN);
 
-    // The operand value is still on the wasm stack from genConsumeOperands;
-    // produce it as the result of the GT_CKFINITE node.
+    // op1's value is still on top of the wasm operand stack; produce it
+    // as the result of the GT_CKFINITE node.
     //
     WasmProduceReg(treeNode);
 }

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1968,8 +1968,14 @@ void CodeGen::genCodeForNegNot(GenTreeOp* tree)
 //    codeKind -- kind of throw helper call needed
 //
 // Notes:
-//    On entry the predicate for the throw helper is the only item on the Wasm stack.
-//    An exception is thrown if the predicate is true.
+//    On entry the predicate (an i32) for the throw helper must be on top of the
+//    Wasm stack. An exception is thrown if the predicate is non-zero.
+//
+//    Additional values may be present on the stack underneath the predicate; only
+//    the predicate is consumed on the fall-through path, so those values remain
+//    available to the caller. On the throwing path the stack is unwound to the
+//    target helper block (or discarded by 'unreachable' inside the inline 'if'),
+//    so anything underneath is irrelevant in that case.
 //
 void CodeGen::genJumpToThrowHlpBlk(SpecialCodeKind codeKind)
 {

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -710,6 +710,10 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_INDEX_ADDR:
             LowerIndexAddr(node->AsIndexAddr());
             break;
+
+        case GT_CKFINITE:
+            LowerCkfinite(node->AsOp());
+            break;
 #endif // defined(TARGET_WASM)
 
         default:

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -458,6 +458,7 @@ private:
     static void SetMultiplyUsed(GenTree* node DEBUGARG(const char* reason));
     GenTree*    LowerNeg(GenTreeOp* node);
     void        LowerIndexAddr(GenTreeIndexAddr* indexAddr);
+    void        LowerCkfinite(GenTreeOp* node);
 #endif
 
     bool TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* parent);

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -371,6 +371,21 @@ void Lowering::LowerRotate(GenTree* tree)
 }
 
 //------------------------------------------------------------------------
+// LowerCkfinite: Lowers a GT_CKFINITE node.
+//
+// Mark the operand as multiply-used since codegen needs to read it twice:
+// once for the finiteness check and once for the produced value.
+//
+// Arguments:
+//    node - the GT_CKFINITE node to be lowered
+//
+void Lowering::LowerCkfinite(GenTreeOp* node)
+{
+    assert(node->OperIs(GT_CKFINITE));
+    SetMultiplyUsed(node->gtGetOp1() DEBUGARG("LowerCkfinite op1 (finiteness check)"));
+}
+
+//------------------------------------------------------------------------
 // LowerIndexAddr: Lowers a GT_INDEX_ADDR node
 //
 // Mark operands that need multiple uses for exception-inducing checks.

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -498,6 +498,10 @@ void WasmRegAlloc::CollectReferencesForNode(GenTree* node)
             CollectReferencesForIndexAddr(node->AsIndexAddr());
             break;
 
+        case GT_CKFINITE:
+            ConsumeTemporaryRegForOperand(node->gtGetOp1() DEBUGARG("ckfinite finiteness check"));
+            break;
+
         default:
             assert(!node->OperIsLocalStore());
             break;


### PR DESCRIPTION
Adds wasm codegen for the CKFINITE.

Sequence here was shorter than masking off and testing the exponent, especially for doubles.