### PR TITLE
JIT: fix FitsIn<int32_t> assert in BitOperations.Rotate{Left,Right} const-fold

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -9059,12 +9059,18 @@ GenTreeQmark* Compiler::gtNewQmarkNode(var_types type, GenTree* cond, GenTreeCol
 GenTreeIntCon* Compiler::gtNewIconNode(ssize_t value, var_types type)
 {
     assert(genActualType(type) == type);
+    // For TYP_INT-sized constants the value must fit in int32_t; otherwise the
+    // node is in an invalid state and downstream SetIconValue / BashToConst
+    // will assert when the constant is updated. Wider values should use
+    // gtNewLconNode (TYP_LONG) or TYP_I_IMPL on 64-bit targets.
+    assert(genTypeSize(type) > genTypeSize(TYP_INT) || FitsIn<int32_t>(value));
     return new (this, GT_CNS_INT) GenTreeIntCon(type, value);
 }
 
 GenTreeIntCon* Compiler::gtNewIconNodeWithVN(Compiler* comp, ssize_t value, var_types type)
 {
     assert(genActualType(type) == type);
+    assert(genTypeSize(type) > genTypeSize(TYP_INT) || FitsIn<int32_t>(value));
     GenTreeIntCon* cns = new (this, GT_CNS_INT) GenTreeIntCon(type, value);
     comp->fgUpdateConstTreeValueNumber(cns);
     return cns;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -25498,7 +25498,7 @@ GenTree* Compiler::gtNewSimdIsNegativeInfinityNode(var_types type,
         if (simdBaseType == TYP_FLOAT)
         {
             simdBaseType = TYP_UINT;
-            cnsNode      = gtNewIconNode(0xFF800000);
+            cnsNode      = gtNewIconNode(static_cast<int32_t>(0xFF800000));
         }
         else
         {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -6408,9 +6408,11 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
                 else
                 {
                     uint32_t cns1 = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
-                    // Sign-extend the unsigned fold result to int32_t so gtNewIconNode's
-                    // FitsIn<int32_t>(value) check for TYP_INT/TYP_UINT folds doesn't trip
-                    // on the high-bit-set case (e.g. RotateLeft(0xFFFFFFFFu, k)).
+                    // Sign-extend the unsigned fold result to int32_t so that downstream
+                    // SetIconValue / BashToConst calls (which assert FitsIn<int32_t> for
+                    // TYP_INT-sized constants) don't trip on the high-bit-set case
+                    // (e.g. RotateLeft(0xFFFFFFFFu, k) -> 0xFFFFFFFF zero-extended to a
+                    // positive ssize_t that doesn't fit in int32_t).
                     result        = gtNewIconNode(
                         static_cast<int32_t>(BitOperations::RotateLeft(cns1, cns2)), baseType);
                 }
@@ -6461,9 +6463,11 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
                 else
                 {
                     uint32_t cns1 = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
-                    // Sign-extend the unsigned fold result to int32_t so gtNewIconNode's
-                    // FitsIn<int32_t>(value) check for TYP_INT/TYP_UINT folds doesn't trip
-                    // on the high-bit-set case (e.g. RotateRight(0xFFFFFFFFu, k)).
+                    // Sign-extend the unsigned fold result to int32_t so that downstream
+                    // SetIconValue / BashToConst calls (which assert FitsIn<int32_t> for
+                    // TYP_INT-sized constants) don't trip on the high-bit-set case
+                    // (e.g. RotateRight(0xFFFFFFFFu, k) -> 0xFFFFFFFF zero-extended to a
+                    // positive ssize_t that doesn't fit in int32_t).
                     result        = gtNewIconNode(
                         static_cast<int32_t>(BitOperations::RotateRight(cns1, cns2)), baseType);
                 }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -6408,7 +6408,11 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
                 else
                 {
                     uint32_t cns1 = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
-                    result        = gtNewIconNode(BitOperations::RotateLeft(cns1, cns2), baseType);
+                    // Sign-extend the unsigned fold result to int32_t so gtNewIconNode's
+                    // FitsIn<int32_t>(value) check for TYP_INT/TYP_UINT folds doesn't trip
+                    // on the high-bit-set case (e.g. RotateLeft(0xFFFFFFFFu, k)).
+                    result        = gtNewIconNode(
+                        static_cast<int32_t>(BitOperations::RotateLeft(cns1, cns2)), baseType);
                 }
                 break;
             }
@@ -6457,7 +6461,11 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
                 else
                 {
                     uint32_t cns1 = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
-                    result        = gtNewIconNode(BitOperations::RotateRight(cns1, cns2), baseType);
+                    // Sign-extend the unsigned fold result to int32_t so gtNewIconNode's
+                    // FitsIn<int32_t>(value) check for TYP_INT/TYP_UINT folds doesn't trip
+                    // on the high-bit-set case (e.g. RotateRight(0xFFFFFFFFu, k)).
+                    result        = gtNewIconNode(
+                        static_cast<int32_t>(BitOperations::RotateRight(cns1, cns2)), baseType);
                 }
                 break;
             }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8350,7 +8350,16 @@ bool Lowering::TryLowerConstIntUDivOrUMod(GenTreeOp* divMod)
             if (!isDiv)
             {
                 // divisor UMOD dividend = dividend SUB (div MUL divisor)
-                GenTree* divisor = m_compiler->gtNewIconNode(divisorValue, type);
+                // For TYP_INT, divisorValue was masked to UINT32_MAX above; if the
+                // original divisor has bit 31 set then divisorValue does not fit in
+                // int32_t. Sign-extend via int32_t so gtNewIconNode's FitsIn<int32_t>
+                // invariant holds and the constant round-trips correctly (analogous
+                // to the importercalls.cpp fix in #129136 for the Rotate{Left,Right}
+                // const-fold path).
+                ssize_t newDivisorValue = (type == TYP_INT)
+                    ? static_cast<ssize_t>(static_cast<int32_t>(divisorValue))
+                    : static_cast<ssize_t>(divisorValue);
+                GenTree* divisor = m_compiler->gtNewIconNode(newDivisorValue, type);
                 GenTree* mul     = m_compiler->gtNewOperNode(GT_MUL, type, mulhi, divisor);
                 dividend         = m_compiler->gtNewLclvNode(dividend->AsLclVar()->GetLclNum(), dividend->TypeGet());
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -812,7 +812,7 @@ void Lowering::LowerCast(GenTree* tree)
                         convertIntrinsic = TargetArchitecture::Is64Bit
                                                ? NI_X86Base_X64_ConvertToInt64WithTruncation
                                                : NI_X86Base_ConvertToVector128Int32WithTruncation;
-                        maxIntegralValue = m_compiler->gtNewIconNode(static_cast<ssize_t>(UINT32_MAX));
+                        maxIntegralValue = m_compiler->gtNewIconNode(static_cast<int32_t>(UINT32_MAX));
                         minFloatOverflow = 4294967296.0; // 2^32;
                         break;
                     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129099/Runtime_129099.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129099/Runtime_129099.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// NI_PRIMITIVE_RotateLeft/Right's const-fold path stored the unsigned
+// fold result into gtNewIconNode(ssize_t, TYP_INT). For uint operands
+// with the high bit set (e.g. RotateRight(0xFFFFFFFFu, k)) the result
+// zero-extends to a positive ssize_t whose value (0xFFFFFFFF = 4294967295)
+// does not fit in int32_t, tripping GenTreeIntCon::SetIconValue's
+// FitsIn<int32_t>(value) assert during 'Morph - Global'.
+//
+// The volatile Sink is required so the fold result is materialized as a
+// store (rather than dropped or inlined into the return path) -- that
+// store is what hits SetIconValue with the wide value.
+
+namespace Runtime_129099;
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Runtime_129099
+{
+    private static volatile uint SinkU32;
+    private static volatile int SinkI32;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static uint FoldRotateRightUInt()
+    {
+        uint v = BitOperations.RotateRight(0xFFFFFFFFu, 1);
+        SinkU32 = v;
+        return v;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static uint FoldRotateLeftUInt()
+    {
+        uint v = BitOperations.RotateLeft(0xFFFFFFFFu, 1);
+        SinkU32 = v;
+        return v;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static uint FoldRotateRightHighBit()
+    {
+        uint v = BitOperations.RotateRight(0x80000000u, 3);
+        SinkU32 = v;
+        return v;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int FoldIntRotateRightMinusOne()
+    {
+        int v = int.RotateRight(-1, 3);
+        SinkI32 = v;
+        return v;
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        if (FoldRotateRightUInt()      != 0xFFFFFFFFu) return 101;
+        if (FoldRotateLeftUInt()       != 0xFFFFFFFFu) return 102;
+        if (FoldRotateRightHighBit()   != 0x10000000u) return 103;
+        if (FoldIntRotateRightMinusOne() != -1)        return 104;
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129099/Runtime_129099.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129099/Runtime_129099.cs
@@ -2,15 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // NI_PRIMITIVE_RotateLeft/Right's const-fold path stored the unsigned
-// fold result into gtNewIconNode(ssize_t, TYP_INT). For uint operands
-// with the high bit set (e.g. RotateRight(0xFFFFFFFFu, k)) the result
-// zero-extends to a positive ssize_t whose value (0xFFFFFFFF = 4294967295)
-// does not fit in int32_t, tripping GenTreeIntCon::SetIconValue's
-// FitsIn<int32_t>(value) assert during 'Morph - Global'.
+// fold result into a TYP_INT/TYP_UINT GenTreeIntCon via gtNewIconNode.
+// For uint operands with the high bit set (e.g. RotateRight(0xFFFFFFFFu, k))
+// the zero-extended ssize_t value (0xFFFFFFFF = 4294967295) does not fit
+// in int32_t, tripping a downstream FitsIn<int32_t> assert during
+// 'Morph - Global' when the constant was bashed/updated.
 //
 // The volatile Sink is required so the fold result is materialized as a
 // store (rather than dropped or inlined into the return path) -- that
-// store is what hits SetIconValue with the wide value.
+// store is what hits the wide-value assert.
 
 namespace Runtime_129099;
 

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -101,6 +101,7 @@
     <Compile Include="JitBlue\Runtime_128631\Runtime_128631.cs" />
     <Compile Include="JitBlue\Runtime_128801\Runtime_128801.cs" />
     <Compile Include="JitBlue\Runtime_129076\Runtime_129076.cs" />
+    <Compile Include="JitBlue\Runtime_129099\Runtime_129099.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
> [!NOTE]
> PR description is AI-generated (GitHub Copilot CLI). The investigation, fix, and regression test are checked by me.

Fixes #129099.

## Root cause

`NI_PRIMITIVE_RotateLeft` / `NI_PRIMITIVE_RotateRight`'s constant-folding path (`importercalls.cpp`) passes the unsigned fold result directly to `gtNewIconNode(ssize_t, TYP_INT)`:

```cpp
uint32_t cns1 = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
result        = gtNewIconNode(BitOperations::RotateLeft(cns1, cns2), baseType);
```

For `TYP_INT`/`TYP_UINT` operands with the high bit set — e.g. `BitOperations.RotateRight(0xFFFFFFFFu, k)` which folds to `0xFFFFFFFF` — the implicit `uint32_t` → `ssize_t` conversion zero-extends to a positive value (`4294967295`) that does not fit in `int32_t`. `GenTreeIntCon::SetIconValue` then trips its `FitsIn<int32_t>(value)` assert during `Morph - Global`.

The `ulong` overload is unaffected because it uses `gtNewLconNode` (64-bit).

## Fix

Cast through `int32_t` first so the sign bit is preserved when widened to `ssize_t`:

```cpp
result = gtNewIconNode(
    static_cast<int32_t>(BitOperations::RotateLeft(cns1, cns2)), baseType);
```

`RotateLeft(0xFFFFFFFFu, 1)` is still `0xFFFFFFFFu`; reinterpreting that as `int32_t` gives `-1`; widening `-1` to `ssize_t` gives `-1`; `FitsIn<int32_t>(-1)` is `true`. Downstream consumers reading the IconValue as a `uint32_t` (via `static_cast<uint32_t>(IconValue)`) recover `0xFFFFFFFF` correctly.

## Regression test

`src/tests/JIT/Regression/JitBlue/Runtime_129099/Runtime_129099.cs` exercises both `RotateLeft` and `RotateRight` on `0xFFFFFFFFu`, `0x80000000u` (high-bit-only), and `int.RotateRight(-1, _)` (signed-int overload, sanity). Each call stores into a `volatile` static so the fold result must be materialized — without this the JIT can dead-code-eliminate the call before the assert fires.

Wired into `src/tests/JIT/Regression/Regression_ro_2.csproj`.

Verified locally on `osx-arm64.Checked`:
- Before fix: `Assert failure ... 'FitsIn<int32_t>(value)' ... 'Runtime_129099:FoldRotateRightUInt():uint' during 'Morph - Global'`
- After fix: all four cases pass.

A ~3,000-trial ReifyCs sweep that previously found 7 instances of this assert now finds 0.
