### PR TITLE
cDAC: dereference OBJECTHANDLE in collectible thread-statics

### DIFF
--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -302,7 +302,9 @@ TargetPointer IThread.GetThreadLocalStaticBase(TargetPointer threadPointer, Targ
             if (collectibleCount > indexOffset)
             {
                 TargetPointer collectibleArray = target.ReadPointer(threadLocalDataPtr + /* ThreadLocalData::CollectibleTlsArrayData offset */);
-                threadLocalStaticBase = target.ReadPointer(collectibleArray + (ulong)(indexOffset * target.PointerSize));
+                // The collectible TLS array slot holds an OBJECTHANDLE; dereference the handle to the object
+                TargetPointer handleSlotAddress = collectibleArray + (ulong)(indexOffset * target.PointerSize);
+                threadLocalStaticBase = target.ReadPointer(target.ReadPointer(handleSlotAddress));
             }
             break;
         case TLSIndexType.DirectOnThreadLocalData:

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -304,7 +304,9 @@ TargetPointer IThread.GetThreadLocalStaticBase(TargetPointer threadPointer, Targ
                 TargetPointer collectibleArray = target.ReadPointer(threadLocalDataPtr + /* ThreadLocalData::CollectibleTlsArrayData offset */);
                 // The collectible TLS array slot holds an OBJECTHANDLE; dereference the handle to the object
                 TargetPointer handleSlotAddress = collectibleArray + (ulong)(indexOffset * target.PointerSize);
-                threadLocalStaticBase = target.ReadPointer(target.ReadPointer(handleSlotAddress));
+                TargetPointer handle = target.ReadPointer(handleSlotAddress);
+                if (handle != TargetPointer.Null && target.TryReadPointer(handle, out TargetPointer obj))
+                    threadLocalStaticBase = obj;
             }
             break;
         case TLSIndexType.DirectOnThreadLocalData:

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -216,10 +216,6 @@ internal readonly struct Thread_1 : IThread
                 if (collectibleCount > indexOffset)
                 {
                     TargetPointer collectibleArray = threadLocalData.CollectibleTlsArrayData;
-                    // The collectible TLS array slot holds an OBJECTHANDLE. Constructing an
-                    // ObjectHandle from the slot address reads the handle from the slot and
-                    // dereferences it to the object (matching the native
-                    // GetThreadLocalStaticBaseNoCreate, which does ObjectFromHandleUnchecked).
                     TargetPointer handleSlotAddress = collectibleArray + (ulong)(indexOffset * _target.PointerSize);
                     threadLocalStaticBase = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(handleSlotAddress).Object;
                 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -216,11 +216,12 @@ internal readonly struct Thread_1 : IThread
                 if (collectibleCount > indexOffset)
                 {
                     TargetPointer collectibleArray = threadLocalData.CollectibleTlsArrayData;
-                    // The collectible TLS array slot holds an OBJECTHANDLE, not the object directly.
-                    // Dereference the handle to get the static base (matches the native
+                    // The collectible TLS array slot holds an OBJECTHANDLE. Constructing an
+                    // ObjectHandle from the slot address reads the handle from the slot and
+                    // dereferences it to the object (matching the native
                     // GetThreadLocalStaticBaseNoCreate, which does ObjectFromHandleUnchecked).
-                    TargetPointer handleAddress = collectibleArray + (ulong)(indexOffset * _target.PointerSize);
-                    threadLocalStaticBase = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(handleAddress).Object;
+                    TargetPointer handleSlotAddress = collectibleArray + (ulong)(indexOffset * _target.PointerSize);
+                    threadLocalStaticBase = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(handleSlotAddress).Object;
                 }
                 break;
             case TLSIndexType.DirectOnThreadLocalData:

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -216,7 +216,11 @@ internal readonly struct Thread_1 : IThread
                 if (collectibleCount > indexOffset)
                 {
                     TargetPointer collectibleArray = threadLocalData.CollectibleTlsArrayData;
-                    threadLocalStaticBase = _target.ReadPointer(collectibleArray + (ulong)(indexOffset * _target.PointerSize));
+                    // The collectible TLS array slot holds an OBJECTHANDLE, not the object directly.
+                    // Dereference the handle to get the static base (matches the native
+                    // GetThreadLocalStaticBaseNoCreate, which does ObjectFromHandleUnchecked).
+                    TargetPointer handleAddress = collectibleArray + (ulong)(indexOffset * _target.PointerSize);
+                    threadLocalStaticBase = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(handleAddress).Object;
                 }
                 break;
             case TLSIndexType.DirectOnThreadLocalData:


### PR DESCRIPTION
The collectable branch for thread statics currently returns the slot of an object, whereas the NonCollectible branch returns the object itself.  Changing this matches the ObjectFromHandleUnchecked in request.cpp (and what clrmd expects on the other end).