### PR TITLE
Disable SystemCoreLibDirectory on ReadyToRun

### DIFF
--- a/src/tests/Loader/SystemCoreLibDirectory/SystemCoreLibDirectory.csproj
+++ b/src/tests/Loader/SystemCoreLibDirectory/SystemCoreLibDirectory.csproj
@@ -4,6 +4,9 @@
     <NativeAotIncompatible>true</NativeAotIncompatible>
     <!-- This test exercises the CoreCLR system assembly binder -->
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
+    <!-- Loading SPCL from a separate directory is incompatible with R2R composite mode
+         because the composite image won't be found beside the redirected assembly. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SystemCoreLibDirectory.cs" />


### PR DESCRIPTION
This test copies SPC.dll to a custom path and then tests that it is able to load it from this path, instead of the default path. The problem is when the framework is R2R compiled in composite mode. The new SPC.dll will point to the composite image. This tweaked SPC.dll gets copied to another location where the loading of the R2R image fails. I believe the runtime crashing here is the right behavior and tweaking the test to copy framework-r2r.dll as well seems like overkill.