### PR TITLE
Fix standalone coreclr tests build

### DIFF
--- a/src/tests/Common/XUnitLogChecker/XUnitLogChecker.csproj
+++ b/src/tests/Common/XUnitLogChecker/XUnitLogChecker.csproj
@@ -5,9 +5,9 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishTrimmed Condition="'$(SelfContained)' != 'false'">true</PublishTrimmed>
     <PublishAot Condition="'$(UseNativeAotForComponents)' == 'true'">true</PublishAot>
-    <PublishSingleFile Condition="'$(UseNativeAotForComponents)' != 'true'">true</PublishSingleFile>
+    <PublishSingleFile Condition="'$(UseNativeAotForComponents)' != 'true' And '$(SelfContained)' != 'false'">true</PublishSingleFile>
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 

--- a/src/tests/JIT/Directed/VectorABI/VectorMgdMgd_r.csproj
+++ b/src/tests/JIT/Directed/VectorABI/VectorMgdMgd_r.csproj
@@ -5,5 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="VectorMgdMgd.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/tailcall/mutual_recursion.fs
+++ b/src/tests/JIT/Directed/tailcall/mutual_recursion.fs
@@ -562,3 +562,9 @@ type Driver() =
 let main () =
     let driver = Driver()
     driver.Start()
+
+[<EntryPoint>]
+let entryPoint _argv =
+    let driver = Driver()
+    driver.Start()
+    100

--- a/src/tests/JIT/Generics/Coverage/chaos65204782cs.csproj
+++ b/src/tests/JIT/Generics/Coverage/chaos65204782cs.csproj
@@ -7,5 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="chaos65204782cs.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_87393/Runtime_87393.fs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_87393/Runtime_87393.fs
@@ -41,3 +41,13 @@ module Main =
         let v = f.M 0 65000 0 0 0 0 0 0 0 0 0 0 0 0 0 0
         Assert.Equal(2112532500, v)
 
+    [<EntryPoint>]
+    let entryPoint _argv =
+        let f : Foo = Bar()
+        let v = f.M 0 65000 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        if v = 2112532500 then
+            printfn "PASS"
+            100
+        else
+            printfn "FAIL: Result was %A" v
+            -1

--- a/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_do.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_do.csproj
@@ -5,5 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="bigvtbl.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_ro.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_ro.csproj
@@ -5,5 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="bigvtbl.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/async/async-versions/async-versions.il
+++ b/src/tests/async/async-versions/async-versions.il
@@ -210,4 +210,28 @@
         callvirt instance void [System.Runtime]System.Threading.Tasks.Task::Wait()
         ret
     }
+
+    // --- Entry point for standalone executable ---------------------------
+
+    .method public hidebysig static int32 Main() cil managed
+    {
+        .entrypoint
+        .maxstack 1
+
+        .try
+        {
+            call void AsyncVersions::JmpToSuspendingTest()
+            call void AsyncVersions::JmpToCompletedTest()
+            call void AsyncVersions::TailToSuspendingTest()
+            call void AsyncVersions::TailToCompletedTest()
+            ldc.i4.s 100
+            ret
+        }
+        catch [System.Runtime]System.Exception
+        {
+            pop
+            ldc.i4.s 101
+            ret
+        }
+    }
 }

--- a/src/tests/async/capacity/capacity.csproj
+++ b/src/tests/async/capacity/capacity.csproj
@@ -7,5 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/userevents/common/userevents_common.csproj
+++ b/src/tests/tracing/userevents/common/userevents_common.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <IsTestProject>false</IsTestProject>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These changes allow to build coreclr tests with `BuildAllTestsAsStandalone=true` and for Tizen armel.