### PR TITLE
[RyuJIT Wasm]: Fix incorrect assert for shift amount type in codegenwasm.cpp

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1743,7 +1743,7 @@ void CodeGen::genCodeForShift(GenTree* tree)
 
     if (treeNode->TypeIs(TYP_LONG))
     {
-        assert(treeNode->gtGetOp2()->TypeIs(TYP_INT));
+        assert(genActualType(treeNode->gtGetOp2()->TypeGet()) == TYP_INT);
         // Zero-extend the shift amount to 64 bits for long shifts/rotates.
         // Wasteful if the amount was a constant, perhaps we should contain it if so.
         GetEmitter()->emitIns(INS_i64_extend_u_i32);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1737,10 +1737,9 @@ void CodeGen::genCodeForShift(GenTree* tree)
     GenTreeOp* treeNode = tree->AsOp();
     genConsumeOperands(treeNode);
 
-    // TODO-WASM: Zero-extend the 2nd operand for shifts and rotates as needed when the 1st and 2nd operand are
-    // different types. The shift operand width in IR is always TYP_INT; the WASM operations have the same widths
-    // for both the shift and shiftee. So the shift may need to be extended (zero-extended) for TYP_LONG.
-
+    // The shift operand width in IR is always int or small int, so the operand's actual type should be TYP_INT.
+    // However, the WASM operations have the same widths for both the shift and shiftee so
+    // the shift width may need to be zero-extended if the shift result type is TYP_LONG.
     if (treeNode->TypeIs(TYP_LONG))
     {
         assert(genActualType(treeNode->gtGetOp2()->TypeGet()) == TYP_INT);


### PR DESCRIPTION
Fixes #129263; This came up due to the following IL in a regression test:
```
 ldc.i8 0xa60d377f2863e61c
 ldsflda unsigned int16 ILGEN_0x3c109d11::field_0x1
 ldind.u2
 shr.un
```
We have a load of a ushort as the shift operand, and this is preserved through import down to codegen.
We were asserting that the exact type for the shift amount operand is `TYP_INT`, when this may not be the case since the shift amount could be a smaller integer type that still fits in `TYP_INT`. Instead, the assert should use `genActualType`