### PR TITLE
Arm64:[PAC-RET] Use hint-space instruction for stripping return address

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -160,11 +160,16 @@ NESTED_END OnHijackTripThread, _TEXT
 // void* PacStripPtr(void *);
 // This function strips the pointer of PAC info that is passed as an argument.
 // We prefer to strip a pointer where it's not going to be used to branch execution to.
+// It is a no-op on non-PAC enabled machines.
 .arch_extension pauth
-    LEAF_ENTRY PacStripPtr, _TEXT
-        xpaci x0
-        ret
-    LEAF_END PacStripPtr, _TEXT
+    NESTED_ENTRY PacStripPtr, _TEXT, NoHandler
+        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -16
+        mov lr, x0
+        xpaclri
+        mov x0, lr
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 16
+        EPILOG_RETURN
+    NESTED_END PacStripPtr, _TEXT
 
 // void* PacSignPtr(void *, void *);
 // This function signs the input pointer using x1 as salt. It is a no-op on non-PAC enabled machines.

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -323,10 +323,15 @@ OnHijackTripThreadReturn
 ; void* PacStripPtr(void *);
 ; This function strips the pointer of PAC info that is passed as an argument.
 ; We prefer to strip a pointer where it's not going to be used to branch execution to.
-    LEAF_ENTRY PacStripPtr
-        DCD     0xDAC143E0  ; xpaci x0 instruction in binary to avoid requiring PAC-enabled assemblers
-        ret
-    LEAF_END PacStripPtr
+; It is a no-op on non-PAC enabled machines.
+    NESTED_ENTRY PacStripPtr
+        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, #-16!
+        mov lr, x0
+        DCD     0xD50320FF  ; xpaclri instruction in binary to avoid requiring PAC-enabled assemblers
+        mov x0, lr
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 16
+        EPILOG_RETURN
+    NESTED_END
 
 ; void* PacSignPtr(void *, void *);
 ; This function signs the input pointer using x1 as salt. It is a no-op on non-PAC enabled machines.

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -325,11 +325,11 @@ OnHijackTripThreadReturn
 ; We prefer to strip a pointer where it's not going to be used to branch execution to.
 ; It is a no-op on non-PAC enabled machines.
     NESTED_ENTRY PacStripPtr
-        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, #-16!
+        PROLOG_SAVE_REG_PAIR fp, lr, #-16!
         mov lr, x0
         DCD     0xD50320FF  ; xpaclri instruction in binary to avoid requiring PAC-enabled assemblers
         mov x0, lr
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 16
+        EPILOG_RESTORE_REG_PAIR fp, lr, #16!
         EPILOG_RETURN
     NESTED_END
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet/issues/7079

Storing FP/LR along with the unwind info. It handle a scenario if unwinding takes place when `lr` is clobbered, as raised [here](https://github.com/dotnet/runtime/pull/125436#discussion_r3178534384).


cc: @dotnet/arm64-contrib @a74nh @jkotas @dhartglassMSFT