### PR TITLE
[cdac] Run cDAC unit + DataGenerator tests in runtime-diagnostics pipeline

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -531,6 +531,7 @@
 
   <ItemGroup Condition="$(_subset.Contains('+tools.cdactests+'))">
     <ProjectToBuild Include="$(SharedNativeRoot)managed\cdac\tests\UnitTests\Microsoft.Diagnostics.DataContractReader.Tests.csproj" Test="true" Category="tools"/>
+    <ProjectToBuild Include="$(SharedNativeRoot)managed\cdac\tests\DataGenerator\Microsoft.Diagnostics.DataContractReader.DataGeneratorTests.csproj" Test="true" Category="tools"/>
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+tools.cdacdumptests+'))">

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -279,6 +279,30 @@ extends:
               condition: failed()
 
     #
+    # cDAC Unit Tests + DataGenerator Tests — managed-side tests that don't need a
+    # real runtime. Independent stage; runs on linux_x64 Checked on every trigger
+    # (PR/manual/schedule).
+    #
+    - stage: CdacUnitTests
+      dependsOn: []
+      jobs:
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: checked
+          platforms:
+          - linux_x64
+          jobParameters:
+            nameSuffix: CdacUnitTests
+            # tools.cdactests builds + tests both the cDAC UnitTests project
+            # and the DataGeneratorTests project (both wired under that subset
+            # in eng/Subsets.props).
+            buildArgs: -s clr.aot+clr.iltools+clr.corelib+clr.nativecorelib+libs.sfx+clr.toolstests+tools.cdac+tools.cdactests -c $(_BuildConfig) -test
+            timeoutInMinutes: 120
+            enablePublishTestResults: true
+            testResultsFormat: 'xunit'
+
+    #
     # cDAC Dump Tests — Build, generate dumps, and run tests on Helix (single-leg mode)
     #
     - ${{ if and(eq(parameters.cdacDumpTestMode, 'single-leg'), ne(variables['Build.Reason'], 'Schedule')) }}:

--- a/src/native/managed/cdac/tests/DataGenerator/TestTarget.cs
+++ b/src/native/managed/cdac/tests/DataGenerator/TestTarget.cs
@@ -199,6 +199,9 @@ internal sealed class TestTarget : Target
     public override TargetNUInt ReadNUInt(ulong address)
         => new TargetNUInt(PointerSize == 8 ? Read<ulong>(address) : Read<uint>(address));
 
+    public override TargetNInt ReadNInt(ulong address)
+        => new TargetNInt(PointerSize == 8 ? Read<long>(address) : Read<int>(address));
+
     public override void Write<T>(ulong address, T value)
     {
         Span<byte> span = GetSpan(address, System.Runtime.CompilerServices.Unsafe.SizeOf<T>());


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with assistance from GitHub Copilot CLI.

## Summary

The cDAC has four test projects under `src/native/managed/cdac/tests/`:

| Project | Where it ran (before) |
|---|---|
| `UnitTests/Microsoft.Diagnostics.DataContractReader.Tests.csproj` | runtime.yml `CLR_Tools_Tests` (main CI) |
| `DumpTests/...DumpTests.csproj` | runtime-diagnostics.yml |
| `StressTests/...StressTests.csproj` | runtime-diagnostics.yml |
| `DataGenerator/...DataGeneratorTests.csproj` | **not built or executed in CI** |

This PR puts the cDAC managed-side test projects under the cDAC-focused pipeline.

## Changes

1. **`eng/Subsets.props`** -- DataGeneratorTests added to the existing `tools.cdactests` subset (no new subset). One subset now builds both managed-side cDAC test projects.

2. **`eng/pipelines/runtime-diagnostics.yml`** -- new `CdacUnitTests` stage that runs `tools.cdactests` on linux_x64 Checked with `-test`. Independent of the dump/stress legs (no native runtime needed). Publishes xunit results. Now the cDAC unit tests + DataGenerator tests live in the cDAC-focused pipeline next to the dump/stress tests.

3. **`src/native/managed/cdac/tests/DataGenerator/TestTarget.cs`** -- override the new `Target.ReadNInt` abstract method (added in #128784) on the test-only TestTarget mock so the DataGeneratorTests project compiles. Mirrors the existing `ReadNUInt` override (`new TargetNInt(PointerSize == 8 ? Read<long> : Read<int>)`).

## Note

`runtime.yml`'s existing `CLR_Tools_Tests` leg still runs the cDAC UnitTests via the same `tools.cdactests` subset, so coverage is unchanged there -- this PR is purely additive (adds DataGen coverage, and pulls everything into the cDAC pipeline for easier triage).