### PR TITLE
Some X25519 fixes for OpenSSL key handling

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
@@ -8,7 +8,7 @@ namespace System.Security.Cryptography
     public sealed partial class X25519DiffieHellmanOpenSsl
     {
         private readonly SafeEvpPKeyHandle _key;
-        private readonly bool _hasPrivate;
+        private readonly bool _hasExportablePrivate;
 
         public partial X25519DiffieHellmanOpenSsl(SafeEvpPKeyHandle pkeyHandle)
         {
@@ -20,7 +20,7 @@ namespace System.Security.Cryptography
             }
 
             _key = pkeyHandle.DuplicateHandle();
-            bool isValid = Interop.Crypto.X25519IsValidHandle(_key, out _hasPrivate);
+            bool isValid = Interop.Crypto.X25519IsValidHandle(_key, out _hasExportablePrivate);
 
             if (!isValid)
             {
@@ -80,7 +80,7 @@ namespace System.Security.Cryptography
         protected override void ExportPrivateKeyCore(Span<byte> destination)
         {
             Debug.Assert(destination.Length == PrivateKeySizeInBytes);
-            ThrowIfPrivateNeeded();
+            ThrowIfExportablePrivateNeeded();
             Interop.Crypto.X25519ExportPrivateKey(_key, destination);
         }
 
@@ -92,7 +92,7 @@ namespace System.Security.Cryptography
 
         protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
         {
-            ThrowIfPrivateNeeded();
+            ThrowIfExportablePrivateNeeded();
             return TryExportPkcs8PrivateKeyImpl(destination, out bytesWritten);
         }
 
@@ -106,9 +106,9 @@ namespace System.Security.Cryptography
             base.Dispose(disposing);
         }
 
-        private void ThrowIfPrivateNeeded()
+        private void ThrowIfExportablePrivateNeeded()
         {
-            if (!_hasPrivate)
+            if (!_hasExportablePrivate)
                 throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
         }
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
@@ -38,7 +38,6 @@ namespace System.Security.Cryptography
         protected override unsafe void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
         {
             Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
-            ThrowIfPrivateNeeded();
 
             int written;
 
@@ -68,7 +67,6 @@ namespace System.Security.Cryptography
         {
             Debug.Assert(otherPartyPublicKey.Length == PublicKeySizeInBytes);
             Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
-            ThrowIfPrivateNeeded();
 
             int written = Interop.Crypto.X25519DeriveSecretAgreementWithBytes(_key, otherPartyPublicKey, destination);
 

--- a/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanBaseTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanBaseTests.cs
@@ -163,7 +163,7 @@ namespace System.Security.Cryptography.Tests
             using X25519DiffieHellman publicOnly = ImportPublicKey(xdh.ExportPublicKey());
             using X25519DiffieHellman other = GenerateKey();
 
-            Assert.Throws<CryptographicException>(() => publicOnly.DeriveRawSecretAgreement(other));
+            Assert.ThrowsAny<CryptographicException>(() => publicOnly.DeriveRawSecretAgreement(other));
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace System.Security.Cryptography.Tests
             using X25519DiffieHellman publicOnly = ImportPublicKey(xdh.ExportPublicKey());
             using X25519DiffieHellman other = GenerateKey();
 
-            Assert.Throws<CryptographicException>(() =>
+            Assert.ThrowsAny<CryptographicException>(() =>
                 publicOnly.DeriveRawSecretAgreement(other, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
         }
 
@@ -184,7 +184,7 @@ namespace System.Security.Cryptography.Tests
             using X25519DiffieHellman publicOnly = ImportPublicKey(xdh.ExportPublicKey());
             using X25519DiffieHellman other = GenerateKey();
 
-            Assert.Throws<CryptographicException>(() => publicOnly.DeriveRawSecretAgreement(other.ExportPublicKey()));
+            Assert.ThrowsAny<CryptographicException>(() => publicOnly.DeriveRawSecretAgreement(other.ExportPublicKey()));
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace System.Security.Cryptography.Tests
             using X25519DiffieHellman publicOnly = ImportPublicKey(xdh.ExportPublicKey());
             using X25519DiffieHellman other = GenerateKey();
 
-            Assert.Throws<CryptographicException>(() =>
+            Assert.ThrowsAny<CryptographicException>(() =>
                 publicOnly.DeriveRawSecretAgreement(
                     other.ExportPublicKey(),
                     new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.c
@@ -8,6 +8,8 @@
 #include "openssl.h"
 #include <assert.h>
 
+#define X25519_KEY_SIZE_IN_BYTES 32
+
 static int32_t ExportRawKeyMaterial(
     const EVP_PKEY* key,
     uint8_t* destination,
@@ -157,16 +159,39 @@ int32_t CryptoNative_X25519IsValidHandle(const EVP_PKEY* key, int32_t* hasPrivat
         return 0;
     }
 
-    size_t privateKeyLength = 0;
+    uint8_t privateKey[X25519_KEY_SIZE_IN_BYTES];
+    size_t privateKeyLength = sizeof(privateKey);
+    int32_t ret = 0;
 
-    if (EVP_PKEY_get_raw_private_key(key, NULL, &privateKeyLength) == 1)
+    // In OpenSSL 1.1.1, a NULL buffer for a private key will succeed even if the EVP_PKEY does not have a private key
+    // because it thinks you are asking it "how big a buffer do I need to contain the private key". Only after you
+    // give it a buffer big enough will it error saying the key does not have a private key.
+    // In OpenSSL 3.0 it will error saying it does not have a private key, even when all you are doing is asking how
+    // big the private key is. So always give it a buffer big enough.
+    if (EVP_PKEY_get_raw_private_key(key, privateKey, &privateKeyLength) == 1)
     {
-        *hasPrivateKey = 1;
+        if (privateKeyLength == sizeof(privateKey))
+        {
+            ret = 1;
+            *hasPrivateKey = 1;
+            goto done;
+        }
+        else
+        {
+            // This means the X25519 key is not the correct size somehow. We can't work with an X25519 key that does not
+            // use correct key sizes, so report it as an invalid handle.
+            goto done;
+        }
     }
     else
     {
+        // We still want to return success in this case, this is the "the key is only public" case.
+        ret = 1;
         ERR_clear_error();
+        goto done;
     }
 
-    return 1;
+done:
+    OPENSSL_cleanse(privateKey, sizeof(privateKey));
+    return ret;
 }


### PR DESCRIPTION
This makes a couple of fixes to the X25519 implementation.

1. Our "Does this X25519 instance have an exportable key" check for OpenSSL did not work correct on OpenSSL 1.1.1. This is explained in the comments. This doesn't functionally fix anything, developers just get a better error.

2. With X25519DiffieHellmanOpenSsl, we were guarding DeriveRawSecretAgreementCore with _hasPrivate. This is not right for the X25519DiffieHellmanOpenSsl implementation because we got the key handle from somewhere else, so we don't know if the private key is exportable or not. Instead we just have to let the provider tell us if the key agreement worked or not. We can still use this check for the PKCS#8 and private key exports.