### PR TITLE
Bump remaining macOS Helix queues to current versions

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -137,14 +137,14 @@ jobs:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.jobParameters.helixQueueGroup, 'superpmi-diffs')) }}:
         - OSX.15.Arm64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - OSX.14.Arm64
+        - $(helix_macos_arm64_latest_internal)
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - $(helix_macos_x64)
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - OSX.13.Amd64
+        - $(helix_macos_x64_latest_internal)
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -132,10 +132,8 @@ jobs:
 
     # OSX arm64
     - ${{ if eq(parameters.platform, 'osx_arm64') }}:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(parameters.jobParameters.helixQueueGroup, 'superpmi-diffs')) }}:
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - $(helix_macos_arm64)
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.jobParameters.helixQueueGroup, 'superpmi-diffs')) }}:
-        - OSX.15.Arm64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - $(helix_macos_arm64_latest_internal)
 

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -479,7 +479,7 @@ def main(main_args):
                 helix_queue = "azurelinux.3.amd64.open"
         elif platform_name == "osx":
             if arch == "arm64": # public osx_arm64
-                helix_queue = "OSX.15.Arm64.Open"
+                helix_queue = "OSX.26.Arm64.Open"
             else: # public osx_x64
                 helix_queue = "OSX.15.Amd64.Open"
     else:
@@ -497,7 +497,7 @@ def main(main_args):
                 helix_queue = "azurelinux.3.amd64"
         elif platform_name == "osx":
             if arch == "arm64": # internal osx_arm64
-                helix_queue = "OSX.15.Arm64"
+                helix_queue = "OSX.26.Arm64"
             else: # internal osx_x64
                 helix_queue = "OSX.15.Amd64"
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with assistance from GitHub Copilot.

A few hardcoded macOS Helix queue references in `main` were missed during the centralization of queue names into `eng/pipelines/helix-platforms.yml`. This PR migrates them to the shared `$(helix_macos_*)` variables, which also bumps them to the current "latest" macOS versions.

## Changes

- `eng/pipelines/coreclr/templates/helix-queues-setup.yml`:
  - Internal `osx_arm64`: `OSX.14.Arm64` → `$(helix_macos_arm64_latest_internal)` (OSX.26)
  - Internal `osx_x64`: `OSX.13.Amd64` → `$(helix_macos_x64_latest_internal)` (OSX.15)
  - `superpmi-diffs` public queue: `OSX.15.Arm64.Open` → `$(helix_macos_arm64)` (OSX.26). Since this now matches the regular public `osx_arm64` queue, the conditional split was consolidated.
- `src/coreclr/scripts/superpmi_collect_setup.py`: arm64 SPMI collection queues bumped from OSX.15 to OSX.26 (public and internal), matching arm64 latest.

A similar cleanup was done on release/10.0 in #122990.