### PR TITLE
[Wasm R2R] Retype integer constant struct returns to the native return type

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5864,9 +5864,8 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
                 // so that targets with a typed value stack (Wasm) emit e.g. an i64.const
                 // rather than an i32.const. Mirrors the float/double case above.
 #if defined(TARGET_WASM)
-                if (genActualType(retVal) != genActualType(nativeReturnType))
+                if ((genActualType(retVal) != genActualType(nativeReturnType)) && retVal->IsIntegralConst(0))
                 {
-                    assert(retVal->IsIntegralConst(0));
                     retVal->BashToZeroConst(nativeReturnType);
                 }
 #endif // defined(TARGET_WASM)

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5863,11 +5863,13 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
                 // (e.g. LONG) integer struct return. Retype it to the native return type
                 // so that targets with a typed value stack (Wasm) emit e.g. an i64.const
                 // rather than an i32.const. Mirrors the float/double case above.
+#if defined(TARGET_WASM)
                 if (genActualType(retVal) != genActualType(nativeReturnType))
                 {
                     assert(retVal->IsIntegralConst(0));
                     retVal->BashToZeroConst(nativeReturnType);
                 }
+#endif // defined(TARGET_WASM)
             }
             break;
         }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5859,6 +5859,16 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
             else
             {
                 assert(varTypeUsesIntReg(nativeReturnType));
+#ifdef TARGET_WASM
+                // Wasm has a typed value stack, so the constant's type must match the
+                // type the function returns. Retype an INT constant (e.g. a zero from a
+                // promoted/zero-initialized struct field) to the wider native return
+                // type so codegen emits an i64.const rather than an i32.const.
+                if (genActualType(retVal) != genActualType(nativeReturnType))
+                {
+                    retVal->ChangeType(genActualType(nativeReturnType));
+                }
+#endif // TARGET_WASM
             }
             break;
         }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5861,10 +5861,11 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
                 assert(varTypeUsesIntReg(nativeReturnType));
 #ifdef TARGET_WASM
                 // Wasm has a typed value stack, so the constant's type must match the
-                // type the function returns. Retype an INT constant (e.g. a zero from a
-                // promoted/zero-initialized struct field) to the wider native return
-                // type so codegen emits an i64.const rather than an i32.const.
-                if (genActualType(retVal) != genActualType(nativeReturnType))
+                // type the function returns. ZeroObj assertion propagation can create an
+                // INT zero for a wider (e.g. LONG) struct return; retype it so codegen
+                // emits an i64.const rather than an i32.const. Only the zero constant can
+                // be widened unambiguously here (matching the float/double case above).
+                if (retVal->IsIntegralConst(0) && (genActualType(retVal) != genActualType(nativeReturnType)))
                 {
                     retVal->ChangeType(genActualType(nativeReturnType));
                 }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5859,17 +5859,15 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
             else
             {
                 assert(varTypeUsesIntReg(nativeReturnType));
-#ifdef TARGET_WASM
-                // Wasm has a typed value stack, so the constant's type must match the
-                // type the function returns. ZeroObj assertion propagation can create an
-                // INT zero for a wider (e.g. LONG) struct return; retype it so codegen
-                // emits an i64.const rather than an i32.const. Only the zero constant can
-                // be widened unambiguously here (matching the float/double case above).
-                if (retVal->IsIntegralConst(0) && (genActualType(retVal) != genActualType(nativeReturnType)))
+                // ZeroObj assertion propagation can create an INT zero for a wider
+                // (e.g. LONG) integer struct return. Retype it to the native return type
+                // so that targets with a typed value stack (Wasm) emit e.g. an i64.const
+                // rather than an i32.const. Mirrors the float/double case above.
+                if (genActualType(retVal) != genActualType(nativeReturnType))
                 {
-                    retVal->ChangeType(genActualType(nativeReturnType));
+                    assert(retVal->IsIntegralConst(0));
+                    retVal->BashToZeroConst(nativeReturnType);
                 }
-#endif // TARGET_WASM
             }
             break;
         }


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## Problem

When `Lowering::LowerRetStruct` retypes a struct return to a primitive `nativeReturnType` and the return value is a `GT_CNS_INT`, the integer branch leaves the constant as `TYP_INT` even when the native return type is wider (e.g. `TYP_LONG`). On register targets this is harmless because integer registers are untyped, but wasm has a *typed* value stack, so codegen emits `i32.const 0` for an `i64`-typed return.

## Where it surfaced

Validating the R2R-compiled `System.Private.CoreLib` for wasm. `System.Runtime.Intrinsics.Vector64<byte>.get_Zero` reduces (after the unsupported-base-type check inlines away for `byte`) to `return default;` — a zero-initialized 8-byte struct, which the wasm ABI lowers to an `i64` return. The emitted body ended with `i32.const 0`, and wasmtime rejected the module:

```
Invalid input WebAssembly code: type mismatch: expected i64, found i32
```

This is the first small-struct-constant return in corelib's code section; with it fixed the entire corelib validates.

## Fix

Retype the integer constant to the native return type under `TARGET_WASM` so codegen emits an `i64.const`. The change is `TARGET_WASM`-guarded and does not affect other targets. It applies to both the browser and wasi wasm targets, which share the same JIT.

## Validation

- Regenerated the wasm R2R `System.Private.CoreLib` with the fixed JIT; the full module now passes `wasmtime` validation (previously failed at `Vector64<byte>.get_Zero`).
- Confirmed the emitted body now ends with `i64.const 0` instead of `i32.const 0`.

I held off on adding a dedicated regression test since this class of bug is caught implicitly once the wasm R2R corelib is built and validated/loaded (corelib itself contains the triggering method). Happy to add a targeted test if reviewers prefer an earlier, JIT-level signal.
