### PR TITLE
JIT: Tail-merge don't produce empty blocks

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5212,6 +5212,23 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
 
                     fgUnlinkStmt(predBlock, stmt);
 
+                    bool canRemove =
+                        predBlock->isEmpty() && !predBlock->HasFlag(BBF_DONT_REMOVE) && predBlock != fgFirstBB;
+                    if (canRemove)
+                    {
+                        for (BasicBlock* const pred : predBlock->PredBlocksEditing())
+                        {
+                            fgReplaceJumpTarget(pred, predBlock, commSucc);
+                        }
+
+                        fgRemoveBlock(predBlock, true);
+
+                        if (commSucc->hasProfileWeight())
+                        {
+                            commSucc->increaseBBProfileWeight(predBlock->bbWeight);
+                        }
+                    }
+
                     // Add one of the matching stmts to block, and
                     // update its flags.
                     //
@@ -5344,15 +5361,32 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
 
                 // Fix up the flow.
                 //
-                if (commSucc != nullptr)
+                bool canRemove = predBlock->isEmpty() && !predBlock->HasFlag(BBF_DONT_REMOVE) && predBlock != fgFirstBB;
+                if (canRemove)
                 {
-                    assert(predBlock->KindIs(BBJ_ALWAYS));
-                    fgRedirectEdge(predBlock->TargetEdgeRef(), crossJumpTarget);
+                    for (BasicBlock* const pred : predBlock->PredBlocksEditing())
+                    {
+                        fgReplaceJumpTarget(pred, predBlock, crossJumpTarget);
+                    }
+                    fgRemoveBlock(predBlock, true);
+
+                    if (commSucc != nullptr && commSucc->hasProfileWeight())
+                    {
+                        commSucc->increaseBBProfileWeight(predBlock->bbWeight);
+                    }
                 }
                 else
                 {
-                    FlowEdge* const newEdge = fgAddRefPred(crossJumpTarget, predBlock);
-                    predBlock->SetKindAndTargetEdge(BBJ_ALWAYS, newEdge);
+                    if (commSucc != nullptr)
+                    {
+                        assert(predBlock->KindIs(BBJ_ALWAYS));
+                        fgRedirectEdge(predBlock->TargetEdgeRef(), crossJumpTarget);
+                    }
+                    else
+                    {
+                        FlowEdge* const newEdge = fgAddRefPred(crossJumpTarget, predBlock);
+                        predBlock->SetKindAndTargetEdge(BBJ_ALWAYS, newEdge);
+                    }
                 }
 
                 // For tail merge we have a common successor of predBlock and
@@ -5398,6 +5432,13 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
         for (BasicBlock* const predBlock : block->PredBlocks())
         {
             if (predBlock->GetUniqueSucc() != block)
+            {
+                continue;
+            }
+
+            // If this block was already processed, skip it
+            //
+            if (predBlock->isEmpty())
             {
                 continue;
             }
@@ -5498,9 +5539,9 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
         predInfo.Reset();
         for (BasicBlock* const block : retOrThrowBlocks.BottomUpOrder())
         {
-            // If this block was already merged, skip it
+            // If this block was already processed, skip it
             //
-            if (!block->KindIs(BBJ_RETURN, BBJ_THROW))
+            if (!block->KindIs(BBJ_RETURN, BBJ_THROW) || block->isEmpty())
             {
                 continue;
             }


### PR DESCRIPTION
I had an other change for improving the `crossJumpVictim` selection logic in tail-merge, but it had random regressions because downstream phases get confused depending on where empty blocks are. This PR stops producing empty blocks in tail-merge which fixes that.
It also makes sense given how we are running directly after "optimize control flow" phase which just got rid of all empty blocks.
