### PR TITLE
[ci-scan] Tighten agentic CI workflow dedup and feedback emission

### DIFF
--- a/.github/workflows/ci-failure-scan-feedback.md
+++ b/.github/workflows/ci-failure-scan-feedback.md
@@ -168,8 +168,10 @@ The two workflows are evaluated on separate axes; do NOT merge their quality num
 
    Branch on the result:
 
-   - Existing PR found -> emit `push_to_pull_request_branch` to add the new edits as a commit on that PR's branch, then emit `update_pull_request` to append a new dated section to its body. Do NOT call `create_pull_request`.
+   - Existing PR found -> emit `push_to_pull_request_branch` (with the existing PR's `pull_request_number` from the search above, since this is a scheduled run with no triggering PR) to add the new edits as a commit on that PR's branch, then emit `update_pull_request` (same `pull_request_number`) to append a new dated section to its body. Do NOT call `create_pull_request`.
    - No existing PR -> emit one `create_pull_request`. Title: `[ci-scan-feedback] <one-line summary>`.
+
+   **Emission order.** Emit the Step 7 tracker `update_issue` / `create_issue` BEFORE these PR safe-outputs. The safe-outputs processor runs messages in emission order and cancels every later message once one fails, so a PR-push or patch error here must never cancel the daily tracker snapshot.
 
    The PR body (or the appended section, when updating) MUST contain:
    - `## Triggering signals` — bullet list of `(issue/PR #, quoted maintainer comment or rubric finding, link)`.
@@ -323,7 +325,7 @@ The two workflows are evaluated on separate axes; do NOT merge their quality num
    - Do NOT emit charts (mermaid or otherwise).
    - Do NOT emit historical weekly buckets. The body is a current snapshot.
 
-   If the tracker exists -> emit one `update_issue` with the new body. If not -> emit one `create_issue` titled `[ci-scan-feedback] KPI Tracker`. Either way, this step ALWAYS fires (never call `noop` for the tracker — a daily snapshot is the point).
+   If the tracker exists -> emit one `update_issue` with the new body. If not -> emit one `create_issue` titled `[ci-scan-feedback] KPI Tracker`. Either way, this step ALWAYS fires (never call `noop` for the tracker — a daily snapshot is the point). Emit this tracker output BEFORE the Step 6 PR safe-outputs (see the Step 6 "Emission order" note) so a PR-push failure cannot cancel the snapshot.
 
 ## Output to agent log
 

--- a/.github/workflows/ci-failure-scan.md
+++ b/.github/workflows/ci-failure-scan.md
@@ -243,7 +243,7 @@ printf '%s\t%s\n' "$xkey" "aw_<id>" >> /tmp/gh-aw/agent/filed.tsv               
 Follow exactly these sections from `.github/workflows/shared/create-kbe.instructions.md`, in this order:
 
 1. `<a id="search-existing-kbe"></a>` / `## Search for an existing KBE`
-2. `<a id="search-recently-closed-kbe"></a>` / `## Search recently-closed KBEs (open-only dedup gap)`
+2. `<a id="search-recently-closed-kbe"></a>` / `## Search recently-closed KBEs`
 3. `<a id="search-area-team-tracker"></a>` / `## Search for an area-team tracker`
 4. `<a id="search-existing-prs"></a>` / `## Search for existing PRs already handling the failure`
 5. `<a id="verify-embedded-issues"></a>` / `## Verify every embedded issue number exists`

--- a/.github/workflows/ci-failure-scan.md
+++ b/.github/workflows/ci-failure-scan.md
@@ -243,9 +243,10 @@ printf '%s\t%s\n' "$xkey" "aw_<id>" >> /tmp/gh-aw/agent/filed.tsv               
 Follow exactly these sections from `.github/workflows/shared/create-kbe.instructions.md`, in this order:
 
 1. `<a id="search-existing-kbe"></a>` / `## Search for an existing KBE`
-2. `<a id="search-area-team-tracker"></a>` / `## Search for an area-team tracker`
-3. `<a id="search-existing-prs"></a>` / `## Search for existing PRs already handling the failure`
-4. `<a id="verify-embedded-issues"></a>` / `## Verify every embedded issue number exists`
+2. `<a id="search-recently-closed-kbe"></a>` / `## Search recently-closed KBEs (open-only dedup gap)`
+3. `<a id="search-area-team-tracker"></a>` / `## Search for an area-team tracker`
+4. `<a id="search-existing-prs"></a>` / `## Search for existing PRs already handling the failure`
+5. `<a id="verify-embedded-issues"></a>` / `## Verify every embedded issue number exists`
 
 When searching, account for the fact that the same signature can be filed in
 different `ErrorMessage` representations. A KBE recorded in `<a id="kbe-array-form"></a>`
@@ -261,6 +262,7 @@ Record the same outcomes described there:
 - `existing-kbe #<n>`
 - `linked-tracker #<n>`
 - `existing-PR #<n>`
+- `skipped: recently-closed dup #<n>, needs human review`
 - `skipped: integrity-filtered candidate, needs human review`
 
 #### Step 4.7 — Verify the candidate KBE actually matches

--- a/.github/workflows/shared/create-kbe.instructions.md
+++ b/.github/workflows/shared/create-kbe.instructions.md
@@ -54,11 +54,18 @@ best-match ranking can place noisier hits above the correct one.
    `_osx_arm64`) and type-width suffixes (`_byte_short`, `_long_ulong`,
    `_8bit`, `_16bit`, `_32bit`); search the stem in `in:title` and `in:body`.
    Catches sibling KBEs at different bit widths or instantiations.
+7. Bare signature, open issues, no label filter:
+   `is:issue is:open in:title "<test-name>"` and
+   `is:issue is:open "<assertion-text>" in:body`. Catches a pre-existing
+   human-filed report (`Test failure: ...`) that lacks both the
+   `Known Build Error` and area labels, so the label-scoped variations above
+   skip over it.
 
 Variations 4 and 5 catch sibling failures filed for the same test class on a
 different platform or runtime variant, plus pre-existing area-team trackers
 that lack the `Known Build Error` label. Variation 6 catches siblings at
-different bit widths or instantiations.
+different bit widths or instantiations. Variation 7 catches an open human
+report with no label at all.
 
 If two candidate KBEs share more than 70% of their `ErrorMessage` /
 `ErrorPattern` tokens, do **not** guess: record
@@ -77,6 +84,33 @@ On any visible hit whose title or body references the same test class on any
 platform, record `existing-kbe #<n>` (or `linked-tracker #<n>` for variation 5
 when the hit lacks the KBE label) and continue. A hit changes the final action;
 it does not end the inspection.
+
+<a id="search-recently-closed-kbe"></a>
+
+## Search recently-closed KBEs (open-only dedup gap)
+
+The existing-KBE search above is open-only. A `[ci-scan]` KBE that was already
+closed (as fixed, duplicate, or stale) is invisible to it, so a recurring
+signature gets re-filed from scratch the next time it surfaces — the exact churn
+that produced several closed KBEs for one failure
+(`X509Certificate2CollectionRemoveRangeArray`, `crossgen2_comparison.py`). After
+the open search misses, also scan recently-closed candidates:
+
+- `is:issue is:closed label:"Known Build Error" "<assertion-or-test-name>" closed:>=<30-days-ago>`
+- `is:issue is:closed in:title "<test-name>" closed:>=<30-days-ago>` — catches a
+  closed `[ci-scan]` predecessor and a human-filed report that never carried the
+  KBE label.
+
+On a closed-candidate hit, compare the failing AzDO build's `finishTime` (read
+it from the build metadata, not the queue time) against the issue's `closed_at`:
+
+- Closed **after** the failing build finished, or closed within the last 7 days:
+  the failure is already handled or under active triage. Record
+  `skipped: recently-closed dup #<n>, needs human review` and do not file.
+- The same signature reproduces in a build that finished **after** `closed_at` (a
+  genuine post-close recurrence): file a fresh KBE and name the closed
+  predecessor `#<n>` in the body so the regression is explicit, mirroring the
+  merged-fix-PR recurrence rule below.
 
 <a id="search-area-team-tracker"></a>
 

--- a/.github/workflows/shared/create-kbe.instructions.md
+++ b/.github/workflows/shared/create-kbe.instructions.md
@@ -87,18 +87,16 @@ it does not end the inspection.
 
 <a id="search-recently-closed-kbe"></a>
 
-## Search recently-closed KBEs (open-only dedup gap)
+## Search recently-closed KBEs
 
-The existing-KBE search above is open-only. A `[ci-scan]` KBE that was already
-closed (as fixed, duplicate, or stale) is invisible to it, so a recurring
-signature gets re-filed from scratch the next time it surfaces — the exact churn
-that produced several closed KBEs for one failure
-(`X509Certificate2CollectionRemoveRangeArray`, `crossgen2_comparison.py`). After
-the open search misses, also scan recently-closed candidates:
+The existing-KBE search above is open-only, so a `[ci-scan]` KBE already closed
+as fixed, duplicate, or stale is invisible and a recurring signature gets
+re-filed from scratch. After the open search misses, also scan recently-closed
+candidates:
 
 - `is:issue is:closed label:"Known Build Error" "<assertion-or-test-name>" closed:>=<30-days-ago>`
-- `is:issue is:closed in:title "<test-name>" closed:>=<30-days-ago>` — catches a
-  closed `[ci-scan]` predecessor and a human-filed report that never carried the
+- `is:issue is:closed in:title "<test-name>" closed:>=<30-days-ago>` to catch a
+  closed `[ci-scan]` predecessor or a human-filed report that never carried the
   KBE label.
 
 On a closed-candidate hit, compare the failing AzDO build's `finishTime` (read


### PR DESCRIPTION
## Description

The detection step only searched open issues, so it could miss a recently-closed predecessor or an unlabeled human report of the same failure and file a duplicate Known Build Error; this change adds a no-label open-issue search and a recently-closed search so a repeat failure is skipped for human review instead of refiled, unless it genuinely reproduces after the earlier issue was closed, while the feedback step now passes the pull request number explicitly when it pushes or updates a branch on a scheduled run (which previously failed because there is no triggering pull request) and emits the KPI tracker update before the pull request outputs so a push or patch failure can no longer drop the daily snapshot, and because the prompts are imported at runtime no compiled workflow files need regenerating.
