### PR TITLE
[browser][coreCLR] Make DOTNET_INTEROP dependency optional

### DIFF
--- a/src/native/corehost/browserhost/libBrowserHost.footer.js
+++ b/src/native/corehost/browserhost/libBrowserHost.footer.js
@@ -29,7 +29,6 @@ function libBrowserHostFactory() {
     ];
     let commonDeps = [
         "$DOTNET",
-        "$DOTNET_INTEROP",
         "$ENV",
         "$FS",
         "$libBrowserHostFn",


### PR DESCRIPTION
`[UnmanagedCallersOnly(EntryPoint = "SystemInteropJS_GetManagedStackTrace")]` 

And similar UCOs are IL trimmed when JS interop is not used in the app/test.

Fixes https://github.com/dotnet/runtime/issues/129229