### PR TITLE
Fix Array::GetDirectPointerToNonObjectElements DAC regression

### DIFF
--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -607,7 +607,7 @@ class Array : public ArrayBase
     {
         WRAPPER_NO_CONTRACT;
         SUPPORTS_DAC;
-        return PTR_KIND(m_Array);
+        return PTR_KIND(GetDataPtr());
     }
 };
 

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -607,7 +607,7 @@ class Array : public ArrayBase
     {
         WRAPPER_NO_CONTRACT;
         SUPPORTS_DAC;
-        return PTR_KIND(GetDataPtr());
+        return dac_cast<PTR_KIND>(PTR_HOST_MEMBER_TADDR(Array, this, m_Array));
     }
 };
 


### PR DESCRIPTION
In DAC mode, m_Array yields a host address, but PTR_KIND requires a target address. GetDataPtr() computes the correct target address via dac_cast<PTR_BYTE>(this) + offset.

This was broken by PR #128961 which changed from GetDataPtr() to m_Array, breaking debugger inspection of exception stack traces, ConditionalWeakTable lookups, and stack frame helper arrays in DAC mode.