### PR TITLE
JIT: Fix arm64 shifted-register containment for long compares

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -12730,20 +12730,47 @@ bool Lowering::TryLowerAndOrToCCMP(GenTreeOp* tree, GenTree** next)
     bool         canConvertOp2ToCCMP = CanConvertOpToCCMP(op2, tree);
     bool         canConvertOp1ToCCMP = CanConvertOpToCCMP(op1, tree);
 
-    if (canConvertOp2ToCCMP &&
-        (!canConvertOp1ToCCMP ||
-         ((op2->gtGetOp1()->IsIntegralConst() || !op2->gtGetOp1()->isContained()) &&
-          (op2->gtGetOp2() == nullptr || op2->gtGetOp2()->IsIntegralConst() || !op2->gtGetOp2()->isContained()))) &&
+    // The CCMP-side operands cannot stay contained: Arm64 ccmp only accepts a register
+    // or imm5 second operand (no shifted-register form), and xarch APX ccmp likewise has
+    // ContainCheckConditionalCompare re-contain only immediates. The existing post-
+    // conversion ClearContained() calls below will un-contain the CCMP-side operands; the
+    // leading cmp on the other side keeps its contained operand (Arm64 cmp supports the
+    // shifted-register form, xarch cmp supports memory).
+    //
+    // Earlier this code bailed entirely when both candidate relops had contained operands.
+    // That bail produces a cset/orr/cbnz fallback that is strictly worse than letting CCMP
+    // form with one un-contained operand. Allow the conversion in that case while still
+    // preferring a candidate whose operands are already free of containment when possible,
+    // so we don't add an unnecessary un-contain instruction.
+    //
+    // Memory containment counts as "dirty" for CCMP-side preference because un-containing
+    // a load on the CCMP side adds a separate load instruction; the leading cmp side can
+    // keep its memory containment.
+    auto ccmpSideOperandsAreClean = [](GenTree* relop) {
+        GenTree* relopOp1 = relop->gtGetOp1();
+        GenTree* relopOp2 = relop->gtGetOp2();
+        return (relopOp1->IsIntegralConst() || !relopOp1->isContained()) &&
+               ((relopOp2 == nullptr) || relopOp2->IsIntegralConst() || !relopOp2->isContained());
+    };
+
+    if (canConvertOp2ToCCMP && (!canConvertOp1ToCCMP || ccmpSideOperandsAreClean(op2)) &&
         TryLowerConditionToFlagsNode(tree, op1, &cond1, false))
     {
         // Fall through, converting op2 to the CCMP
     }
-    else if (canConvertOp1ToCCMP &&
-             (!op1->gtGetOp1()->isContained() || op1->gtGetOp1()->IsIntegralConst() ||
-              IsContainableMemoryOp(op1->gtGetOp1())) &&
-             (op1->gtGetOp2() == nullptr || !op1->gtGetOp2()->isContained() || op1->gtGetOp2()->IsIntegralConst() ||
-              IsContainableMemoryOp(op1->gtGetOp2())) &&
+    else if (canConvertOp1ToCCMP && ccmpSideOperandsAreClean(op1) &&
              TryLowerConditionToFlagsNode(tree, op2, &cond1, false))
+    {
+        std::swap(op1, op2);
+    }
+    else if (canConvertOp2ToCCMP && TryLowerConditionToFlagsNode(tree, op1, &cond1, false))
+    {
+        // Both relops have contained operands and op2 is eligible. Convert op2 without
+        // swapping: this keeps op1's contained operand on the leading cmp and only
+        // un-contains op2's operands. Preserves original instruction order, which tends
+        // to give register allocator slightly tighter live ranges than a swap.
+    }
+    else if (canConvertOp1ToCCMP && TryLowerConditionToFlagsNode(tree, op2, &cond1, false))
     {
         std::swap(op1, op2);
     }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -270,7 +270,11 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
         }
 
         const ssize_t shiftAmount = shiftAmountNode->AsIntCon()->IconValue();
-        const ssize_t maxShift    = (static_cast<ssize_t>(genTypeSize(parentNode)) * BITS_PER_BYTE) - 1;
+        // The contained shift's width is determined by its own type, which matches the parent's
+        // operand width. We cannot use genTypeSize(parentNode) here because for compare-like
+        // parents (e.g. GT_EQ/GT_NE/GT_TEST_EQ/GT_TEST_NE) the parent's type is TYP_INT even
+        // when the comparison's operands - and thus the contained shift - are TYP_LONG.
+        const ssize_t maxShift = (static_cast<ssize_t>(genTypeSize(childNode)) * BITS_PER_BYTE) - 1;
 
         if ((shiftAmount < 0x01) || (shiftAmount > maxShift))
         {

--- a/src/tests/JIT/opt/Compares/compareAnd2Chains.cs
+++ b/src/tests/JIT/opt/Compares/compareAnd2Chains.cs
@@ -600,7 +600,34 @@ public class ComparisonTestAnd2Chains
             return 101;
         }
 
+        // Regression: CCMP must still form when both relops have a contained shift.
+        // See dotnet/runtime#129188.
+        if (Eq_long_shifted_2_consume(0, 0, 0) != 1)
+        {
+            Console.WriteLine("ComparisonTestAnd2Chains:Eq_long_shifted_2_consume failed");
+            return 101;
+        }
+        if (Eq_long_shifted_2_consume(1, 2, 3) != 0)
+        {
+            Console.WriteLine("ComparisonTestAnd2Chains:Eq_long_shifted_2_consume failed (neg)");
+            return 101;
+        }
+
         Console.WriteLine("PASSED");
         return 100;
+    }
+
+    // Both relops have a contained shift on op2. Prior to dotnet/runtime#129188's
+    // follow-up, the CCMP transformation would bail because the CCMP-side operand
+    // was contained, and we would emit a cset/orr fallback. The fix lets CCMP form
+    // with one un-contained shift, giving (asr + cmp shifted + ccmp + cset).
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Eq_long_shifted_2_consume(long a, long b, long c)
+    {
+        //ARM64-FULL-LINE:      asr {{x[0-9]+}}, {{x[0-9]+}}, #63
+        //ARM64-FULL-LINE-NEXT: cmp {{x[0-9]+}}, {{x[0-9]+}},  ASR #63
+        //ARM64-FULL-LINE-NEXT: ccmp {{x[0-9]+}}, {{x[0-9]+}}, 0, eq
+        //ARM64-FULL-LINE-NEXT: cset {{x[0-9]+}}, eq
+        return ((a == (b >> 63)) & (a == (c >> 63))) ? 1 : 0;
     }
 }

--- a/src/tests/JIT/opt/InstructionCombining/And.cs
+++ b/src/tests/JIT/opt/InstructionCombining/And.cs
@@ -254,8 +254,7 @@ namespace TestAnd
         [MethodImpl(MethodImplOptions.NoInlining)]
         static int AndsLargeShift64Bit(ulong a, ulong b)
         {
-            //ARM64-FULL-LINE: lsr {{x[0-9]+}}, {{x[0-9]+}}, #38
-            //ARM64-FULL-LINE: tst {{x[0-9]+}}, {{x[0-9]+}}
+            //ARM64-FULL-LINE: tst {{x[0-9]+}}, {{x[0-9]+}}, LSR #38
             if ((a & (b>>230)) != 0) {
                 return 1;
             }

--- a/src/tests/JIT/opt/InstructionCombining/Cmp.cs
+++ b/src/tests/JIT/opt/InstructionCombining/Cmp.cs
@@ -50,6 +50,11 @@ namespace TestCompare
                 fail = true;
             }
 
+            if (!CmpLargeShift64BitSwap(0x580000000000000, 0xB))
+            {
+                fail = true;
+            }
+
             if (!CmpOptimizeBoolsReturn(5, 3, 10))
             {
                 fail = true;
@@ -151,9 +156,19 @@ namespace TestCompare
         [MethodImpl(MethodImplOptions.NoInlining)]
         static bool CmpLargeShift64Bit(long a, long b)
         {
-            //ARM64-FULL-LINE: lsl {{x[0-9]+}}, {{x[0-9]+}}, #55
-            //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
+            //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}, LSL #55
             if (a == (b<<119))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool CmpLargeShift64BitSwap(long a, long b)
+        {
+            //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}, LSL #55
+            if ((b<<119) == a)
             {
                 return true;
             }


### PR DESCRIPTION
In Lowering::IsContainableUnaryOrBinaryOp, the maximum shift amount permitted for a contained shift (LSH/RSH/RSZ) was computed from the parent node's type. For comparison parents (GT_EQ/GT_NE/GT_LT/etc. and GT_TEST_EQ/GT_TEST_NE) the parent's type is TYP_INT regardless of operand width, so any shift amount in 32..63 fed into a 64-bit comparison would fail containment. As a result, we emitted

    lsl  x1, x1, #55
    cmp  x0, x1

instead of the optimized

    cmp  x0, x1, LSL #55

and similarly for ANDS-feeding patterns like (a & (b >> 38)) != 0.

Use the shift node's own type to derive maxShift; for binary parents where parent and child types agree this is unchanged, and for compares it gives the correct operand width (31 for int, 63 for long).

Update the existing FileCheck tests in Cmp.cs and And.cs that documented the old buggy codegen, and add CmpLargeShift64BitSwap to cover the swapped-operand long-compare path.

Fixes #111889