### PR TITLE
Make Condition to not use ConditionalWeakTable

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -29,7 +29,6 @@
 #endif // FEATURE_COMINTEROP
 
 #include "request_common.h"
-#include "conditionalweaktable.h"
 
 #ifndef USE_DAC_TABLE_RVA
 extern "C" bool TryGetSymbol(ICorDebugDataTarget* dataTarget, uint64_t baseAddress, const char* symbolName, uint64_t* symbolAddress);
@@ -6088,7 +6087,77 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetThreadOwningMonitorLock(VMPTR_
 // Not implemented as this API is not believed to be called by any current consumers.
 HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
-    return E_NOTIMPL;
+    DD_ENTER_MAY_THROW;
+
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        Object* pObj = vmObject.GetDacPtr();
+
+        SyncBlock* psb = pObj->PassiveGetSyncBlock();
+
+        // no sync block means no wait list
+        if(psb == NULL)
+            return hr;
+
+        // The managed Lock (if any) for this object is referenced from the sync block.
+        // If there is no Lock, there can be no Condition installed on it and therefore no waiters.
+        OBJECTHANDLE lockHandle = psb->GetLockIfExists();
+        if (lockHandle == (OBJECTHANDLE)NULL)
+            return hr;
+
+        OBJECTREF lockObj = ObjectFromHandle(lockHandle);
+        if (lockObj == NULL)
+            return hr;
+
+        // Lock._waitEventOrCondition holds either an AutoResetEvent or a Condition. Only when a
+        // Condition has been installed does the Lock have a Monitor wait list to enumerate.
+        FieldDesc* pWaitEventOrConditionField = (&g_CoreLib)->GetField(FIELD__LOCK__WAIT_EVENT_OR_CONDITION);
+        OBJECTREF condition = pWaitEventOrConditionField->GetRefValue(lockObj);
+        if (condition == NULL)
+            return hr;
+
+        PTR_MethodTable pConditionMT = CoreLibBinder::GetExistingClass(CLASS__CONDITION);
+        if (condition->GetMethodTable() != pConditionMT)
+            return hr;
+
+        MapSHash<TADDR, Thread*> waiterToThreadMap;
+        FieldDesc* pConditionWaiterField = (&g_CoreLib)->GetField(FIELD__CONDITION__WAITERS_HEAD);
+        FieldDesc* pWaiterNextField = (&g_CoreLib)->GetField(FIELD__WAITER__NEXT);
+        FieldDesc* pThisThreadWaiterField = (&g_CoreLib)->GetField(FIELD__CONDITION__CURRENT_THREAD_WAITER);
+
+        // Build a map of Waiter objects to their owning Threads.
+        for (Thread *pThread = ThreadStore::GetThreadList(NULL); pThread != NULL; pThread = ThreadStore::GetThreadList(pThread))
+        {
+            PTR_PTR_Object pThisThreadWaiterStorage = dac_cast<PTR_PTR_Object>(pThread->GetStaticFieldAddrNoCreate(pThisThreadWaiterField));
+            if (pThisThreadWaiterStorage == NULL || *pThisThreadWaiterStorage == NULL)
+            {
+                continue; // this thread is not waiting on the monitor for this object. It has never waited on any monitor.
+            }
+
+            OBJECTREF pThisThreadWaiter = *pThisThreadWaiterStorage;
+            waiterToThreadMap.Add(dac_cast<TADDR>(pThisThreadWaiter), pThread);
+        }
+
+        // Iterate through the waiters in the condition object and invoke the user's callback for each thread
+        for (OBJECTREF pWaiter = pConditionWaiterField->GetRefValue(condition); pWaiter != NULL; pWaiter = pWaiterNextField->GetRefValue(pWaiter))
+        {
+            Thread* pThread = NULL;
+            if (!waiterToThreadMap.Lookup(dac_cast<TADDR>(pWaiter), &pThread))
+            {
+                // This waiter is not in the map, so we can't find its thread.
+                LOG((LF_CORDB, LL_INFO10000, "D::EMEWL: Waiter not found in waiter->thread map.\n"));
+                continue;
+            }
+            VMPTR_Thread vmThread = VMPTR_Thread::NullPtr();
+            vmThread.SetDacTargetPtr(PTR_HOST_TO_TADDR(pThread));
+            // Invoke the user's callback with the thread and user data
+            fpCallback(vmThread, pUserData);
+        }
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -29,6 +29,7 @@
 #endif // FEATURE_COMINTEROP
 
 #include "request_common.h"
+#include "conditionalweaktable.h"
 
 #ifndef USE_DAC_TABLE_RVA
 extern "C" bool TryGetSymbol(ICorDebugDataTarget* dataTarget, uint64_t baseAddress, const char* symbolName, uint64_t* symbolAddress);
@@ -6087,77 +6088,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetThreadOwningMonitorLock(VMPTR_
 // Not implemented as this API is not believed to be called by any current consumers.
 HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
-    DD_ENTER_MAY_THROW;
-
-    HRESULT hr = S_OK;
-    EX_TRY
-    {
-
-        Object* pObj = vmObject.GetDacPtr();
-
-        SyncBlock* psb = pObj->PassiveGetSyncBlock();
-
-        // no sync block means no wait list
-        if(psb == NULL)
-            return hr;
-
-        // The managed Lock (if any) for this object is referenced from the sync block.
-        // If there is no Lock, there can be no Condition installed on it and therefore no waiters.
-        OBJECTHANDLE lockHandle = psb->GetLockIfExists();
-        if (lockHandle == (OBJECTHANDLE)NULL)
-            return hr;
-
-        OBJECTREF lockObj = ObjectFromHandle(lockHandle);
-        if (lockObj == NULL)
-            return hr;
-
-        // Lock._waitEventOrCondition holds either an AutoResetEvent or a Condition. Only when a
-        // Condition has been installed does the Lock have a Monitor wait list to enumerate.
-        FieldDesc* pWaitEventOrConditionField = (&g_CoreLib)->GetField(FIELD__LOCK__WAIT_EVENT_OR_CONDITION);
-        OBJECTREF condition = pWaitEventOrConditionField->GetRefValue(lockObj);
-        if (condition == NULL)
-            return hr;
-
-        PTR_MethodTable pConditionMT = CoreLibBinder::GetExistingClass(CLASS__CONDITION);
-        if (condition->GetMethodTable() != pConditionMT)
-            return hr;
-
-        MapSHash<TADDR, Thread*> waiterToThreadMap;
-        FieldDesc* pConditionWaiterField = (&g_CoreLib)->GetField(FIELD__CONDITION__WAITERS_HEAD);
-        FieldDesc* pWaiterNextField = (&g_CoreLib)->GetField(FIELD__WAITER__NEXT);
-        FieldDesc* pThisThreadWaiterField = (&g_CoreLib)->GetField(FIELD__CONDITION__CURRENT_THREAD_WAITER);
-
-        // Build a map of Waiter objects to their owning Threads.
-        for (Thread *pThread = ThreadStore::GetThreadList(NULL); pThread != NULL; pThread = ThreadStore::GetThreadList(pThread))
-        {
-            PTR_PTR_Object pThisThreadWaiterStorage = dac_cast<PTR_PTR_Object>(pThread->GetStaticFieldAddrNoCreate(pThisThreadWaiterField));
-            if (pThisThreadWaiterStorage == NULL || *pThisThreadWaiterStorage == NULL)
-            {
-                continue; // this thread is not waiting on the monitor for this object. It has never waited on any monitor.
-            }
-
-            OBJECTREF pThisThreadWaiter = *pThisThreadWaiterStorage;
-            waiterToThreadMap.Add(dac_cast<TADDR>(pThisThreadWaiter), pThread);
-        }
-
-        // Iterate through the waiters in the condition object and invoke the user's callback for each thread
-        for (OBJECTREF pWaiter = pConditionWaiterField->GetRefValue(condition); pWaiter != NULL; pWaiter = pWaiterNextField->GetRefValue(pWaiter))
-        {
-            Thread* pThread = NULL;
-            if (!waiterToThreadMap.Lookup(dac_cast<TADDR>(pWaiter), &pThread))
-            {
-                // This waiter is not in the map, so we can't find its thread.
-                LOG((LF_CORDB, LL_INFO10000, "D::EMEWL: Waiter not found in waiter->thread map.\n"));
-                continue;
-            }
-            VMPTR_Thread vmThread = VMPTR_Thread::NullPtr();
-            vmThread.SetDacTargetPtr(PTR_HOST_TO_TADDR(pThread));
-            // Invoke the user's callback with the thread and user data
-            fpCallback(vmThread, pUserData);
-        }
-    }
-    EX_CATCH_HRESULT(hr);
-    return hr;
+    return E_NOTIMPL;
 }
 
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -629,6 +629,7 @@ DEFINE_CLASS(OLE_AUT_BINDER,        System,                 OleAutBinder)
 END_ILLINK_FEATURE_SWITCH()
 
 DEFINE_CLASS(MONITOR,               Threading,              Monitor)
+DEFINE_FIELD(MONITOR,               CONDITION_TABLE,        s_conditionTable)
 DEFINE_METHOD(MONITOR,              SYNCHRONIZED_METHOD_ENTER, SynchronizedMethodEnter, SM_Obj_RefBool_RetVoid)
 DEFINE_METHOD(MONITOR,              SYNCHRONIZED_METHOD_EXIT,  SynchronizedMethodExit,  SM_Obj_RefBool_RetVoid)
 
@@ -636,7 +637,6 @@ DEFINE_CLASS(LOCK,                  Threading,              Lock)
 DEFINE_FIELD(LOCK,                  OWNING_THREAD_ID,       _owningThreadId)
 DEFINE_FIELD(LOCK,                  STATE,                  _state)
 DEFINE_FIELD(LOCK,                  RECURSION_COUNT,        _recursionCount)
-DEFINE_FIELD(LOCK,                  WAIT_EVENT_OR_CONDITION,_waitEventOrCondition)
 DEFINE_METHOD(LOCK,                 CTOR,                   .ctor,                IM_RetVoid)
 DEFINE_METHOD(LOCK,                 INITIALIZE_FOR_MONITOR, InitializeForMonitor, SM_PtrLock_Int_UInt_PtrException_RetVoid)
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -629,7 +629,6 @@ DEFINE_CLASS(OLE_AUT_BINDER,        System,                 OleAutBinder)
 END_ILLINK_FEATURE_SWITCH()
 
 DEFINE_CLASS(MONITOR,               Threading,              Monitor)
-DEFINE_FIELD(MONITOR,               CONDITION_TABLE,        s_conditionTable)
 DEFINE_METHOD(MONITOR,              SYNCHRONIZED_METHOD_ENTER, SynchronizedMethodEnter, SM_Obj_RefBool_RetVoid)
 DEFINE_METHOD(MONITOR,              SYNCHRONIZED_METHOD_EXIT,  SynchronizedMethodExit,  SM_Obj_RefBool_RetVoid)
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -629,7 +629,6 @@ DEFINE_CLASS(OLE_AUT_BINDER,        System,                 OleAutBinder)
 END_ILLINK_FEATURE_SWITCH()
 
 DEFINE_CLASS(MONITOR,               Threading,              Monitor)
-DEFINE_FIELD(MONITOR,               CONDITION_TABLE,        s_conditionTable)
 DEFINE_METHOD(MONITOR,              SYNCHRONIZED_METHOD_ENTER, SynchronizedMethodEnter, SM_Obj_RefBool_RetVoid)
 DEFINE_METHOD(MONITOR,              SYNCHRONIZED_METHOD_EXIT,  SynchronizedMethodExit,  SM_Obj_RefBool_RetVoid)
 
@@ -637,6 +636,7 @@ DEFINE_CLASS(LOCK,                  Threading,              Lock)
 DEFINE_FIELD(LOCK,                  OWNING_THREAD_ID,       _owningThreadId)
 DEFINE_FIELD(LOCK,                  STATE,                  _state)
 DEFINE_FIELD(LOCK,                  RECURSION_COUNT,        _recursionCount)
+DEFINE_FIELD(LOCK,                  WAIT_EVENT_OR_CONDITION,_waitEventOrCondition)
 DEFINE_METHOD(LOCK,                 CTOR,                   .ctor,                IM_RetVoid)
 DEFINE_METHOD(LOCK,                 INITIALIZE_FOR_MONITOR, InitializeForMonitor, SM_PtrLock_Int_UInt_PtrException_RetVoid)
 

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1272,7 +1272,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\CancellationTokenRegistration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\CancellationTokenSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\CompressedStack.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Condition.cs" Condition="'$(FeatureMono)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Condition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\StackCrawlMark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\EventResetMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\EventWaitHandle.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -47,6 +47,11 @@ namespace System.Threading
         }
 
         private readonly Lock _lock;
+
+        // When condition is installed in a Lock it takes the same field as waitEvent would.
+        // If waitEvent is also needed it is available through here.
+        internal AutoResetEvent? _waitEvent;
+
         private Waiter? _waitersHead;
         private Waiter? _waitersTail;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable 0420 //passing volatile fields by ref
-
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 
@@ -203,15 +201,14 @@ namespace System.Threading
             _waitersHead = null;
             _waitersTail = null;
 
-            do
+            while (waiter is not null)
             {
                 Waiter? next = waiter.next;
                 waiter.next = null;
                 waiter.prev = null;
-                AutoResetEvent ev = waiter.ev;
+                waiter.ev.Set();
                 waiter = next;
-                ev.Set();
-            } while (waiter is not null);
+            }
         }
 
         public void SignalOne()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -57,7 +57,7 @@ namespace System.Threading
 
         internal Lock AssociatedLock => _lock;
 
-        private unsafe void AssertIsInList(Waiter waiter)
+        private void AssertIsInList(Waiter waiter)
         {
             Debug.Assert(_waitersHead != null && _waitersTail != null);
             Debug.Assert((_waitersHead == waiter) == (waiter.prev == null));
@@ -69,7 +69,7 @@ namespace System.Threading
             Debug.Fail("Waiter is not in the waiter list");
         }
 
-        private unsafe void AssertIsNotInList(Waiter waiter)
+        private void AssertIsNotInList(Waiter waiter)
         {
             Debug.Assert(waiter.next == null && waiter.prev == null);
             Debug.Assert((_waitersHead == null) == (_waitersTail == null));
@@ -79,7 +79,7 @@ namespace System.Threading
                     Debug.Fail("Waiter is in the waiter list, but should not be");
         }
 
-        private unsafe void AddWaiter(Waiter waiter)
+        private void AddWaiter(Waiter waiter)
         {
             Debug.Assert(_lock.IsHeldByCurrentThread);
             AssertIsNotInList(waiter);
@@ -92,7 +92,7 @@ namespace System.Threading
             _waitersHead ??= waiter;
         }
 
-        private unsafe void RemoveWaiter(Waiter waiter)
+        private void RemoveWaiter(Waiter waiter)
         {
             Debug.Assert(_lock.IsHeldByCurrentThread);
             AssertIsInList(waiter);
@@ -119,7 +119,7 @@ namespace System.Threading
             _lock = @lock;
         }
 
-        public unsafe bool Wait(int millisecondsTimeout, object associatedObjectForMonitorWait)
+        public bool Wait(int millisecondsTimeout, object associatedObjectForMonitorWait)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(millisecondsTimeout, -1);
 
@@ -154,7 +154,7 @@ namespace System.Threading
                 else if (!success)
                 {
                     //
-                    // The wait timed out, but we were signalled before we could reacquire the lock.
+                    // The wait timed out, but we were signaled before we could reacquire the lock.
                     // Since WaitOne timed out, it didn't trigger the auto-reset of the AutoResetEvent.
                     // So, we need to manually reset the event.
                     //
@@ -168,7 +168,7 @@ namespace System.Threading
             return waiter.signalled;
         }
 
-        public unsafe void SignalAll()
+        public void SignalAll()
         {
             if (!_lock.IsHeldByCurrentThread)
                 throw new SynchronizationLockException();
@@ -177,7 +177,7 @@ namespace System.Threading
                 SignalOne();
         }
 
-        public unsafe void SignalOne()
+        public void SignalOne()
         {
             if (!_lock.IsHeldByCurrentThread)
                 throw new SynchronizationLockException();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -15,7 +15,6 @@ namespace System.Threading
             public Waiter? next;
             public Waiter? prev;
             public AutoResetEvent ev = new AutoResetEvent(false);
-            public bool signalled;
         }
 
         [ThreadStatic]
@@ -36,7 +35,6 @@ namespace System.Threading
                 waiter = new Waiter();
             }
 
-            waiter.signalled = false;
             return waiter;
         }
 
@@ -49,7 +47,7 @@ namespace System.Threading
         private readonly Lock _lock;
 
         // When condition is installed in a Lock it takes the same field as waitEvent would.
-        // If waitEvent is also needed it is available through here.
+        // If waitEvent is also needed, it is available through here.
         internal AutoResetEvent? _waitEvent;
 
         private Waiter? _waitersHead;
@@ -77,6 +75,13 @@ namespace System.Threading
             for (Waiter? current = _waitersHead; current != null; current = current.next)
                 if (current == waiter)
                     Debug.Fail("Waiter is in the waiter list, but should not be");
+        }
+
+        // Returns true if the waiter cannot be possibly in the list.
+        // (i.e. not reachable via _waitersHead)
+        internal bool NotInList(Waiter waiter)
+        {
+            return _waitersHead != waiter && waiter.prev == null;
         }
 
         private void AddWaiter(Waiter waiter)
@@ -133,6 +138,7 @@ namespace System.Threading
 
             uint recursionCount = _lock.ExitAll();
             bool success = false;
+            bool wasSignaled;
             try
             {
                 success =
@@ -147,7 +153,9 @@ namespace System.Threading
                 _lock.Reenter(recursionCount);
                 Debug.Assert(_lock.IsHeldByCurrentThread);
 
-                if (!waiter.signalled)
+                // If the waiter is still in the list, it was not signaled.
+                wasSignaled = NotInList(waiter);
+                if (!wasSignaled)
                 {
                     RemoveWaiter(waiter);
                 }
@@ -165,7 +173,7 @@ namespace System.Threading
                 ReleaseWaiterForCurrentThread(waiter);
             }
 
-            return waiter.signalled;
+            return wasSignaled;
         }
 
         public void SignalAll()
@@ -186,7 +194,6 @@ namespace System.Threading
             if (waiter != null)
             {
                 RemoveWaiter(waiter);
-                waiter.signalled = true;
                 waiter.ev.Set();
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -35,6 +35,7 @@ namespace System.Threading
                 waiter = new Waiter();
             }
 
+            Debug.Assert(waiter.next is null && waiter.prev is null);
             return waiter;
         }
 
@@ -55,6 +56,7 @@ namespace System.Threading
 
         internal Lock AssociatedLock => _lock;
 
+        [Conditional("DEBUG")]
         private void AssertIsInList(Waiter waiter)
         {
             Debug.Assert(_waitersHead != null && _waitersTail != null);
@@ -67,6 +69,7 @@ namespace System.Threading
             Debug.Fail("Waiter is not in the waiter list");
         }
 
+        [Conditional("DEBUG")]
         private void AssertIsNotInList(Waiter waiter)
         {
             Debug.Assert(waiter.next == null && waiter.prev == null);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -14,7 +14,7 @@ namespace System.Threading
         {
             public Waiter? next;
             public Waiter? prev;
-            public AutoResetEvent ev = new AutoResetEvent(false);
+            public readonly AutoResetEvent ev = new AutoResetEvent(false);
         }
 
         [ThreadStatic]
@@ -92,12 +92,17 @@ namespace System.Threading
             Debug.Assert(_lock.IsHeldByCurrentThread);
             AssertIsNotInList(waiter);
 
-            waiter.prev = _waitersTail;
-            waiter.prev?.next = waiter;
-
+            Waiter? tail = _waitersTail;
+            waiter.prev = tail;
+            if (tail is null)
+            {
+                _waitersHead = waiter;
+            }
+            else
+            {
+                tail.next = waiter;
+            }
             _waitersTail = waiter;
-
-            _waitersHead ??= waiter;
         }
 
         private void RemoveWaiter(Waiter waiter)
@@ -184,8 +189,29 @@ namespace System.Threading
             if (!_lock.IsHeldByCurrentThread)
                 throw new SynchronizationLockException();
 
-            while (_waitersHead != null)
-                SignalOne();
+            Waiter? waiter = _waitersHead;
+            if (waiter is null)
+            {
+                return;
+            }
+
+            // Detach the entire waiter list in one operation, then walk it and signal each waiter.
+            // Per-waiter prev/next must be cleared BEFORE calling ev.Set() so that the woken thread
+            // observes the waiter as not in the list (see NotInList) and the cached Waiter is clean.
+            // Woken threads cannot make progress until the caller releases _lock, so it is safe to
+            // continue walking the detached list after signaling each waiter.
+            _waitersHead = null;
+            _waitersTail = null;
+
+            do
+            {
+                Waiter? next = waiter.next;
+                waiter.next = null;
+                waiter.prev = null;
+                AutoResetEvent ev = waiter.ev;
+                waiter = next;
+                ev.Set();
+            } while (waiter is not null);
         }
 
         public void SignalOne()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -52,7 +52,39 @@ namespace System.Threading
         private short _spinCount;
 
         private ushort _waiterStartTimeMs;
-        private AutoResetEvent? _waitEvent;
+
+        private object? _waitEventOrCondition;
+        private AutoResetEvent? WaitEvent
+        {
+            get
+            {
+                object? weoc = _waitEventOrCondition;
+                if (weoc is Condition c)
+                    return c._waitEvent;
+
+                return (AutoResetEvent?)weoc;
+            }
+        }
+
+        internal Condition GetOrCreateCondition()
+        {
+            // The loop terminates as _waitEventOrCondition has limited number of
+            // state transitions with no cycles.
+            while (true)
+            {
+                object? weoc = _waitEventOrCondition;
+                if (weoc is Condition c)
+                    return c;
+
+                Condition newCondition = new Condition(this);
+                newCondition._waitEvent = WaitEvent;
+
+                if (Interlocked.CompareExchange(ref _waitEventOrCondition, newCondition, weoc) == weoc)
+                {
+                    return newCondition;
+                }
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Lock"/> class.
@@ -513,7 +545,8 @@ namespace System.Threading
                 NativeRuntimeEventSource.Log.IsEnabled(
                     EventLevel.Informational,
                     NativeRuntimeEventSource.Keywords.ContentionKeyword);
-            AutoResetEvent waitEvent = _waitEvent ?? CreateWaitEvent(areContentionEventsEnabled);
+
+            AutoResetEvent waitEvent = WaitEvent ?? CreateWaitEvent(areContentionEventsEnabled);
             if (State.TryLockBeforeWait(this))
             {
                 // Lock was acquired and a waiter was not registered
@@ -652,8 +685,13 @@ namespace System.Threading
         private AutoResetEvent CreateWaitEvent(bool areContentionEventsEnabled)
         {
             var newWaitEvent = new AutoResetEvent(false);
-            AutoResetEvent? waitEventBeforeUpdate = Interlocked.CompareExchange(ref _waitEvent, newWaitEvent, null);
-            if (waitEventBeforeUpdate == null)
+            object? weocBeforeUpdate = Interlocked.CompareExchange(ref _waitEventOrCondition, newWaitEvent, null);
+            if (weocBeforeUpdate is Condition c)
+            {
+                weocBeforeUpdate = Interlocked.CompareExchange(ref c._waitEvent, newWaitEvent, null);
+            }
+
+            if (weocBeforeUpdate == null)
             {
                 // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
                 if (areContentionEventsEnabled && NativeRuntimeEventSource.Log.IsEnabled())
@@ -665,7 +703,7 @@ namespace System.Threading
             }
 
             newWaitEvent.Dispose();
-            return waitEventBeforeUpdate;
+            return (AutoResetEvent)weocBeforeUpdate;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -674,8 +712,8 @@ namespace System.Threading
             if (State.TrySetIsWaiterSignaledToWake(this, state))
             {
                 // Signal a waiter to wake
-                Debug.Assert(_waitEvent != null);
-                bool signaled = _waitEvent.Set();
+                Debug.Assert(WaitEvent != null);
+                bool signaled = WaitEvent.Set();
                 Debug.Assert(signaled);
             }
         }
@@ -695,14 +733,14 @@ namespace System.Threading
         }
 
         internal static long ContentionCount => s_contentionCount;
-        internal void Dispose() => _waitEvent?.Dispose();
+        internal void Dispose() => WaitEvent?.Dispose();
 
         internal nint LockIdForEvents
         {
             get
             {
-                Debug.Assert(_waitEvent != null);
-                return _waitEvent.SafeWaitHandle.DangerousGetHandle();
+                Debug.Assert(WaitEvent != null);
+                return WaitEvent.SafeWaitHandle.DangerousGetHandle();
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -965,6 +965,23 @@ namespace System.Threading
             return (short)-adaptiveSpinPeriod;
         }
 
+        internal bool Wait(int millisecondsTimeout)
+        {
+#pragma warning disable CS9216 // A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
+            return GetOrCreateCondition().Wait(millisecondsTimeout, this);
+#pragma warning restore CS9216 // A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
+        }
+
+        internal void Pulse()
+        {
+            GetOrCreateCondition().SignalOne();
+        }
+
+        internal void PulseAll()
+        {
+            GetOrCreateCondition().SignalAll();
+        }
+
         private struct State : IEquatable<State>
         {
             // Layout constants for Lock._state

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -968,8 +968,13 @@ namespace System.Threading
         internal bool Wait(int millisecondsTimeout)
         {
 #pragma warning disable CS9216 // A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
-            return GetOrCreateCondition().Wait(millisecondsTimeout, this);
+            return Wait(millisecondsTimeout, this);
 #pragma warning restore CS9216 // A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
+        }
+
+        internal bool Wait(int millisecondsTimeout, object associatedObject)
+        {
+            return GetOrCreateCondition().Wait(millisecondsTimeout, associatedObject);
         }
 
         internal void Pulse()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -39,7 +39,7 @@ namespace System.Threading
 
         // A lock used for waiting and pulsing. Lazily initialized via EnsureLockObjectCreated()
         // We are not using thin/object lock here since our use pattern makes it nearly certain that
-        // a thin lock would be inflated.
+        // a thin lock would be inflated even if we use m_lock only once.
         private Lock? m_lock;
 
         private ManualResetEvent? m_eventObj; // A true Win32 event used for waiting.
@@ -202,7 +202,7 @@ namespace System.Threading
 #pragma warning disable IDE0060 // Remove unused parameter spinCount, on single-threaded systems, the spin count is not used.
         private void Initialize(bool initialState, int spinCount)
         {
-            IsSet = initialState;
+            m_combinedState = initialState ? SignalledState_BitMask : 0;
 
             // the spinCount argument has been validated by the ctors.
             // but we now sanity check our predefined constants.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -40,7 +40,7 @@ namespace System.Threading
         private object? m_lock;
         // A lock used for waiting and pulsing. Lazily initialized via EnsureLockObjectCreated()
 
-        private volatile ManualResetEvent? m_eventObj; // A true Win32 event used for waiting.
+        private ManualResetEvent? m_eventObj; // A true Win32 event used for waiting.
 
         // -- State -- //
         // For a packed word a uint would seem better, but Interlocked.* doesn't support them as uint isn't CLS-compliant.
@@ -549,28 +549,27 @@ namespace System.Threading
                 // We must register and unregister the token outside of the lock, to avoid deadlocks.
                 using (cancellationToken.UnsafeRegister(s_cancellationTokenCallback, this))
                 {
-                    lock (m_lock)
+                    // Loop to cope with spurious wakeups from other waits being canceled
+                    while (!IsSet)
                     {
-                        // Loop to cope with spurious wakeups from other waits being canceled
-                        while (!IsSet)
+                        // If our token was canceled, we must throw and exit.
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        // update timeout (delays in wait commencement are due to spinning and/or spurious wakeups from other waits being canceled)
+                        if (startTime != 0)
                         {
-                            // If our token was canceled, we must throw and exit.
-                            cancellationToken.ThrowIfCancellationRequested();
+                            // TimeoutHelper.UpdateTimeOut returns a long but the value is capped as millisecondsTimeout is an int.
+                            realMillisecondsTimeout = (int)TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout);
+                            if (realMillisecondsTimeout <= 0)
+                                return false;
+                        }
 
-                            // update timeout (delays in wait commencement are due to spinning and/or spurious wakeups from other waits being canceled)
-                            if (startTime != 0)
-                            {
-                                // TimeoutHelper.UpdateTimeOut returns a long but the value is capped as millisecondsTimeout is an int.
-                                realMillisecondsTimeout = (int)TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout);
-                                if (realMillisecondsTimeout <= 0)
-                                    return false;
-                            }
-
+                        lock (m_lock)
+                        {
                             // There is a race condition that Set will fail to see that there are waiters as Set does not take the lock,
                             // so after updating waiters, we must check IsSet again.
                             // Also, we must ensure there cannot be any reordering of the assignment to Waiters and the
-                            // read from IsSet.  This is guaranteed as Waiters{set;} involves an Interlocked.CompareExchange
-                            // operation which provides a full memory barrier.
+                            // read from IsSet.  This is guaranteed as InterlockedIncrementWaiters is a full memory barrier.
                             // If we see IsSet=false, then we are guaranteed that Set() will see that we are
                             // waiting and will pulse the monitor correctly.
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -132,11 +132,22 @@ namespace System.Threading
 
         private void InterlockedIncrementWaiters()
         {
-            int newWaiters = Interlocked.Increment(ref m_combinedState) & NumWaitersState_BitMask;
+            int currentState = m_combinedState;
+            while (true)
+            {
+                // it is possible for the max number of waiters to be exceeded via user-code, hence we use a real exception here.
+                if ((currentState & NumWaitersState_BitMask) >= NumWaitersState_MaxValue)
+                    throw new InvalidOperationException(SR.Format(SR.ManualResetEventSlim_ctor_TooManyWaiters, NumWaitersState_MaxValue));
 
-            // it is possible for the max number of waiters to be exceeded via user-code, hence we use a real exception here.
-            if (newWaiters >= NumWaitersState_MaxValue)
-                throw new InvalidOperationException(SR.Format(SR.ManualResetEventSlim_ctor_TooManyWaiters, NumWaitersState_MaxValue));
+                // The waiters count has room for one more, so adding 1 to the full state
+                // cannot carry out of NumWaitersState_BitMask.
+                int oldState = Interlocked.CompareExchange(ref m_combinedState, currentState + 1, currentState);
+                if (oldState == currentState)
+                    return;
+
+                // Highly unlikely contention, since we increment/decrement while holding a lock, just try again.
+                currentState = oldState;
+            }
         }
 
         private void InterlockedDecrementWaiters()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -99,9 +99,10 @@ namespace System.Threading
         {
             get
             {
-                return m_combinedState < 0;
+                // Volatile to make sure checking IsSet is not optimized away or reordered
+                // when called as a public API.
+                return Volatile.Read(ref m_combinedState) < 0;
             }
-
             private set
             {
                 if (value)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -502,7 +502,6 @@ namespace System.Threading
 
                 // We spin briefly before falling back to allocating and/or waiting on a true event.
                 long startTime = 0;
-                bool bNeedTimeoutAdjustment = false;
                 int realMillisecondsTimeout = millisecondsTimeout; // this will be adjusted if necessary.
 
                 if (millisecondsTimeout != Timeout.Infinite)
@@ -514,7 +513,6 @@ namespace System.Threading
                     // decide to block in the kernel below.
 
                     startTime = Environment.TickCount64;
-                    bNeedTimeoutAdjustment = true;
                 }
 
                 // Spin
@@ -549,7 +547,7 @@ namespace System.Threading
                             cancellationToken.ThrowIfCancellationRequested();
 
                             // update timeout (delays in wait commencement are due to spinning and/or spurious wakeups from other waits being canceled)
-                            if (bNeedTimeoutAdjustment)
+                            if (startTime != 0)
                             {
                                 // TimeoutHelper.UpdateTimeOut returns a long but the value is capped as millisecondsTimeout is an int.
                                 realMillisecondsTimeout = (int)TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -44,11 +44,10 @@ namespace System.Threading
 
         // -- State -- //
         // For a packed word a uint would seem better, but Interlocked.* doesn't support them as uint isn't CLS-compliant.
-        private volatile int m_combinedState; // ie a uint. Used for the state items listed below.
+        private int m_combinedState; // ie a uint. Used for the state items listed below.
 
         // 1-bit for  signalled state
         private const int SignalledState_BitMask = unchecked((int)0x80000000); // 1000 0000 0000 0000 0000 0000 0000 0000
-        private const int SignalledState_ShiftCount = 31;
 
         // 1-bit for disposed state
         private const int Dispose_BitMask = unchecked((int)0x40000000); // 0100 0000 0000 0000 0000 0000 0000 0000
@@ -60,7 +59,6 @@ namespace System.Threading
 
         // 19-bits for m_waiters.  This allows support of 512K threads waiting which should be ample
         private const int NumWaitersState_BitMask = unchecked((int)0x0007FFFF); // 0000 0000 0000 0111 1111 1111 1111 1111
-        private const int NumWaitersState_ShiftCount = 0;
         private const int NumWaitersState_MaxValue = (1 << 19) - 1; // 512K-1
         // ----------- //
 
@@ -68,7 +66,7 @@ namespace System.Threading
         /// Gets the underlying <see cref="Threading.WaitHandle"/> object for this <see
         /// cref="ManualResetEventSlim"/>.
         /// </summary>
-        /// <value>The underlying <see cref="Threading.WaitHandle"/> event object fore this <see
+        /// <value>The underlying <see cref="Threading.WaitHandle"/> event object for this <see
         /// cref="ManualResetEventSlim"/>.</value>
         /// <remarks>
         /// Accessing this property forces initialization of an underlying event object if one hasn't
@@ -97,8 +95,22 @@ namespace System.Threading
         /// <value>true if the event has is set; otherwise, false.</value>
         public bool IsSet
         {
-            get => 0 != ExtractStatePortion(m_combinedState, SignalledState_BitMask);
-            private set => UpdateStateAtomically(((value) ? 1 : 0) << SignalledState_ShiftCount, SignalledState_BitMask);
+            get
+            {
+                return m_combinedState < 0;
+            }
+
+            private set
+            {
+                if (value)
+                {
+                    Interlocked.Or(ref m_combinedState, SignalledState_BitMask);
+                }
+                else
+                {
+                    Interlocked.And(ref m_combinedState, ~SignalledState_BitMask);
+                }
+            }
         }
 
         /// <summary>
@@ -116,23 +128,21 @@ namespace System.Threading
             }
         }
 
-        /// <summary>
-        /// How many threads are waiting.
-        /// </summary>
-        private int Waiters
+        private void InterlockedIncrementWaiters()
         {
-            get => ExtractStatePortionAndShiftRight(m_combinedState, NumWaitersState_BitMask, NumWaitersState_ShiftCount);
-            set
-            {
-                // setting to <0 would indicate an internal flaw, hence Assert is appropriate.
-                Debug.Assert(value >= 0, "NumWaiters should never be less than zero. This indicates an internal error.");
+            int newWaiters = Interlocked.Increment(ref m_combinedState) & NumWaitersState_BitMask;
 
-                // it is possible for the max number of waiters to be exceeded via user-code, hence we use a real exception here.
-                if (value >= NumWaitersState_MaxValue)
-                    throw new InvalidOperationException(SR.Format(SR.ManualResetEventSlim_ctor_TooManyWaiters, NumWaitersState_MaxValue));
+            // it is possible for the max number of waiters to be exceeded via user-code, hence we use a real exception here.
+            if (newWaiters >= NumWaitersState_MaxValue)
+                throw new InvalidOperationException(SR.Format(SR.ManualResetEventSlim_ctor_TooManyWaiters, NumWaitersState_MaxValue));
+        }
 
-                UpdateStateAtomically(value << NumWaitersState_ShiftCount, NumWaitersState_BitMask);
-            }
+        private void InterlockedDecrementWaiters()
+        {
+            int newWaiters = Interlocked.Decrement(ref m_combinedState) & NumWaitersState_BitMask;
+
+            // setting to <0 would indicate an internal flaw, hence Assert is appropriate.
+            Debug.Assert(newWaiters >= 0, "NumWaiters should never be less than zero. This indicates an internal error.");
         }
 
         //-----------------------------------------------------------------------------------
@@ -190,7 +200,8 @@ namespace System.Threading
 #pragma warning disable IDE0060 // Remove unused parameter spinCount, on single-threaded systems, the spin count is not used.
         private void Initialize(bool initialState, int spinCount)
         {
-            m_combinedState = initialState ? (1 << SignalledState_ShiftCount) : 0;
+            IsSet = initialState;
+
             // the spinCount argument has been validated by the ctors.
             // but we now sanity check our predefined constants.
             Debug.Assert(DEFAULT_SPIN_SP >= 0, "Internal error - DEFAULT_SPIN_SP is outside the legal range.");
@@ -213,7 +224,7 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// This method lazily initializes the event object. It uses CAS to guarantee that
+        /// This method lazily initializes the public wait object. It uses CAS to guarantee that
         /// many threads racing to call this at once don't result in more than one event
         /// being stored and used. The event will be signaled or unsignaled depending on
         /// the state of the thin-event itself, with synchronization taken into account.
@@ -235,7 +246,7 @@ namespace System.Threading
                 // Now that the event is published, verify that the state hasn't changed since
                 // we snapped the preInitializeState. Another thread could have done that
                 // between our initial observation above and here. The barrier incurred from
-                // the CAS above (in addition to m_state being volatile) prevents this read
+                // the CAS above prevents this read
                 // from moving earlier and being collapsed with our original one.
                 bool currentIsSet = IsSet;
                 if (currentIsSet != preInitializeIsSet)
@@ -275,10 +286,10 @@ namespace System.Threading
             // We need to ensure that IsSet=true does not get reordered past the read of m_eventObj
             // This would be a legal movement according to the .NET memory model.
             // The code is safe as IsSet involves an Interlocked.CompareExchange which provides a full memory barrier.
-            IsSet = true;
+            long origState = Interlocked.Or(ref m_combinedState, SignalledState_BitMask);
 
-            // If there are waiting threads, we need to pulse them.
-            if (Waiters > 0)
+            // If there were waiting threads at Set time, we need to pulse them.
+            if ((origState & NumWaitersState_BitMask) != 0)
             {
                 Debug.Assert(m_lock != null); // if waiters>0, then m_lock has already been created.
                 lock (m_lock)
@@ -563,11 +574,11 @@ namespace System.Threading
                             // If we see IsSet=false, then we are guaranteed that Set() will see that we are
                             // waiting and will pulse the monitor correctly.
 
-                            Waiters++;
+                            InterlockedIncrementWaiters();
 
                             if (IsSet) // This check must occur after updating Waiters.
                             {
-                                Waiters--; // revert the increment.
+                                InterlockedDecrementWaiters(); // revert the increment.
                                 return true;
                             }
 
@@ -581,7 +592,7 @@ namespace System.Threading
                             finally
                             {
                                 // Clean up: we're done waiting.
-                                Waiters--;
+                                InterlockedDecrementWaiters();
                             }
                             // Now just loop back around, and the right thing will happen.  Either:
                             //     1. We had a spurious wake-up due to some other wait being canceled via a different cancellationToken (rewait)
@@ -657,38 +668,6 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Private helper method for updating parts of a bit-string state value.
-        /// Mainly called from the IsSet and Waiters properties setters
-        /// </summary>
-        /// <remarks>
-        /// Note: the parameter types must be int as CompareExchange cannot take a Uint
-        /// </remarks>
-        /// <param name="newBits">The new value</param>
-        /// <param name="updateBitsMask">The mask used to set the bits</param>
-        private void UpdateStateAtomically(int newBits, int updateBitsMask)
-        {
-            SpinWait sw = default;
-
-            Debug.Assert((newBits | updateBitsMask) == updateBitsMask, "newBits do not fall within the updateBitsMask.");
-
-            while (true)
-            {
-                int oldState = m_combinedState; // cache the old value for testing in CAS
-
-                // Procedure:(1) zero the updateBits.  eg oldState = [11111111] flag= [00111000] newState = [11000111]
-                //           then (2) map in the newBits. eg [11000111] newBits=00101000, newState=[11101111]
-                int newState = (oldState & ~updateBitsMask) | newBits;
-
-                if (Interlocked.CompareExchange(ref m_combinedState, newState, oldState) == oldState)
-                {
-                    return;
-                }
-
-                sw.SpinOnce(sleep1Threshold: -1);
-            }
-        }
-
-        /// <summary>
         /// Private helper method - performs Mask and shift, particular helpful to extract a field from a packed word.
         /// eg ExtractStatePortionAndShiftRight(0x12345678, 0xFF000000, 24) => 0x12, ie extracting the top 8-bits as a simple integer
         ///
@@ -703,21 +682,6 @@ namespace System.Threading
             // convert to uint before shifting so that right-shift does not replicate the sign-bit,
             // then convert back to int.
             return unchecked((int)(((uint)(state & mask)) >> rightBitShiftCount));
-        }
-
-        /// <summary>
-        /// Performs a Mask operation, but does not perform the shift.
-        /// This is acceptable for boolean values for which the shift is unnecessary
-        /// eg (val &amp; Mask) != 0 is an appropriate way to extract a boolean rather than using
-        /// ((val &amp; Mask) &gt;&gt; shiftAmount) == 1
-        ///
-        /// ?? is there a common place to put this rather than being private to MRES?
-        /// </summary>
-        /// <param name="state"></param>
-        /// <param name="mask"></param>
-        private static int ExtractStatePortion(int state, int mask)
-        {
-            return state & mask;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -153,10 +153,10 @@ namespace System.Threading
 
         private void InterlockedDecrementWaiters()
         {
-            int newWaiters = Interlocked.Decrement(ref m_combinedState) & NumWaitersState_BitMask;
-
             // setting to <0 would indicate an internal flaw, hence Assert is appropriate.
-            Debug.Assert(newWaiters >= 0, "NumWaiters should never be less than zero. This indicates an internal error.");
+            Debug.Assert((m_combinedState & NumWaitersState_BitMask) != 0, "NumWaiters should never be less than zero. This indicates an internal error.");
+
+            Interlocked.Decrement(ref m_combinedState);
         }
 
         //-----------------------------------------------------------------------------------

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -37,8 +37,10 @@ namespace System.Threading
         // These are the default spin counts we use on single-proc and MP machines.
         private const int DEFAULT_SPIN_SP = 1;
 
-        private object? m_lock;
         // A lock used for waiting and pulsing. Lazily initialized via EnsureLockObjectCreated()
+        // We are not using thin/object lock here since our use pattern makes it nearly certain that
+        // a thin lock would be inflated.
+        private Lock? m_lock;
 
         private ManualResetEvent? m_eventObj; // A true Win32 event used for waiting.
 
@@ -219,7 +221,7 @@ namespace System.Threading
         {
             if (m_lock is null)
             {
-                Interlocked.CompareExchange(ref m_lock, new object(), null); // failure is benign. Someone else set the value.
+                Interlocked.CompareExchange(ref m_lock, new Lock(), null); // failure is benign. Someone else set the value.
             }
         }
 
@@ -292,9 +294,9 @@ namespace System.Threading
             if ((origState & NumWaitersState_BitMask) != 0)
             {
                 Debug.Assert(m_lock != null); // if waiters>0, then m_lock has already been created.
-                lock (m_lock)
+                using (m_lock.EnterScope())
                 {
-                    Monitor.PulseAll(m_lock);
+                    m_lock.PulseAll();
                 }
             }
 
@@ -564,7 +566,7 @@ namespace System.Threading
                                 return false;
                         }
 
-                        lock (m_lock)
+                        using (m_lock.EnterScope())
                         {
                             // There is a race condition that Set will fail to see that there are waiters as Set does not take the lock,
                             // so after updating waiters, we must check IsSet again.
@@ -585,7 +587,7 @@ namespace System.Threading
                             try
                             {
                                 // ** the actual wait **
-                                if (!Monitor.Wait(m_lock, realMillisecondsTimeout))
+                                if (!m_lock.Wait(realMillisecondsTimeout))
                                     return false; // return immediately if the timeout has expired.
                             }
                             finally
@@ -660,9 +662,9 @@ namespace System.Threading
             Debug.Assert(obj is ManualResetEventSlim, "Expected a ManualResetEventSlim");
             ManualResetEventSlim mre = (ManualResetEventSlim)obj;
             Debug.Assert(mre.m_lock != null); // the lock should have been created before this callback is registered for use.
-            lock (mre.m_lock)
+            using (mre.m_lock.EnterScope())
             {
-                Monitor.PulseAll(mre.m_lock); // awaken all waiters
+                mre.m_lock.PulseAll(); // awaken all waiters
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -296,12 +296,11 @@ namespace System.Threading
         /// <exception cref="OperationCanceledException">The object has been canceled.</exception>
         private void Set(bool duringCancellation)
         {
-            // We need to ensure that IsSet=true does not get reordered past the read of m_eventObj
-            // This would be a legal movement according to the .NET memory model.
-            // The code is safe as IsSet involves an Interlocked.CompareExchange which provides a full memory barrier.
+            // We need to ensure that the state change happens before we read the m_eventObj.
+            // Interlocked guarantees that.
             long origState = Interlocked.Or(ref m_combinedState, SignalledState_BitMask);
 
-            // If there were waiting threads at Set time, we need to pulse them.
+            // If there were waiting threads when we flipped the state, we need to pulse them.
             if ((origState & NumWaitersState_BitMask) != 0)
             {
                 Debug.Assert(m_lock != null); // if waiters>0, then m_lock has already been created.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -86,7 +86,7 @@ namespace System.Threading
             ArgumentNullException.ThrowIfNull(obj);
             RuntimeFeature.ThrowIfMultithreadingIsNotSupported();
 
-            return GetLockObject(obj).Wait(millisecondsTimeout);
+            return GetLockObject(obj).Wait(millisecondsTimeout, obj);
         }
 
         public static void Pulse(object obj)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -80,7 +80,7 @@ namespace System.Threading
 
         #region Object->Condition mapping
 #pragma warning disable CA1823 // Avoid unused private fields
-        // TODO: this is unused, except in DacDbiInterfaceImpl::EnumerateMonitorEventWaitList, fix and remove
+        // TODO: this is unused, except in DacDbiInterfaceImpl::EnumerateMonitorEventWaitList, fix that and remove
         private static readonly ConditionalWeakTable<object, Condition> s_conditionTable = [];
 #pragma warning restore CA1823 // Avoid unused private fields
         #endregion

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -95,7 +95,9 @@ namespace System.Threading
         [UnsupportedOSPlatform("browser")]
         public static bool Wait(object obj, int millisecondsTimeout)
         {
+            ArgumentNullException.ThrowIfNull(obj);
             RuntimeFeature.ThrowIfMultithreadingIsNotSupported();
+
             return GetCondition(obj).Wait(millisecondsTimeout, obj);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -78,6 +78,13 @@ namespace System.Threading
             throw new ArgumentException(SR.Argument_MustBeFalse, "lockTaken");
         }
 
+        #region Object->Condition mapping
+#pragma warning disable CA1823 // Avoid unused private fields
+        // TODO: this is unused, except in DacDbiInterfaceImpl::EnumerateMonitorEventWaitList, fix that and remove
+        private static readonly ConditionalWeakTable<object, Condition> s_conditionTable = [];
+#pragma warning restore CA1823 // Avoid unused private fields
+        #endregion
+
         #region Public Wait/Pulse methods
 
         [UnsupportedOSPlatform("browser")]

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -78,17 +78,15 @@ namespace System.Threading
             throw new ArgumentException(SR.Argument_MustBeFalse, "lockTaken");
         }
 
-        #region Object->Condition mapping
-
-        private static readonly ConditionalWeakTable<object, Condition> s_conditionTable = [];
-        private static readonly Func<object, Condition> s_createCondition = (o) => new Condition(GetLockObject(o));
+        #region Condition Wait/Pulse
 
         private static Condition GetCondition(object obj)
         {
             Debug.Assert(
                 obj is not Condition,
                 "Do not use Monitor.Pulse or Wait on a Condition instance; use the methods on Condition instead.");
-            return s_conditionTable.GetOrAdd(obj, s_createCondition);
+
+            return GetLockObject(obj).GetOrCreateCondition();
         }
         #endregion
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -78,18 +78,6 @@ namespace System.Threading
             throw new ArgumentException(SR.Argument_MustBeFalse, "lockTaken");
         }
 
-        #region Condition Wait/Pulse
-
-        private static Condition GetCondition(object obj)
-        {
-            Debug.Assert(
-                obj is not Condition,
-                "Do not use Monitor.Pulse or Wait on a Condition instance; use the methods on Condition instead.");
-
-            return GetLockObject(obj).GetOrCreateCondition();
-        }
-        #endregion
-
         #region Public Wait/Pulse methods
 
         [UnsupportedOSPlatform("browser")]
@@ -98,21 +86,21 @@ namespace System.Threading
             ArgumentNullException.ThrowIfNull(obj);
             RuntimeFeature.ThrowIfMultithreadingIsNotSupported();
 
-            return GetCondition(obj).Wait(millisecondsTimeout, obj);
+            return GetLockObject(obj).Wait(millisecondsTimeout);
         }
 
         public static void Pulse(object obj)
         {
             ArgumentNullException.ThrowIfNull(obj);
 
-            GetCondition(obj).SignalOne();
+            GetLockObject(obj).Pulse();
         }
 
         public static void PulseAll(object obj)
         {
             ArgumentNullException.ThrowIfNull(obj);
 
-            GetCondition(obj).SignalAll();
+            GetLockObject(obj).PulseAll();
         }
 
         #endregion

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -78,13 +78,6 @@ namespace System.Threading
             throw new ArgumentException(SR.Argument_MustBeFalse, "lockTaken");
         }
 
-        #region Object->Condition mapping
-#pragma warning disable CA1823 // Avoid unused private fields
-        // TODO: this is unused, except in DacDbiInterfaceImpl::EnumerateMonitorEventWaitList, fix that and remove
-        private static readonly ConditionalWeakTable<object, Condition> s_conditionTable = [];
-#pragma warning restore CA1823 // Avoid unused private fields
-        #endregion
-
         #region Public Wait/Pulse methods
 
         [UnsupportedOSPlatform("browser")]

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -78,6 +78,13 @@ namespace System.Threading
             throw new ArgumentException(SR.Argument_MustBeFalse, "lockTaken");
         }
 
+        #region Object->Condition mapping
+#pragma warning disable CA1823 // Avoid unused private fields
+        // TODO: this is unused, except in DacDbiInterfaceImpl::EnumerateMonitorEventWaitList, fix and remove
+        private static readonly ConditionalWeakTable<object, Condition> s_conditionTable = [];
+#pragma warning restore CA1823 // Avoid unused private fields
+        #endregion
+
         #region Public Wait/Pulse methods
 
         [UnsupportedOSPlatform("browser")]

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
@@ -86,11 +86,9 @@ namespace System.Threading
                     case ObjectKind.Lock:
                         return ((Lock)Unsafe.AsRef<object>(_objectPtr)).OwningManagedThreadId;
 
-#if !MONO
                     case ObjectKind.Condition:
                         Debug.Assert(_objectKind == ObjectKind.Condition);
                         return ((Condition)Unsafe.AsRef<object>(_objectPtr)).AssociatedLock.OwningManagedThreadId;
-#endif
 
                     default:
                         throw new UnreachableException();
@@ -107,9 +105,7 @@ namespace System.Threading
             public Scope(Lock lockObj, int timeoutMs) : this(lockObj, ObjectKind.Lock, timeoutMs) { }
 #pragma warning restore CS9216
 
-#if !MONO
             public Scope(Condition condition, int timeoutMs) : this(condition, ObjectKind.Condition, timeoutMs) { }
-#endif
 
             private Scope(object obj, ObjectKind objectKind, int timeoutMs)
             {


### PR DESCRIPTION

Main motivation is that `ManualResetEventSlim` uses `Monitor.Wait` to implement `Wait` that is: 
* cancellable 
* interruptible (in `Thread.Interrupt` sense) and
* aware of synchronization context

`Monitor.Wait` is a good fit to implement such pattern and should generally perform well enough. 

`ManualResetEventSlim` in turn is used in `Task.Wait` and some scenarios can wait on Tasks relatively frequently. 

In such scenarios using `ConditionalWaitTable` for Lock->Condition association may have two inconveniences: 

* it may result in quite a few dependent handles being alive and that can have impact on GC. 
In particular because dependent handles currently do not age and need to be revisited in every Gen0, even if both objects referred from the handle may be Gen2 objects. 
(we should probably address #79062, regardless of this PR)

* Allocating an entry in `ConditionalWaitTable` acquires table-wide lock and on large enough core count may contend.

It seems there is a relatively simple way to arrange Lock->Condition link without involving `ConditionalWaitTable`, thus why not.

The change also enables `Wait`/`Pulse`/`PulseAll` functionality on `Lock`, but only internally. 
It can be exposed as a public API, but it would be a separate discussion.