### PR TITLE
Pool the dictionary buffer when training a Zstandard dictionary

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDictionary.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDictionary.cs
@@ -103,6 +103,7 @@ namespace System.IO.Compression
             // This incidentally also protects against concurrent modifications of the sampleLengths that could cause
             // access violations later in native code.
             byte[] lengthsArray = ArrayPool<byte>.Shared.Rent(sampleLengths.Length * Unsafe.SizeOf<nuint>());
+            byte[]? dictionaryBuffer = null;
             try
             {
                 Span<nuint> lengthsAsNuint = MemoryMarshal.Cast<byte, nuint>(lengthsArray.AsSpan(0, sampleLengths.Length * Unsafe.SizeOf<nuint>()));
@@ -127,34 +128,30 @@ namespace System.IO.Compression
 
                 ArgumentOutOfRangeException.ThrowIfLessThan(maxDictionarySize, 256, nameof(maxDictionarySize));
 
-                byte[] dictionaryBuffer = ArrayPool<byte>.Shared.Rent(maxDictionarySize);
-                try
-                {
-                    nuint dictSize;
+                dictionaryBuffer = ArrayPool<byte>.Shared.Rent(maxDictionarySize);
+                nuint dictSize;
 
-                    unsafe
+                unsafe
+                {
+                    fixed (byte* samplesPtr = &MemoryMarshal.GetReference(samples))
+                    fixed (byte* dictPtr = dictionaryBuffer)
+                    fixed (nuint* lengthsAsNuintPtr = &MemoryMarshal.GetReference(lengthsAsNuint))
                     {
-                        fixed (byte* samplesPtr = &MemoryMarshal.GetReference(samples))
-                        fixed (byte* dictPtr = dictionaryBuffer)
-                        fixed (nuint* lengthsAsNuintPtr = &MemoryMarshal.GetReference(lengthsAsNuint))
-                        {
-                            dictSize = Interop.Zstd.ZDICT_trainFromBuffer(
-                                    dictPtr, (nuint)maxDictionarySize,
-                                    samplesPtr, lengthsAsNuintPtr, (uint)sampleLengths.Length);
-                        }
-
-                        ZstandardUtils.ThrowIfError(dictSize);
-                        return Create(dictionaryBuffer.AsSpan(0, (int)dictSize));
+                        dictSize = Interop.Zstd.ZDICT_trainFromBuffer(
+                                dictPtr, (nuint)maxDictionarySize,
+                                samplesPtr, lengthsAsNuintPtr, (uint)sampleLengths.Length);
                     }
-                }
-                finally
-                {
-                    // Clear before returning: the trained dictionary is derived from caller-supplied samples.
-                    ArrayPool<byte>.Shared.Return(dictionaryBuffer, clearArray: true);
+
+                    ZstandardUtils.ThrowIfError(dictSize);
+                    return Create(dictionaryBuffer.AsSpan(0, (int)dictSize));
                 }
             }
             finally
             {
+                if (dictionaryBuffer is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(dictionaryBuffer);
+                }
                 ArrayPool<byte>.Shared.Return(lengthsArray);
             }
         }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDictionary.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDictionary.cs
@@ -127,23 +127,30 @@ namespace System.IO.Compression
 
                 ArgumentOutOfRangeException.ThrowIfLessThan(maxDictionarySize, 256, nameof(maxDictionarySize));
 
-                byte[] dictionaryBuffer = new byte[maxDictionarySize];
-
-                nuint dictSize;
-
-                unsafe
+                byte[] dictionaryBuffer = ArrayPool<byte>.Shared.Rent(maxDictionarySize);
+                try
                 {
-                    fixed (byte* samplesPtr = &MemoryMarshal.GetReference(samples))
-                    fixed (byte* dictPtr = dictionaryBuffer)
-                    fixed (nuint* lengthsAsNuintPtr = &MemoryMarshal.GetReference(lengthsAsNuint))
-                    {
-                        dictSize = Interop.Zstd.ZDICT_trainFromBuffer(
-                                dictPtr, (nuint)maxDictionarySize,
-                                samplesPtr, lengthsAsNuintPtr, (uint)sampleLengths.Length);
-                    }
+                    nuint dictSize;
 
-                    ZstandardUtils.ThrowIfError(dictSize);
-                    return Create(dictionaryBuffer.AsSpan(0, (int)dictSize));
+                    unsafe
+                    {
+                        fixed (byte* samplesPtr = &MemoryMarshal.GetReference(samples))
+                        fixed (byte* dictPtr = dictionaryBuffer)
+                        fixed (nuint* lengthsAsNuintPtr = &MemoryMarshal.GetReference(lengthsAsNuint))
+                        {
+                            dictSize = Interop.Zstd.ZDICT_trainFromBuffer(
+                                    dictPtr, (nuint)maxDictionarySize,
+                                    samplesPtr, lengthsAsNuintPtr, (uint)sampleLengths.Length);
+                        }
+
+                        ZstandardUtils.ThrowIfError(dictSize);
+                        return Create(dictionaryBuffer.AsSpan(0, (int)dictSize));
+                    }
+                }
+                finally
+                {
+                    // Clear before returning: the trained dictionary is derived from caller-supplied samples.
+                    ArrayPool<byte>.Shared.Return(dictionaryBuffer, clearArray: true);
                 }
             }
             finally


### PR DESCRIPTION
`ZstandardDictionary.Train` allocates `new byte[maxDictionarySize]` on every call to hold the trained dictionary returned by the native `ZDICT_trainFromBuffer`. Upstream zstd guidance puts a reasonable dictionary size at ~100 KB and the CLI defaults to 112,640 bytes — both above the .NET 85,000-byte LOH threshold. So for the recommended-and-up sizes, every training call costs a fresh Large Object Heap allocation that survives until the next gen2 collection. This change rents the buffer from `ArrayPool<byte>.Shared` and returns it (with `clearArray: true`) once the trained dictionary has been copied into its own array.

## Why dictionary sizes are LOH-heavy

Upstream zstd ([`zdict.h`](https://github.com/facebook/zstd/blob/dev/lib/zdict.h)):
> *"A reasonable dictionary size, the `dictBufferCapacity`, is about 100KB. The zstd CLI defaults to a 110KB dictionary."*

CLI manpage ([`zstd.1.md`](https://github.com/facebook/zstd/blob/dev/programs/zstd.1.md)): `--maxdict=#` default is **112640 bytes**.

The managed wrapper repeats this guidance ([`ZstandardDictionary.cs:85-87`](../blob/main/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDictionary.cs#L85-L87)) and only guards the lower bound (`ThrowIfLessThan(maxDictionarySize, 256, ...)` at [line 128](../blob/main/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardDictionary.cs#L128)) — there is no upper-bound check, so MB-sized buffers are also legal.

.NET LOH threshold is [85,000 bytes](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap#how-an-object-ends-up-on-the-loh), so the recommended ~100 KB dictionary and the 112,640-byte CLI default both land on the LOH on every call.

## Empirical evidence

I modelled the exact allocation pattern (`new byte[N]` vs `Rent`/`Return`) and measured per-call allocations with `GC.GetAllocatedBytesForCurrentThread` (Release build, 1,000 iterations, workstation GC, .NET 11 preview):

| Buffer size | `new byte[]` per call | `Rent` per call (steady state) | Reduction | Hits LOH? |
|---:|---:|---:|---:|:---:|
| 4 KB | 4,120 B | 0 B | 100 % | no |
| 50 KB | 50,024 B | 0 B | 100 % | no |
| **100 KB (zstd recommended)** | **102,424 B** | **0 B** | **100 %** | **YES** |
| **110 KB (zstd CLI default)** | **112,664 B** | **0 B** | **100 %** | **YES** |
| 1 MB | 1,048,600 B | 0 B | 100 % | YES |

For the recommended/default dictionary sizes, every `Train` call previously produced a ~100 KB LOH allocation that only a gen2 collection could reclaim. After this change, steady-state `Train` allocations for the dictionary buffer drop to zero.

### Reproducer

`Program.cs` (run from a scratch `net11.0` console project, `dotnet run -c Release`):

```csharp
// Licensed to the .NET Foundation under one or more agreements.
// The .NET Foundation licenses this file to you under the MIT license.
using System;
using System.Buffers;
using System.Runtime.CompilerServices;

int[] sizes = { 4_096, 50_000, 102_400, 112_640, 1_048_576 };
const int Iterations = 1_000;

foreach (int size in sizes)
{
    BeforePath(size);
    AfterPath(size);
    GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();

    long b0 = GC.GetAllocatedBytesForCurrentThread();
    for (int i = 0; i < Iterations; i++) BeforePath(size);
    long b1 = GC.GetAllocatedBytesForCurrentThread();

    GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();

    long a0 = GC.GetAllocatedBytesForCurrentThread();
    for (int i = 0; i < Iterations; i++) AfterPath(size);
    long a1 = GC.GetAllocatedBytesForCurrentThread();

    Console.WriteLine($"size={size,9:N0}  new/iter={(b1 - b0) / Iterations,9:N0} B  rent/iter={(a1 - a0) / Iterations,9:N0} B");
}

[MethodImpl(MethodImplOptions.NoInlining)]
static void BeforePath(int n)
{
    byte[] b = new byte[n];
    b[0] = 1;
    GC.KeepAlive(b);
}

[MethodImpl(MethodImplOptions.NoInlining)]
static void AfterPath(int n)
{
    byte[] b = ArrayPool<byte>.Shared.Rent(n);
    try
    {
        b[0] = 1;
        GC.KeepAlive(b);
    }
    finally
    {
        ArrayPool<byte>.Shared.Return(b, clearArray: true);
    }
}
```

Output (workstation GC, single thread):

```
size=    4,096  new/iter=    4,120 B  rent/iter=        0 B
size=   50,000  new/iter=   50,024 B  rent/iter=        0 B
size=  102,400  new/iter=  102,424 B  rent/iter=        0 B
size=  112,640  new/iter=  112,664 B  rent/iter=        0 B
size=1,048,576  new/iter=1,048,600 B  rent/iter=        0 B
```

The 24-byte overhead per allocation is the 64-bit `byte[]` object header (sync block + method table pointer + length). `Rent` reports 0 bytes/iter because the pool returns the same array each iteration after warm-up. The pre-PR path stays on the SOH for the first two rows and lands on the LOH for the last three.
