### PR TITLE
[browser][coreCLR] set "LANG" env variable

### DIFF
--- a/src/native/libs/Common/JavaScript/loader/icu.ts
+++ b/src/native/libs/Common/JavaScript/loader/icu.ts
@@ -9,6 +9,10 @@ export function getIcuResourceName(): string | null {
             loaderConfig.applicationCulture = culture;
         }
 
+        if (culture) {
+            loaderConfig.environmentVariables!["LANG"] = `${culture}.UTF-8`;
+        }
+
         const icuFiles = loaderConfig.resources.icu;
         let icuFile = null;
         if (loaderConfig.globalizationMode === GlobalizationMode.Custom) {

--- a/src/native/libs/Common/JavaScript/loader/icu.ts
+++ b/src/native/libs/Common/JavaScript/loader/icu.ts
@@ -9,7 +9,7 @@ export function getIcuResourceName(): string | null {
             loaderConfig.applicationCulture = culture;
         }
 
-        if (culture) {
+        if (culture && loaderConfig.environmentVariables!["LANG"] === undefined) {
             loaderConfig.environmentVariables!["LANG"] = `${culture}.UTF-8`;
         }
 


### PR DESCRIPTION
## Summary

The CoreCLR WebAssembly browser loader used `applicationCulture` **only** to select the ICU shard in `getIcuResourceName()`. It never propagated the culture into the runtime's `LANG` environment variable. As a result, the runtime's default locale (`InstalledUICulture` / `UserDefaultCulture`) stayed at the loader/Emscripten default (`en_US.UTF-8`) even when the app requested a different `applicationCulture`.

This change sets `LANG = "<applicationCulture>.UTF-8"` in the loader, mirroring what Mono already does in `src/mono/browser/runtime/loader/config.ts`.

## Problem

On CoreCLR-WASM the runtime default culture is driven by `LANG` (via `uloc_getDefault()` → `getenv("LANG")` in `pal_locale.c`), **not** by `applicationCulture`. With `LANG` left at the default, a Blazor WebAssembly app started with a non-default culture (e.g. `Blazor.start({ webAssembly: { applicationCulture: "fr-FR" } })` from `?culture=fr-FR`) failed:

```
InvalidOperationException: Blazor detected a change in the application's culture
that is not supported with the current project configuration...
```

This is thrown by `WebAssemblyCultureProvider.ThrowIfCultureChangeIsUnsupported` when sharded ICU is in use (`__BLAZOR_SHARDED_ICU == "1"`, the default) **and** `CultureInfo.CurrentCulture != InitialCulture`. `InitialCulture` came from the configured `applicationCulture` (`fr-FR`), but `CurrentCulture` fell back to the runtime default (`en-US`) because `LANG` was never applied.

## Fix

In `src/native/libs/Common/JavaScript/loader/icu.ts`, after finalizing `loaderConfig.applicationCulture`, set:

```ts
if (culture && loaderConfig.environmentVariables!["LANG"] === undefined) {
    loaderConfig.environmentVariables!["LANG"] = `${culture}.UTF-8`;
}
```

The `=== undefined` guard is conservative: it only sets `LANG` when the culture is known and the user has not already supplied their own `LANG` (e.g. via `dotnet.withEnvironmentVariable("LANG", ...)`), so explicit user configuration is never overridden.

The host applies env vars to the Emscripten `ENV` in `host/index.ts::setupEmscripten`, which runs during `dotnetInitializeModule` **after** `getIcuResourceName()` is called in `loader/run.ts`, so the ordering is correct.

## Behavior change (A/B with `?culture=fr-FR`)

**Before** (`applicationCulture=fr-FR` only):
- `getenv("LANG")` = `en_US.UTF-8` (default)
- `InstalledUICulture` / `UserDefaultCulture` = `en-US`
- `CurrentCulture` falls back to `en-US` ≠ `InitialCulture` (`fr-FR`) → Blazor throws, page fails to render.

**After** (`LANG=fr-FR.UTF-8`):
- `getenv("LANG")` = `fr-FR.UTF-8`
- `InstalledUICulture` / `UserDefaultCulture` = `fr-FR`
- `CurrentCulture == InitialCulture` (`fr-FR`) → no throw, page renders.

This eliminates the Blazor culture-change exception and makes the CoreCLR-WASM runtime default culture match `applicationCulture`, exactly mirroring Mono.

## How satellite assemblies are loaded

In short: **Blazor (`LoadCurrentCultureResourcesAsync`) → `INTERNAL.loadSatelliteAssemblies` → `fetchSatelliteAssemblies` → `fetchAssembly`/`registerDllBytes` (download + copy into WASM heap) → `external_assembly_probe`/`BrowserHost_ExternalAssemblyProbe` (runtime resolves from memory)**. This PR only ensures the culture used in step 1 is correct; the download path itself is unchanged.

Related https://github.com/dotnet/aspnetcore/pull/66331