### PR TITLE
Clean up in rangecheck

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1339,55 +1339,6 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
 
 /*****************************************************************************
  *
- * If tree is a constant node holding an integral value, retrieve the value in
- * pConstant. If the method returns true, pConstant holds the appropriate
- * constant. Set "vnBased" to true to indicate local or global assertion prop.
- * "pFlags" indicates if the constant is a handle marked by GTF_ICON_HDL_MASK.
- */
-bool Compiler::optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pConstant, GenTreeFlags* pFlags)
-{
-    // Is Local assertion prop?
-    if (!vnBased)
-    {
-        if (tree->OperIs(GT_CNS_INT))
-        {
-            *pConstant = tree->AsIntCon()->IconValue();
-            *pFlags    = tree->GetIconHandleFlag();
-            return true;
-        }
-        return false;
-    }
-
-    // Global assertion prop
-    ValueNum vn = vnStore->VNConservativeNormalValue(tree->gtVNPair);
-    if (!vnStore->IsVNConstant(vn))
-    {
-        return false;
-    }
-
-    // ValueNumber 'vn' indicates that this node evaluates to a constant
-
-    var_types vnType = vnStore->TypeOfVN(vn);
-    if (vnType == TYP_INT)
-    {
-        *pConstant = vnStore->ConstantValue<int>(vn);
-        *pFlags    = vnStore->IsVNHandle(vn) ? vnStore->GetHandleFlags(vn) : GTF_EMPTY;
-        return true;
-    }
-#ifdef TARGET_64BIT
-    else if (vnType == TYP_LONG)
-    {
-        *pConstant = vnStore->ConstantValue<INT64>(vn);
-        *pFlags    = vnStore->IsVNHandle(vn) ? vnStore->GetHandleFlags(vn) : GTF_EMPTY;
-        return true;
-    }
-#endif
-
-    return false;
-}
-
-/*****************************************************************************
- *
  *  Given an assertion add it to the assertion table
  *
  *  If it is already in the assertion table return the assertionIndex that

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9075,7 +9075,6 @@ public:
     // Assertion prop data flow functions.
     PhaseStatus optAssertionPropMain();
     Statement*  optVNAssertionPropCurStmt(BasicBlock* block, Statement* stmt);
-    bool        optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pConstant, GenTreeFlags* pIconFlags);
     ASSERT_TP*  optInitAssertionDataflowFlags();
     ASSERT_TP*  optComputeAssertionGen();
 

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -785,18 +785,9 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
 
             case VNF_MDARR_LENGTH:
             case VNF_ARR_LENGTH:
-            {
                 result.lLimit = Limit(Limit::keConstant, 0);
                 result.uLimit = Limit(Limit::keConstant, CORINFO_Array_MaxLength);
-
-                int size;
-                if (comp->vnStore->TryGetNewArrSize(comp->vnStore->GetArrForLenVn(num), &size) && (size >= 0))
-                {
-                    result.lLimit = Limit(Limit::keConstant, size);
-                    result.uLimit = Limit(Limit::keConstant, size);
-                }
-            }
-            break;
+                break;
 
             case VNF_GT:
             case VNF_GT_UN:

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -798,13 +798,6 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
             }
             break;
 
-            case VNF_StrFastAllocate:
-            {
-                result.lLimit = Limit(Limit::keConstant, 0);
-                result.uLimit = Limit(Limit::keConstant, CORINFO_String_MaxLength);
-            }
-            break;
-
             case VNF_GT:
             case VNF_GT_UN:
             case VNF_GE:

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -272,73 +272,15 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
         return;
     }
 
-    GenTree*          comma   = treeParent->OperIs(GT_COMMA) ? treeParent : nullptr;
-    GenTreeBoundsChk* bndsChk = tree->AsBoundsChk();
-    m_preferredBound          = m_compiler->vnStore->VNConservativeNormalValue(bndsChk->GetArrayLength()->gtVNPair);
-    GenTree* treeIndex        = bndsChk->GetIndex();
+    GenTree*          comma     = treeParent->OperIs(GT_COMMA) ? treeParent : nullptr;
+    GenTreeBoundsChk* bndsChk   = tree->AsBoundsChk();
+    GenTree*          treeIndex = bndsChk->GetIndex();
 
     // Take care of constant index first, like a[2], for example.
-    ValueNum idxVn    = m_compiler->vnStore->VNConservativeNormalValue(treeIndex->gtVNPair);
-    ValueNum arrLenVn = m_compiler->vnStore->VNConservativeNormalValue(bndsChk->GetArrayLength()->gtVNPair);
-    int      arrSize  = 0;
+    ValueNum idxVn    = m_compiler->optConservativeNormalVN(treeIndex);
+    ValueNum arrLenVn = m_compiler->optConservativeNormalVN(bndsChk->GetArrayLength());
 
-    if (m_compiler->vnStore->IsVNConstant(arrLenVn))
-    {
-        ssize_t      constVal  = -1;
-        GenTreeFlags iconFlags = GTF_EMPTY;
-
-        if (m_compiler->optIsTreeKnownIntValue(true, bndsChk->GetArrayLength(), &constVal, &iconFlags))
-        {
-            arrSize = (int)constVal;
-        }
-    }
-    else
-    {
-        arrSize = GetArrLength(arrLenVn);
-
-        // if we can't find the array length, see if there
-        // are any assertions about the array size we can use to get a minimum length
-        if (arrSize <= 0)
-        {
-            JITDUMP("Looking for array size assertions for: " FMT_VN "\n", arrLenVn);
-            Range arrLength = Range(Limit(Limit::keDependent));
-            MergeEdgeAssertions(m_compiler, arrLenVn, arrLenVn, block->bbAssertionIn, &arrLength);
-            if (arrLength.lLimit.IsConstant())
-            {
-                arrSize = arrLength.lLimit.GetConstant();
-            }
-            else
-            {
-                // Fast path didn't find anything - do the slow SSA-based search.
-                arrLength = GetRangeWorker(block, bndsChk->GetArrayLength(), false DEBUGARG(0));
-                if (arrLength.lLimit.IsConstant())
-                {
-                    arrSize = arrLength.lLimit.GetConstant();
-                }
-            }
-        }
-    }
-
-    JITDUMP("ArrSize for lengthVN:%03X = %d\n", arrLenVn, arrSize);
-    if (m_compiler->vnStore->IsVNConstant(idxVn) && (arrSize > 0))
-    {
-        ssize_t      idxVal    = -1;
-        GenTreeFlags iconFlags = GTF_EMPTY;
-        if (!m_compiler->optIsTreeKnownIntValue(true, treeIndex, &idxVal, &iconFlags))
-        {
-            return;
-        }
-
-        JITDUMP("[RangeCheck::OptimizeRangeCheck] Is index %d in <0, arrLenVn " FMT_VN " sz:%d>.\n", idxVal, arrLenVn,
-                arrSize);
-        if ((idxVal < arrSize) && (idxVal >= 0))
-        {
-            JITDUMP("Removing range check\n");
-            m_compiler->optRemoveRangeCheck(bndsChk, comma, stmt);
-            m_updateStmt = true;
-            return;
-        }
-    }
+    m_preferredBound = arrLenVn;
 
     // Special case: arr[arr.Length - CNS] if we know that arr.Length >= CNS
     // We assume that SUB(x, CNS) is canonized into ADD(x, -CNS)
@@ -427,6 +369,9 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
     {
         return;
     }
+
+    Range arrSizeRng = GetRangeFromAssertions(m_compiler, arrLenVn, block->bbAssertionIn);
+    int   arrSize    = arrSizeRng.LowerLimit().GetConstant();
 
     // Is the range between the lower and upper bound values.
     if (BetweenBounds(range, bndsChk->GetArrayLength(), arrSize))
@@ -840,9 +785,25 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
 
             case VNF_MDARR_LENGTH:
             case VNF_ARR_LENGTH:
+            {
                 result.lLimit = Limit(Limit::keConstant, 0);
                 result.uLimit = Limit(Limit::keConstant, CORINFO_Array_MaxLength);
-                break;
+
+                int size;
+                if (comp->vnStore->TryGetNewArrSize(comp->vnStore->GetArrForLenVn(num), &size) && (size >= 0))
+                {
+                    result.lLimit = Limit(Limit::keConstant, size);
+                    result.uLimit = Limit(Limit::keConstant, size);
+                }
+            }
+            break;
+
+            case VNF_StrFastAllocate:
+            {
+                result.lLimit = Limit(Limit::keConstant, 0);
+                result.uLimit = Limit(Limit::keConstant, CORINFO_String_MaxLength);
+            }
+            break;
 
             case VNF_GT:
             case VNF_GT_UN:


### PR DESCRIPTION
Minor cleanup in `rangecheck.cpp`:
- Range Check was trying to do what assertionprop already did - handle constant indices. Removed with zero diffs.
- The previous code had a correctness issue - it called a slow SSA-based `GetRangeWorker` for Array's length but didn't use `DoesOverflow` that must be called for `GetRangeWorker`. Instead, I just call the VN-based `GetRangeFromAssertions` (that plays nicely with overflows) and it seems to be enough, a few minor regression, a minor TP improvement.


> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1455184&view=ms.vss-build-web.run-extensions-tab) (from an incorrect call to  `GetRangeWorker` without `DoesOverflow`)