### PR TITLE
JIT: remove unsound NOT(relop) VN simplification

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2575,12 +2575,6 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN)
                 {
                     *resultVN = funcApp.GetArg(0);
                 }
-                // NOT(relop(x,y)) ==> Reverse(relop)(x,y)
-                //
-                else if (VNFuncIsComparison(funcApp.GetFunc()))
-                {
-                    *resultVN = GetRelatedRelop(arg0VN, VN_RELATION_KIND::VRK_Reverse);
-                }
             }
         }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129076/Runtime_129076.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129076/Runtime_129076.cs
@@ -7,6 +7,8 @@
 // so downstream uses comparing the value arithmetically (here `~v3 >= -1`)
 // folded the wrong way.
 
+namespace Runtime_129076;
+
 using System.Runtime.CompilerServices;
 using Xunit;
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129076/Runtime_129076.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129076/Runtime_129076.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// VN was simplifying NOT(relop(x,y)) to Reverse(relop)(x,y). GT_NOT is
+// bitwise complement, not logical negation: ~(x relop y) produces -1 or
+// -2 for a 0/1 relop result, while Reverse(relop)(x,y) produces 0 or 1,
+// so downstream uses comparing the value arithmetically (here `~v3 >= -1`)
+// folded the wrong way.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Runtime_129076
+{
+    private static volatile int Input_p0 = unchecked((int)0x800335C5);
+    private static volatile int Input_p1 = 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Func(int p0, int p1)
+    {
+        unchecked
+        {
+            int v1 = unchecked((int)0x000335C5) & p1;
+            int v3 = (v1 != p0) ? 1 : 0;
+            if (v3 == 0) return 99;
+            int v4 = ~v3;
+            return (v4 >= -1) ? 1 : 0;
+        }
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return Func(Input_p0, Input_p1) == 0 ? 100 : 1;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129076/Runtime_129076.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129076/Runtime_129076.csproj
@@ -1,8 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <Optimize>True</Optimize>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="$(MSBuildProjectName).cs" />
-  </ItemGroup>
-</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129076/Runtime_129076.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129076/Runtime_129076.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -100,6 +100,7 @@
     <Compile Include="JitBlue\Runtime_127446\Runtime_127446.cs" />
     <Compile Include="JitBlue\Runtime_128631\Runtime_128631.cs" />
     <Compile Include="JitBlue\Runtime_128801\Runtime_128801.cs" />
+    <Compile Include="JitBlue\Runtime_129076\Runtime_129076.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by GitHub Copilot CLI on @AndyAyersMS's machine.

VNForFunc was rewriting `NOT(relop(x,y))` to `Reverse(relop)(x,y)`. `GT_NOT` is bitwise complement, not logical negation: for a 0/1 relop result, `~v` produces -1 or -2, while `Reverse(relop)` produces 0 or 1, so downstream arithmetic uses of the complemented value (here `~v3 >= -1` in the repro) folded the wrong way.

Removes the case; keeps `NOT(NOT(x)) ==> x` which is correct.

SuperPMI asmdiffs across all 10 osx-arm64 Checked collections (2,302,269 contexts, 871K MinOpts + 1.4M FullOpts): 0 diffs. The peephole never fires on real-world code.

Fixes #129076.
