### PR TITLE
Add async DataAnnotations bridge for Microsoft.Extensions.Options

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.Async.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.Async.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the https://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Extensions.Options
+{
+    public partial class DataAnnotationValidateOptions<TOptions> : Microsoft.Extensions.Options.IAsyncValidateOptions<TOptions>
+    {
+        public System.Threading.Tasks.Task<Microsoft.Extensions.Options.ValidateOptionsResult> ValidateAsync(string? name, TOptions options, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.csproj
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.csproj
@@ -7,6 +7,10 @@
     <Compile Include="Microsoft.Extensions.Options.DataAnnotations.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <Compile Include="Microsoft.Extensions.Options.DataAnnotations.Async.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.Async.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.Async.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NET11_0_OR_GREATER
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -8,52 +10,40 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Options
 {
     /// <summary>
-    /// Implementation of <see cref="IValidateOptions{TOptions}"/> that uses DataAnnotation's <see cref="Validator"/> for validation.
+    /// Async validation implementation for <see cref="DataAnnotationValidateOptions{TOptions}"/>.
     /// </summary>
-    /// <typeparam name="TOptions">The instance being validated.</typeparam>
-#if NET11_0_OR_GREATER
-    public partial class DataAnnotationValidateOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] TOptions>
-        : IValidateOptions<TOptions>, IAsyncValidateOptions<TOptions>
-        where TOptions : class
-#else
-    public partial class DataAnnotationValidateOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] TOptions>
-        : IValidateOptions<TOptions>
-        where TOptions : class
-#endif
+    public partial class DataAnnotationValidateOptions<TOptions>
     {
         /// <summary>
-        /// Initializes a new instance of <see cref="DataAnnotationValidateOptions{TOptions}"/> .
-        /// </summary>
-        /// <param name="name">The name of the option.</param>
-        [RequiresUnreferencedCode("The implementation of Validate method on this type will walk through all properties of the passed in options object, and its type cannot be " +
-            "statically analyzed so its members may be trimmed.")]
-        public DataAnnotationValidateOptions(string? name)
-        {
-            Name = name;
-        }
-
-        /// <summary>
-        /// Gets the options name.
-        /// </summary>
-        public string? Name { get; }
-
-        /// <summary>
-        /// Validates a specific named options instance (or all when <paramref name="name"/> is null).
+        /// Asynchronously validates a specific named options instance (or all when <paramref name="name"/> is null).
         /// </summary>
         /// <param name="name">The name of the options instance being validated.</param>
         /// <param name="options">The options instance.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        /// <remarks>
+        /// The <paramref name="cancellationToken"/> is propagated from
+        /// <c>Host.StartAsync(CancellationToken)</c>. By default, no startup timeout
+        /// is applied. Configure <see cref="T:Microsoft.Extensions.Hosting.HostOptions.StartupTimeout"/> or pass
+        /// a <see cref="CancellationToken"/> with a timeout to <c>Host.StartAsync</c>
+        /// to bound I/O-bound async validators:
+        /// <code>
+        /// builder.Services.Configure&lt;HostOptions&gt;(opts =&gt;
+        ///     opts.StartupTimeout = TimeSpan.FromSeconds(30));
+        /// </code>
+        /// </remarks>
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "Suppressing the warnings on this method since the constructor of the type is annotated as RequiresUnreferencedCode.")]
-        public ValidateOptionsResult Validate(string? name, TOptions options)
+        public async Task<ValidateOptionsResult> ValidateAsync(string? name, TOptions options, CancellationToken cancellationToken = default)
         {
             // Null name is used to configure all named options.
-            if (Name != null && Name != name)
+            if (Name is not null && Name != name)
             {
                 // Ignored if not validating this instance.
                 return ValidateOptionsResult.Skip;
@@ -66,7 +56,9 @@ namespace Microsoft.Extensions.Options
             HashSet<object>? visited = null;
             List<string>? errors = null;
 
-            if (TryValidateOptions(options, options.GetType().Name, validationResults, ref errors, ref visited))
+            (bool success, errors) = await TryValidateOptionsAsync(options, options.GetType().Name, validationResults, errors, visited, cancellationToken).ConfigureAwait(false);
+
+            if (success)
             {
                 return ValidateOptionsResult.Success;
             }
@@ -76,25 +68,41 @@ namespace Microsoft.Extensions.Options
             return ValidateOptionsResult.Fail(errors);
         }
 
+        /// <remarks>
+        /// Async counterpart of <see cref="TryValidateOptions"/>. Uses a tuple return
+        /// <c>(bool success, List&lt;string&gt;? errors)</c> instead of <c>ref</c> parameters
+        /// because <c>async</c> methods cannot have <c>ref</c>/<c>out</c> parameters.
+        ///
+        /// <c>visited</c> does not need to be returned — it is created <em>before</em> each
+        /// recursive call, so the callee always receives a non-null, shared instance.
+        /// <c>errors</c> must be returned because it may be lazily created
+        /// (<c>errors ??= new List&lt;string&gt;()</c>) inside the callee.
+        /// </remarks>
         [RequiresUnreferencedCode("This method on this type will walk through all properties of the passed in options object, and its type cannot be " +
             "statically analyzed so its members may be trimmed.")]
-        private static bool TryValidateOptions(object options, string qualifiedName, List<ValidationResult> results, ref List<string>? errors, ref HashSet<object>? visited)
+        private static async Task<(bool success, List<string>? errors)> TryValidateOptionsAsync(
+            object options,
+            string qualifiedName,
+            List<ValidationResult> results,
+            List<string>? errors,
+            HashSet<object>? visited,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(options is not null);
 
             if (visited is not null && visited.Contains(options))
             {
-                return true;
+                return (true, errors);
             }
 
             results.Clear();
 
-            bool res = Validator.TryValidateObject(options, new ValidationContext(options), results, validateAllProperties: true);
+            bool res = await Validator.TryValidateObjectAsync(options, new ValidationContext(options), results, validateAllProperties: true, cancellationToken).ConfigureAwait(false);
             if (!res)
             {
                 errors ??= new List<string>();
 
-                foreach (ValidationResult result in results!)
+                foreach (ValidationResult result in results)
                 {
                     errors.Add($"DataAnnotation validation failed for '{qualifiedName}' members: '{string.Join(",", result.MemberNames)}' with the error: '{result.ErrorMessage}'.");
                 }
@@ -108,7 +116,7 @@ namespace Microsoft.Extensions.Options
                     continue;
                 }
 
-                object? value = propertyInfo!.GetValue(options);
+                object? value = propertyInfo.GetValue(options);
 
                 if (value is null)
                 {
@@ -120,25 +128,29 @@ namespace Microsoft.Extensions.Options
                     visited ??= new HashSet<object>(ReferenceEqualityComparer.Instance);
                     visited.Add(options);
 
-                    results ??= new List<ValidationResult>();
-                    res = TryValidateOptions(value, $"{qualifiedName}.{propertyInfo.Name}", results, ref errors, ref visited) && res;
+                    bool innerRes;
+                    (innerRes, errors) = await TryValidateOptionsAsync(value, $"{qualifiedName}.{propertyInfo.Name}", results, errors, visited, cancellationToken).ConfigureAwait(false);
+                    res = innerRes && res;
                 }
                 else if (value is IEnumerable enumerable &&
                          propertyInfo.GetCustomAttribute<ValidateEnumeratedItemsAttribute>() is not null)
                 {
                     visited ??= new HashSet<object>(ReferenceEqualityComparer.Instance);
                     visited.Add(options);
-                    results ??= new List<ValidationResult>();
 
                     int index = 0;
                     foreach (object item in enumerable)
                     {
-                        res = TryValidateOptions(item, $"{qualifiedName}.{propertyInfo.Name}[{index++}]", results, ref errors, ref visited) && res;
+                        bool innerRes;
+                        (innerRes, errors) = await TryValidateOptionsAsync(item, $"{qualifiedName}.{propertyInfo.Name}[{index++}]", results, errors, visited, cancellationToken).ConfigureAwait(false);
+                        res = innerRes && res;
                     }
                 }
             }
 
-            return res;
+            return (res, errors);
         }
     }
 }
+
+#endif

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.Async.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.Async.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.Options
         /// <remarks>
         /// The <paramref name="cancellationToken"/> is propagated from
         /// <c>Host.StartAsync(CancellationToken)</c>. By default, no startup timeout
-        /// is applied. Configure <see cref="T:Microsoft.Extensions.Hosting.HostOptions.StartupTimeout"/> or pass
+        /// is applied. Configure <c>HostOptions.StartupTimeout</c> or pass
         /// a <see cref="CancellationToken"/> with a timeout to <c>Host.StartAsync</c>
         /// to bound I/O-bound async validators:
         /// <code>

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
@@ -12,8 +12,13 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class OptionsBuilderDataAnnotationsExtensions
     {
         /// <summary>
-        /// Register this options instance for validation of its DataAnnotations.
+        /// Registers this options instance for validation of its DataAnnotations.
         /// </summary>
+        /// <remarks>
+        /// Synchronous validation runs on every options access. When targeting .NET 11 or later,
+        /// asynchronous validation (including <c>AsyncValidationAttribute</c>-derived attributes)
+        /// runs once at startup when <c>ValidateOnStart()</c> is also called.
+        /// </remarks>
         /// <typeparam name="TOptions">The options type to be configured.</typeparam>
         /// <param name="optionsBuilder">The options builder to add the services to.</param>
         /// <returns>The <see cref="OptionsBuilder{TOptions}"/> so that additional calls can be chained.</returns>
@@ -21,7 +26,11 @@ namespace Microsoft.Extensions.DependencyInjection
             " members may be trimmed.")]
         public static OptionsBuilder<TOptions> ValidateDataAnnotations<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] TOptions>(this OptionsBuilder<TOptions> optionsBuilder) where TOptions : class
         {
-            optionsBuilder.Services.AddSingleton<IValidateOptions<TOptions>>(new DataAnnotationValidateOptions<TOptions>(optionsBuilder.Name));
+            var instance = new DataAnnotationValidateOptions<TOptions>(optionsBuilder.Name);
+            optionsBuilder.Services.AddSingleton<IValidateOptions<TOptions>>(instance);
+#if NET11_0_OR_GREATER
+            optionsBuilder.Services.AddSingleton<IAsyncValidateOptions<TOptions>>(instance);
+#endif
             return optionsBuilder;
         }
     }

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
@@ -15,9 +15,16 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Registers this options instance for validation of its DataAnnotations.
         /// </summary>
         /// <remarks>
-        /// Synchronous validation runs on every options access. When targeting .NET 11 or later,
+        /// Synchronous validation runs when the options instance is created or accessed. When targeting .NET 11 or later,
         /// asynchronous validation (including <c>AsyncValidationAttribute</c>-derived attributes)
-        /// runs once at startup when <c>ValidateOnStart()</c> is also called.
+        /// runs once at startup, and only when <c>ValidateOnStart()</c> is also called.
+        /// If <c>ValidateOnStart()</c> is not called, attributes deriving from
+        /// <c>AsyncValidationAttribute</c> are never evaluated asynchronously: runtime options access triggers only
+        /// synchronous validation, which invokes the attribute's synchronous fallback instead.
+        /// When using <c>AsyncValidationAttribute</c>-derived attributes, ensure the synchronous
+        /// <c>IsValid</c> fallback does not throw: synchronous validation still runs on every
+        /// options access, so a throwing fallback surfaces as an exception on each access (for example
+        /// when resolving <c>IOptions{TOptions}.Value</c>), even if startup validation succeeded.
         /// </remarks>
         /// <typeparam name="TOptions">The options type to be configured.</typeparam>
         /// <param name="optionsBuilder">The options builder to add the services to.</param>

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -901,5 +903,133 @@ namespace Microsoft.Extensions.Options.Tests
             var unvalidated = monitor.Get("unvalidated");
             Assert.NotNull(unvalidated);
         }
+
+#if NET11_0_OR_GREATER
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_ReportsAnnotationFailures()
+        {
+            var options = new AnnotatedOptions
+            {
+                StringLength = "111111",
+                IntRange = 10,
+                Custom = "nowhere",
+                Dep1 = "Not dep2"
+            };
+
+            var validator = new DataAnnotationValidateOptions<AnnotatedOptions>(Options.DefaultName);
+
+            ValidateOptionsResult syncResult = validator.Validate(Options.DefaultName, options);
+            Assert.True(syncResult.Failed);
+
+            ValidateOptionsResult asyncResult = await validator.ValidateAsync(Options.DefaultName, options);
+            Assert.True(asyncResult.Failed);
+            Assert.Equal(syncResult.Failures, asyncResult.Failures);
+            Assert.Equal(5, asyncResult.Failures.Count());
+            Assert.Contains("DataAnnotation validation failed", asyncResult.Failures.First());
+        }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_SucceedsWhenValid()
+        {
+            var options = new AnnotatedOptions
+            {
+                Required = "value",
+                StringLength = "1234",
+                IntRange = 0,
+                Custom = "USA",
+                Dep1 = "dep",
+                Dep2 = "dep"
+            };
+
+            var validator = new DataAnnotationValidateOptions<AnnotatedOptions>(Options.DefaultName);
+            ValidateOptionsResult result = await validator.ValidateAsync(Options.DefaultName, options);
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_SkipsWhenNameMismatch()
+        {
+            var validator = new DataAnnotationValidateOptions<AnnotatedOptions>("expected");
+            ValidateOptionsResult result = await validator.ValidateAsync("other", new AnnotatedOptions());
+            Assert.True(result.Skipped);
+        }
+
+        [Theory]
+        [InlineData("named1")]
+        [InlineData(null)]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_NameMatching(string? registeredName)
+        {
+            var options = new AnnotatedOptions
+            {
+                StringLength = "111111",
+                IntRange = 10,
+                Custom = "nowhere",
+                Dep1 = "Not dep2"
+            };
+
+            var validator = new DataAnnotationValidateOptions<AnnotatedOptions>(registeredName);
+
+            ValidateOptionsResult defaultResult = await validator.ValidateAsync(Options.DefaultName, options);
+
+            if (registeredName is null)
+            {
+                Assert.True(defaultResult.Failed);
+            }
+            else
+            {
+                Assert.True(defaultResult.Skipped);
+            }
+        }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_ThrowsOnNullOptions()
+        {
+            var validator = new DataAnnotationValidateOptions<AnnotatedOptions>(Options.DefaultName);
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => validator.ValidateAsync(Options.DefaultName, null!, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task ValidateDataAnnotations_ValidateOnStart_AsyncStartupValidator_Success()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions<AnnotatedOptions>()
+                .Configure(o =>
+                {
+                    o.Required = "required";
+                    o.StringLength = "1111";
+                    o.IntRange = 0;
+                    o.Custom = "USA";
+                    o.Dep1 = "dep";
+                    o.Dep2 = "dep";
+                })
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            using ServiceProvider sp = services.BuildServiceProvider();
+            var asyncValidator = sp.GetRequiredService<IAsyncStartupValidator>();
+            await asyncValidator.ValidateAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_AcceptsCancellationToken()
+        {
+            var options = new AnnotatedOptions
+            {
+                Required = "value",
+                StringLength = "1234",
+                IntRange = 0,
+                Custom = "USA",
+                Dep1 = "dep",
+                Dep2 = "dep"
+            };
+
+            var validator = new DataAnnotationValidateOptions<AnnotatedOptions>(Options.DefaultName);
+            using var cts = new CancellationTokenSource();
+
+            ValidateOptionsResult result = await validator.ValidateAsync(Options.DefaultName, options, cts.Token);
+            Assert.True(result.Succeeded);
+        }
+#endif // NET11_0_OR_GREATER
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
@@ -905,6 +905,45 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
 #if NET11_0_OR_GREATER
+        private sealed class AsyncOnlyFailAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext) => ValidationResult.Success;
+
+            protected override async Task<ValidationResult?> IsValidAsync(object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                await Task.Yield();
+                if (value is null)
+                {
+                    return ValidationResult.Success;
+                }
+
+                return new ValidationResult("Async-only failure", new[] { validationContext.MemberName! });
+            }
+        }
+
+        private class AsyncAnnotatedOptions
+        {
+            [AsyncOnlyFail]
+            public string? Value { get; set; }
+        }
+
+        private class ParentWithNestedAsync
+        {
+            [Required]
+            public string? Name { get; set; }
+
+            [ValidateObjectMembers]
+            public AsyncAnnotatedOptions? Child { get; set; }
+        }
+
+        private class ParentWithEnumeratedAsync
+        {
+            [ValidateEnumeratedItems]
+            public List<AsyncAnnotatedOptions>? Items { get; set; }
+        }
+#endif
+
+#if NET11_0_OR_GREATER
         [Fact]
         public async Task DataAnnotationValidateOptions_ValidateAsync_ReportsAnnotationFailures()
         {
@@ -923,9 +962,9 @@ namespace Microsoft.Extensions.Options.Tests
 
             ValidateOptionsResult asyncResult = await validator.ValidateAsync(Options.DefaultName, options);
             Assert.True(asyncResult.Failed);
-            Assert.Equal(syncResult.Failures, asyncResult.Failures);
+            Assert.Equal(syncResult.Failures.OrderBy(f => f), asyncResult.Failures.OrderBy(f => f));
             Assert.Equal(5, asyncResult.Failures.Count());
-            Assert.Contains("DataAnnotation validation failed", asyncResult.Failures.First());
+            Assert.All(asyncResult.Failures, f => Assert.Contains("DataAnnotation validation failed", f));
         }
 
         [Fact]
@@ -1029,6 +1068,72 @@ namespace Microsoft.Extensions.Options.Tests
 
             ValidateOptionsResult result = await validator.ValidateAsync(Options.DefaultName, options, cts.Token);
             Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_DetectsAsyncOnlyFailure()
+        {
+            var options = new AsyncAnnotatedOptions { Value = "test" };
+            var validator = new DataAnnotationValidateOptions<AsyncAnnotatedOptions>(Options.DefaultName);
+
+            ValidateOptionsResult syncResult = validator.Validate(Options.DefaultName, options);
+            Assert.True(syncResult.Succeeded);
+
+            ValidateOptionsResult asyncResult = await validator.ValidateAsync(Options.DefaultName, options);
+            Assert.True(asyncResult.Failed);
+            Assert.Contains("Async-only failure", asyncResult.FailureMessage);
+        }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_AsyncOnlySuccess()
+        {
+            var options = new AsyncAnnotatedOptions { Value = null };
+            var validator = new DataAnnotationValidateOptions<AsyncAnnotatedOptions>(Options.DefaultName);
+
+            ValidateOptionsResult result = await validator.ValidateAsync(Options.DefaultName, options);
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_NestedObjectRecursion()
+        {
+            var options = new ParentWithNestedAsync
+            {
+                Name = "parent",
+                Child = new AsyncAnnotatedOptions { Value = "test" }
+            };
+            var validator = new DataAnnotationValidateOptions<ParentWithNestedAsync>(Options.DefaultName);
+
+            ValidateOptionsResult syncResult = validator.Validate(Options.DefaultName, options);
+            Assert.True(syncResult.Succeeded);
+
+            ValidateOptionsResult asyncResult = await validator.ValidateAsync(Options.DefaultName, options);
+            Assert.True(asyncResult.Failed);
+            Assert.Contains("ParentWithNestedAsync.Child", asyncResult.FailureMessage);
+            Assert.Contains("Async-only failure", asyncResult.FailureMessage);
+        }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_EnumeratedItemsRecursion()
+        {
+            var options = new ParentWithEnumeratedAsync
+            {
+                Items = new List<AsyncAnnotatedOptions>
+                {
+                    new() { Value = "a" },
+                    new() { Value = "b" }
+                }
+            };
+            var validator = new DataAnnotationValidateOptions<ParentWithEnumeratedAsync>(Options.DefaultName);
+
+            ValidateOptionsResult syncResult = validator.Validate(Options.DefaultName, options);
+            Assert.True(syncResult.Succeeded);
+
+            ValidateOptionsResult asyncResult = await validator.ValidateAsync(Options.DefaultName, options);
+            Assert.True(asyncResult.Failed);
+            Assert.Contains("[0]", asyncResult.FailureMessage);
+            Assert.Contains("[1]", asyncResult.FailureMessage);
+            Assert.Contains("Async-only failure", asyncResult.FailureMessage);
         }
 #endif // NET11_0_OR_GREATER
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/129056

Implements the async DataAnnotations bridge for `Microsoft.Extensions.Options` as approved in [API review](https://github.com/dotnet/runtime/issues/129056#issuecomment-4662588914).

Follow-up to https://github.com/dotnet/runtime/pull/128788 (async Options pipeline) and https://github.com/dotnet/runtime/pull/128656 (`AsyncValidationAttribute` / `Validator.TryValidateObjectAsync`).

Source generator support (`[OptionsValidator]` emitting `ValidateAsync()`) is tracked separately in https://github.com/dotnet/runtime/issues/128882.

### What's included

- `DataAnnotationValidateOptions<TOptions>` now also implements `IAsyncValidateOptions<TOptions>` — `ValidateAsync` mirrors the sync `Validate()` recursive walk but delegates to `Validator.TryValidateObjectAsync`, which evaluates both sync attributes (Phase 1) and `AsyncValidationAttribute`s (Phase 2)
- `ValidateDataAnnotations()` registers the same instance as both `IValidateOptions<T>` and `IAsyncValidateOptions<T>` — no new public types or extension methods
- Ref assembly update for the async surface (`Microsoft.Extensions.Options.DataAnnotations.Async.cs`)
- Tests covering `ValidateAsync` success, failure, name matching, null options, `IAsyncStartupValidator` integration, and cancellation token acceptance

### Implementation notes

- `ValidateAsync` uses a tuple return `(bool success, List<string>? errors)` instead of `ref` parameters because `async` methods cannot have `ref`/`out` parameters
- `TryValidateOptionsAsync` recursively walks `[ValidateObjectMembers]` and `[ValidateEnumeratedItems]` properties, matching the sync `TryValidateOptions` behavior
- Guarded with `#if NET11_0_OR_GREATER` since `Validator.TryValidateObjectAsync` and `IAsyncValidateOptions<T>` are .NET 11+ APIs