### PR TITLE
JIT: clone "i != arr.Length" loops to eliminate bounds checks

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -6848,9 +6848,20 @@ genTreeOps NaturalLoopIterInfo::TestOper()
 bool NaturalLoopIterInfo::IsIncreasingLoop()
 {
     // Increasing loop is the one that has "+=" increment operation and "< or <=" limit check.
-    bool isLessThanLimitCheck = GenTree::StaticOperIs(TestOper(), GT_LT, GT_LE);
-    return (isLessThanLimitCheck &&
-            (((IterOper() == GT_ADD) && (IterConst() > 0)) || ((IterOper() == GT_SUB) && (IterConst() < 0))));
+    // We also recognize "!=" against a limit when the IV step is exactly +1 (or -1 with GT_SUB):
+    // such loops visit indices [init, limit) provided that "init <= limit" holds on entry.
+    // Stride must be ±1 to avoid parity/overflow issues where the IV could skip past the limit
+    // (e.g. "for (i = 0; i != 5; i += 2)" never terminates and wraps around).
+    const genTreeOps testOp = TestOper();
+    if (GenTree::StaticOperIs(testOp, GT_LT, GT_LE))
+    {
+        return (((IterOper() == GT_ADD) && (IterConst() > 0)) || ((IterOper() == GT_SUB) && (IterConst() < 0)));
+    }
+    if (testOp == GT_NE)
+    {
+        return ((IterOper() == GT_ADD) && (IterConst() == 1)) || ((IterOper() == GT_SUB) && (IterConst() == -1));
+    }
+    return false;
 }
 
 //------------------------------------------------------------------------
@@ -6864,9 +6875,18 @@ bool NaturalLoopIterInfo::IsDecreasingLoop()
 {
     // Decreasing loop is the one that has "-=" decrement operation and "> or >=" limit check. If the operation is
     // "+=", make sure the constant is negative to give an effect of decrementing the iterator.
-    bool isGreaterThanLimitCheck = GenTree::StaticOperIs(TestOper(), GT_GT, GT_GE);
-    return (isGreaterThanLimitCheck &&
-            (((IterOper() == GT_ADD) && (IterConst() < 0)) || ((IterOper() == GT_SUB) && (IterConst() > 0))));
+    // As with IsIncreasingLoop, we also recognize "!=" against a limit when the IV step is exactly -1
+    // (or +1 with GT_SUB); the stride must be exactly +/-1 to avoid parity/overflow issues.
+    const genTreeOps testOp = TestOper();
+    if (GenTree::StaticOperIs(testOp, GT_GT, GT_GE))
+    {
+        return (((IterOper() == GT_ADD) && (IterConst() < 0)) || ((IterOper() == GT_SUB) && (IterConst() > 0)));
+    }
+    if (testOp == GT_NE)
+    {
+        return ((IterOper() == GT_ADD) && (IterConst() == -1)) || ((IterOper() == GT_SUB) && (IterConst() == 1));
+    }
+    return false;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1189,10 +1189,11 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
     }
 
     NaturalLoopIterInfo* iterInfo = context->GetLoopIterInfo(loop->GetIndex());
-    // Note we see cases where the test oper is NE (array.Len) which we could handle
-    // with some extra care.
+    // Loop tests we can reason about for cloning: ordered relops (LT/LE/GT/GE) and
+    // NE limits (treated as LT/GT-equivalent when stride is exactly +/-1; see
+    // NaturalLoopIterInfo::IsIncreasingLoop/IsDecreasingLoop).
     //
-    if (!GenTree::StaticOperIs(iterInfo->TestOper(), GT_LT, GT_LE, GT_GT, GT_GE))
+    if (!GenTree::StaticOperIs(iterInfo->TestOper(), GT_LT, GT_LE, GT_GT, GT_GE, GT_NE))
     {
         // We can't reason about how this loop iterates
         return false;
@@ -1312,9 +1313,17 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
         }
 
         // TestOper() returns the stays-in-loop relop in IV-on-lhs form, already
-        // adjusted for IsReversed and ExitedOnTrue.
-        LC_Condition zeroTrip(iterInfo->TestOper(), LC_Expr(initIdent), LC_Expr(limitIdent),
-                              iterInfo->TestTree->IsUnsigned());
+        // adjusted for IsReversed and ExitedOnTrue. For GT_NE we substitute an
+        // ordered relop (LT for increasing, GT for decreasing) so that the
+        // runtime guard strictly orders init and limit. Using the raw "init !=
+        // limit" form would let a misordered init pass while the fast clone
+        // (with bounds checks removed) wraps the IV through the type.
+        genTreeOps zeroTripOp = iterInfo->TestOper();
+        if (zeroTripOp == GT_NE)
+        {
+            zeroTripOp = iterInfo->IsIncreasingLoop() ? GT_LT : GT_GT;
+        }
+        LC_Condition zeroTrip(zeroTripOp, LC_Expr(initIdent), LC_Expr(limitIdent), iterInfo->TestTree->IsUnsigned());
         context->EnsureConditions(loop->GetIndex())->Push(zeroTrip);
         JITDUMP("Added zero-trip guard cloning condition\n");
     }
@@ -1427,19 +1436,29 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
     // GT_LT loop test: (start < end) ==> (end <= arrLen)
     // GT_LE loop test: (start <= end) ==> (end < arrLen)
     //
+    // GT_NE loop test (stride = +/-1; see IsIncreasing/DecreasingLoop):
+    //   For increasing: visited indices are [init..end-1] => guard end <= arrLen (same as LT).
+    //     `ident` is the loop's end value, so the per-access condition is (end <= arrLen).
+    //   For decreasing: visited indices are [end+1..init] => guard init < arrLen (same as GT).
+    //     `ident` is the loop's init value (set in the init-conditions section above and not
+    //     overwritten by the GT_NE limit branch), so the per-access condition is
+    //     (init < arrLen). This is why the switch below maps decreasing GT_NE to GT_LT.
+    //
     // Decreasing loops
     // Always check if iter var is less than array length.
     genTreeOps opLimitCondition;
     switch (iterInfo->TestOper())
     {
         case GT_LT:
-
             opLimitCondition = GT_LE;
             break;
         case GT_LE:
         case GT_GE:
         case GT_GT:
             opLimitCondition = GT_LT;
+            break;
+        case GT_NE:
+            opLimitCondition = isIncreasingLoop ? GT_LE : GT_LT;
             break;
         default:
             unreached();
@@ -1494,6 +1513,54 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
                 assert(!"Unknown opt type");
                 return false;
         }
+    }
+
+    // For GT_NE loops (with stride exactly +/-1; see IsIncreasing/DecreasingLoop),
+    // the cloned fast path preserves the "i != limit" exit test. If the IV starts
+    // past the limit, the loop would wrap around the type and access arbitrary
+    // memory because the fast path has its bounds checks removed. Guard the fast
+    // path with an ordered "init RELOP limit" condition (init <= limit for
+    // increasing, init >= limit for decreasing) so that a misordered init falls
+    // back to the slow path with bounds checks.
+    if (iterInfo->TestOper() == GT_NE)
+    {
+        LC_Ident neInitIdent;
+        if (iterInfo->HasConstInit)
+        {
+            assert(iterInfo->ConstInitValue >= 0);
+            neInitIdent = LC_Ident::CreateConst(static_cast<unsigned>(iterInfo->ConstInitValue));
+        }
+        else
+        {
+            const unsigned initLcl = iterInfo->IterVar;
+            assert(genActualTypeIsInt(lvaGetDesc(initLcl)));
+            neInitIdent = LC_Ident::CreateVar(initLcl, iterInfo->Iterator()->TypeGet());
+        }
+
+        LC_Ident neLimitIdent;
+        if (iterInfo->HasConstLimit)
+        {
+            const int limit = iterInfo->ConstLimit();
+            assert(limit >= 0);
+            neLimitIdent = LC_Ident::CreateConst(static_cast<unsigned>(limit));
+        }
+        else if (iterInfo->HasInvariantLocalLimit)
+        {
+            const unsigned limitLcl = iterInfo->VarLimit();
+            assert(genActualTypeIsInt(lvaGetDesc(limitLcl)));
+            neLimitIdent = LC_Ident::CreateVar(limitLcl, iterInfo->Limit()->TypeGet());
+        }
+        else
+        {
+            assert(iterInfo->HasArrayLengthLimit);
+            assert(limitArrIndex != nullptr);
+            neLimitIdent = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen));
+        }
+
+        const genTreeOps cmpOp = isIncreasingLoop ? GT_LE : GT_GE;
+        LC_Condition     initLimitCond(cmpOp, LC_Expr(neInitIdent), LC_Expr(neLimitIdent));
+        context->EnsureConditions(loop->GetIndex())->Push(initLimitCond);
+        JITDUMP("Added NE init-vs-limit cloning condition\n");
     }
 
     JITDUMP("Conditions: ");

--- a/src/tests/JIT/Regression/JitBlue/Runtime_84697/Runtime_84697.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_84697/Runtime_84697.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Runtime_84697;
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_84697
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        int ok = 0;
+
+        byte[] bytes = new byte[10];
+        for (int i = 0; i < bytes.Length; i++) bytes[i] = (byte)i;
+
+        if (SumByteArrayNE(bytes) == 45) ok++;
+        if (SumByteArrayLT(bytes) == 45) ok++;
+        if (SumByteArrayNE(Array.Empty<byte>()) == 0) ok++;
+        if (SumStringNE("hello") == 'h' + 'e' + 'l' + 'l' + 'o') ok++;
+        if (SumSpanNE(new int[] { 1, 2, 3, 4, 5 }) == 15) ok++;
+        if (SumNEDecreasing(bytes) == 45) ok++;
+        if (SumNEStride2(bytes) == 0 + 2 + 4 + 6 + 8) ok++;
+        if (SumNEFromOffset(bytes, 3) == 3 + 4 + 5 + 6 + 7 + 8 + 9) ok++;
+        if (SumNEFromOffset(bytes, bytes.Length) == 0) ok++;
+
+        // Soundness: when init > length and stride is +1, the NE loop would wrap
+        // around without bounds checks if loop cloning got the entry guard wrong.
+        // The slow path must run and throw IndexOutOfRangeException.
+        bool threw = false;
+        try
+        {
+            SumNEFromOffset(bytes, 100);
+        }
+        catch (IndexOutOfRangeException)
+        {
+            threw = true;
+        }
+        if (threw) ok++;
+
+        // Soundness: a decreasing "i != someLen" loop indexing a different array.
+        // The loop visits init, init-1, ... and could OOB-read accessArr if a
+        // fast clone bypasses the access array's bounds checks. Whether or not
+        // the loop is cloned, the expected behavior is throwing IndexOutOfRange.
+        bool threw2 = false;
+        try
+        {
+            SumDecreasingNETwoArrays(new byte[1], new byte[5], 1000);
+        }
+        catch (IndexOutOfRangeException)
+        {
+            threw2 = true;
+        }
+        if (threw2) ok++;
+
+        return ok == 11 ? 100 : 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int SumByteArrayNE(byte[] src)
+    {
+        int sum = 0;
+        for (int i = 0; i != src.Length; i++)
+            sum += src[i];
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int SumByteArrayLT(byte[] src)
+    {
+        int sum = 0;
+        for (int i = 0; i < src.Length; i++)
+            sum += src[i];
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int SumStringNE(string s)
+    {
+        int sum = 0;
+        for (int i = 0; i != s.Length; i++)
+            sum += s[i];
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int SumSpanNE(ReadOnlySpan<int> sp)
+    {
+        int sum = 0;
+        for (int i = 0; i != sp.Length; i++)
+            sum += sp[i];
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int SumNEDecreasing(byte[] src)
+    {
+        int sum = 0;
+        for (int i = src.Length - 1; i != -1; i--)
+            sum += src[i];
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int SumNEStride2(byte[] src)
+    {
+        int sum = 0;
+        for (int i = 0; i != src.Length; i += 2)
+            sum += src[i];
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int SumNEFromOffset(byte[] src, int start)
+    {
+        int sum = 0;
+        for (int i = start; i != src.Length; i++)
+            sum += src[i];
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int SumDecreasingNETwoArrays(byte[] limitArr, byte[] accessArr, int startIdx)
+    {
+        int sum = 0;
+        for (int i = startIdx; i != limitArr.Length; i--)
+            sum += accessArr[i];
+        return sum;
+    }
+}

--- a/src/tests/JIT/Regression/Regression_o_3.csproj
+++ b/src/tests/JIT/Regression/Regression_o_3.csproj
@@ -90,6 +90,7 @@
     <Compile Include="JitBlue\Runtime_83387\Runtime_83387.cs" />
     <Compile Include="JitBlue\Runtime_83941\Runtime_83941.cs" />
     <Compile Include="JitBlue\Runtime_84693\Runtime_84693.cs" />
+    <Compile Include="JitBlue\Runtime_84697\Runtime_84697.cs" />
     <Compile Include="JitBlue\Runtime_85225\Runtime_85225.cs" />
     <Compile Include="JitBlue\Runtime_85226\Runtime_85226.cs" />
     <Compile Include="JitBlue\Runtime_85382\Runtime_85382.cs" />


### PR DESCRIPTION
Loops with `i != end` previously kept their per-iteration bounds checks while the equivalent `<` / `>` forms did not, because loop cloning bailed on GT_NE.

Recognize GT_NE with stride exactly +/-1 as an increasing or decreasing loop in NaturalLoopIterInfo, extend optDeriveLoopCloningConditions to emit the right per-access and zero-trip conditions for GT_NE, and add a new "init RELOP end" cloning condition so that a misordered init (which for GT_NE would wrap the IV through the type rather than exit at the first test) falls back to the slow path. Builds on #129176 which fixes the latent decreasing-loop soundness gap.

A follow-on change to assertion prop / range check will catch the remaining NE-loop BCE cases that fall outside loop cloning (e.g. loops the cloning heuristic rejects).

Contributes to #84697.