### PR TITLE
Add dnx shim to dotnet-host package

### DIFF
--- a/src/installer/pkg/sfx/installers/dnx
+++ b/src/installer/pkg/sfx/installers/dnx
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+
+SCRIPT="$(readlink -f "$0")"
+DIR="$(dirname "$SCRIPT")"
+DOTNET="$DIR/dotnet"
+SDK_VERSION=$("$DOTNET" --list-sdks | tail -1 | cut -d' ' -f1)
+SDK_PATH="$DIR/sdk/$SDK_VERSION/dotnet.dll"
+
+"$DOTNET" exec "$SDK_PATH" dnx "$@"

--- a/src/installer/pkg/sfx/installers/dnx
+++ b/src/installer/pkg/sfx/installers/dnx
@@ -3,10 +3,23 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
-SCRIPT="$(readlink -f "$0")"
-DIR="$(dirname "$SCRIPT")"
+# Resolve symlinks portably (macOS's BSD readlink does not support -f).
+SCRIPT="$0"
+while [ -L "$SCRIPT" ]; do
+  LINK=$(readlink "$SCRIPT")
+  case "$LINK" in
+    /*) SCRIPT="$LINK" ;;
+    *)  SCRIPT="$(dirname "$SCRIPT")/$LINK" ;;
+  esac
+done
+DIR="$(cd "$(dirname "$SCRIPT")" && pwd -P)"
+
 DOTNET="$DIR/dotnet"
 SDK_VERSION=$("$DOTNET" --list-sdks | tail -1 | cut -d' ' -f1)
+if [ -z "$SDK_VERSION" ]; then
+  echo "Error: dnx requires a .NET SDK to be installed, but none was found." >&2
+  exit 1
+fi
 SDK_PATH="$DIR/sdk/$SDK_VERSION/dotnet.dll"
 
-"$DOTNET" exec "$SDK_PATH" dnx "$@"
+exec "$DOTNET" exec "$SDK_PATH" dnx "$@"

--- a/src/installer/pkg/sfx/installers/dnx
+++ b/src/installer/pkg/sfx/installers/dnx
@@ -15,7 +15,7 @@ done
 DIR="$(cd "$(dirname "$SCRIPT")" && pwd -P)"
 
 DOTNET="$DIR/dotnet"
-SDK_VERSION=$("$DOTNET" --list-sdks | tail -1 | cut -d' ' -f1)
+SDK_VERSION=$("$DOTNET" --list-sdks | tail -n 1 | cut -d' ' -f1)
 if [ -z "$SDK_VERSION" ]; then
   echo "Error: dnx requires a .NET SDK to be installed, but none was found." >&2
   exit 1

--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -48,10 +48,16 @@
       <FilesToPublish Include="$(InstallerProjectRoot)pkg\LICENSE-MSFT.TXT"
             Destination="$(OutputPath)LICENSE.txt"
             Condition="'$(TargetsUnix)' != 'true'"/>
+      <FilesToPublish Include="$(MSBuildThisFileDirectory)dnx"
+            Destination="$(OutputPath)dnx"
+            Condition="'$(TargetsUnix)' == 'true'" />
     </ItemGroup>
 
     <Copy SourceFiles="@(FilesToPublish)"
           DestinationFiles="%(FilesToPublish.Destination)" />
+
+    <Exec Command="chmod 755 &quot;$(OutputPath)dnx&quot;"
+          Condition="'$(TargetsUnix)' == 'true'" />
   </Target>
 
   <Target Name="PublishSymbolsToDisk">
@@ -72,6 +78,7 @@
 
   <ItemGroup>
     <LinuxPackageSymlink Include="/usr/bin/dotnet" LinkTarget="../share/dotnet/dotnet" />
+    <LinuxPackageSymlink Include="/usr/bin/dnx" LinkTarget="../share/dotnet/dnx" />
     <LinuxPackageConflicts Include="dotnet;dotnet-nightly" />
     <RpmOwnedDirectory Include="/usr/share/dotnet" />
   </ItemGroup>

--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -57,7 +57,7 @@
           DestinationFiles="%(FilesToPublish.Destination)" />
 
     <Exec Command="chmod 755 &quot;$(OutputPath)dnx&quot;"
-          Condition="'$(TargetsUnix)' == 'true'" />
+          Condition="'$(TargetsUnix)' == 'true' and !$([MSBuild]::IsOSPlatform('windows'))" />
   </Target>
 
   <Target Name="PublishSymbolsToDisk">


### PR DESCRIPTION
Per the [.NET distribution-packaging guidelines](https://learn.microsoft.com/dotnet/core/distribution-packaging), the dnx dispatcher script lives in the host package alongside the dotnet binary, with a `/usr/bin/dnx` symlink that resolves into `/usr/share/dotnet/dnx`. The script is SDK-version-independent.

Previously dnx was shipped from dotnet/sdk's Linux SDK package, which caused a dpkg file conflict on systems where Canonical's `dotnet-host` package was already installed (dotnet/sdk#53834).

This also updates the migrated `dnx` script with a fix for https://github.com/dotnet/sdk/issues/54687.

This PR must ship alongside a corresponding dotnet/sdk change (https://github.com/dotnet/sdk/pull/54688) that removes dnx from the `dotnet-sdk` package.

Contributes to dotnet/sdk#53834