### PR TITLE
JIT: stop walking parent try regions across funclet boundaries

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -7816,6 +7816,17 @@ FlowGraphTryRegions* FlowGraphTryRegions::Build(Compiler* comp, FlowGraphDfsTree
 
                 if (region != nullptr)
                 {
+                    // If this block lives in a different handler region than the
+                    // parent try's begin block, the block is inside a funclet
+                    // that is nested inside the parent try's IL range but is
+                    // not part of the parent try's code body. Don't add it to
+                    // the parent region.
+                    //
+                    if (!includeHandlerBlocks &&
+                        !BasicBlock::sameHndRegion(block, region->m_ehDsc->ebdTryBeg))
+                    {
+                        break;
+                    }
                     tryIndex = comp->ehGetIndex(region->m_ehDsc);
                 }
             }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -7822,8 +7822,7 @@ FlowGraphTryRegions* FlowGraphTryRegions::Build(Compiler* comp, FlowGraphDfsTree
                     // not part of the parent try's code body. Don't add it to
                     // the parent region.
                     //
-                    if (!includeHandlerBlocks &&
-                        !BasicBlock::sameHndRegion(block, region->m_ehDsc->ebdTryBeg))
+                    if (!includeHandlerBlocks && !BasicBlock::sameHndRegion(block, region->m_ehDsc->ebdTryBeg))
                     {
                         break;
                     }


### PR DESCRIPTION
In FlowGraphTryRegions::Build, when walking up the parent try-region chain to add a block to all ancestors, stop if the block sits in a different handler region than the parent's try-begin block. Such a block lives inside a funclet that is nested in the parent try's IL range but is not part of the parent try's code body.

This matches the sameHndRegion check used for the initial region add.

Without this, fgWasmControlFlow can place a funclet's body block inside an outer try's RPO segment, producing a layout backedge that is not a loop back-edge and asserting in fgwasm.cpp:1355.

Fixes #129262.