### PR TITLE
Reduce raw global / typeinfo usage in cDAC Legacy interfaces

### DIFF
--- a/docs/design/datacontracts/Loader.md
+++ b/docs/design/datacontracts/Loader.md
@@ -54,14 +54,6 @@ record struct ModuleLookupTables(
     TargetPointer MethodDefToILCodeVersioningState,
     uint TableDataOffset);
 
-// Aggregate view of the runtime's domain singletons.
-readonly struct RuntimeDomainInfo
-{
-    TargetPointer SystemDomain { get; init; }
-    TargetPointer DefaultAppDomain { get; init; }
-    uint DefaultAppDomainId { get; init; }
-}
-
 readonly struct LoaderHeapBlockData
 {
     TargetPointer Address { get; init; }
@@ -91,7 +83,7 @@ ModuleHandle GetModuleHandleFromAssemblyPtr(TargetPointer assemblyPointer);
 IEnumerable<ModuleHandle> GetModuleHandles(TargetPointer appDomain, AssemblyIterationFlags iterationFlags);
 TargetPointer GetRootAssembly();
 string GetAppDomainFriendlyName();
-RuntimeDomainInfo GetDomainInfo();
+TargetPointer GetAppDomain();
 TargetPointer GetModule(ModuleHandle handle);
 TargetPointer GetAssembly(ModuleHandle handle);
 TargetPointer GetPEAssembly(ModuleHandle handle);
@@ -253,7 +245,6 @@ enum ClrModifiableAssemblies : uint
 | --- | --- | --- |
 | `AppDomain` | TargetPointer | Pointer to the global AppDomain |
 | `SystemDomain` | TargetPointer | Pointer to the global SystemDomain |
-| `DefaultADID` | uint | Id of the default AppDomain |
 | `EEConfig` | TargetPointer | Pointer to the global EEConfig (runtime configuration) |
 
 
@@ -405,15 +396,16 @@ IEnumerable<ModuleHandle> GetModuleHandles(TargetPointer appDomain, AssemblyIter
 
 TargetPointer GetRootAssembly()
 {
-    TargetPointer defaultAppDomain = GetDomainInfo().DefaultAppDomain;
-    AppDomain appDomain = // read AppDomain object starting at defaultAppDomain
+    TargetPointer appDomainPointer = target.ReadGlobalPointer("AppDomain");
+    AppDomain appDomain = // read AppDomain object starting at appDomainPointer
     return appDomain.RootAssembly;
 }
 
 string ILoader.GetAppDomainFriendlyName()
 {
-    TargetPointer defaultAppDomain = GetDomainInfo().DefaultAppDomain;
-    TargetPointer namePtr = defaultAppDomain + /* AppDomain::FriendlyName offset */;
+    TargetPointer appDomainPointer = target.ReadGlobalPointer("AppDomain");
+    TargetPointer appDomain = target.ReadPointer(appDomainPointer)
+    TargetPointer namePtr = appDomain + /* AppDomain::FriendlyName offset */;
     // Match native AppDomain::GetFriendlyName(): return "DefaultDomain" when pointer is null.
     if (namePtr == TargetPointer.Null)
         return "DefaultDomain";
@@ -421,24 +413,10 @@ string ILoader.GetAppDomainFriendlyName()
     return new string(name);
 }
 
-RuntimeDomainInfo GetDomainInfo()
+TargetPointer GetAppDomain()
 {
-    // Tolerate missing-or-uninitialized globals: callers that only need one of
-    // the values shouldn't fail because an unrelated global is unavailable.
-    static TargetPointer TryReadGlobalIndirectPointer(string name)
-    {
-        if (!target.TryReadGlobalPointer(name, out TargetPointer? ptrPtr))
-            return TargetPointer.Null;
-        if (!target.TryReadPointer(ptrPtr.Value, out TargetPointer value))
-            return TargetPointer.Null;
-        return value;
-    }
-    return new RuntimeDomainInfo
-    {
-        SystemDomain = TryReadGlobalIndirectPointer("SystemDomain"),
-        DefaultAppDomain = TryReadGlobalIndirectPointer("AppDomain"),
-        DefaultAppDomainId = target.TryReadGlobal("DefaultADID", out uint? id) ? id.Value : 0u,
-    };
+    TargetPointer appDomainPointer = target.ReadGlobalPointer("AppDomain");
+    return target.ReadPointer(appDomainPointer);
 }
 
 TargetPointer ILoader.GetModule(ModuleHandle handle)
@@ -799,13 +777,15 @@ bool IsAssemblyLoaded(ModuleHandle handle)
 
 TargetPointer GetGlobalLoaderAllocator()
 {
-    TargetPointer systemDomain = GetDomainInfo().SystemDomain;
+    TargetPointer systemDomainPointer = target.ReadGlobalPointer("SystemDomain");
+    TargetPointer systemDomain = target.ReadPointer(systemDomainPointer);
     return systemDomain + /* SystemDomain::GlobalLoaderAllocator offset */;
 }
 
 TargetPointer GetSystemAssembly()
 {
-    TargetPointer systemDomain = GetDomainInfo().SystemDomain;
+    TargetPointer systemDomainPointer = target.ReadGlobalPointer("SystemDomain");
+    TargetPointer systemDomain = target.ReadPointer(systemDomainPointer);
     return target.ReadPointer(systemDomain + /* SystemDomain::SystemAssembly offset */);
 }
 

--- a/docs/design/datacontracts/Loader.md
+++ b/docs/design/datacontracts/Loader.md
@@ -51,7 +51,16 @@ record struct ModuleLookupTables(
     TargetPointer MethodDefToDesc,
     TargetPointer TypeDefToMethodTable,
     TargetPointer TypeRefToMethodTable,
-    TargetPointer MethodDefToILCodeVersioningState);
+    TargetPointer MethodDefToILCodeVersioningState,
+    uint TableDataOffset);
+
+// Aggregate view of the runtime's domain singletons.
+readonly struct RuntimeDomainInfo
+{
+    TargetPointer SystemDomain { get; init; }
+    TargetPointer DefaultAppDomain { get; init; }
+    uint DefaultAppDomainId { get; init; }
+}
 
 readonly struct LoaderHeapBlockData
 {
@@ -82,6 +91,7 @@ ModuleHandle GetModuleHandleFromAssemblyPtr(TargetPointer assemblyPointer);
 IEnumerable<ModuleHandle> GetModuleHandles(TargetPointer appDomain, AssemblyIterationFlags iterationFlags);
 TargetPointer GetRootAssembly();
 string GetAppDomainFriendlyName();
+RuntimeDomainInfo GetDomainInfo();
 TargetPointer GetModule(ModuleHandle handle);
 TargetPointer GetAssembly(ModuleHandle handle);
 TargetPointer GetPEAssembly(ModuleHandle handle);
@@ -243,6 +253,7 @@ enum ClrModifiableAssemblies : uint
 | --- | --- | --- |
 | `AppDomain` | TargetPointer | Pointer to the global AppDomain |
 | `SystemDomain` | TargetPointer | Pointer to the global SystemDomain |
+| `DefaultADID` | uint | Id of the default AppDomain |
 | `EEConfig` | TargetPointer | Pointer to the global EEConfig (runtime configuration) |
 
 
@@ -394,21 +405,40 @@ IEnumerable<ModuleHandle> GetModuleHandles(TargetPointer appDomain, AssemblyIter
 
 TargetPointer GetRootAssembly()
 {
-    TargetPointer appDomainPointer = target.ReadGlobalPointer("AppDomain");
-    AppDomain appDomain = // read AppDomain object starting at appDomainPointer
+    TargetPointer defaultAppDomain = GetDomainInfo().DefaultAppDomain;
+    AppDomain appDomain = // read AppDomain object starting at defaultAppDomain
     return appDomain.RootAssembly;
 }
 
 string ILoader.GetAppDomainFriendlyName()
 {
-    TargetPointer appDomainPointer = target.ReadGlobalPointer("AppDomain");
-    TargetPointer appDomain = target.ReadPointer(appDomainPointer)
-    TargetPointer namePtr = appDomain + /* AppDomain::FriendlyName offset */;
+    TargetPointer defaultAppDomain = GetDomainInfo().DefaultAppDomain;
+    TargetPointer namePtr = defaultAppDomain + /* AppDomain::FriendlyName offset */;
     // Match native AppDomain::GetFriendlyName(): return "DefaultDomain" when pointer is null.
     if (namePtr == TargetPointer.Null)
         return "DefaultDomain";
     char[] name = // Read<char> from target starting at namePtr until null terminator
     return new string(name);
+}
+
+RuntimeDomainInfo GetDomainInfo()
+{
+    // Tolerate missing-or-uninitialized globals: callers that only need one of
+    // the values shouldn't fail because an unrelated global is unavailable.
+    static TargetPointer TryReadGlobalIndirectPointer(string name)
+    {
+        if (!target.TryReadGlobalPointer(name, out TargetPointer? ptrPtr))
+            return TargetPointer.Null;
+        if (!target.TryReadPointer(ptrPtr.Value, out TargetPointer value))
+            return TargetPointer.Null;
+        return value;
+    }
+    return new RuntimeDomainInfo
+    {
+        SystemDomain = TryReadGlobalIndirectPointer("SystemDomain"),
+        DefaultAppDomain = TryReadGlobalIndirectPointer("AppDomain"),
+        DefaultAppDomainId = target.TryReadGlobal("DefaultADID", out uint? id) ? id.Value : 0u,
+    };
 }
 
 TargetPointer ILoader.GetModule(ModuleHandle handle)
@@ -678,6 +708,7 @@ TargetPointer ILoader.GetAssemblyLoadContext(ModuleHandle handle)
 
 ModuleLookupTables GetLookupTables(ModuleHandle handle)
 {
+    uint tableDataOffset = (uint)/* ModuleLookupMap::TableData offset */;
     return new ModuleLookupTables(
         FieldDefToDescMap: target.ReadPointer(handle.Address + /* Module::FieldDefToDescMap */),
         ManifestModuleReferencesMap: target.ReadPointer(handle.Address + /* Module::ManifestModuleReferencesMap */),
@@ -686,7 +717,8 @@ ModuleLookupTables GetLookupTables(ModuleHandle handle)
         TypeDefToMethodTableMap: target.ReadPointer(handle.Address + /* Module::TypeDefToMethodTableMap */),
         TypeRefToMethodTableMap: target.ReadPointer(handle.Address + /* Module::TypeRefToMethodTableMap */),
         MethodDefToILCodeVersioningState: target.ReadPointer(handle.Address + /*
-        Module::MethodDefToILCodeVersioningState */));
+        Module::MethodDefToILCodeVersioningState */),
+        TableDataOffset: tableDataOffset);
 }
 
 TargetPointer GetModuleLookupMapElement(TargetPointer table, uint token, out TargetNUInt flags);
@@ -767,15 +799,13 @@ bool IsAssemblyLoaded(ModuleHandle handle)
 
 TargetPointer GetGlobalLoaderAllocator()
 {
-    TargetPointer systemDomainPointer = target.ReadGlobalPointer("SystemDomain");
-    TargetPointer systemDomain = target.ReadPointer(systemDomainPointer);
+    TargetPointer systemDomain = GetDomainInfo().SystemDomain;
     return systemDomain + /* SystemDomain::GlobalLoaderAllocator offset */;
 }
 
 TargetPointer GetSystemAssembly()
 {
-    TargetPointer systemDomainPointer = target.ReadGlobalPointer("SystemDomain");
-    TargetPointer systemDomain = target.ReadPointer(systemDomainPointer);
+    TargetPointer systemDomain = GetDomainInfo().SystemDomain;
     return target.ReadPointer(systemDomain + /* SystemDomain::SystemAssembly offset */);
 }
 

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -66,6 +66,9 @@ partial interface IRuntimeTypeSystem : IContract
     // True if the MethodTable is the System.Object MethodTable (g_pObjectClass)
     public virtual bool IsObject(TypeHandle typeHandle);
     public virtual bool IsString(TypeHandle typeHandle);
+    // Returns the address of one of the runtime's well-known singleton MethodTables, or
+    // TargetPointer.Null if the runtime has not yet initialized that global.
+    public virtual TargetPointer GetWellKnownMethodTable(WellKnownMethodTable kind);
     // True if the type is a GC-collectable object reference.
     public virtual bool IsObjRef(TypeHandle typeHandle);
     // True if the MethodTable represents a type that contains managed references
@@ -182,6 +185,18 @@ public enum GenericContextLoc
     InstArgMethodDesc,
     InstArgMethodTable,
     ThisPtr,
+}
+
+// Identifies one of the runtime's well-known singleton MethodTables, each addressable
+// via a dedicated global pointer (e.g. g_pObjectClass, g_pStringClass, g_pFreeObjectMethodTable).
+public enum WellKnownMethodTable
+{
+    Object,
+    String,
+    Array,
+    Exception,
+    Free,
+    Canon,
 }
 ```
 
@@ -472,6 +487,10 @@ The contract depends on the following globals
 | `FreeObjectMethodTable` | A pointer to the address of a `MethodTable` used by the GC to indicate reclaimed memory
 | `MulticastDelegateMethodTable` | A pointer to the address of the `System.MulticastDelegate` `MethodTable` (`g_pMulticastDelegateClass`)
 | `ObjectMethodTable` | A pointer to the address of the `System.Object` `MethodTable` (`g_pObjectClass`)
+| `StringMethodTable` | A pointer to the address of the `System.String` `MethodTable` (`g_pStringClass`)
+| `ObjectArrayMethodTable` | A pointer to the address of the `object[]` `MethodTable` (`g_pPredefinedArrayTypes[ELEMENT_TYPE_OBJECT]`)
+| `ExceptionMethodTable` | A pointer to the address of the `System.Exception` `MethodTable` (`g_pExceptionClass`)
+| `CanonMethodTable` | A pointer to the address of the canonical `MethodTable` used for shared generics (`System.__Canon`)
 | `StaticsPointerMask` | For masking out a bit of DynamicStaticsInfo pointer fields
 | `ArrayBaseSize` | The base size of an array object; used to compute multidimensional array rank from `MethodTable::BaseSize`
 
@@ -615,6 +634,28 @@ Contracts used:
     public bool IsObject(TypeHandle TypeHandle) => ObjectMethodTablePointer != TargetPointer.Null && ObjectMethodTablePointer == TypeHandle.Address;
 
     public bool IsString(TypeHandle TypeHandle) => !typeHandle.IsMethodTable() ? false : _methodTables[TypeHandle.Address].Flags.IsString;
+
+    public TargetPointer GetWellKnownMethodTable(WellKnownMethodTable kind)
+    {
+        // Map the well-known kind to the corresponding runtime global. Returns
+        // TargetPointer.Null if the global is missing or the pointer it stores has
+        // not yet been initialized (e.g. SOS load notifications can run before the
+        // runtime has populated the MT globals).
+        string globalName = kind switch
+        {
+            WellKnownMethodTable.Object => "ObjectMethodTable",
+            WellKnownMethodTable.String => "StringMethodTable",
+            WellKnownMethodTable.Array => "ObjectArrayMethodTable",
+            WellKnownMethodTable.Exception => "ExceptionMethodTable",
+            WellKnownMethodTable.Free => "FreeObjectMethodTable",
+            WellKnownMethodTable.Canon => "CanonMethodTable",
+        };
+        if (!target.TryReadGlobalPointer(globalName, out TargetPointer? ptrPtr))
+            return TargetPointer.Null;
+        if (!target.TryReadPointer(ptrPtr.Value, out TargetPointer value))
+            return TargetPointer.Null;
+        return value;
+    }
 
     public bool IsObjRef(TypeHandle typeHandle) => // Returns true if GetSignatureCorElementType returns Class, Array, or SzArray.
 

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2414,7 +2414,7 @@ ClrDataAccess::GetAppDomainStoreData(struct DacpAppDomainStoreData *adsData)
 {
     SOSDacEnter();
 
-    adsData->systemDomain = HOST_CDADDR(SystemDomain::System());
+    adsData->systemDomain = (CLRDATA_ADDRESS)NULL;
     adsData->sharedDomain = (CLRDATA_ADDRESS)NULL;
 
     // Get an accurate count of appdomains.
@@ -2445,29 +2445,26 @@ ClrDataAccess::GetAppDomainData(CLRDATA_ADDRESS addr, struct DacpAppDomainData *
         appdomainData->pStubHeap = HOST_CDADDR(pLoaderAllocator->GetStubHeap());
         appdomainData->appDomainStage = STAGE_OPEN;
 
-        if (addr != HOST_CDADDR(SystemDomain::System()))
+        PTR_AppDomain pAppDomain = PTR_AppDomain(TO_TADDR(addr));
+
+        appdomainData->dwId = DefaultADID;
+
+        AppDomain::AssemblyIterator i = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(
+            kIncludeLoading | kIncludeLoaded | kIncludeExecution));
+        CollectibleAssemblyHolder<Assembly *> pAssembly;
+
+        while (i.Next(pAssembly.This()))
         {
-            PTR_AppDomain pAppDomain = PTR_AppDomain(TO_TADDR(addr));
-
-            appdomainData->dwId = DefaultADID;
-
-            AppDomain::AssemblyIterator i = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(
-                kIncludeLoading | kIncludeLoaded | kIncludeExecution));
-            CollectibleAssemblyHolder<Assembly *> pAssembly;
-
-            while (i.Next(pAssembly.This()))
+            if (pAssembly->IsLoaded())
             {
-                if (pAssembly->IsLoaded())
-                {
-                    appdomainData->AssemblyCount++;
-                }
+                appdomainData->AssemblyCount++;
             }
+        }
 
-            AppDomain::FailedAssemblyIterator j = pAppDomain->IterateFailedAssembliesEx();
-            while (j.Next())
-            {
-                appdomainData->FailedAssemblyCount++;
-            }
+        AppDomain::FailedAssemblyIterator j = pAppDomain->IterateFailedAssembliesEx();
+        while (j.Next())
+        {
+            appdomainData->FailedAssemblyCount++;
         }
     }
 
@@ -2558,40 +2555,32 @@ ClrDataAccess::GetAssemblyList(CLRDATA_ADDRESS addr, int count, CLRDATA_ADDRESS 
 
     SOSDacEnter();
 
-    if (addr == HOST_CDADDR(SystemDomain::System()))
+    PTR_AppDomain pAppDomain = PTR_AppDomain(TO_TADDR(addr));
+    AppDomain::AssemblyIterator i = pAppDomain->IterateAssembliesEx(
+        (AssemblyIterationFlags)(kIncludeLoading | kIncludeLoaded | kIncludeExecution));
+    CollectibleAssemblyHolder<Assembly *> pAssembly;
+
+    int n = 0;
+    if (values)
     {
-        // We shouldn't be asking for the assemblies in SystemDomain
-        hr = E_INVALIDARG;
+        while (i.Next(pAssembly.This()) && (n < count))
+        {
+            if (pAssembly->IsLoaded())
+            {
+                // Note: DAC doesn't need to keep the assembly alive - see code:CollectibleAssemblyHolder#CAH_DAC
+                values[n++] = HOST_CDADDR(pAssembly.Extract());
+            }
+        }
     }
     else
     {
-        PTR_AppDomain pAppDomain = PTR_AppDomain(TO_TADDR(addr));
-        AppDomain::AssemblyIterator i = pAppDomain->IterateAssembliesEx(
-            (AssemblyIterationFlags)(kIncludeLoading | kIncludeLoaded | kIncludeExecution));
-        CollectibleAssemblyHolder<Assembly *> pAssembly;
-
-        int n = 0;
-        if (values)
-        {
-            while (i.Next(pAssembly.This()) && (n < count))
-            {
-                if (pAssembly->IsLoaded())
-                {
-                    // Note: DAC doesn't need to keep the assembly alive - see code:CollectibleAssemblyHolder#CAH_DAC
-                    values[n++] = HOST_CDADDR(pAssembly.Extract());
-                }
-            }
-        }
-        else
-        {
-            while (i.Next(pAssembly.This()))
-                if (pAssembly->IsLoaded())
-                    n++;
-        }
-
-        if (pNeeded)
-            *pNeeded = n;
+        while (i.Next(pAssembly.This()))
+            if (pAssembly->IsLoaded())
+                n++;
     }
+
+    if (pNeeded)
+        *pNeeded = n;
 
     SOSDacLeave();
     return hr;
@@ -2631,48 +2620,37 @@ ClrDataAccess::GetAppDomainName(CLRDATA_ADDRESS addr, unsigned int count, _Inout
 {
     SOSDacEnter();
 
-    if (addr == HOST_CDADDR(SystemDomain::System()))
+    PTR_AppDomain pAppDomain = PTR_AppDomain(TO_TADDR(addr));
+
+    size_t countAsSizeT = count;
+    if (pAppDomain->m_friendlyName.IsValid())
     {
-        // SystemDomain doesn't have this field.
+        LPCWSTR friendlyName = (LPCWSTR)pAppDomain->m_friendlyName;
+        size_t friendlyNameLen = u16_strlen(friendlyName);
+
+        if (pNeeded)
+        {
+            *pNeeded = (unsigned int)(friendlyNameLen + 1);
+        }
+
+        if (name && count > 0)
+        {
+            if (countAsSizeT > (friendlyNameLen + 1))
+            {
+                countAsSizeT = friendlyNameLen + 1;
+            }
+            memcpy(name, friendlyName, countAsSizeT * sizeof(WCHAR));
+            name[countAsSizeT - 1] = 0;
+        }
+    }
+    else
+    {
         if (pNeeded)
             *pNeeded = 1;
         if (name && count > 0)
             name[0] = 0;
-    }
-    else
-    {
-        PTR_AppDomain pAppDomain = PTR_AppDomain(TO_TADDR(addr));
 
-        size_t countAsSizeT = count;
-        if (pAppDomain->m_friendlyName.IsValid())
-        {
-            LPCWSTR friendlyName = (LPCWSTR)pAppDomain->m_friendlyName;
-            size_t friendlyNameLen = u16_strlen(friendlyName);
-
-            if (pNeeded)
-            {
-                *pNeeded = (unsigned int)(friendlyNameLen + 1);
-            }
-
-            if (name && count > 0)
-            {
-                if (countAsSizeT > (friendlyNameLen + 1))
-                {
-                    countAsSizeT = friendlyNameLen + 1;
-                }
-                memcpy(name, friendlyName, countAsSizeT * sizeof(WCHAR));
-                name[countAsSizeT - 1] = 0;
-            }
-        }
-        else
-        {
-            if (pNeeded)
-                *pNeeded = 1;
-            if (name && count > 0)
-                name[0] = 0;
-
-            hr = S_OK;
-        }
+        hr = S_OK;
     }
 
     SOSDacLeave();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -79,7 +79,15 @@ public record struct ModuleLookupTables(
     TargetPointer MethodDefToDesc,
     TargetPointer TypeDefToMethodTable,
     TargetPointer TypeRefToMethodTable,
-    TargetPointer MethodDefToILCodeVersioningState);
+    TargetPointer MethodDefToILCodeVersioningState,
+    uint TableDataOffset);
+
+public readonly struct RuntimeDomainInfo
+{
+    public TargetPointer SystemDomain { get; init; }
+    public TargetPointer DefaultAppDomain { get; init; }
+    public uint DefaultAppDomainId { get; init; }
+}
 
 public readonly struct LoaderHeapBlockData
 {
@@ -97,6 +105,7 @@ public interface ILoader : IContract
     IEnumerable<ModuleHandle> GetModuleHandles(TargetPointer appDomain, AssemblyIterationFlags iterationFlags) => throw new NotImplementedException();
     TargetPointer GetRootAssembly() => throw new NotImplementedException();
     string GetAppDomainFriendlyName() => throw new NotImplementedException();
+    RuntimeDomainInfo GetDomainInfo() => throw new NotImplementedException();
     TargetPointer GetModule(ModuleHandle handle) => throw new NotImplementedException();
     TargetPointer GetAssembly(ModuleHandle handle) => throw new NotImplementedException();
     TargetPointer GetPEAssembly(ModuleHandle handle) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -82,13 +82,6 @@ public record struct ModuleLookupTables(
     TargetPointer MethodDefToILCodeVersioningState,
     uint TableDataOffset);
 
-public readonly struct RuntimeDomainInfo
-{
-    public TargetPointer SystemDomain { get; init; }
-    public TargetPointer DefaultAppDomain { get; init; }
-    public uint DefaultAppDomainId { get; init; }
-}
-
 public readonly struct LoaderHeapBlockData
 {
     public TargetPointer Address { get; init; }
@@ -105,7 +98,7 @@ public interface ILoader : IContract
     IEnumerable<ModuleHandle> GetModuleHandles(TargetPointer appDomain, AssemblyIterationFlags iterationFlags) => throw new NotImplementedException();
     TargetPointer GetRootAssembly() => throw new NotImplementedException();
     string GetAppDomainFriendlyName() => throw new NotImplementedException();
-    RuntimeDomainInfo GetDomainInfo() => throw new NotImplementedException();
+    TargetPointer GetAppDomain() => throw new NotImplementedException();
     TargetPointer GetModule(ModuleHandle handle) => throw new NotImplementedException();
     TargetPointer GetAssembly(ModuleHandle handle) => throw new NotImplementedException();
     TargetPointer GetPEAssembly(ModuleHandle handle) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -99,6 +99,16 @@ public enum GenericContextLoc
     ThisPtr,
 }
 
+public enum WellKnownMethodTable
+{
+    Object,
+    String,
+    Array,
+    Exception,
+    Free,
+    Canon,
+}
+
 
 public interface IRuntimeTypeSystem : IContract
 {
@@ -133,6 +143,9 @@ public interface IRuntimeTypeSystem : IContract
     // True if the MethodTable is the System.Object MethodTable (g_pObjectClass)
     bool IsObject(TypeHandle typeHandle) => throw new NotImplementedException();
     bool IsString(TypeHandle typeHandle) => throw new NotImplementedException();
+    // Returns the address of one of the runtime's well-known singleton MethodTables,
+    // or TargetPointer.Null if the runtime has not yet initialized that global.
+    TargetPointer GetWellKnownMethodTable(WellKnownMethodTable kind) => throw new NotImplementedException();
     bool IsObjRef(TypeHandle typeHandle) => throw new NotImplementedException();
     // True if the MethodTable represents a type that contains managed references
     bool ContainsGCPointers(TypeHandle typeHandle) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
@@ -89,7 +89,6 @@ public static class Constants
         public const string EEJitManagerAddress = nameof(EEJitManagerAddress);
         public const string StubCodeBlockLast = nameof(StubCodeBlockLast);
 
-        public const string DefaultADID = nameof(DefaultADID);
         public const string StaticsPointerMask = nameof(StaticsPointerMask);
         public const string PtrArrayOffsetToDataArray = nameof(PtrArrayOffsetToDataArray);
         public const string NumberOfTlsOffsetsNotUsedInNoncollectibleArray = nameof(NumberOfTlsOffsetsNotUsedInNoncollectibleArray);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -141,39 +141,25 @@ internal readonly struct Loader_1 : ILoader
 
     TargetPointer ILoader.GetRootAssembly()
     {
-        TargetPointer defaultAppDomain = ((ILoader)this).GetDomainInfo().DefaultAppDomain;
+        TargetPointer defaultAppDomain = ((ILoader)this).GetAppDomain();
         Data.AppDomain appDomain = _target.ProcessedData.GetOrAdd<Data.AppDomain>(defaultAppDomain);
         return appDomain.RootAssembly;
     }
 
     string ILoader.GetAppDomainFriendlyName()
     {
-        TargetPointer defaultAppDomain = ((ILoader)this).GetDomainInfo().DefaultAppDomain;
+        TargetPointer defaultAppDomain = ((ILoader)this).GetAppDomain();
         Data.AppDomain appDomain = _target.ProcessedData.GetOrAdd<Data.AppDomain>(defaultAppDomain);
         return appDomain.FriendlyName != TargetPointer.Null
             ? _target.ReadUtf16String(appDomain.FriendlyName)
             : DefaultDomainFriendlyName;
     }
 
-    RuntimeDomainInfo ILoader.GetDomainInfo()
+    TargetPointer ILoader.GetAppDomain()
     {
-        return new RuntimeDomainInfo
-        {
-            SystemDomain = TryReadGlobalIndirectPointer(_target, Constants.Globals.SystemDomain),
-            DefaultAppDomain = TryReadGlobalIndirectPointer(_target, Constants.Globals.AppDomain),
-            DefaultAppDomainId = _target.TryReadGlobal(Constants.Globals.DefaultADID, out uint? id) && id is not null ? id.Value : 0u,
-        };
-
-        // Tolerate missing-or-uninitialized globals: callers that only need one of
-        // the values shouldn't fail because an unrelated global is unavailable.
-        static TargetPointer TryReadGlobalIndirectPointer(Target target, string name)
-        {
-            if (!target.TryReadGlobalPointer(name, out TargetPointer? ptrPtr) || ptrPtr is null)
-                return TargetPointer.Null;
-            if (!target.TryReadPointer(ptrPtr.Value, out TargetPointer value))
-                return TargetPointer.Null;
-            return value;
-        }
+        TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
+        TargetPointer appDomain = _target.ReadPointer(appDomainPointer);
+        return appDomain;
     }
 
     TargetPointer ILoader.GetModule(ModuleHandle handle)
@@ -609,15 +595,15 @@ internal readonly struct Loader_1 : ILoader
 
     TargetPointer ILoader.GetGlobalLoaderAllocator()
     {
-        TargetPointer systemDomainAddr = ((ILoader)this).GetDomainInfo().SystemDomain;
-        Data.SystemDomain systemDomain = _target.ProcessedData.GetOrAdd<Data.SystemDomain>(systemDomainAddr);
+        TargetPointer systemDomainPointer = _target.ReadGlobalPointer(Constants.Globals.SystemDomain);
+        Data.SystemDomain systemDomain = _target.ProcessedData.GetOrAdd<Data.SystemDomain>(_target.ReadPointer(systemDomainPointer));
         return systemDomain.GlobalLoaderAllocator;
     }
 
     TargetPointer ILoader.GetSystemAssembly()
     {
-        TargetPointer systemDomainAddr = ((ILoader)this).GetDomainInfo().SystemDomain;
-        Data.SystemDomain systemDomain = _target.ProcessedData.GetOrAdd<Data.SystemDomain>(systemDomainAddr);
+        TargetPointer systemDomainPointer = _target.ReadGlobalPointer(Constants.Globals.SystemDomain);
+        Data.SystemDomain systemDomain = _target.ProcessedData.GetOrAdd<Data.SystemDomain>(_target.ReadPointer(systemDomainPointer));
         return systemDomain.SystemAssembly;
     }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -141,18 +141,39 @@ internal readonly struct Loader_1 : ILoader
 
     TargetPointer ILoader.GetRootAssembly()
     {
-        TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-        Data.AppDomain appDomain = _target.ProcessedData.GetOrAdd<Data.AppDomain>(_target.ReadPointer(appDomainPointer));
+        TargetPointer defaultAppDomain = ((ILoader)this).GetDomainInfo().DefaultAppDomain;
+        Data.AppDomain appDomain = _target.ProcessedData.GetOrAdd<Data.AppDomain>(defaultAppDomain);
         return appDomain.RootAssembly;
     }
 
     string ILoader.GetAppDomainFriendlyName()
     {
-        TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-        Data.AppDomain appDomain = _target.ProcessedData.GetOrAdd<Data.AppDomain>(_target.ReadPointer(appDomainPointer));
+        TargetPointer defaultAppDomain = ((ILoader)this).GetDomainInfo().DefaultAppDomain;
+        Data.AppDomain appDomain = _target.ProcessedData.GetOrAdd<Data.AppDomain>(defaultAppDomain);
         return appDomain.FriendlyName != TargetPointer.Null
             ? _target.ReadUtf16String(appDomain.FriendlyName)
             : DefaultDomainFriendlyName;
+    }
+
+    RuntimeDomainInfo ILoader.GetDomainInfo()
+    {
+        return new RuntimeDomainInfo
+        {
+            SystemDomain = TryReadGlobalIndirectPointer(_target, Constants.Globals.SystemDomain),
+            DefaultAppDomain = TryReadGlobalIndirectPointer(_target, Constants.Globals.AppDomain),
+            DefaultAppDomainId = _target.TryReadGlobal(Constants.Globals.DefaultADID, out uint? id) && id is not null ? id.Value : 0u,
+        };
+
+        // Tolerate missing-or-uninitialized globals: callers that only need one of
+        // the values shouldn't fail because an unrelated global is unavailable.
+        static TargetPointer TryReadGlobalIndirectPointer(Target target, string name)
+        {
+            if (!target.TryReadGlobalPointer(name, out TargetPointer? ptrPtr) || ptrPtr is null)
+                return TargetPointer.Null;
+            if (!target.TryReadPointer(ptrPtr.Value, out TargetPointer value))
+                return TargetPointer.Null;
+            return value;
+        }
     }
 
     TargetPointer ILoader.GetModule(ModuleHandle handle)
@@ -494,6 +515,8 @@ internal readonly struct Loader_1 : ILoader
     ModuleLookupTables ILoader.GetLookupTables(ModuleHandle handle)
     {
         Data.Module module = _target.ProcessedData.GetOrAdd<Data.Module>(handle.Address);
+        Target.TypeInfo lookupMapTypeInfo = _target.GetTypeInfo(DataType.ModuleLookupMap);
+        uint tableDataOffset = (uint)lookupMapTypeInfo.Fields[Constants.FieldNames.ModuleLookupMap.TableData].Offset;
         return new ModuleLookupTables(
             module.FieldDefToDescMap,
             module.ManifestModuleReferencesMap,
@@ -501,7 +524,8 @@ internal readonly struct Loader_1 : ILoader
             module.MethodDefToDescMap,
             module.TypeDefToMethodTableMap,
             module.TypeRefToMethodTableMap,
-            module.MethodDefToILCodeVersioningStateMap);
+            module.MethodDefToILCodeVersioningStateMap,
+            tableDataOffset);
     }
 
     private static (bool Done, uint NextIndex) IterateLookupMap(uint index) => (false, index + 1);
@@ -585,15 +609,15 @@ internal readonly struct Loader_1 : ILoader
 
     TargetPointer ILoader.GetGlobalLoaderAllocator()
     {
-        TargetPointer systemDomainPointer = _target.ReadGlobalPointer(Constants.Globals.SystemDomain);
-        Data.SystemDomain systemDomain = _target.ProcessedData.GetOrAdd<Data.SystemDomain>(_target.ReadPointer(systemDomainPointer));
+        TargetPointer systemDomainAddr = ((ILoader)this).GetDomainInfo().SystemDomain;
+        Data.SystemDomain systemDomain = _target.ProcessedData.GetOrAdd<Data.SystemDomain>(systemDomainAddr);
         return systemDomain.GlobalLoaderAllocator;
     }
 
     TargetPointer ILoader.GetSystemAssembly()
     {
-        TargetPointer systemDomainPointer = _target.ReadGlobalPointer(Constants.Globals.SystemDomain);
-        Data.SystemDomain systemDomain = _target.ProcessedData.GetOrAdd<Data.SystemDomain>(_target.ReadPointer(systemDomainPointer));
+        TargetPointer systemDomainAddr = ((ILoader)this).GetDomainInfo().SystemDomain;
+        Data.SystemDomain systemDomain = _target.ProcessedData.GetOrAdd<Data.SystemDomain>(systemDomainAddr);
         return systemDomain.SystemAssembly;
     }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -584,6 +584,26 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
     public bool IsObject(TypeHandle typeHandle) => ObjectMethodTablePointer != TargetPointer.Null && ObjectMethodTablePointer == typeHandle.Address;
 
     public bool IsString(TypeHandle typeHandle) => !typeHandle.IsMethodTable() ? false : _methodTables[typeHandle.Address].Flags.IsString;
+
+    public TargetPointer GetWellKnownMethodTable(WellKnownMethodTable kind)
+    {
+        string globalName = kind switch
+        {
+            WellKnownMethodTable.Object => Constants.Globals.ObjectMethodTable,
+            WellKnownMethodTable.String => Constants.Globals.StringMethodTable,
+            WellKnownMethodTable.Array => Constants.Globals.ObjectArrayMethodTable,
+            WellKnownMethodTable.Exception => Constants.Globals.ExceptionMethodTable,
+            WellKnownMethodTable.Free => Constants.Globals.FreeObjectMethodTable,
+            WellKnownMethodTable.Canon => Constants.Globals.CanonMethodTable,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        if (!_target.TryReadGlobalPointer(globalName, out TargetPointer? ptrPtr) || ptrPtr is null)
+            return TargetPointer.Null;
+        if (!_target.TryReadPointer(ptrPtr.Value, out TargetPointer value))
+            return TargetPointer.Null;
+        return value;
+    }
     public bool IsObjRef(TypeHandle typeHandle)
     {
         CorElementType elementType = GetSignatureCorElementType(typeHandle);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -604,6 +604,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             return TargetPointer.Null;
         return value;
     }
+
     public bool IsObjRef(TypeHandle typeHandle)
     {
         CorElementType elementType = GetSignatureCorElementType(typeHandle);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataAppDomain.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataAppDomain.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 [GeneratedComClass]
 public sealed unsafe partial class ClrDataAppDomain : IXCLRDataAppDomain
 {
+    private const uint DefaultAppDomainId = 1;
+
     private readonly Target _target;
     private readonly TargetPointer _appDomain;
     private readonly IXCLRDataAppDomain? _legacyImpl;
@@ -103,7 +105,7 @@ public sealed unsafe partial class ClrDataAppDomain : IXCLRDataAppDomain
             if (id is null)
                 throw new ArgumentNullException(nameof(id));
 
-            *id = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomainId;
+            *id = DefaultAppDomainId;
         }
         catch (System.Exception ex)
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataAppDomain.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataAppDomain.cs
@@ -103,7 +103,7 @@ public sealed unsafe partial class ClrDataAppDomain : IXCLRDataAppDomain
             if (id is null)
                 throw new ArgumentNullException(nameof(id));
 
-            *id = _target.ReadGlobal<uint>(Constants.Globals.DefaultADID);
+            *id = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomainId;
         }
         catch (System.Exception ex)
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
@@ -108,7 +108,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
 
         try
         {
-            TargetPointer appDomainAddr = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            TargetPointer appDomainAddr = _target.Contracts.Loader.GetAppDomain();
 
             if (appDomainAddr != TargetPointer.Null)
             {
@@ -357,7 +357,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
                 throw new InvalidCastException(); // E_NOINTERFACE
 
             MethodDescHandle mdh = rts.GetMethodDescHandle(methodDesc);
-            TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            TargetPointer appDomain = _target.Contracts.Loader.GetAppDomain();
 
             method.Interface = new ClrDataMethodInstance(_target, mdh, appDomain, legacyMethod);
         }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
@@ -108,8 +108,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
 
         try
         {
-            TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-            TargetPointer appDomainAddr = _target.ReadPointer(appDomainPointer);
+            TargetPointer appDomainAddr = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
 
             if (appDomainAddr != TargetPointer.Null)
             {
@@ -358,8 +357,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
                 throw new InvalidCastException(); // E_NOINTERFACE
 
             MethodDescHandle mdh = rts.GetMethodDescHandle(methodDesc);
-            TargetPointer appDomain = _target.ReadPointer(
-                _target.ReadGlobalPointer(Constants.Globals.AppDomain));
+            TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
 
             method.Interface = new ClrDataMethodInstance(_target, mdh, appDomain, legacyMethod);
         }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataTask.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataTask.cs
@@ -38,7 +38,7 @@ public sealed unsafe partial class ClrDataTask : IXCLRDataTask
         }
         try
         {
-            TargetPointer currentAppDomain = _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.AppDomain));
+            TargetPointer currentAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
             appDomain.Interface = new ClrDataAppDomain(_target, currentAppDomain, legacyAppDomain);
         }
         catch (System.Exception ex)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataTask.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataTask.cs
@@ -38,7 +38,7 @@ public sealed unsafe partial class ClrDataTask : IXCLRDataTask
         }
         try
         {
-            TargetPointer currentAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            TargetPointer currentAppDomain = _target.Contracts.Loader.GetAppDomain();
             appDomain.Interface = new ClrDataAppDomain(_target, currentAppDomain, legacyAppDomain);
         }
         catch (System.Exception ex)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 [GeneratedComClass]
 public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
 {
+    private const uint DefaultAppDomainId = 1;
+
     private readonly Target _target;
     private readonly IDacDbiInterface? _legacy;
 
@@ -108,7 +110,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         int hr = HResults.S_OK;
         try
         {
-            *pRetVal = vmAppDomain == 0 ? 0u : _target.Contracts.Loader.GetDomainInfo().DefaultAppDomainId;
+            *pRetVal = vmAppDomain == 0 ? 0u : DefaultAppDomainId;
         }
         catch (System.Exception ex)
         {
@@ -1140,7 +1142,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         int hr = HResults.S_OK;
         try
         {
-            TargetPointer defaultAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            TargetPointer defaultAppDomain = _target.Contracts.Loader.GetAppDomain();
             *pRetVal = defaultAppDomain;
         }
         catch (System.Exception ex)
@@ -1342,7 +1344,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         try
         {
             TargetPointer threadPtr = new TargetPointer(vmThread);
-            TargetPointer currentAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            TargetPointer currentAppDomain = _target.Contracts.Loader.GetAppDomain();
             IStackWalk stackwalk = _target.Contracts.StackWalk;
 
             foreach (Contracts.StackFrameData frame in stackwalk.GetFrames(threadPtr))
@@ -2858,7 +2860,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             if (fpCallback is null)
                 throw new ArgumentNullException(nameof(fpCallback));
 
-            ulong vmAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain.Value;
+            ulong vmAppDomain = _target.Contracts.Loader.GetAppDomain().Value;
 
             IException exceptionContract = _target.Contracts.Exception;
             foreach (ExceptionStackFrameInfo frame in exceptionContract.GetExceptionStackFrames(new TargetPointer(vmObject)))

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -108,7 +108,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         int hr = HResults.S_OK;
         try
         {
-            *pRetVal = vmAppDomain == 0 ? 0u : _target.ReadGlobal<uint>(Constants.Globals.DefaultADID);
+            *pRetVal = vmAppDomain == 0 ? 0u : _target.Contracts.Loader.GetDomainInfo().DefaultAppDomainId;
         }
         catch (System.Exception ex)
         {
@@ -1140,8 +1140,8 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         int hr = HResults.S_OK;
         try
         {
-            TargetPointer appDomainPtr = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-            *pRetVal = _target.ReadPointer(appDomainPtr);
+            TargetPointer defaultAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            *pRetVal = defaultAppDomain;
         }
         catch (System.Exception ex)
         {
@@ -1342,7 +1342,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         try
         {
             TargetPointer threadPtr = new TargetPointer(vmThread);
-            TargetPointer currentAppDomain = _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.AppDomain));
+            TargetPointer currentAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
             IStackWalk stackwalk = _target.Contracts.StackWalk;
 
             foreach (Contracts.StackFrameData frame in stackwalk.GetFrames(threadPtr))
@@ -2542,7 +2542,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             *pcGenericClassTypeParams = cClassParams;
 
             // Resolve the System.__Canon TypeHandle for per-parameter fallback.
-            TargetPointer canonMtPtr = _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.CanonMethodTable));
+            TargetPointer canonMtPtr = rts.GetWellKnownMethodTable(WellKnownMethodTable.Canon);
             TypeHandle thCanon = rts.GetTypeHandle(canonMtPtr);
 
             DebuggerIPCE_ExpandedTypeData entry;
@@ -2802,7 +2802,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
             TargetPointer objectAddress = new TargetPointer(vmObject);
             TargetPointer parentMT = _target.Contracts.Object.GetMethodTableAddress(objectAddress);
-            TargetPointer exceptionMT = _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.ExceptionMethodTable));
+            TargetPointer exceptionMT = rts.GetWellKnownMethodTable(WellKnownMethodTable.Exception);
 
             while (parentMT != TargetPointer.Null)
             {
@@ -2858,8 +2858,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             if (fpCallback is null)
                 throw new ArgumentNullException(nameof(fpCallback));
 
-            TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-            ulong vmAppDomain = _target.ReadPointer(appDomainPointer).Value;
+            ulong vmAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain.Value;
 
             IException exceptionContract = _target.Contracts.Exception;
             foreach (ExceptionStackFrameInfo frame in exceptionContract.GetExceptionStackFrames(new TargetPointer(vmObject)))

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/Helpers/HeapWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/Helpers/HeapWalk.cs
@@ -27,7 +27,7 @@ internal sealed class HeapWalk : IEnum<COR_HEAPOBJECT>
     {
         _gc = target.Contracts.GC;
         _rts = target.Contracts.RuntimeTypeSystem;
-        _freeObjectMT = target.ReadPointer(target.ReadGlobalPointer(Constants.Globals.FreeObjectMethodTable));
+        _freeObjectMT = _rts.GetWellKnownMethodTable(WellKnownMethodTable.Free);
         _cache = new LinearReadCache(target);
         // use these fields directly instead of through RuntimeTypeSystem so that we can use our cache that we really only need for heap walking
         _numComponentsOffsetArray = (uint)target.GetTypeInfo(DataType.Array).Fields[Constants.FieldNames.Array.NumComponents].Offset;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -265,7 +265,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
             _mainMethodDesc = methodDesc;
             if (appDomain == TargetPointer.Null)
             {
-                _appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+                _appDomain = _target.Contracts.Loader.GetAppDomain();
             }
             else
             {
@@ -658,7 +658,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
 
                 case JitNotificationData jit:
                 {
-                    TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+                    TargetPointer appDomain = _target.Contracts.Loader.GetAppDomain();
 
                     IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
                     MethodDescHandle methodDesc = rts.GetMethodDescHandle(jit.MethodDescAddress);
@@ -719,7 +719,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
                 {
                     if (notify is IXCLRDataExceptionNotification4 notify4)
                     {
-                        TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+                        TargetPointer appDomain = _target.Contracts.Loader.GetAppDomain();
                         IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
                         MethodDescHandle methodDesc = rts.GetMethodDescHandle(exceptionCatcherEnter.MethodDescAddress);
                         notify4.ExceptionCatcherEnter(new ClrDataMethodInstance(_target, methodDesc, appDomain, null), exceptionCatcherEnter.NativeOffset);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -265,8 +265,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
             _mainMethodDesc = methodDesc;
             if (appDomain == TargetPointer.Null)
             {
-                TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-                _appDomain = _target.ReadPointer(appDomainPointer);
+                _appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
             }
             else
             {
@@ -659,8 +658,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
 
                 case JitNotificationData jit:
                 {
-                    TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-                    TargetPointer appDomain = _target.ReadPointer(appDomainPointer);
+                    TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
 
                     IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
                     MethodDescHandle methodDesc = rts.GetMethodDescHandle(jit.MethodDescAddress);
@@ -721,8 +719,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
                 {
                     if (notify is IXCLRDataExceptionNotification4 notify4)
                     {
-                        TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-                        TargetPointer appDomain = _target.ReadPointer(appDomainPointer);
+                        TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
                         IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
                         MethodDescHandle methodDesc = rts.GetMethodDescHandle(exceptionCatcherEnter.MethodDescAddress);
                         notify4.ExceptionCatcherEnter(new ClrDataMethodInstance(_target, methodDesc, appDomain, null), exceptionCatcherEnter.NativeOffset);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -37,11 +37,6 @@ public sealed unsafe partial class SOSDacImpl
 {
     private readonly Target _target;
 
-    // When this class is created, the runtime may not have loaded the string and object method tables and set the global pointers.
-    // This is also the case for the GetUsefulGlobals API, which can be called as part of load notifications before runtime start.
-    // They should be set when actually requested via other DAC APIs, so we lazily read the global pointers.
-    private readonly Lazy<TargetPointer> _stringMethodTable;
-    private readonly Lazy<TargetPointer> _objectMethodTable;
     private readonly ulong _rcwMask = 1UL;
 
     private readonly ISOSDacInterface? _legacyImpl;
@@ -67,11 +62,6 @@ public sealed unsafe partial class SOSDacImpl
     public SOSDacImpl(Target target, object? legacyObj)
     {
         _target = target;
-        _stringMethodTable = new Lazy<TargetPointer>(
-            () => _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.StringMethodTable)));
-
-        _objectMethodTable = new Lazy<TargetPointer>(
-            () => _target.ReadPointer(_target.ReadGlobalPointer(Constants.Globals.ObjectMethodTable)));
 
         // Get all the interfaces for delegating to the legacy DAC
         if (legacyObj is not null)
@@ -126,9 +116,9 @@ public sealed unsafe partial class SOSDacImpl
 
             *data = default;
             data->AppDomainPtr = addr;
-            TargetPointer systemDomainPointer = _target.ReadGlobalPointer(Constants.Globals.SystemDomain);
-            ClrDataAddress systemDomain = _target.ReadPointer(systemDomainPointer).ToClrDataAddress(_target);
             Contracts.ILoader loader = _target.Contracts.Loader;
+            Contracts.RuntimeDomainInfo domainInfo = loader.GetDomainInfo();
+            ClrDataAddress systemDomain = domainInfo.SystemDomain.ToClrDataAddress(_target);
             TargetPointer globalLoaderAllocator = loader.GetGlobalLoaderAllocator();
             data->pHighFrequencyHeap = loader.GetHighFrequencyHeap(globalLoaderAllocator).ToClrDataAddress(_target);
             data->pLowFrequencyHeap = loader.GetLowFrequencyHeap(globalLoaderAllocator).ToClrDataAddress(_target);
@@ -137,7 +127,7 @@ public sealed unsafe partial class SOSDacImpl
             if (addr != systemDomain)
             {
                 TargetPointer pAppDomain = addr.ToTargetPointer(_target);
-                data->dwId = _target.ReadGlobal<uint>(Constants.Globals.DefaultADID);
+                data->dwId = domainInfo.DefaultAppDomainId;
 
                 IEnumerable<Contracts.ModuleHandle> modules = loader.GetModuleHandles(
                     pAppDomain,
@@ -193,8 +183,7 @@ public sealed unsafe partial class SOSDacImpl
         try
         {
             uint i = 0;
-            TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-            TargetPointer appDomain = _target.ReadPointer(appDomainPointer);
+            TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
 
             if (appDomain != TargetPointer.Null && values.Length > 0)
             {
@@ -233,8 +222,7 @@ public sealed unsafe partial class SOSDacImpl
         try
         {
             ILoader loader = _target.Contracts.Loader;
-            TargetPointer systemDomainPtr = _target.ReadGlobalPointer(Constants.Globals.SystemDomain);
-            ClrDataAddress systemDomain = _target.ReadPointer(systemDomainPtr).ToClrDataAddress(_target);
+            ClrDataAddress systemDomain = loader.GetDomainInfo().SystemDomain.ToClrDataAddress(_target);
 
             string? friendlyName = null;
             if (addr != systemDomain)
@@ -308,10 +296,9 @@ public sealed unsafe partial class SOSDacImpl
         try
         {
             appDomainStoreData->sharedDomain = 0;
-            TargetPointer systemDomainPtr = _target.ReadGlobalPointer(Constants.Globals.SystemDomain);
-            appDomainStoreData->systemDomain = _target.ReadPointer(systemDomainPtr).ToClrDataAddress(_target);
-            TargetPointer appDomainPtr = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-            appDomainStoreData->DomainCount = _target.ReadPointer(appDomainPtr) != 0 ? 1 : 0;
+            Contracts.RuntimeDomainInfo domainInfo = _target.Contracts.Loader.GetDomainInfo();
+            appDomainStoreData->systemDomain = domainInfo.SystemDomain.ToClrDataAddress(_target);
+            appDomainStoreData->DomainCount = domainInfo.DefaultAppDomain != TargetPointer.Null ? 1 : 0;
         }
         catch (System.Exception ex)
         {
@@ -363,9 +350,8 @@ public sealed unsafe partial class SOSDacImpl
             data->AssemblyPtr = assembly;
             data->DomainPtr = domain;
 
-            TargetPointer ppAppDomain = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-            TargetPointer pAppDomain = _target.ReadPointer(ppAppDomain);
-            data->ParentDomain = pAppDomain.ToClrDataAddress(_target);
+            TargetPointer defaultAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            data->ParentDomain = defaultAppDomain.ToClrDataAddress(_target);
 
             ILoader loader = _target.Contracts.Loader;
             Contracts.ModuleHandle moduleHandle = loader.GetModuleHandleFromAssemblyPtr(assembly.ToTargetPointer(_target));
@@ -415,13 +401,12 @@ public sealed unsafe partial class SOSDacImpl
             if (addr == 0)
                 throw new ArgumentException();
             TargetPointer appDomain = addr.ToTargetPointer(_target);
-            TargetPointer systemDomainPtr = _target.ReadGlobalPointer(Constants.Globals.SystemDomain);
-            ClrDataAddress systemDomain = _target.ReadPointer(systemDomainPtr).ToClrDataAddress(_target);
+            ILoader loader = _target.Contracts.Loader;
+            ClrDataAddress systemDomain = loader.GetDomainInfo().SystemDomain.ToClrDataAddress(_target);
             if (addr == systemDomain)
                 // We shouldn't be asking for the assemblies in SystemDomain
                 throw new ArgumentException();
 
-            ILoader loader = _target.Contracts.Loader;
             List<Contracts.ModuleHandle> modules = loader.GetModuleHandles(
                 appDomain,
                 AssemblyIterationFlags.IncludeLoading |
@@ -897,7 +882,7 @@ public sealed unsafe partial class SOSDacImpl
                             break;
                         case Contracts.HostCodeHeapInfo host:
                             codeHeaps[i].codeHeapType = DacpJitCodeHeapInfo.CodeHeapType.CODEHEAP_HOST;
-                            codeHeaps[i].baseAddr    = host.BaseAddress.ToClrDataAddress(_target);
+                            codeHeaps[i].baseAddr = host.BaseAddress.ToClrDataAddress(_target);
                             codeHeaps[i].currentAddr = host.CurrentAddress.ToClrDataAddress(_target);
                             break;
                         default:
@@ -1642,8 +1627,7 @@ public sealed unsafe partial class SOSDacImpl
             IGC gc = _target.Contracts.GC;
             List<HandleData> handles = gc.GetHandles(types);
 
-            TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-            TargetPointer appDomain = _target.ReadPointer(appDomainPointer);
+            TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
             ClrDataAddress appDomainClrAddress = appDomain.ToClrDataAddress(_target);
 
             SOSHandleData[] sosHandles = new SOSHandleData[handles.Count];
@@ -3160,16 +3144,18 @@ public sealed unsafe partial class SOSDacImpl
 
             data->LoaderAllocator = contract.GetLoaderAllocator(handle).ToClrDataAddress(_target);
 
-            Target.TypeInfo lookupMapTypeInfo = _target.GetTypeInfo(DataType.ModuleLookupMap);
-            ulong tableDataOffset = (ulong)lookupMapTypeInfo.Fields[Constants.FieldNames.ModuleLookupMap.TableData].Offset;
-
             Contracts.ModuleLookupTables tables = contract.GetLookupTables(handle);
-            data->FieldDefToDescMap = _target.ReadPointer(tables.FieldDefToDesc + tableDataOffset).ToClrDataAddress(_target);
-            data->ManifestModuleReferencesMap = _target.ReadPointer(tables.ManifestModuleReferences + tableDataOffset).ToClrDataAddress(_target);
-            data->MemberRefToDescMap = _target.ReadPointer(tables.MemberRefToDesc + tableDataOffset).ToClrDataAddress(_target);
-            data->MethodDefToDescMap = _target.ReadPointer(tables.MethodDefToDesc + tableDataOffset).ToClrDataAddress(_target);
-            data->TypeDefToMethodTableMap = _target.ReadPointer(tables.TypeDefToMethodTable + tableDataOffset).ToClrDataAddress(_target);
-            data->TypeRefToMethodTableMap = _target.ReadPointer(tables.TypeRefToMethodTable + tableDataOffset).ToClrDataAddress(_target);
+            data->FieldDefToDescMap = ReadMapBase(_target, tables.FieldDefToDesc, tables.TableDataOffset);
+            data->ManifestModuleReferencesMap = ReadMapBase(_target, tables.ManifestModuleReferences, tables.TableDataOffset);
+            data->MemberRefToDescMap = ReadMapBase(_target, tables.MemberRefToDesc, tables.TableDataOffset);
+            data->MethodDefToDescMap = ReadMapBase(_target, tables.MethodDefToDesc, tables.TableDataOffset);
+            data->TypeDefToMethodTableMap = ReadMapBase(_target, tables.TypeDefToMethodTable, tables.TableDataOffset);
+            data->TypeRefToMethodTableMap = ReadMapBase(_target, tables.TypeRefToMethodTable, tables.TableDataOffset);
+
+            static ClrDataAddress ReadMapBase(Target target, TargetPointer table, uint offset)
+                => table == TargetPointer.Null
+                    ? default
+                    : target.ReadPointer(table + offset).ToClrDataAddress(target);
 
             // Always 0 - .NET no longer has these concepts
             data->dwModuleID = 0;
@@ -3354,14 +3340,14 @@ public sealed unsafe partial class SOSDacImpl
                 ulong numComponentsOffset = (ulong)_target.GetTypeInfo(DataType.Array).Fields[Constants.FieldNames.Array.NumComponents].Offset;
                 data->Size += _target.Read<uint>(objAddr + numComponentsOffset) * data->dwComponentSize;
             }
-            else if (mt == _stringMethodTable.Value)
+            else if (mt == runtimeTypeSystemContract.GetWellKnownMethodTable(Contracts.WellKnownMethodTable.String))
             {
                 data->ObjectType = DacpObjectType.OBJ_STRING;
 
                 // Update the size to include the string character components
                 data->Size += (uint)objectContract.GetStringValue(objPtr).Length * data->dwComponentSize;
             }
-            else if (mt == _objectMethodTable.Value)
+            else if (mt == runtimeTypeSystemContract.GetWellKnownMethodTable(Contracts.WellKnownMethodTable.Object))
             {
                 data->ObjectType = DacpObjectType.OBJ_OBJECT;
             }
@@ -4232,8 +4218,7 @@ public sealed unsafe partial class SOSDacImpl
                             data->HoldingThread = threadPtr.ToClrDataAddress(_target);
                         }
 
-                        TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-                        TargetPointer appDomain = _target.ReadPointer(appDomainPointer);
+                        TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
                         data->appDomainPtr = appDomain.ToClrDataAddress(_target);
 
                         data->AdditionalThreadCount = syncBlock.GetAdditionalThreadCount(syncBlockAddr);
@@ -4326,8 +4311,7 @@ public sealed unsafe partial class SOSDacImpl
             data->allocContextLimit = threadData.AllocContextLimit.ToClrDataAddress(_target);
             data->fiberData = 0;    // Always set to 0 - fibers are no longer supported
 
-            TargetPointer appDomainPointer = _target.ReadGlobalPointer(Constants.Globals.AppDomain);
-            TargetPointer appDomain = _target.ReadPointer(appDomainPointer);
+            TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
             data->context = appDomain.ToClrDataAddress(_target);
             data->domain = appDomain.ToClrDataAddress(_target);
 
@@ -4517,21 +4501,12 @@ public sealed unsafe partial class SOSDacImpl
         {
             if (data == null)
                 throw new ArgumentException();
-            data->ArrayMethodTable = _target.ReadPointer(
-                _target.ReadGlobalPointer(Constants.Globals.ObjectArrayMethodTable))
-                .ToClrDataAddress(_target);
-            data->StringMethodTable = _target.ReadPointer(
-                _target.ReadGlobalPointer(Constants.Globals.StringMethodTable))
-                .ToClrDataAddress(_target);
-            data->ObjectMethodTable = _target.ReadPointer(
-                _target.ReadGlobalPointer(Constants.Globals.ObjectMethodTable))
-                .ToClrDataAddress(_target);
-            data->ExceptionMethodTable = _target.ReadPointer(
-                _target.ReadGlobalPointer(Constants.Globals.ExceptionMethodTable))
-                .ToClrDataAddress(_target);
-            data->FreeMethodTable = _target.ReadPointer(
-                _target.ReadGlobalPointer(Constants.Globals.FreeObjectMethodTable))
-                .ToClrDataAddress(_target);
+            Contracts.IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+            data->ArrayMethodTable = rts.GetWellKnownMethodTable(Contracts.WellKnownMethodTable.Array).ToClrDataAddress(_target);
+            data->StringMethodTable = rts.GetWellKnownMethodTable(Contracts.WellKnownMethodTable.String).ToClrDataAddress(_target);
+            data->ObjectMethodTable = rts.GetWellKnownMethodTable(Contracts.WellKnownMethodTable.Object).ToClrDataAddress(_target);
+            data->ExceptionMethodTable = rts.GetWellKnownMethodTable(Contracts.WellKnownMethodTable.Exception).ToClrDataAddress(_target);
+            data->FreeMethodTable = rts.GetWellKnownMethodTable(Contracts.WellKnownMethodTable.Free).ToClrDataAddress(_target);
         }
         catch (System.Exception ex)
         {
@@ -4986,7 +4961,7 @@ public sealed unsafe partial class SOSDacImpl
 #endif
         return hr;
     }
-#endregion ISOSDacInterface
+    #endregion ISOSDacInterface
 
     #region ISOSDacInterface2
     int ISOSDacInterface2.GetObjectExceptionData(ClrDataAddress objectAddress, DacpExceptionObjectData* data)
@@ -6107,7 +6082,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress rcwLocal = 0;
             uint neededLocal = 0;
-            ClrDataAddress[]? mowListLocal =  count > 0 ? new ClrDataAddress[count] : null;
+            ClrDataAddress[]? mowListLocal = count > 0 ? new ClrDataAddress[count] : null;
             int hrLocal = _legacyImpl10.GetObjectComWrappersData(objAddr, rcw == null ? null : &rcwLocal, count, mowListLocal, &neededLocal);
             Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK || hr == HResults.S_FALSE)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -35,6 +35,8 @@ public sealed unsafe partial class SOSDacImpl
       ISOSDacInterface11, ISOSDacInterface12, ISOSDacInterface13, ISOSDacInterface14, ISOSDacInterface15,
       ISOSDacInterface16
 {
+    private const uint DefaultAppDomainId = 1;
+
     private readonly Target _target;
 
     private readonly ulong _rcwMask = 1UL;
@@ -117,37 +119,33 @@ public sealed unsafe partial class SOSDacImpl
             *data = default;
             data->AppDomainPtr = addr;
             Contracts.ILoader loader = _target.Contracts.Loader;
-            Contracts.RuntimeDomainInfo domainInfo = loader.GetDomainInfo();
-            ClrDataAddress systemDomain = domainInfo.SystemDomain.ToClrDataAddress(_target);
             TargetPointer globalLoaderAllocator = loader.GetGlobalLoaderAllocator();
             data->pHighFrequencyHeap = loader.GetHighFrequencyHeap(globalLoaderAllocator).ToClrDataAddress(_target);
             data->pLowFrequencyHeap = loader.GetLowFrequencyHeap(globalLoaderAllocator).ToClrDataAddress(_target);
             data->pStubHeap = loader.GetStubHeap(globalLoaderAllocator).ToClrDataAddress(_target);
             data->appDomainStage = DacpAppDomainDataStage.STAGE_OPEN;
-            if (addr != systemDomain)
+
+            TargetPointer pAppDomain = addr.ToTargetPointer(_target);
+            data->dwId = DefaultAppDomainId;
+
+            IEnumerable<Contracts.ModuleHandle> modules = loader.GetModuleHandles(
+                pAppDomain,
+                AssemblyIterationFlags.IncludeLoading |
+                AssemblyIterationFlags.IncludeLoaded |
+                AssemblyIterationFlags.IncludeExecution);
+
+            foreach (Contracts.ModuleHandle module in modules)
             {
-                TargetPointer pAppDomain = addr.ToTargetPointer(_target);
-                data->dwId = domainInfo.DefaultAppDomainId;
-
-                IEnumerable<Contracts.ModuleHandle> modules = loader.GetModuleHandles(
-                    pAppDomain,
-                    AssemblyIterationFlags.IncludeLoading |
-                    AssemblyIterationFlags.IncludeLoaded |
-                    AssemblyIterationFlags.IncludeExecution);
-
-                foreach (Contracts.ModuleHandle module in modules)
+                if (loader.IsAssemblyLoaded(module))
                 {
-                    if (loader.IsAssemblyLoaded(module))
-                    {
-                        data->AssemblyCount++;
-                    }
+                    data->AssemblyCount++;
                 }
-
-                IEnumerable<Contracts.ModuleHandle> failedModules = loader.GetModuleHandles(
-                    pAppDomain,
-                    AssemblyIterationFlags.IncludeFailedToLoad);
-                data->FailedAssemblyCount = failedModules.Count();
             }
+
+            IEnumerable<Contracts.ModuleHandle> failedModules = loader.GetModuleHandles(
+                pAppDomain,
+                AssemblyIterationFlags.IncludeFailedToLoad);
+            data->FailedAssemblyCount = failedModules.Count();
         }
         catch (System.Exception ex)
         {
@@ -183,7 +181,7 @@ public sealed unsafe partial class SOSDacImpl
         try
         {
             uint i = 0;
-            TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            TargetPointer appDomain = _target.Contracts.Loader.GetAppDomain();
 
             if (appDomain != TargetPointer.Null && values.Length > 0)
             {
@@ -222,23 +220,19 @@ public sealed unsafe partial class SOSDacImpl
         try
         {
             ILoader loader = _target.Contracts.Loader;
-            ClrDataAddress systemDomain = loader.GetDomainInfo().SystemDomain.ToClrDataAddress(_target);
 
             string? friendlyName = null;
-            if (addr != systemDomain)
+            try
             {
-                try
-                {
-                    friendlyName = loader.GetAppDomainFriendlyName();
-                }
-                catch (VirtualReadException)
-                {
-                    // The FriendlyName field is a PTR_CWSTR (pointer to wide char string).
-                    // ReadUtf16String throws VirtualReadException when the pointer targets
-                    // unreadable memory (e.g. the name is not yet set during early init).
-                    // The native DAC handles this via PTR_AppDomain->m_friendlyName.IsValid()
-                    // and falls through to return an empty string. Match that behavior here.
-                }
+                friendlyName = loader.GetAppDomainFriendlyName();
+            }
+            catch (VirtualReadException)
+            {
+                // The FriendlyName field is a PTR_CWSTR (pointer to wide char string).
+                // ReadUtf16String throws VirtualReadException when the pointer targets
+                // unreadable memory (e.g. the name is not yet set during early init).
+                // The native DAC handles this via PTR_AppDomain->m_friendlyName.IsValid()
+                // and falls through to return an empty string. Match that behavior here.
             }
 
             if (friendlyName is null || friendlyName.Length == 0)
@@ -296,9 +290,9 @@ public sealed unsafe partial class SOSDacImpl
         try
         {
             appDomainStoreData->sharedDomain = 0;
-            Contracts.RuntimeDomainInfo domainInfo = _target.Contracts.Loader.GetDomainInfo();
-            appDomainStoreData->systemDomain = domainInfo.SystemDomain.ToClrDataAddress(_target);
-            appDomainStoreData->DomainCount = domainInfo.DefaultAppDomain != TargetPointer.Null ? 1 : 0;
+            appDomainStoreData->systemDomain = 0;
+            TargetPointer defaultAppDomain = _target.Contracts.Loader.GetAppDomain();
+            appDomainStoreData->DomainCount = defaultAppDomain != TargetPointer.Null ? 1 : 0;
         }
         catch (System.Exception ex)
         {
@@ -350,7 +344,7 @@ public sealed unsafe partial class SOSDacImpl
             data->AssemblyPtr = assembly;
             data->DomainPtr = domain;
 
-            TargetPointer defaultAppDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            TargetPointer defaultAppDomain = _target.Contracts.Loader.GetAppDomain();
             data->ParentDomain = defaultAppDomain.ToClrDataAddress(_target);
 
             ILoader loader = _target.Contracts.Loader;
@@ -402,10 +396,6 @@ public sealed unsafe partial class SOSDacImpl
                 throw new ArgumentException();
             TargetPointer appDomain = addr.ToTargetPointer(_target);
             ILoader loader = _target.Contracts.Loader;
-            ClrDataAddress systemDomain = loader.GetDomainInfo().SystemDomain.ToClrDataAddress(_target);
-            if (addr == systemDomain)
-                // We shouldn't be asking for the assemblies in SystemDomain
-                throw new ArgumentException();
 
             List<Contracts.ModuleHandle> modules = loader.GetModuleHandles(
                 appDomain,
@@ -882,7 +872,7 @@ public sealed unsafe partial class SOSDacImpl
                             break;
                         case Contracts.HostCodeHeapInfo host:
                             codeHeaps[i].codeHeapType = DacpJitCodeHeapInfo.CodeHeapType.CODEHEAP_HOST;
-                            codeHeaps[i].baseAddr = host.BaseAddress.ToClrDataAddress(_target);
+                            codeHeaps[i].baseAddr    = host.BaseAddress.ToClrDataAddress(_target);
                             codeHeaps[i].currentAddr = host.CurrentAddress.ToClrDataAddress(_target);
                             break;
                         default:
@@ -1627,7 +1617,7 @@ public sealed unsafe partial class SOSDacImpl
             IGC gc = _target.Contracts.GC;
             List<HandleData> handles = gc.GetHandles(types);
 
-            TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            TargetPointer appDomain = _target.Contracts.Loader.GetAppDomain();
             ClrDataAddress appDomainClrAddress = appDomain.ToClrDataAddress(_target);
 
             SOSHandleData[] sosHandles = new SOSHandleData[handles.Count];
@@ -3337,7 +3327,7 @@ public sealed unsafe partial class SOSDacImpl
                 // Free objects have their component count explicitly set at the same offset as that for arrays
                 // Update the size to include those components
                 Target.TypeInfo arrayTypeInfo = _target.GetTypeInfo(DataType.Array);
-                ulong numComponentsOffset = (ulong)_target.GetTypeInfo(DataType.Array).Fields[Constants.FieldNames.Array.NumComponents].Offset;
+                ulong numComponentsOffset = (ulong)arrayTypeInfo.Fields[Constants.FieldNames.Array.NumComponents].Offset;
                 data->Size += _target.Read<uint>(objAddr + numComponentsOffset) * data->dwComponentSize;
             }
             else if (mt == runtimeTypeSystemContract.GetWellKnownMethodTable(Contracts.WellKnownMethodTable.String))
@@ -4218,7 +4208,7 @@ public sealed unsafe partial class SOSDacImpl
                             data->HoldingThread = threadPtr.ToClrDataAddress(_target);
                         }
 
-                        TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+                        TargetPointer appDomain = _target.Contracts.Loader.GetAppDomain();
                         data->appDomainPtr = appDomain.ToClrDataAddress(_target);
 
                         data->AdditionalThreadCount = syncBlock.GetAdditionalThreadCount(syncBlockAddr);
@@ -4311,7 +4301,7 @@ public sealed unsafe partial class SOSDacImpl
             data->allocContextLimit = threadData.AllocContextLimit.ToClrDataAddress(_target);
             data->fiberData = 0;    // Always set to 0 - fibers are no longer supported
 
-            TargetPointer appDomain = _target.Contracts.Loader.GetDomainInfo().DefaultAppDomain;
+            TargetPointer appDomain = _target.Contracts.Loader.GetAppDomain();
             data->context = appDomain.ToClrDataAddress(_target);
             data->domain = appDomain.ToClrDataAddress(_target);
 
@@ -4961,7 +4951,7 @@ public sealed unsafe partial class SOSDacImpl
 #endif
         return hr;
     }
-    #endregion ISOSDacInterface
+#endregion ISOSDacInterface
 
     #region ISOSDacInterface2
     int ISOSDacInterface2.GetObjectExceptionData(ClrDataAddress objectAddress, DacpExceptionObjectData* data)
@@ -6082,7 +6072,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress rcwLocal = 0;
             uint neededLocal = 0;
-            ClrDataAddress[]? mowListLocal = count > 0 ? new ClrDataAddress[count] : null;
+            ClrDataAddress[]? mowListLocal =  count > 0 ? new ClrDataAddress[count] : null;
             int hrLocal = _legacyImpl10.GetObjectComWrappersData(objAddr, rcw == null ? null : &rcwLocal, count, mowListLocal, &neededLocal);
             Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK || hr == HResults.S_FALSE)

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataTaskTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataTaskTests.cs
@@ -17,9 +17,7 @@ public unsafe class ClrDataTaskTests
         TargetTestHelpers helpers = new(arch);
 
         ulong appDomainGlobalPtrAddr = 0x1000;
-        ulong systemDomainGlobalPtrAddr = 0x1100;
         ulong expectedAppDomain = 0x2000;
-        ulong expectedSystemDomain = 0x3000;
 
         var targetBuilder = new TestPlaceholderTarget.Builder(arch);
         byte[] appDomainPtrData = new byte[helpers.PointerSize];
@@ -30,20 +28,10 @@ public unsafe class ClrDataTaskTests
             Data = appDomainPtrData,
             Name = "AppDomainGlobalPointer"
         });
-        byte[] systemDomainPtrData = new byte[helpers.PointerSize];
-        helpers.WritePointer(systemDomainPtrData, expectedSystemDomain);
-        targetBuilder.MemoryBuilder.AddHeapFragment(new MockMemorySpace.HeapFragment
-        {
-            Address = systemDomainGlobalPtrAddr,
-            Data = systemDomainPtrData,
-            Name = "SystemDomainGlobalPointer"
-        });
 
         var target = targetBuilder
             .AddGlobals(
-                (Constants.Globals.AppDomain, appDomainGlobalPtrAddr),
-                (Constants.Globals.SystemDomain, systemDomainGlobalPtrAddr),
-                (Constants.Globals.DefaultADID, 1ul))
+                (Constants.Globals.AppDomain, appDomainGlobalPtrAddr))
             .AddContract<Contracts.ILoader>("c1")
             .Build();
 

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataTaskTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataTaskTests.cs
@@ -16,21 +16,35 @@ public unsafe class ClrDataTaskTests
     {
         TargetTestHelpers helpers = new(arch);
 
-        ulong globalPtrAddr = 0x1000;
+        ulong appDomainGlobalPtrAddr = 0x1000;
+        ulong systemDomainGlobalPtrAddr = 0x1100;
         ulong expectedAppDomain = 0x2000;
+        ulong expectedSystemDomain = 0x3000;
 
         var targetBuilder = new TestPlaceholderTarget.Builder(arch);
-        byte[] ptrData = new byte[helpers.PointerSize];
-        helpers.WritePointer(ptrData, expectedAppDomain);
+        byte[] appDomainPtrData = new byte[helpers.PointerSize];
+        helpers.WritePointer(appDomainPtrData, expectedAppDomain);
         targetBuilder.MemoryBuilder.AddHeapFragment(new MockMemorySpace.HeapFragment
         {
-            Address = globalPtrAddr,
-            Data = ptrData,
+            Address = appDomainGlobalPtrAddr,
+            Data = appDomainPtrData,
             Name = "AppDomainGlobalPointer"
+        });
+        byte[] systemDomainPtrData = new byte[helpers.PointerSize];
+        helpers.WritePointer(systemDomainPtrData, expectedSystemDomain);
+        targetBuilder.MemoryBuilder.AddHeapFragment(new MockMemorySpace.HeapFragment
+        {
+            Address = systemDomainGlobalPtrAddr,
+            Data = systemDomainPtrData,
+            Name = "SystemDomainGlobalPointer"
         });
 
         var target = targetBuilder
-            .AddGlobals((Constants.Globals.AppDomain, globalPtrAddr))
+            .AddGlobals(
+                (Constants.Globals.AppDomain, appDomainGlobalPtrAddr),
+                (Constants.Globals.SystemDomain, systemDomainGlobalPtrAddr),
+                (Constants.Globals.DefaultADID, 1ul))
+            .AddContract<Contracts.ILoader>("c1")
             .Build();
 
         TargetPointer taskAddress = new TargetPointer(0x5000);

--- a/src/native/managed/cdac/tests/UnitTests/DacDbiImplTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/DacDbiImplTests.cs
@@ -271,15 +271,10 @@ public unsafe class DacDbiImplTests
 
     private static (DacDbiImpl DacDbi, TestPlaceholderTarget Target) CreateDacDbiWithExceptionMT(
         MockTarget.Architecture arch,
-        TargetPointer exceptionMT,
         Mock<IObject> mockObject,
         Mock<IRuntimeTypeSystem> mockRts)
     {
         var builder = new TestPlaceholderTarget.Builder(arch);
-        var allocator = builder.MemoryBuilder.CreateAllocator(0x0030_0000, 0x0030_1000);
-        var globalFragment = allocator.Allocate((ulong)(arch.Is64Bit ? 8 : 4), "ExceptionMethodTable");
-        new TargetTestHelpers(arch).WritePointer(globalFragment.Data, exceptionMT.Value);
-        builder.AddGlobals((Constants.Globals.ExceptionMethodTable, globalFragment.Address));
         builder.AddMockContract(mockObject);
         builder.AddMockContract(mockRts);
         var target = builder.Build();
@@ -323,6 +318,7 @@ public unsafe class DacDbiImplTests
         mockObject.Setup(o => o.GetMethodTableAddress(objectAddr)).Returns(objectMT);
 
         var mockRts = new Mock<IRuntimeTypeSystem>();
+        mockRts.Setup(r => r.GetWellKnownMethodTable(WellKnownMethodTable.Exception)).Returns(exceptionMT);
         if (intermediateMTs.Length == 0 && !isException)
         {
             mockRts.Setup(r => r.GetTypeHandle(objectMT)).Returns(new TypeHandle(objectMT));
@@ -339,7 +335,7 @@ public unsafe class DacDbiImplTests
             mockRts.Setup(r => r.GetParentMethodTable(new TypeHandle(current))).Returns(parent);
         }
 
-        var (dacDbi, _) = CreateDacDbiWithExceptionMT(arch, exceptionMT, mockObject, mockRts);
+        var (dacDbi, _) = CreateDacDbiWithExceptionMT(arch, mockObject, mockRts);
 
         Interop.BOOL result;
         int hr = dacDbi.IsExceptionObject(objectAddr.Value, &result);


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI-generated by GitHub Copilot.

Refactors the `Microsoft.Diagnostics.DataContractReader.Legacy` project to stop reading runtime globals and typeinfo by string key, routing them through typed contract accessors instead. Behavior-preserving: each refactor moves an existing read down one layer (from Legacy into the corresponding `Contracts/*_1` impl) without changing what bytes get read.

### Changes

**1. `ILoader.GetLookupTables` owns the `ModuleLookupMap.TableData` offset**

Adds a `TableDataOffset` field to the existing `ModuleLookupTables` record struct, populated by `Loader_1.GetLookupTables`. `SOSDacImpl.GetModuleData` no longer reads raw typeinfo via `_target.GetTypeInfo(DataType.ModuleLookupMap)` and instead consumes the offset from the struct, going through a small `ReadMapBase` helper that null-guards the table pointer.

This removes the only direct `GetTypeInfo` call in the Legacy project.

**2. `ILoader.GetAppDomain` for the global AppDomain pointer**

Adds a simple `GetAppDomain()` accessor on `ILoader` that reads and dereferences the `AppDomain` global pointer. All Legacy call sites that previously did `ReadGlobalPointer` + `ReadPointer` inline now call this single method.

`RuntimeDomainInfo` struct and `GetDomainInfo()` were removed per review feedback. `DefaultADID` was removed from the data contract -- Legacy call sites use a local `const uint DefaultAppDomainId = 1` instead.

**3. `IRuntimeTypeSystem.GetWellKnownMethodTable` for runtime singleton MTs**

Introduces a `WellKnownMethodTable` enum (`Object`, `String`, `Array`, `Exception`, `Free`, `Canon`) and a `GetWellKnownMethodTable(kind)` accessor on `IRuntimeTypeSystem`. `RuntimeTypeSystem_1` implements it with a safe `TryReadGlobalPointer` + `TryReadPointer` pair so callers (e.g. `GetUsefulGlobals` during early load notifications) get `TargetPointer.Null` when the runtime has not yet initialized a given global, matching the prior lazy-read behavior.

Refactors the Legacy project to use the new accessor:
- `SOSDacImpl`: removes the `_stringMethodTable` / `_objectMethodTable` lazy fields; `GetObjectData` routes through the contract; `GetUsefulGlobals` reads all 5 well-known MTs via the contract.
- `DacDbiImpl`: `IsExceptionObject` (Exception MT) and `EnumerateTypeParameters` (Canon MT).
- `Dbi/Helpers/HeapWalk`: ctor (Free MT).

**4. DAC: Remove SystemDomain special-casing**

`GetAppDomainStoreData` now reports `systemDomain = 0`. The SystemDomain guard in `GetAppDomainData`, `GetAssemblyList`, and `GetAppDomainName` has been removed -- these methods now always treat the address as an AppDomain.

> [!IMPORTANT]
> **Breaking behavior change:** `DacpAppDomainStoreData::systemDomain` will now be `NULL`. SOS consumers that assume `systemDomain` is always valid need to be updated. The companion diagnostics PR handles this: https://github.com/dotnet/diagnostics/pull/5878

### Testing

All cDAC unit tests pass (2493 passed, 16 skipped). Test updates:
- `ClrDataTaskTests.GetCurrentAppDomain` registers the `ILoader` contract.
- `DacDbiImplTests.IsExceptionObject` now mocks `IRuntimeTypeSystem.GetWellKnownMethodTable` instead of setting up the raw `ExceptionMethodTable` global.

### Out of scope

Several additional Legacy raw-global sites (e.g. `DacNotificationFlags`, `StressLog`, `FeatureCOMInterop`, `SOSBreakingChangeVersion`, `TlsIndexBase`/`OffsetOfCurrentThreadInfo`) remain and can be addressed in follow-up PRs where the contract-side surface is justified by callers beyond a single SOS API.