### PR TITLE
Add doc comment on AsyncValidationAttribute to not make threading assumptions

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
@@ -8,7 +8,7 @@ namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
     ///     Base class for validation attributes that require asynchronous operations, such as database lookups or API calls.
-    ///     Derived classes should never make any threading assumptions. Implementations of this attribute may or may not be called in parallel.
+    ///     Derived implementations must be thread-safe, as instances of this attribute may be invoked concurrently from multiple threads.
     /// </summary>
     public abstract class AsyncValidationAttribute : ValidationAttribute
     {

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
@@ -8,6 +8,7 @@ namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
     ///     Base class for validation attributes that require asynchronous operations, such as database lookups or API calls.
+    ///     Derived classes should never make any threading assumptions. Implementations of this attribute may or may not be called in parallel.
     /// </summary>
     public abstract class AsyncValidationAttribute : ValidationAttribute
     {


### PR DESCRIPTION
Calling this out explicitly in the doc comment so attribute authors are very well aware.