### PR TITLE
JIT: extend loop cloning for span+stride>1 and ±const limits

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2002,6 +2002,11 @@ struct NaturalLoopIterInfo
     // allowMissingBaseCase=true.
     bool NeedsZeroTripGuard : 1;
 
+    // Constant peeled from the loop limit so that the effective limit is
+    // `LimitBase() + LimitOffset`. Non-zero only for HasInvariantLocalLimit
+    // and HasArrayLengthLimit.
+    int LimitOffset = 0;
+
     NaturalLoopIterInfo()
         : ExitedOnTrue(false)
         , HasConstInit(false)
@@ -2021,6 +2026,7 @@ struct NaturalLoopIterInfo
     bool IsDecreasingLoop();
     GenTree* Iterator();
     GenTree* Limit();
+    GenTree* LimitBase();
     int ConstLimit();
     unsigned VarLimit();
     bool ArrLenLimit(Compiler* comp, ArrIndex* index);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5888,7 +5888,7 @@ bool FlowGraphNaturalLoop::MatchLimit(unsigned iterVar, GenTree* test, NaturalLo
         }
     }
 
-    if ((peeledBase != nullptr) && !peeledBase->IsCnsIntOrI())
+    if ((peeledBase != nullptr) && !peeledBase->IsCnsIntOrI() && (peeledOffset != 0))
     {
         limitOp           = peeledBase;
         info->LimitOffset = peeledOffset;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5769,6 +5769,8 @@ bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info, bool allo
             printf("invariant local limit ");
         if (info->HasArrayLengthLimit)
             printf("array length limit ");
+        if (info->LimitOffset != 0)
+            printf("offset %d ", info->LimitOffset);
         printf(")\n");
     }
 #endif
@@ -5798,6 +5800,7 @@ bool FlowGraphNaturalLoop::MatchLimit(unsigned iterVar, GenTree* test, NaturalLo
     info->HasSimdLimit           = false;
     info->HasArrayLengthLimit    = false;
     info->HasInvariantLocalLimit = false;
+    info->LimitOffset            = 0;
 
     Compiler* comp = m_dfsTree->GetCompiler();
 
@@ -5840,6 +5843,55 @@ bool FlowGraphNaturalLoop::MatchLimit(unsigned iterVar, GenTree* test, NaturalLo
     if (!iterOp->TypeIs(TYP_INT))
     {
         return false;
+    }
+
+    // Recognize `base ± const` limits (e.g. `arr.Length - 4`, `lcl + 8`) by
+    // peeling the constant into LimitOffset and form-checking the base.
+    // Skip the peel when the base is itself a constant (morph should have
+    // folded that already).
+    int      peeledOffset = 0;
+    GenTree* peeledBase   = nullptr;
+    if (limitOp->OperIs(GT_ADD, GT_SUB) && limitOp->TypeIs(TYP_INT))
+    {
+        GenTree* lop1 = limitOp->gtGetOp1();
+        GenTree* lop2 = limitOp->gtGetOp2();
+        if (lop2->IsCnsIntOrI() && lop2->TypeIs(TYP_INT))
+        {
+            ssize_t cns = lop2->AsIntCon()->IconValue();
+            if ((cns >= INT32_MIN) && (cns <= INT32_MAX))
+            {
+                int signedCns = (int)cns;
+                if (limitOp->OperIs(GT_SUB))
+                {
+                    // Guard against the -INT32_MIN overflow.
+                    if (signedCns != INT32_MIN)
+                    {
+                        peeledOffset = -signedCns;
+                        peeledBase   = lop1;
+                    }
+                }
+                else
+                {
+                    peeledOffset = signedCns;
+                    peeledBase   = lop1;
+                }
+            }
+        }
+        else if (lop1->IsCnsIntOrI() && lop1->TypeIs(TYP_INT) && limitOp->OperIs(GT_ADD))
+        {
+            ssize_t cns = lop1->AsIntCon()->IconValue();
+            if ((cns >= INT32_MIN) && (cns <= INT32_MAX))
+            {
+                peeledOffset = (int)cns;
+                peeledBase   = lop2;
+            }
+        }
+    }
+
+    if ((peeledBase != nullptr) && !peeledBase->IsCnsIntOrI())
+    {
+        limitOp           = peeledBase;
+        info->LimitOffset = peeledOffset;
     }
 
     // Check what type of limit we have - constant, variable or arr-len.
@@ -6912,6 +6964,33 @@ GenTree* NaturalLoopIterInfo::Limit()
 }
 
 //------------------------------------------------------------------------
+// LimitBase: Get the base subtree of the loop limit, with the LimitOffset
+// peeled off.
+//
+// Returns:
+//   The form-checked base tree (CNS_INT / LCL_VAR / ARR_LENGTH); identical
+//   to Limit() when LimitOffset == 0.
+//
+GenTree* NaturalLoopIterInfo::LimitBase()
+{
+    GenTree* lim = Limit();
+    if (LimitOffset == 0)
+    {
+        return lim;
+    }
+
+    assert(lim->OperIs(GT_ADD, GT_SUB) && lim->TypeIs(TYP_INT));
+    GenTree* op1 = lim->gtGetOp1();
+    GenTree* op2 = lim->gtGetOp2();
+    if (op2->IsCnsIntOrI())
+    {
+        return op1;
+    }
+    assert(op1->IsCnsIntOrI() && lim->OperIs(GT_ADD));
+    return op2;
+}
+
+//------------------------------------------------------------------------
 // ConstLimit: Get the constant value of the iterator limit, i.e. when the loop
 // condition is "i RELOP const".
 //
@@ -6924,7 +7003,8 @@ GenTree* NaturalLoopIterInfo::Limit()
 int NaturalLoopIterInfo::ConstLimit()
 {
     assert(HasConstLimit);
-    GenTree* limit = Limit();
+    assert(LimitOffset == 0);
+    GenTree* limit = LimitBase();
     assert(limit->OperIsConst());
     return (int)limit->AsIntCon()->gtIconVal;
 }
@@ -6943,7 +7023,7 @@ unsigned NaturalLoopIterInfo::VarLimit()
 {
     assert(HasInvariantLocalLimit);
 
-    GenTree* limit = Limit();
+    GenTree* limit = LimitBase();
     assert(limit->OperIs(GT_LCL_VAR));
     return limit->AsLclVarCommon()->GetLclNum();
 }
@@ -6966,7 +7046,7 @@ bool NaturalLoopIterInfo::ArrLenLimit(Compiler* comp, ArrIndex* index)
 {
     assert(HasArrayLengthLimit);
 
-    GenTree* limit = Limit();
+    GenTree* limit = LimitBase();
     assert(limit->OperIs(GT_ARR_LENGTH));
 
     // Check if we have a.length or a[i][j].length

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5847,15 +5847,15 @@ bool FlowGraphNaturalLoop::MatchLimit(unsigned iterVar, GenTree* test, NaturalLo
 
     // Recognize `base ± const` limits (e.g. `arr.Length - 4`, `lcl + 8`) by
     // peeling the constant into LimitOffset and form-checking the base.
-    // Skip the peel when the base is itself a constant (morph should have
-    // folded that already).
+    // Morph canonicalizes commutative ops so that any constant operand sits on
+    // op2, and folds `base ± 0`, so we only need to look for `base op2-cns`.
     int      peeledOffset = 0;
     GenTree* peeledBase   = nullptr;
     if (limitOp->OperIs(GT_ADD, GT_SUB) && limitOp->TypeIs(TYP_INT))
     {
         GenTree* lop1 = limitOp->gtGetOp1();
         GenTree* lop2 = limitOp->gtGetOp2();
-        if (lop2->IsCnsIntOrI() && lop2->TypeIs(TYP_INT))
+        if (lop2->IsCnsIntOrI() && lop2->TypeIs(TYP_INT) && !lop1->IsCnsIntOrI())
         {
             ssize_t cns = lop2->AsIntCon()->IconValue();
             if ((cns >= INT32_MIN) && (cns <= INT32_MAX))
@@ -5877,18 +5877,9 @@ bool FlowGraphNaturalLoop::MatchLimit(unsigned iterVar, GenTree* test, NaturalLo
                 }
             }
         }
-        else if (lop1->IsCnsIntOrI() && lop1->TypeIs(TYP_INT) && limitOp->OperIs(GT_ADD))
-        {
-            ssize_t cns = lop1->AsIntCon()->IconValue();
-            if ((cns >= INT32_MIN) && (cns <= INT32_MAX))
-            {
-                peeledOffset = (int)cns;
-                peeledBase   = lop2;
-            }
-        }
     }
 
-    if ((peeledBase != nullptr) && !peeledBase->IsCnsIntOrI() && (peeledOffset != 0))
+    if ((peeledBase != nullptr) && (peeledOffset != 0))
     {
         limitOp           = peeledBase;
         info->LimitOffset = peeledOffset;

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1464,7 +1464,7 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
         LC_Condition geZero;
         if (isIncreasingLoop)
         {
-            // For increasing loop, thelimit value needs to be checked against the array length
+            // For increasing loop, the limit value needs to be checked against the array length
             ident  = LC_Ident::CreateVar(limitLcl, iterInfo->LimitBase()->TypeGet(), iterInfo->LimitOffset);
             geZero = LC_Condition(GT_GE, LC_Expr(ident), LC_Expr(LC_Ident::CreateConst(0u)));
         }

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -165,9 +165,23 @@ GenTree* LC_Ident::ToGenTree(Compiler* comp, BasicBlock* bb)
             assert(constant <= INT32_MAX);
             return comp->gtNewIconNode(constant);
         case Var:
-            return comp->gtNewLclvNode(lclNum, comp->lvaTable[lclNum].lvType);
+        {
+            GenTree* node = comp->gtNewLclvNode(lclNum, comp->lvaTable[lclNum].lvType);
+            if (offset != 0)
+            {
+                node = comp->gtNewOperNode(GT_ADD, node->TypeGet(), node, comp->gtNewIconNode(offset));
+            }
+            return node;
+        }
         case ArrAccess:
-            return arrAccess.ToGenTree(comp, bb);
+        {
+            GenTree* node = arrAccess.ToGenTree(comp, bb);
+            if (offset != 0)
+            {
+                node = comp->gtNewOperNode(GT_ADD, node->TypeGet(), node, comp->gtNewIconNode(offset));
+            }
+            return node;
+        }
         case SpanAccess:
             return spanAccess.ToGenTree(comp);
         case Null:
@@ -1223,12 +1237,61 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
         return false;
     }
 
-    // We don't know exactly whether we might be dealing with a Span<T> or not,
-    // but if we suspect we are, we need to be careful about the stride:
-    // As Span<>.Length can be INT32_MAX unlike arrays.
-    if (hasSpans && (stride > 1))
+    // Span<>.Length can be INT32_MAX, unlike Array.MaxLength. For an
+    // increasing loop with stride > 1, the IV after the final in-loop
+    // increment is at most `limit + s` (LE) or `limit + s - 1` (LT), so
+    // a limit near INT32_MAX would wrap the IV and let the bounds-check-
+    // stripped fast clone access memory past the span. Bound the limit
+    // base accordingly. Decreasing loops are safe via the existing
+    // `limit >= 0` condition plus the stride cap above. HasArrayLengthLimit
+    // is bounded implicitly by Array.MaxLength.
+    if (hasSpans && (stride > 1) && isIncreasingLoop)
     {
-        return false;
+        const int     adjustForLE    = (iterInfo->TestOper() == GT_LE) ? 1 : 0;
+        const int     offset         = iterInfo->LimitOffset;
+        const int64_t maxLimitBase64 = (int64_t)INT32_MAX - stride + 1 - adjustForLE - offset;
+
+        if (iterInfo->HasConstLimit)
+        {
+            assert(offset == 0);
+            const int limitVal = iterInfo->ConstLimit();
+            if ((int64_t)limitVal > maxLimitBase64)
+            {
+                JITDUMP("> Span stride %d: const limit %d exceeds overflow bound %lld\n", stride, limitVal,
+                        (long long)maxLimitBase64);
+                return false;
+            }
+        }
+        else if (iterInfo->HasInvariantLocalLimit)
+        {
+            if (maxLimitBase64 >= INT32_MAX)
+            {
+                // Offset already absorbs the stride; guard is vacuous.
+                JITDUMP("Span stride>1 overflow guard trivially holds (offset %d)\n", offset);
+            }
+            else if (maxLimitBase64 < 0)
+            {
+                JITDUMP("> Span stride %d, offset %d: overflow guard unsatisfiable\n", stride, offset);
+                return false;
+            }
+            else
+            {
+                const unsigned limitLcl = iterInfo->VarLimit();
+                if (!genActualTypeIsInt(lvaGetDesc(limitLcl)))
+                {
+                    JITDUMP("> Span stride %d: limit var V%02u not TYP_INT-compatible\n", stride, limitLcl);
+                    return false;
+                }
+
+                const int    maxLimit      = (int)maxLimitBase64;
+                LC_Ident     limitVarIdent = LC_Ident::CreateVar(limitLcl, iterInfo->LimitBase()->TypeGet());
+                LC_Ident     maxConstIdent = LC_Ident::CreateConst(static_cast<unsigned>(maxLimit));
+                LC_Condition overflowGuard(GT_LE, LC_Expr(limitVarIdent), LC_Expr(maxConstIdent));
+                context->EnsureConditions(loop->GetIndex())->Push(overflowGuard);
+                JITDUMP("Added Span stride>1 overflow guard: V%02u <= %d\n", limitLcl, maxLimit);
+            }
+        }
+        // HasArrayLengthLimit: bounded by Array.MaxLength, no extra guard.
     }
 
     // If the loop limit is an array length, compute the underlying ArrIndex
@@ -1299,12 +1362,13 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
                 JITDUMP("> NeedsZeroTripGuard: limit var V%02u not compatible with TYP_INT\n", limitLcl);
                 return false;
             }
-            limitIdent = LC_Ident::CreateVar(limitLcl, iterInfo->Limit()->TypeGet());
+            limitIdent = LC_Ident::CreateVar(limitLcl, iterInfo->LimitBase()->TypeGet(), iterInfo->LimitOffset);
         }
         else if (iterInfo->HasArrayLengthLimit)
         {
             assert(limitArrIndex != nullptr);
-            limitIdent = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen));
+            limitIdent = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen),
+                                                   iterInfo->LimitOffset);
         }
         else
         {
@@ -1401,12 +1465,14 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
         if (isIncreasingLoop)
         {
             // For increasing loop, thelimit value needs to be checked against the array length
-            ident  = LC_Ident::CreateVar(limitLcl, iterInfo->Limit()->TypeGet());
+            ident  = LC_Ident::CreateVar(limitLcl, iterInfo->LimitBase()->TypeGet(), iterInfo->LimitOffset);
             geZero = LC_Condition(GT_GE, LC_Expr(ident), LC_Expr(LC_Ident::CreateConst(0u)));
         }
         else
         {
-            geZero = LC_Condition(GT_GE, LC_Expr(LC_Ident::CreateVar(limitLcl, iterInfo->Limit()->TypeGet())),
+            geZero = LC_Condition(GT_GE,
+                                  LC_Expr(LC_Ident::CreateVar(limitLcl, iterInfo->LimitBase()->TypeGet(),
+                                                              iterInfo->LimitOffset)),
                                   LC_Expr(LC_Ident::CreateConst(0u)));
         }
 
@@ -1423,7 +1489,20 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
             // init-conditions section above) -- overwriting it with the loop test's limit
             // array length would let the fast clone access an unrelated array out of bounds
             // when init > accessArr.Length (see https://github.com/dotnet/runtime/issues/129176).
-            ident = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen));
+            ident = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen),
+                                              iterInfo->LimitOffset);
+        }
+
+        // arr.Length is non-negative, but arr.Length + offset can be < 0 when
+        // offset < 0 and the array is short. Guard the fast clone against
+        // out-of-bounds access on the low side.
+        if (iterInfo->LimitOffset < 0)
+        {
+            LC_Ident arrLenIdent =
+                LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen),
+                                          iterInfo->LimitOffset);
+            LC_Condition geZero(GT_GE, LC_Expr(arrLenIdent), LC_Expr(LC_Ident::CreateConst(0u)));
+            context->EnsureConditions(loop->GetIndex())->Push(geZero);
         }
     }
     else
@@ -1548,13 +1627,14 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
         {
             const unsigned limitLcl = iterInfo->VarLimit();
             assert(genActualTypeIsInt(lvaGetDesc(limitLcl)));
-            neLimitIdent = LC_Ident::CreateVar(limitLcl, iterInfo->Limit()->TypeGet());
+            neLimitIdent = LC_Ident::CreateVar(limitLcl, iterInfo->LimitBase()->TypeGet(), iterInfo->LimitOffset);
         }
         else
         {
             assert(iterInfo->HasArrayLengthLimit);
             assert(limitArrIndex != nullptr);
-            neLimitIdent = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen));
+            neLimitIdent = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen),
+                                                     iterInfo->LimitOffset);
         }
 
         const genTreeOps cmpOp = isIncreasingLoop ? GT_LE : GT_GE;

--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -597,6 +597,7 @@ private:
     LC_Ident(IdentType type)
         : type(type)
         , lclType(TYP_UNDEF)
+        , offset(0)
     {
     }
 
@@ -605,9 +606,14 @@ public:
     IdentType type;
     var_types lclType;
 
+    // Constant added to the materialized value. Used by Var and ArrAccess
+    // to represent `lcl + k` and `arr.Length + k`.
+    int offset;
+
     LC_Ident()
         : type(Invalid)
         , lclType(TYP_UNDEF)
+        , offset(0)
     {
     }
 
@@ -626,11 +632,11 @@ public:
             case ClassHandle:
                 return (clsHnd == that.clsHnd);
             case Var:
-                return (lclNum == that.lclNum) && (lclType == that.lclType);
+                return (lclNum == that.lclNum) && (lclType == that.lclType) && (offset == that.offset);
             case IndirOfLocal:
                 return (lclNum == that.lclNum) && (indirOffs == that.indirOffs) && (lclType == that.lclType);
             case ArrAccess:
-                return (arrAccess == that.arrAccess);
+                return (arrAccess == that.arrAccess) && (offset == that.offset);
             case SpanAccess:
                 return (spanAccess == that.spanAccess);
             case Null:
@@ -661,6 +667,10 @@ public:
                 break;
             case Var:
                 printf("V%02u", lclNum);
+                if (offset > 0)
+                    printf("+%d", offset);
+                else if (offset < 0)
+                    printf("%d", offset);
                 break;
             case IndirOfLocal:
                 if (indirOffs != 0)
@@ -677,6 +687,10 @@ public:
                 break;
             case ArrAccess:
                 arrAccess.Print();
+                if (offset > 0)
+                    printf("+%d", offset);
+                else if (offset < 0)
+                    printf("%d", offset);
                 break;
             case SpanAccess:
                 spanAccess.Print();
@@ -700,11 +714,12 @@ public:
     // Convert this symbolic representation into a tree node.
     GenTree* ToGenTree(Compiler* comp, BasicBlock* bb);
 
-    static LC_Ident CreateVar(unsigned lclNum, var_types lclType)
+    static LC_Ident CreateVar(unsigned lclNum, var_types lclType, int offset = 0)
     {
         LC_Ident id(Var);
         id.lclNum  = lclNum;
         id.lclType = lclType;
+        id.offset  = offset;
         return id;
     }
 
@@ -724,10 +739,11 @@ public:
         return id;
     }
 
-    static LC_Ident CreateArrAccess(const LC_Array& arrLen)
+    static LC_Ident CreateArrAccess(const LC_Array& arrLen, int offset = 0)
     {
         LC_Ident id(ArrAccess);
         id.arrAccess = arrLen;
+        id.offset    = offset;
         return id;
     }
 

--- a/src/tests/JIT/opt/Cloning/OffsetLimit.cs
+++ b/src/tests/JIT/opt/Cloning/OffsetLimit.cs
@@ -1,0 +1,211 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class OffsetLimit
+{
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int SpanLengthMinus4(Span<int> a)
+    {
+        int sum = 0;
+        for (int i = 0; i < a.Length - 4; i++)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int SpanLengthMinusVector128Count(Span<int> a)
+    {
+        int sum = 0;
+        for (int i = 0; i < a.Length - Vector128<int>.Count; i += Vector128<int>.Count)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int ArrayLengthMinus3(int[] a)
+    {
+        int sum = 0;
+        for (int i = 0; i < a.Length - 3; i++)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int ArrayLengthPlus0Stride2(int[] a)
+    {
+        int sum = 0;
+        for (int i = 0; i < a.Length + 0; i += 2)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int VarMinusK(int[] a, int n)
+    {
+        int sum = 0;
+        for (int i = 0; i < n - 4; i++)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int DecGtArrayLengthMinusK(int[] a, int initVal)
+    {
+        int sum = 0;
+        for (int i = initVal; i > a.Length - 5; i--)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int IncLeSpanLengthMinusK(Span<int> a)
+    {
+        int sum = 0;
+        for (int i = 0; i <= a.Length - 5; i += 2)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    static int[] MakeArray(int n)
+    {
+        int[] a = new int[n];
+        for (int i = 0; i < n; i++) a[i] = i + 1;
+        return a;
+    }
+
+    static int ExpectedInc(int from, int toExclusive, int stride, int[] src)
+    {
+        int sum = 0;
+        for (int i = from; i < toExclusive; i += stride) sum += src[i];
+        return sum;
+    }
+
+    static int ExpectedIncLe(int from, int toInclusive, int stride, int[] src)
+    {
+        int sum = 0;
+        for (int i = from; i <= toInclusive; i += stride) sum += src[i];
+        return sum;
+    }
+
+    static int ExpectedDecGt(int from, int toExclusive, int stride, int[] src)
+    {
+        int sum = 0;
+        for (int i = from; i > toExclusive; i -= stride) sum += src[i];
+        return sum;
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public static void SpanLengthMinus4Test(int n)
+    {
+        int[] a = MakeArray(n);
+        int got = SpanLengthMinus4(a);
+        int want = ExpectedInc(0, Math.Max(0, n - 4), 1, a);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public static void SpanLengthMinusVector128CountTest(int n)
+    {
+        int[] a = MakeArray(n);
+        int got = SpanLengthMinusVector128Count(a);
+        int stride = Vector128<int>.Count;
+        int want = ExpectedInc(0, Math.Max(0, n - stride), stride, a);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public static void ArrayLengthMinus3Test(int n)
+    {
+        int[] a = MakeArray(n);
+        int got = ArrayLengthMinus3(a);
+        int want = ExpectedInc(0, Math.Max(0, n - 3), 1, a);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(50)]
+    [InlineData(99)]
+    public static void ArrayLengthPlus0Stride2Test(int n)
+    {
+        int[] a = MakeArray(n);
+        int got = ArrayLengthPlus0Stride2(a);
+        int want = ExpectedInc(0, n, 2, a);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(0, 100)]
+    [InlineData(3, 100)]
+    [InlineData(50, 100)]
+    [InlineData(100, 100)]
+    public static void VarMinusKTest(int n, int len)
+    {
+        int[] a = MakeArray(len);
+        int got = VarMinusK(a, n);
+        int want = ExpectedInc(0, Math.Max(0, n - 4), 1, a);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(99, 100)]
+    [InlineData(50, 100)]
+    [InlineData(5, 10)]
+    public static void DecGtArrayLengthMinusKTest(int initVal, int len)
+    {
+        int[] a = MakeArray(len);
+        int got = DecGtArrayLengthMinusK(a, initVal);
+        int want = ExpectedDecGt(initVal, len - 5, 1, a);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(50)]
+    [InlineData(99)]
+    [InlineData(100)]
+    public static void IncLeSpanLengthMinusKTest(int n)
+    {
+        int[] a = MakeArray(n);
+        int got = IncLeSpanLengthMinusK(a);
+        int want = ExpectedIncLe(0, n - 5, 2, a);
+        Assert.Equal(want, got);
+    }
+}

--- a/src/tests/JIT/opt/Cloning/OffsetLimit.cs
+++ b/src/tests/JIT/opt/Cloning/OffsetLimit.cs
@@ -196,6 +196,20 @@ public class OffsetLimit
         Assert.Equal(want, got);
     }
 
+    // When the array is shorter than the constant offset, `a.Length - K` is
+    // negative and the decreasing loop steps past index 0. The source loop
+    // throws IndexOutOfRangeException; the `arr.Length + offset >= 0` guard
+    // in loop cloning must keep the fast (bounds-check-free) clone from
+    // silently accepting these accesses.
+    [Theory]
+    [InlineData(2, 3)]
+    [InlineData(0, 1)]
+    public static void DecGtArrayLengthMinusKShortArrayTest(int initVal, int len)
+    {
+        int[] a = MakeArray(len);
+        Assert.Throws<IndexOutOfRangeException>(() => DecGtArrayLengthMinusK(a, initVal));
+    }
+
     [Theory]
     [InlineData(5)]
     [InlineData(50)]

--- a/src/tests/JIT/opt/Cloning/OffsetLimit.csproj
+++ b/src/tests/JIT/opt/Cloning/OffsetLimit.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/Cloning/SpanNonUnitStride.cs
+++ b/src/tests/JIT/opt/Cloning/SpanNonUnitStride.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class SpanNonUnitStride
+{
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int SumIncLtStride2(Span<int> a)
+    {
+        int sum = 0;
+        for (int i = 0; i < a.Length; i += 2)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int SumIncLtStride3(Span<int> a)
+    {
+        int sum = 0;
+        for (int i = 0; i < a.Length; i += 3)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int SumIncLeStride2(Span<int> a, int n)
+    {
+        int sum = 0;
+        for (int i = 0; i <= n; i += 2)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int SumDecGtStride2(Span<int> a, int n)
+    {
+        int sum = 0;
+        for (int i = n; i > 0; i -= 2)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int SumDecGeStride3(Span<int> a, int n)
+    {
+        int sum = 0;
+        for (int i = n; i >= 0; i -= 3)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int SumIncLtStride2ConstLimit(Span<int> a)
+    {
+        int sum = 0;
+        for (int i = 0; i < 50; i += 2)
+        {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    static int[] MakeArray(int n)
+    {
+        int[] a = new int[n];
+        for (int i = 0; i < n; i++)
+        {
+            a[i] = i + 1;
+        }
+        return a;
+    }
+
+    static int ExpectedIncLt(int n, int stride)
+    {
+        int sum = 0;
+        for (int i = 0; i < n; i += stride)
+        {
+            sum += i + 1;
+        }
+        return sum;
+    }
+
+    static int ExpectedIncLe(int n, int stride)
+    {
+        int sum = 0;
+        for (int i = 0; i <= n; i += stride)
+        {
+            sum += i + 1;
+        }
+        return sum;
+    }
+
+    static int ExpectedDecGt(int n, int stride)
+    {
+        int sum = 0;
+        for (int i = n; i > 0; i -= stride)
+        {
+            sum += i + 1;
+        }
+        return sum;
+    }
+
+    static int ExpectedDecGe(int n, int stride)
+    {
+        int sum = 0;
+        for (int i = n; i >= 0; i -= stride)
+        {
+            sum += i + 1;
+        }
+        return sum;
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(50)]
+    [InlineData(99)]
+    [InlineData(100)]
+    public static void IncLtStride2(int n)
+    {
+        Span<int> span = MakeArray(n);
+        int got = SumIncLtStride2(span);
+        int want = ExpectedIncLt(n, 2);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    [InlineData(50)]
+    [InlineData(99)]
+    [InlineData(100)]
+    public static void IncLtStride3(int n)
+    {
+        Span<int> span = MakeArray(n);
+        int got = SumIncLtStride3(span);
+        int want = ExpectedIncLt(n, 3);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(0, 100)]
+    [InlineData(1, 100)]
+    [InlineData(48, 100)]
+    [InlineData(99, 100)]
+    public static void IncLeStride2(int n, int len)
+    {
+        Span<int> span = MakeArray(len);
+        int got = SumIncLeStride2(span, n);
+        int want = ExpectedIncLe(n, 2);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(1, 100)]
+    [InlineData(2, 100)]
+    [InlineData(50, 100)]
+    [InlineData(99, 100)]
+    public static void DecGtStride2(int n, int len)
+    {
+        Span<int> span = MakeArray(len);
+        int got = SumDecGtStride2(span, n);
+        int want = ExpectedDecGt(n, 2);
+        Assert.Equal(want, got);
+    }
+
+    [Theory]
+    [InlineData(0, 100)]
+    [InlineData(1, 100)]
+    [InlineData(50, 100)]
+    [InlineData(99, 100)]
+    public static void DecGeStride3(int n, int len)
+    {
+        Span<int> span = MakeArray(len);
+        int got = SumDecGeStride3(span, n);
+        int want = ExpectedDecGe(n, 3);
+        Assert.Equal(want, got);
+    }
+
+    [Fact]
+    public static void IncLtStride2ConstLimit()
+    {
+        Span<int> span = MakeArray(60);
+        int got = SumIncLtStride2ConstLimit(span);
+        int want = ExpectedIncLt(50, 2);
+        Assert.Equal(want, got);
+    }
+}

--- a/src/tests/JIT/opt/Cloning/SpanNonUnitStride.csproj
+++ b/src/tests/JIT/opt/Cloning/SpanNonUnitStride.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Enable cloning of loops over Span<T> when the stride `s` is greater than 1, guarded by a runtime `limit <= INT_MAX - s + 1` condition on the increasing var-limit case. Other forms are already implicitly safe.

Extend MatchLimit to peel a constant offset off the limit so loops like 

```C#
  for (int i = 0; i < span.Length - K; i += K) { ... }
```

become clonable. Add a LimitOffset to NaturalLoopIterInfo that feeds into LC_Ident, the zero-trip / per-access / NE / overflow guards, and a new `arr.Length + offset >= 0` guard (for very short array lengths and negative offsets).