### PR TITLE
[Wasm RyuJit] Enable native wasm fast tail calls

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1177,6 +1177,9 @@ protected:
     void genCodeForSwap(GenTreeOp* tree);
     void genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode);
     void genCodeForPhysReg(GenTreePhysReg* tree);
+#ifdef TARGET_WASM
+    void genCodeForFrameSize(GenTree* tree);
+#endif // TARGET_WASM
 #ifdef SWIFT_SUPPORT
     void genCodeForSwiftErrorReg(GenTree* tree);
 #endif // SWIFT_SUPPORT

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2590,43 +2590,24 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
 
     ArrayStack<CorInfoWasmType> typeStack(m_compiler->getAllocator(CMK_Codegen));
 
-    // For a fast tail call wasm requires the callee's result type to match the enclosing
-    // function's, so derive it from the caller's signature (call->gtType is TYP_VOID).
-    if (params.isJump)
-    {
-        if (m_compiler->info.compRetBuffArg != BAD_VAR_NUM)
-        {
-            // The enclosing method returns its struct via a retbuf arg, so the wasm-level
-            // return is empty.
-            typeStack.Push(CORINFO_WASM_TYPE_VOID);
-        }
-        else if (m_compiler->info.compRetType == TYP_VOID)
-        {
-            typeStack.Push(CORINFO_WASM_TYPE_VOID);
-        }
-        else if (m_compiler->info.compRetType == TYP_STRUCT)
-        {
-            typeStack.Push(
-                m_compiler->info.compCompHnd->getWasmLowering(m_compiler->info.compMethodInfo->args.retTypeClass));
-        }
-        else
-        {
-            // Normalize small ints (bool/byte/short/...).
-            typeStack.Push((CorInfoWasmType)emitter::GetWasmValueTypeCode(
-                ActualTypeToWasmValueType(m_compiler->info.compRetType)));
-        }
-    }
-    else if (call->TypeIs(TYP_STRUCT))
-    {
-        typeStack.Push(m_compiler->info.compCompHnd->getWasmLowering(call->gtRetClsHnd));
-    }
-    else if (call->TypeIs(TYP_VOID))
+    // Compute the wasm-level result type for the call. Use call->gtReturnType
+    // (the call's "exact" return type) rather than call->gtType, since the latter is
+    // overwritten to TYP_VOID for fast tail calls and for retbuf calls. Calls that
+    // return via a retbuf produce no wasm-level value. For fast tail calls we rely
+    // on fgCanFastTailCall to ensure caller/callee result types are compatible.
+    const var_types callRetType = (var_types)call->gtReturnType;
+    if (call->ShouldHaveRetBufArg() || (callRetType == TYP_VOID))
     {
         typeStack.Push(CORINFO_WASM_TYPE_VOID);
     }
+    else if (callRetType == TYP_STRUCT)
+    {
+        typeStack.Push(m_compiler->info.compCompHnd->getWasmLowering(call->gtRetClsHnd));
+    }
     else
     {
-        typeStack.Push((CorInfoWasmType)emitter::GetWasmValueTypeCode(TypeToWasmValueType(call->TypeGet())));
+        // Normalize small ints (bool/byte/short/...).
+        typeStack.Push((CorInfoWasmType)emitter::GetWasmValueTypeCode(ActualTypeToWasmValueType(callRetType)));
     }
 
     for (const CallArg& arg : call->gtArgs.Args())

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -812,6 +812,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             genCodeForPhysReg(treeNode->AsPhysReg());
             break;
 
+        case GT_FRAME_SIZE:
+            genCodeForFrameSize(treeNode);
+            break;
+
         case GT_JTRUE:
             genCodeForJTrue(treeNode->AsOp());
             break;
@@ -2414,19 +2418,22 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
 {
     assert(genIsValidReg(tree->gtSrcReg));
     GetEmitter()->emitIns_I(INS_local_get, emitActualTypeSize(tree), WasmRegToIndex(tree->gtSrcReg));
+    WasmProduceReg(tree);
+}
 
-    if ((tree->gtLIRFlags & LIR::Flags::WasmFastTailCallSp) != 0)
-    {
-        // Fast tail call SP arg: undo the prolog SP adjustment (asserts funclet tail calls don't happen).
-        assert(m_compiler->funCurrentFuncIdx() == ROOT_FUNC_IDX);
-        assert(tree->gtSrcReg == GetStackPointerReg(m_compiler->funCurrentFuncIdx()));
-        if (m_compiler->compLclFrameSize != 0)
-        {
-            GetEmitter()->emitIns_I(INS_I_const, EA_PTRSIZE, m_compiler->compLclFrameSize);
-            GetEmitter()->emitIns(INS_I_add);
-        }
-    }
-
+//------------------------------------------------------------------------
+// genCodeForFrameSize: Produce code for a GT_FRAME_SIZE node.
+//
+// Emits an i32/i64 const for compLclFrameSize, which is only known after the
+// final frame layout (well after the IR is built).
+//
+// Arguments:
+//    tree - the GT_FRAME_SIZE node
+//
+void CodeGen::genCodeForFrameSize(GenTree* tree)
+{
+    assert(tree->OperIs(GT_FRAME_SIZE));
+    GetEmitter()->emitIns_I(INS_I_const, EA_PTRSIZE, m_compiler->compLclFrameSize);
     WasmProduceReg(tree);
 }
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -370,9 +370,15 @@ void CodeGen::genFnEpilog(BasicBlock* block)
 
     bool jmpEpilog = block->HasFlag(BBF_HAS_JMP);
 
+    // BBF_HAS_JMP on wasm comes only from fast tail calls. The return_call already
+    // left the function, but the body still needs an INS_end if this is the last block.
     if (jmpEpilog)
     {
-        NYI_WASM("genFnEpilog: jmpEpilog");
+        if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+        {
+            instGen(INS_end);
+        }
+        return;
     }
 
     // TODO-WASM: shadow stack maintenance
@@ -2408,6 +2414,19 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
 {
     assert(genIsValidReg(tree->gtSrcReg));
     GetEmitter()->emitIns_I(INS_local_get, emitActualTypeSize(tree), WasmRegToIndex(tree->gtSrcReg));
+
+    if ((tree->gtLIRFlags & LIR::Flags::WasmFastTailCallSp) != 0)
+    {
+        // Fast tail call SP arg: undo the prolog SP adjustment (asserts funclet tail calls don't happen).
+        assert(m_compiler->funCurrentFuncIdx() == ROOT_FUNC_IDX);
+        assert(tree->gtSrcReg == GetStackPointerReg(m_compiler->funCurrentFuncIdx()));
+        if (m_compiler->compLclFrameSize != 0)
+        {
+            GetEmitter()->emitIns_I(INS_I_const, EA_PTRSIZE, m_compiler->compLclFrameSize);
+            GetEmitter()->emitIns(INS_I_add);
+        }
+    }
+
     WasmProduceReg(tree);
 }
 
@@ -2571,7 +2590,33 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
 
     ArrayStack<CorInfoWasmType> typeStack(m_compiler->getAllocator(CMK_Codegen));
 
-    if (call->TypeIs(TYP_STRUCT))
+    // For a fast tail call wasm requires the callee's result type to match the enclosing
+    // function's, so derive it from the caller's signature (call->gtType is TYP_VOID).
+    if (params.isJump)
+    {
+        if (m_compiler->info.compRetBuffArg != BAD_VAR_NUM)
+        {
+            // The enclosing method returns its struct via a retbuf arg, so the wasm-level
+            // return is empty.
+            typeStack.Push(CORINFO_WASM_TYPE_VOID);
+        }
+        else if (m_compiler->info.compRetType == TYP_VOID)
+        {
+            typeStack.Push(CORINFO_WASM_TYPE_VOID);
+        }
+        else if (m_compiler->info.compRetType == TYP_STRUCT)
+        {
+            typeStack.Push(
+                m_compiler->info.compCompHnd->getWasmLowering(m_compiler->info.compMethodInfo->args.retTypeClass));
+        }
+        else
+        {
+            // Normalize small ints (bool/byte/short/...).
+            typeStack.Push((CorInfoWasmType)emitter::GetWasmValueTypeCode(
+                ActualTypeToWasmValueType(m_compiler->info.compRetType)));
+        }
+    }
+    else if (call->TypeIs(TYP_STRUCT))
     {
         typeStack.Push(m_compiler->info.compCompHnd->getWasmLowering(call->gtRetClsHnd));
     }

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -370,6 +370,9 @@ GTNODE(SWITCH_TABLE     , GenTreeOp          ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTH
 //-----------------------------------------------------------------------------
 
 GTNODE(PHYSREG          , GenTreePhysReg     ,0,0,GTK_LEAF|DBK_NOTHIR)              // read from a physical register
+#ifdef TARGET_WASM
+GTNODE(FRAME_SIZE       , GenTree            ,0,0,GTK_LEAF|DBK_NOTHIR)              // compLclFrameSize; resolved by wasm codegen
+#endif // TARGET_WASM
 GTNODE(RETURNTRAP       , GenTreeOp          ,0,0,GTK_UNOP|GTK_NOVALUE|DBK_NOTHIR)  // a conditional call to wait on gc
 GTNODE(PUTARG_REG       , GenTreeOp          ,0,0,GTK_UNOP|DBK_NOTHIR)              // operator that places outgoing arg in register
 GTNODE(PUTARG_STK       , GenTreePutArgStk   ,0,0,GTK_UNOP|GTK_NOVALUE|DBK_NOTHIR)  // operator that places outgoing arg in stack

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -44,7 +44,10 @@ public:
 #ifdef TARGET_WASM
             MultiplyUsed = 0x08, // Set by lowering on nodes that the RA should allocate into
                                  // a dedicated register (WASM local), for multiple uses.
-#endif                           // TARGET_WASM
+
+            WasmFastTailCallSp = 0x10, // SP arg of a fast tail call; codegen adds compLclFrameSize
+                                       // to undo the prolog's SP adjustment.
+#endif                                 // TARGET_WASM
         };
     };
 

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -44,10 +44,7 @@ public:
 #ifdef TARGET_WASM
             MultiplyUsed = 0x08, // Set by lowering on nodes that the RA should allocate into
                                  // a dedicated register (WASM local), for multiple uses.
-
-            WasmFastTailCallSp = 0x10, // SP arg of a fast tail call; codegen adds compLclFrameSize
-                                       // to undo the prolog's SP adjustment.
-#endif                                 // TARGET_WASM
+#endif                           // TARGET_WASM
         };
     };
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4264,11 +4264,15 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
     // the fast tail call cannot be performed. This is common to all platforms.
     // Note that the GC'ness of on stack args need not match since the arg setup area is marked
     // as non-interruptible for fast tail calls.
+    //
+    // Wasm passes args via fresh wasm locals, not the caller's stack, so this check doesn't apply.
+#ifndef TARGET_WASM
     if (calleeArgStackSize > callerArgStackSize)
     {
         reportFastTailCallDecision("Not enough incoming arg space");
         return false;
     }
+#endif // !TARGET_WASM
 
     // For Windows some struct parameters are copied on the local frame
     // and then passed by reference. We cannot fast tail call in these situation

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -572,19 +572,26 @@ void WasmRegAlloc::CollectReferencesForCall(GenTreeCall* callNode)
         ConsumeTemporaryRegForOperand(thisArg->GetNode() DEBUGARG("call this argument"));
     }
 
-    // Tag the SP arg of a fast tail call so codegen undoes the prolog SP adjustment.
+    // For a fast tail call, wrap the SP arg with ADD(SP, FRAME_SIZE) so codegen
+    // undoes the prolog's SP adjustment and the callee sees the incoming SP.
     // The arg has been rewritten to GT_PHYSREG above (args are visited before the call).
     if (callNode->IsFastTailCall())
     {
         CallArg* const spArg = callNode->gtArgs.FindWellKnownArg(WellKnownArg::WasmShadowStackPointer);
         if (spArg != nullptr)
         {
-            GenTree* const argNode = spArg->GetNode();
-            assert(argNode != nullptr);
-            assert(argNode->OperIs(GT_PHYSREG));
-            assert(argNode->AsPhysReg()->gtSrcReg == m_perFuncletData[m_currentFunclet]->m_spReg);
+            GenTree* const physReg = spArg->GetNode();
+            assert(physReg != nullptr);
+            assert(physReg->OperIs(GT_PHYSREG));
+            assert(physReg->AsPhysReg()->gtSrcReg == m_perFuncletData[m_currentFunclet]->m_spReg);
+            // Fast tail calls from funclets are not supported.
+            assert(m_currentFunclet == ROOT_FUNC_IDX);
 
-            argNode->gtLIRFlags |= LIR::Flags::WasmFastTailCallSp;
+            GenTree* const frameSize = new (m_compiler, GT_FRAME_SIZE) GenTree(GT_FRAME_SIZE, TYP_I_IMPL);
+            GenTree* const spAdjust  = m_compiler->gtNewOperNode(GT_ADD, TYP_I_IMPL, physReg, frameSize);
+
+            CurrentRange().InsertAfter(physReg, frameSize, spAdjust);
+            spArg->NodeRef() = spAdjust;
         }
     }
 }

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -571,6 +571,22 @@ void WasmRegAlloc::CollectReferencesForCall(GenTreeCall* callNode)
     {
         ConsumeTemporaryRegForOperand(thisArg->GetNode() DEBUGARG("call this argument"));
     }
+
+    // Tag the SP arg of a fast tail call so codegen undoes the prolog SP adjustment.
+    // The arg has been rewritten to GT_PHYSREG above (args are visited before the call).
+    if (callNode->IsFastTailCall())
+    {
+        CallArg* const spArg = callNode->gtArgs.FindWellKnownArg(WellKnownArg::WasmShadowStackPointer);
+        if (spArg != nullptr)
+        {
+            GenTree* const argNode = spArg->GetNode();
+            assert(argNode != nullptr);
+            assert(argNode->OperIs(GT_PHYSREG));
+            assert(argNode->AsPhysReg()->gtSrcReg == m_perFuncletData[m_currentFunclet]->m_spReg);
+
+            argNode->gtLIRFlags |= LIR::Flags::WasmFastTailCallSp;
+        }
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/targetwasm.h
+++ b/src/coreclr/jit/targetwasm.h
@@ -23,8 +23,8 @@
 #define FEATURE_FIXED_OUT_ARGS   0       // Preallocate the outgoing arg area in the prolog
 #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers
 #define FEATURE_MULTIREG_STRUCT_PROMOTE 1  // True when we want to promote fields of a multireg struct into registers
-#define FEATURE_FASTTAILCALL     0       // Tail calls made as epilog+jmp
-#define FEATURE_TAILCALL_OPT     0       // opportunistic Tail calls (i.e. without ".tail" prefix) made as fast tail calls.
+#define FEATURE_FASTTAILCALL     1       // Tail calls made as epilog+jmp. On wasm the "jmp" is the native return_call / return_call_indirect opcode.
+#define FEATURE_TAILCALL_OPT     1       // opportunistic Tail calls (i.e. without ".tail" prefix) made as fast tail calls.
 #define FEATURE_IMPLICIT_BYREFS       1  // Support for struct parameters passed via pointers to shadow copies
 #define FEATURE_MULTIREG_ARGS_OR_RET  0  // Support for passing and/or returning single values in more than one register
 #define FEATURE_MULTIREG_ARGS         0  // Support for passing a single argument in more than one register

--- a/src/coreclr/jit/targetwasm.h
+++ b/src/coreclr/jit/targetwasm.h
@@ -24,7 +24,7 @@
 #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers
 #define FEATURE_MULTIREG_STRUCT_PROMOTE 1  // True when we want to promote fields of a multireg struct into registers
 #define FEATURE_FASTTAILCALL     1       // Tail calls made as epilog+jmp. On wasm the "jmp" is the native return_call / return_call_indirect opcode.
-#define FEATURE_TAILCALL_OPT     1       // opportunistic Tail calls (i.e. without ".tail" prefix) made as fast tail calls.
+#define FEATURE_TAILCALL_OPT     0       // opportunistic Tail calls (i.e. without ".tail" prefix) made as fast tail calls.
 #define FEATURE_IMPLICIT_BYREFS       1  // Support for struct parameters passed via pointers to shadow copies
 #define FEATURE_MULTIREG_ARGS_OR_RET  0  // Support for passing and/or returning single values in more than one register
 #define FEATURE_MULTIREG_ARGS         0  // Support for passing a single argument in more than one register


### PR DESCRIPTION
Set FEATURE_FASTTAILCALL=1. Explicit tail calls lower to return_call / return_call_indirect. Tag the SP arg so codegen adds compLclFrameSize to undo the prolog adjustment, so the callee receives the incoming shadow-stack pointer.

Leaving implicit tail calls as normal calls for now.