### PR TITLE
cDAC stress build break: match GetObjectStringData's quirky dac behavior

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1613,11 +1613,8 @@ ClrDataAccess::GetObjectStringData(CLRDATA_ADDRESS obj, unsigned int count, _Ino
                 stringData[0] = W('\0');
             }
         }
-        else
-        {
-            hr = E_INVALIDARG;
-        }
 
+        // A size-only query (no output buffer) reports the needed size via pNeeded and succeeds.
         if (pNeeded)
             *pNeeded = needed;
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -3441,11 +3441,25 @@ public sealed unsafe partial class SOSDacImpl
         int hr = HResults.S_OK;
         try
         {
-            if (obj == 0 || (stringData == null && pNeeded == null) || (stringData is not null && count <= 0))
+            // Mirror ClrDataAccess::GetObjectStringData argument validation: reject a null object,
+            // or a request that provides neither an output buffer nor a size-out parameter.
+            if (obj == 0)
                 throw new ArgumentException();
+            if ((stringData == null || count == 0) && pNeeded == null)
+                throw new ArgumentException();
+
             Contracts.IObject contract = _target.Contracts.Object;
             string str = contract.GetStringValue(obj.ToTargetPointer(_target));
+
+            // Always reports the needed size via pNeeded; copies characters only when an output
+            // buffer (stringData with count > 0) is provided.
             OutputBufferHelpers.CopyStringToBuffer(stringData, count, pNeeded, str);
+
+            // Match the legacy DAC: a size-only query (count == 0) still reports the needed size
+            // via *pNeeded but returns E_INVALIDARG rather than S_OK. Callers (e.g. CLRMA) rely on
+            // this to size their buffer before the real copy.
+            if (count == 0)
+                hr = HResults.E_INVALIDARG;
         }
         catch (System.Exception ex)
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -3468,15 +3468,13 @@ public sealed unsafe partial class SOSDacImpl
                 hrLocal = _legacyImpl.GetObjectStringData(obj, count, stringDataArg, pNeededArg);
             }
 
-            // The native DAC returns E_INVALIDARG for a size-only query (no output buffer) even on a
-            // valid string, while still populating *pNeeded; the cDAC returns S_OK for that case.
-            // Callers (e.g. CLRMA) ignore the HRESULT and use the reported size, so allow the cDAC to
-            // succeed where the DAC fails rather than replicating the DAC's quirk.
-            Debug.ValidateHResult(hr, hrLocal, HResultValidationMode.AllowCdacSuccess);
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
-                Debug.Assert(stringData == null || new ReadOnlySpan<char>(stringDataLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(stringData)));
+                // Compare against the legacy buffer using the cDAC string length: neededLocal is only
+                // populated when a size-out was requested from the legacy DAC (mirroring the caller).
+                Debug.Assert(stringData == null || new ReadOnlySpan<char>(stringDataLocal, 0, new string(stringData).Length).SequenceEqual(new string(stringData)));
             }
         }
 #endif

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -3456,11 +3456,16 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             char[] stringDataLocal = new char[count];
-            uint neededLocal;
+            uint neededLocal = 0;
             int hrLocal;
             fixed (char* ptr = stringDataLocal)
             {
-                hrLocal = _legacyImpl.GetObjectStringData(obj, count, ptr, &neededLocal);
+                // Invoke the legacy DAC under the same argument contract the caller gave the cDAC:
+                // only pass an output buffer when the caller did, and only request the size-out when
+                // the caller did. This keeps the HRESULT comparison apples-to-apples.
+                char* stringDataArg = stringData is null ? null : ptr;
+                uint* pNeededArg = pNeeded is null ? null : &neededLocal;
+                hrLocal = _legacyImpl.GetObjectStringData(obj, count, stringDataArg, pNeededArg);
             }
 
             // The native DAC returns E_INVALIDARG for a size-only query (no output buffer) even on a

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -3441,25 +3441,11 @@ public sealed unsafe partial class SOSDacImpl
         int hr = HResults.S_OK;
         try
         {
-            // Mirror ClrDataAccess::GetObjectStringData argument validation: reject a null object,
-            // or a request that provides neither an output buffer nor a size-out parameter.
-            if (obj == 0)
+            if (obj == 0 || (stringData == null && pNeeded == null) || (stringData is not null && count <= 0))
                 throw new ArgumentException();
-            if ((stringData == null || count == 0) && pNeeded == null)
-                throw new ArgumentException();
-
             Contracts.IObject contract = _target.Contracts.Object;
             string str = contract.GetStringValue(obj.ToTargetPointer(_target));
-
-            // Always reports the needed size via pNeeded; copies characters only when an output
-            // buffer (stringData with count > 0) is provided.
             OutputBufferHelpers.CopyStringToBuffer(stringData, count, pNeeded, str);
-
-            // Match the legacy DAC: a size-only query (count == 0) still reports the needed size
-            // via *pNeeded but returns E_INVALIDARG rather than S_OK. Callers (e.g. CLRMA) rely on
-            // this to size their buffer before the real copy.
-            if (count == 0)
-                hr = HResults.E_INVALIDARG;
         }
         catch (System.Exception ex)
         {
@@ -3476,7 +3462,12 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetObjectStringData(obj, count, ptr, &neededLocal);
             }
-            Debug.ValidateHResult(hr, hrLocal);
+
+            // The native DAC returns E_INVALIDARG for a size-only query (no output buffer) even on a
+            // valid string, while still populating *pNeeded; the cDAC returns S_OK for that case.
+            // Callers (e.g. CLRMA) ignore the HRESULT and use the reported size, so allow the cDAC to
+            // succeed where the DAC fails rather than replicating the DAC's quirk.
+            Debug.ValidateHResult(hr, hrLocal, HResultValidationMode.AllowCdacSuccess);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);


### PR DESCRIPTION
The legacy DAC (ClrDataAccess::GetObjectStringData) returns E_INVALIDARG when called on a valid string with no output buffer (stringData == null or count == 0), while still populating *pNeeded. The cDAC implementation returned S_OK in that case, which trips the cDAC-vs-DAC HResult parity assert (SOSDacImpl.cs ValidateHResult) when clrma sizes an exception string. Mirror the cDac: fix the weird behavior that we don't depend on in the legacy dac, and assert similar data here.

This fixes the build/test-break in the cDac introduced by https://github.com/dotnet/diagnostics/pull/5865.