### PR TITLE
Update release/8.0 osx x64 Helix queue

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -113,7 +113,7 @@ jobs:
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - OSX.14.Amd64.Open
+        - OSX.15.Amd64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - OSX.14.Amd64
 

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -79,7 +79,7 @@ jobs:
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
-      - OSX.14.Amd64.Open
+      - OSX.15.Amd64.Open
 
     # Android
     - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:


### PR DESCRIPTION
## Summary
- move the remaining release/8.0 public osx x64 Helix queue references from OSX.14.Amd64.Open to OSX.15.Amd64.Open

## Testing
- not run (queue mapping update only)