### PR TITLE
Implement computed goto dispatch for the CoreCLR interpreter

### DIFF
--- a/src/coreclr/debug/ee/interpreterwalker.cpp
+++ b/src/coreclr/debug/ee/interpreterwalker.cpp
@@ -161,7 +161,7 @@ void InterpreterWalker::Decode()
         m_nextIP = NULL;
         LOG((LF_CORDB, LL_INFO10000, "InterpreterWalker::Decode: WALK_THROW\n"));
     }
-    else if (m_opcode == INTOP_BREAKPOINT || m_opcode == INTOP_HALT)
+    else if (m_opcode == INTOP_BREAKPOINT)
     {
         m_type = WALK_BREAK;
         m_nextIP = m_skipIP;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -8312,9 +8312,13 @@ void InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
 
     if (m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM))
     {
+#ifdef FEATURE_PORTABLE_ENTRYPOINTS
+        assert(!"Generating INTOP_STORESTUBCONTEXT on invalid platform");
+#else
         m_hiddenArgumentVar = CreateVarExplicit(InterpTypeI, NULL, sizeof(void *));
         AddIns(INTOP_STORESTUBCONTEXT);
         m_pLastNewIns->SetDVar(m_hiddenArgumentVar);
+#endif
     }
 
     CorInfoInitClassResult initOnFunctionStart = m_compHnd->initClass(NULL, NULL, METHOD_BEING_COMPILED_CONTEXT());

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -75,9 +75,16 @@ OPDEF(INTOP_LDLOCA, "ldloca", 3, 1, 0, InterpOpInt)
 OPDEF(INTOP_SWITCH, "switch", 0, 0, 1, InterpOpSwitch)
 
 OPDEF(INTOP_SAFEPOINT, "safepoint", 1, 0, 0, InterpOpNoArgs)
+
+#ifdef PERFTRACING_DISABLE_THREADS
 OPDEF(INTOP_PROF_SAMPLEPOINT, "prof.samplepoint", 1, 0, 0, InterpOpNoArgs)
+#endif
+
+#if defined(TARGET_BROWSER) && defined(PERFTRACING_DISABLE_THREADS)
 OPDEF(INTOP_PROF_ENTER, "prof.enter", 2, 0, 0, InterpOpMethodHandle)
 OPDEF(INTOP_PROF_LEAVE, "prof.leave", 1, 0, 0, InterpOpNoArgs)
+#endif
+
 OPDEF(INTOP_BR, "br", 2, 0, 0, InterpOpBranch)
 
 OPDEF(INTOP_BRFALSE_I4, "brfalse.i4", 3, 0, 1, InterpOpBranch)

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -437,8 +437,14 @@ OPDEF(INTOP_ZEROBLK_IMM, "zeroblk.imm", 3, 0, 1, InterpOpInt)
 OPDEF(INTOP_INITBLK, "initblk", 4, 0, 3, InterpOpNoArgs)
 OPDEF(INTOP_CPBLK, "cpblk", 4, 0, 3, InterpOpNoArgs)
 OPDEF(INTOP_LOCALLOC, "localloc", 3, 1, 1, InterpOpNoArgs)
+
+#ifdef DEBUGGING_SUPPORTED
 OPDEF(INTOP_BREAKPOINT, "breakpoint", 1, 0, 0, InterpOpNoArgs)
+#endif
+
+#ifdef DEBUG
 OPDEF(INTOP_HALT, "halt", 1, 0, 0, InterpOpNoArgs)
+#endif
 
 OPDEF(INTOP_THROW, "throw", 4, 0, 1, InterpOpInt)
 OPDEF(INTOP_RETHROW, "rethrow", 1, 0, 0, InterpOpInt)
@@ -475,9 +481,15 @@ OPDEF(INTOP_EXCHANGEADD_I4, "exchangeadd.i4", 4, 1, 2, InterpOpNoArgs)
 OPDEF(INTOP_EXCHANGEADD_I8, "exchangeadd.i8", 4, 1, 2, InterpOpNoArgs)
 OPDEF(INTOP_SQRT_R4, "sqrt.r4", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_SQRT_R8, "sqrt.r8", 3, 1, 1, InterpOpNoArgs)
+
+#ifndef FEATURE_PORTABLE_ENTRYPOINTS
 OPDEF(INTOP_STORESTUBCONTEXT, "storestubcontext", 2, 1, 0, InterpOpNoArgs)
+#endif
+
+#ifdef DEBUGGING_SUPPORTED
 OPDEF(INTOP_DEBUG_METHOD_ENTER, "debug.method.enter", 2, 0, 0, InterpOpInt)
 OPDEF(INTOP_DEBUG_SEQ_POINT, "debug.seq.point", 1, 0, 0, InterpOpNoArgs)
+#endif
 
 // All instructions after this point are IROPS, instructions that are not emitted/executed
 OPDEF(INTOP_NOP, "nop", 1, 0, 0, InterpOpNoArgs)

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -6,6 +6,8 @@
 // are stored in uint32_t slots in the instruction stream for simplicity. In the future
 // we should add compact opcodes where all data is in uint16_t slots.
 
+OPDEF(INTOP_INVALID, "invalid", 1, 0, 0, InterpOpNoArgs)
+
 OPDEF(INTOP_RET, "ret", 2, 0, 1, InterpOpNoArgs)
 OPDEF(INTOP_RET_I1, "ret.i1", 2, 0, 1, InterpOpNoArgs)
 OPDEF(INTOP_RET_U1, "ret.u1", 2, 0, 1, InterpOpNoArgs)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -847,7 +847,7 @@ NOINLINE static void InterpThrow(InterpMethodContextFrame* pFrame, const int32_t
 
 // When enabled, each opcode dispatches directly to the next one via an indirect goto,
 // avoiding the overhead of the central switch dispatch.
-#if (defined(__GNUC__) || defined(__clang__)) && !defined(TARGET_WASM) && !defined(DEBUG)
+#if !defined(TARGET_WINDOWS) && !defined(TARGET_WASM) && !defined(DEBUG)
 #define USE_COMPUTED_GOTO 1
 #endif
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -4721,6 +4721,7 @@ do                                                                      \
 #if USE_COMPUTED_GOTO
                 // Labels for IR-only opcodes that are never emitted.
                 // The dispatch table needs valid labels for all enum values.
+                INTOP_CASE(INTOP_INVALID)
                 INTOP_CASE(INTOP_NOP)
                 INTOP_CASE(INTOP_DEF)
                 INTOP_CASE(INTOP_MOV_SRC_OFF)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -4719,20 +4719,8 @@ do                                                                      \
                     INTOP_NEXT;
                 }
 #if USE_COMPUTED_GOTO
-                // Labels for opcodes that are conditionally compiled out or never emitted.
+                // Labels for IR-only opcodes that are never emitted.
                 // The dispatch table needs valid labels for all enum values.
-#ifndef DEBUG
-                INTOP_CASE(INTOP_HALT)
-#endif
-#ifndef DEBUGGING_SUPPORTED
-                INTOP_CASE(INTOP_BREAKPOINT)
-                INTOP_CASE(INTOP_DEBUG_METHOD_ENTER)
-                INTOP_CASE(INTOP_DEBUG_SEQ_POINT)
-#endif
-#ifdef FEATURE_PORTABLE_ENTRYPOINTS
-                INTOP_CASE(INTOP_STORESTUBCONTEXT)
-#endif
-                // IR-only opcodes (never emitted to bytecode)
                 INTOP_CASE(INTOP_NOP)
                 INTOP_CASE(INTOP_DEF)
                 INTOP_CASE(INTOP_MOV_SRC_OFF)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -835,6 +835,22 @@ static void InterpBreakpoint(const int32_t *ip, const InterpMethodContextFrame *
 #define LOCAL_VAR(offset,type) (*LOCAL_VAR_ADDR(offset, type))
 #define NULL_CHECK(o) do { if ((o) == NULL) { COMPlusThrow(kNullReferenceException); } } while (0)
 
+// When enabled, each opcode dispatches directly to the next one via an indirect goto,
+// avoiding the overhead of the central switch dispatch.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(TARGET_WASM) && !defined(DEBUG)
+#define USE_COMPUTED_GOTO 1
+#endif
+
+#if USE_COMPUTED_GOTO
+#define INTOP_CASE(x) LABEL_ ## x:
+#define INTOP_DISPATCH(op) pFrame->ip = op; opcode = (uint32_t)(op); goto *s_dispatchTable[opcode]
+#define INTOP_NEXT INTOP_DISPATCH(ip[0])
+#else
+#define INTOP_CASE(x) case x:
+#define INTOP_DISPATCH(op) opcode = (uint32_t)(op); goto SWITCH_OPCODE
+#define INTOP_NEXT break
+#endif // USE_COMPUTED_GOTO
+
 
 static OBJECTREF CreateMultiDimArray(MethodTable* arrayClass, int8_t* stack, int32_t dimsOffset, int numArgs)
 {
@@ -1385,6 +1401,15 @@ void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFr
     MethodDesc* targetMethod;
     uint32_t opcode;
 
+#if USE_COMPUTED_GOTO
+    static const void* const s_dispatchTable[] = {
+        #define OPDEF(a,b,c,d,e,f) &&LABEL_ ## a,
+        #include "intops.def"
+        #undef OPDEF
+    };
+    static_assert(sizeof(s_dispatchTable) / sizeof(s_dispatchTable[0]) == INTOP_LAST, "Dispatch table size mismatch");
+#endif // USE_COMPUTED_GOTO
+
 MAIN_LOOP:
     try
     {
@@ -1392,26 +1417,23 @@ MAIN_LOOP:
         INSTALL_UNWIND_AND_CONTINUE_HANDLER;
         while (true)
         {
-            // Interpreter-TODO: This is only needed to enable SOS see the exact location in the interpreted method.
-            // Neither the GC nor the managed debugger needs that as they walk the stack when the runtime is suspended
-            // and we can save the IP to the frame at the suspension time.
-            // It will be useful for testing e.g. the debug info at various locations in the current method, so let's
-            // keep it for such purposes until we don't need it anymore.
+#if USE_COMPUTED_GOTO
+            INTOP_NEXT;
+#else
             pFrame->ip = (int32_t*)ip;
             opcode = ip[0];
-#ifdef DEBUGGING_SUPPORTED
 SWITCH_OPCODE:
-#endif // DEBUGGING_SUPPORTED
             switch (opcode)
             {
+#endif // !USE_COMPUTED_GOTO
 #ifdef DEBUG
-                case INTOP_HALT:
+                INTOP_CASE(INTOP_HALT)
                     InterpHalt();
                     ip++;
-                    break;
+                    INTOP_NEXT;
 #endif // DEBUG
 #ifdef DEBUGGING_SUPPORTED
-                case INTOP_BREAKPOINT:
+                INTOP_CASE(INTOP_BREAKPOINT)
                 {
                     LOG((LF_CORDB, LL_INFO10000, "InterpExecMethod: Hit breakpoint at IP %p\n", ip));
                     InterpBreakpoint(ip, pFrame, stack, pInterpreterFrame);
@@ -1423,15 +1445,14 @@ SWITCH_OPCODE:
                     {
                         LOG((LF_CORDB, LL_INFO10000, "InterpExecMethod: Post-callback bypass at IP %p with opcode 0x%x\n", ip, bypassOpcode));
                         pThreadContext->ClearBypass();
-                        opcode = bypassOpcode;
-                        goto SWITCH_OPCODE;
+                        INTOP_DISPATCH(bypassOpcode);
                     }
 
                     // No bypass
                     LOG((LF_CORDB, LL_INFO10000, "InterpExecMethod: No bypass after callback at IP %p - staying on breakpoint\n", ip));
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_DEBUG_METHOD_ENTER:
+                INTOP_CASE(INTOP_DEBUG_METHOD_ENTER)
                 {
                     if (CORDebuggerAttached() && g_pDebugInterface != NULL && g_pDebugInterface->IsMethodEnterEnabled())
                     {
@@ -1447,101 +1468,101 @@ SWITCH_OPCODE:
                         g_pDebugInterface->OnMethodEnter((void*)callbackIp);
                     }
                     ip += 2;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_DEBUG_SEQ_POINT:
+                INTOP_CASE(INTOP_DEBUG_SEQ_POINT)
                     ip++;
-                    break;
+                    INTOP_NEXT;
 #endif // DEBUGGING_SUPPORTED
-                case INTOP_INITLOCALS:
+                INTOP_CASE(INTOP_INITLOCALS)
                     memset(LOCAL_VAR_ADDR(ip[1], void), 0, ip[2]);
                     ip += 3;
-                    break;
-                case INTOP_MEMBAR:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_MEMBAR)
                     MemoryBarrier();
                     ip++;
-                    break;
+                    INTOP_NEXT;
 #ifndef FEATURE_PORTABLE_ENTRYPOINTS
-                case INTOP_STORESTUBCONTEXT:
+                INTOP_CASE(INTOP_STORESTUBCONTEXT)
                 {
                     UMEntryThunkData* thunkData = GetMostRecentUMEntryThunkData();
                     _ASSERTE(thunkData);
                     LOCAL_VAR(ip[1], void*) = thunkData;
                     ip += 2;
-                    break;
+                    INTOP_NEXT;
                 }
 #endif // !FEATURE_PORTABLE_ENTRYPOINTS
-                case INTOP_LDC_I4:
+                INTOP_CASE(INTOP_LDC_I4)
                     LOCAL_VAR(ip[1], int32_t) = ip[2];
                     ip += 3;
-                    break;
-                case INTOP_LDC_I4_0:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDC_I4_0)
                     LOCAL_VAR(ip[1], int32_t) = 0;
                     ip += 2;
-                    break;
-                case INTOP_LDC_I8_0:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDC_I8_0)
                     LOCAL_VAR(ip[1], int64_t) = 0;
                     ip += 2;
-                    break;
-                case INTOP_LDC_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDC_I8)
                     LOCAL_VAR(ip[1], int64_t) = (int64_t)(uint32_t)ip[2] + ((int64_t)ip[3] << 32);
                     ip += 4;
-                    break;
-                case INTOP_LDC_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDC_R4)
                     LOCAL_VAR(ip[1], int32_t) = ip[2];
                     ip += 3;
-                    break;
-                case INTOP_LDC_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDC_R8)
                     LOCAL_VAR(ip[1], int64_t) = (int64_t)(uint32_t)ip[2] + ((int64_t)ip[3] << 32);
                     ip += 4;
-                    break;
-                case INTOP_LDPTR:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDPTR)
                     LOCAL_VAR(ip[1], void*) = pMethod->pDataItems[ip[2]];
                     ip += 3;
-                    break;
-                case INTOP_LDPTR_DEREF:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDPTR_DEREF)
                     LOCAL_VAR(ip[1], void*) = *(void**)pMethod->pDataItems[ip[2]];
                     ip += 3;
-                    break;
-                case INTOP_NULLCHECK:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_NULLCHECK)
                     NULL_CHECK(LOCAL_VAR(ip[1], void*));
                     ip += 2;
-                    break;
-                case INTOP_RET:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_RET)
                     // Return stack slot sized value
                     *(int64_t*)pFrame->pRetVal = LOCAL_VAR(ip[1], int64_t);
                     goto EXIT_FRAME;
-                case INTOP_RET_I1:
+                INTOP_CASE(INTOP_RET_I1)
                     // Return int8 value
                     *(int64_t*)pFrame->pRetVal = (int8_t)LOCAL_VAR(ip[1], int32_t);
                     goto EXIT_FRAME;
-                case INTOP_RET_U1:
+                INTOP_CASE(INTOP_RET_U1)
                     // Return uint8 value
                     *(int64_t*)pFrame->pRetVal = (uint8_t)LOCAL_VAR(ip[1], int32_t);
                     goto EXIT_FRAME;
-                case INTOP_RET_I2:
+                INTOP_CASE(INTOP_RET_I2)
                     // Return int16 value
                     *(int64_t*)pFrame->pRetVal = (int16_t)LOCAL_VAR(ip[1], int32_t);
                     goto EXIT_FRAME;
-                case INTOP_RET_U2:
+                INTOP_CASE(INTOP_RET_U2)
                     // Return uint16 value
                     *(int64_t*)pFrame->pRetVal = (uint16_t)LOCAL_VAR(ip[1], int32_t);
                     goto EXIT_FRAME;
-                case INTOP_RET_VT:
+                INTOP_CASE(INTOP_RET_VT)
                     memmove(pFrame->pRetVal, LOCAL_VAR_ADDR(ip[1], void), ip[2]);
                     goto EXIT_FRAME;
-                case INTOP_RET_VOID:
+                INTOP_CASE(INTOP_RET_VOID)
                     goto EXIT_FRAME;
 
-                case INTOP_LDLOCA:
+                INTOP_CASE(INTOP_LDLOCA)
                     LOCAL_VAR(ip[1], void*) = LOCAL_VAR_ADDR(ip[2], void);
                     ip += 3;
-                    break;
-                case INTOP_LOAD_FRAMEVAR:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LOAD_FRAMEVAR)
                     _ASSERTE((pExceptionClauseArgs != NULL) && (pExceptionClauseArgs->isFilter));
                     LOCAL_VAR(ip[1], void*) = pExceptionClauseArgs->pFrame->pStack;
                     ip += 2;
-                    break;
+                    INTOP_NEXT;
 
 #define MOV(argtype1,argtype2) \
     LOCAL_VAR(ip [1], argtype1) = LOCAL_VAR(ip [2], argtype2); \
@@ -1550,356 +1571,356 @@ SWITCH_OPCODE:
                 // which is our minimum "register" size in interp. They are only needed when
                 // the address of the local is taken and we should try to optimize them out
                 // because the local can't be propagated.
-                case INTOP_MOV_I4_I1: MOV(int32_t, int8_t); break;
-                case INTOP_MOV_I4_U1: MOV(int32_t, uint8_t); break;
-                case INTOP_MOV_I4_I2: MOV(int32_t, int16_t); break;
-                case INTOP_MOV_I4_U2: MOV(int32_t, uint16_t); break;
+                INTOP_CASE(INTOP_MOV_I4_I1) MOV(int32_t, int8_t); INTOP_NEXT;
+                INTOP_CASE(INTOP_MOV_I4_U1) MOV(int32_t, uint8_t); INTOP_NEXT;
+                INTOP_CASE(INTOP_MOV_I4_I2) MOV(int32_t, int16_t); INTOP_NEXT;
+                INTOP_CASE(INTOP_MOV_I4_U2) MOV(int32_t, uint16_t); INTOP_NEXT;
                 // Normal moves between vars
-                case INTOP_MOV_4: MOV(int32_t, int32_t); break;
-                case INTOP_MOV_8: MOV(int64_t, int64_t); break;
+                INTOP_CASE(INTOP_MOV_4) MOV(int32_t, int32_t); INTOP_NEXT;
+                INTOP_CASE(INTOP_MOV_8) MOV(int64_t, int64_t); INTOP_NEXT;
 #undef MOV
 
-                case INTOP_MOV_VT:
+                INTOP_CASE(INTOP_MOV_VT)
                     memmove(LOCAL_VAR_ADDR(ip[1], void), LOCAL_VAR_ADDR(ip[2], void), ip[3]);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CKFINITE_R4:
+                INTOP_CASE(INTOP_CKFINITE_R4)
                     LOCAL_VAR(ip[1], float) = CkfiniteHelper(LOCAL_VAR(ip[2], float));
                     ip += 3;
-                    break;
-                case INTOP_CKFINITE_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CKFINITE_R8)
                     LOCAL_VAR(ip[1], double) = CkfiniteHelper(LOCAL_VAR(ip[2], double));
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_R8_UN_I4:
+                INTOP_CASE(INTOP_CONV_R8_UN_I4)
                     LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], uint32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_R8_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_R8_UN_I8)
                     LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], uint64_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_R4_UN_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_R4_UN_I4)
                     LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], uint32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_R4_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_R4_UN_I8)
                     LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], uint64_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I1_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I1_I4)
                     LOCAL_VAR(ip[1], int32_t) = (int8_t)LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I1_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I1_I8)
                     LOCAL_VAR(ip[1], int32_t) = (int8_t)LOCAL_VAR(ip[2], int64_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I1_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I1_R4)
                     ConvFpHelper<int8_t, int32_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I1_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I1_R8)
                     ConvFpHelper<int8_t, int32_t, double>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U1_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U1_I4)
                     LOCAL_VAR(ip[1], int32_t) = (uint8_t)LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U1_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U1_I8)
                     LOCAL_VAR(ip[1], int32_t) = (uint8_t)LOCAL_VAR(ip[2], int64_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U1_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U1_R4)
                     ConvFpHelper<uint8_t, int32_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U1_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U1_R8)
                     ConvFpHelper<uint8_t, int32_t, double>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I2_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I2_I4)
                     LOCAL_VAR(ip[1], int32_t) = (int16_t)LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I2_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I2_I8)
                     LOCAL_VAR(ip[1], int32_t) = (int16_t)LOCAL_VAR(ip[2], int64_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I2_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I2_R4)
                     ConvFpHelper<int16_t, int32_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I2_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I2_R8)
                     ConvFpHelper<int16_t, int32_t, double>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U2_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U2_I4)
                     LOCAL_VAR(ip[1], int32_t) = (uint16_t)LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U2_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U2_I8)
                     LOCAL_VAR(ip[1], int32_t) = (uint16_t)LOCAL_VAR(ip[2], int64_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U2_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U2_R4)
                     ConvFpHelper<uint16_t, int32_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U2_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U2_R8)
                     ConvFpHelper<uint16_t, int32_t, double>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I4_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I4_R4)
                     ConvFpHelper<int32_t, int32_t, float>(stack, ip);
                     ip += 3;
-                    break;;
-                case INTOP_CONV_I4_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I4_R8)
                     ConvFpHelper<int32_t, int32_t, double>(stack, ip);
                     ip += 3;
-                    break;;
-                case INTOP_CONV_U4_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U4_R4)
                     ConvFpHelper<uint32_t, uint32_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U4_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U4_R8)
                     ConvFpHelper<uint32_t, uint32_t, double>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I8_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I8_I4)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I8_U4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I8_U4)
                     LOCAL_VAR(ip[1], int64_t) = (uint32_t)LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;;
-                case INTOP_CONV_I8_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I8_R4)
                     ConvFpHelper<int64_t, int64_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_I8_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_I8_R8)
                     ConvFpHelper<int64_t, int64_t, double>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_R4_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_R4_I4)
                     LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_R4_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_R4_I8)
                     LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], int64_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_R4_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_R4_R8)
                     LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], double);
                     ip += 3;
-                    break;
-                case INTOP_CONV_R8_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_R8_I4)
                     LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_R8_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_R8_I8)
                     LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], int64_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_R8_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_R8_R4)
                     LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], float);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U8_U4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U8_U4)
                     LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint32_t);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U8_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U8_R4)
                     ConvFpHelper<uint64_t, uint64_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U8_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U8_R8)
                     ConvFpHelper<uint64_t, uint64_t, double>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_I1_I4:
+                INTOP_CASE(INTOP_CONV_OVF_I1_I4)
                     ConvOvfHelper<int8_t, int32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I1_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I1_I8)
                     ConvOvfHelper<int8_t, int64_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I1_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I1_R4)
                     ConvOvfFpHelper<int8_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I1_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I1_R8)
                     ConvOvfFpHelper<int8_t, double>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_U1_I4:
+                INTOP_CASE(INTOP_CONV_OVF_U1_I4)
                     ConvOvfHelper<uint8_t, int32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U1_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U1_I8)
                     ConvOvfHelper<uint8_t, int64_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U1_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U1_R4)
                     ConvOvfFpHelper<uint8_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U1_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U1_R8)
                     ConvOvfFpHelper<uint8_t, double>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_I2_I4:
+                INTOP_CASE(INTOP_CONV_OVF_I2_I4)
                     ConvOvfHelper<int16_t, int32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I2_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I2_I8)
                     ConvOvfHelper<int16_t, int64_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I2_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I2_R4)
                     ConvOvfFpHelper<int16_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I2_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I2_R8)
                     ConvOvfFpHelper<int16_t, double>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_U2_I4:
+                INTOP_CASE(INTOP_CONV_OVF_U2_I4)
                     ConvOvfHelper<uint16_t, int32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U2_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U2_I8)
                     ConvOvfHelper<uint16_t, int64_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U2_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U2_R4)
                     ConvOvfFpHelper<uint16_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U2_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U2_R8)
                     ConvOvfFpHelper<uint16_t, double>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_I4_U4:
+                INTOP_CASE(INTOP_CONV_OVF_I4_U4)
                     ConvOvfHelper<int32_t, uint32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I4_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I4_I8)
                     ConvOvfHelper<int32_t, int64_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I4_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I4_R4)
                     ConvOvfFpHelper<int32_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I4_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I4_R8)
                     ConvOvfFpHelper<int32_t, double>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_U4_I4:
+                INTOP_CASE(INTOP_CONV_OVF_U4_I4)
                     ConvOvfHelper<uint32_t, int32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U4_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U4_I8)
                     ConvOvfHelper<uint32_t, int64_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U4_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U4_R4)
                     ConvOvfFpHelper<uint32_t, float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U4_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U4_R8)
                     ConvOvfFpHelper<uint32_t, double>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_I8_U8:
+                INTOP_CASE(INTOP_CONV_OVF_I8_U8)
                     ConvOvfHelper<int64_t, uint64_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I8_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I8_R4)
                     ConvOvfFpHelperI64<float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I8_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I8_R8)
                     ConvOvfFpHelperI64<double>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_U8_I4:
+                INTOP_CASE(INTOP_CONV_OVF_U8_I4)
                     ConvOvfHelper<uint64_t, int32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U8_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U8_I8)
                     ConvOvfHelper<uint64_t, int64_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U8_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U8_R4)
                     ConvOvfFpHelperU64<float>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U8_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U8_R8)
                     ConvOvfFpHelperU64<double>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_I1_U4:
+                INTOP_CASE(INTOP_CONV_OVF_I1_U4)
                     ConvOvfHelper<int8_t, uint32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I1_U8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I1_U8)
                     ConvOvfHelper<int8_t, uint64_t>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_U1_U4:
+                INTOP_CASE(INTOP_CONV_OVF_U1_U4)
                     ConvOvfHelper<uint8_t, uint32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U1_U8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U1_U8)
                     ConvOvfHelper<uint8_t, uint64_t>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_I2_U4:
+                INTOP_CASE(INTOP_CONV_OVF_I2_U4)
                     ConvOvfHelper<int16_t, uint32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_I2_U8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_I2_U8)
                     ConvOvfHelper<int16_t, uint64_t>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_U2_U4:
+                INTOP_CASE(INTOP_CONV_OVF_U2_U4)
                     ConvOvfHelper<uint16_t, uint32_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_OVF_U2_U8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_OVF_U2_U8)
                     ConvOvfHelper<uint16_t, uint64_t>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_I4_U8:
+                INTOP_CASE(INTOP_CONV_OVF_I4_U8)
                     ConvOvfHelper<int32_t, uint64_t>(stack, ip);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CONV_OVF_U4_U8:
+                INTOP_CASE(INTOP_CONV_OVF_U4_U8)
                     ConvOvfHelper<uint32_t, uint64_t>(stack, ip);
                     ip += 3;
-                    break;
-                case INTOP_CONV_U4_U8_SAT:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CONV_U4_U8_SAT)
                 {
                     uint64_t val = LOCAL_VAR(ip[2], uint64_t);
                     if (val > UINT32_MAX)
@@ -1907,9 +1928,9 @@ SWITCH_OPCODE:
                     else
                         LOCAL_VAR(ip[1], uint32_t) = (uint32_t)val;
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_SWITCH:
+                INTOP_CASE(INTOP_SWITCH)
                 {
                     uint32_t val = LOCAL_VAR(ip[1], uint32_t);
                     uint32_t n = ip[2];
@@ -1923,10 +1944,10 @@ SWITCH_OPCODE:
                     {
                         ip += n;
                     }
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_SAFEPOINT:
+                INTOP_CASE(INTOP_SAFEPOINT)
                     if (g_TrapReturningThreads)
                     {
                         Thread *pThread = GetThread();
@@ -1942,30 +1963,30 @@ SWITCH_OPCODE:
                         GCX_PREEMP();
                     }
                     ip++;
-                    break;
+                    INTOP_NEXT;
 
 #ifdef PERFTRACING_DISABLE_THREADS
-                case INTOP_PROF_SAMPLEPOINT:
+                INTOP_CASE(INTOP_PROF_SAMPLEPOINT)
                     SamplingProfiler_OnSamplepoint();
                     ip++;
-                    break;
+                    INTOP_NEXT;
 #endif // PERFTRACING_DISABLE_THREADS
 
 #if defined(TARGET_BROWSER) && defined(PERFTRACING_DISABLE_THREADS)
-                case INTOP_PROF_ENTER:
+                INTOP_CASE(INTOP_PROF_ENTER)
                     BrowserProfiler_OnMethodEnter(pMethod->pDataItems[ip[1]]);
                     ip += 2;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_PROF_LEAVE:
+                INTOP_CASE(INTOP_PROF_LEAVE)
                     BrowserProfiler_OnMethodLeave(pMethod->methodHnd);
                     ip++;
-                    break;
+                    INTOP_NEXT;
 #endif // TARGET_BROWSER && PERFTRACING_DISABLE_THREADS
 
-                case INTOP_BR:
+                INTOP_CASE(INTOP_BR)
                     ip += ip[1];
-                    break;
+                    INTOP_NEXT;
 
 #define BR_UNOP(datatype, op)           \
     if (LOCAL_VAR(ip[1], datatype) op)  \
@@ -1973,18 +1994,18 @@ SWITCH_OPCODE:
     else \
         ip += 3;
 
-                case INTOP_BRFALSE_I4:
+                INTOP_CASE(INTOP_BRFALSE_I4)
                     BR_UNOP(int32_t, == 0);
-                    break;
-                case INTOP_BRFALSE_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BRFALSE_I8)
                     BR_UNOP(int64_t, == 0);
-                    break;
-                case INTOP_BRTRUE_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BRTRUE_I4)
                     BR_UNOP(int32_t, != 0);
-                    break;
-                case INTOP_BRTRUE_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BRTRUE_I8)
                     BR_UNOP(int64_t, != 0);
-                    break;
+                    INTOP_NEXT;
 #undef BR_UNOP
 
 #define BR_BINOP_COND(cond) \
@@ -1996,234 +2017,234 @@ SWITCH_OPCODE:
 #define BR_BINOP(datatype, op) \
     BR_BINOP_COND(LOCAL_VAR(ip[1], datatype) op LOCAL_VAR(ip[2], datatype))
 
-                case INTOP_BEQ_I4:
+                INTOP_CASE(INTOP_BEQ_I4)
                     BR_BINOP(int32_t, ==);
-                    break;
-                case INTOP_BEQ_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BEQ_I8)
                     BR_BINOP(int64_t, ==);
-                    break;
-                case INTOP_BEQ_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BEQ_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(!isunordered(f1, f2) && f1 == f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BEQ_R8:
+                INTOP_CASE(INTOP_BEQ_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(!isunordered(d1, d2) && d1 == d2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BGE_I4:
+                INTOP_CASE(INTOP_BGE_I4)
                     BR_BINOP(int32_t, >=);
-                    break;
-                case INTOP_BGE_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BGE_I8)
                     BR_BINOP(int64_t, >=);
-                    break;
-                case INTOP_BGE_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BGE_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(!isunordered(f1, f2) && f1 >= f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BGE_R8:
+                INTOP_CASE(INTOP_BGE_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(!isunordered(d1, d2) && d1 >= d2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BGT_I4:
+                INTOP_CASE(INTOP_BGT_I4)
                     BR_BINOP(int32_t, >);
-                    break;
-                case INTOP_BGT_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BGT_I8)
                     BR_BINOP(int64_t, >);
-                    break;
-                case INTOP_BGT_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BGT_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(!isunordered(f1, f2) && f1 > f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BGT_R8:
+                INTOP_CASE(INTOP_BGT_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(!isunordered(d1, d2) && d1 > d2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BLT_I4:
+                INTOP_CASE(INTOP_BLT_I4)
                     BR_BINOP(int32_t, <);
-                    break;
-                case INTOP_BLT_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BLT_I8)
                     BR_BINOP(int64_t, <);
-                    break;
-                case INTOP_BLT_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BLT_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(!isunordered(f1, f2) && f1 < f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BLT_R8:
+                INTOP_CASE(INTOP_BLT_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(!isunordered(d1, d2) && d1 < d2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BLE_I4:
+                INTOP_CASE(INTOP_BLE_I4)
                     BR_BINOP(int32_t, <=);
-                    break;
-                case INTOP_BLE_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BLE_I8)
                     BR_BINOP(int64_t, <=);
-                    break;
-                case INTOP_BLE_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BLE_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(!isunordered(f1, f2) && f1 <= f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BLE_R8:
+                INTOP_CASE(INTOP_BLE_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(!isunordered(d1, d2) && d1 <= d2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BNE_UN_I4:
+                INTOP_CASE(INTOP_BNE_UN_I4)
                     BR_BINOP(uint32_t, !=);
-                    break;
-                case INTOP_BNE_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BNE_UN_I8)
                     BR_BINOP(uint64_t, !=);
-                    break;
-                case INTOP_BNE_UN_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BNE_UN_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(isunordered(f1, f2) || f1 != f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BNE_UN_R8:
+                INTOP_CASE(INTOP_BNE_UN_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(isunordered(d1, d2) || d1 != d2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BGE_UN_I4:
+                INTOP_CASE(INTOP_BGE_UN_I4)
                     BR_BINOP(uint32_t, >=);
-                    break;
-                case INTOP_BGE_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BGE_UN_I8)
                     BR_BINOP(uint64_t, >=);
-                    break;
-                case INTOP_BGE_UN_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BGE_UN_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(isunordered(f1, f2) || f1 >= f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BGE_UN_R8:
+                INTOP_CASE(INTOP_BGE_UN_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(isunordered(d1, d2) || d1 >= d2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BGT_UN_I4:
+                INTOP_CASE(INTOP_BGT_UN_I4)
                     BR_BINOP(uint32_t, >);
-                    break;
-                case INTOP_BGT_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BGT_UN_I8)
                     BR_BINOP(uint64_t, >);
-                    break;
-                case INTOP_BGT_UN_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BGT_UN_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(isunordered(f1, f2) || f1 > f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BGT_UN_R8:
+                INTOP_CASE(INTOP_BGT_UN_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(isunordered(d1, d2) || d1 > d2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BLE_UN_I4:
+                INTOP_CASE(INTOP_BLE_UN_I4)
                     BR_BINOP(uint32_t, <=);
-                    break;
-                case INTOP_BLE_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BLE_UN_I8)
                     BR_BINOP(uint64_t, <=);
-                    break;
-                case INTOP_BLE_UN_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BLE_UN_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(isunordered(f1, f2) || f1 <= f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BLE_UN_R8:
+                INTOP_CASE(INTOP_BLE_UN_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(isunordered(d1, d2) || d1 <= d2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BLT_UN_I4:
+                INTOP_CASE(INTOP_BLT_UN_I4)
                     BR_BINOP(uint32_t, <);
-                    break;
-                case INTOP_BLT_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BLT_UN_I8)
                     BR_BINOP(uint64_t, <);
-                    break;
-                case INTOP_BLT_UN_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_BLT_UN_R4)
                 {
                     float f1 = LOCAL_VAR(ip[1], float);
                     float f2 = LOCAL_VAR(ip[2], float);
                     BR_BINOP_COND(isunordered(f1, f2) || f1 < f2);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_BLT_UN_R8:
+                INTOP_CASE(INTOP_BLT_UN_R8)
                 {
                     double d1 = LOCAL_VAR(ip[1], double);
                     double d2 = LOCAL_VAR(ip[2], double);
                     BR_BINOP_COND(isunordered(d1, d2) || d1 < d2);
-                    break;
+                    INTOP_NEXT;
                 }
 #undef BR_BINOP_COND
 #undef BR_BINOP
 
-                case INTOP_ADD_I4:
+                INTOP_CASE(INTOP_ADD_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) + LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_ADD_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_ADD_I8)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) + LOCAL_VAR(ip[3], int64_t);
                     ip += 4;
-                    break;
-                case INTOP_ADD_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_ADD_R4)
                     LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) + LOCAL_VAR(ip[3], float);
                     ip += 4;
-                    break;
-                case INTOP_ADD_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_ADD_R8)
                     LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) + LOCAL_VAR(ip[3], double);
                     ip += 4;
-                    break;
-                case INTOP_ADD_I4_IMM:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_ADD_I4_IMM)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) + ip[3];
                     ip += 4;
-                    break;
-                case INTOP_ADD_I8_IMM:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_ADD_I8_IMM)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) + ip[3];
                     ip += 4;
-                    break;
-                case INTOP_ADD_OVF_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_ADD_OVF_I4)
                 {
                     int32_t i1 = LOCAL_VAR(ip[2], int32_t);
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
@@ -2232,9 +2253,9 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_ADD_OVF_I8:
+                INTOP_CASE(INTOP_ADD_OVF_I8)
                 {
                     int64_t i1 = LOCAL_VAR(ip[2], int64_t);
                     int64_t i2 = LOCAL_VAR(ip[3], int64_t);
@@ -2243,9 +2264,9 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_ADD_OVF_UN_I4:
+                INTOP_CASE(INTOP_ADD_OVF_UN_I4)
                 {
                     uint32_t i1 = LOCAL_VAR(ip[2], uint32_t);
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
@@ -2254,9 +2275,9 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], uint32_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_ADD_OVF_UN_I8:
+                INTOP_CASE(INTOP_ADD_OVF_UN_I8)
                 {
                     uint64_t i1 = LOCAL_VAR(ip[2], uint64_t);
                     uint64_t i2 = LOCAL_VAR(ip[3], uint64_t);
@@ -2265,26 +2286,26 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], uint64_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_SUB_I4:
+                INTOP_CASE(INTOP_SUB_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) - LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_SUB_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_SUB_I8)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) - LOCAL_VAR(ip[3], int64_t);
                     ip += 4;
-                    break;
-                case INTOP_SUB_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_SUB_R4)
                     LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) - LOCAL_VAR(ip[3], float);
                     ip += 4;
-                    break;
-                case INTOP_SUB_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_SUB_R8)
                     LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) - LOCAL_VAR(ip[3], double);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_SUB_OVF_I4:
+                INTOP_CASE(INTOP_SUB_OVF_I4)
                 {
                     int32_t i1 = LOCAL_VAR(ip[2], int32_t);
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
@@ -2293,9 +2314,9 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_SUB_OVF_I8:
+                INTOP_CASE(INTOP_SUB_OVF_I8)
                 {
                     int64_t i1 = LOCAL_VAR(ip[2], int64_t);
                     int64_t i2 = LOCAL_VAR(ip[3], int64_t);
@@ -2304,9 +2325,9 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_SUB_OVF_UN_I4:
+                INTOP_CASE(INTOP_SUB_OVF_UN_I4)
                 {
                     uint32_t i1 = LOCAL_VAR(ip[2], uint32_t);
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
@@ -2315,9 +2336,9 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], uint32_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_SUB_OVF_UN_I8:
+                INTOP_CASE(INTOP_SUB_OVF_UN_I8)
                 {
                     uint64_t i1 = LOCAL_VAR(ip[2], uint64_t);
                     uint64_t i2 = LOCAL_VAR(ip[3], uint64_t);
@@ -2326,26 +2347,26 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], uint64_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_MUL_I4:
+                INTOP_CASE(INTOP_MUL_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) * LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_MUL_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_MUL_I8)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) * LOCAL_VAR(ip[3], int64_t);
                     ip += 4;
-                    break;
-                case INTOP_MUL_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_MUL_R4)
                     LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) * LOCAL_VAR(ip[3], float);
                     ip += 4;
-                    break;
-                case INTOP_MUL_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_MUL_R8)
                     LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) * LOCAL_VAR(ip[3], double);
                     ip += 4;
-                    break;
-                case INTOP_MUL_OVF_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_MUL_OVF_I4)
                 {
                     int32_t i1 = LOCAL_VAR(ip[2], int32_t);
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
@@ -2354,10 +2375,10 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_MUL_OVF_I8:
+                INTOP_CASE(INTOP_MUL_OVF_I8)
                 {
                     int64_t i1 = LOCAL_VAR(ip[2], int64_t);
                     int64_t i2 = LOCAL_VAR(ip[3], int64_t);
@@ -2366,10 +2387,10 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_MUL_OVF_UN_I4:
+                INTOP_CASE(INTOP_MUL_OVF_UN_I4)
                 {
                     uint32_t i1 = LOCAL_VAR(ip[2], uint32_t);
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
@@ -2378,10 +2399,10 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], uint32_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_MUL_OVF_UN_I8:
+                INTOP_CASE(INTOP_MUL_OVF_UN_I8)
                 {
                     uint64_t i1 = LOCAL_VAR(ip[2], uint64_t);
                     uint64_t i2 = LOCAL_VAR(ip[3], uint64_t);
@@ -2390,9 +2411,9 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], uint64_t) = i3;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_DIV_I4:
+                INTOP_CASE(INTOP_DIV_I4)
                 {
                     int32_t i1 = LOCAL_VAR(ip[2], int32_t);
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
@@ -2402,9 +2423,9 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i1 / i2;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_DIV_I8:
+                INTOP_CASE(INTOP_DIV_I8)
                 {
                     int64_t l1 = LOCAL_VAR(ip[2], int64_t);
                     int64_t l2 = LOCAL_VAR(ip[3], int64_t);
@@ -2414,36 +2435,36 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = l1 / l2;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_DIV_R4:
+                INTOP_CASE(INTOP_DIV_R4)
                     LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) / LOCAL_VAR(ip[3], float);
                     ip += 4;
-                    break;
-                case INTOP_DIV_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_DIV_R8)
                     LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) / LOCAL_VAR(ip[3], double);
                     ip += 4;
-                    break;
-                case INTOP_DIV_UN_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_DIV_UN_I4)
                 {
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
                     if (i2 == 0)
                         COMPlusThrow(kDivideByZeroException);
                     LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) / i2;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_DIV_UN_I8:
+                INTOP_CASE(INTOP_DIV_UN_I8)
                 {
                     uint64_t l2 = LOCAL_VAR(ip[3], uint64_t);
                     if (l2 == 0)
                         COMPlusThrow(kDivideByZeroException);
                     LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) / l2;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_REM_I4:
+                INTOP_CASE(INTOP_REM_I4)
                 {
                     int32_t i1 = LOCAL_VAR(ip[2], int32_t);
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
@@ -2453,9 +2474,9 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i1 % i2;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_REM_I8:
+                INTOP_CASE(INTOP_REM_I8)
                 {
                     int64_t l1 = LOCAL_VAR(ip[2], int64_t);
                     int64_t l2 = LOCAL_VAR(ip[3], int64_t);
@@ -2465,109 +2486,109 @@ SWITCH_OPCODE:
                         COMPlusThrow(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = l1 % l2;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_REM_R4:
+                INTOP_CASE(INTOP_REM_R4)
                     LOCAL_VAR(ip[1], float) = fmodf(LOCAL_VAR(ip[2], float), LOCAL_VAR(ip[3], float));
                     ip += 4;
-                    break;
-                case INTOP_REM_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_REM_R8)
                     LOCAL_VAR(ip[1], double) = fmod(LOCAL_VAR(ip[2], double), LOCAL_VAR(ip[3], double));
                     ip += 4;
-                    break;
-                case INTOP_REM_UN_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_REM_UN_I4)
                 {
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
                     if (i2 == 0)
                         COMPlusThrow(kDivideByZeroException);
                     LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) % i2;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_REM_UN_I8:
+                INTOP_CASE(INTOP_REM_UN_I8)
                 {
                     uint64_t l2 = LOCAL_VAR(ip[3], uint64_t);
                     if (l2 == 0)
                         COMPlusThrow(kDivideByZeroException);
                     LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) % l2;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_SHL_I4:
+                INTOP_CASE(INTOP_SHL_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) << LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_SHL_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_SHL_I8)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) << LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_SHR_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_SHR_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) >> LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_SHR_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_SHR_I8)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) >> LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_SHR_UN_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_SHR_UN_I4)
                     LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) >> LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_SHR_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_SHR_UN_I8)
                     LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) >> LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_NEG_I4:
+                INTOP_CASE(INTOP_NEG_I4)
                     LOCAL_VAR(ip[1], int32_t) = - LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;
-                case INTOP_NEG_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_NEG_I8)
                     LOCAL_VAR(ip[1], int64_t) = - LOCAL_VAR(ip[2], int64_t);
                     ip += 3;
-                    break;
-                case INTOP_NEG_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_NEG_R4)
                     LOCAL_VAR(ip[1], float) = - LOCAL_VAR(ip[2], float);
                     ip += 3;
-                    break;
-                case INTOP_NEG_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_NEG_R8)
                     LOCAL_VAR(ip[1], double) = - LOCAL_VAR(ip[2], double);
                     ip += 3;
-                    break;
-                case INTOP_NOT_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_NOT_I4)
                     LOCAL_VAR(ip[1], int32_t) = ~ LOCAL_VAR(ip[2], int32_t);
                     ip += 3;
-                    break;
-                case INTOP_NOT_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_NOT_I8)
                     LOCAL_VAR(ip[1], int64_t) = ~ LOCAL_VAR(ip[2], int64_t);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_AND_I4:
+                INTOP_CASE(INTOP_AND_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) & LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_AND_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_AND_I8)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) & LOCAL_VAR(ip[3], int64_t);
                     ip += 4;
-                    break;
-                case INTOP_OR_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_OR_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) | LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_OR_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_OR_I8)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) | LOCAL_VAR(ip[3], int64_t);
                     ip += 4;
-                    break;
-                case INTOP_XOR_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_XOR_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) ^ LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_XOR_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_XOR_I8)
                     LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) ^ LOCAL_VAR(ip[3], int64_t);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
 
 #define CMP_BINOP_FP(datatype, op, noOrderVal)      \
     do {                                            \
@@ -2580,84 +2601,84 @@ SWITCH_OPCODE:
         ip += 4;                                    \
     } while (0)
 
-                case INTOP_CZERO_I:
+                INTOP_CASE(INTOP_CZERO_I)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], intptr_t) != 0;
                     ip += 4;
-                    break;
-                case INTOP_CEQ_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CEQ_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) == LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_CEQ_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CEQ_I8)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int64_t) == LOCAL_VAR(ip[3], int64_t);
                     ip += 4;
-                    break;
-                case INTOP_CEQ_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CEQ_R4)
                     CMP_BINOP_FP(float, ==, 0);
-                    break;
-                case INTOP_CEQ_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CEQ_R8)
                     CMP_BINOP_FP(double, ==, 0);
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CGT_I4:
+                INTOP_CASE(INTOP_CGT_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) > LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_CGT_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CGT_I8)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int64_t) > LOCAL_VAR(ip[3], int64_t);
                     ip += 4;
-                    break;
-                case INTOP_CGT_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CGT_R4)
                     CMP_BINOP_FP(float, >, 0);
-                    break;
-                case INTOP_CGT_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CGT_R8)
                     CMP_BINOP_FP(double, >, 0);
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CGT_UN_I4:
+                INTOP_CASE(INTOP_CGT_UN_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint32_t) > LOCAL_VAR(ip[3], uint32_t);
                     ip += 4;
-                    break;
-                case INTOP_CGT_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CGT_UN_I8)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint64_t) > LOCAL_VAR(ip[3], uint64_t);
                     ip += 4;
-                    break;
-                case INTOP_CGT_UN_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CGT_UN_R4)
                     CMP_BINOP_FP(float, >, 1);
-                    break;
-                case INTOP_CGT_UN_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CGT_UN_R8)
                     CMP_BINOP_FP(double, >, 1);
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CLT_I4:
+                INTOP_CASE(INTOP_CLT_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) < LOCAL_VAR(ip[3], int32_t);
                     ip += 4;
-                    break;
-                case INTOP_CLT_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CLT_I8)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int64_t) < LOCAL_VAR(ip[3], int64_t);
                     ip += 4;
-                    break;
-                case INTOP_CLT_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CLT_R4)
                     CMP_BINOP_FP(float, <, 0);
-                    break;
-                case INTOP_CLT_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CLT_R8)
                     CMP_BINOP_FP(double, <, 0);
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_CLT_UN_I4:
+                INTOP_CASE(INTOP_CLT_UN_I4)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint32_t) < LOCAL_VAR(ip[3], uint32_t);
                     ip += 4;
-                    break;
-                case INTOP_CLT_UN_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CLT_UN_I8)
                     LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint64_t) < LOCAL_VAR(ip[3], uint64_t);
                     ip += 4;
-                    break;
-                case INTOP_CLT_UN_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CLT_UN_R4)
                     CMP_BINOP_FP(float, <, 1);
-                    break;
-                case INTOP_CLT_UN_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_CLT_UN_R8)
                     CMP_BINOP_FP(double, <, 1);
-                    break;
+                    INTOP_NEXT;
 #undef CMP_BINOP_FP
 
 #define LDIND(dtype, ftype)                                 \
@@ -2668,38 +2689,38 @@ SWITCH_OPCODE:
         ip += 4;                                            \
     } while (0)
 
-                case INTOP_LDIND_I1:
+                INTOP_CASE(INTOP_LDIND_I1)
                     LDIND(int32_t, int8_t);
-                    break;
-                case INTOP_LDIND_U1:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDIND_U1)
                     LDIND(int32_t, uint8_t);
-                    break;
-                case INTOP_LDIND_I2:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDIND_I2)
                     LDIND(int32_t, int16_t);
-                    break;
-                case INTOP_LDIND_U2:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDIND_U2)
                     LDIND(int32_t, uint16_t);
-                    break;
-                case INTOP_LDIND_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDIND_I4)
                     LDIND(int32_t, int32_t);
-                    break;
-                case INTOP_LDIND_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDIND_I8)
                     LDIND(int64_t, int64_t);
-                    break;
-                case INTOP_LDIND_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDIND_R4)
                     LDIND(float, float);
-                    break;
-                case INTOP_LDIND_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_LDIND_R8)
                     LDIND(double, double);
-                    break;
+                    INTOP_NEXT;
 #undef LDIND
-                case INTOP_LDIND_VT:
+                INTOP_CASE(INTOP_LDIND_VT)
                 {
                     char *src = LOCAL_VAR(ip[2], char*);
                     NULL_CHECK(src);
                     memcpy(LOCAL_VAR_ADDR(ip[1], void), (char*)src + ip[3], ip[4]);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
 #define STIND(dtype, ftype)                                         \
@@ -2711,66 +2732,66 @@ SWITCH_OPCODE:
         ip += 4;                                                    \
     } while (0)
 
-                case INTOP_STIND_I1:
+                INTOP_CASE(INTOP_STIND_I1)
                     STIND(int32_t, int8_t);
-                    break;
-                case INTOP_STIND_U1:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_STIND_U1)
                     STIND(int32_t, uint8_t);
-                    break;
-                case INTOP_STIND_I2:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_STIND_I2)
                     STIND(int32_t, int16_t);
-                    break;
-                case INTOP_STIND_U2:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_STIND_U2)
                     STIND(int32_t, uint16_t);
-                    break;
-                case INTOP_STIND_I4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_STIND_I4)
                     STIND(int32_t, int32_t);
-                    break;
-                case INTOP_STIND_I8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_STIND_I8)
                     STIND(int64_t, int64_t);
-                    break;
-                case INTOP_STIND_R4:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_STIND_R4)
                     STIND(float, float);
-                    break;
-                case INTOP_STIND_R8:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_STIND_R8)
                     STIND(double, double);
-                    break;
+                    INTOP_NEXT;
 #undef STIND
-                case INTOP_STIND_O:
+                INTOP_CASE(INTOP_STIND_O)
                 {
                     char *dst = LOCAL_VAR(ip[1], char*);
                     OBJECTREF storeObj = LOCAL_VAR(ip[2], OBJECTREF);
                     NULL_CHECK(dst);
                     SetObjectReferenceUnchecked((OBJECTREF*)(dst + ip[3]), storeObj);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STIND_VT_NOREF:
+                INTOP_CASE(INTOP_STIND_VT_NOREF)
                 {
                     char *dest = LOCAL_VAR(ip[1], char*);
                     NULL_CHECK(dest);
                     memcpyNoGCRefs(dest + ip[3], LOCAL_VAR_ADDR(ip[2], void), ip[4]);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STIND_VT:
+                INTOP_CASE(INTOP_STIND_VT)
                 {
                     MethodTable *pMT = (MethodTable*)pMethod->pDataItems[ip[4]];
                     char *dest = LOCAL_VAR(ip[1], char*);
                     NULL_CHECK(dest);
                     CopyValueClassUnchecked(dest + ip[3], LOCAL_VAR_ADDR(ip[2], void), pMT);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDFLDA:
+                INTOP_CASE(INTOP_LDFLDA)
                 {
                     char *src = LOCAL_VAR(ip[2], char*);
                     NULL_CHECK(src);
                     LOCAL_VAR(ip[1], char*) = src + ip[3];
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_CALL_HELPER_P_P:
+                INTOP_CASE(INTOP_CALL_HELPER_P_P)
                 {
                     void* helperArg = pMethod->pDataItems[ip[3]];
 
@@ -2793,10 +2814,10 @@ SWITCH_OPCODE:
 
                     LOCAL_VAR(ip[1], void*) = Call_HELPER_FTN_P_P(helperFtn, helperArg);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_P_S:
+                INTOP_CASE(INTOP_CALL_HELPER_P_S)
                 {
                     void* helperArg = LOCAL_VAR(ip[2], void*);
 
@@ -2818,10 +2839,10 @@ SWITCH_OPCODE:
 
                     LOCAL_VAR(ip[1], void*) = Call_HELPER_FTN_P_P(helperFtn, helperArg);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_P_PS:
+                INTOP_CASE(INTOP_CALL_HELPER_P_PS)
                 {
                     void* helperArg1 = pMethod->pDataItems[ip[4]];
                     void* helperArg2 = LOCAL_VAR(ip[2], void*);
@@ -2845,10 +2866,10 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     LOCAL_VAR(ip[1], void*) = Call_HELPER_FTN_P_PP(helperFtn, helperArg1, helperArg2);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_P_SP:
+                INTOP_CASE(INTOP_CALL_HELPER_P_SP)
                 {
                     void* helperArg1 = LOCAL_VAR(ip[2], void*);
                     void* helperArg2 = pMethod->pDataItems[ip[4]];
@@ -2872,10 +2893,10 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     LOCAL_VAR(ip[1], void*) = Call_HELPER_FTN_P_PP(helperFtn, helperArg1, helperArg2);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_P_G:
+                INTOP_CASE(INTOP_CALL_HELPER_P_G)
                 {
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[4]];
                     void* helperArg = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
@@ -2898,10 +2919,10 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     LOCAL_VAR(ip[1], void*) = Call_HELPER_FTN_P_P(helperFtn, helperArg);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_P_GS:
+                INTOP_CASE(INTOP_CALL_HELPER_P_GS)
                 {
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
                     void* helperArg1 = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
@@ -2926,10 +2947,10 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     LOCAL_VAR(ip[1], void*) = Call_HELPER_FTN_P_PP(helperFtn, helperArg1, helperArg2);
                     ip += 6;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_P_GA:
+                INTOP_CASE(INTOP_CALL_HELPER_P_GA)
                 {
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
                     void* helperArg1 = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
@@ -2954,10 +2975,10 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     LOCAL_VAR(ip[1], void*) = Call_HELPER_FTN_P_PP(helperFtn, helperArg1, helperArg2);
                     ip += 6;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_P_PA:
+                INTOP_CASE(INTOP_CALL_HELPER_P_PA)
                 {
                     void* helperArg1 = pMethod->pDataItems[ip[4]];
                     void* helperArg2 = LOCAL_VAR_ADDR(ip[2], void*);
@@ -2980,10 +3001,10 @@ SWITCH_OPCODE:
 
                     LOCAL_VAR(ip[1], void*) = Call_HELPER_FTN_P_PP(helperFtn, helperArg1, helperArg2);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_V_AGS:
+                INTOP_CASE(INTOP_CALL_HELPER_V_AGS)
                 {
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
                     void* helperArg1 = LOCAL_VAR_ADDR(ip[1], void*);
@@ -3010,10 +3031,10 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     Call_HELPER_FTN_V_PPP(helperFtn, helperArg1, helperArg2, helperArg3);
                     ip += 6;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_V_APS:
+                INTOP_CASE(INTOP_CALL_HELPER_V_APS)
                 {
                     void* helperArg1 = LOCAL_VAR_ADDR(ip[1], void*);
                     void* helperArg2 = pMethod->pDataItems[ip[4]];
@@ -3039,10 +3060,10 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     Call_HELPER_FTN_V_PPP(helperFtn, helperArg1, helperArg2, helperArg3);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_V_SA:
+                INTOP_CASE(INTOP_CALL_HELPER_V_SA)
                 {
                     void* helperArg1 = LOCAL_VAR(ip[1], void*);
                     void* helperArg2 = LOCAL_VAR_ADDR(ip[2], void*);
@@ -3066,9 +3087,9 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     Call_HELPER_FTN_V_PP(helperFtn, helperArg1, helperArg2);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_CALL_HELPER_V_SS:
+                INTOP_CASE(INTOP_CALL_HELPER_V_SS)
                 {
                     void* helperArg1 = LOCAL_VAR(ip[1], void*);
                     void* helperArg2 = LOCAL_VAR(ip[2], void*);
@@ -3091,10 +3112,10 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     Call_HELPER_FTN_V_PP(helperFtn, helperArg1, helperArg2);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_HELPER_V_SSS:
+                INTOP_CASE(INTOP_CALL_HELPER_V_SSS)
                 {
                     void* helperArg1 = LOCAL_VAR(ip[1], void*);
                     void* helperArg2 = LOCAL_VAR(ip[2], void*);
@@ -3119,11 +3140,11 @@ SWITCH_OPCODE:
                     _ASSERTE(helperFtn != NULL);
                     Call_HELPER_FTN_V_PPP(helperFtn, helperArg1, helperArg2, helperArg3);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALLVIRT_TAIL:
-                case INTOP_CALLVIRT:
+                INTOP_CASE(INTOP_CALLVIRT_TAIL)
+                INTOP_CASE(INTOP_CALLVIRT)
                 {
                     frameNeedsTailcallUpdate = (opcode == INTOP_CALLVIRT_TAIL);
                     returnOffset = ip[1];
@@ -3170,8 +3191,8 @@ SWITCH_OPCODE:
                     goto CALL_INTERP_METHOD;
                 }
 
-                case INTOP_CALLI_TAIL:
-                case INTOP_CALLI:
+                INTOP_CASE(INTOP_CALLI_TAIL)
+                INTOP_CASE(INTOP_CALLI)
                 {
                     frameNeedsTailcallUpdate = (opcode == INTOP_CALLI_TAIL);
                     returnOffset = ip[1];
@@ -3241,10 +3262,10 @@ SWITCH_OPCODE:
                         InvokeCalliStub(&param);
                     }
 
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_PINVOKE:
+                INTOP_CASE(INTOP_CALL_PINVOKE)
                 {
                     // This opcode handles p/invokes that don't use a managed wrapper for marshaling. These
                     //  calls are special in that they need an InlinedCallFrame in order for proper EH to happen
@@ -3277,11 +3298,11 @@ SWITCH_OPCODE:
                         InvokeUnmanagedMethodWithTransition(&param);
                     }
 
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALLDELEGATE_TAIL:
-                case INTOP_CALLDELEGATE:
+                INTOP_CASE(INTOP_CALLDELEGATE_TAIL)
+                INTOP_CASE(INTOP_CALLDELEGATE)
                 {
                     frameNeedsTailcallUpdate = (opcode == INTOP_CALLDELEGATE_TAIL);
                     returnOffset = ip[1];
@@ -3372,7 +3393,7 @@ SWITCH_OPCODE:
                             stack = pFrame->pStack;
                             ip = pFrame->startIp->GetByteCodes();
                             pThreadContext->pStackPointer = stack + pMethod->allocaSize;
-                            break;
+                            INTOP_NEXT;
                         }
                         else if (isOpenVirtual)
                         {
@@ -3403,15 +3424,17 @@ SWITCH_OPCODE:
                     frameNeedsTailcallUpdate = false;
                     DelegateInvokeMethodParam param = { targetMethod, callArgsAddress, returnValueAddress, targetAddress, pInterpreterFrame->GetContinuationPtr() };
                     InvokeDelegateInvokeMethod(&param);
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_NULLCHECK:
+                INTOP_CASE(INTOP_CALL_NULLCHECK)
                     // Check the target this pointer in the call for null
                     NULL_CHECK(LOCAL_VAR(ip[2], void*));
+#if !USE_COMPUTED_GOTO
                     FALLTHROUGH;
-                case INTOP_CALL_TAIL:
-                case INTOP_CALL:
+#endif
+                INTOP_CASE(INTOP_CALL_TAIL)
+                INTOP_CASE(INTOP_CALL)
                 {
                     frameNeedsTailcallUpdate = (opcode == INTOP_CALL_TAIL);
                     returnOffset = ip[1];
@@ -3440,7 +3463,7 @@ CALL_INTERP_METHOD:
                         frameNeedsTailcallUpdate = false;
                         ManagedMethodParam param = { targetMethod, callArgsAddress, returnValueAddress, (PCODE)NULL, pInterpreterFrame->GetContinuationPtr() };
                         InvokeManagedMethod(&param);
-                        break;
+                        INTOP_NEXT;
                     }
 
                     if (frameNeedsTailcallUpdate)
@@ -3485,9 +3508,9 @@ CALL_INTERP_METHOD:
                         UNREACHABLE();
                     }
                     pThreadContext->pStackPointer = stack + pMethod->allocaSize;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_NEWOBJ_GENERIC:
+                INTOP_CASE(INTOP_NEWOBJ_GENERIC)
                 {
                     returnOffset = ip[1];
                     callArgsOffset = ip[2];
@@ -3505,7 +3528,7 @@ CALL_INTERP_METHOD:
 
                     goto CALL_INTERP_SLOT;
                 }
-                case INTOP_NEWOBJ:
+                INTOP_CASE(INTOP_NEWOBJ)
                 {
                     returnOffset = ip[1];
                     callArgsOffset = ip[2];
@@ -3521,22 +3544,22 @@ CALL_INTERP_METHOD:
 
                     goto CALL_INTERP_SLOT;
                 }
-                case INTOP_NEWMDARR:
+                INTOP_CASE(INTOP_NEWMDARR)
                 {
                     LOCAL_VAR(ip[1], OBJECTREF) = CreateMultiDimArray((MethodTable*)pMethod->pDataItems[ip[3]], stack, ip[2], ip[4]);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_NEWMDARR_GENERIC:
+                INTOP_CASE(INTOP_NEWMDARR_GENERIC)
                 {
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[4]];
                     MethodTable *pMTArray = (MethodTable*)DoGenericLookup(LOCAL_VAR(ip[3], void*), pLookup);
 
                     LOCAL_VAR(ip[1], OBJECTREF) = CreateMultiDimArray(pMTArray, stack, ip[2], ip[5]);
                     ip += 6;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_NEWOBJ_VT:
+                INTOP_CASE(INTOP_NEWOBJ_VT)
                 {
                     returnOffset = ip[1];
                     callArgsOffset = ip[2];
@@ -3553,15 +3576,15 @@ CALL_INTERP_METHOD:
                     ip += 5;
                     goto CALL_INTERP_SLOT;
                 }
-                case INTOP_ZEROBLK_IMM:
+                INTOP_CASE(INTOP_ZEROBLK_IMM)
                 {
                     void* dst = LOCAL_VAR(ip[1], void*);
                     NULL_CHECK(dst);
                     memset(dst, 0, ip[2]);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_CPBLK:
+                INTOP_CASE(INTOP_CPBLK)
                 {
                     void* dst = LOCAL_VAR(ip[1], void*);
                     void* src = LOCAL_VAR(ip[2], void*);
@@ -3571,9 +3594,9 @@ CALL_INTERP_METHOD:
                     else
                         memcpyNoGCRefs(dst, src, size);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_INITBLK:
+                INTOP_CASE(INTOP_INITBLK)
                 {
                     void* dst = LOCAL_VAR(ip[1], void*);
                     uint8_t value = LOCAL_VAR(ip[2], uint8_t);
@@ -3583,9 +3606,9 @@ CALL_INTERP_METHOD:
                     else
                         memset(dst, value, size);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LOCALLOC:
+                INTOP_CASE(INTOP_LOCALLOC)
                 {
                     size_t len = LOCAL_VAR(ip[2], size_t);
                     void* pMemory = NULL;
@@ -3605,9 +3628,9 @@ CALL_INTERP_METHOD:
 
                     LOCAL_VAR(ip[1], void*) = pMemory;
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_THROW:
+                INTOP_CASE(INTOP_THROW)
                 {
                     OBJECTREF throwable = LOCAL_VAR(ip[1], OBJECTREF);
                     if (!throwable)
@@ -3623,22 +3646,22 @@ CALL_INTERP_METHOD:
                     pInterpreterFrame->SetIsFaulting(true);
                     DispatchManagedException(throwable);
                     UNREACHABLE();
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_RETHROW:
+                INTOP_CASE(INTOP_RETHROW)
                 {
                     pInterpreterFrame->SetIsFaulting(true);
                     DispatchRethrownManagedException();
                     UNREACHABLE();
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LOAD_EXCEPTION:
+                INTOP_CASE(INTOP_LOAD_EXCEPTION)
                     // This opcode loads the exception object coming from a catch / filter funclet caller to a variable.
                     _ASSERTE(pExceptionClauseArgs != NULL);
                     LOCAL_VAR(ip[1], OBJECTREF) = pExceptionClauseArgs->throwable;
                     ip += 2;
-                    break;
-                case INTOP_UNBOX_ANY:
+                    INTOP_NEXT;
+                INTOP_CASE(INTOP_UNBOX_ANY)
                 {
                     int dreg = ip[1];
                     int sreg = ip[2];
@@ -3666,9 +3689,9 @@ CALL_INTERP_METHOD:
                     LOCAL_VAR(dreg, void*) = Call_HELPER_FTN_BOX_UNBOX(helper, pMT, src);
 
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_UNBOX_END:
+                INTOP_CASE(INTOP_UNBOX_END)
                 {
                     MethodTable *pMT = (MethodTable*)pMethod->pDataItems[ip[3]];
                     void *dest = LOCAL_VAR_ADDR(ip[1], void);
@@ -3677,9 +3700,9 @@ CALL_INTERP_METHOD:
                     CopyValueClassUnchecked(dest, src, pMT);
 
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_UNBOX_ANY_GENERIC:
+                INTOP_CASE(INTOP_UNBOX_ANY_GENERIC)
                 {
                     int dreg = ip[1];
                     int sreg = ip[3];
@@ -3709,9 +3732,9 @@ CALL_INTERP_METHOD:
                     LOCAL_VAR(dreg, void*) = Call_HELPER_FTN_BOX_UNBOX(helper, pMTBoxedObj, src);
 
                     ip += 6;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_UNBOX_END_GENERIC:
+                INTOP_CASE(INTOP_UNBOX_END_GENERIC)
                 {
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[4]];
                     MethodTable *pMT = (MethodTable*)DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
@@ -3721,9 +3744,9 @@ CALL_INTERP_METHOD:
                     CopyValueClassUnchecked(dest, src, pMT->IsNullable() ? pMT->GetInstantiation()[0].AsMethodTable() : pMT);
 
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_NEWARR:
+                INTOP_CASE(INTOP_NEWARR)
                 {
                     int32_t length = LOCAL_VAR(ip[2], int32_t);
 
@@ -3734,9 +3757,9 @@ CALL_INTERP_METHOD:
                     LOCAL_VAR(ip[1], OBJECTREF) = ObjectToOBJECTREF(arr);
 
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_NEWARR_GENERIC:
+                INTOP_CASE(INTOP_NEWARR_GENERIC)
                 {
                     int32_t length = LOCAL_VAR(ip[3], int32_t);
 
@@ -3749,7 +3772,7 @@ CALL_INTERP_METHOD:
                     LOCAL_VAR(ip[1], OBJECTREF) = ObjectToOBJECTREF(arr);
 
                     ip += 6;
-                    break;
+                    INTOP_NEXT;
                 }
 #define LDELEM(dtype,etype)                                                    \
 do {                                                                           \
@@ -3769,48 +3792,48 @@ do {                                                                           \
     LOCAL_VAR(ip[1], dtype) = *pElem;                                          \
     ip += 4;                                                                   \
 } while (0)
-                case INTOP_LDELEM_I1:
+                INTOP_CASE(INTOP_LDELEM_I1)
                 {
                     LDELEM(int32_t, int8_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEM_U1:
+                INTOP_CASE(INTOP_LDELEM_U1)
                 {
                     LDELEM(int32_t, uint8_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEM_I2:
+                INTOP_CASE(INTOP_LDELEM_I2)
                 {
                     LDELEM(int32_t, int16_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEM_U2:
+                INTOP_CASE(INTOP_LDELEM_U2)
                 {
                     LDELEM(int32_t, uint16_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEM_I4:
+                INTOP_CASE(INTOP_LDELEM_I4)
                 {
                     LDELEM(int32_t, int32_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEM_I8:
+                INTOP_CASE(INTOP_LDELEM_I8)
                 {
                     LDELEM(int64_t, int64_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEM_R4:
+                INTOP_CASE(INTOP_LDELEM_R4)
                 {
                     LDELEM(float, float);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEM_R8:
+                INTOP_CASE(INTOP_LDELEM_R8)
                 {
                     LDELEM(double, double);
-                    break;
+                    INTOP_NEXT;
                 }
 #undef LDELEM
-                case INTOP_LDELEM_REF:
+                INTOP_CASE(INTOP_LDELEM_REF)
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[2], ArrayBase*);
                     if (arr == NULL)
@@ -3827,9 +3850,9 @@ do {                                                                           \
                     VALIDATEOBJECT(elem);
                     LOCAL_VAR(ip[1], Object*) = elem;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEM_VT:
+                INTOP_CASE(INTOP_LDELEM_VT)
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[2], ArrayBase*);
                     if (arr == NULL)
@@ -3847,7 +3870,7 @@ do {                                                                           \
                     MethodTable* pElemMT = arr->GetArrayElementTypeHandle().AsMethodTable();
                     CopyValueClassUnchecked(LOCAL_VAR_ADDR(ip[1], void), elemAddr, pElemMT);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 #define STELEM(dtype,etype)                                                    \
 do {                                                                           \
@@ -3867,48 +3890,48 @@ do {                                                                           \
     *pElem = (etype)LOCAL_VAR(ip[3], dtype);                                   \
     ip += 4;                                                                   \
 } while (0)
-                case INTOP_STELEM_I1:
+                INTOP_CASE(INTOP_STELEM_I1)
                 {
                     STELEM(int32_t, int8_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STELEM_I2:
+                INTOP_CASE(INTOP_STELEM_I2)
                 {
                     STELEM(int32_t, int16_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STELEM_I4:
+                INTOP_CASE(INTOP_STELEM_I4)
                 {
                     STELEM(int32_t, int32_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STELEM_I8:
+                INTOP_CASE(INTOP_STELEM_I8)
                 {
                     STELEM(int64_t, int64_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STELEM_U1:
+                INTOP_CASE(INTOP_STELEM_U1)
                 {
                     STELEM(int32_t, uint8_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STELEM_U2:
+                INTOP_CASE(INTOP_STELEM_U2)
                 {
                     STELEM(int32_t, uint16_t);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STELEM_R4:
+                INTOP_CASE(INTOP_STELEM_R4)
                 {
                     STELEM(float, float);
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STELEM_R8:
+                INTOP_CASE(INTOP_STELEM_R8)
                 {
                     STELEM(double, double);
-                    break;
+                    INTOP_NEXT;
                 }
 #undef STELEM
-                case INTOP_STELEM_REF:
+                INTOP_CASE(INTOP_STELEM_REF)
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[1], ArrayBase*);
                     if (arr == NULL)
@@ -3937,9 +3960,9 @@ do {                                                                           \
                     uint8_t* pData = arr->GetDataPtr();
                     SetObjectReferenceUnchecked((OBJECTREF*)(pData + idx * sizeof(OBJECTREF)), elemRef);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STELEM_VT:
+                INTOP_CASE(INTOP_STELEM_VT)
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[1], ArrayBase*);
                     if (arr == NULL)
@@ -3958,9 +3981,9 @@ do {                                                                           \
 
                     CopyValueClassUnchecked(elemAddr, LOCAL_VAR_ADDR(ip[3], void), pMT);
                     ip += 6;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_STELEM_VT_NOREF:
+                INTOP_CASE(INTOP_STELEM_VT_NOREF)
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[1], ArrayBase*);
                     if (arr == NULL)
@@ -3978,9 +4001,9 @@ do {                                                                           \
 
                     memcpyNoGCRefs(elemAddr, LOCAL_VAR_ADDR(ip[3], void), elemSize);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEMA:
+                INTOP_CASE(INTOP_LDELEMA)
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[2], ArrayBase*);
                     if (arr == NULL)
@@ -3997,9 +4020,9 @@ do {                                                                           \
                     void* elemAddr = pData + idx * elemSize;
                     LOCAL_VAR(ip[1], void*) = elemAddr;
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LDELEMA_REF:
+                INTOP_CASE(INTOP_LDELEMA_REF)
                 {
                     BASEARRAYREF arrayRef = LOCAL_VAR(ip[2], BASEARRAYREF);
                     if (arrayRef == NULL)
@@ -4023,10 +4046,10 @@ do {                                                                           \
 
                     LOCAL_VAR(ip[1], void*) = elemAddr;
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_LDELEMA_REF_GENERIC:
+                INTOP_CASE(INTOP_LDELEMA_REF_GENERIC)
                 {
                     BASEARRAYREF arrayRef = LOCAL_VAR(ip[2], BASEARRAYREF);
                     if (arrayRef == NULL)
@@ -4051,10 +4074,10 @@ do {                                                                           \
 
                     LOCAL_VAR(ip[1], void*) = elemAddr;
                     ip += 6;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CONV_NI:
+                INTOP_CASE(INTOP_CONV_NI)
                 {
                     NULL_CHECK(LOCAL_VAR(ip[2], void*));
                     int64_t index = LOCAL_VAR(ip[3], int64_t);
@@ -4064,20 +4087,20 @@ do {                                                                           \
                     }
                     LOCAL_VAR(ip[1], int64_t) = index;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_GENERICLOOKUP:
+                INTOP_CASE(INTOP_GENERICLOOKUP)
                 {
                     int dreg = ip[1];
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[3]];
                     void* result = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
                     LOCAL_VAR(dreg, void*) = result;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_COMPARE_EXCHANGE_U1:
+                INTOP_CASE(INTOP_COMPARE_EXCHANGE_U1)
                 {
                     uint8_t* dst = LOCAL_VAR(ip[2], uint8_t*);
                     NULL_CHECK(dst);
@@ -4105,10 +4128,10 @@ do {                                                                           \
                         break;
                     } while (true);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_COMPARE_EXCHANGE_U2:
+                INTOP_CASE(INTOP_COMPARE_EXCHANGE_U2)
                 {
                     uint16_t* dst = LOCAL_VAR(ip[2], uint16_t*);
                     NULL_CHECK(dst);
@@ -4141,7 +4164,7 @@ do {                                                                           \
                         break;
                     } while (true);
                     ip += 5;
-                    break;
+                    INTOP_NEXT;
                 }
 
 
@@ -4156,16 +4179,16 @@ do                                                                      \
     LOCAL_VAR(ip[1], type) = old;                                       \
     ip += 5;                                                            \
 } while (0)
-                case INTOP_COMPARE_EXCHANGE_I4:
+                INTOP_CASE(INTOP_COMPARE_EXCHANGE_I4)
                 {
                     COMPARE_EXCHANGE(int32_t);
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_COMPARE_EXCHANGE_I8:
+                INTOP_CASE(INTOP_COMPARE_EXCHANGE_I8)
                 {
                     COMPARE_EXCHANGE(int64_t);
-                    break;
+                    INTOP_NEXT;
                 }
 #undef COMPARE_EXCHANGE
 
@@ -4180,7 +4203,7 @@ do                                                                      \
     ip += 4;                                                            \
 } while (0)
 
-                case INTOP_EXCHANGE_U1:
+                INTOP_CASE(INTOP_EXCHANGE_U1)
                 {
                     uint8_t* dst = LOCAL_VAR(ip[2], uint8_t*);
                     NULL_CHECK(dst);
@@ -4201,10 +4224,10 @@ do                                                                      \
                         }
                     } while (true);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_EXCHANGE_U2:
+                INTOP_CASE(INTOP_EXCHANGE_U2)
                 {
                     uint16_t* dst = LOCAL_VAR(ip[2], uint16_t*);
                     NULL_CHECK(dst);
@@ -4230,23 +4253,23 @@ do                                                                      \
                         }
                     } while (true);
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_EXCHANGE_I4:
+                INTOP_CASE(INTOP_EXCHANGE_I4)
                 {
                     EXCHANGE(int32_t);
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_EXCHANGE_I8:
+                INTOP_CASE(INTOP_EXCHANGE_I8)
                 {
                     EXCHANGE(int64_t);
-                    break;
+                    INTOP_NEXT;
                 }
 #undef EXCHANGE
 
-                case INTOP_EXCHANGEADD_I4:
+                INTOP_CASE(INTOP_EXCHANGEADD_I4)
                 {
                     LONG* dst = LOCAL_VAR(ip[2], LONG*);
                     NULL_CHECK(dst);
@@ -4254,10 +4277,10 @@ do                                                                      \
                     LONG old = InterlockedExchangeAdd(dst, newValue);
                     LOCAL_VAR(ip[1], LONG) = old;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_EXCHANGEADD_I8:
+                INTOP_CASE(INTOP_EXCHANGEADD_I8)
                 {
                     LONG64* dst = LOCAL_VAR(ip[2], LONG64*);
                     NULL_CHECK(dst);
@@ -4265,26 +4288,26 @@ do                                                                      \
                     LONG64 old = InterlockedExchangeAdd64(dst, newValue);
                     LOCAL_VAR(ip[1], LONG64) = old;
                     ip += 4;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_SQRT_R4:
+                INTOP_CASE(INTOP_SQRT_R4)
                 {
                     float value = LOCAL_VAR(ip[2], float);
                     LOCAL_VAR(ip[1], float) = sqrtf(value);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_SQRT_R8:
+                INTOP_CASE(INTOP_SQRT_R8)
                 {
                     double value = LOCAL_VAR(ip[2], double);
                     LOCAL_VAR(ip[1], double) = sqrt(value);
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CALL_FINALLY:
+                INTOP_CASE(INTOP_CALL_FINALLY)
                 {
                     const int32_t* targetIp = ip + ip[1];
                     // Save current execution state for when we return from called method
@@ -4307,20 +4330,20 @@ do                                                                      \
 
                     // Set execution state for the new frame
                     ip = targetIp;
-                    break;
+                    INTOP_NEXT;
                 }
-                case INTOP_LEAVE_FILTER:
+                INTOP_CASE(INTOP_LEAVE_FILTER)
                     *(int64_t*)pFrame->pRetVal = LOCAL_VAR(ip[1], int32_t);
                     goto EXIT_FRAME;
-                case INTOP_LEAVE_CATCH:
+                INTOP_CASE(INTOP_LEAVE_CATCH)
                     *(const int32_t**)pFrame->pRetVal = ip + ip[1];
                     goto EXIT_FRAME;
-                case INTOP_THROW_PNSE:
+                INTOP_CASE(INTOP_THROW_PNSE)
                     COMPlusThrow(kPlatformNotSupportedException);
-                    break;
+                    INTOP_NEXT;
 
-                case INTOP_HANDLE_CONTINUATION_GENERIC:
-                case INTOP_HANDLE_CONTINUATION:
+                INTOP_CASE(INTOP_HANDLE_CONTINUATION_GENERIC)
+                INTOP_CASE(INTOP_HANDLE_CONTINUATION)
                 {
                     int32_t helperOffset = opcode == INTOP_HANDLE_CONTINUATION_GENERIC ? 4 : 3;
                     int32_t ipAdjust = opcode == INTOP_HANDLE_CONTINUATION_GENERIC ? 5 : 4;
@@ -4340,7 +4363,7 @@ do                                                                      \
                         // No continuation to handle.
                         LOCAL_VAR(ip[1], void*) = NULL; // We don't allocate a continuation here
                         ip += ipAdjust; // (4 or 5 for this opcode)
-                        break;
+                        INTOP_NEXT;
                     }
                     MethodTable *pContinuationType = pAsyncSuspendData->continuationTypeHnd;
 
@@ -4391,10 +4414,10 @@ do                                                                      \
                         Object* chainedContinuationObj = OBJECTREFToObject(chainedContinuation);
                         *pDest = ObjectToOBJECTREF((Object*)Call_HELPER_FTN_P_PP(helperFtn, chainedContinuationObj, pContinuationType));
                     }
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CAPTURE_CONTEXT_ON_SUSPEND:
+                INTOP_CASE(INTOP_CAPTURE_CONTEXT_ON_SUSPEND)
                 {
                     CONTINUATIONREF continuation = LOCAL_VAR(ip[2], CONTINUATIONREF);
 
@@ -4403,7 +4426,7 @@ do                                                                      \
                         LOCAL_VAR(ip[1], CONTINUATIONREF) = continuation;
                         // No continuation to handle.
                         ip += 4;
-                        break;
+                        INTOP_NEXT;
                     }
 
                     InterpAsyncSuspendData *pAsyncSuspendData = (InterpAsyncSuspendData*)pMethod->pDataItems[ip[3]];
@@ -4451,11 +4474,11 @@ do                                                                      \
                     else
                     {
                         ip += 4;
-                        break;
+                        INTOP_NEXT;
                     }
                 }
 
-                case INTOP_RESTORE_CONTEXTS_ON_SUSPEND:
+                INTOP_CASE(INTOP_RESTORE_CONTEXTS_ON_SUSPEND)
                 {
                     CONTINUATIONREF newContinuation = LOCAL_VAR(ip[2], CONTINUATIONREF);
                     CONTINUATIONREF continuationArg = LOCAL_VAR(ip[3], CONTINUATIONREF);
@@ -4466,7 +4489,7 @@ do                                                                      \
                         LOCAL_VAR(ip[1], CONTINUATIONREF) = newContinuation;
                         // No continuation to handle.
                         ip += 6;
-                        break;
+                        INTOP_NEXT;
                     }
 
                     OBJECTREF executionContext = LOCAL_VAR(ip[4], OBJECTREF);
@@ -4486,29 +4509,29 @@ do                                                                      \
                     goto CALL_INTERP_METHOD;
                 }
 
-                case INTOP_GET_CONTINUATION:
+                INTOP_CASE(INTOP_GET_CONTINUATION)
                 {
                     LOCAL_VAR(ip[1], OBJECTREF) = pInterpreterFrame->GetContinuation();
                     pInterpreterFrame->SetContinuation(NULL);
                     ip += 2;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_SET_CONTINUATION:
+                INTOP_CASE(INTOP_SET_CONTINUATION)
                 {
                     pInterpreterFrame->SetContinuation(LOCAL_VAR(ip[1], CONTINUATIONREF));
                     ip += 2;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_SET_CONTINUATION_NULL:
+                INTOP_CASE(INTOP_SET_CONTINUATION_NULL)
                 {
                     pInterpreterFrame->SetContinuation(NULL);
                     ip += 1;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_HANDLE_CONTINUATION_SUSPEND:
+                INTOP_CASE(INTOP_HANDLE_CONTINUATION_SUSPEND)
                 {
                     InterpAsyncSuspendData *pAsyncSuspendData = (InterpAsyncSuspendData*)pMethod->pDataItems[ip[2]];
                     CONTINUATIONREF continuation = LOCAL_VAR(ip[1], CONTINUATIONREF);
@@ -4517,7 +4540,7 @@ do                                                                      \
                     {
                         // No continuation to handle.
                         ip += 3 + 2; // (3 for this opcode + 2 for the continuation resume which follows)
-                        break;
+                        INTOP_NEXT;
                     }
                     ip += 3;
 
@@ -4570,20 +4593,20 @@ do                                                                      \
                     goto EXIT_FRAME;
                 }
 
-                case INTOP_RET_EXISTING_CONTINUATION:
+                INTOP_CASE(INTOP_RET_EXISTING_CONTINUATION)
                 {
                     if (pInterpreterFrame->GetContinuation() == NULL)
                     {
                         // No continuation returned
                         ip++;
-                        break;
+                        INTOP_NEXT;
                     }
 
                     // Otherwise exit without modifying current continuation
                     goto EXIT_FRAME;
                 }
 
-                case INTOP_HANDLE_CONTINUATION_RESUME:
+                INTOP_CASE(INTOP_HANDLE_CONTINUATION_RESUME)
                 {
                     InterpAsyncSuspendData *pAsyncSuspendData = (InterpAsyncSuspendData*)pMethod->pDataItems[ip[1]];
                     CONTINUATIONREF continuation = (CONTINUATIONREF)ObjectToOBJECTREF(*(Object**)(stack + pAsyncSuspendData->continuationArgOffset));
@@ -4623,10 +4646,10 @@ do                                                                      \
                     }
 
                     ip += 2;
-                    break;
+                    INTOP_NEXT;
                 }
 
-                case INTOP_CHECK_FOR_CONTINUATION:
+                INTOP_CASE(INTOP_CHECK_FOR_CONTINUATION)
                 {
                     CONTINUATIONREF continuation = LOCAL_VAR(ip[1], CONTINUATIONREF);
                     _ASSERTE(pInterpreterFrame->GetContinuation() == NULL);
@@ -4642,15 +4665,37 @@ do                                                                      \
                         // And before it should be an INTOP_HANDLE_CONTINUATION_SUSPEND opcode
                         _ASSERTE(*ip == INTOP_HANDLE_CONTINUATION_RESUME);
                         _ASSERTE(*(ip-3) == INTOP_HANDLE_CONTINUATION_SUSPEND);
-                        break;
+                        INTOP_NEXT;
                     }
                     ip += 3;
-                    break;
+                    INTOP_NEXT;
                 }
+#if USE_COMPUTED_GOTO
+                // Labels for opcodes that are conditionally compiled out or never emitted.
+                // The dispatch table needs valid labels for all enum values.
+#ifndef DEBUG
+                INTOP_CASE(INTOP_HALT)
+#endif
+#ifndef DEBUGGING_SUPPORTED
+                INTOP_CASE(INTOP_BREAKPOINT)
+                INTOP_CASE(INTOP_DEBUG_METHOD_ENTER)
+                INTOP_CASE(INTOP_DEBUG_SEQ_POINT)
+#endif
+#ifdef FEATURE_PORTABLE_ENTRYPOINTS
+                INTOP_CASE(INTOP_STORESTUBCONTEXT)
+#endif
+                // IR-only opcodes (never emitted to bytecode)
+                INTOP_CASE(INTOP_NOP)
+                INTOP_CASE(INTOP_DEF)
+                INTOP_CASE(INTOP_MOV_SRC_OFF)
+                    EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("Unimplemented or invalid interpreter opcode\n"));
+                    INTOP_NEXT;
+#else
                 default:
                     EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("Unimplemented or invalid interpreter opcode\n"));
-                    break;
+                    INTOP_NEXT;
             }
+#endif // !USE_COMPUTED_GOTO
         }
         UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
         UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -833,7 +833,17 @@ static void InterpBreakpoint(const int32_t *ip, const InterpMethodContextFrame *
 
 #define LOCAL_VAR_ADDR(offset,type) ((type*)(stack + (offset)))
 #define LOCAL_VAR(offset,type) (*LOCAL_VAR_ADDR(offset, type))
-#define NULL_CHECK(o) do { if ((o) == NULL) { COMPlusThrow(kNullReferenceException); } } while (0)
+
+// Helper that saves the current IP into the frame before throwing.
+// This ensures EH and GC can unwind the interpreter frame correctly.
+NOINLINE static void InterpThrow(InterpMethodContextFrame* pFrame, const int32_t* ip, RuntimeExceptionKind exType)
+{
+    pFrame->ip = ip;
+    COMPlusThrow(exType);
+}
+
+#define NULL_CHECK(o) do { if ((o) == NULL) { INTERP_THROW(kNullReferenceException); } } while (0)
+#define INTERP_THROW(exType) InterpThrow(pFrame, ip, exType)
 
 // When enabled, each opcode dispatches directly to the next one via an indirect goto,
 // avoiding the overhead of the central switch dispatch.
@@ -843,7 +853,7 @@ static void InterpBreakpoint(const int32_t *ip, const InterpMethodContextFrame *
 
 #if USE_COMPUTED_GOTO
 #define INTOP_CASE(x) LABEL_ ## x:
-#define INTOP_DISPATCH(op) pFrame->ip = op; opcode = (uint32_t)(op); goto *s_dispatchTable[opcode]
+#define INTOP_DISPATCH(op) opcode = (uint32_t)(op); goto *s_dispatchTable[opcode]
 #define INTOP_NEXT INTOP_DISPATCH(ip[0])
 #else
 #define INTOP_CASE(x) case x:
@@ -934,7 +944,7 @@ template <typename TResult, typename TIntermediate, typename TSource> static voi
         LOCAL_VAR(ip[1], int32_t) = (int32_t)result;
 }
 
-template <typename TResult, typename TSource> static void ConvOvfFpHelper(int8_t *stack, const int32_t *ip)
+template <typename TResult, typename TSource> static void ConvOvfFpHelper(int8_t *stack, const int32_t *ip, InterpMethodContextFrame *pFrame)
 {
     static_assert(!std::numeric_limits<TSource>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles");
     static_assert(std::numeric_limits<TResult>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles to be converted to integers");
@@ -949,7 +959,7 @@ template <typename TResult, typename TSource> static void ConvOvfFpHelper(int8_t
     bool inRange = (src > minValue) && (src < maxValue);
 
     if (!inRange)
-        COMPlusThrow(kOverflowException);
+        InterpThrow(pFrame, ip, kOverflowException);
 
     TResult truncated = (TResult)src;
     // According to spec, for result types smaller than int32, we store them on the stack as int32
@@ -958,7 +968,7 @@ template <typename TResult, typename TSource> static void ConvOvfFpHelper(int8_t
 
 // I64 and U64 versions based on mono_math.h
 
-template <typename TSource> static void ConvOvfFpHelperI64(int8_t *stack, const int32_t *ip)
+template <typename TSource> static void ConvOvfFpHelperI64(int8_t *stack, const int32_t *ip, InterpMethodContextFrame *pFrame)
 {
     static_assert(!std::numeric_limits<TSource>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles");
 
@@ -971,13 +981,13 @@ template <typename TSource> static void ConvOvfFpHelperI64(int8_t *stack, const 
 
     bool inRange = (src > minValue) && (src < maxValue);
     if (!inRange)
-        COMPlusThrow(kOverflowException);
+        InterpThrow(pFrame, ip, kOverflowException);
 
     int64_t truncated = (int64_t)src;
     LOCAL_VAR(ip[1], int64_t) = truncated;
 }
 
-template <typename TSource> static void ConvOvfFpHelperU64(int8_t *stack, const int32_t *ip)
+template <typename TSource> static void ConvOvfFpHelperU64(int8_t *stack, const int32_t *ip, InterpMethodContextFrame *pFrame)
 {
     static_assert(!std::numeric_limits<TSource>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles");
 
@@ -989,13 +999,13 @@ template <typename TSource> static void ConvOvfFpHelperU64(int8_t *stack, const 
 
     bool inRange = (src > minValue) && (src < maxValue);
     if (!inRange)
-        COMPlusThrow(kOverflowException);
+        InterpThrow(pFrame, ip, kOverflowException);
 
     uint64_t truncated = (uint64_t)src;
     LOCAL_VAR(ip[1], uint64_t) = truncated;
 }
 
-template <typename TResult, typename TSource> void ConvOvfHelper(int8_t *stack, const int32_t *ip)
+template <typename TResult, typename TSource> void ConvOvfHelper(int8_t *stack, const int32_t *ip, InterpMethodContextFrame *pFrame)
 {
     static_assert(std::numeric_limits<TSource>::is_integer, "ConvOvfHelper is only for use on integers");
     constexpr bool shrinking = sizeof(TResult) < sizeof(TSource);
@@ -1051,21 +1061,21 @@ template <typename TResult, typename TSource> void ConvOvfHelper(int8_t *stack, 
     }
     else
     {
-        COMPlusThrow(kOverflowException);
+        InterpThrow(pFrame, ip, kOverflowException);
     }
 }
 
-static float CkfiniteHelper(float value)
+static float CkfiniteHelper(float value, InterpMethodContextFrame *pFrame, const int32_t *ip)
 {
     if (!std::isfinite(value))
-        COMPlusThrow(kOverflowException);
+        InterpThrow(pFrame, ip, kOverflowException);
     return value;
 }
 
-static double CkfiniteHelper(double value)
+static double CkfiniteHelper(double value, InterpMethodContextFrame *pFrame, const int32_t *ip)
 {
     if (!std::isfinite(value))
-        COMPlusThrow(kOverflowException);
+        InterpThrow(pFrame, ip, kOverflowException);
     return value;
 }
 
@@ -1080,7 +1090,8 @@ void* DoGenericLookup(void* genericVarAsPtr, InterpGenericLookup* pLookup)
     if (pLookup->lookupType == InterpGenericLookupType::This)
     {
         OBJECTREF thisPtr = ObjectToOBJECTREF((Object*)genericVarAsPtr);
-        NULL_CHECK(thisPtr);
+        if (thisPtr == NULL)
+            COMPlusThrow(kNullReferenceException);
         pMT = thisPtr->GetMethodTable();
         lookup = (uint8_t*)pMT;
     }
@@ -1167,7 +1178,8 @@ extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuationWorker(
     frames(pTransitionBlock);
 
     CONTINUATIONREF contRef = (CONTINUATIONREF)ObjectToOBJECTREF(cont);
-    NULL_CHECK(contRef);
+    if (contRef == NULL)
+        COMPlusThrow(kNullReferenceException);
 
     // We are working with an interpreter async continuation, move things around to get the InterpAsyncSuspendData
     size_t resumeDataOffset = offsetof(InterpAsyncSuspendData, resumeInfo);
@@ -1420,7 +1432,6 @@ MAIN_LOOP:
 #if USE_COMPUTED_GOTO
             INTOP_NEXT;
 #else
-            pFrame->ip = (int32_t*)ip;
             opcode = ip[0];
 SWITCH_OPCODE:
             switch (opcode)
@@ -1435,6 +1446,7 @@ SWITCH_OPCODE:
 #ifdef DEBUGGING_SUPPORTED
                 INTOP_CASE(INTOP_BREAKPOINT)
                 {
+                    pFrame->ip = ip;
                     LOG((LF_CORDB, LL_INFO10000, "InterpExecMethod: Hit breakpoint at IP %p\n", ip));
                     InterpBreakpoint(ip, pFrame, stack, pInterpreterFrame);
 
@@ -1454,6 +1466,7 @@ SWITCH_OPCODE:
                 }
                 INTOP_CASE(INTOP_DEBUG_METHOD_ENTER)
                 {
+                    pFrame->ip = ip;
                     if (CORDebuggerAttached() && g_pDebugInterface != NULL && g_pDebugInterface->IsMethodEnterEnabled())
                     {
                         // ip[1] holds the native offset of the first INTOP_DEBUG_SEQ_POINT,
@@ -1586,11 +1599,11 @@ SWITCH_OPCODE:
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CKFINITE_R4)
-                    LOCAL_VAR(ip[1], float) = CkfiniteHelper(LOCAL_VAR(ip[2], float));
+                    LOCAL_VAR(ip[1], float) = CkfiniteHelper(LOCAL_VAR(ip[2], float), pFrame, ip);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CKFINITE_R8)
-                    LOCAL_VAR(ip[1], double) = CkfiniteHelper(LOCAL_VAR(ip[2], double));
+                    LOCAL_VAR(ip[1], double) = CkfiniteHelper(LOCAL_VAR(ip[2], double), pFrame, ip);
                     ip += 3;
                     INTOP_NEXT;
 
@@ -1744,180 +1757,180 @@ SWITCH_OPCODE:
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_I1_I4)
-                    ConvOvfHelper<int8_t, int32_t>(stack, ip);
+                    ConvOvfHelper<int8_t, int32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I1_I8)
-                    ConvOvfHelper<int8_t, int64_t>(stack, ip);
+                    ConvOvfHelper<int8_t, int64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I1_R4)
-                    ConvOvfFpHelper<int8_t, float>(stack, ip);
+                    ConvOvfFpHelper<int8_t, float>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I1_R8)
-                    ConvOvfFpHelper<int8_t, double>(stack, ip);
+                    ConvOvfFpHelper<int8_t, double>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_U1_I4)
-                    ConvOvfHelper<uint8_t, int32_t>(stack, ip);
+                    ConvOvfHelper<uint8_t, int32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U1_I8)
-                    ConvOvfHelper<uint8_t, int64_t>(stack, ip);
+                    ConvOvfHelper<uint8_t, int64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U1_R4)
-                    ConvOvfFpHelper<uint8_t, float>(stack, ip);
+                    ConvOvfFpHelper<uint8_t, float>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U1_R8)
-                    ConvOvfFpHelper<uint8_t, double>(stack, ip);
+                    ConvOvfFpHelper<uint8_t, double>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_I2_I4)
-                    ConvOvfHelper<int16_t, int32_t>(stack, ip);
+                    ConvOvfHelper<int16_t, int32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I2_I8)
-                    ConvOvfHelper<int16_t, int64_t>(stack, ip);
+                    ConvOvfHelper<int16_t, int64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I2_R4)
-                    ConvOvfFpHelper<int16_t, float>(stack, ip);
+                    ConvOvfFpHelper<int16_t, float>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I2_R8)
-                    ConvOvfFpHelper<int16_t, double>(stack, ip);
+                    ConvOvfFpHelper<int16_t, double>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_U2_I4)
-                    ConvOvfHelper<uint16_t, int32_t>(stack, ip);
+                    ConvOvfHelper<uint16_t, int32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U2_I8)
-                    ConvOvfHelper<uint16_t, int64_t>(stack, ip);
+                    ConvOvfHelper<uint16_t, int64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U2_R4)
-                    ConvOvfFpHelper<uint16_t, float>(stack, ip);
+                    ConvOvfFpHelper<uint16_t, float>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U2_R8)
-                    ConvOvfFpHelper<uint16_t, double>(stack, ip);
+                    ConvOvfFpHelper<uint16_t, double>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_I4_U4)
-                    ConvOvfHelper<int32_t, uint32_t>(stack, ip);
+                    ConvOvfHelper<int32_t, uint32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I4_I8)
-                    ConvOvfHelper<int32_t, int64_t>(stack, ip);
+                    ConvOvfHelper<int32_t, int64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I4_R4)
-                    ConvOvfFpHelper<int32_t, float>(stack, ip);
+                    ConvOvfFpHelper<int32_t, float>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I4_R8)
-                    ConvOvfFpHelper<int32_t, double>(stack, ip);
+                    ConvOvfFpHelper<int32_t, double>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_U4_I4)
-                    ConvOvfHelper<uint32_t, int32_t>(stack, ip);
+                    ConvOvfHelper<uint32_t, int32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U4_I8)
-                    ConvOvfHelper<uint32_t, int64_t>(stack, ip);
+                    ConvOvfHelper<uint32_t, int64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U4_R4)
-                    ConvOvfFpHelper<uint32_t, float>(stack, ip);
+                    ConvOvfFpHelper<uint32_t, float>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U4_R8)
-                    ConvOvfFpHelper<uint32_t, double>(stack, ip);
+                    ConvOvfFpHelper<uint32_t, double>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_I8_U8)
-                    ConvOvfHelper<int64_t, uint64_t>(stack, ip);
+                    ConvOvfHelper<int64_t, uint64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I8_R4)
-                    ConvOvfFpHelperI64<float>(stack, ip);
+                    ConvOvfFpHelperI64<float>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I8_R8)
-                    ConvOvfFpHelperI64<double>(stack, ip);
+                    ConvOvfFpHelperI64<double>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_U8_I4)
-                    ConvOvfHelper<uint64_t, int32_t>(stack, ip);
+                    ConvOvfHelper<uint64_t, int32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U8_I8)
-                    ConvOvfHelper<uint64_t, int64_t>(stack, ip);
+                    ConvOvfHelper<uint64_t, int64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U8_R4)
-                    ConvOvfFpHelperU64<float>(stack, ip);
+                    ConvOvfFpHelperU64<float>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U8_R8)
-                    ConvOvfFpHelperU64<double>(stack, ip);
+                    ConvOvfFpHelperU64<double>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_I1_U4)
-                    ConvOvfHelper<int8_t, uint32_t>(stack, ip);
+                    ConvOvfHelper<int8_t, uint32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I1_U8)
-                    ConvOvfHelper<int8_t, uint64_t>(stack, ip);
+                    ConvOvfHelper<int8_t, uint64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_U1_U4)
-                    ConvOvfHelper<uint8_t, uint32_t>(stack, ip);
+                    ConvOvfHelper<uint8_t, uint32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U1_U8)
-                    ConvOvfHelper<uint8_t, uint64_t>(stack, ip);
+                    ConvOvfHelper<uint8_t, uint64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_I2_U4)
-                    ConvOvfHelper<int16_t, uint32_t>(stack, ip);
+                    ConvOvfHelper<int16_t, uint32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_I2_U8)
-                    ConvOvfHelper<int16_t, uint64_t>(stack, ip);
+                    ConvOvfHelper<int16_t, uint64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_U2_U4)
-                    ConvOvfHelper<uint16_t, uint32_t>(stack, ip);
+                    ConvOvfHelper<uint16_t, uint32_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_OVF_U2_U8)
-                    ConvOvfHelper<uint16_t, uint64_t>(stack, ip);
+                    ConvOvfHelper<uint16_t, uint64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_I4_U8)
-                    ConvOvfHelper<int32_t, uint64_t>(stack, ip);
+                    ConvOvfHelper<int32_t, uint64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_CONV_OVF_U4_U8)
-                    ConvOvfHelper<uint32_t, uint64_t>(stack, ip);
+                    ConvOvfHelper<uint32_t, uint64_t>(stack, ip, pFrame);
                     ip += 3;
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_CONV_U4_U8_SAT)
@@ -1948,6 +1961,7 @@ SWITCH_OPCODE:
                 }
 
                 INTOP_CASE(INTOP_SAFEPOINT)
+                    pFrame->ip = ip;
                     if (g_TrapReturningThreads)
                     {
                         Thread *pThread = GetThread();
@@ -1967,6 +1981,7 @@ SWITCH_OPCODE:
 
 #ifdef PERFTRACING_DISABLE_THREADS
                 INTOP_CASE(INTOP_PROF_SAMPLEPOINT)
+                    pFrame->ip = ip;
                     SamplingProfiler_OnSamplepoint();
                     ip++;
                     INTOP_NEXT;
@@ -2250,7 +2265,7 @@ SWITCH_OPCODE:
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
                     int32_t i3;
                     if (!ClrSafeInt<int32_t>::addition(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2261,7 +2276,7 @@ SWITCH_OPCODE:
                     int64_t i2 = LOCAL_VAR(ip[3], int64_t);
                     int64_t i3;
                     if (!ClrSafeInt<int64_t>::addition(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2272,7 +2287,7 @@ SWITCH_OPCODE:
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
                     uint32_t i3;
                     if (!ClrSafeInt<uint32_t>::addition(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], uint32_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2283,7 +2298,7 @@ SWITCH_OPCODE:
                     uint64_t i2 = LOCAL_VAR(ip[3], uint64_t);
                     uint64_t i3;
                     if (!ClrSafeInt<uint64_t>::addition(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], uint64_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2311,7 +2326,7 @@ SWITCH_OPCODE:
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
                     int32_t i3;
                     if (!ClrSafeInt<int32_t>::subtraction(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2322,7 +2337,7 @@ SWITCH_OPCODE:
                     int64_t i2 = LOCAL_VAR(ip[3], int64_t);
                     int64_t i3;
                     if (!ClrSafeInt<int64_t>::subtraction(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2333,7 +2348,7 @@ SWITCH_OPCODE:
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
                     uint32_t i3;
                     if (!ClrSafeInt<uint32_t>::subtraction(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], uint32_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2344,7 +2359,7 @@ SWITCH_OPCODE:
                     uint64_t i2 = LOCAL_VAR(ip[3], uint64_t);
                     uint64_t i3;
                     if (!ClrSafeInt<uint64_t>::subtraction(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], uint64_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2372,7 +2387,7 @@ SWITCH_OPCODE:
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
                     int32_t i3;
                     if (!ClrSafeInt<int32_t>::multiply(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2384,7 +2399,7 @@ SWITCH_OPCODE:
                     int64_t i2 = LOCAL_VAR(ip[3], int64_t);
                     int64_t i3;
                     if (!ClrSafeInt<int64_t>::multiply(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2396,7 +2411,7 @@ SWITCH_OPCODE:
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
                     uint32_t i3;
                     if (!ClrSafeInt<uint32_t>::multiply(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], uint32_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2408,7 +2423,7 @@ SWITCH_OPCODE:
                     uint64_t i2 = LOCAL_VAR(ip[3], uint64_t);
                     uint64_t i3;
                     if (!ClrSafeInt<uint64_t>::multiply(i1, i2, i3))
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], uint64_t) = i3;
                     ip += 4;
                     INTOP_NEXT;
@@ -2418,9 +2433,9 @@ SWITCH_OPCODE:
                     int32_t i1 = LOCAL_VAR(ip[2], int32_t);
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
                     if (i2 == 0)
-                        COMPlusThrow(kDivideByZeroException);
+                        INTERP_THROW(kDivideByZeroException);
                     if (i2 == -1 && i1 == INT32_MIN)
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i1 / i2;
                     ip += 4;
                     INTOP_NEXT;
@@ -2430,9 +2445,9 @@ SWITCH_OPCODE:
                     int64_t l1 = LOCAL_VAR(ip[2], int64_t);
                     int64_t l2 = LOCAL_VAR(ip[3], int64_t);
                     if (l2 == 0)
-                        COMPlusThrow(kDivideByZeroException);
+                        INTERP_THROW(kDivideByZeroException);
                     if (l2 == -1 && l1 == INT64_MIN)
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = l1 / l2;
                     ip += 4;
                     INTOP_NEXT;
@@ -2449,7 +2464,7 @@ SWITCH_OPCODE:
                 {
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
                     if (i2 == 0)
-                        COMPlusThrow(kDivideByZeroException);
+                        INTERP_THROW(kDivideByZeroException);
                     LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) / i2;
                     ip += 4;
                     INTOP_NEXT;
@@ -2458,7 +2473,7 @@ SWITCH_OPCODE:
                 {
                     uint64_t l2 = LOCAL_VAR(ip[3], uint64_t);
                     if (l2 == 0)
-                        COMPlusThrow(kDivideByZeroException);
+                        INTERP_THROW(kDivideByZeroException);
                     LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) / l2;
                     ip += 4;
                     INTOP_NEXT;
@@ -2469,9 +2484,9 @@ SWITCH_OPCODE:
                     int32_t i1 = LOCAL_VAR(ip[2], int32_t);
                     int32_t i2 = LOCAL_VAR(ip[3], int32_t);
                     if (i2 == 0)
-                        COMPlusThrow(kDivideByZeroException);
+                        INTERP_THROW(kDivideByZeroException);
                     if (i2 == -1 && i1 == INT32_MIN)
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int32_t) = i1 % i2;
                     ip += 4;
                     INTOP_NEXT;
@@ -2481,9 +2496,9 @@ SWITCH_OPCODE:
                     int64_t l1 = LOCAL_VAR(ip[2], int64_t);
                     int64_t l2 = LOCAL_VAR(ip[3], int64_t);
                     if (l2 == 0)
-                        COMPlusThrow(kDivideByZeroException);
+                        INTERP_THROW(kDivideByZeroException);
                     if (l2 == -1 && l1 == INT64_MIN)
-                        COMPlusThrow(kOverflowException);
+                        INTERP_THROW(kOverflowException);
                     LOCAL_VAR(ip[1], int64_t) = l1 % l2;
                     ip += 4;
                     INTOP_NEXT;
@@ -2500,7 +2515,7 @@ SWITCH_OPCODE:
                 {
                     uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
                     if (i2 == 0)
-                        COMPlusThrow(kDivideByZeroException);
+                        INTERP_THROW(kDivideByZeroException);
                     LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) % i2;
                     ip += 4;
                     INTOP_NEXT;
@@ -2509,7 +2524,7 @@ SWITCH_OPCODE:
                 {
                     uint64_t l2 = LOCAL_VAR(ip[3], uint64_t);
                     if (l2 == 0)
-                        COMPlusThrow(kDivideByZeroException);
+                        INTERP_THROW(kDivideByZeroException);
                     LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) % l2;
                     ip += 4;
                     INTOP_NEXT;
@@ -2793,6 +2808,7 @@ SWITCH_OPCODE:
                 }
                 INTOP_CASE(INTOP_CALL_HELPER_P_P)
                 {
+                    pFrame->ip = ip;
                     void* helperArg = pMethod->pDataItems[ip[3]];
 
                     MethodDesc *pILTargetMethod = NULL;
@@ -2819,6 +2835,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_P_S)
                 {
+                    pFrame->ip = ip;
                     void* helperArg = LOCAL_VAR(ip[2], void*);
 
                     MethodDesc *pILTargetMethod = NULL;
@@ -2844,6 +2861,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_P_PS)
                 {
+                    pFrame->ip = ip;
                     void* helperArg1 = pMethod->pDataItems[ip[4]];
                     void* helperArg2 = LOCAL_VAR(ip[2], void*);
 
@@ -2871,6 +2889,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_P_SP)
                 {
+                    pFrame->ip = ip;
                     void* helperArg1 = LOCAL_VAR(ip[2], void*);
                     void* helperArg2 = pMethod->pDataItems[ip[4]];
 
@@ -2898,6 +2917,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_P_G)
                 {
+                    pFrame->ip = ip;
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[4]];
                     void* helperArg = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
 
@@ -2924,6 +2944,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_P_GS)
                 {
+                    pFrame->ip = ip;
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
                     void* helperArg1 = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
                     void* helperArg2 = LOCAL_VAR(ip[3], void*);
@@ -2952,6 +2973,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_P_GA)
                 {
+                    pFrame->ip = ip;
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
                     void* helperArg1 = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
                     void* helperArg2 = LOCAL_VAR_ADDR(ip[3], void*);
@@ -2980,6 +3002,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_P_PA)
                 {
+                    pFrame->ip = ip;
                     void* helperArg1 = pMethod->pDataItems[ip[4]];
                     void* helperArg2 = LOCAL_VAR_ADDR(ip[2], void*);
 
@@ -3006,6 +3029,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_V_AGS)
                 {
+                    pFrame->ip = ip;
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
                     void* helperArg1 = LOCAL_VAR_ADDR(ip[1], void*);
                     void* helperArg2 = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
@@ -3036,6 +3060,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_V_APS)
                 {
+                    pFrame->ip = ip;
                     void* helperArg1 = LOCAL_VAR_ADDR(ip[1], void*);
                     void* helperArg2 = pMethod->pDataItems[ip[4]];
                     void* helperArg3 = LOCAL_VAR(ip[2], void*);
@@ -3065,6 +3090,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_V_SA)
                 {
+                    pFrame->ip = ip;
                     void* helperArg1 = LOCAL_VAR(ip[1], void*);
                     void* helperArg2 = LOCAL_VAR_ADDR(ip[2], void*);
 
@@ -3091,6 +3117,7 @@ SWITCH_OPCODE:
                 }
                 INTOP_CASE(INTOP_CALL_HELPER_V_SS)
                 {
+                    pFrame->ip = ip;
                     void* helperArg1 = LOCAL_VAR(ip[1], void*);
                     void* helperArg2 = LOCAL_VAR(ip[2], void*);
                     MethodDesc *pILTargetMethod = NULL;
@@ -3117,6 +3144,7 @@ SWITCH_OPCODE:
 
                 INTOP_CASE(INTOP_CALL_HELPER_V_SSS)
                 {
+                    pFrame->ip = ip;
                     void* helperArg1 = LOCAL_VAR(ip[1], void*);
                     void* helperArg2 = LOCAL_VAR(ip[2], void*);
                     void* helperArg3 = LOCAL_VAR(ip[3], void*);
@@ -3146,6 +3174,7 @@ SWITCH_OPCODE:
                 INTOP_CASE(INTOP_CALLVIRT_TAIL)
                 INTOP_CASE(INTOP_CALLVIRT)
                 {
+                    pFrame->ip = ip;
                     frameNeedsTailcallUpdate = (opcode == INTOP_CALLVIRT_TAIL);
                     returnOffset = ip[1];
                     callArgsOffset = ip[2];
@@ -3304,6 +3333,7 @@ SWITCH_OPCODE:
                 INTOP_CASE(INTOP_CALLDELEGATE_TAIL)
                 INTOP_CASE(INTOP_CALLDELEGATE)
                 {
+                    pFrame->ip = ip;
                     frameNeedsTailcallUpdate = (opcode == INTOP_CALLDELEGATE_TAIL);
                     returnOffset = ip[1];
                     callArgsOffset = ip[2];
@@ -3512,6 +3542,7 @@ CALL_INTERP_METHOD:
                 }
                 INTOP_CASE(INTOP_NEWOBJ_GENERIC)
                 {
+                    pFrame->ip = ip;
                     returnOffset = ip[1];
                     callArgsOffset = ip[2];
                     methodSlot = ip[4];
@@ -3530,6 +3561,7 @@ CALL_INTERP_METHOD:
                 }
                 INTOP_CASE(INTOP_NEWOBJ)
                 {
+                    pFrame->ip = ip;
                     returnOffset = ip[1];
                     callArgsOffset = ip[2];
                     methodSlot = ip[3];
@@ -3546,12 +3578,14 @@ CALL_INTERP_METHOD:
                 }
                 INTOP_CASE(INTOP_NEWMDARR)
                 {
+                    pFrame->ip = ip;
                     LOCAL_VAR(ip[1], OBJECTREF) = CreateMultiDimArray((MethodTable*)pMethod->pDataItems[ip[3]], stack, ip[2], ip[4]);
                     ip += 5;
                     INTOP_NEXT;
                 }
                 INTOP_CASE(INTOP_NEWMDARR_GENERIC)
                 {
+                    pFrame->ip = ip;
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[4]];
                     MethodTable *pMTArray = (MethodTable*)DoGenericLookup(LOCAL_VAR(ip[3], void*), pLookup);
 
@@ -3590,7 +3624,7 @@ CALL_INTERP_METHOD:
                     void* src = LOCAL_VAR(ip[2], void*);
                     uint32_t size = LOCAL_VAR(ip[3], uint32_t);
                     if (size && (!dst || !src))
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
                     else
                         memcpyNoGCRefs(dst, src, size);
                     ip += 4;
@@ -3602,7 +3636,7 @@ CALL_INTERP_METHOD:
                     uint8_t value = LOCAL_VAR(ip[2], uint8_t);
                     uint32_t size = LOCAL_VAR(ip[3], uint32_t);
                     if (size && !dst)
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
                     else
                         memset(dst, value, size);
                     ip += 4;
@@ -3618,7 +3652,7 @@ CALL_INTERP_METHOD:
                         pMemory = pThreadContext->frameDataAllocator.Alloc(pFrame, len);
                         if (pMemory == NULL)
                         {
-                            COMPlusThrowOM();
+                            INTERP_THROW(kOutOfMemoryException);
                         }
                         if (pMethod->initLocals)
                         {
@@ -3632,6 +3666,7 @@ CALL_INTERP_METHOD:
                 }
                 INTOP_CASE(INTOP_THROW)
                 {
+                    pFrame->ip = ip;
                     OBJECTREF throwable = LOCAL_VAR(ip[1], OBJECTREF);
                     if (!throwable)
                     {
@@ -3650,6 +3685,7 @@ CALL_INTERP_METHOD:
                 }
                 INTOP_CASE(INTOP_RETHROW)
                 {
+                    pFrame->ip = ip;
                     pInterpreterFrame->SetIsFaulting(true);
                     DispatchRethrownManagedException();
                     UNREACHABLE();
@@ -3663,6 +3699,7 @@ CALL_INTERP_METHOD:
                     INTOP_NEXT;
                 INTOP_CASE(INTOP_UNBOX_ANY)
                 {
+                    pFrame->ip = ip;
                     int dreg = ip[1];
                     int sreg = ip[2];
                     MethodTable *pMT = (MethodTable*)pMethod->pDataItems[ip[4]];
@@ -3704,6 +3741,7 @@ CALL_INTERP_METHOD:
                 }
                 INTOP_CASE(INTOP_UNBOX_ANY_GENERIC)
                 {
+                    pFrame->ip = ip;
                     int dreg = ip[1];
                     int sreg = ip[3];
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
@@ -3736,6 +3774,7 @@ CALL_INTERP_METHOD:
                 }
                 INTOP_CASE(INTOP_UNBOX_END_GENERIC)
                 {
+                    pFrame->ip = ip;
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[4]];
                     MethodTable *pMT = (MethodTable*)DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
                     void *dest = LOCAL_VAR_ADDR(ip[1], void);
@@ -3748,6 +3787,7 @@ CALL_INTERP_METHOD:
                 }
                 INTOP_CASE(INTOP_NEWARR)
                 {
+                    pFrame->ip = ip;
                     int32_t length = LOCAL_VAR(ip[2], int32_t);
 
                     MethodTable* arrayClsHnd = (MethodTable*)pMethod->pDataItems[ip[3]];
@@ -3761,6 +3801,7 @@ CALL_INTERP_METHOD:
                 }
                 INTOP_CASE(INTOP_NEWARR_GENERIC)
                 {
+                    pFrame->ip = ip;
                     int32_t length = LOCAL_VAR(ip[3], int32_t);
 
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
@@ -3778,13 +3819,13 @@ CALL_INTERP_METHOD:
 do {                                                                           \
     ArrayBase* arr = LOCAL_VAR(ip[2], ArrayBase*);                             \
     if (arr == NULL)                                                           \
-        COMPlusThrow(kNullReferenceException);                                 \
+        INTERP_THROW(kNullReferenceException);                                 \
                                                                                \
     VALIDATEOBJECT(arr);                                                       \
     uint32_t len = arr->GetNumComponents();                                    \
     uint32_t idx = (uint32_t)LOCAL_VAR(ip[3], int32_t);                        \
     if (idx >= len)                                                            \
-        COMPlusThrow(kIndexOutOfRangeException);                               \
+        INTERP_THROW(kIndexOutOfRangeException);                               \
                                                                                \
     uint8_t* pData = arr->GetDataPtr();                                        \
     etype* pElem = reinterpret_cast<etype*>(pData + idx * sizeof(etype));      \
@@ -3837,13 +3878,13 @@ do {                                                                           \
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[2], ArrayBase*);
                     if (arr == NULL)
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
 
                     VALIDATEOBJECT(arr);
                     uint32_t len = arr->GetNumComponents();
                     uint32_t idx = (uint32_t)LOCAL_VAR(ip[3], int32_t);
                     if (idx >= len)
-                        COMPlusThrow(kIndexOutOfRangeException);
+                        INTERP_THROW(kIndexOutOfRangeException);
 
                     uint8_t* pData = arr->GetDataPtr();
                     Object* elem = *(Object**)(pData + idx * sizeof(OBJECTREF));
@@ -3856,13 +3897,13 @@ do {                                                                           \
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[2], ArrayBase*);
                     if (arr == NULL)
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
 
                     VALIDATEOBJECT(arr);
                     uint32_t len = arr->GetNumComponents();
                     uint32_t idx = (uint32_t)LOCAL_VAR(ip[3], int32_t);
                     if (idx >= len)
-                        COMPlusThrow(kIndexOutOfRangeException);
+                        INTERP_THROW(kIndexOutOfRangeException);
 
                     uint8_t* pData = arr->GetDataPtr();
                     size_t componentSize = arr->GetMethodTable()->GetComponentSize();
@@ -3876,13 +3917,13 @@ do {                                                                           \
 do {                                                                           \
     ArrayBase* arr = LOCAL_VAR(ip[1], ArrayBase*);                             \
     if (arr == NULL)                                                           \
-        COMPlusThrow(kNullReferenceException);                                 \
+        INTERP_THROW(kNullReferenceException);                                 \
                                                                                \
     VALIDATEOBJECT(arr);                                                       \
     uint32_t len = arr->GetNumComponents();                                    \
     uint32_t idx = (uint32_t)LOCAL_VAR(ip[2], int32_t);                        \
     if (idx >= len)                                                            \
-        COMPlusThrow(kIndexOutOfRangeException);                               \
+        INTERP_THROW(kIndexOutOfRangeException);                               \
                                                                                \
     uint8_t* pData = arr->GetDataPtr();                                        \
     etype* pElem = reinterpret_cast<etype*>(pData + idx * sizeof(etype));      \
@@ -3933,15 +3974,16 @@ do {                                                                           \
 #undef STELEM
                 INTOP_CASE(INTOP_STELEM_REF)
                 {
+                    pFrame->ip = ip;
                     ArrayBase* arr = LOCAL_VAR(ip[1], ArrayBase*);
                     if (arr == NULL)
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
 
                     VALIDATEOBJECT(arr);
                     uint32_t len = arr->GetNumComponents();
                     uint32_t idx = (uint32_t)LOCAL_VAR(ip[2], int32_t);
                     if (idx >= len)
-                        COMPlusThrow(kIndexOutOfRangeException);
+                        INTERP_THROW(kIndexOutOfRangeException);
 
                     OBJECTREF elemRef = LOCAL_VAR(ip[3], OBJECTREF);
 
@@ -3949,7 +3991,7 @@ do {                                                                           \
                     {
                         TypeHandle arrayElemType = arr->GetArrayElementTypeHandle();
                         if (!ObjIsInstanceOf(OBJECTREFToObject(elemRef), arrayElemType.AsMethodTable()))
-                            COMPlusThrow(kArrayTypeMismatchException);
+                            INTERP_THROW(kArrayTypeMismatchException);
 
                         // ObjIsInstanceOf can trigger GC, so the object references have to be re-fetched
                         arr = LOCAL_VAR(ip[1], ArrayBase*);
@@ -3966,13 +4008,13 @@ do {                                                                           \
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[1], ArrayBase*);
                     if (arr == NULL)
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
 
                     VALIDATEOBJECT(arr);
                     uint32_t len = arr->GetNumComponents();
                     uint32_t idx = (uint32_t)LOCAL_VAR(ip[2], int32_t);
                     if (idx >= len)
-                        COMPlusThrow(kIndexOutOfRangeException);
+                        INTERP_THROW(kIndexOutOfRangeException);
 
                     uint8_t* pData = arr->GetDataPtr();
                     size_t elemSize = ip[4];
@@ -3987,13 +4029,13 @@ do {                                                                           \
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[1], ArrayBase*);
                     if (arr == NULL)
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
 
                     VALIDATEOBJECT(arr);
                     uint32_t len = arr->GetNumComponents();
                     uint32_t idx = (uint32_t)LOCAL_VAR(ip[2], int32_t);
                     if (idx >= len)
-                        COMPlusThrow(kIndexOutOfRangeException);
+                        INTERP_THROW(kIndexOutOfRangeException);
 
                     uint8_t* pData = arr->GetDataPtr();
                     size_t elemSize = ip[4];
@@ -4007,13 +4049,13 @@ do {                                                                           \
                 {
                     ArrayBase* arr = LOCAL_VAR(ip[2], ArrayBase*);
                     if (arr == NULL)
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
 
                     VALIDATEOBJECT(arr);
                     uint32_t len = arr->GetNumComponents();
                     uint32_t idx = (uint32_t)LOCAL_VAR(ip[3], int32_t);
                     if (idx >= len)
-                        COMPlusThrow(kIndexOutOfRangeException);
+                        INTERP_THROW(kIndexOutOfRangeException);
 
                     uint8_t* pData = arr->GetDataPtr();
                     size_t elemSize = ip[4];
@@ -4026,13 +4068,13 @@ do {                                                                           \
                 {
                     BASEARRAYREF arrayRef = LOCAL_VAR(ip[2], BASEARRAYREF);
                     if (arrayRef == NULL)
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
 
                     ArrayBase* arr = (ArrayBase*)OBJECTREFToObject(arrayRef);
                     uint32_t len = arr->GetNumComponents();
                     uint32_t idx = (uint32_t)LOCAL_VAR(ip[3], int32_t);
                     if (idx >= len)
-                        COMPlusThrow(kIndexOutOfRangeException);
+                        INTERP_THROW(kIndexOutOfRangeException);
 
                     uint8_t* pData = arr->GetDataPtr();
                     void* elemAddr = pData + idx * sizeof(void*);
@@ -4041,7 +4083,7 @@ do {                                                                           \
                     MethodTable* expectedMT = (MethodTable*)pMethod->pDataItems[ip[4]];
                     if (arrayElemMT != expectedMT)
                     {
-                        COMPlusThrow(kArrayTypeMismatchException);
+                        INTERP_THROW(kArrayTypeMismatchException);
                     }
 
                     LOCAL_VAR(ip[1], void*) = elemAddr;
@@ -4051,15 +4093,16 @@ do {                                                                           \
 
                 INTOP_CASE(INTOP_LDELEMA_REF_GENERIC)
                 {
+                    pFrame->ip = ip;
                     BASEARRAYREF arrayRef = LOCAL_VAR(ip[2], BASEARRAYREF);
                     if (arrayRef == NULL)
-                        COMPlusThrow(kNullReferenceException);
+                        INTERP_THROW(kNullReferenceException);
 
                     ArrayBase* arr = (ArrayBase*)OBJECTREFToObject(arrayRef);
                     uint32_t len = arr->GetNumComponents();
                     uint32_t idx = (uint32_t)LOCAL_VAR(ip[3], int32_t);
                     if (idx >= len)
-                        COMPlusThrow(kIndexOutOfRangeException);
+                        INTERP_THROW(kIndexOutOfRangeException);
 
                     uint8_t* pData = arr->GetDataPtr();
                     void* elemAddr = pData + idx * sizeof(void*);
@@ -4069,7 +4112,7 @@ do {                                                                           \
                     MethodTable* expectedMT = (MethodTable*)DoGenericLookup(LOCAL_VAR(ip[4], void*), pLookup);
                     if (arrayElemMT != expectedMT)
                     {
-                        COMPlusThrow(kArrayTypeMismatchException);
+                        INTERP_THROW(kArrayTypeMismatchException);
                     }
 
                     LOCAL_VAR(ip[1], void*) = elemAddr;
@@ -4083,7 +4126,7 @@ do {                                                                           \
                     int64_t index = LOCAL_VAR(ip[3], int64_t);
                     if ((index < 0) || (index > UINT_MAX))
                     {
-                        COMPlusThrow(kIndexOutOfRangeException);
+                        INTERP_THROW(kIndexOutOfRangeException);
                     }
                     LOCAL_VAR(ip[1], int64_t) = index;
                     ip += 4;
@@ -4092,6 +4135,7 @@ do {                                                                           \
 
                 INTOP_CASE(INTOP_GENERICLOOKUP)
                 {
+                    pFrame->ip = ip;
                     int dreg = ip[1];
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[3]];
                     void* result = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
@@ -4144,7 +4188,7 @@ do {                                                                           \
                     if (shift & 8)
                     {
                         // Attempt to do 16-bit exchange on 2-byte unaligned address
-                        COMPlusThrow(kAccessViolationException);
+                        INTERP_THROW(kAccessViolationException);
                     }
                     ULONG mask = ~(((ULONG)0xFFFF) << shift);
                     do
@@ -4239,7 +4283,7 @@ do                                                                      \
                     if (shift & 1)
                     {
                         // Attempt to do 16-bit exchange on 2-byte unaligned address
-                        COMPlusThrow(kAccessViolationException);
+                        INTERP_THROW(kAccessViolationException);
                     }
                     ULONG mask = ~(((ULONG)0xFFFF) << shift);
                     do
@@ -4339,12 +4383,13 @@ do                                                                      \
                     *(const int32_t**)pFrame->pRetVal = ip + ip[1];
                     goto EXIT_FRAME;
                 INTOP_CASE(INTOP_THROW_PNSE)
-                    COMPlusThrow(kPlatformNotSupportedException);
+                    INTERP_THROW(kPlatformNotSupportedException);
                     INTOP_NEXT;
 
                 INTOP_CASE(INTOP_HANDLE_CONTINUATION_GENERIC)
                 INTOP_CASE(INTOP_HANDLE_CONTINUATION)
                 {
+                    pFrame->ip = ip;
                     int32_t helperOffset = opcode == INTOP_HANDLE_CONTINUATION_GENERIC ? 4 : 3;
                     int32_t ipAdjust = opcode == INTOP_HANDLE_CONTINUATION_GENERIC ? 5 : 4;
                     int32_t suspendDataOffset = opcode == INTOP_HANDLE_CONTINUATION_GENERIC ? 3 : 2;
@@ -4419,6 +4464,7 @@ do                                                                      \
 
                 INTOP_CASE(INTOP_CAPTURE_CONTEXT_ON_SUSPEND)
                 {
+                    pFrame->ip = ip;
                     CONTINUATIONREF continuation = LOCAL_VAR(ip[2], CONTINUATIONREF);
 
                     if (continuation == NULL)
@@ -4533,6 +4579,7 @@ do                                                                      \
 
                 INTOP_CASE(INTOP_HANDLE_CONTINUATION_SUSPEND)
                 {
+                    pFrame->ip = ip;
                     InterpAsyncSuspendData *pAsyncSuspendData = (InterpAsyncSuspendData*)pMethod->pDataItems[ip[2]];
                     CONTINUATIONREF continuation = LOCAL_VAR(ip[1], CONTINUATIONREF);
 
@@ -4608,6 +4655,7 @@ do                                                                      \
 
                 INTOP_CASE(INTOP_HANDLE_CONTINUATION_RESUME)
                 {
+                    pFrame->ip = ip;
                     InterpAsyncSuspendData *pAsyncSuspendData = (InterpAsyncSuspendData*)pMethod->pDataItems[ip[1]];
                     CONTINUATIONREF continuation = (CONTINUATIONREF)ObjectToOBJECTREF(*(Object**)(stack + pAsyncSuspendData->continuationArgOffset));
                     _ASSERTE(pInterpreterFrame->GetContinuation() == NULL);


### PR DESCRIPTION
Instead of making each opcode dispatch to the loop start where we switch on the opcode, we transform every switch case into a label, we let the compiler statically populate the s_dispatchTable which maps each opcode to the label address. This makes opcode dispatch a simple load + branch to the label address from this table. This makes the interpreter 25% faster.

It is unclear whether this has any impact on wasm. Likely not, because wasm has control flow limitations that make random branches impossible.

As an additional optimization, we avoid saving `pFrame->ip` for each opcode. Removing this can improve execution speed by around 3%. Instead we explicitly save `pFrame->ip` in opcodes that can trigger GC or throw exception. Add InterpThrow helper to ensure `pFrame->ip` is set before all throws.