### PR TITLE
Separate frozen object owning type from allocation site

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SerializedFrozenObjectNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SerializedFrozenObjectNode.cs
@@ -34,6 +34,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             sb.Append(nameMangler.CompilationUnitPrefix).Append("__FrozenObj_"u8)
                 .Append(nameMangler.GetMangledTypeName(_owningType))
+                .Append('_')
                 .Append(_allocationSiteId.ToStringInvariant());
         }
 


### PR DESCRIPTION
Fixes #129074.

Type names ending with numbers could clash with the callsite ID.