### PR TITLE
Update --bootstrap docs with current reality

### DIFF
--- a/docs/workflow/building/coreclr/cross-building.md
+++ b/docs/workflow/building/coreclr/cross-building.md
@@ -222,6 +222,10 @@ src/tests/build.sh -cross -$arch -$os -p:LibrariesConfiguration=Debug --use-boot
 
 # Libraries tests (produces zipped per-library test archives under artifacts/helix/tests/).
 ./build.sh libs.tests --cross --arch $arch --os $os --use-bootstrap -p:ArchiveTests=true
+
+# A single library's test project can also be built and archived on its own.
+# The resulting zip lands under artifacts/helix/tests.
+./dotnet.sh build src/libraries/System.Formats.Nrbf/tests -p:CrossBuild=true -p:UseBootstrap=true -p:ArchiveTests=true -p:TargetOS=$os -p:TargetArchitecture=$arch
 ```
 
 Without `--use-bootstrap`, restore would fail with `NU1102` errors because the apphost/runtime/targeting packs for `freebsd-arm64` are not published to NuGet feeds.
@@ -279,6 +283,5 @@ unzip /tmp/System.Text.RegularExpressions.Unit.Tests.zip
 
 #### Notes
 
-* `--use-bootstrap` works on any platform; on community-supported platforms it is the only way to build the tests because the targeting/runtime/apphost packs are not published to NuGet feeds.
-* If restore still fails after passing the flag, double-check that the `bootstrap` subset built successfully and produced `artifacts/bin/bootstrap/`.
-* Building/packing an individual library test project (e.g. `./dotnet.sh build src/libraries/System.Formats.Nrbf/tests -p:UseBootstrap=true -p:ArchiveTests=true ...`) currently produces an unusable archive (missing `xunit.console.runtimeconfig.json` and similar). Until that is fixed, build the whole `libs.tests` subset as shown above.
+* `--bootstrap` works on any platform; on community-supported platforms it is the only way to build the tests because the targeting/runtime/apphost packs are not published to NuGet feeds.
+* If restore still fails after passing the flag, double-check that the `bootstrap` subset built successfully and produced `artifacts/bootstrap/`.

--- a/docs/workflow/building/coreclr/cross-building.md
+++ b/docs/workflow/building/coreclr/cross-building.md
@@ -224,7 +224,7 @@ src/tests/build.sh -cross -$arch -$os -p:LibrariesConfiguration=Debug --use-boot
 ./build.sh libs.tests --cross --arch $arch --os $os --use-bootstrap -p:ArchiveTests=true
 
 # A single library's test project can also be built and archived on its own.
-# The resulting zip lands under artifacts/helix/tests.
+# The resulting zip lands under artifacts/helix/tests/.
 ./dotnet.sh build src/libraries/System.Formats.Nrbf/tests -p:CrossBuild=true -p:UseBootstrap=true -p:ArchiveTests=true -p:TargetOS=$os -p:TargetArchitecture=$arch
 ```
 


### PR DESCRIPTION
Somehow `ArchiveTests=true` is now working for individual library builds too. Not sure what fixed it since last month when I last tested and wrote this note (maybe I had a typo in test command?).

```sh
$ ./dotnet.sh build src/libraries/System.Formats.Nrbf/tests -p:UseBootstrap=true -p:ArchiveTests=true -p:TargetOS=linux -p:TargetArchitecture=riscv64 -p:CrossBuild=true                        

  Determining projects to restore...
...
  System.Formats.Nrbf -> /runtime/artifacts/bin/System.Formats.Nrbf/Debug/net462/System.Formats.Nrbf.dll
  System.Text.Json -> /runtime/artifacts/bin/System.Text.Json/ref/Debug/net462/System.Text.Json.dll
  System.Formats.Nrbf.Tests -> /runtime/artifacts/bin/System.Formats.Nrbf.Tests/Debug/net11.0/System.Formats.Nrbf.Tests.dll
  System.Text.Json -> /runtime/artifacts/bin/System.Text.Json/Debug/net462/System.Text.Json.dll
  Zipping directory "/runtime/artifacts/bin/System.Formats.Nrbf.Tests/Debug/net11.0/" to "/runtime/artifacts/helix/tests/linux.AnyCPU.Debug/System.Formats.Nrbf.Tests.zip".
  System.Formats.Nrbf.Tests -> /runtime/artifacts/bin/System.Formats.Nrbf.Tests/Debug/net481/System.Formats.Nrbf.Tests.dll
  Zipping directory "/runtime/artifacts/bin/System.Formats.Nrbf.Tests/Debug/net481/" to "/runtime/artifacts/helix/tests/linux.AnyCPU.Debug/System.Formats.Nrbf.Tests.zip".

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:21.55
```