### PR TITLE
JIT: Only zero GC slots of address-exposed structs under SkipLocalsInit

### DIFF
--- a/src/coreclr/jit/asyncanalysis.cpp
+++ b/src/coreclr/jit/asyncanalysis.cpp
@@ -179,9 +179,12 @@ static void UpdateMutatedLocal(Compiler* compiler, GenTree* node, VARSET_TP& mut
         // We could improve this a bit by still skipping it but inserting
         // explicit zero init on resumption, but these cases seem to be rare
         // and that would require tracking additional information.
+        // Note: a GC-sparse struct is only GC-slot zeroed in the prolog under SkipLocalsInit, so its
+        // non-GC bytes are not zeroed there; such an explicit full zero init must still be honored.
         if (IsDefaultValue(node->AsLclVarCommon()->Data()) &&
             !compiler->fgVarNeedsExplicitZeroInit(node->AsLclVarCommon()->GetLclNum(), /* bbInALoop */ false,
-                                                  /* bbIsReturn */ false))
+                                                  /* bbIsReturn */ false) &&
+            compiler->fgVarPrologFullyZeroInits(node->AsLclVarCommon()->GetLclNum()))
         {
             return;
         }

--- a/src/coreclr/jit/asyncanalysis.cpp
+++ b/src/coreclr/jit/asyncanalysis.cpp
@@ -179,8 +179,8 @@ static void UpdateMutatedLocal(Compiler* compiler, GenTree* node, VARSET_TP& mut
         // We could improve this a bit by still skipping it but inserting
         // explicit zero init on resumption, but these cases seem to be rare
         // and that would require tracking additional information.
-        // Note: a GC-sparse struct is only GC-slot zeroed in the prolog under SkipLocalsInit, so its
-        // non-GC bytes are not zeroed there; such an explicit full zero init must still be honored.
+        // Note: a GC-sparse struct is only GC-slot zeroed in the prolog under SkipLocalsInit, so an
+        // explicit full zero init (fgVarPrologFullyZeroInits) must still be honored.
         if (IsDefaultValue(node->AsLclVarCommon()->Data()) &&
             !compiler->fgVarNeedsExplicitZeroInit(node->AsLclVarCommon()->GetLclNum(), /* bbInALoop */ false,
                                                   /* bbIsReturn */ false) &&

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -3690,24 +3690,6 @@ void CodeGen::genCheckUseBlockInit()
     unsigned initStkLclCnt = 0; // The number of int-sized stack local variables that need to be initialized (variables
                                 // larger than int count for more than 1).
 
-    // Computes how many int-sized stack slots a must-init local will actually zero in the prolog.
-    // Under SkipLocalsInit (!compInitMem), a struct with GC fields only needs its GC slots zeroed for
-    // GC safety (see the per-slot zeroing path in genZeroInitFrame); its non-GC bytes are left
-    // uninitialized. Such a struct therefore contributes only its GC-pointer slots here, which keeps
-    // GC-sparse structs below the block-init threshold so the prolog zeroes just the GC slots instead
-    // of the whole struct. For a fully-GC struct the GC-slot count equals the full size, so its
-    // contribution (and hence its codegen) is unchanged and it continues to use block initialization.
-    auto getInitSlotCount = [this](unsigned lclNum, LclVarDsc* dsc) -> unsigned {
-        if (!m_compiler->info.compInitMem && dsc->TypeIs(TYP_STRUCT) && dsc->HasGCPtr() &&
-            (dsc->lvExactSize() >= TARGET_POINTER_SIZE))
-        {
-            // Only the GC slots will be zeroed; each pointer-sized GC slot is
-            // (TARGET_POINTER_SIZE / sizeof(int)) int-sized slots.
-            return dsc->GetLayout()->GetGCPtrCount() * (TARGET_POINTER_SIZE / sizeof(int));
-        }
-        return roundUp(m_compiler->lvaLclStackHomeSize(lclNum), TARGET_POINTER_SIZE) / sizeof(int);
-    };
-
     unsigned   varNum;
     LclVarDsc* varDsc;
 
@@ -3786,7 +3768,7 @@ void CodeGen::genCheckUseBlockInit()
                             if (!varDsc->lvIsInReg() || varDsc->IsLiveInOutOfHandler())
                             {
                                 // Var is on the stack at entry.
-                                initStkLclCnt += getInitSlotCount(varNum, varDsc);
+                                initStkLclCnt += m_compiler->lvaGetPrologZeroInitSlotCount(varNum);
                                 counted = true;
                             }
                         }
@@ -3843,7 +3825,7 @@ void CodeGen::genCheckUseBlockInit()
 
                     if (!counted)
                     {
-                        initStkLclCnt += getInitSlotCount(varNum, varDsc);
+                        initStkLclCnt += m_compiler->lvaGetPrologZeroInitSlotCount(varNum);
                         counted = true;
                     }
                 }

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -3690,6 +3690,24 @@ void CodeGen::genCheckUseBlockInit()
     unsigned initStkLclCnt = 0; // The number of int-sized stack local variables that need to be initialized (variables
                                 // larger than int count for more than 1).
 
+    // Computes how many int-sized stack slots a must-init local will actually zero in the prolog.
+    // Under SkipLocalsInit (!compInitMem), a struct with GC fields only needs its GC slots zeroed for
+    // GC safety (see the per-slot zeroing path in genZeroInitFrame); its non-GC bytes are left
+    // uninitialized. Such a struct therefore contributes only its GC-pointer slots here, which keeps
+    // GC-sparse structs below the block-init threshold so the prolog zeroes just the GC slots instead
+    // of the whole struct. For a fully-GC struct the GC-slot count equals the full size, so its
+    // contribution (and hence its codegen) is unchanged and it continues to use block initialization.
+    auto getInitSlotCount = [this](unsigned lclNum, LclVarDsc* dsc) -> unsigned {
+        if (!m_compiler->info.compInitMem && dsc->TypeIs(TYP_STRUCT) && dsc->HasGCPtr() &&
+            (dsc->lvExactSize() >= TARGET_POINTER_SIZE))
+        {
+            // Only the GC slots will be zeroed; each pointer-sized GC slot is
+            // (TARGET_POINTER_SIZE / sizeof(int)) int-sized slots.
+            return dsc->GetLayout()->GetGCPtrCount() * (TARGET_POINTER_SIZE / sizeof(int));
+        }
+        return roundUp(m_compiler->lvaLclStackHomeSize(lclNum), TARGET_POINTER_SIZE) / sizeof(int);
+    };
+
     unsigned   varNum;
     LclVarDsc* varDsc;
 
@@ -3768,8 +3786,7 @@ void CodeGen::genCheckUseBlockInit()
                             if (!varDsc->lvIsInReg() || varDsc->IsLiveInOutOfHandler())
                             {
                                 // Var is on the stack at entry.
-                                initStkLclCnt +=
-                                    roundUp(m_compiler->lvaLclStackHomeSize(varNum), TARGET_POINTER_SIZE) / sizeof(int);
+                                initStkLclCnt += getInitSlotCount(varNum, varDsc);
                                 counted = true;
                             }
                         }
@@ -3826,8 +3843,7 @@ void CodeGen::genCheckUseBlockInit()
 
                     if (!counted)
                     {
-                        initStkLclCnt +=
-                            roundUp(m_compiler->lvaLclStackHomeSize(varNum), TARGET_POINTER_SIZE) / sizeof(int);
+                        initStkLclCnt += getInitSlotCount(varNum, varDsc);
                         counted = true;
                     }
                 }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6264,6 +6264,12 @@ public:
     // Returns "true" if the variable needs explicit zero initialization.
     inline bool fgVarNeedsExplicitZeroInit(unsigned varNum, bool bbInALoop, bool bbIsReturn);
 
+    // Returns the number of int-sized stack slots the prolog zero-initializes for a must-init local.
+    inline unsigned lvaGetPrologZeroInitSlotCount(unsigned lclNum);
+
+    // Returns "true" if the prolog zero-initializes every byte of the local (not just its GC slots).
+    inline bool fgVarPrologFullyZeroInits(unsigned lclNum);
+
     // The value numbers for this compilation.
     ValueNumStore* vnStore = nullptr;
     class ValueNumberState* vnState = nullptr;

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4293,6 +4293,72 @@ bool Compiler::fgVarIsNeverZeroInitializedInProlog(unsigned varNum)
 }
 
 //------------------------------------------------------------------------------
+// fgVarPrologFullyZeroInits : Check whether the prolog zero-initializes every byte of a local (when it
+//    is zero-initialized in the prolog at all), as opposed to only its GC slots.
+//
+// Arguments:
+//    lclNum - local var number
+//
+// Returns:
+//    true  - the prolog (if it zero-inits this local) zeroes all of its bytes;
+//    false - only the local's GC slots are guaranteed zeroed.
+//
+// Notes:
+//    Under SkipLocalsInit (!compInitMem) an address-exposed struct with both GC and non-GC slots only
+//    needs its GC slots zeroed in the prolog for GC safety (see lvaGetPrologZeroInitSlotCount /
+//    CodeGen::genZeroInitFrame); its non-GC bytes are left uninitialized. We restrict this to
+//    address-exposed structs (out-params / by-ref locals - the cases that actually benefit) so that
+//    value-numbered locals keep their "fully zeroed by the prolog" guarantee.
+//
+//    fgVarNeedsExplicitZeroInit returning false is enough for callers that only rely on the prolog for
+//    GC safety (i.e. to suppress inserting an explicit init), but callers that treat the whole local as
+//    zero - value numbering its fields as zero, removing a dominating explicit full zero-init, or
+//    skipping an explicit re-init - must additionally check this.
+//
+bool Compiler::fgVarPrologFullyZeroInits(unsigned lclNum)
+{
+    LclVarDsc* varDsc = lvaGetDesc(lclNum);
+    // The GC-slot-only prolog init applies to address-exposed, GC-sparse structs under SkipLocalsInit
+    // (out-params / by-ref locals). We exclude any local whose explicit zero-init was suppressed or
+    // removed elsewhere (lvSuppressedZeroInit): those relied on the prolog to fully zero them, so they
+    // are kept on full block init (and are therefore still fully zeroed here).
+    if (!info.compInitMem && varDsc->IsAddressExposed() && !varDsc->lvSuppressedZeroInit &&
+        varDsc->TypeIs(TYP_STRUCT) && varDsc->HasGCPtr() && (varDsc->lvExactSize() >= TARGET_POINTER_SIZE))
+    {
+        // A fully-GC struct is still fully zeroed; a GC-sparse struct only has its GC slots zeroed.
+        ClassLayout* layout = varDsc->GetLayout();
+        return layout->GetGCPtrCount() == layout->GetSlotCount();
+    }
+    return true;
+}
+
+//------------------------------------------------------------------------------
+// lvaGetPrologZeroInitSlotCount : Number of int-sized stack slots the prolog zero-initializes for a
+//    must-init local.
+//
+// Arguments:
+//    lclNum - local var number
+//
+// Returns:
+//    The number of int-sized (4-byte) slots that will be zeroed in the prolog for this local.
+//
+// Notes:
+//    A struct whose prolog init only zeroes its GC slots (see fgVarPrologFullyZeroInits) contributes
+//    just its GC-pointer slots; everything else contributes its full size. Used by
+//    CodeGen::genCheckUseBlockInit to decide between block init and per-slot init.
+//
+unsigned Compiler::lvaGetPrologZeroInitSlotCount(unsigned lclNum)
+{
+    if (!fgVarPrologFullyZeroInits(lclNum))
+    {
+        // Only the GC slots will be zeroed; each pointer-sized GC slot is
+        // (TARGET_POINTER_SIZE / sizeof(int)) int-sized slots.
+        return lvaGetDesc(lclNum)->GetLayout()->GetGCPtrCount() * (TARGET_POINTER_SIZE / sizeof(int));
+    }
+    return roundUp(lvaLclStackHomeSize(lclNum), TARGET_POINTER_SIZE) / sizeof(int);
+}
+
+//------------------------------------------------------------------------------
 // fgVarNeedsExplicitZeroInit : Check whether the variable needs an explicit zero initialization.
 //
 // Arguments:
@@ -4351,9 +4417,12 @@ bool Compiler::fgVarNeedsExplicitZeroInit(unsigned varNum, bool bbInALoop, bool 
             return false;
         }
 
-        // Below conditions guarantee block initialization, which will initialize
-        // all struct fields. If the logic for block initialization in CodeGen::genCheckUseBlockInit()
-        // changes, these conditions need to be updated.
+        // The conditions below cause the variable to be (GC-safely) zero-initialized in the prolog, so
+        // no explicit zero-init is needed to make it safe to suppress. Note that under SkipLocalsInit a
+        // GC-sparse struct only has its GC slots zeroed in the prolog (see genCheckUseBlockInit /
+        // lvaGetPrologZeroInitSlotCount), not all of its bytes; callers that rely on the whole local
+        // being zero must additionally check fgVarPrologFullyZeroInits. This must stay consistent with
+        // the block-init logic in CodeGen::genCheckUseBlockInit().
 #ifdef TARGET_WASM
         // On WASM the prolog always uses a single memory.fill to zero any
         // locals that need initialization, regardless of size.

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4293,35 +4293,20 @@ bool Compiler::fgVarIsNeverZeroInitializedInProlog(unsigned varNum)
 }
 
 //------------------------------------------------------------------------------
-// fgVarPrologFullyZeroInits : Check whether the prolog zero-initializes every byte of a local (when it
-//    is zero-initialized in the prolog at all), as opposed to only its GC slots.
+// fgVarPrologFullyZeroInits : Whether the prolog zeroes every byte of a local, not just its GC slots.
 //
 // Arguments:
 //    lclNum - local var number
 //
 // Returns:
-//    true  - the prolog (if it zero-inits this local) zeroes all of its bytes;
-//    false - only the local's GC slots are guaranteed zeroed.
-//
-// Notes:
-//    Under SkipLocalsInit (!compInitMem) an address-exposed struct with both GC and non-GC slots only
-//    needs its GC slots zeroed in the prolog for GC safety (see lvaGetPrologZeroInitSlotCount /
-//    CodeGen::genZeroInitFrame); its non-GC bytes are left uninitialized. We restrict this to
-//    address-exposed structs (out-params / by-ref locals - the cases that actually benefit) so that
-//    value-numbered locals keep their "fully zeroed by the prolog" guarantee.
-//
-//    fgVarNeedsExplicitZeroInit returning false is enough for callers that only rely on the prolog for
-//    GC safety (i.e. to suppress inserting an explicit init), but callers that treat the whole local as
-//    zero - value numbering its fields as zero, removing a dominating explicit full zero-init, or
-//    skipping an explicit re-init - must additionally check this.
+//    true if the prolog (when it zero-inits this local) zeroes all of its bytes; false if only its GC
+//    slots are zeroed (an address-exposed GC-sparse struct under SkipLocalsInit, see genZeroInitFrame).
 //
 bool Compiler::fgVarPrologFullyZeroInits(unsigned lclNum)
 {
     LclVarDsc* varDsc = lvaGetDesc(lclNum);
-    // The GC-slot-only prolog init applies to address-exposed, GC-sparse structs under SkipLocalsInit
-    // (out-params / by-ref locals). We exclude any local whose explicit zero-init was suppressed or
-    // removed elsewhere (lvSuppressedZeroInit): those relied on the prolog to fully zero them, so they
-    // are kept on full block init (and are therefore still fully zeroed here).
+    // Exclude locals with a suppressed/removed explicit init (lvSuppressedZeroInit): they rely on the
+    // prolog to fully zero them, so they stay on full block init.
     if (!info.compInitMem && varDsc->IsAddressExposed() && !varDsc->lvSuppressedZeroInit &&
         varDsc->TypeIs(TYP_STRUCT) && varDsc->HasGCPtr() && (varDsc->lvExactSize() >= TARGET_POINTER_SIZE))
     {
@@ -4333,26 +4318,20 @@ bool Compiler::fgVarPrologFullyZeroInits(unsigned lclNum)
 }
 
 //------------------------------------------------------------------------------
-// lvaGetPrologZeroInitSlotCount : Number of int-sized stack slots the prolog zero-initializes for a
-//    must-init local.
+// lvaGetPrologZeroInitSlotCount : Number of int-sized stack slots the prolog zeroes for a must-init local.
 //
 // Arguments:
 //    lclNum - local var number
 //
 // Returns:
-//    The number of int-sized (4-byte) slots that will be zeroed in the prolog for this local.
-//
-// Notes:
-//    A struct whose prolog init only zeroes its GC slots (see fgVarPrologFullyZeroInits) contributes
-//    just its GC-pointer slots; everything else contributes its full size. Used by
-//    CodeGen::genCheckUseBlockInit to decide between block init and per-slot init.
+//    The int-sized (4-byte) slot count: just the GC-pointer slots for a GC-slot-only init (see
+//    fgVarPrologFullyZeroInits), otherwise the full size. Used by CodeGen::genCheckUseBlockInit.
 //
 unsigned Compiler::lvaGetPrologZeroInitSlotCount(unsigned lclNum)
 {
     if (!fgVarPrologFullyZeroInits(lclNum))
     {
-        // Only the GC slots will be zeroed; each pointer-sized GC slot is
-        // (TARGET_POINTER_SIZE / sizeof(int)) int-sized slots.
+        // Each pointer-sized GC slot is (TARGET_POINTER_SIZE / sizeof(int)) int-sized slots.
         return lvaGetDesc(lclNum)->GetLayout()->GetGCPtrCount() * (TARGET_POINTER_SIZE / sizeof(int));
     }
     return roundUp(lvaLclStackHomeSize(lclNum), TARGET_POINTER_SIZE) / sizeof(int);
@@ -4418,11 +4397,8 @@ bool Compiler::fgVarNeedsExplicitZeroInit(unsigned varNum, bool bbInALoop, bool 
         }
 
         // The conditions below cause the variable to be (GC-safely) zero-initialized in the prolog, so
-        // no explicit zero-init is needed to make it safe to suppress. Note that under SkipLocalsInit a
-        // GC-sparse struct only has its GC slots zeroed in the prolog (see genCheckUseBlockInit /
-        // lvaGetPrologZeroInitSlotCount), not all of its bytes; callers that rely on the whole local
-        // being zero must additionally check fgVarPrologFullyZeroInits. This must stay consistent with
-        // the block-init logic in CodeGen::genCheckUseBlockInit().
+        // an explicit init can be suppressed. Note a GC-sparse struct only has its GC slots zeroed under
+        // SkipLocalsInit; callers needing the whole local zeroed must also check fgVarPrologFullyZeroInits.
 #ifdef TARGET_WASM
         // On WASM the prolog always uses a single memory.fill to zero any
         // locals that need initialization, regardless of size.

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -11597,9 +11597,8 @@ PhaseStatus Compiler::fgValueNumber()
             // The last clause covers the use-before-def variables (the ones that are live-in to the first block),
             // these are variables that are read before being initialized (at least on some control flow paths)
             // if they are not must-init, then they get VNF_InitVal(i), as with the param case.)
-            // A var is only known to start out as zero if the prolog fully zero-initializes it. Under
-            // SkipLocalsInit a GC-sparse struct only has its GC slots zeroed in the prolog, so we must
-            // not value-number its (uninitialized) non-GC fields as zero.
+            // Only treat as zero if the prolog fully zeroes it: under SkipLocalsInit a GC-sparse struct
+            // only has its GC slots zeroed, so its non-GC fields must not be value-numbered as zero.
             bool isZeroed = !fgVarNeedsExplicitZeroInit(lclNum, /* bbInALoop */ false, /* bbIsReturn */ false) &&
                             fgVarPrologFullyZeroInits(lclNum);
             ValueNum  initVal = ValueNumStore::NoVN; // We must assign a new value to initVal

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -11597,9 +11597,13 @@ PhaseStatus Compiler::fgValueNumber()
             // The last clause covers the use-before-def variables (the ones that are live-in to the first block),
             // these are variables that are read before being initialized (at least on some control flow paths)
             // if they are not must-init, then they get VNF_InitVal(i), as with the param case.)
-            bool      isZeroed = !fgVarNeedsExplicitZeroInit(lclNum, /* bbInALoop */ false, /* bbIsReturn */ false);
-            ValueNum  initVal  = ValueNumStore::NoVN; // We must assign a new value to initVal
-            var_types typ      = varDsc->TypeGet();
+            // A var is only known to start out as zero if the prolog fully zero-initializes it. Under
+            // SkipLocalsInit a GC-sparse struct only has its GC slots zeroed in the prolog, so we must
+            // not value-number its (uninitialized) non-GC fields as zero.
+            bool isZeroed = !fgVarNeedsExplicitZeroInit(lclNum, /* bbInALoop */ false, /* bbIsReturn */ false) &&
+                            fgVarPrologFullyZeroInits(lclNum);
+            ValueNum  initVal = ValueNumStore::NoVN; // We must assign a new value to initVal
+            var_types typ     = varDsc->TypeGet();
 
             if (isZeroed)
             {


### PR DESCRIPTION
Closes #129174