### PR TITLE
FileStream.Unix: prevent open to cause setting the controlling terminal.

### DIFF
--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -344,6 +344,9 @@ intptr_t SystemNative_Open(const char* path, int32_t flags, int32_t mode)
         return -1;
     }
 
+    // Prevent terminal devices from becoming the controlling terminal of this process.
+    flags |= O_NOCTTY;
+
     int result;
     while ((result = open(path, flags, (mode_t)mode)) < 0 && errno == EINTR);
 #if !HAVE_O_CLOEXEC


### PR DESCRIPTION
This passes the O_NOCTTY flag to prevent terminal devices from becoming the controlling terminal of the process.
Without this flag, opening a terminal device (like a serial port) on a process with no controlling terminal would make it the controlling terminal. When the serial port then disconnects, the .NET process can get an unexpected SIGHUP which causes it to terminate.

Fixes https://github.com/dotnet/runtime/issues/129156.

@adamsitnik ptal.