### PR TITLE
[cDAC]: Implement GetTypedByRefInfo, GetStringData, GetArrayData, GetBasicObjectInfo

### DIFF
--- a/docs/design/datacontracts/Object.md
+++ b/docs/design/datacontracts/Object.md
@@ -42,8 +42,7 @@ TargetPointer GetSyncBlockAddress(TargetPointer address);
 
 DelegateInfo GetDelegateInfo(TargetPointer address);
 
-// Returns the logical size of the object in bytes (base size plus any variable-size
-// component data), padded up to the minimum allocated object size.
+// Returns the logical size of the object in bytes (base size plus any variable-size component data).
 ulong GetSize(TargetPointer address);
 ```
 
@@ -250,11 +249,6 @@ ulong GetSize(TargetPointer address)
         uint numComponents = target.Read<uint>(address + /* Array::m_NumComponents offset */);
         size += (ulong)numComponents * componentSize;
     }
-
-    // Round up to the minimum allocated object size. The GC will not produce an
-    // object smaller than 2 pointers plus the object header, so report at least
-    // that much regardless of the type's declared base size.
-    ulong minObjectSize = (ulong)(2 * (uint)target.PointerSize) + target.ReadGlobal<uint>("ObjectHeaderSize");
-    return size < minObjectSize ? minObjectSize : size;
+    return size;
 }
 ```

--- a/docs/design/datacontracts/Object.md
+++ b/docs/design/datacontracts/Object.md
@@ -26,6 +26,10 @@ string GetStringValue(TargetPointer address);
 // Get the pointer to the data corresponding to a managed array object. Error if address does not represent a array.
 TargetPointer GetArrayData(TargetPointer address, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds);
 
+// Get the length (in chars) and the offset from the object base to the first character
+// for a managed string object. Error if address does not represent a string.
+void GetStringData(TargetPointer address, out uint length, out uint offsetToFirstChar);
+
 // Get built-in COM data for the object if available. Returns false if address does not represent a COM object using built-in COM.
 bool GetBuiltInComData(TargetPointer address, out TargetPointer rcw, out TargetPointer ccw, out TargetPointer ccf);
 
@@ -37,6 +41,10 @@ int TryGetHashCode(TargetPointer address);
 TargetPointer GetSyncBlockAddress(TargetPointer address);
 
 DelegateInfo GetDelegateInfo(TargetPointer address);
+
+// Returns the logical size of the object in bytes (base size plus any variable-size
+// component data), padded up to the minimum allocated object size.
+ulong GetSize(TargetPointer address);
 ```
 
 ## Version 1
@@ -96,6 +104,19 @@ string GetStringValue(TargetPointer address)
     Span<byte> span = stackalloc byte[(int)length * sizeof(char)];
     target.ReadBuffer(address + /* String::m_FirstChar offset */, span);
     return new string(MemoryMarshal.Cast<byte, char>(span));
+}
+
+void GetStringData(TargetPointer address, out uint length, out uint offsetToFirstChar)
+{
+    TargetPointer mt = GetMethodTableAddress(address);
+    if (mt == TargetPointer.Null)
+        throw new ArgumentException("Address represents a set-free object");
+    TargetPointer stringMethodTable = target.ReadPointer(target.ReadGlobalPointer("StringMethodTable"));
+    if (mt != stringMethodTable)
+        throw new ArgumentException("Address does not represent a string object", nameof(address));
+
+    length = target.Read<uint>(address + /* String::m_StringLength offset */);
+    offsetToFirstChar = /* String::m_FirstChar offset */;
 }
 
 TargetPointer GetArrayData(TargetPointer address, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds)
@@ -209,5 +230,31 @@ DelegateInfo GetDelegateInfo(TargetPointer address)
     };
 
     return new DelegateInfo(targetObject, targetMethodPtr, delegateType);
+}
+
+ulong GetSize(TargetPointer address)
+{
+    TargetPointer mt = GetMethodTableAddress(address);
+    if (mt == TargetPointer.Null)
+        throw new ArgumentException("Address represents a set-free object");
+
+    Contracts.IRuntimeTypeSystem rts = target.Contracts.RuntimeTypeSystem;
+    TypeHandle typeHandle = rts.GetTypeHandle(mt);
+
+    ulong size = rts.GetBaseSize(typeHandle);
+    uint componentSize = rts.GetComponentSize(typeHandle);
+    if (componentSize > 0)
+    {
+        // Variable-size object (array or string): add the component data size.
+        // Both Array and String share the m_NumComponents/m_StringLength field layout.
+        uint numComponents = target.Read<uint>(address + /* Array::m_NumComponents offset */);
+        size += (ulong)numComponents * componentSize;
+    }
+
+    // Round up to the minimum allocated object size. The GC will not produce an
+    // object smaller than 2 pointers plus the object header, so report at least
+    // that much regardless of the type's declared base size.
+    ulong minObjectSize = (ulong)(2 * (uint)target.PointerSize) + target.ReadGlobal<uint>("ObjectHeaderSize");
+    return size < minObjectSize ? minObjectSize : size;
 }
 ```

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -18,6 +18,8 @@ struct TypeHandle
     public bool IsNull => Address != 0;
 }
 
+readonly record struct TypedByRefInfo(TargetPointer Data, TargetPointer TypeHandle);
+
 internal enum CorElementType
 {
     // Values defined in ECMA-335 - II.23.1.16 Element types used in signatures
@@ -131,6 +133,7 @@ partial interface IRuntimeTypeSystem : IContract
     bool IsPointer(TypeHandle typeHandle);
     bool IsTypeDesc(TypeHandle typeHandle);
     TargetPointer GetLoaderModule(TypeHandle typeHandle);
+    TypedByRefInfo GetTypedByRefInfo(TargetPointer typedByRef);
 
     #endregion TypeHandle inspection APIs
 }
@@ -513,6 +516,8 @@ The contract additionally depends on these data descriptors
 | `GenericsDictInfo` | `NumTypeArgs` | Number of type arguments in the type or method instantiation described by this `GenericsDictInfo` |
 | `LoaderAllocator` | `IsCollectible` | Non-zero if the `LoaderAllocator` is collectible. |
 | `LoaderAllocator` | `CreationNumber` | Monotonically-increasing creation number assigned to each collectible `LoaderAllocator`. |
+| `TypedByRef` | `Data` | Managed pointer (the byref) stored in a `System.TypedReference` value |
+| `TypedByRef` | `Type` | Raw `TypeHandle` pointer of the referent type |
 
 The value of the `NativeCodeVersionNode::OptimizationTier` field is one of:
 ```csharp
@@ -1192,6 +1197,14 @@ Contracts used:
             }
         }
         return target.ReadPointer(mt.AuxiliaryData + /* MethodTableAuxiliaryData::LoaderModule offset */);
+    }
+
+    public TypedByRefInfo GetTypedByRefInfo(TargetPointer typedByRef)
+    {
+        // Read both fields of a TypedByRef using the TypedByRef data descriptor.
+        TargetPointer data = target.ReadPointer(typedByRef + /* TypedByRef::Data offset */);
+        TargetPointer typeHandle = target.ReadPointer(typedByRef + /* TypedByRef::Type offset */);
+        return new TypedByRefInfo(data, typeHandle);
     }
 ```
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -6008,10 +6008,6 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetBasicObjectInfo(CORDB_ADDRESS 
             if (objPtr->GetGCSafeMethodTable() == g_pStringClass)
             {
                 pObjTypeData->elementType = ELEMENT_TYPE_STRING;
-                if(*pObjSize < MIN_OBJECT_SIZE)
-                {
-                    *pObjSize = PtrAlign(*pObjSize);
-                }
             }
         }
     }

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5814,34 +5814,6 @@ bool DacDbiInterfaceImpl::CheckRef(PTR_Object objPtr)
     return objRefBad;
 } // DacDbiInterfaceImpl::CheckRef
 
-// DacDbiInterfaceImpl::InitObjectData
-// Initialize basic object information: type handle, object size, offset to fields and expanded type
-// information.
-// Arguments:
-//     input:  objPtr      - address of object of interest
-//     output: pObjectData - object information
-// Note: It is assumed that pObjectData is non-null.
-void DacDbiInterfaceImpl::InitObjectData(PTR_Object                objPtr,
-                                         DebuggerIPCE_ObjectData * pObjectData)
-{
-    _ASSERTE(pObjectData != NULL);
-    // Save basic object info.
-    pObjectData->objSize = objPtr->GetSize();
-    pObjectData->objOffsetToVars = dac_cast<TADDR>((objPtr)->GetData()) - dac_cast<TADDR>(objPtr);
-
-    IfFailThrow(TypeHandleToExpandedTypeInfo(AllBoxed, (CORDB_ADDRESS)objPtr->GetGCSafeTypeHandle().AsTAddr(), &(pObjectData->objTypeData)));
-
-    // If this is a string object, set the type to ELEMENT_TYPE_STRING.
-    if (objPtr->GetGCSafeMethodTable() == g_pStringClass)
-    {
-        pObjectData->objTypeData.elementType = ELEMENT_TYPE_STRING;
-        if(pObjectData->objSize < MIN_OBJECT_SIZE)
-        {
-            pObjectData->objSize = PtrAlign(pObjectData->objSize);
-        }
-    }
-} // DacDbiInterfaceImpl::InitObjectData
-
 // DAC/DBI API
 
 // Get object information for a TypedByRef object (System.TypedReference).
@@ -5886,7 +5858,7 @@ void DacDbiInterfaceImpl::InitObjectData(PTR_Object                objPtr,
 // }
 
 // Initializes the objRef and typedByRefType fields of pObjectData (type info for the referent).
-HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, CORDB_ADDRESS * pObjRef, DebuggerIPCE_BasicTypeData * pTypedByRefType)
 {
      DD_ENTER_MAY_THROW;
 
@@ -5899,31 +5871,30 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTypedByRefInfo(CORDB_ADDRESS p
         PTR_TypedByRef refAddr = PTR_TypedByRef(TADDR(pTypedByRef));
 
         _ASSERTE(refAddr != NULL);
-        _ASSERTE(pObjectData != NULL);
+        _ASSERTE(pObjRef != NULL);
+        _ASSERTE(pTypedByRefType != NULL);
 
         // The type of the referent is in the type field of the TypedByRef. We need to initialize the object
         // data type information.
-        TypeHandleToBasicTypeInfo(refAddr->type,
-                                  &(pObjectData->typedByrefInfo.typedByrefType));
+        TypeHandleToBasicTypeInfo(refAddr->type, pTypedByRefType);
 
         // The reference to the object is in the data field of the TypedByRef.
-        CORDB_ADDRESS tempRef = dac_cast<TADDR>(refAddr->data);
-        pObjectData->objRef = CORDB_ADDRESS_TO_PTR(tempRef);
+        *pObjRef = dac_cast<TADDR>(refAddr->data);
 
         LOG((LF_CORDB, LL_INFO10000, "D::GASOI: sending REFANY result: "
              "ref=0x%08x, cls=0x%08x, mod=0x%p\n",
-             pObjectData->objRef,
-             pObjectData->typedByrefType.metadataToken,
-             pObjectData->typedByrefType.vmAssembly.GetDacPtr()));
+             *pObjRef,
+             pTypedByRefType->metadataToken,
+             pTypedByRefType->vmAssembly.GetDacPtr()));
     }
     EX_CATCH_HRESULT(hr);
     return hr;
 }
 
-// Get the string data associated withn obj and put it into the pointers
+// Get the string data associated with obj and put it into the pointers
 // DAC/DBI API
 // Get the string length and offset to string base for a string object
-HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStringData(CORDB_ADDRESS objectAddress, UINT * pLength, UINT * pOffsetToStringBase)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5942,8 +5913,8 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStringData(CORDB_ADDRESS objec
         PTR_StringObject pStrObj = dac_cast<PTR_StringObject>(objPtr);
 
         _ASSERTE(pStrObj != NULL);
-        pObjectData->stringInfo.length = pStrObj->GetStringLength();
-        pObjectData->stringInfo.offsetToStringBase = (UINT_PTR) pStrObj->GetBufferOffset();
+        *pLength = pStrObj->GetStringLength();
+        *pOffsetToStringBase = (UINT_PTR) pStrObj->GetBufferOffset();
 
     }
     EX_CATCH_HRESULT(hr);
@@ -5954,7 +5925,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStringData(CORDB_ADDRESS objec
 // DAC/DBI API
 // Get information for an array type referent of an objRef, including rank, upper and lower
 // bounds, element size and type, and the number of elements.
-HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetArrayData(CORDB_ADDRESS objectAddress, BOOL * pIsValidArray, DacDbiArrayInfo * pArrayInfo)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5970,42 +5941,41 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetArrayData(CORDB_ADDRESS object
             LOG((LF_CORDB, LL_INFO10000,
                  "D::GASOI: object should be an array.\n"));
 
-            pObjectData->objRefBad = true;
+            *pIsValidArray = FALSE;
         }
         else
         {
+            *pIsValidArray = TRUE;
             PTR_ArrayBase arrPtr = dac_cast<PTR_ArrayBase>(objPtr);
 
             // this is also returned in the type information for the array - we return both for sanity checking...
-            pObjectData->arrayInfo.rank = arrPtr->GetRank();
-            pObjectData->arrayInfo.componentCount = arrPtr->GetNumComponents();
-            pObjectData->arrayInfo.offsetToArrayBase = arrPtr->GetDataPtrOffset(pMT);
+            pArrayInfo->rank = arrPtr->GetRank();
+            pArrayInfo->componentCount = arrPtr->GetNumComponents();
+            pArrayInfo->offsetToArrayBase = arrPtr->GetDataPtrOffset(pMT);
 
             if (arrPtr->IsMultiDimArray())
             {
-                pObjectData->arrayInfo.offsetToUpperBounds = SIZE_T(arrPtr->GetBoundsOffset(pMT));
+                pArrayInfo->offsetToUpperBounds = SIZE_T(arrPtr->GetBoundsOffset(pMT));
 
-                pObjectData->arrayInfo.offsetToLowerBounds = SIZE_T(arrPtr->GetLowerBoundsOffset(pMT));
+                pArrayInfo->offsetToLowerBounds = SIZE_T(arrPtr->GetLowerBoundsOffset(pMT));
             }
             else
             {
-                pObjectData->arrayInfo.offsetToUpperBounds = 0;
-                pObjectData->arrayInfo.offsetToLowerBounds = 0;
+                pArrayInfo->offsetToUpperBounds = 0;
+                pArrayInfo->offsetToLowerBounds = 0;
             }
 
-            pObjectData->arrayInfo.elementSize = arrPtr->GetComponentSize();
+            pArrayInfo->elementSize = (UINT)arrPtr->GetComponentSize();
 
             LOG((LF_CORDB, LL_INFO10000, "D::GOI: array info: "
-                "baseOff=%d, lowerOff=%d, upperOff=%d, cnt=%d, rank=%d, rank (2) = %d,"
-                 "eleSize=%d, eleType=0x%02x\n",
-                 pObjectData->arrayInfo.offsetToArrayBase,
-                 pObjectData->arrayInfo.offsetToLowerBounds,
-                 pObjectData->arrayInfo.offsetToUpperBounds,
-                 pObjectData->arrayInfo.componentCount,
-                 pObjectData->arrayInfo.rank,
-                 pObjectData->objTypeData.ArrayTypeData.arrayRank,
-                 pObjectData->arrayInfo.elementSize,
-                 pObjectData->objTypeData.ArrayTypeData.arrayTypeArg.elementType));
+                "baseOff=%u, lowerOff=%u, upperOff=%u, cnt=%u, rank=%u, "
+                 "eleSize=%u\n",
+                 pArrayInfo->offsetToArrayBase,
+                 pArrayInfo->offsetToLowerBounds,
+                 pArrayInfo->offsetToUpperBounds,
+                 pArrayInfo->componentCount,
+                 pArrayInfo->rank,
+                 pArrayInfo->elementSize));
         }
     }
     EX_CATCH_HRESULT(hr);
@@ -6014,7 +5984,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetArrayData(CORDB_ADDRESS object
 
 // DAC/DBI API: Get information about an object for which we have a reference, including the object size and
 // type information.
-HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetBasicObjectInfo(CORDB_ADDRESS objectAddress, BOOL * pIsValidRef, UINT * pObjSize, UINT * pObjOffsetToVars, DebuggerIPCE_ExpandedTypeData * pObjTypeData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6023,12 +5993,26 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetBasicObjectInfo(CORDB_ADDRESS 
     {
 
         PTR_Object objPtr = PTR_Object(TADDR(objectAddress));
-        pObjectData->objRefBad = CheckRef(objPtr);
-        if (pObjectData->objRefBad != true)
+        BOOL objRefBad = CheckRef(objPtr);
+        *pIsValidRef = !objRefBad;
+        if (!objRefBad)
         {
             // initialize object type, size, offset information. Note: We may have a different element type
             // after this. For example, we may start with E_T_CLASS but return with something more specific.
-            InitObjectData(objPtr, pObjectData);
+            *pObjSize = (UINT)objPtr->GetSize();
+            *pObjOffsetToVars = (UINT)(dac_cast<TADDR>((objPtr)->GetData()) - dac_cast<TADDR>(objPtr));
+
+            IfFailThrow(TypeHandleToExpandedTypeInfo(AllBoxed, (CORDB_ADDRESS)objPtr->GetGCSafeTypeHandle().AsTAddr(), pObjTypeData));
+
+            // If this is a string object, set the type to ELEMENT_TYPE_STRING.
+            if (objPtr->GetGCSafeMethodTable() == g_pStringClass)
+            {
+                pObjTypeData->elementType = ELEMENT_TYPE_STRING;
+                if(*pObjSize < MIN_OBJECT_SIZE)
+                {
+                    *pObjSize = PtrAlign(*pObjSize);
+                }
+            }
         }
     }
     EX_CATCH_HRESULT(hr);

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -537,20 +537,20 @@ private:
 // ============================================================================
 
 public:
-    // Get object information for a TypedByRef object. Initializes the objRef and typedByRefType fields of
-    // pObjectData (type info for the referent).
-    HRESULT STDMETHODCALLTYPE GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, DebuggerIPCE_ObjectData * pObjectData);
+    // Get object information for a TypedByRef object. Fills the objRef and typedByRefType
+    // (type info for the referent).
+    HRESULT STDMETHODCALLTYPE GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, CORDB_ADDRESS * pObjRef, DebuggerIPCE_BasicTypeData * pTypedByRefType);
 
     // Get the string length and offset to string base for a string object
-    HRESULT STDMETHODCALLTYPE GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT STDMETHODCALLTYPE GetStringData(CORDB_ADDRESS objectAddress, UINT * pLength, UINT * pOffsetToStringBase);
 
     // Get information for an array type referent of an objRef, including rank, upper and lower bounds,
     // element size and type, and the number of elements.
-    HRESULT STDMETHODCALLTYPE GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT STDMETHODCALLTYPE GetArrayData(CORDB_ADDRESS objectAddress, BOOL * pIsValidArray, DacDbiArrayInfo * pArrayInfo);
 
     // Get information about an object for which we have a reference, including the object size and
     // type information.
-    HRESULT STDMETHODCALLTYPE GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT STDMETHODCALLTYPE GetBasicObjectInfo(CORDB_ADDRESS objectAddress, BOOL * pIsValidRef, UINT * pObjSize, UINT * pObjOffsetToVars, DebuggerIPCE_ExpandedTypeData * pObjTypeData);
 
     // Returns the thread which owns the monitor lock on an object and the acquisition count
     HRESULT STDMETHODCALLTYPE GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal);
@@ -567,11 +567,6 @@ private:
     // tell this for certain without walking the GC heap, but we do some fast tests to rule out clearly
     // invalid object addresses. See code:DacDbiInterfaceImpl::FastSanityCheckObject for more details.
     bool CheckRef(PTR_Object objPtr);
-
-    // Initialize basic object information: type handle, object size, offset to fields and expanded type
-    // information.
-    void InitObjectData(PTR_Object                objPtr,
-                        DebuggerIPCE_ObjectData * pObjectData);
 
 // ============================================================================
 // CordbAssembly, CordbModule

--- a/src/coreclr/debug/di/divalue.cpp
+++ b/src/coreclr/debug/di/divalue.cpp
@@ -877,7 +877,7 @@ HRESULT CordbReferenceValue::GetType(CorElementType *pType)
         // We may not have a CordbType if we were created from a GC handle to NULL
         _ASSERTE( m_info.objTypeData.elementType == ELEMENT_TYPE_CLASS );
         _ASSERTE(!m_valueHome.ObjHandleIsNull());
-        _ASSERTE( m_info.objRef == NULL );
+        _ASSERTE( m_info.objRef == (CORDB_ADDRESS)NULL );
         *pType = m_info.objTypeData.elementType;
     }
     else
@@ -917,7 +917,7 @@ HRESULT CordbReferenceValue::IsNull(BOOL * pfIsNull)
     FAIL_IF_NEUTERED(this);
     VALIDATE_POINTER_TO_OBJECT(pfIsNull, BOOL *);
 
-   if (m_isLiteral || (m_info.objRef == NULL))
+   if (m_isLiteral || (m_info.objRef == (CORDB_ADDRESS)NULL))
         *pfIsNull = TRUE;
     else
         *pfIsNull = FALSE;
@@ -939,7 +939,7 @@ HRESULT CordbReferenceValue::GetValue(CORDB_ADDRESS *pAddress)
     if (m_isLiteral)
         *pAddress = (CORDB_ADDRESS)NULL;
     else
-        *pAddress = PTR_TO_CORDB_ADDRESS(m_info.objRef);
+        *pAddress = m_info.objRef;
 
     return S_OK;
 }
@@ -973,7 +973,7 @@ HRESULT CordbReferenceValue::SetValue(CORDB_ADDRESS address)
 
     // Either we know the type, or it's a handle to a null value
     _ASSERTE((m_type != NULL) ||
-             (!m_valueHome.ObjHandleIsNull() && (m_info.objRef == NULL)));
+             (!m_valueHome.ObjHandleIsNull() && (m_info.objRef == (CORDB_ADDRESS)NULL)));
 
 	EX_TRY
 	{
@@ -991,7 +991,8 @@ HRESULT CordbReferenceValue::SetValue(CORDB_ADDRESS address)
         if (m_info.objTypeData.elementType == ELEMENT_TYPE_STRING)
         {
             // update information about the string
-            InitRef(MemoryRange(&m_info.objRef, sizeof (void *)));
+            void * pObjRef = CORDB_ADDRESS_TO_PTR(m_info.objRef);
+            InitRef(MemoryRange(&pObjRef, sizeof (void *)));
         }
 
         // All other data in m_info is no longer valid, and we may have invalidated other
@@ -1034,7 +1035,7 @@ HRESULT CordbReferenceValue::Dereference(ICorDebugValue **ppValue)
     {
         // We may know ahead of time (depending on the reference type) if
         // the reference is bad.
-        if ((m_info.objRefBad) || (m_info.objRef == NULL))
+        if ((m_info.objRefBad) || (m_info.objRef == (CORDB_ADDRESS)NULL))
         {
             ThrowHR(CORDBG_E_BAD_REFERENCE_VALUE);
         }
@@ -1099,7 +1100,7 @@ HRESULT CordbReferenceValue::DereferenceCommon(
 
             if (isBoxedVCObject)
             {
-                TargetBuffer remoteValue(PTR_TO_CORDB_ADDRESS(pInfo->objRef), (ULONG)pInfo->objSize);
+                TargetBuffer remoteValue(pInfo->objRef, (ULONG)pInfo->objSize);
                 EX_TRY
                 {
                     RSSmartPtr<CordbBoxValue> pBoxValue(new CordbBoxValue(
@@ -1137,7 +1138,7 @@ HRESULT CordbReferenceValue::DereferenceCommon(
     case ELEMENT_TYPE_SZARRAY:
         {
             LOG((LF_CORDB, LL_INFO1000, "DereferenceInternal: type array/szarray\n"));
-            TargetBuffer remoteValue(PTR_TO_CORDB_ADDRESS(pInfo->objRef), (ULONG)pInfo->objSize); // sizeof(void *)?
+            TargetBuffer remoteValue(pInfo->objRef, (ULONG)pInfo->objSize);
             EX_TRY
             {
                 RSSmartPtr<CordbArrayValue> pArrayValue(new CordbArrayValue(
@@ -1388,7 +1389,7 @@ void CordbReferenceValue::SanityCheckPointer (CorElementType type)
     {
         // We should never dereference a function pointer, so all references
         // are considered "bad."
-        if (m_info.objRef != NULL)
+        if (m_info.objRef != (CORDB_ADDRESS)NULL)
         {
             if (type == ELEMENT_TYPE_PTR)
             {
@@ -1453,7 +1454,8 @@ void CordbReferenceValue::GetPointerData(CorElementType type, MemoryRange localV
         //                                           ---------------    |
 
         _ASSERTE(localValue.Size() == sizeof(void *));
-        localCopy(&(m_info.objRef), localValue);
+        void * pObjRef = CORDB_ADDRESS_TO_PTR(m_info.objRef);
+        localCopy(&pObjRef, localValue);
     }
     else
     {
@@ -1467,7 +1469,7 @@ void CordbReferenceValue::GetPointerData(CorElementType type, MemoryRange localV
         EX_CATCH_HRESULT(hr);
         if (FAILED(hr))
         {
-            m_info.objRef = NULL;
+            m_info.objRef = (CORDB_ADDRESS)NULL;
             m_info.objRefBad = TRUE;
             ThrowHR(hr);
         }
@@ -1651,7 +1653,7 @@ HRESULT CordbReferenceValue::InitRef(MemoryRange localValue)
     // If the helper thread is dead, then pretend this is a bad reference.
     if (GetProcess()->m_helperThreadDead)
     {
-        m_info.objRef = NULL;
+        m_info.objRef = (CORDB_ADDRESS)NULL;
         m_info.objRefBad = TRUE;
         return hr;
     }
@@ -4350,7 +4352,7 @@ HRESULT CordbHandleValue::RefreshHandleValue()
     // If reference is already gone bad or reference is NULL,
     // don't bother to refetch in the future.
     //
-    if ((m_info.objRefBad) || (m_info.objRef == NULL))
+    if ((m_info.objRefBad) || (m_info.objRef == (CORDB_ADDRESS)NULL))
     {
         m_fCanBeValid = FALSE;
     }
@@ -4646,12 +4648,12 @@ HRESULT CordbHandleValue::IsNull(BOOL *pbNull)
             return hr;
         }
 
-        if (m_info.objRef == NULL)
+        if (m_info.objRef == (CORDB_ADDRESS)NULL)
         {
             *pbNull = TRUE;
         }
     }
-    else if (m_info.objRef == NULL)
+    else if (m_info.objRef == (CORDB_ADDRESS)NULL)
     {
         *pbNull = TRUE;
     }
@@ -4681,7 +4683,7 @@ HRESULT CordbHandleValue::GetValue(CORDB_ADDRESS *pValue)
     }
 
     RefreshHandleValue();
-    *pValue = PTR_TO_CORDB_ADDRESS(m_info.objRef);
+    *pValue = m_info.objRef;
     return S_OK;
 }   // CordbHandleValue::GetValue
 
@@ -4719,7 +4721,7 @@ HRESULT CordbHandleValue::Dereference(ICorDebugValue **ppValue)
         return hr;
     }
 
-    if ((m_info.objRefBad) || (m_info.objRef == NULL))
+    if ((m_info.objRefBad) || (m_info.objRef == (CORDB_ADDRESS)NULL))
     {
         return CORDBG_E_BAD_REFERENCE_VALUE;
     }

--- a/src/coreclr/debug/di/divalue.cpp
+++ b/src/coreclr/debug/di/divalue.cpp
@@ -985,7 +985,7 @@ HRESULT CordbReferenceValue::SetValue(CORDB_ADDRESS address)
     {
         // That worked, so update the copy of the value we have in
         // our local cache.
-        m_info.objRef = CORDB_ADDRESS_TO_PTR(address);
+        m_info.objRef = address;
 
 
         if (m_info.objTypeData.elementType == ELEMENT_TYPE_STRING)
@@ -1058,7 +1058,7 @@ HRESULT CordbReferenceValue::DereferenceCommon(
     CordbAppDomain * pAppDomain,
     CordbType * pType,
     CordbType * pRealTypeOfTypedByref,
-    DebuggerIPCE_ObjectData * pInfo,
+    DacDbiObjectData * pInfo,
     ICorDebugValue **ppValue
 )
 {
@@ -1488,11 +1488,11 @@ void CordbReferenceValue::GetPointerData(CorElementType type, MemoryRange localV
 // Arguments:
 //     input:  objectType  - type of the referent of the objRef being examined
 //     output: pObjectData - information about the reference to be initialized
-void PreInitObjectData(DebuggerIPCE_ObjectData * pObjectData, void * objAddress, CorElementType objectType)
+void PreInitObjectData(DacDbiObjectData * pObjectData, CORDB_ADDRESS objAddress, CorElementType objectType)
 {
     _ASSERTE(pObjectData != NULL);
 
-    memset(pObjectData, 0, sizeof(DebuggerIPCE_ObjectData));
+    memset(pObjectData, 0, sizeof(DacDbiObjectData));
     pObjectData->objRef = objAddress;
     pObjectData->objTypeData.elementType = objectType;
 
@@ -1513,27 +1513,30 @@ void CordbReferenceValue::GetObjectData(CordbProcess *            pProcess,
                                         void *                    objectAddress,
                                         CorElementType            type,
                                         VMPTR_AppDomain           vmAppdomain,
-                                        DebuggerIPCE_ObjectData * pInfo)
+                                        DacDbiObjectData * pInfo)
 {
     IDacDbiInterface *pInterface = pProcess->GetDAC();
     CORDB_ADDRESS objTargetAddr = PTR_TO_CORDB_ADDRESS(objectAddress);
 
     // make sure we don't end up with old garbage values in case the reference is bad
-    PreInitObjectData(pInfo, objectAddress, type);
-
-    IfFailThrow(pInterface->GetBasicObjectInfo(objTargetAddr, type, pInfo));
+    PreInitObjectData(pInfo, objTargetAddr, type);
+    BOOL isValidRef = FALSE;
+    IfFailThrow(pInterface->GetBasicObjectInfo(objTargetAddr, &isValidRef, &pInfo->objSize, &pInfo->objOffsetToVars, &pInfo->objTypeData));
+    pInfo->objRefBad = !isValidRef;
 
     if (!pInfo->objRefBad)
     {
         // for certain referent types, we need a bit more information:
         if (pInfo->objTypeData.elementType == ELEMENT_TYPE_STRING)
         {
-            IfFailThrow(pInterface->GetStringData(objTargetAddr, pInfo));
+            IfFailThrow(pInterface->GetStringData(objTargetAddr, &pInfo->stringInfo.length, &pInfo->stringInfo.offsetToStringBase));
         }
         else if ((pInfo->objTypeData.elementType == ELEMENT_TYPE_ARRAY) ||
                  (pInfo->objTypeData.elementType == ELEMENT_TYPE_SZARRAY))
         {
-            IfFailThrow(pInterface->GetArrayData(objTargetAddr, pInfo));
+            BOOL isValidArray = FALSE;
+            IfFailThrow(pInterface->GetArrayData(objTargetAddr, &isValidArray, &pInfo->arrayInfo));
+            pInfo->objRefBad = !isValidArray;
         }
     }
 
@@ -1553,18 +1556,18 @@ void CordbReferenceValue::GetTypedByRefData(CordbProcess *            pProcess,
                                             CORDB_ADDRESS             pTypedByRef,
                                             CorElementType            type,
                                             VMPTR_AppDomain           vmAppDomain,
-                                            DebuggerIPCE_ObjectData * pInfo)
+                                            DacDbiObjectData * pInfo)
 {
 
     // make sure we don't end up with old garbage values since we don't set all the values for TypedByRef objects
-    PreInitObjectData(pInfo, CORDB_ADDRESS_TO_PTR(pTypedByRef), type);
+    PreInitObjectData(pInfo, pTypedByRef, type);
 
     // Though pTypedByRef is the value of the object ref represented by an instance of CordbReferenceValue,
     // it is not the address of an object, as we would ordinarily expect. Instead, in the special case of
     // TypedByref objects, it is actually the address of the TypedByRef struct which  contains the
     // type and the object address.
 
-    IfFailThrow(pProcess->GetDAC()->GetTypedByRefInfo(pTypedByRef, pInfo));
+    IfFailThrow(pProcess->GetDAC()->GetTypedByRefInfo(pTypedByRef, &pInfo->objRef, &pInfo->typedByrefType));
 } // CordbReferenceValue::GetTypedByRefData
 
 //  get the address of the object referenced
@@ -1615,7 +1618,7 @@ void CordbReferenceValue::UpdateTypeInfo()
     if (m_info.objTypeData.elementType == ELEMENT_TYPE_TYPEDBYREF)
 {
         IfFailThrow(CordbType::TypeDataToType(m_appdomain,
-                    &m_info.typedByrefInfo.typedByrefType,
+                    &m_info.typedByrefType,
                     &m_realTypeOfTypedByref));
     }
 } // CordbReferenceValue::UpdateTypeInfo
@@ -1727,7 +1730,7 @@ HRESULT CordbReferenceValue::InitRef(MemoryRange localValue)
 CordbObjectValue::CordbObjectValue(CordbAppDomain *          pAppdomain,
                                    CordbType *               pType,
                                    TargetBuffer              remoteValue,
-                                   DebuggerIPCE_ObjectData *pObjectData )
+                                   DacDbiObjectData *pObjectData )
     : CordbValue(pAppdomain, pType, remoteValue.pAddress,
                 false, pAppdomain->GetProcess()->GetContinueNeuterList()),
       m_info(*pObjectData),
@@ -3589,7 +3592,7 @@ HRESULT CordbBoxValue::GetMonitorEventWaitList(ICorDebugThreadEnum **ppThreadEnu
 //         remoteValue - buffer describing the remote location of the value
 CordbArrayValue::CordbArrayValue(CordbAppDomain *          pAppdomain,
                                  CordbType *               pType,
-                                 DebuggerIPCE_ObjectData * pObjectInfo,
+                                 DacDbiObjectData * pObjectInfo,
                                  TargetBuffer              remoteValue)
     : CordbValue(pAppdomain,
                  pType,
@@ -3909,7 +3912,7 @@ HRESULT CordbArrayValue::GetElementAtPosition(ULONG32 nPosition,
         else  _ASSERTE(cbElemSize != 0);
 
         m_idxLower = nPosition;
-        m_idxUpper = min(m_idxLower + len, m_info.arrayInfo.componentCount);
+        m_idxUpper = min(m_idxLower + len, (SIZE_T)m_info.arrayInfo.componentCount);
         _ASSERTE(m_idxLower < m_idxUpper);
 
         SIZE_T cbOffsetFrom = m_info.arrayInfo.offsetToArrayBase + m_idxLower * cbElemSize;

--- a/src/coreclr/debug/di/divalue.cpp
+++ b/src/coreclr/debug/di/divalue.cpp
@@ -1117,7 +1117,7 @@ HRESULT CordbReferenceValue::DereferenceCommon(
             else
             {
                 RSSmartPtr<CordbObjectValue> pObj;
-                TargetBuffer remoteValue(PTR_TO_CORDB_ADDRESS(pInfo->objRef), (ULONG)pInfo->objSize);
+                TargetBuffer remoteValue(pInfo->objRef, (ULONG)pInfo->objSize);
                 // Note: we call Init() by default when we create (or refresh) a reference value, so we
                 // never have to do it again.
                 EX_TRY

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -2280,7 +2280,7 @@ HRESULT CordbProcess::GetObjectInternal(CORDB_ADDRESS addr, ICorDebugObjectValue
                 _ASSERTE(pType != NULL);
                 _ASSERTE(cdbAppDomain != NULL);
 
-                DacDbiObjectData objData;
+                DacDbiObjectData objData = {};
                 BOOL isValidRef = FALSE;
 
                 IfFailThrow(m_pDacPrimitives->GetBasicObjectInfo(addr, &isValidRef, &objData.objSize, &objData.objOffsetToVars, &objData.objTypeData));

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -2280,10 +2280,12 @@ HRESULT CordbProcess::GetObjectInternal(CORDB_ADDRESS addr, ICorDebugObjectValue
                 _ASSERTE(pType != NULL);
                 _ASSERTE(cdbAppDomain != NULL);
 
-                DebuggerIPCE_ObjectData objData;
-                IfFailThrow(m_pDacPrimitives->GetBasicObjectInfo(addr, ELEMENT_TYPE_CLASS, &objData));
+                DacDbiObjectData objData;
+                BOOL isValidRef = FALSE;
 
-                NewHolder<CordbObjectValue> pNewObjectValue(new CordbObjectValue(cdbAppDomain, pType, TargetBuffer(addr, (ULONG)objData.objSize), &objData));
+                IfFailThrow(m_pDacPrimitives->GetBasicObjectInfo(addr, &isValidRef, &objData.objSize, &objData.objOffsetToVars, &objData.objTypeData));
+                objData.objRefBad = !isValidRef;
+                NewHolder<CordbObjectValue> pNewObjectValue(new CordbObjectValue(cdbAppDomain, pType, TargetBuffer(addr, objData.objSize), &objData));
                 hr = pNewObjectValue->Init();
 
                 if (SUCCEEDED(hr))

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -8971,7 +8971,7 @@ public:
                        void *                    objectAddress,
                        CorElementType            type,
                        VMPTR_AppDomain           vmAppdomain,
-                       DebuggerIPCE_ObjectData * pInfo);
+                       DacDbiObjectData * pInfo);
 
     // get information about a TypedByRef object when the reference is the address of a TypedByRef structure.
     static
@@ -8979,7 +8979,7 @@ public:
                            CORDB_ADDRESS             pTypedByRef,
                            CorElementType            type,
                            VMPTR_AppDomain           vmAppDomain,
-                           DebuggerIPCE_ObjectData * pInfo);
+                           DacDbiObjectData * pInfo);
 
     //  get the address of the object referenced
     void * GetObjectAddress(MemoryRange localValue);
@@ -9008,7 +9008,7 @@ public:
     static HRESULT DereferenceCommon(CordbAppDomain *          pAppDomain,
                                      CordbType *               pType,
                                      CordbType *               pRealTypeOfTypedByref,
-                                     DebuggerIPCE_ObjectData * m_pInfo,
+                                     DacDbiObjectData * m_pInfo,
                                      ICorDebugValue **         ppValue);
 
     // Returns a pointer to the ValueHome field
@@ -9020,7 +9020,7 @@ public:
     //-----------------------------------------------------------
 
 public:
-    DebuggerIPCE_ObjectData  m_info;
+    DacDbiObjectData  m_info;
     CordbType *              m_realTypeOfTypedByref; // weak ref
 
     RefValueHome             m_valueHome;
@@ -9060,7 +9060,7 @@ public:
     CordbObjectValue(CordbAppDomain *          appdomain,
                      CordbType *               type,
                      TargetBuffer              remoteValue,
-                     DebuggerIPCE_ObjectData * pObjectData );
+                     DacDbiObjectData * pObjectData );
 
     virtual ~CordbObjectValue();
 
@@ -9202,7 +9202,7 @@ public:
 
     HRESULT Init();
 
-    DebuggerIPCE_ObjectData GetInfo() { return m_info; }
+    DacDbiObjectData GetInfo() { return m_info; }
     CordbHangingFieldTable * GetHangingFieldTable() { return &m_hangingFieldsInstance; }
 
     // Returns a pointer to the ValueHome field
@@ -9213,7 +9213,7 @@ protected:
     //-----------------------------------------------------------
     // Data members
     //-----------------------------------------------------------
-    DebuggerIPCE_ObjectData  m_info;
+    DacDbiObjectData  m_info;
     BYTE *                   m_pObjectCopy;     // local cached copy of the object
     BYTE *                   m_objectLocalVars; // var base in _this_ process
                                                 // points _into_ m_pObjectCopy
@@ -9525,7 +9525,7 @@ class CordbArrayValue : public CordbValue,
 public:
     CordbArrayValue(CordbAppDomain *          appdomain,
                     CordbType *               type,
-                    DebuggerIPCE_ObjectData * pObjectInfo,
+                    DacDbiObjectData *        pObjectInfo,
                     TargetBuffer              remoteValue);
     virtual ~CordbArrayValue();
 
@@ -9647,7 +9647,7 @@ public:
 
 private:
     // contains information about the array, such as rank, number of elements, element size, etc.
-    DebuggerIPCE_ObjectData  m_info;
+    DacDbiObjectData  m_info;
 
     // type of the elements
     CordbType               *m_elemtype;
@@ -9792,7 +9792,7 @@ private:
 
     BOOL                m_fCanBeValid;      // true if object "can" be valid. False when object is no longer valid.
     CorDebugHandleType m_handleType;        // handle type can be strong or weak
-    DebuggerIPCE_ObjectData  m_info;
+    DacDbiObjectData  m_info;
 ; // ICORDebugClass of this object when we create the handle
 };
 

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -1740,45 +1740,43 @@ public:
     // functions to get information about reference/handle referents for ICDValue
     // ----------------------------------------------------------------------------
 
-    // Get object information for a TypedByRef object. Initializes the objRef and typedByRefType fields of
-    // pObjectData (type info for the referent).
+    // Get object information for a TypedByRef object (System.TypedReference).
     // Arguments:
-    //     input:  pTypedByRef - pointer to a TypedByRef struct
-    //     output: pObjectData - information about the object referenced by pTypedByRef
+    //     input:  pTypedByRef     - address of the TypedByRef struct
+    //     output: pObjRef         - the managed pointer value (data field of TypedByRef)
+    //             pTypedByRefType - basic type information for the referent type
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT STDMETHODCALLTYPE GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, OUT CORDB_ADDRESS * pObjRef, OUT DebuggerIPCE_BasicTypeData * pTypedByRefType) = 0;
 
     // Get the string length and offset to string base for a string object
     // Arguments:
-    //     input:  objPtr - address of a string object
-    //     output: pObjectData - fills in the string fields stringInfo.offsetToStringBase and
-    //             stringInfo.length
+    //     input:  objectAddress        - address of a string object
+    //     output: pLength              - the string length in characters
+    //             pOffsetToStringBase  - byte offset from the object base to the first character
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT STDMETHODCALLTYPE GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetStringData(CORDB_ADDRESS objectAddress, OUT UINT * pLength, OUT UINT * pOffsetToStringBase) = 0;
 
     // Get information for an array type referent of an objRef, including rank, upper and lower bounds,
     // element size and type, and the number of elements.
     // Arguments:
     //     input:  objectAddress - the address of an array object
-    //     output: pObjectData   - fills in the array-related fields:
-    //                             arrayInfo.offsetToArrayBase,
-    //                             arrayInfo.offsetToLowerBounds,
-    //                             arrayInfo.offsetToUpperBounds,
-    //                             arrayInfo.componentCount,
-    //                             arrayInfo.rank,
-    //                             arrayInfo.elementSize,
+    //     output: pIsValidArray - FALSE if the object is not actually an array
+    //             pArrayInfo    - filled with array layout information
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT STDMETHODCALLTYPE GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetArrayData(CORDB_ADDRESS objectAddress, OUT BOOL * pIsValidArray, OUT DacDbiArrayInfo * pArrayInfo) = 0;
 
     // Get information about an object for which we have a reference, including the object size and
     // type information.
     // Arguments:
-    //     input:  objectAddress - address of the object for which we want information
-    //             type          - the basic type of the object (we may find more specific type
-    //                             information for the object)
-    //     output: pObjectData   - fills in the size and type information fields
+    //     input:  objectAddress    - address of the object for which we want information
+    //             type             - the basic type of the object (we may find more specific type
+    //                                information for the object)
+    //     output: pIsValidRef      - FALSE if the object reference is bad
+    //             pObjSize         - size of the object in bytes
+    //             pObjOffsetToVars - byte offset from the object base to the first field
+    //             pObjTypeData     - expanded type information for the object
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT STDMETHODCALLTYPE GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetBasicObjectInfo(CORDB_ADDRESS objectAddress, OUT BOOL * pIsValidRef, OUT UINT * pObjSize, OUT UINT * pObjOffsetToVars, OUT DebuggerIPCE_ExpandedTypeData * pObjTypeData) = 0;
 
     // Get the address of the Debugger control block on the helper thread. The debugger control block
     // contains information about the status of the debugger, handles to various events and space to hold

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -1769,8 +1769,6 @@ public:
     // type information.
     // Arguments:
     //     input:  objectAddress    - address of the object for which we want information
-    //             type             - the basic type of the object (we may find more specific type
-    //                                information for the object)
     //     output: pIsValidRef      - FALSE if the object reference is bad
     //             pObjSize         - size of the object in bytes
     //             pObjOffsetToVars - byte offset from the object base to the first field

--- a/src/coreclr/debug/inc/dacdbistructures.h
+++ b/src/coreclr/debug/inc/dacdbistructures.h
@@ -899,5 +899,41 @@ struct MSLAYOUT DacThreadAllocInfo
     ULONG64 m_allocBytesUOH;
 };
 
+// Array layout info returned by IDacDbiInterface::GetArrayData.
+struct DacDbiArrayInfo
+{
+    UINT rank;
+    UINT componentCount;
+    UINT offsetToArrayBase;
+    UINT offsetToUpperBounds;   // 0 for SZArray
+    UINT offsetToLowerBounds;   // 0 for SZArray
+    UINT elementSize;
+};
+
+struct MSLAYOUT DacDbiObjectData
+{
+    CORDB_ADDRESS   objRef;
+    BOOL            objRefBad;
+    UINT            objSize;
+
+    // Offset from the beginning of the object to the beginning of the first field
+    UINT            objOffsetToVars;
+
+    // The type of the object....
+    struct DebuggerIPCE_ExpandedTypeData objTypeData;
+
+    union MSLAYOUT
+    {
+        struct MSLAYOUT
+        {
+            UINT          length;
+            UINT          offsetToStringBase;
+        } stringInfo;
+
+        DacDbiArrayInfo arrayInfo;
+        DebuggerIPCE_BasicTypeData typedByrefType; // the type of the thing contained in a typedByref...
+    };
+};
+
 #include "dacdbistructures.inl"
 #endif // DACDBISTRUCTURES_H_

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -1357,50 +1357,6 @@ struct MSLAYOUT DebuggerIPCE_TypeArgData
     Portable<UINT> numTypeArgs; // number of immediate children on the type tree
 };
 
-
-//
-// DebuggerIPCE_ObjectData holds the results of a
-// GetAndSendObjectInfo, i.e., all the info about an object that the
-// Right Side would need to access it. (This include array, string,
-// and nstruct info.)
-//
-struct MSLAYOUT DebuggerIPCE_ObjectData
-{
-    void           *objRef;
-    bool            objRefBad;
-    SIZE_T          objSize;
-
-    // Offset from the beginning of the object to the beginning of the first field
-    SIZE_T          objOffsetToVars;
-
-    // The type of the object....
-    struct DebuggerIPCE_ExpandedTypeData objTypeData;
-
-    union MSLAYOUT
-    {
-        struct MSLAYOUT
-        {
-            SIZE_T          length;
-            SIZE_T          offsetToStringBase;
-        } stringInfo;
-
-        struct MSLAYOUT
-        {
-            SIZE_T          rank;
-            SIZE_T          offsetToArrayBase;
-            SIZE_T          offsetToLowerBounds; // 0 if not present
-            SIZE_T          offsetToUpperBounds; // 0 if not present
-            SIZE_T          componentCount;
-            SIZE_T          elementSize;
-        } arrayInfo;
-
-        struct MSLAYOUT
-        {
-            struct DebuggerIPCE_BasicTypeData typedByrefType; // the type of the thing contained in a typedByref...
-        } typedByrefInfo;
-    };
-};
-
 //
 // Remote enregistered info used by CordbValues and for passing
 // variable homes between the left and right sides during a func eval.

--- a/src/coreclr/inc/dacdbi.idl
+++ b/src/coreclr/inc/dacdbi.idl
@@ -26,7 +26,8 @@ struct DebuggerIPCE_ExpandedTypeData;
 struct DebuggerIPCE_BasicTypeData;
 struct EnCHangingFieldInfo;
 struct DacExceptionCallStackData;
-struct DebuggerIPCE_ObjectData;
+struct DacDbiObjectData;
+struct DacDbiArrayInfo;
 struct MonitorLockInfo;
 struct DacGcReference;
 struct DacSharedReJitInfo;
@@ -341,10 +342,10 @@ interface IDacDbiInterface : IUnknown
     HRESULT EnumerateRcwCachedInterfacePointers([in] VMPTR_Object vmObject, [in] FP_RCW_INTERFACE_CALLBACK fpCallback, [in] CALLBACK_DATA pUserData);
 
     // Object Data
-    HRESULT GetTypedByRefInfo([in] CORDB_ADDRESS pTypedByRef, [out] struct DebuggerIPCE_ObjectData * pObjectData);
-    HRESULT GetStringData([in] CORDB_ADDRESS objectAddress, [out] struct DebuggerIPCE_ObjectData * pObjectData);
-    HRESULT GetArrayData([in] CORDB_ADDRESS objectAddress, [out] struct DebuggerIPCE_ObjectData * pObjectData);
-    HRESULT GetBasicObjectInfo([in] CORDB_ADDRESS objectAddress, [in] CorElementType type, [out] struct DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT GetTypedByRefInfo([in] CORDB_ADDRESS pTypedByRef, [out] CORDB_ADDRESS * pObjRef, [out] struct DebuggerIPCE_BasicTypeData * pTypedByRefType);
+    HRESULT GetStringData([in] CORDB_ADDRESS objectAddress, [out] UINT * pLength, [out] UINT * pOffsetToStringBase);
+    HRESULT GetArrayData([in] CORDB_ADDRESS objectAddress, [out] BOOL * pIsValidArray, [out] struct DacDbiArrayInfo * pArrayInfo);
+    HRESULT GetBasicObjectInfo([in] CORDB_ADDRESS objectAddress, [out] BOOL * pIsValidRef, [out] UINT * pObjSize, [out] UINT * pObjOffsetToVars, [out] struct DebuggerIPCE_ExpandedTypeData * pObjTypeData);
 
     // Debugger Control Block
     HRESULT GetDebuggerControlBlockAddress([out] CORDB_ADDRESS * pRetVal);

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -201,6 +201,12 @@ CDAC_TYPE_FIELD(Delegate, T_POINTER, MethodPtrAux, cdac_data<DelegateObject>::Me
 CDAC_TYPE_FIELD(Delegate, T_NINT, InvocationCount, cdac_data<DelegateObject>::InvocationCount)
 CDAC_TYPE_END(Delegate)
 
+CDAC_TYPE_BEGIN(TypedByRef)
+CDAC_TYPE_INDETERMINATE(TypedByRef)
+CDAC_TYPE_FIELD(TypedByRef, T_POINTER, Data, offsetof(TypedByRef, data))
+CDAC_TYPE_FIELD(TypedByRef, EXTERN_TYPE(TypeHandle), Type, offsetof(TypedByRef, type))
+CDAC_TYPE_END(TypedByRef)
+
 CDAC_TYPE_BEGIN(StackTraceArrayHeader)
 CDAC_TYPE_SIZE(cdac_data<StackTraceArray>::HeaderSize)
 CDAC_TYPE_FIELD(StackTraceArrayHeader, T_UINT32, Size, cdac_data<StackTraceArray>::Size)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IObject.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IObject.cs
@@ -28,6 +28,8 @@ public interface IObject : IContract
     // Returns the SyncBlock address for the object, or TargetPointer.Null if no sync block is associated with it.
     TargetPointer GetSyncBlockAddress(TargetPointer address) => throw new NotImplementedException();
     DelegateInfo GetDelegateInfo(TargetPointer address) => throw new NotImplementedException();
+    ulong GetSize(TargetPointer address) => throw new NotImplementedException();
+    void GetStringData(TargetPointer address, out uint length, out uint offsetToFirstChar) => throw new NotImplementedException();
 }
 
 public readonly struct Object : IObject

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -70,6 +70,8 @@ public readonly struct MethodDescHandle
     public TargetPointer Address { get; }
 }
 
+public readonly record struct TypedByRefInfo(TargetPointer Data, TargetPointer TypeHandle);
+
 public enum ArrayFunctionType
 {
     Get = 0,
@@ -201,6 +203,7 @@ public interface IRuntimeTypeSystem : IContract
     bool IsFunctionPointer(TypeHandle typeHandle, out ReadOnlySpan<TypeHandle> retAndArgTypes, out SignatureCallingConvention callConv) => throw new NotImplementedException();
     bool IsPointer(TypeHandle typeHandle) => throw new NotImplementedException();
     bool IsTypeDesc(TypeHandle typeHandle) => throw new NotImplementedException();
+    TypedByRefInfo GetTypedByRefInfo(TargetPointer typedByRef) => throw new NotImplementedException();
     // Returns null if the TypeHandle is not a class/struct/generic variable
     #endregion TypeHandle inspection APIs
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Object_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Object_1.cs
@@ -206,7 +206,6 @@ internal readonly struct Object_1 : IObject
             Data.Array arr = _target.ProcessedData.GetOrAdd<Data.Array>(address);
             size += (ulong)arr.NumComponents * componentSize;
         }
-        ulong minObjectSize = (ulong)(2 * (uint)_target.PointerSize) + _target.GetTypeInfo(DataType.ObjectHeader).Size!.Value;
-        return size < minObjectSize ? minObjectSize : size;
+        return size;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Object_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Object_1.cs
@@ -53,6 +53,19 @@ internal readonly struct Object_1 : IObject
         return new string(MemoryMarshal.Cast<byte, char>(span));
     }
 
+    public void GetStringData(TargetPointer address, out uint length, out uint offsetToFirstChar)
+    {
+        TargetPointer mt = GetMethodTableAddress(address);
+        if (mt == TargetPointer.Null)
+            throw new ArgumentException("Address represents a set-free object");
+        if (mt != _stringMethodTable)
+            throw new ArgumentException("Address does not represent a string object", nameof(address));
+
+        Data.String str = _target.ProcessedData.GetOrAdd<Data.String>(address);
+        length = str.StringLength;
+        offsetToFirstChar = (uint)(str.FirstChar.Value - address.Value);
+    }
+
     public TargetPointer GetArrayData(TargetPointer address, out uint count, out TargetPointer boundsStart, out TargetPointer lowerBounds)
     {
         TargetPointer mt = GetMethodTableAddress(address);
@@ -174,5 +187,26 @@ internal readonly struct Object_1 : IObject
             TargetObject: targetObject,
             TargetMethodPtr: targetMethodPtr,
             DelegateType: delegateType);
+    }
+
+    public ulong GetSize(TargetPointer address)
+    {
+        TargetPointer mt = GetMethodTableAddress(address);
+        if (mt == TargetPointer.Null)
+            throw new ArgumentException("Address represents a free object");
+        Contracts.IRuntimeTypeSystem typeSystemContract = _target.Contracts.RuntimeTypeSystem;
+        TypeHandle typeHandle = typeSystemContract.GetTypeHandle(mt);
+
+        ulong size = typeSystemContract.GetBaseSize(typeHandle);
+        uint componentSize = typeSystemContract.GetComponentSize(typeHandle);
+        if (componentSize > 0)
+        {
+            // Variable-size object (array or string): add the component data size.
+            // Both Array and String share the m_NumComponents/m_StringLength field layout.
+            Data.Array arr = _target.ProcessedData.GetOrAdd<Data.Array>(address);
+            size += (ulong)arr.NumComponents * componentSize;
+        }
+        ulong minObjectSize = (ulong)(2 * (uint)_target.PointerSize) + _target.GetTypeInfo(DataType.ObjectHeader).Size!.Value;
+        return size < minObjectSize ? minObjectSize : size;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -1241,6 +1241,12 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
     public bool IsTypeDesc(TypeHandle typeHandle) => typeHandle.IsTypeDesc();
 
+    public TypedByRefInfo GetTypedByRefInfo(TargetPointer typedByRef)
+    {
+        Data.TypedByRef typedByRefData = _target.ProcessedData.GetOrAdd<Data.TypedByRef>(typedByRef);
+        return new TypedByRefInfo(typedByRefData.Data, typedByRefData.Type);
+    }
+
     public TargetPointer GetLoaderModule(TypeHandle typeHandle)
     {
         if (typeHandle.IsTypeDesc())

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TypedByRef.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TypedByRef.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+[CdacType(nameof(DataType.TypedByRef))]
+internal sealed partial class TypedByRef : IData<TypedByRef>
+{
+    [Field]
+    public TargetPointer Data { get; }
+
+    [Field]
+    public TargetPointer Type { get; }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
@@ -98,6 +98,7 @@ public enum DataType
     InterpMethodContextFrame,
     Array,
     Delegate,
+    TypedByRef,
     StackTraceArrayHeader,
     StackTraceElement,
     SyncBlock,

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -3130,13 +3130,13 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
 
     public int GetBasicObjectInfo(ulong objectAddress, Interop.BOOL* pIsValidRef, uint* pObjSize, uint* pObjOffsetToVars, DebuggerIPCE_ExpandedTypeData* pObjTypeData)
     {
-        *pIsValidRef = Interop.BOOL.TRUE;
-        *pObjSize = 0;
-        *pObjOffsetToVars = 0;
-        *pObjTypeData = default;
         int hr = HResults.S_OK;
         try
         {
+            *pIsValidRef = Interop.BOOL.TRUE;
+            *pObjSize = 0;
+            *pObjOffsetToVars = 0;
+            *pObjTypeData = default;
             IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
             // verify the object reference is readable and has a valid MethodTable
             TypeHandle th = default;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -2990,17 +2990,207 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         return hr;
     }
 
-    public int GetTypedByRefInfo(ulong pTypedByRef, nint pObjectData)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetTypedByRefInfo(pTypedByRef, pObjectData) : HResults.E_NOTIMPL;
+    public int GetTypedByRefInfo(ulong pTypedByRef, ulong* pObjRef, DebuggerIPCE_BasicTypeData* pTypedByRefType)
+    {
+        *pObjRef = 0;
+        *pTypedByRefType = default;
+        int hr = HResults.S_OK;
+        try
+        {
+            IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+            TypedByRefInfo info = rts.GetTypedByRefInfo(pTypedByRef);
+            TypeHandle th = rts.GetTypeHandle(info.TypeHandle);
+            FillBasicTypeInfo(rts, th, out DebuggerIPCE_BasicTypeData typeData);
+            *pTypedByRefType = typeData;
+            *pObjRef = info.Data.Value;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            ulong objRefLocal = 0;
+            DebuggerIPCE_BasicTypeData typeLocal;
+            int hrLocal = _legacy.GetTypedByRefInfo(pTypedByRef, &objRefLocal, &typeLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            Debug.Assert(*pObjRef == objRefLocal, $"cDAC objRef: 0x{*pObjRef:x}, DAC: 0x{objRefLocal:x}");
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(pTypedByRefType->elementType == typeLocal.elementType,
+                    $"cDAC elementType: {pTypedByRefType->elementType}, DAC: {typeLocal.elementType}");
+                Debug.Assert(pTypedByRefType->metadataToken == typeLocal.metadataToken,
+                    $"cDAC metadataToken: 0x{pTypedByRefType->metadataToken:x}, DAC: 0x{typeLocal.metadataToken:x}");
+                Debug.Assert(pTypedByRefType->vmAssembly == typeLocal.vmAssembly,
+                    $"cDAC vmAssembly: 0x{pTypedByRefType->vmAssembly:x}, DAC: 0x{typeLocal.vmAssembly:x}");
+            }
+        }
+#endif
+        return hr;
+    }
 
-    public int GetStringData(ulong objectAddress, nint pObjectData)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetStringData(objectAddress, pObjectData) : HResults.E_NOTIMPL;
+    public int GetStringData(ulong objectAddress, uint* pLength, uint* pOffsetToStringBase)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+            TargetPointer mtAddr = _target.Contracts.Object.GetMethodTableAddress(objectAddress);
+            TypeHandle th = rts.GetTypeHandle(mtAddr);
+            if (!rts.IsString(th))
+            {
+                throw Marshal.GetExceptionForHR(CorDbgHResults.CORDBG_E_TARGET_INCONSISTENT)!;
+            }
+            _target.Contracts.Object.GetStringData(objectAddress, out uint length, out uint offset);
+            *pLength = length;
+            *pOffsetToStringBase = offset;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            uint lengthLocal, offsetLocal;
+            int hrLocal = _legacy.GetStringData(objectAddress, &lengthLocal, &offsetLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(*pLength == lengthLocal, $"cDAC length: {*pLength}, DAC: {lengthLocal}");
+                Debug.Assert(*pOffsetToStringBase == offsetLocal, $"cDAC offsetToStringBase: {*pOffsetToStringBase}, DAC: {offsetLocal}");
+            }
+        }
+#endif
+        return hr;
+    }
 
-    public int GetArrayData(ulong objectAddress, nint pObjectData)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetArrayData(objectAddress, pObjectData) : HResults.E_NOTIMPL;
+    public int GetArrayData(ulong objectAddress, Interop.BOOL* pIsValidArray, DacDbiArrayInfo* pArrayInfo)
+    {
+        *pIsValidArray = Interop.BOOL.FALSE;
+        *pArrayInfo = default;
+        int hr = HResults.S_OK;
+        try
+        {
+            IObject objectContract = _target.Contracts.Object;
+            IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+            TargetPointer mt = objectContract.GetMethodTableAddress(objectAddress);
+            TypeHandle th = rts.GetTypeHandle(mt);
+            if (rts.IsArray(th, out uint rank))
+            {
+                TargetPointer dataStart = objectContract.GetArrayData(objectAddress, out uint numComponents, out TargetPointer boundsStart, out TargetPointer lowerBounds);
+                *pIsValidArray = Interop.BOOL.TRUE;
 
-    public int GetBasicObjectInfo(ulong objectAddress, int type, nint pObjectData)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetBasicObjectInfo(objectAddress, type, pObjectData) : HResults.E_NOTIMPL;
+                uint offsetToArrayBase = (uint)(dataStart - objectAddress);
+                uint offsetToUpperBounds = 0;
+                uint offsetToLowerBounds = 0;
+                if (rts.GetSignatureCorElementType(th) == CorElementType.Array)
+                {
+                    offsetToUpperBounds = (uint)(boundsStart - objectAddress);
+                    offsetToLowerBounds = (uint)(lowerBounds - objectAddress);
+                }
+
+                pArrayInfo->rank = rank;
+                pArrayInfo->componentCount = numComponents;
+                pArrayInfo->offsetToArrayBase = offsetToArrayBase;
+                pArrayInfo->offsetToUpperBounds = offsetToUpperBounds;
+                pArrayInfo->offsetToLowerBounds = offsetToLowerBounds;
+                pArrayInfo->elementSize = rts.GetComponentSize(th);
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            Interop.BOOL isValidLocal;
+            DacDbiArrayInfo arrayInfoLocal;
+            int hrLocal = _legacy.GetArrayData(objectAddress, &isValidLocal, &arrayInfoLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(*pIsValidArray == isValidLocal, $"cDAC isValidArray: {*pIsValidArray}, DAC: {isValidLocal}");
+                if (*pIsValidArray == Interop.BOOL.TRUE)
+                {
+                    Debug.Assert(pArrayInfo->rank == arrayInfoLocal.rank, $"cDAC rank: {pArrayInfo->rank}, DAC: {arrayInfoLocal.rank}");
+                    Debug.Assert(pArrayInfo->componentCount == arrayInfoLocal.componentCount, $"cDAC componentCount: {pArrayInfo->componentCount}, DAC: {arrayInfoLocal.componentCount}");
+                    Debug.Assert(pArrayInfo->offsetToArrayBase == arrayInfoLocal.offsetToArrayBase, $"cDAC offsetToArrayBase: {pArrayInfo->offsetToArrayBase}, DAC: {arrayInfoLocal.offsetToArrayBase}");
+                    Debug.Assert(pArrayInfo->offsetToUpperBounds == arrayInfoLocal.offsetToUpperBounds, $"cDAC offsetToUpperBounds: {pArrayInfo->offsetToUpperBounds}, DAC: {arrayInfoLocal.offsetToUpperBounds}");
+                    Debug.Assert(pArrayInfo->offsetToLowerBounds == arrayInfoLocal.offsetToLowerBounds, $"cDAC offsetToLowerBounds: {pArrayInfo->offsetToLowerBounds}, DAC: {arrayInfoLocal.offsetToLowerBounds}");
+                    Debug.Assert(pArrayInfo->elementSize == arrayInfoLocal.elementSize, $"cDAC elementSize: {pArrayInfo->elementSize}, DAC: {arrayInfoLocal.elementSize}");
+                }
+            }
+        }
+#endif
+        return hr;
+    }
+
+    public int GetBasicObjectInfo(ulong objectAddress, Interop.BOOL* pIsValidRef, uint* pObjSize, uint* pObjOffsetToVars, DebuggerIPCE_ExpandedTypeData* pObjTypeData)
+    {
+        *pIsValidRef = Interop.BOOL.TRUE;
+        *pObjSize = 0;
+        *pObjOffsetToVars = 0;
+        *pObjTypeData = default;
+        int hr = HResults.S_OK;
+        try
+        {
+            IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+            // verify the object reference is readable and has a valid MethodTable
+            TypeHandle th = default;
+            try
+            {
+                TargetPointer mt = _target.Contracts.Object.GetMethodTableAddress(objectAddress);
+                th = rts.GetTypeHandle(mt);
+            }
+            catch
+            {
+                *pIsValidRef = Interop.BOOL.FALSE;
+            }
+
+            if (*pIsValidRef == Interop.BOOL.TRUE)
+            {
+                // objOffsetToVars = offset from the object base to the first field = sizeof(Object) = pointer size
+                *pObjOffsetToVars = (uint)_target.GetTypeInfo(DataType.Object).Size!.Value;
+                *pObjSize = (uint)_target.Contracts.Object.GetSize(objectAddress);
+                TypeHandleToExpandedTypeInfoImpl(rts, AreValueTypesBoxed.AllBoxed, th, pObjTypeData);
+
+                // If this is a string, force elementType to ELEMENT_TYPE_STRING
+                if (rts.IsString(th))
+                {
+                    WriteLittleEndian(ref pObjTypeData->elementType, (int)CorElementType.String);
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            Interop.BOOL isValidLocal;
+            uint objSizeLocal, objOffsetLocal;
+            DebuggerIPCE_ExpandedTypeData typeDataLocal;
+            int hrLocal = _legacy.GetBasicObjectInfo(objectAddress, &isValidLocal, &objSizeLocal, &objOffsetLocal, &typeDataLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(*pIsValidRef == isValidLocal, $"cDAC isValidRef: {*pIsValidRef}, DAC: {isValidLocal}");
+                if (*pIsValidRef == Interop.BOOL.TRUE)
+                {
+                    Debug.Assert(*pObjSize == objSizeLocal, $"cDAC objSize: {*pObjSize}, DAC: {objSizeLocal}");
+                    Debug.Assert(*pObjOffsetToVars == objOffsetLocal, $"cDAC objOffsetToVars: {*pObjOffsetToVars}, DAC: {objOffsetLocal}");
+                    Debug.Assert(pObjTypeData->elementType == typeDataLocal.elementType,
+                        $"cDAC elementType: {pObjTypeData->elementType}, DAC: {typeDataLocal.elementType}");
+                }
+            }
+        }
+#endif
+        return hr;
+    }
 
     public int GetDebuggerControlBlockAddress(ulong* pRetVal)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
@@ -307,6 +307,17 @@ public unsafe struct ArgInfoList
     public int m_nEntries;
 }
 
+[StructLayout(LayoutKind.Sequential)]
+public struct DacDbiArrayInfo
+{
+    public uint rank;
+    public uint componentCount;
+    public uint offsetToArrayBase;
+    public uint offsetToUpperBounds;   // 0 for SZArray
+    public uint offsetToLowerBounds;   // 0 for SZArray
+    public uint elementSize;
+}
+
 public enum DynamicMethodType
 {
     kNone = 0,
@@ -609,16 +620,16 @@ public unsafe partial interface IDacDbiInterface
     int EnumerateRcwCachedInterfacePointers(ulong vmObject, /*FP_RCW_INTERFACE_CALLBACK*/ delegate* unmanaged<ulong, nint, void> fpCallback, nint pUserData);
 
     [PreserveSig]
-    int GetTypedByRefInfo(ulong pTypedByRef, nint pObjectData);
+    int GetTypedByRefInfo(ulong pTypedByRef, ulong* pObjRef, DebuggerIPCE_BasicTypeData* pTypedByRefType);
 
     [PreserveSig]
-    int GetStringData(ulong objectAddress, nint pObjectData);
+    int GetStringData(ulong objectAddress, uint* pLength, uint* pOffsetToStringBase);
 
     [PreserveSig]
-    int GetArrayData(ulong objectAddress, nint pObjectData);
+    int GetArrayData(ulong objectAddress, Interop.BOOL* pIsValidArray, DacDbiArrayInfo* pArrayInfo);
 
     [PreserveSig]
-    int GetBasicObjectInfo(ulong objectAddress, int type, nint pObjectData);
+    int GetBasicObjectInfo(ulong objectAddress, Interop.BOOL* pIsValidRef, uint* pObjSize, uint* pObjOffsetToVars, DebuggerIPCE_ExpandedTypeData* pObjTypeData);
 
     [PreserveSig]
     int GetDebuggerControlBlockAddress(ulong* pRetVal);

--- a/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
@@ -1246,4 +1246,79 @@ public class MethodTableTests
         Assert.Equal(startOff + elemSize, series2[1].Offset);
         Assert.Equal((uint)target.PointerSize, series2[1].Size);
     }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetTypedByRefInfo_ReadsDataAndTypeHandle(MockTarget.Architecture arch)
+    {
+        const ulong ExpectedData = 0xDDDD_DDD0;
+        const ulong ExpectedTypeHandle = 0xEEEE_EEE0;
+        const ulong TypedByRefAddress = 0x4900_0000;
+
+        TestPlaceholderTarget target = CreateTargetWithTypedByRef(
+            arch,
+            TypedByRefAddress,
+            data: ExpectedData,
+            type: ExpectedTypeHandle);
+
+        IRuntimeTypeSystem rts = target.Contracts.RuntimeTypeSystem;
+        TypedByRefInfo info = rts.GetTypedByRefInfo(TypedByRefAddress);
+
+        Assert.Equal(ExpectedData, info.Data.Value);
+        Assert.Equal(ExpectedTypeHandle, info.TypeHandle.Value);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetTypedByRefInfo_ZeroFields_ReturnsNullPointers(MockTarget.Architecture arch)
+    {
+        const ulong TypedByRefAddress = 0x4900_0000;
+
+        TestPlaceholderTarget target = CreateTargetWithTypedByRef(
+            arch,
+            TypedByRefAddress,
+            data: 0,
+            type: 0);
+
+        IRuntimeTypeSystem rts = target.Contracts.RuntimeTypeSystem;
+        TypedByRefInfo info = rts.GetTypedByRefInfo(TypedByRefAddress);
+
+        Assert.Equal(TargetPointer.Null, info.Data);
+        Assert.Equal(TargetPointer.Null, info.TypeHandle);
+    }
+
+    private static TestPlaceholderTarget CreateTargetWithTypedByRef(
+        MockTarget.Architecture arch,
+        ulong typedByRefAddress,
+        ulong data,
+        ulong type)
+    {
+        var targetBuilder = new TestPlaceholderTarget.Builder(arch);
+        MockRTS rtsBuilder = new(targetBuilder.MemoryBuilder);
+
+        Layout typedByRefLayout = new SequentialLayoutBuilder("TypedByRef", arch)
+            .AddPointerField("Data")
+            .AddPointerField("Type")
+            .Build();
+
+        TargetTestHelpers helpers = rtsBuilder.Builder.TargetTestHelpers;
+        byte[] bytes = new byte[typedByRefLayout.Size];
+        helpers.WritePointer(bytes.AsSpan(typedByRefLayout.GetField("Data").Offset, helpers.PointerSize), data);
+        helpers.WritePointer(bytes.AsSpan(typedByRefLayout.GetField("Type").Offset, helpers.PointerSize), type);
+        rtsBuilder.Builder.AddHeapFragment(new MockMemorySpace.HeapFragment
+        {
+            Name = "TypedByRef",
+            Address = typedByRefAddress,
+            Data = bytes,
+        });
+
+        Dictionary<DataType, Target.TypeInfo> types = CreateContractTypes(rtsBuilder);
+        types[DataType.TypedByRef] = TargetTestHelpers.CreateTypeInfo(typedByRefLayout);
+
+        return targetBuilder
+            .AddTypes(types)
+            .AddGlobals(CreateContractGlobals(rtsBuilder))
+            .AddContract<IRuntimeTypeSystem>(version: "c1")
+            .Build();
+    }
 }

--- a/src/native/managed/cdac/tests/UnitTests/ObjectTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ObjectTests.cs
@@ -118,6 +118,59 @@ public unsafe class ObjectTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
+    public void StringData(MockTarget.Architecture arch)
+    {
+        TargetPointer TestStringAddress = default;
+        int offsetToFirstChar = 0;
+        string expected = "test_string_value";
+        IObject contract = CreateObjectContract(
+            arch,
+            objectBuilder =>
+            {
+                offsetToFirstChar = objectBuilder.StringLayout.GetField("m_FirstChar").Offset;
+                TestStringAddress = objectBuilder.AddStringObject(expected);
+            });
+
+        contract.GetStringData(TestStringAddress, out uint length, out uint actualOffsetToFirstChar);
+
+        Assert.Equal((uint)expected.Length, length);
+        Assert.Equal((uint)offsetToFirstChar, actualOffsetToFirstChar);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void Size(MockTarget.Architecture arch)
+    {
+        TargetPointer TestObjectAddress = default;
+        TargetPointer TestArrayAddress = default;
+        Array array = new int[10];
+        TargetTestHelpers targetTestHelpers = new(arch);
+        IObject contract = CreateObjectContract(
+            arch,
+            objectBuilder =>
+            {
+                MockEEClass eeClass = objectBuilder.RTSBuilder.AddEEClass("TestClass");
+                MockMethodTable methodTable = objectBuilder.RTSBuilder.AddMethodTable("TestClass");
+                methodTable.BaseSize = objectBuilder.Builder.TargetTestHelpers.ObjectBaseSize;
+                eeClass.MethodTable = methodTable.Address;
+                methodTable.EEClassOrCanonMT = eeClass.Address;
+                TestObjectAddress = objectBuilder.AddObject(methodTable.Address);
+
+                TestArrayAddress = objectBuilder.AddArrayObject(array);
+            });
+
+        // Fixed-size object: size is just the base size, no component data.
+        Assert.Equal(targetTestHelpers.ObjectBaseSize, contract.GetSize(TestObjectAddress));
+
+        // Variable-size object (array): base size plus component count times component size.
+        // The mock encodes the component size as the array length in the method table flags.
+        ulong componentSize = (uint)array.Length;
+        ulong expectedArraySize = targetTestHelpers.ArrayBaseBaseSize + (ulong)array.Length * componentSize;
+        Assert.Equal(expectedArraySize, contract.GetSize(TestArrayAddress));
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
     public void ArrayData(MockTarget.Architecture arch)
     {
         TargetPointer SingleDimensionArrayAddress = default;

--- a/src/native/managed/cdac/tests/UnitTests/ObjectTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ObjectTests.cs
@@ -141,9 +141,10 @@ public unsafe class ObjectTests
     [ClassData(typeof(MockTarget.StdArch))]
     public void Size(MockTarget.Architecture arch)
     {
+        const int TestArrayLength = 10;
         TargetPointer TestObjectAddress = default;
         TargetPointer TestArrayAddress = default;
-        Array array = new int[10];
+        Array testArray = new int[TestArrayLength];
         TargetTestHelpers targetTestHelpers = new(arch);
         IObject contract = CreateObjectContract(
             arch,
@@ -156,16 +157,17 @@ public unsafe class ObjectTests
                 methodTable.EEClassOrCanonMT = eeClass.Address;
                 TestObjectAddress = objectBuilder.AddObject(methodTable.Address);
 
-                TestArrayAddress = objectBuilder.AddArrayObject(array);
+                TestArrayAddress = objectBuilder.AddArrayObject(testArray);
             });
 
         // Fixed-size object: size is just the base size, no component data.
         Assert.Equal(targetTestHelpers.ObjectBaseSize, contract.GetSize(TestObjectAddress));
 
         // Variable-size object (array): base size plus component count times component size.
-        // The mock encodes the component size as the array length in the method table flags.
-        ulong componentSize = (uint)array.Length;
-        ulong expectedArraySize = targetTestHelpers.ArrayBaseBaseSize + (ulong)array.Length * componentSize;
+        // AddArrayObject encodes the component size as the array length in the method table flags,
+        // so the expected component size here matches TestArrayLength rather than sizeof(int).
+        ulong componentSize = TestArrayLength;
+        ulong expectedArraySize = targetTestHelpers.ArrayBaseBaseSize + TestArrayLength * componentSize;
         Assert.Equal(expectedArraySize, contract.GetSize(TestArrayAddress));
     }
 


### PR DESCRIPTION
* Add two cDAC APIs on Object contract:

```csharp
void GetStringData(TargetPointer address, out uint length, out uint offsetToFirstChar);
ulong GetSize(TargetPointer address);
```

* Add one cDAC API on RuntimeTypeSystem:

```csharp
TypedByRefInfo GetTypedByRefInfo(TargetPointer typedByRef);
```

* Implement DacDbi APIs, slightly modifying out params to be more specific to each API
* Moving, renaming, and re-typing DebuggerIPCE_ObjectData
* Add unit tests for `GetStringData` and `GetSize` to `ObjectTests.cs`, covering string length/offset and both fixed-size object and variable-size array sizing across architectures