### PR TITLE
[Wasm R2R] Bypass dynamic LDVIRTFTN helper

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2729,7 +2729,7 @@ GenTree* Compiler::impImportLdvirtftn(GenTree*                thisPtr,
                                                         runtimeMethodHandle);
     }
 
-#ifdef FEATURE_READYTORUN
+#if defined(FEATURE_READYTORUN) && !defined(TARGET_WASM)
     else if (IsAot())
     {
         if (!pCallInfo->exactContextNeedsRuntimeLookup)
@@ -2746,7 +2746,10 @@ GenTree* Compiler::impImportLdvirtftn(GenTree*                thisPtr,
             call = gtNewRuntimeLookupHelperCallNode(&pCallInfo->codePointerLookup.runtimeLookup, ctxTree, nullptr);
         }
     }
-#endif
+#endif // FEATURE_READYTORUN && !TARGET_WASM
+    // Wasm R2R cannot use the CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR fast path because it
+    // relies on DelayLoad_Helper_Obj dynamic-helper thunks, which are not implemented on wasm.
+    // Fall through to the runtime CORINFO_HELP_VIRTUAL_FUNC_PTR helper instead.
 
     if (call == nullptr)
     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2729,6 +2729,9 @@ GenTree* Compiler::impImportLdvirtftn(GenTree*                thisPtr,
                                                         runtimeMethodHandle);
     }
 
+    // Wasm R2R cannot use the CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR fast path because it
+    // relies on DelayLoad_Helper_Obj dynamic-helper thunks, which are not implemented on wasm.
+    // Fall through to the runtime CORINFO_HELP_VIRTUAL_FUNC_PTR helper instead.
 #if defined(FEATURE_READYTORUN) && !defined(TARGET_WASM)
     else if (IsAot())
     {
@@ -2747,9 +2750,6 @@ GenTree* Compiler::impImportLdvirtftn(GenTree*                thisPtr,
         }
     }
 #endif // FEATURE_READYTORUN && !TARGET_WASM
-    // Wasm R2R cannot use the CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR fast path because it
-    // relies on DelayLoad_Helper_Obj dynamic-helper thunks, which are not implemented on wasm.
-    // Fall through to the runtime CORINFO_HELP_VIRTUAL_FUNC_PTR helper instead.
 
     if (call == nullptr)
     {


### PR DESCRIPTION
Wasm does not implement the DelayLoad_Helper_Obj stub backing CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR, so route virtual function pointer lookups through the runtime CORINFO_HELP_VIRTUAL_FUNC_PTR helper instead.