### PR TITLE
Fix return type misclasiffication in TransitionBlock.cs

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -370,7 +370,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                         fpReturnSize += 1;
                                     }
 
-                                    if (descriptor.eightByteClassifications0 == SystemVClassificationType.SystemVClassificationTypeSSE)
+                                    if (descriptor.eightByteClassifications1 == SystemVClassificationType.SystemVClassificationTypeSSE)
                                     {
                                         fpReturnSize += 2;
                                     }


### PR DESCRIPTION
The ComputeReturnValueTreatment has a typo that causes wrong return type classification for structs passed in registers on x64 Unix. It causes wrong classification when there are two eightbytes, the first eightbyte is classified as SystemVClassificationTypeSSE and the second one is not. It may lead to GC hole in that case.