### PR TITLE
Add sshd and Copilot CLI to Android Dev Container

### DIFF
--- a/.devcontainer/android/devcontainer.json
+++ b/.devcontainer/android/devcontainer.json
@@ -20,7 +20,9 @@
 	},
 
 	"features": {
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/sshd:1": {},
+		"ghcr.io/devcontainers/features/copilot-cli:1": {}
 	},
 
 	// Configure tool-specific properties.


### PR DESCRIPTION
This is the Android Codespace equivalent of https://github.com/dotnet/runtime/pull/124855.