### PR TITLE
[cdac] Share one coreclr build between cDAC dump + stress test legs

### DIFF
--- a/eng/pipelines/cdac/prepare-cdac-helix-steps.yml
+++ b/eng/pipelines/cdac/prepare-cdac-helix-steps.yml
@@ -7,13 +7,18 @@ parameters:
   buildDebuggees: true
   skipDebuggeeCopy: false
   runtimeConfiguration: 'Checked'
+  # Configuration used to rebuild the cDAC managed assemblies + DumpTests
+  # csproj during payload prep. The dump tests load the managed cDAC
+  # directly, so we ship Debug binaries here even when the rest of the
+  # build is Release. Defaults to $(_BuildConfig) for backward compatibility.
+  cdacTestConfig: '$(_BuildConfig)'
 
 steps:
 - ${{ if parameters.buildDebuggees }}:
   - script: $(Build.SourcesDirectory)$(dir).dotnet$(dir)dotnet$(exeExt) msbuild
       $(Build.SourcesDirectory)/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
       /t:BuildDebuggeesOnly
-      /p:Configuration=$(_BuildConfig)
+      /p:Configuration=${{ parameters.cdacTestConfig }}
       /p:TargetArchitecture=$(archType)
       /p:RuntimeConfiguration=${{ parameters.runtimeConfiguration }}
       -bl:$(Build.SourcesDirectory)/artifacts/log/BuildDebuggees.binlog
@@ -23,7 +28,7 @@ steps:
     $(Build.SourcesDirectory)/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
     /p:PrepareHelixPayload=true
     /p:SkipDebuggeeCopy=${{ parameters.skipDebuggeeCopy }}
-    /p:Configuration=$(_BuildConfig)
+    /p:Configuration=${{ parameters.cdacTestConfig }}
     /p:HelixPayloadDir=$(Build.SourcesDirectory)/artifacts/helixPayload/cdac
     /p:SkipDumpVersions=net10.0
     -bl:$(Build.SourcesDirectory)/artifacts/log/DumpTestPayload.binlog

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -279,6 +279,39 @@ extends:
               condition: failed()
 
     #
+    # cDAC Shared Build — One coreclr+libs build per platform, consumed by
+    # both CdacDumpTests and CdacStressTests (and the X-plat dump stages)
+    # so we don't rebuild coreclr per test leg. Runtime is built Checked;
+    # cDAC native shim ships in the Release testhost (used by stress tests
+    # in-process); dump tests will rebuild the cDAC managed assemblies at
+    # /p:Configuration=Debug during payload prep.
+    #
+    - ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
+      - stage: CdacBuild
+        dependsOn: []
+        jobs:
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/global-build-job.yml
+            buildConfig: release
+            platforms: ${{ parameters.cdacDumpPlatforms }}
+            jobParameters:
+              nameSuffix: CdacBuild
+              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests+tools.cdacstresstests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
+              isOfficialBuild: ${{ variables.isOfficialBuild }}
+              timeoutInMinutes: 180
+              postBuildSteps:
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: $(Build.SourcesDirectory)/artifacts/bin
+                  includeRootFolder: false
+                  archiveType: $(archiveType)
+                  archiveExtension: $(archiveExtension)
+                  tarCompression: $(tarCompression)
+                  artifactName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)
+                  displayName: cDAC Shared Build Artifacts
+
+    #
     # cDAC Dump Tests — Build, generate dumps, and run tests on Helix (single-leg mode)
     #
     - ${{ if and(eq(parameters.cdacDumpTestMode, 'single-leg'), ne(variables['Build.Reason'], 'Schedule')) }}:

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -279,46 +279,45 @@ extends:
               condition: failed()
 
     #
-    # cDAC Shared Build — One coreclr+libs build per platform, consumed by
-    # both CdacDumpTests and CdacStressTests (and the X-plat dump stages)
-    # so we don't rebuild coreclr per test leg. Runtime is built Checked;
-    # cDAC native shim ships in the Release testhost (used by stress tests
-    # in-process); dump tests will rebuild the cDAC managed assemblies at
-    # /p:Configuration=Debug during payload prep.
+    # cDAC Stage — single stage containing the shared build + all per-platform
+    # test legs (dump tests, stress tests, x-plat dump generation). Putting
+    # them in one stage lets each test job depend on its OWN platform's
+    # CdacBuild job via job-level `dependsOnGlobalBuilds`, so linux_x64 dump
+    # tests start as soon as linux_x64 build is done -- no waiting for the
+    # slowest platform's build.
     #
-    - ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
-      - stage: CdacBuild
-        dependsOn: []
-        jobs:
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/common/global-build-job.yml
-            buildConfig: release
-            platforms: ${{ parameters.cdacDumpPlatforms }}
-            jobParameters:
-              nameSuffix: CdacBuild
-              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests+tools.cdacstresstests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
-              isOfficialBuild: ${{ variables.isOfficialBuild }}
-              timeoutInMinutes: 180
-              postBuildSteps:
-              - template: /eng/pipelines/common/upload-artifact-step.yml
-                parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/bin
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)
-                  displayName: cDAC Shared Build Artifacts
+    # Runtime is built Checked; the cDAC native shim ships in the Release
+    # testhost (used by stress tests in-process); dump tests rebuild the
+    # cDAC managed assemblies at /p:Configuration=Debug during payload prep.
+    #
+    - stage: Cdac
+      dependsOn: []
+      jobs:
+      # ---- Shared per-platform build (always runs; downstream jobs depend on
+      # this via job-level dependsOnGlobalBuilds: - nameSuffix: CdacBuild) ----
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          platforms: ${{ parameters.cdacDumpPlatforms }}
+          jobParameters:
+            nameSuffix: CdacBuild
+            buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests+tools.cdacstresstests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            timeoutInMinutes: 180
+            postBuildSteps:
+            - template: /eng/pipelines/common/upload-artifact-step.yml
+              parameters:
+                rootFolder: $(Build.SourcesDirectory)/artifacts/bin
+                includeRootFolder: false
+                archiveType: $(archiveType)
+                archiveExtension: $(archiveExtension)
+                tarCompression: $(tarCompression)
+                artifactName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)
+                displayName: cDAC Shared Build Artifacts
 
-    #
-    # cDAC Dump Tests — Build, generate dumps, and run tests on Helix (single-leg mode)
-    #
-    - ${{ if and(eq(parameters.cdacDumpTestMode, 'single-leg'), ne(variables['Build.Reason'], 'Schedule')) }}:
-      - stage: CdacDumpTests
-        dependsOn:
-        - CdacBuild
-        jobs:
+      # ---- cDAC Dump Tests (single-leg mode, not on schedule) ----
+      - ${{ if and(eq(parameters.cdacDumpTestMode, 'single-leg'), ne(variables['Build.Reason'], 'Schedule')) }}:
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
             jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -368,16 +367,8 @@ extends:
                 displayName: 'Fail on test errors'
                 condition: always()
 
-    #
-    # cDAC GC Stress Tests — runs in-process cDAC vs runtime stack-ref
-    # verification at GC stress points. Independent stage with its own build
-    # so its status/failures don't get conflated with the dump tests.
-    #
-    - ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
-      - stage: CdacStressTests
-        dependsOn:
-        - CdacBuild
-        jobs:
+      # ---- cDAC GC Stress Tests (not on schedule) ----
+      - ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
             jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -428,16 +419,8 @@ extends:
                 continueOnError: true
                 condition: failed()
 
-    #
-    # cDAC X-Plat Dump Generation and Testing — Two-stage flow:
-    # 1. Generate dumps on each platform via Helix, download and publish as artifacts
-    # 2. Download all platforms' dumps and run tests on each target platform
-    #
-    - ${{ if or(eq(parameters.cdacDumpTestMode, 'xplat'), eq(variables['Build.Reason'], 'Schedule')) }}:
-      - stage: CdacXPlatDumpGen
-        dependsOn:
-        - CdacBuild
-        jobs:
+      # ---- cDAC X-Plat Dump Generation (xplat mode or schedule) ----
+      - ${{ if or(eq(parameters.cdacDumpTestMode, 'xplat'), eq(variables['Build.Reason'], 'Schedule')) }}:
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
             jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -492,10 +475,16 @@ extends:
                 displayName: 'Fail on dump generation errors'
                 condition: always()
 
+    #
+    # cDAC X-Plat Dump Tests — runs after all source platforms have generated
+    # their dumps. This stage IS cross-platform-synchronizing (every target
+    # platform's test needs every source platform's dumps), so it remains a
+    # separate stage depending on Cdac.
+    #
+    - ${{ if or(eq(parameters.cdacDumpTestMode, 'xplat'), eq(variables['Build.Reason'], 'Schedule')) }}:
       - stage: CdacXPlatDumpTests
         dependsOn:
-        - CdacBuild
-        - CdacXPlatDumpGen
+        - Cdac
         jobs:
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -507,8 +496,10 @@ extends:
               nameSuffix: CdacXPlatDumpTest
               buildArgs: -s tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
               timeoutInMinutes: 180
-              dependsOnGlobalBuilds:
-              - nameSuffix: CdacBuild
+              # No dependsOnGlobalBuilds: this stage depends on the entire Cdac
+              # stage (which already has the per-platform CdacBuild jobs), and
+              # AzDO does not support cross-stage job-level deps. The stage-level
+              # dependsOn: Cdac above is sufficient.
               preBuildSteps:
                 - template: /eng/pipelines/common/download-artifact-step.yml
                   parameters:
@@ -522,9 +513,6 @@ extends:
                   buildDebuggees: false
                   skipDebuggeeCopy: true
                   cdacTestConfig: Debug
-                parameters:
-                  buildDebuggees: false
-                  skipDebuggeeCopy: true
               # Download dump artifacts from all source platforms
               - ${{ each platform in parameters.cdacXPlatDumpPlatforms }}:
                 - task: DownloadPipelineArtifact@2

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -316,7 +316,8 @@ extends:
     #
     - ${{ if and(eq(parameters.cdacDumpTestMode, 'single-leg'), ne(variables['Build.Reason'], 'Schedule')) }}:
       - stage: CdacDumpTests
-        dependsOn: []
+        dependsOn:
+        - CdacBuild
         jobs:
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -326,10 +327,24 @@ extends:
             shouldContinueOnError: true
             jobParameters:
               nameSuffix: CdacDumpTest
-              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
+              # Tiny rebuild that triggers .dotnet init; coreclr+libs+tools.cdac
+              # come from CdacBuildArtifacts. prepare-cdac-helix-steps below
+              # rebuilds the cDAC managed assemblies at Debug for the dump tests.
+              buildArgs: -s tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
               timeoutInMinutes: 180
+              dependsOnGlobalBuilds:
+              - nameSuffix: CdacBuild
+              preBuildSteps:
+                - template: /eng/pipelines/common/download-artifact-step.yml
+                  parameters:
+                    artifactName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)
+                    artifactFileName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)
+                    unpackFolder: $(Build.SourcesDirectory)/artifacts/bin
+                    displayName: 'cDAC Shared Build Artifacts'
               postBuildSteps:
               - template: /eng/pipelines/cdac/prepare-cdac-helix-steps.yml
+                parameters:
+                  cdacTestConfig: Debug
               - template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
                 parameters:
                   displayName: 'Send cDAC Dump Tests to Helix'
@@ -360,7 +375,8 @@ extends:
     #
     - ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
       - stage: CdacStressTests
-        dependsOn: []
+        dependsOn:
+        - CdacBuild
         jobs:
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -370,8 +386,19 @@ extends:
             shouldContinueOnError: true
             jobParameters:
               nameSuffix: CdacStressTest
-              buildArgs: -s clr+libs+tools.cdac+tools.cdacstresstests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig)
+              # Tiny rebuild that triggers .dotnet init; coreclr+libs+tools.cdac
+              # come from CdacBuildArtifacts and aren't rebuilt.
+              buildArgs: -s tools.cdacstresstests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig)
               timeoutInMinutes: 180
+              dependsOnGlobalBuilds:
+              - nameSuffix: CdacBuild
+              preBuildSteps:
+                - template: /eng/pipelines/common/download-artifact-step.yml
+                  parameters:
+                    artifactName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)
+                    artifactFileName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)
+                    unpackFolder: $(Build.SourcesDirectory)/artifacts/bin
+                    displayName: 'cDAC Shared Build Artifacts'
               postBuildSteps:
               - template: /eng/pipelines/cdac/prepare-cdac-stress-helix-steps.yml
               - template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
@@ -408,7 +435,8 @@ extends:
     #
     - ${{ if or(eq(parameters.cdacDumpTestMode, 'xplat'), eq(variables['Build.Reason'], 'Schedule')) }}:
       - stage: CdacXPlatDumpGen
-        dependsOn: []
+        dependsOn:
+        - CdacBuild
         jobs:
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -418,10 +446,21 @@ extends:
             shouldContinueOnError: true
             jobParameters:
               nameSuffix: CdacXPlatDumpGen
-              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
+              buildArgs: -s tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
               timeoutInMinutes: 180
+              dependsOnGlobalBuilds:
+              - nameSuffix: CdacBuild
+              preBuildSteps:
+                - template: /eng/pipelines/common/download-artifact-step.yml
+                  parameters:
+                    artifactName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)
+                    artifactFileName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)
+                    unpackFolder: $(Build.SourcesDirectory)/artifacts/bin
+                    displayName: 'cDAC Shared Build Artifacts'
               postBuildSteps:
               - template: /eng/pipelines/cdac/prepare-cdac-helix-steps.yml
+                parameters:
+                  cdacTestConfig: Debug
               - template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
                 parameters:
                   displayName: 'Send cDAC Dump Gen to Helix'
@@ -455,6 +494,7 @@ extends:
 
       - stage: CdacXPlatDumpTests
         dependsOn:
+        - CdacBuild
         - CdacXPlatDumpGen
         jobs:
         - template: /eng/pipelines/common/platform-matrix.yml
@@ -465,10 +505,23 @@ extends:
             shouldContinueOnError: true
             jobParameters:
               nameSuffix: CdacXPlatDumpTest
-              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
+              buildArgs: -s tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
               timeoutInMinutes: 180
+              dependsOnGlobalBuilds:
+              - nameSuffix: CdacBuild
+              preBuildSteps:
+                - template: /eng/pipelines/common/download-artifact-step.yml
+                  parameters:
+                    artifactName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)
+                    artifactFileName: CdacBuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)
+                    unpackFolder: $(Build.SourcesDirectory)/artifacts/bin
+                    displayName: 'cDAC Shared Build Artifacts'
               postBuildSteps:
               - template: /eng/pipelines/cdac/prepare-cdac-helix-steps.yml
+                parameters:
+                  buildDebuggees: false
+                  skipDebuggeeCopy: true
+                  cdacTestConfig: Debug
                 parameters:
                   buildDebuggees: false
                   skipDebuggeeCopy: true


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with assistance from GitHub Copilot CLI.

## Summary

Refactors `runtime-diagnostics.yml` so the cDAC dump tests and stress tests share **one** coreclr+libs build per platform, and so per-platform pipelines run in parallel (no waiting on slower platforms).

## Before

```
Stage CdacBuild       (8 plats, full build each)
Stage CdacDumpTests   (8 plats, full build each)   <- 8 redundant builds
Stage CdacStressTests (4 plats, full build each)   <- 4 redundant builds
Stage CdacXPlatDumpGen (6 plats, full build each)  <- 6 redundant builds
Stage CdacXPlatDumpTests (6 plats, full build each) <- 6 redundant builds
```

Each test leg rebuilt coreclr from scratch.

## After

```
Stage Cdac (single stage, jobs in parallel except for stated deps)
  build_<plat>_CdacBuild              x8  (publishes artifacts/bin tar)
  build_<plat>_CdacDumpTest           x8  job-dep CdacBuild_<plat>   [single-leg, !Schedule]
  build_<plat>_CdacStressTest         x4  job-dep CdacBuild_<plat>   [!Schedule]
  build_<plat>_CdacXPlatDumpGen       x6  job-dep CdacBuild_<plat>   [xplat OR Schedule]
Stage CdacXPlatDumpTests              dependsOn: Cdac (intrinsic xplat sync)
  build_<plat>_CdacXPlatDumpTest      x6
```

- **One** full coreclr+libs build per platform.
- **Per-platform parallelism**: `linux_x64` dump tests start as soon as `linux_x64` build is done; no waiting on `osx_arm64` to finish building.
- Pattern follows the canonical `runtime.yml` `dependsOnGlobalBuilds` mechanism (see `runtime.yml:1591,1622,1653`).

## How the Release / Debug cDAC split works

The user requested:
- Build coreclr in **Checked** (`-rc checked`).
- **Stress tests** use the **Release native cDAC shim** (loaded in-process by the runtime).
- **Dump tests** use the **Debug managed cDAC assemblies** (referenced directly by the DumpTests project).

These coexist because they live in different artifact locations:
- CdacBuild runs `-c Release -rc checked` → native shim ships in the Release testhost.
- Stress test legs keep `cdacTestConfig: $(_BuildConfig)` (Release) — they pick up the Release native shim from the testhost.
- Dump test legs pass new `cdacTestConfig: Debug` parameter — payload-prep MSBuild walks the DumpTests project graph and rebuilds the managed cDAC assemblies at Debug in a separate output directory.

## Files changed

- `eng/pipelines/runtime-diagnostics.yml` — collapsed 5 stages into 2, wired job-level deps.
- `eng/pipelines/cdac/prepare-cdac-helix-steps.yml` — added `cdacTestConfig` parameter (defaults to `$(_BuildConfig)` for back-compat).
- (Existing `Build` / SOS stage untouched — different subset, different platforms.)

## Validation

- Local YAML syntax check passes.
- Needs a manual pipeline trigger to validate end-to-end behavior (shared artifact download, per-platform parallelism, Debug-cDAC payload prep on the dump side).