### PR TITLE
[wasm][coreclr] Re-enable System.Formats.Nrbf tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -185,8 +185,6 @@
 
   <!-- https://github.com/dotnet/runtime/issues/125495 - These tests are disabled on browser/CoreCLR because of crashes and test failures. -->
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(RunDisabledWasmTests)' != 'true'">
-    <!-- test failures -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Formats.Nrbf\tests\System.Formats.Nrbf.Tests.csproj" />
     <!-- long running suites -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq\tests\System.Linq.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Memory\tests\System.Memory.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -183,7 +183,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.IO.FileSystem.Tests\DisabledFileLockingTests\System.IO.FileSystem.DisabledFileLocking.Tests.csproj" />
   </ItemGroup>
 
-  <!-- https://github.com/dotnet/runtime/issues/125495 - These tests are disabled on browser/CoreCLR because of crashes and test failures. -->
+  <!-- https://github.com/dotnet/runtime/issues/125495 - Some test suites are disabled on browser/CoreCLR (e.g., long running suites). -->
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(RunDisabledWasmTests)' != 'true'">
     <!-- long running suites -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq\tests\System.Linq.Tests.csproj" />

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -212,7 +212,7 @@
     DependsOnTargets=ResolveReferences guarantees @(ReferenceCopyLocalPaths) is populated before we prune;
     _GatherWasmFilesToBuild (unlike _ComputeWasmBuildCandidates) does not pull it in on its own.
   -->
-  <Target Name="_CoreCLRPreferAppLocalAssembliesOverRuntimePack"
+  <Target Name="_CoreCLRResolveRuntimePackVsAppLocalConflicts"
           BeforeTargets="_ComputeWasmBuildCandidates;_GatherWasmFilesToBuild"
           DependsOnTargets="ResolveReferences"
           Condition="'$(IsBrowserWasmProject)' == 'true'">

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -201,8 +201,9 @@
     wins, exactly as a desktop self-contained publish would. This is version-based, not an unconditional
     app-local preference: when the runtime-pack copy is the higher version it is the one that is kept. The
     wasm build path normally never reaches that resolver for runtime-pack files, which is why the stub
-    leaks into _framework. We feed the resolver only the same-named runtime-pack/app-local pairs and drop
-    whichever copies it discards; assemblies that exist in just one place are untouched.
+    leaks into _framework. We feed the resolver only the same-named runtime-pack/app-local pairs that deploy
+    to the _framework root (no culture subdirectory) and drop whichever copies it discards; assemblies that
+    exist in just one place, and culture-specific satellites, are untouched.
 
     Robustness on user systems: ResolvePackageFileConflicts ships in the .NET SDK, so it is present for any
     Microsoft.NET.Sdk browser-wasm build (in-repo or on a user machine). If the SDK build tasks assembly is
@@ -219,12 +220,14 @@
     <PropertyGroup>
       <!-- Resolve the runtime pack dir the same way the WebAssembly SDK does (Browser.targets): prefer
            the property, fall back to the ResolvedRuntimePack metadata (WBT/Helix-created projects leave
-           the property empty). Normalize once (full path + trailing slash) so the StartsWith checks
-           below reliably match %(FullPath), which uses native separators. All comparisons use the
-           OrdinalIgnoreCase StringComparison so a casing difference between the property and the
-           enumerated item paths (common on case-insensitive filesystems) cannot silently misclassify a
-           copy. Path membership uses StartsWith(string, StringComparison); name membership uses
-           IndexOf(string, StringComparison) with the "!= -1" test kept OUTSIDE the $() (MSBuild's
+           the property empty). A browser-wasm CoreCLR app resolves exactly one runtime pack
+           (Microsoft.NETCore.App), so the metadata expansion is unambiguous — the same single-pack
+           assumption the SDK's own Browser.targets relies on. Normalize once (full path + trailing slash)
+           so the StartsWith checks below reliably match %(FullPath), which uses native separators. All
+           comparisons use the OrdinalIgnoreCase StringComparison so a casing difference between the
+           property and the enumerated item paths (common on case-insensitive filesystems) cannot silently
+           misclassify a copy. Path membership uses StartsWith(string, StringComparison); name membership
+           uses IndexOf(string, StringComparison) with the "!= -1" test kept OUTSIDE the $() (MSBuild's
            property-function expander returns the int index but rejects a trailing comparison operator
            inside the $(), which is the MSB4184 trap). Both overloads exist on .NET Framework MSBuild;
            the Contains(string, StringComparison) overload does not, so it is avoided. -->
@@ -233,11 +236,17 @@
       <_CoreCLRRuntimePackDir Condition="'$(_CoreCLRRuntimePackDir)' != ''">$([MSBuild]::NormalizeDirectory('$(_CoreCLRRuntimePackDir)'))</_CoreCLRRuntimePackDir>
     </PropertyGroup>
     <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
-      <!-- Split copy-local managed assemblies into app-local vs runtime-pack copies. -->
+      <!-- Split copy-local managed assemblies into app-local vs runtime-pack copies. Restrict both sets to
+           assemblies that deploy to the _framework root: ComputeWasmBuildAssets keys the bundle on a culture-
+           qualified RelativePath (_framework/<culture>/<name> for satellites, _framework/<name> otherwise), so
+           same-named satellites in different cultures never actually collide. Matching the conflict set only by
+           file name would wrongly pair them, so we exclude anything with a culture/subdirectory (empty
+           DestinationSubDirectory and Culture == root deployment). Satellite-vs-satellite version skew is out of
+           scope here and is left to the downstream first-wins dedup. -->
       <_CoreCLRAppLocalAssembly Include="@(ReferenceCopyLocalPaths)"
-                                Condition="'%(Extension)' == '.dll' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))" />
+                                Condition="'%(Extension)' == '.dll' and '%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == '' and '%(ReferenceCopyLocalPaths.Culture)' == '' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))" />
       <_CoreCLRRuntimePackAssembly Include="@(ReferenceCopyLocalPaths)"
-                                   Condition="'%(Extension)' == '.dll' and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))" />
+                                   Condition="'%(Extension)' == '.dll' and '%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == '' and '%(ReferenceCopyLocalPaths.Culture)' == '' and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))" />
     </ItemGroup>
     <PropertyGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
       <!-- ;-delimited name lists wrapped in leading/trailing ';' so an IndexOf of ';name;' below is an
@@ -263,15 +272,23 @@
                                  PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_CoreCLRConflictWinners" />
     </ResolvePackageFileConflicts>
+    <!-- Drop the discarded copies. Mirror the SDK's _HandlePackageFileConflicts (remove every candidate, then
+         re-add the winners) instead of removing a computed "loser" subset by identity: @(ReferenceCopyLocalPaths)
+         removal matches on ItemSpec only, so an Exclude-derived loser list is fragile if an ItemSpec ever repeats
+         with different metadata. ReferenceCopyLocalPathsWithoutConflicts carries the winners' full metadata, so
+         re-including them is lossless, and removing both candidate copies first guarantees the loser is gone. -->
     <ItemGroup Condition="'@(_CoreCLRConflictCandidate)' != '' and Exists('$(MicrosoftNETBuildTasksAssembly)')">
-      <_CoreCLRConflictLoser Include="@(_CoreCLRConflictCandidate)" Exclude="@(_CoreCLRConflictWinners)" />
-      <ReferenceCopyLocalPaths Remove="@(_CoreCLRConflictLoser)" />
+      <ReferenceCopyLocalPaths Remove="@(_CoreCLRConflictCandidate)" />
+      <ReferenceCopyLocalPaths Include="@(_CoreCLRConflictWinners)" />
     </ItemGroup>
 
-    <!-- Fallback when the SDK conflict-resolution task is unavailable: prefer app-local (copy-local wins). -->
+    <!-- Fallback when the SDK conflict-resolution task is unavailable: prefer app-local (copy-local wins). Same
+         root-only restriction as the split above so a runtime-pack satellite is never removed on a bare file-name
+         match against an unrelated app-local satellite in a different culture. -->
     <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != '' and '@(_CoreCLRConflictCandidate)' != '' and !Exists('$(MicrosoftNETBuildTasksAssembly)')">
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
                                Condition="'%(Extension)' == '.dll'
+                                          and '%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == '' and '%(ReferenceCopyLocalPaths.Culture)' == ''
                                           and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))
                                           and $(_CoreCLRAppLocalAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase)) != -1" />
     </ItemGroup>

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -219,7 +219,9 @@
       <!-- Resolve the runtime pack dir the same way the WebAssembly SDK does (Browser.targets): prefer
            the property, fall back to the ResolvedRuntimePack metadata (WBT/Helix-created projects leave
            the property empty). Normalize once (full path + trailing slash) so the StartsWith checks
-           below reliably match %(FullPath), which uses native separators. -->
+           below reliably match %(FullPath), which uses native separators. The path/name comparisons
+           use OrdinalIgnoreCase so a casing difference between the property and the enumerated item
+           paths (common on case-insensitive filesystems) cannot silently misclassify a copy. -->
       <_CoreCLRRuntimePackDir>$(MicrosoftNetCoreAppRuntimePackDir)</_CoreCLRRuntimePackDir>
       <_CoreCLRRuntimePackDir Condition="'$(_CoreCLRRuntimePackDir)' == ''">%(ResolvedRuntimePack.PackageDirectory)</_CoreCLRRuntimePackDir>
       <_CoreCLRRuntimePackDir Condition="'$(_CoreCLRRuntimePackDir)' != ''">$([MSBuild]::NormalizeDirectory('$(_CoreCLRRuntimePackDir)'))</_CoreCLRRuntimePackDir>
@@ -227,9 +229,9 @@
     <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
       <!-- Split copy-local managed assemblies into app-local vs runtime-pack copies. -->
       <_CoreCLRAppLocalAssembly Include="@(ReferenceCopyLocalPaths)"
-                                Condition="'%(Extension)' == '.dll' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)'))" />
+                                Condition="'%(Extension)' == '.dll' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))" />
       <_CoreCLRRuntimePackAssembly Include="@(ReferenceCopyLocalPaths)"
-                                   Condition="'%(Extension)' == '.dll' and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)'))" />
+                                   Condition="'%(Extension)' == '.dll' and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))" />
     </ItemGroup>
     <PropertyGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
       <_CoreCLRAppLocalAssemblyNames>;@(_CoreCLRAppLocalAssembly->'%(FileName)%(Extension)');</_CoreCLRAppLocalAssemblyNames>
@@ -238,9 +240,9 @@
     <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
       <!-- The conflict set: copies of the same file name present in BOTH the runtime pack and app-local. -->
       <_CoreCLRConflictCandidate Include="@(_CoreCLRRuntimePackAssembly)"
-                                 Condition="$(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);'))" />
+                                 Condition="$(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase))" />
       <_CoreCLRConflictCandidate Include="@(_CoreCLRAppLocalAssembly)"
-                                 Condition="$(_CoreCLRRuntimePackAssemblyNames.Contains(';%(FileName)%(Extension);'))" />
+                                 Condition="$(_CoreCLRRuntimePackAssemblyNames.Contains(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase))" />
     </ItemGroup>
 
     <!-- Version-based resolution (parity with SDK publish/desktop): keep the higher AssemblyVersion.
@@ -262,8 +264,8 @@
     <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != '' and '@(_CoreCLRConflictCandidate)' != '' and !Exists('$(MicrosoftNETBuildTasksAssembly)')">
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
                                Condition="'%(Extension)' == '.dll'
-                                          and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)'))
-                                          and $(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);'))" />
+                                          and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))
+                                          and $(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase))" />
     </ItemGroup>
   </Target>
 

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -194,25 +194,29 @@
   -->
   <Target Name="_CoreCLRPreferAppLocalAssembliesOverRuntimePack"
           BeforeTargets="_ComputeWasmBuildCandidates;_GatherWasmFilesToBuild"
-          Condition="'$(IsBrowserWasmProject)' == 'true' and '$(MicrosoftNetCoreAppRuntimePackDir)' != ''">
+          Condition="'$(IsBrowserWasmProject)' == 'true'">
     <PropertyGroup>
-      <!-- Normalize once (canonical separators + trailing slash) so the StartsWith checks below
-           reliably match %(FullPath), which uses native separators. -->
-      <_CoreCLRRuntimePackDirNormalized>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackDir)'))</_CoreCLRRuntimePackDirNormalized>
+      <!-- Resolve the runtime pack dir the same way the WebAssembly SDK does (Browser.targets): prefer
+           the property, fall back to the ResolvedRuntimePack metadata (WBT/Helix-created projects leave
+           the property empty). Normalize once (full path + trailing slash) so the StartsWith checks
+           below reliably match %(FullPath), which uses native separators. -->
+      <_CoreCLRRuntimePackDir>$(MicrosoftNetCoreAppRuntimePackDir)</_CoreCLRRuntimePackDir>
+      <_CoreCLRRuntimePackDir Condition="'$(_CoreCLRRuntimePackDir)' == ''">%(ResolvedRuntimePack.PackageDirectory)</_CoreCLRRuntimePackDir>
+      <_CoreCLRRuntimePackDir Condition="'$(_CoreCLRRuntimePackDir)' != ''">$([MSBuild]::NormalizeDirectory('$(_CoreCLRRuntimePackDir)'))</_CoreCLRRuntimePackDir>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
       <!-- App-local (non-runtime-pack) managed assemblies copied next to the app. -->
       <_CoreCLRAppLocalAssembly Include="@(ReferenceCopyLocalPaths)"
-                                Condition="'%(Extension)' == '.dll' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDirNormalized)'))" />
+                                Condition="'%(Extension)' == '.dll' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)'))" />
     </ItemGroup>
     <PropertyGroup>
       <_CoreCLRAppLocalAssemblyNames>;@(_CoreCLRAppLocalAssembly->'%(FileName)%(Extension)');</_CoreCLRAppLocalAssemblyNames>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
       <!-- Drop runtime-pack copies shadowed by a same-named app-local assembly. -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
                                Condition="'%(Extension)' == '.dll'
-                                          and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDirNormalized)'))
+                                          and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)'))
                                           and $(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);'))" />
     </ItemGroup>
   </Target>

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -220,9 +220,14 @@
       <!-- Resolve the runtime pack dir the same way the WebAssembly SDK does (Browser.targets): prefer
            the property, fall back to the ResolvedRuntimePack metadata (WBT/Helix-created projects leave
            the property empty). Normalize once (full path + trailing slash) so the StartsWith checks
-           below reliably match %(FullPath), which uses native separators. The path/name comparisons
-           use OrdinalIgnoreCase so a casing difference between the property and the enumerated item
-           paths (common on case-insensitive filesystems) cannot silently misclassify a copy. -->
+           below reliably match %(FullPath), which uses native separators. All comparisons use the
+           OrdinalIgnoreCase StringComparison so a casing difference between the property and the
+           enumerated item paths (common on case-insensitive filesystems) cannot silently misclassify a
+           copy. Path membership uses StartsWith(string, StringComparison); name membership uses
+           IndexOf(string, StringComparison) with the "!= -1" test kept OUTSIDE the $() (MSBuild's
+           property-function expander returns the int index but rejects a trailing comparison operator
+           inside the $(), which is the MSB4184 trap). Both overloads exist on .NET Framework MSBuild;
+           the Contains(string, StringComparison) overload does not, so it is avoided. -->
       <_CoreCLRRuntimePackDir>$(MicrosoftNetCoreAppRuntimePackDir)</_CoreCLRRuntimePackDir>
       <_CoreCLRRuntimePackDir Condition="'$(_CoreCLRRuntimePackDir)' == ''">%(ResolvedRuntimePack.PackageDirectory)</_CoreCLRRuntimePackDir>
       <_CoreCLRRuntimePackDir Condition="'$(_CoreCLRRuntimePackDir)' != ''">$([MSBuild]::NormalizeDirectory('$(_CoreCLRRuntimePackDir)'))</_CoreCLRRuntimePackDir>
@@ -235,15 +240,17 @@
                                    Condition="'%(Extension)' == '.dll' and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))" />
     </ItemGroup>
     <PropertyGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
+      <!-- ;-delimited name lists wrapped in leading/trailing ';' so an IndexOf of ';name;' below is an
+           exact whole-name membership test (never a substring of a longer name). -->
       <_CoreCLRAppLocalAssemblyNames>;@(_CoreCLRAppLocalAssembly->'%(FileName)%(Extension)');</_CoreCLRAppLocalAssemblyNames>
       <_CoreCLRRuntimePackAssemblyNames>;@(_CoreCLRRuntimePackAssembly->'%(FileName)%(Extension)');</_CoreCLRRuntimePackAssemblyNames>
     </PropertyGroup>
     <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
       <!-- The conflict set: copies of the same file name present in BOTH the runtime pack and app-local. -->
       <_CoreCLRConflictCandidate Include="@(_CoreCLRRuntimePackAssembly)"
-                                 Condition="$(_CoreCLRAppLocalAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase) != -1)" />
+                                 Condition="$(_CoreCLRAppLocalAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase)) != -1" />
       <_CoreCLRConflictCandidate Include="@(_CoreCLRAppLocalAssembly)"
-                                 Condition="$(_CoreCLRRuntimePackAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase) != -1)" />
+                                 Condition="$(_CoreCLRRuntimePackAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase)) != -1" />
     </ItemGroup>
 
     <!-- Version-based resolution (parity with SDK publish/desktop): keep the higher AssemblyVersion.
@@ -266,7 +273,7 @@
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
                                Condition="'%(Extension)' == '.dll'
                                           and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))
-                                          and $(_CoreCLRAppLocalAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase) != -1)" />
+                                          and $(_CoreCLRAppLocalAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase)) != -1" />
     </ItemGroup>
   </Target>
 

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -178,6 +178,14 @@
                      '$(WasmBuildingForNestedPublish)' != 'true' and
                      '$(UsingBrowserRuntimeWorkload)' != 'true'" />
 
+  <!-- The SDK declares this in Microsoft.NET.ConflictResolution.targets for every Microsoft.NET.Sdk build
+       (which every browser-wasm app is). Re-declare it here, guarded, so the task resolves on user systems
+       regardless of import order; the guard also lets the target degrade gracefully where the SDK build
+       tasks assembly is unavailable. -->
+  <UsingTask TaskName="ResolvePackageFileConflicts"
+             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)"
+             Condition="'$(MicrosoftNETBuildTasksAssembly)' != '' and Exists('$(MicrosoftNETBuildTasksAssembly)')" />
+
   <!-- ======================== Prefer app-local assemblies over runtime-pack copies ========================
 
     For a self-contained browser-wasm app, @(ReferenceCopyLocalPaths) can contain two copies of the
@@ -188,9 +196,17 @@
     shared framework ships a non-functional 8.1.0.0 stub while the app references the functional 11.0.0.0
     build, so an Assembly.Load for 11.0.0.0 then fails with FileNotFoundException.
 
-    Resolve it the way a self-contained app loads assemblies (copy-local wins): drop runtime-pack copies
-    shadowed by a same-named app-local copy before the candidates are gathered. Apps without an app-local
-    copy of a framework assembly are unaffected.
+    Resolve the shadowed pairs with the SDK's own conflict resolver (ResolvePackageFileConflicts) — the
+    same task SDK publish uses (Microsoft.NET.ConflictResolution.targets) — so the higher AssemblyVersion
+    wins, exactly as a desktop self-contained publish would. The wasm build path normally never reaches
+    that resolver for runtime-pack files, which is why the stub leaks into _framework. We feed the resolver
+    only the same-named runtime-pack/app-local pairs and drop whichever copies it discards; assemblies that
+    exist in just one place are untouched.
+
+    Robustness on user systems: ResolvePackageFileConflicts ships in the .NET SDK, so it is present for any
+    Microsoft.NET.Sdk browser-wasm build (in-repo or on a user machine). If the SDK build tasks assembly is
+    somehow unavailable, fall back to "copy-local wins" (drop the shadowed runtime-pack copies) so the fix
+    still applies — matching how a self-contained app loads assemblies.
 
     DependsOnTargets=ResolveReferences guarantees @(ReferenceCopyLocalPaths) is populated before we prune;
     _GatherWasmFilesToBuild (unlike _ComputeWasmBuildCandidates) does not pull it in on its own.
@@ -209,15 +225,36 @@
       <_CoreCLRRuntimePackDir Condition="'$(_CoreCLRRuntimePackDir)' != ''">$([MSBuild]::NormalizeDirectory('$(_CoreCLRRuntimePackDir)'))</_CoreCLRRuntimePackDir>
     </PropertyGroup>
     <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
-      <!-- App-local (non-runtime-pack) managed assemblies copied next to the app. -->
+      <!-- Split copy-local managed assemblies into app-local vs runtime-pack copies. -->
       <_CoreCLRAppLocalAssembly Include="@(ReferenceCopyLocalPaths)"
                                 Condition="'%(Extension)' == '.dll' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)'))" />
+      <_CoreCLRRuntimePackAssembly Include="@(ReferenceCopyLocalPaths)"
+                                   Condition="'%(Extension)' == '.dll' and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)'))" />
     </ItemGroup>
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
       <_CoreCLRAppLocalAssemblyNames>;@(_CoreCLRAppLocalAssembly->'%(FileName)%(Extension)');</_CoreCLRAppLocalAssemblyNames>
+      <_CoreCLRRuntimePackAssemblyNames>;@(_CoreCLRRuntimePackAssembly->'%(FileName)%(Extension)');</_CoreCLRRuntimePackAssemblyNames>
     </PropertyGroup>
     <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
-      <!-- Drop runtime-pack copies shadowed by a same-named app-local assembly. -->
+      <!-- The conflict set: copies of the same file name present in BOTH the runtime pack and app-local. -->
+      <_CoreCLRConflictCandidate Include="@(_CoreCLRRuntimePackAssembly)"
+                                 Condition="$(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);'))" />
+      <_CoreCLRConflictCandidate Include="@(_CoreCLRAppLocalAssembly)"
+                                 Condition="$(_CoreCLRRuntimePackAssemblyNames.Contains(';%(FileName)%(Extension);'))" />
+    </ItemGroup>
+
+    <!-- Version-based resolution (parity with SDK publish/desktop): keep the higher AssemblyVersion. -->
+    <ResolvePackageFileConflicts Condition="'@(_CoreCLRConflictCandidate)' != '' and Exists('$(MicrosoftNETBuildTasksAssembly)')"
+                                 ReferenceCopyLocalPaths="@(_CoreCLRConflictCandidate)">
+      <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_CoreCLRConflictWinners" />
+    </ResolvePackageFileConflicts>
+    <ItemGroup Condition="'@(_CoreCLRConflictCandidate)' != '' and Exists('$(MicrosoftNETBuildTasksAssembly)')">
+      <_CoreCLRConflictLoser Include="@(_CoreCLRConflictCandidate)" Exclude="@(_CoreCLRConflictWinners)" />
+      <ReferenceCopyLocalPaths Remove="@(_CoreCLRConflictLoser)" />
+    </ItemGroup>
+
+    <!-- Fallback when the SDK conflict-resolution task is unavailable: prefer app-local (copy-local wins). -->
+    <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != '' and '@(_CoreCLRConflictCandidate)' != '' and !Exists('$(MicrosoftNETBuildTasksAssembly)')">
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
                                Condition="'%(Extension)' == '.dll'
                                           and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)'))

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -243,9 +243,14 @@
                                  Condition="$(_CoreCLRRuntimePackAssemblyNames.Contains(';%(FileName)%(Extension);'))" />
     </ItemGroup>
 
-    <!-- Version-based resolution (parity with SDK publish/desktop): keep the higher AssemblyVersion. -->
+    <!-- Version-based resolution (parity with SDK publish/desktop): keep the higher AssemblyVersion.
+         PreferredPackages mirrors the SDK publish call (_HandlePackageFileConflictsForPublish) so that an
+         exact AssemblyVersion+FileVersion tie is broken the same way publish breaks it (preferring the
+         framework package) instead of being left to the downstream first-wins dedup. The property is
+         populated by ResolveTargetingPackAssets, which runs as part of our ResolveReferences dependency. -->
     <ResolvePackageFileConflicts Condition="'@(_CoreCLRConflictCandidate)' != '' and Exists('$(MicrosoftNETBuildTasksAssembly)')"
-                                 ReferenceCopyLocalPaths="@(_CoreCLRConflictCandidate)">
+                                 ReferenceCopyLocalPaths="@(_CoreCLRConflictCandidate)"
+                                 PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_CoreCLRConflictWinners" />
     </ResolvePackageFileConflicts>
     <ItemGroup Condition="'@(_CoreCLRConflictCandidate)' != '' and Exists('$(MicrosoftNETBuildTasksAssembly)')">

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -191,9 +191,13 @@
     Resolve it the way a self-contained app loads assemblies (copy-local wins): drop runtime-pack copies
     shadowed by a same-named app-local copy before the candidates are gathered. Apps without an app-local
     copy of a framework assembly are unaffected.
+
+    DependsOnTargets=ResolveReferences guarantees @(ReferenceCopyLocalPaths) is populated before we prune;
+    _GatherWasmFilesToBuild (unlike _ComputeWasmBuildCandidates) does not pull it in on its own.
   -->
   <Target Name="_CoreCLRPreferAppLocalAssembliesOverRuntimePack"
           BeforeTargets="_ComputeWasmBuildCandidates;_GatherWasmFilesToBuild"
+          DependsOnTargets="ResolveReferences"
           Condition="'$(IsBrowserWasmProject)' == 'true'">
     <PropertyGroup>
       <!-- Resolve the runtime pack dir the same way the WebAssembly SDK does (Browser.targets): prefer

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -240,9 +240,9 @@
     <ItemGroup Condition="'$(_CoreCLRRuntimePackDir)' != ''">
       <!-- The conflict set: copies of the same file name present in BOTH the runtime pack and app-local. -->
       <_CoreCLRConflictCandidate Include="@(_CoreCLRRuntimePackAssembly)"
-                                 Condition="$(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase))" />
+                                 Condition="$(_CoreCLRAppLocalAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase) != -1)" />
       <_CoreCLRConflictCandidate Include="@(_CoreCLRAppLocalAssembly)"
-                                 Condition="$(_CoreCLRRuntimePackAssemblyNames.Contains(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase))" />
+                                 Condition="$(_CoreCLRRuntimePackAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase) != -1)" />
     </ItemGroup>
 
     <!-- Version-based resolution (parity with SDK publish/desktop): keep the higher AssemblyVersion.
@@ -265,7 +265,7 @@
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
                                Condition="'%(Extension)' == '.dll'
                                           and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDir)', System.StringComparison.OrdinalIgnoreCase))
-                                          and $(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase))" />
+                                          and $(_CoreCLRAppLocalAssemblyNames.IndexOf(';%(FileName)%(Extension);', System.StringComparison.OrdinalIgnoreCase) != -1)" />
     </ItemGroup>
   </Target>
 

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -195,10 +195,15 @@
   <Target Name="_CoreCLRPreferAppLocalAssembliesOverRuntimePack"
           BeforeTargets="_ComputeWasmBuildCandidates;_GatherWasmFilesToBuild"
           Condition="'$(IsBrowserWasmProject)' == 'true' and '$(MicrosoftNetCoreAppRuntimePackDir)' != ''">
+    <PropertyGroup>
+      <!-- Normalize once (canonical separators + trailing slash) so the StartsWith checks below
+           reliably match %(FullPath), which uses native separators. -->
+      <_CoreCLRRuntimePackDirNormalized>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackDir)'))</_CoreCLRRuntimePackDirNormalized>
+    </PropertyGroup>
     <ItemGroup>
       <!-- App-local (non-runtime-pack) managed assemblies copied next to the app. -->
       <_CoreCLRAppLocalAssembly Include="@(ReferenceCopyLocalPaths)"
-                                Condition="'%(Extension)' == '.dll' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(MicrosoftNetCoreAppRuntimePackDir)'))" />
+                                Condition="'%(Extension)' == '.dll' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDirNormalized)'))" />
     </ItemGroup>
     <PropertyGroup>
       <_CoreCLRAppLocalAssemblyNames>;@(_CoreCLRAppLocalAssembly->'%(FileName)%(Extension)');</_CoreCLRAppLocalAssemblyNames>
@@ -207,7 +212,7 @@
       <!-- Drop runtime-pack copies shadowed by a same-named app-local assembly. -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
                                Condition="'%(Extension)' == '.dll'
-                                          and $([System.String]::Copy('%(FullPath)').StartsWith('$(MicrosoftNetCoreAppRuntimePackDir)'))
+                                          and $([System.String]::Copy('%(FullPath)').StartsWith('$(_CoreCLRRuntimePackDirNormalized)'))
                                           and $(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);'))" />
     </ItemGroup>
   </Target>

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -186,26 +186,27 @@
              AssemblyFile="$(MicrosoftNETBuildTasksAssembly)"
              Condition="'$(MicrosoftNETBuildTasksAssembly)' != '' and Exists('$(MicrosoftNETBuildTasksAssembly)')" />
 
-  <!-- ======================== Prefer app-local assemblies over runtime-pack copies ========================
+  <!-- ==================== Resolve runtime-pack vs app-local assembly conflicts by version ====================
 
     For a self-contained browser-wasm app, @(ReferenceCopyLocalPaths) can contain two copies of the
     same assembly: the runtime-pack copy (under $(MicrosoftNetCoreAppRuntimePackDir)) and an app-local
     copy referenced out-of-band at a different version. ComputeWasmBuildAssets dedupes the webcil bundle
-    candidates by relative path (first-wins, version-blind), so the runtime-pack copy can shadow the
-    app-local one in _framework. The canonical case is System.Runtime.Serialization.Formatters: the
-    shared framework ships a non-functional 8.1.0.0 stub while the app references the functional 11.0.0.0
-    build, so an Assembly.Load for 11.0.0.0 then fails with FileNotFoundException.
+    candidates by relative path (first-wins, version-blind), so the wrong copy can shadow the other one
+    in _framework. The canonical case is System.Runtime.Serialization.Formatters: the shared framework
+    ships a non-functional 8.1.0.0 stub while the app references the functional 11.0.0.0 build, so an
+    Assembly.Load for 11.0.0.0 then fails with FileNotFoundException.
 
     Resolve the shadowed pairs with the SDK's own conflict resolver (ResolvePackageFileConflicts) — the
     same task SDK publish uses (Microsoft.NET.ConflictResolution.targets) — so the higher AssemblyVersion
-    wins, exactly as a desktop self-contained publish would. The wasm build path normally never reaches
-    that resolver for runtime-pack files, which is why the stub leaks into _framework. We feed the resolver
-    only the same-named runtime-pack/app-local pairs and drop whichever copies it discards; assemblies that
-    exist in just one place are untouched.
+    wins, exactly as a desktop self-contained publish would. This is version-based, not an unconditional
+    app-local preference: when the runtime-pack copy is the higher version it is the one that is kept. The
+    wasm build path normally never reaches that resolver for runtime-pack files, which is why the stub
+    leaks into _framework. We feed the resolver only the same-named runtime-pack/app-local pairs and drop
+    whichever copies it discards; assemblies that exist in just one place are untouched.
 
     Robustness on user systems: ResolvePackageFileConflicts ships in the .NET SDK, so it is present for any
     Microsoft.NET.Sdk browser-wasm build (in-repo or on a user machine). If the SDK build tasks assembly is
-    somehow unavailable, fall back to "copy-local wins" (drop the shadowed runtime-pack copies) so the fix
+    somehow unavailable, fall back to "app-local wins" (drop the shadowed runtime-pack copies) so the fix
     still applies — matching how a self-contained app loads assemblies.
 
     DependsOnTargets=ResolveReferences guarantees @(ReferenceCopyLocalPaths) is populated before we prune;

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -178,6 +178,40 @@
                      '$(WasmBuildingForNestedPublish)' != 'true' and
                      '$(UsingBrowserRuntimeWorkload)' != 'true'" />
 
+  <!-- ======================== Prefer app-local assemblies over runtime-pack copies ========================
+
+    For a self-contained browser-wasm app, @(ReferenceCopyLocalPaths) can contain two copies of the
+    same assembly: the runtime-pack copy (under $(MicrosoftNetCoreAppRuntimePackDir)) and an app-local
+    copy referenced out-of-band at a different version. ComputeWasmBuildAssets dedupes the webcil bundle
+    candidates by relative path (first-wins, version-blind), so the runtime-pack copy can shadow the
+    app-local one in _framework. The canonical case is System.Runtime.Serialization.Formatters: the
+    shared framework ships a non-functional 8.1.0.0 stub while the app references the functional 11.0.0.0
+    build, so an Assembly.Load for 11.0.0.0 then fails with FileNotFoundException.
+
+    Resolve it the way a self-contained app loads assemblies (copy-local wins): drop runtime-pack copies
+    shadowed by a same-named app-local copy before the candidates are gathered. Apps without an app-local
+    copy of a framework assembly are unaffected.
+  -->
+  <Target Name="_CoreCLRPreferAppLocalAssembliesOverRuntimePack"
+          BeforeTargets="_ComputeWasmBuildCandidates;_GatherWasmFilesToBuild"
+          Condition="'$(IsBrowserWasmProject)' == 'true' and '$(MicrosoftNetCoreAppRuntimePackDir)' != ''">
+    <ItemGroup>
+      <!-- App-local (non-runtime-pack) managed assemblies copied next to the app. -->
+      <_CoreCLRAppLocalAssembly Include="@(ReferenceCopyLocalPaths)"
+                                Condition="'%(Extension)' == '.dll' and !$([System.String]::Copy('%(FullPath)').StartsWith('$(MicrosoftNetCoreAppRuntimePackDir)'))" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_CoreCLRAppLocalAssemblyNames>;@(_CoreCLRAppLocalAssembly->'%(FileName)%(Extension)');</_CoreCLRAppLocalAssemblyNames>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- Drop runtime-pack copies shadowed by a same-named app-local assembly. -->
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
+                               Condition="'%(Extension)' == '.dll'
+                                          and $([System.String]::Copy('%(FullPath)').StartsWith('$(MicrosoftNetCoreAppRuntimePackDir)'))
+                                          and $(_CoreCLRAppLocalAssemblyNames.Contains(';%(FileName)%(Extension);'))" />
+    </ItemGroup>
+  </Target>
+
   <!-- ======================== Core Orchestrator ======================== -->
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

Re-enables the `System.Formats.Nrbf.Tests` suite on **browser-wasm + CoreCLR** (removes the `ProjectExclusions` entry in `src/libraries/tests.proj`) and fixes the underlying bundling bug that made it crash.

## Problem

On browser-wasm + CoreCLR, test discovery crashed with:

```
FileNotFoundException: System.Runtime.Serialization.Formatters, Version=11.0.0.0
```

`System.Runtime.Serialization.Formatters` has a version split: the shared framework ships a **non-functional 8.1.0.0 stub**, while the Nrbf test project references the **functional 11.0.0.0** build app-local (`Private="true" SetTargetFramework="...NetCoreAppMinimum"`).

For a self-contained browser-wasm app, `@(ReferenceCopyLocalPaths)` ends up with **both** copies. The WebAssembly SDK task `ComputeWasmBuildAssets` dedupes webcil bundle candidates by relative path on a **first-wins, version-blind** basis, so the **8.1.0.0 stub** got converted to webcil and bundled into `_framework`, shadowing the app-local 11.0.0.0 copy. At runtime, xunit discovery materializes `[InlineData(FormatterTypeStyle.X)]` attribute blobs → `Assembly.Load` of Formatters 11.0.0.0 → only the stub is present → `FileNotFoundException` → discovery aborts (only 6 of ~153 cases were ever found).

### Why desktop isn't affected
- **Framework-dependent** (desktop default): the shared framework / stub is never copied app-local; only the 11.0.0.0 copy is in the output and the host's `deps.json` resolution prefers the higher version.
- **Single-file publish**: the HostModel bundler packs the already version-conflict-resolved `ResolvedFileToPublish` set (`ComputeResolvedFilesToPublishList` prefers the higher `AssemblyVersion`), so the stub is dropped before bundling.

The wasm webcil bundle is assembled at **build** time from candidates that are not version-conflict-resolved against `ProjectReference`s, so it bypassed the resolution that protects the desktop paths.

## Fix

Add a CoreCLR-wasm target (`_CoreCLRResolveRuntimePackVsAppLocalConflicts` in `BrowserWasmApp.CoreCLR.targets`) that runs after `ResolveReferences` and before the webcil bundle candidates are gathered. For assemblies that appear in `@(ReferenceCopyLocalPaths)` as **both** a runtime-pack copy and a same-named app-local copy, it resolves the conflict the same way a self-contained desktop **publish** does:

- It invokes the SDK's `ResolvePackageFileConflicts` task — the same task desktop publish uses — which picks the winner by **higher AssemblyVersion → FileVersion → `PreferredPackages` rank**, and removes the loser from `@(ReferenceCopyLocalPaths)` so only the winning copy reaches the bundle.
- `PreferredPackages="$(PackageConflictPreferredPackages)"` is passed for exact tie-break parity with publish.
- A name-based "app-local wins" fallback is kept only for the (effectively unreachable on a real SDK) case where `$(MicrosoftNETBuildTasksAssembly)` can't be located.

For the canonical case this selects the functional **11.0.0.0** Formatters over the **8.1.0.0** stub, matching desktop self-contained publish. Apps without an app-local copy of a framework assembly are unaffected (no conflict, nothing is removed).

**Behavior note:** because selection is version-based (matching publish) rather than an unconditional app-local preference, an app-local copy with a *lower* version than the runtime-pack copy will now lose — the same outcome it would get from a self-contained publish.

All runtime-pack path/name comparisons use `OrdinalIgnoreCase` so the resolution is robust to user-overridden output-path casing.

## Follow-up

The root cause is the version-blind, first-wins dedup in the shared WebAssembly SDK task `ComputeWasmBuildAssets` (`uniqueRelativePaths.Add(relativePath)`), which both Mono and CoreCLR wasm go through. This PR deliberately scopes the fix to the **CoreCLR-only** targets file to avoid changing the common Mono/CoreCLR bundling path and risking a .NET 11 Mono regression (Mono doesn't hit this bug). Moving the resolution into `ComputeWasmBuildAssets` is tracked by #129741 and planned for after the .NET 12 branch, at which point this workaround target can be removed.

## Validation

Ran `./dotnet.sh build -c Debug /t:Test src/libraries/System.Formats.Nrbf/tests/System.Formats.Nrbf.Tests.csproj /p:TargetOS=browser /p:TargetArchitecture=wasm /p:RuntimeFlavor=CoreCLR /p:Scenario=WasmTestOnChrome`:

- Bundled `_framework` Formatters webcil: **69913 → 156953 bytes** (8.1.0.0 stub → functional 11.0.0.0).
- Discovery: **6 → 153** test cases, no `FileNotFoundException`.
- Result: **4 passed, 0 failed, exit 0**. The `ReadTests` hierarchy correctly **skips** on browser via `[ConditionalClass(IsBinaryFormatterSupported)]` (BinaryFormatter is unsupported on browser by design), leaving the 4 platform-independent `StartsWithPayloadHeaderTests` cases running and passing — the same behavior as any platform without BinaryFormatter support.

> [!NOTE]
> This pull request was authored by GitHub Copilot.
