### PR TITLE
Fix OOM message in Native AOT

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -292,10 +292,10 @@ namespace System
                         }
                         catch
                         {
-                            // If ToString() fails (for example, due to OOM), fall back to printing just the type name.
+                            // If ToString() fails (for example, due to OOM), fall back to a simpler message.
                             try
                             {
-                                Internal.Console.Error.Write(exception.GetType().FullName);
+                                Internal.Console.Error.Write(exception is OutOfMemoryException ? "Out of memory." : exception.GetType().FullName);
                                 Internal.Console.Error.WriteLine();
                             }
                             catch { }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -295,7 +295,8 @@ namespace System
                             // If ToString() fails (for example, due to OOM), fall back to a simpler message.
                             try
                             {
-                                Internal.Console.Error.Write(exception is OutOfMemoryException ? "Out of memory." : exception.GetType().FullName);
+                                // Use an allocation-free MethodTable comparison.
+                                Internal.Console.Error.Write(exception.GetMethodTable() == Internal.Runtime.MethodTable.Of<OutOfMemoryException>() ? "Out of memory." : exception.GetType().FullName);
                                 Internal.Console.Error.WriteLine();
                             }
                             catch { }


### PR DESCRIPTION
Fall back to a string literal when process finishes with an out of memory exception.

Fixes #129209.