### PR TITLE
Fix W3CPropagator baggage parsing after malformed entries

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -104,7 +104,7 @@ namespace System.Diagnostics
                 if (keyValueSeparator <= 0 || keyValueSeparator >= currentEntry.Length - 1)
                 {
                     baggageSpan = nextBaggageSpan;
-                    continue; // invalid format
+                    continue; // skip malformed entry and continue parsing
                 }
 
                 ReadOnlySpan<char> keySpan = currentEntry.Slice(0, keyValueSeparator);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -98,11 +98,13 @@ namespace System.Diagnostics
             {
                 int entrySeparator = baggageSpan.IndexOf(Comma);
                 ReadOnlySpan<char> currentEntry = entrySeparator >= 0 ? baggageSpan.Slice(0, entrySeparator) : baggageSpan;
+                ReadOnlySpan<char> nextBaggageSpan = entrySeparator >= 0 ? baggageSpan.Slice(entrySeparator + 1) : ReadOnlySpan<char>.Empty;
 
                 int keyValueSeparator = currentEntry.IndexOf(Equal);
                 if (keyValueSeparator <= 0 || keyValueSeparator >= currentEntry.Length - 1)
                 {
-                    break; // invalid format
+                    baggageSpan = nextBaggageSpan;
+                    continue; // invalid format
                 }
 
                 ReadOnlySpan<char> keySpan = currentEntry.Slice(0, keyValueSeparator);
@@ -114,7 +116,7 @@ namespace System.Diagnostics
                     baggageList.Add(new KeyValuePair<string, string?>(key, value));
                 }
 
-                baggageSpan = entrySeparator >= 0 ? baggageSpan.Slice(entrySeparator + 1) : ReadOnlySpan<char>.Empty;
+                baggageSpan = nextBaggageSpan;
             } while (baggageSpan.Length > 0);
 
             // reverse order for asp.net compatibility.

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -249,6 +249,24 @@ namespace System.Diagnostics.Tests
             Assert.Null(baggage);
         }
 
+        [Theory]
+        [InlineData("valid1=value1,bad,valid2=value2")]
+        [InlineData("valid1=value1,=bad,valid2=value2")]
+        [InlineData("valid1=value1,bad=,valid2=value2")]
+        [InlineData("bad,valid1=value1,valid2=value2")]
+        public void TestMalformedBaggageEntriesAreSkipped(string input)
+        {
+            IEnumerable<KeyValuePair<string, string?>>? baggage = DecodeBaggage(input);
+
+            Assert.Equal(
+                new[]
+                {
+                    new KeyValuePair<string, string?>("valid2", "value2"),
+                    new KeyValuePair<string, string?>("valid1", "value1"),
+                },
+                baggage);
+        }
+
         [Fact]
         public void TestBaggagePropagationLimits()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/129286
Whole description in the linked issues.