### PR TITLE
Add cDac contract for ResolveFrameHelper

### DIFF
--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -103,6 +103,7 @@ This contract depends on the following descriptors:
 | `SoftwareExceptionFrame` | `ReturnAddress` | Return address saved in Frame |
 | `FramedMethodFrame` | `TransitionBlockPtr` | Pointer to Frame's TransitionBlock |
 | `FramedMethodFrame` | `MethodDescPtr` | Pointer to Frame's method desc |
+| `ResolveHelperFrame` | `TransitionBlockPtr` | Pointer to Frame's TransitionBlock (only present when `FEATURE_RESOLVE_HELPER_DISPATCH` is defined) |
 | `StubDispatchFrame` | `MethodDescPtr` | Pointer to Frame's method desc |
 | `StubDispatchFrame` | `RepresentativeMTPtr` | Pointer to Frame's method table pointer |
 | `StubDispatchFrame` | `RepresentativeSlot` | Frame's method table slot |
@@ -401,6 +402,9 @@ The following Frame types also use this mechanism:
 * CallCountingHelperFrame
 * ExternalMethodFrame
 * DynamicHelperFrame
+* ResolveHelperFrame
+
+`ResolveHelperFrame` additionally restores the argument registers stored in the `TransitionBlock` on all platforms (not just ARM), because the virtual stub dispatch resolve helper relies on the original argument registers to perform dispatch resolution. This mirrors native `ResolveHelperFrame::UpdateRegDisplay`. It is only present when the runtime is built with `FEATURE_RESOLVE_HELPER_DISPATCH`; when the feature is absent its type descriptor and Frame identifier are not emitted, so no Frame is ever classified as a `ResolveHelperFrame`.
 
 #### FuncEvalFrame
 

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -1098,6 +1098,13 @@ CDAC_TYPE_FIELD(FramedMethodFrame, T_POINTER, TransitionBlockPtr, cdac_data<Fram
 CDAC_TYPE_FIELD(FramedMethodFrame, T_POINTER, MethodDescPtr, cdac_data<FramedMethodFrame>::MethodDescPtr)
 CDAC_TYPE_END(FramedMethodFrame)
 
+#ifdef FEATURE_RESOLVE_HELPER_DISPATCH
+CDAC_TYPE_BEGIN(ResolveHelperFrame)
+CDAC_TYPE_SIZE(sizeof(ResolveHelperFrame))
+CDAC_TYPE_FIELD(ResolveHelperFrame, T_POINTER, TransitionBlockPtr, cdac_data<ResolveHelperFrame>::TransitionBlockPtr)
+CDAC_TYPE_END(ResolveHelperFrame)
+#endif // FEATURE_RESOLVE_HELPER_DISPATCH
+
 #ifdef FEATURE_INTERPRETER
 CDAC_TYPE_BEGIN(InterpreterFrame)
 CDAC_TYPE_INDETERMINATE(InterpreterFrame)

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -951,6 +951,14 @@ public:
     }
 
     void UpdateRegDisplay_Impl(const PREGDISPLAY, bool updateFloats = false);
+
+    friend struct cdac_data<ResolveHelperFrame>;
+};
+
+template<>
+struct cdac_data<ResolveHelperFrame>
+{
+    static constexpr size_t TransitionBlockPtr = offsetof(ResolveHelperFrame, m_pTransitionBlock);
 };
 
 #endif // FEATURE_RESOLVE_HELPER_DISPATCH

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/AMD64FrameHandler.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/AMD64FrameHandler.cs
@@ -58,4 +58,10 @@ internal class AMD64FrameHandler(Target target, ContextHolder<AMD64Context> cont
         // that does not support holding any extended state.
         _holder.Context.ContextFlags &= ~(uint)(ContextFlagsValues.CONTEXT_XSTATE & ContextFlagsValues.CONTEXT_AREA_MASK);
     }
+
+    public override void HandleResolveHelperFrame(ResolveHelperFrame frame)
+    {
+        base.HandleResolveHelperFrame(frame);
+        UpdateArgumentRegisters(frame.TransitionBlockPtr);
+    }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/ARM64FrameHandler.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/ARM64FrameHandler.cs
@@ -48,4 +48,10 @@ internal class ARM64FrameHandler(Target target, ContextHolder<ARM64Context> cont
         // that does not support holding any extended state.
         _holder.Context.ContextFlags &= ~(uint)(ContextFlagsValues.CONTEXT_XSTATE & ContextFlagsValues.CONTEXT_AREA_MASK);
     }
+
+    public override void HandleResolveHelperFrame(ResolveHelperFrame frame)
+    {
+        base.HandleResolveHelperFrame(frame);
+        UpdateArgumentRegisters(frame.TransitionBlockPtr);
+    }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/ARMFrameHandler.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/ARMFrameHandler.cs
@@ -46,11 +46,14 @@ internal class ARMFrameHandler(Target target, ContextHolder<ARMContext> contextH
     }
 
     public override void HandleTransitionFrame(FramedMethodFrame framedMethodFrame)
+        => HandleTransitionBlock(framedMethodFrame.TransitionBlockPtr);
+
+    public override void HandleTransitionBlock(TargetPointer transitionBlockPtr)
     {
         // Call the base method to handle common logic
-        base.HandleTransitionFrame(framedMethodFrame);
+        base.HandleTransitionBlock(transitionBlockPtr);
 
-        Data.TransitionBlock transitionBlock = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(framedMethodFrame.TransitionBlockPtr);
+        Data.TransitionBlock transitionBlock = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(transitionBlockPtr);
 
         // On ARM, TransitionFrames update the argument registers
         Data.ArgumentRegisters argumentRegisters = _target.ProcessedData.GetOrAdd<Data.ArgumentRegisters>(transitionBlock.ArgumentRegisters);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/BaseFrameHandler.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/BaseFrameHandler.cs
@@ -42,18 +42,31 @@ internal abstract class BaseFrameHandler(Target target, IPlatformAgnosticContext
     }
 
     public virtual void HandleTransitionFrame(FramedMethodFrame framedMethodFrame)
+        => HandleTransitionBlock(framedMethodFrame.TransitionBlockPtr);
+
+    public virtual void HandleResolveHelperFrame(ResolveHelperFrame frame)
+        => HandleTransitionBlock(frame.TransitionBlockPtr);
+
+    public virtual void HandleTransitionBlock(TargetPointer transitionBlockPtr)
     {
-        Data.TransitionBlock transitionBlock = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(framedMethodFrame.TransitionBlockPtr);
+        Data.TransitionBlock transitionBlock = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(transitionBlockPtr);
         if (_target.GetTypeInfo(DataType.TransitionBlock).Size is not uint transitionBlockSize)
         {
             throw new InvalidOperationException("TransitionBlock size is not set");
         }
 
         _context.InstructionPointer = transitionBlock.ReturnAddress;
-        _context.StackPointer = framedMethodFrame.TransitionBlockPtr + transitionBlockSize;
+        _context.StackPointer = transitionBlockPtr + transitionBlockSize;
 
         Data.CalleeSavedRegisters calleeSavedRegisters = _target.ProcessedData.GetOrAdd<Data.CalleeSavedRegisters>(transitionBlock.CalleeSavedRegisters);
         UpdateFromRegisterDict(calleeSavedRegisters.Registers);
+    }
+
+    protected void UpdateArgumentRegisters(TargetPointer transitionBlockPtr)
+    {
+        Data.TransitionBlock transitionBlock = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(transitionBlockPtr);
+        Data.ArgumentRegisters argumentRegisters = _target.ProcessedData.GetOrAdd<Data.ArgumentRegisters>(transitionBlock.ArgumentRegisters);
+        UpdateFromRegisterDict(argumentRegisters.Registers);
     }
 
     public virtual void HandleFuncEvalFrame(FuncEvalFrame funcEvalFrame)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameHelpers.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameHelpers.cs
@@ -239,12 +239,18 @@ internal sealed class FrameHelpers
             case FrameType.CallCountingHelperFrame:
             case FrameType.ExternalMethodFrame:
             case FrameType.DynamicHelperFrame:
-            case FrameType.ResolveHelperFrame:
-                TargetPointer transitionBlock = frameType == FrameType.ResolveHelperFrame
-                    ? _target.ProcessedData.GetOrAdd<Data.ResolveHelperFrame>(frame.Address).TransitionBlockPtr
-                    : _target.ProcessedData.GetOrAdd<Data.FramedMethodFrame>(frame.Address).TransitionBlockPtr;
-                Data.TransitionBlock tb = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(transitionBlock);
+            {
+                Data.FramedMethodFrame framedMethodFrame = _target.ProcessedData.GetOrAdd<Data.FramedMethodFrame>(frame.Address);
+                Data.TransitionBlock tb = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(framedMethodFrame.TransitionBlockPtr);
                 return tb.ReturnAddress;
+            }
+
+            case FrameType.ResolveHelperFrame:
+            {
+                Data.ResolveHelperFrame resolveHelperFrame = _target.ProcessedData.GetOrAdd<Data.ResolveHelperFrame>(frame.Address);
+                Data.TransitionBlock tb = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(resolveHelperFrame.TransitionBlockPtr);
+                return tb.ReturnAddress;
+            }
 
             // SoftwareExceptionFrame: stored m_ReturnAddress
             case FrameType.SoftwareExceptionFrame:

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameHelpers.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameHelpers.cs
@@ -332,7 +332,6 @@ internal sealed class FrameHelpers
             case FrameType.PInvokeCalliFrame:
             case FrameType.CallCountingHelperFrame:
             case FrameType.ExternalMethodFrame:
-            case FrameType.ResolveHelperFrame:
             case FrameType.InterpreterFrame:
                 return InternalFrameType.M2U;
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameHelpers.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameHelpers.cs
@@ -24,6 +24,7 @@ internal enum FrameType
     ExternalMethodFrame,
     DynamicHelperFrame,
     InterpreterFrame,
+    ResolveHelperFrame,
 
     FuncEvalFrame,
 
@@ -141,7 +142,8 @@ internal sealed class FrameHelpers
     /// </summary>
     public void UpdateContextFromFrame(Data.Frame frame, IPlatformAgnosticContext context)
     {
-        switch (GetFrameType(frame.Identifier))
+        FrameType frameType = GetFrameType(frame.Identifier);
+        switch (frameType)
         {
             case FrameType.InlinedCallFrame:
                 Data.InlinedCallFrame inlinedCallFrame = _target.ProcessedData.GetOrAdd<Data.InlinedCallFrame>(frame.Address);
@@ -164,6 +166,11 @@ internal sealed class FrameHelpers
                 // FrameMethodFrame is the base type for all transition Frames
                 Data.FramedMethodFrame framedMethodFrame = _target.ProcessedData.GetOrAdd<Data.FramedMethodFrame>(frame.Address);
                 GetFrameHandler(context).HandleTransitionFrame(framedMethodFrame);
+                return;
+
+            case FrameType.ResolveHelperFrame:
+                Data.ResolveHelperFrame resolveHelperFrame = _target.ProcessedData.GetOrAdd<Data.ResolveHelperFrame>(frame.Address);
+                GetFrameHandler(context).HandleResolveHelperFrame(resolveHelperFrame);
                 return;
 
             case FrameType.InterpreterFrame:
@@ -232,8 +239,11 @@ internal sealed class FrameHelpers
             case FrameType.CallCountingHelperFrame:
             case FrameType.ExternalMethodFrame:
             case FrameType.DynamicHelperFrame:
-                Data.FramedMethodFrame fmf = _target.ProcessedData.GetOrAdd<Data.FramedMethodFrame>(frame.Address);
-                Data.TransitionBlock tb = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(fmf.TransitionBlockPtr);
+            case FrameType.ResolveHelperFrame:
+                TargetPointer transitionBlock = frameType == FrameType.ResolveHelperFrame
+                    ? _target.ProcessedData.GetOrAdd<Data.ResolveHelperFrame>(frame.Address).TransitionBlockPtr
+                    : _target.ProcessedData.GetOrAdd<Data.FramedMethodFrame>(frame.Address).TransitionBlockPtr;
+                Data.TransitionBlock tb = _target.ProcessedData.GetOrAdd<Data.TransitionBlock>(transitionBlock);
                 return tb.ReturnAddress;
 
             // SoftwareExceptionFrame: stored m_ReturnAddress
@@ -322,6 +332,7 @@ internal sealed class FrameHelpers
             case FrameType.PInvokeCalliFrame:
             case FrameType.CallCountingHelperFrame:
             case FrameType.ExternalMethodFrame:
+            case FrameType.ResolveHelperFrame:
             case FrameType.InterpreterFrame:
                 return InternalFrameType.M2U;
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/IPlatformFrameHandler.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/IPlatformFrameHandler.cs
@@ -14,6 +14,8 @@ internal interface IPlatformFrameHandler
     void HandleInlinedCallFrame(Data.InlinedCallFrame frame);
     void HandleSoftwareExceptionFrame(Data.SoftwareExceptionFrame frame);
     void HandleTransitionFrame(Data.FramedMethodFrame frame);
+    void HandleTransitionBlock(TargetPointer transitionBlockPtr);
+    void HandleResolveHelperFrame(Data.ResolveHelperFrame frame);
     void HandleFuncEvalFrame(Data.FuncEvalFrame frame);
     void HandleResumableFrame(Data.ResumableFrame frame);
     void HandleFaultingExceptionFrame(Data.FaultingExceptionFrame frame);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -77,7 +77,8 @@ internal partial class StackWalk_1 : IStackWalk
             // HijackFrame should be conditioned on the target architecture.
             return ft is FrameType.ResumableFrame
                       or FrameType.RedirectedThreadFrame
-                      or FrameType.HijackFrame;
+                      or FrameType.HijackFrame
+                      or FrameType.ResolveHelperFrame;
         }
 
         /// <summary>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/ResolveHelperFrame.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/ResolveHelperFrame.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+[CdacType(nameof(DataType.ResolveHelperFrame))]
+internal partial class ResolveHelperFrame : IData<ResolveHelperFrame>
+{
+    [Field] public TargetPointer TransitionBlockPtr { get; }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
@@ -166,6 +166,7 @@ public enum DataType
     InlinedCallFrame,
     SoftwareExceptionFrame,
     FramedMethodFrame,
+    ResolveHelperFrame,
     FuncEvalFrame,
     ResumableFrame,
     FaultingExceptionFrame,

--- a/src/native/managed/cdac/tests/TestInfrastructure/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdac/tests/TestInfrastructure/TestPlaceholderTarget.cs
@@ -546,7 +546,7 @@ public class TestPlaceholderTarget : Target
     public override bool TryGetTypeInfo(string typeName, out Target.TypeInfo info)
         => _typeInfoCache.TryGetValue(typeName, out info);
 
-    public override bool TryGetThreadContext(ulong threadId, uint contextFlags, Span<byte> bufferToFill) => throw new NotImplementedException();
+    public override bool TryGetThreadContext(ulong threadId, uint contextFlags, Span<byte> bufferToFill) => false;
 
     public override Target.IDataCache ProcessedData => _dataCache;
     public override ContractRegistry Contracts => _contractRegistry;

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.Frame.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.Frame.cs
@@ -197,22 +197,15 @@ internal sealed class MockRegisterSet : TypedView
     public const string CalleeSavedRegisterName = "rbx";
     public const string ArgumentRegisterName = "rcx";
 
-    private readonly string _fieldName;
-
-    private MockRegisterSet(string fieldName)
-    {
-        _fieldName = fieldName;
-    }
-
     public static Layout<MockRegisterSet> CreateLayout(MockTarget.Architecture architecture, string name)
         => new SequentialLayoutBuilder(name, architecture)
             .AddPointerField(name)
-            .Build<MockRegisterSet>(() => new MockRegisterSet(name));
+            .Build<MockRegisterSet>();
 
     public ulong Register
     {
-        get => ReadPointerField(_fieldName);
-        set => WritePointerField(_fieldName, value);
+        get => ReadPointerField(Layout.Name);
+        set => WritePointerField(Layout.Name, value);
     }
 }
 

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.Frame.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.Frame.cs
@@ -76,6 +76,22 @@ internal sealed class MockFramedMethodFrame : MockFrame
     }
 }
 
+internal sealed class MockResolveHelperFrame : MockFrame
+{
+    private const string TransitionBlockPtrFieldName = "TransitionBlockPtr";
+
+    public static Layout<MockResolveHelperFrame> CreateLayout(Layout<MockFrame> baseLayout)
+        => new SequentialLayoutBuilder("ResolveHelperFrame", baseLayout.Architecture, baseLayout)
+            .AddPointerField(TransitionBlockPtrFieldName)
+            .Build<MockResolveHelperFrame>();
+
+    public ulong TransitionBlockPtr
+    {
+        get => ReadPointerField(TransitionBlockPtrFieldName);
+        set => WritePointerField(TransitionBlockPtrFieldName, value);
+    }
+}
+
 internal sealed class MockFuncEvalFrame : MockFrame
 {
     // Mirrors the cDAC FuncEvalFrame data class which only reads DebuggerEvalPtr.
@@ -142,6 +158,64 @@ internal sealed class MockResumableFrame : MockFrame
     }
 }
 
+internal sealed class MockTransitionBlock : TypedView
+{
+    private const string ReturnAddressFieldName = "ReturnAddress";
+    private const string CalleeSavedRegistersFieldName = "CalleeSavedRegisters";
+    private const string ArgumentRegistersFieldName = "ArgumentRegisters";
+    private const string FirstGCRefMapSlotFieldName = "FirstGCRefMapSlot";
+
+    public static Layout<MockTransitionBlock> CreateLayout(MockTarget.Architecture architecture, Layout<MockRegisterSet> calleeSavedRegistersLayout, Layout<MockRegisterSet> argumentRegistersLayout)
+        => new SequentialLayoutBuilder("TransitionBlock", architecture)
+            .AddPointerField(ReturnAddressFieldName)
+            .AddField(CalleeSavedRegistersFieldName, calleeSavedRegistersLayout.Size)
+            .AddField(ArgumentRegistersFieldName, argumentRegistersLayout.Size)
+            .AddPointerField(FirstGCRefMapSlotFieldName)
+            .Build<MockTransitionBlock>();
+
+    public ulong ReturnAddress
+    {
+        get => ReadPointerField(ReturnAddressFieldName);
+        set => WritePointerField(ReturnAddressFieldName, value);
+    }
+
+    public ulong CalleeSavedRegister
+    {
+        get => ReadPointerField(CalleeSavedRegistersFieldName);
+        set => WritePointerField(CalleeSavedRegistersFieldName, value);
+    }
+
+    public ulong ArgumentRegister
+    {
+        get => ReadPointerField(ArgumentRegistersFieldName);
+        set => WritePointerField(ArgumentRegistersFieldName, value);
+    }
+}
+
+internal sealed class MockRegisterSet : TypedView
+{
+    public const string CalleeSavedRegisterName = "rbx";
+    public const string ArgumentRegisterName = "rcx";
+
+    private readonly string _fieldName;
+
+    private MockRegisterSet(string fieldName)
+    {
+        _fieldName = fieldName;
+    }
+
+    public static Layout<MockRegisterSet> CreateLayout(MockTarget.Architecture architecture, string name)
+        => new SequentialLayoutBuilder(name, architecture)
+            .AddPointerField(name)
+            .Build<MockRegisterSet>(() => new MockRegisterSet(name));
+
+    public ulong Register
+    {
+        get => ReadPointerField(_fieldName);
+        set => WritePointerField(_fieldName, value);
+    }
+}
+
 /// <summary>
 /// Helper for building a Frame chain in the mock target memory. The Frame chain is
 /// terminated with the FRAME_TOP sentinel (~0 sized to the target pointer width).
@@ -168,6 +242,7 @@ internal sealed class MockFrameBuilder
     public const ulong InterpreterFrameIdentifierValue = 0x0001_F009;
     public const ulong HijackFrameIdentifierValue = 0x0001_F00A;
     public const ulong RedirectedThreadFrameIdentifierValue = 0x0001_F00B;
+    public const ulong ResolveHelperFrameIdentifierValue = 0x0001_F00C;
 
     private readonly MockMemorySpace.Builder _builder;
     private readonly MockMemorySpace.BumpAllocator _allocator;
@@ -177,9 +252,13 @@ internal sealed class MockFrameBuilder
     public Layout<MockFrame> FrameLayout { get; }
     public Layout<MockInlinedCallFrame> InlinedCallFrameLayout { get; }
     public Layout<MockFramedMethodFrame> FramedMethodFrameLayout { get; }
+    public Layout<MockResolveHelperFrame> ResolveHelperFrameLayout { get; }
     public Layout<MockFuncEvalFrame> FuncEvalFrameLayout { get; }
     public Layout<MockDebuggerEval> DebuggerEvalLayout { get; }
     public Layout<MockResumableFrame> ResumableFrameLayout { get; }
+    public Layout<MockTransitionBlock> TransitionBlockLayout { get; }
+    public Layout<MockRegisterSet> CalleeSavedRegistersLayout { get; }
+    public Layout<MockRegisterSet> ArgumentRegistersLayout { get; }
 
     public MockFrameBuilder(MockMemorySpace.Builder builder)
         : this(builder, (DefaultAllocationRangeStart, DefaultAllocationRangeEnd))
@@ -196,9 +275,13 @@ internal sealed class MockFrameBuilder
         FrameLayout = MockFrame.CreateLayout(_helpers.Arch);
         InlinedCallFrameLayout = MockInlinedCallFrame.CreateLayout(FrameLayout);
         FramedMethodFrameLayout = MockFramedMethodFrame.CreateLayout(FrameLayout);
+        ResolveHelperFrameLayout = MockResolveHelperFrame.CreateLayout(FrameLayout);
         FuncEvalFrameLayout = MockFuncEvalFrame.CreateLayout(FrameLayout);
         DebuggerEvalLayout = MockDebuggerEval.CreateLayout(_helpers.Arch);
         ResumableFrameLayout = MockResumableFrame.CreateLayout(FrameLayout);
+        CalleeSavedRegistersLayout = MockRegisterSet.CreateLayout(_helpers.Arch, MockRegisterSet.CalleeSavedRegisterName);
+        ArgumentRegistersLayout = MockRegisterSet.CreateLayout(_helpers.Arch, MockRegisterSet.ArgumentRegisterName);
+        TransitionBlockLayout = MockTransitionBlock.CreateLayout(_helpers.Arch, CalleeSavedRegistersLayout, ArgumentRegistersLayout);
     }
 
     public ulong FrameTopTerminator => _terminator;
@@ -237,6 +320,24 @@ internal sealed class MockFrameBuilder
         frame.Next = _terminator;
         frame.MethodDescPtr = methodDescPtr;
         return frame;
+    }
+
+    public MockResolveHelperFrame AddResolveHelperFrame(ulong transitionBlockPtr)
+    {
+        MockResolveHelperFrame frame = ResolveHelperFrameLayout.Create(_allocator.Allocate((ulong)ResolveHelperFrameLayout.Size, "ResolveHelperFrame"));
+        frame.Identifier = ResolveHelperFrameIdentifierValue;
+        frame.Next = _terminator;
+        frame.TransitionBlockPtr = transitionBlockPtr;
+        return frame;
+    }
+
+    public MockTransitionBlock AddTransitionBlock(ulong returnAddress, ulong calleeSavedRegister, ulong argumentRegister)
+    {
+        MockTransitionBlock transitionBlock = TransitionBlockLayout.Create(_allocator.Allocate((ulong)TransitionBlockLayout.Size, "TransitionBlock"));
+        transitionBlock.ReturnAddress = returnAddress;
+        transitionBlock.CalleeSavedRegister = calleeSavedRegister;
+        transitionBlock.ArgumentRegister = argumentRegister;
+        return transitionBlock;
     }
 
     public MockResumableFrame AddRedirectedThreadFrame(ulong targetContextPtr)

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.Frame.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.Frame.cs
@@ -196,6 +196,8 @@ internal sealed class MockRegisterSet : TypedView
 {
     public const string CalleeSavedRegisterName = "rbx";
     public const string ArgumentRegisterName = "rcx";
+    public const string Arm64CalleeSavedRegisterName = "x19";
+    public const string Arm64ArgumentRegisterName = "x0";
 
     public static Layout<MockRegisterSet> CreateLayout(MockTarget.Architecture architecture, string name)
         => new SequentialLayoutBuilder(name, architecture)
@@ -258,7 +260,12 @@ internal sealed class MockFrameBuilder
     {
     }
 
-    public MockFrameBuilder(MockMemorySpace.Builder builder, (ulong Start, ulong End) allocationRange)
+    public MockFrameBuilder(MockMemorySpace.Builder builder, string calleeSavedRegisterName, string argumentRegisterName)
+        : this(builder, (DefaultAllocationRangeStart, DefaultAllocationRangeEnd), calleeSavedRegisterName, argumentRegisterName)
+    {
+    }
+
+    public MockFrameBuilder(MockMemorySpace.Builder builder, (ulong Start, ulong End) allocationRange, string? calleeSavedRegisterName = null, string? argumentRegisterName = null)
     {
         _builder = builder;
         _helpers = builder.TargetTestHelpers;
@@ -272,8 +279,8 @@ internal sealed class MockFrameBuilder
         FuncEvalFrameLayout = MockFuncEvalFrame.CreateLayout(FrameLayout);
         DebuggerEvalLayout = MockDebuggerEval.CreateLayout(_helpers.Arch);
         ResumableFrameLayout = MockResumableFrame.CreateLayout(FrameLayout);
-        CalleeSavedRegistersLayout = MockRegisterSet.CreateLayout(_helpers.Arch, MockRegisterSet.CalleeSavedRegisterName);
-        ArgumentRegistersLayout = MockRegisterSet.CreateLayout(_helpers.Arch, MockRegisterSet.ArgumentRegisterName);
+        CalleeSavedRegistersLayout = MockRegisterSet.CreateLayout(_helpers.Arch, calleeSavedRegisterName ?? MockRegisterSet.CalleeSavedRegisterName);
+        ArgumentRegistersLayout = MockRegisterSet.CreateLayout(_helpers.Arch, argumentRegisterName ?? MockRegisterSet.ArgumentRegisterName);
         TransitionBlockLayout = MockTransitionBlock.CreateLayout(_helpers.Arch, CalleeSavedRegistersLayout, ArgumentRegistersLayout);
     }
 

--- a/src/native/managed/cdac/tests/UnitTests/StackWalkTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/StackWalkTests.cs
@@ -17,8 +17,10 @@ public unsafe class StackWalkTests
     private static TestPlaceholderTarget CreateTarget(
         MockTarget.Architecture arch,
         Action<MockThreadBuilder> configure,
-        Action<MockFrameBuilder>? configureFrames = null)
+        Action<MockFrameBuilder>? configureFrames = null,
+        RuntimeInfoArchitecture? runtimeArchOverride = null)
     {
+        RuntimeInfoArchitecture runtimeArch = runtimeArchOverride ?? GetRuntimeInfoArchitecture(arch);
         TestPlaceholderTarget.Builder targetBuilder = new(arch);
         MockThreadBuilder threadBuilder = new(targetBuilder.MemoryBuilder);
         configure(threadBuilder);
@@ -26,13 +28,15 @@ public unsafe class StackWalkTests
         MockFrameBuilder? frameBuilder = null;
         if (configureFrames is not null)
         {
-            frameBuilder = new MockFrameBuilder(targetBuilder.MemoryBuilder);
+            frameBuilder = runtimeArch == RuntimeInfoArchitecture.Arm64
+                ? new MockFrameBuilder(targetBuilder.MemoryBuilder, MockRegisterSet.Arm64CalleeSavedRegisterName, MockRegisterSet.Arm64ArgumentRegisterName)
+                : new MockFrameBuilder(targetBuilder.MemoryBuilder);
             configureFrames(frameBuilder);
         }
 
         targetBuilder
             .AddTypes(CreateThreadTypes(threadBuilder))
-            .AddGlobalStrings((Constants.Globals.Architecture, GetRuntimeInfoArchitecture(arch).ToString().ToLowerInvariant()))
+            .AddGlobalStrings((Constants.Globals.Architecture, runtimeArch.ToString().ToLowerInvariant()))
             .AddGlobals(
                 (nameof(Constants.Globals.ThreadStore), threadBuilder.ThreadStoreGlobalAddress),
                 (nameof(Constants.Globals.FinalizerThread), threadBuilder.FinalizerThreadGlobalAddress),
@@ -202,8 +206,10 @@ public unsafe class StackWalkTests
         Assert.Equal(InternalFrameType.None, frames[9].InternalFrameType);
     }
 
-    [Fact]
-    public void GetContext_ResolveHelperFrame_UpdatesAmd64ContextFromTransitionBlock()
+    [Theory]
+    [InlineData(RuntimeInfoArchitecture.X64, MockRegisterSet.CalleeSavedRegisterName, MockRegisterSet.ArgumentRegisterName)]
+    [InlineData(RuntimeInfoArchitecture.Arm64, MockRegisterSet.Arm64CalleeSavedRegisterName, MockRegisterSet.Arm64ArgumentRegisterName)]
+    public void GetContext_ResolveHelperFrame_UpdatesContextFromTransitionBlock(RuntimeInfoArchitecture runtimeArch, string calleeSavedRegisterName, string argumentRegisterName)
     {
         MockTarget.Architecture arch = new() { IsLittleEndian = true, Is64Bit = true };
         MockThread? thread = null;
@@ -221,7 +227,8 @@ public unsafe class StackWalkTests
                 MockResolveHelperFrame resolveHelperFrame = frameBuilder.AddResolveHelperFrame(transitionBlock.Address);
                 expectedStackPointer = transitionBlock.Address + (ulong)frameBuilder.TransitionBlockLayout.Size;
                 thread!.Frame = frameBuilder.LinkChain(resolveHelperFrame.Address);
-            });
+            },
+            runtimeArchOverride: runtimeArch);
 
         ThreadData threadData = target.Contracts.Thread.GetThreadData(new TargetPointer(thread!.Address));
         byte[] contextBytes = target.Contracts.StackWalk.GetContext(threadData, ThreadContextSource.None, 0);
@@ -230,9 +237,9 @@ public unsafe class StackWalkTests
 
         Assert.Equal(returnAddress, context.InstructionPointer.Value);
         Assert.Equal(expectedStackPointer, context.StackPointer.Value);
-        Assert.True(context.TryReadRegister(MockRegisterSet.CalleeSavedRegisterName, out TargetNUInt actualCalleeSavedRegister));
+        Assert.True(context.TryReadRegister(calleeSavedRegisterName, out TargetNUInt actualCalleeSavedRegister));
         Assert.Equal(calleeSavedRegister, actualCalleeSavedRegister.Value);
-        Assert.True(context.TryReadRegister(MockRegisterSet.ArgumentRegisterName, out TargetNUInt actualArgumentRegister));
+        Assert.True(context.TryReadRegister(argumentRegisterName, out TargetNUInt actualArgumentRegister));
         Assert.Equal(argumentRegister, actualArgumentRegister.Value);
     }
 

--- a/src/native/managed/cdac/tests/UnitTests/StackWalkTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/StackWalkTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers;
 using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
 using Moq;
 using Xunit;
@@ -31,6 +32,7 @@ public unsafe class StackWalkTests
 
         targetBuilder
             .AddTypes(CreateThreadTypes(threadBuilder))
+            .AddGlobalStrings((Constants.Globals.Architecture, GetRuntimeInfoArchitecture(arch).ToString().ToLowerInvariant()))
             .AddGlobals(
                 (nameof(Constants.Globals.ThreadStore), threadBuilder.ThreadStoreGlobalAddress),
                 (nameof(Constants.Globals.FinalizerThread), threadBuilder.FinalizerThreadGlobalAddress),
@@ -56,15 +58,18 @@ public unsafe class StackWalkTests
 
         return targetBuilder
             .AddContract<IThread>(version: "c1")
+            .AddContract<IRuntimeInfo>(version: "c1")
             .AddContract<IStackWalk>(version: "c1")
             // StackWalk_1's constructor reads these contracts via target.Contracts.{ExecutionManager,GCInfo}
-            // when constructing its GcScanner. Our tests only exercise GetFrames /
-            // IsExceptionHandlingHelperInlinedCallFrame / GetDebuggerEvalData, none of which
-            // invoke ExecutionManager or GCInfo, so empty mocks satisfy construction.
+            // when constructing its GcScanner. These tests don't enumerate GC references,
+            // so empty mocks satisfy construction.
             .AddMockContract(Mock.Of<IExecutionManager>())
             .AddMockContract(Mock.Of<IGCInfo>())
             .Build();
     }
+
+    private static RuntimeInfoArchitecture GetRuntimeInfoArchitecture(MockTarget.Architecture arch)
+        => arch.Is64Bit ? RuntimeInfoArchitecture.X64 : RuntimeInfoArchitecture.X86;
 
     private static Dictionary<DataType, Target.TypeInfo> CreateThreadTypes(MockThreadBuilder threadBuilder)
         => new()
@@ -194,7 +199,7 @@ public unsafe class StackWalkTests
         Assert.Equal(InternalFrameType.None, frames[8].InternalFrameType);
 
         Assert.Equal(resolveHelperAddr, frames[9].FrameAddress.Value);
-        Assert.Equal(InternalFrameType.M2U, frames[9].InternalFrameType);
+        Assert.Equal(InternalFrameType.None, frames[9].InternalFrameType);
     }
 
     [Fact]
@@ -219,7 +224,7 @@ public unsafe class StackWalkTests
             });
 
         ThreadData threadData = target.Contracts.Thread.GetThreadData(new TargetPointer(thread!.Address));
-        byte[] contextBytes = target.Contracts.StackWalk.GetContext(threadData, ThreadContextSource.Default, 0);
+        byte[] contextBytes = target.Contracts.StackWalk.GetContext(threadData, ThreadContextSource.None, 0);
         IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(target);
         context.FillFromBuffer(contextBytes);
 

--- a/src/native/managed/cdac/tests/UnitTests/StackWalkTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/StackWalkTests.cs
@@ -50,7 +50,8 @@ public unsafe class StackWalkTests
                     ("SoftwareExceptionFrameIdentifier", MockFrameBuilder.SoftwareExceptionFrameIdentifierValue),
                     ("DebuggerU2MCatchHandlerFrameIdentifier", MockFrameBuilder.DebuggerU2MCatchHandlerFrameIdentifierValue),
                     ("InterpreterFrameIdentifier", MockFrameBuilder.InterpreterFrameIdentifierValue),
-                    ("HijackFrameIdentifier", MockFrameBuilder.HijackFrameIdentifierValue));
+                    ("HijackFrameIdentifier", MockFrameBuilder.HijackFrameIdentifierValue),
+                    ("ResolveHelperFrameIdentifier", MockFrameBuilder.ResolveHelperFrameIdentifierValue));
         }
 
         return targetBuilder
@@ -82,8 +83,12 @@ public unsafe class StackWalkTests
             [DataType.Frame] = TargetTestHelpers.CreateTypeInfo(frameBuilder.FrameLayout),
             [DataType.InlinedCallFrame] = TargetTestHelpers.CreateTypeInfo(frameBuilder.InlinedCallFrameLayout),
             [DataType.FramedMethodFrame] = TargetTestHelpers.CreateTypeInfo(frameBuilder.FramedMethodFrameLayout),
+            [DataType.ResolveHelperFrame] = TargetTestHelpers.CreateTypeInfo(frameBuilder.ResolveHelperFrameLayout),
             [DataType.FuncEvalFrame] = TargetTestHelpers.CreateTypeInfo(frameBuilder.FuncEvalFrameLayout),
             [DataType.DebuggerEval] = TargetTestHelpers.CreateTypeInfo(frameBuilder.DebuggerEvalLayout),
+            [DataType.TransitionBlock] = TargetTestHelpers.CreateTypeInfo(frameBuilder.TransitionBlockLayout),
+            [DataType.CalleeSavedRegisters] = TargetTestHelpers.CreateTypeInfo(frameBuilder.CalleeSavedRegistersLayout),
+            [DataType.ArgumentRegisters] = TargetTestHelpers.CreateTypeInfo(frameBuilder.ArgumentRegistersLayout),
         };
 
     [Theory]
@@ -126,6 +131,7 @@ public unsafe class StackWalkTests
         ulong u2mAddr = 0;
         ulong interpAddr = 0;
         ulong hijackAddr = 0;
+        ulong resolveHelperAddr = 0;
 
         TestPlaceholderTarget target = CreateTarget(
             arch,
@@ -145,15 +151,18 @@ public unsafe class StackWalkTests
                 u2mAddr = frameBuilder.AddFrame(MockFrameBuilder.DebuggerU2MCatchHandlerFrameIdentifierValue, "DebuggerU2MCatchHandlerFrame").Address;
                 interpAddr = frameBuilder.AddFrame(MockFrameBuilder.InterpreterFrameIdentifierValue, "InterpreterFrame").Address;
                 hijackAddr = frameBuilder.AddFrame(MockFrameBuilder.HijackFrameIdentifierValue, "HijackFrame").Address;
+                MockTransitionBlock transitionBlock = frameBuilder.AddTransitionBlock(0, 0, 0);
+                resolveHelperAddr = frameBuilder.AddResolveHelperFrame(transitionBlock.Address).Address;
 
                 thread!.Frame = frameBuilder.LinkChain(
                     framedMethodAddr, prestubAddr, funcEvalAddr, debuggerExitAddr,
-                    classInitAddr, softwareExAddr, u2mAddr, interpAddr, hijackAddr);
+                    classInitAddr, softwareExAddr, u2mAddr, interpAddr, hijackAddr,
+                    resolveHelperAddr);
             });
 
         IStackWalk contract = target.Contracts.StackWalk;
         StackFrameData[] frames = contract.GetFrames(new TargetPointer(thread!.Address)).ToArray();
-        Assert.Equal(9, frames.Length);
+        Assert.Equal(10, frames.Length);
 
         Assert.Equal(framedMethodAddr, frames[0].FrameAddress.Value);
         Assert.Equal(InternalFrameType.M2U, frames[0].InternalFrameType);
@@ -183,6 +192,43 @@ public unsafe class StackWalkTests
 
         Assert.Equal(hijackAddr, frames[8].FrameAddress.Value);
         Assert.Equal(InternalFrameType.None, frames[8].InternalFrameType);
+
+        Assert.Equal(resolveHelperAddr, frames[9].FrameAddress.Value);
+        Assert.Equal(InternalFrameType.M2U, frames[9].InternalFrameType);
+    }
+
+    [Fact]
+    public void GetContext_ResolveHelperFrame_UpdatesAmd64ContextFromTransitionBlock()
+    {
+        MockTarget.Architecture arch = new() { IsLittleEndian = true, Is64Bit = true };
+        MockThread? thread = null;
+        const ulong returnAddress = 0x1234_5678_9ABC_DEF0;
+        const ulong calleeSavedRegister = 0x1111_2222_3333_4444;
+        const ulong argumentRegister = 0xAAAA_BBBB_CCCC_DDDD;
+        ulong expectedStackPointer = 0;
+
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            threadBuilder => thread = threadBuilder.AddThread(1, 1234),
+            frameBuilder =>
+            {
+                MockTransitionBlock transitionBlock = frameBuilder.AddTransitionBlock(returnAddress, calleeSavedRegister, argumentRegister);
+                MockResolveHelperFrame resolveHelperFrame = frameBuilder.AddResolveHelperFrame(transitionBlock.Address);
+                expectedStackPointer = transitionBlock.Address + (ulong)frameBuilder.TransitionBlockLayout.Size;
+                thread!.Frame = frameBuilder.LinkChain(resolveHelperFrame.Address);
+            });
+
+        ThreadData threadData = target.Contracts.Thread.GetThreadData(new TargetPointer(thread!.Address));
+        byte[] contextBytes = target.Contracts.StackWalk.GetContext(threadData, ThreadContextSource.Default, 0);
+        IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(target);
+        context.FillFromBuffer(contextBytes);
+
+        Assert.Equal(returnAddress, context.InstructionPointer.Value);
+        Assert.Equal(expectedStackPointer, context.StackPointer.Value);
+        Assert.True(context.TryReadRegister(MockRegisterSet.CalleeSavedRegisterName, out TargetNUInt actualCalleeSavedRegister));
+        Assert.Equal(calleeSavedRegister, actualCalleeSavedRegister.Value);
+        Assert.True(context.TryReadRegister(MockRegisterSet.ArgumentRegisterName, out TargetNUInt actualArgumentRegister));
+        Assert.Equal(argumentRegister, actualArgumentRegister.Value);
     }
 
     [Theory]


### PR DESCRIPTION
cDac does not support ResolveFrameHelper, leading to broken stacks/missed roots when it's on the callstack.