### PR TITLE
Add ActiveIssue for all named key tests to mitigate invalid memory access

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamOpenSslNamedKeysTests.manual.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamOpenSslNamedKeysTests.manual.cs
@@ -13,6 +13,7 @@ namespace System.Net.Security.Tests
     // See System.Security.Cryptography/tests/osslplugins/README.md for instructions on how to setup for TPM tests.
     public class SslStreamOpenSslNamedKeys
     {
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunProviderEcDsaTests))]
         public static async Task Provider_TPM2SslStream_ServerCertIsTpmEcDsa()
         {
@@ -21,6 +22,7 @@ namespace System.Net.Security.Tests
             await TestTls(serverOptions, clientOptions);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalTheory(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunProviderRsaTests))]
         [MemberData(nameof(OpenSslNamedKeysHelpers.RSASignaturePaddingValues), MemberType = typeof(OpenSslNamedKeysHelpers))]
         public static async Task Provider_TPM2SslStream_ServerCertIsTpmRsa(RSASignaturePadding padding)

--- a/src/libraries/System.Security.Cryptography/tests/OpenSslNamedKeysTests.manual.cs
+++ b/src/libraries/System.Security.Cryptography/tests/OpenSslNamedKeysTests.manual.cs
@@ -68,6 +68,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.OpenSslPresentOnSystem))]
         public static void NullArguments()
         {
@@ -81,6 +82,7 @@ namespace System.Security.Cryptography.Tests
             Assert.Throws<ArgumentNullException>(() => SafeEvpPKeyHandle.OpenKeyFromProvider(OpenSslNamedKeysHelpers.Tpm2ProviderName, null));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.OpenSslPresentOnSystem))]
         public static void EmptyNameThroughNullCharacter()
         {
@@ -93,6 +95,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ProvidersSupported))]
         public static void EmptyUriThroughNullCharacter()
         {

--- a/src/libraries/System.Security.Cryptography/tests/OpenSslNamedKeysTests.manual.cs
+++ b/src/libraries/System.Security.Cryptography/tests/OpenSslNamedKeysTests.manual.cs
@@ -39,6 +39,7 @@ namespace System.Security.Cryptography.Tests
             "A5F29E03C5AC1888D93744D89638D83AC37774B339E4AFB349C714B12238B0F81A71380F051C585C" +
             "B27434FA544BDAC679E1E16581D0E90203010001").HexToByteArray();
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.OpenSslNotPresentOnSystem))]
         public static void EngineNotSupported_ThrowsPlatformNotSupported()
         {
@@ -46,6 +47,7 @@ namespace System.Security.Cryptography.Tests
             Assert.Throws<PlatformNotSupportedException>(() => SafeEvpPKeyHandle.OpenPrivateKeyFromEngine(OpenSslNamedKeysHelpers.TestEngineName, OpenSslNamedKeysHelpers.TestEngineKeyId));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ProvidersNotSupported))]
         public static void ProvidersNotSupported_ThrowsPlatformNotSupported()
         {
@@ -97,6 +99,7 @@ namespace System.Security.Cryptography.Tests
             Assert.ThrowsAny<CryptographicException>(() => SafeEvpPKeyHandle.OpenKeyFromProvider("default", "\0"));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.OpenSslPresentOnSystem))]
         public static void Engine_NonExisting()
         {
@@ -104,12 +107,14 @@ namespace System.Security.Cryptography.Tests
             Assert.ThrowsAny<CryptographicException>(() => SafeEvpPKeyHandle.OpenPublicKeyFromEngine(OpenSslNamedKeysHelpers.NonExistingEngineOrProviderKeyName, OpenSslNamedKeysHelpers.TestEngineKeyId));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ProvidersSupported))]
         public static void Provider_NonExisting()
         {
             Assert.ThrowsAny<CryptographicException>(() => SafeEvpPKeyHandle.OpenKeyFromProvider(OpenSslNamedKeysHelpers.NonExistingEngineOrProviderKeyName, OpenSslNamedKeysHelpers.AnyProviderKeyUri));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunEngineTests))]
         public static void Engine_NonExistingKey()
         {
@@ -117,12 +122,14 @@ namespace System.Security.Cryptography.Tests
             Assert.ThrowsAny<CryptographicException>(() => SafeEvpPKeyHandle.OpenPublicKeyFromEngine(OpenSslNamedKeysHelpers.TestEngineName, OpenSslNamedKeysHelpers.NonExistingEngineOrProviderKeyName));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunAnyProviderTests))]
         public static void Provider_NonExistingKey()
         {
             Assert.ThrowsAny<CryptographicException>(() => SafeEvpPKeyHandle.OpenKeyFromProvider(OpenSslNamedKeysHelpers.Tpm2ProviderName, OpenSslNamedKeysHelpers.NonExistingEngineOrProviderKeyName));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ProvidersSupported))]
         public static void Provider_Default_RSASignAndDecrypt()
         {
@@ -143,6 +150,7 @@ namespace System.Security.Cryptography.Tests
             Assert.Equal(data, decrypted);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ProvidersSupported))]
         public static void Provider_Default_ECDsaSignAndVerify()
         {
@@ -159,6 +167,7 @@ namespace System.Security.Cryptography.Tests
             Assert.True(originalKey.VerifyData(data, signature, HashAlgorithmName.SHA256), "signature does not verify with the right key");
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ProvidersSupported))]
         public static void Provider_Default_ECDHKeyExchange()
         {
@@ -180,6 +189,7 @@ namespace System.Security.Cryptography.Tests
             Assert.Equal(sharedSecret1, sharedSecret3);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunEngineTests))]
         public static void Engine_OpenExistingPrivateKey()
         {
@@ -190,6 +200,7 @@ namespace System.Security.Cryptography.Tests
             Assert.Equal(s_rsaPubKey, priKey.ExportRSAPublicKey());
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunEngineTests))]
         public static void Engine_OpenExistingPublicKey()
         {
@@ -201,6 +212,7 @@ namespace System.Security.Cryptography.Tests
             Assert.Equal(s_rsaPubKey, pubKey.ExportRSAPublicKey());
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunEngineTests))]
         public static void Engine_UsePrivateKey()
         {
@@ -227,6 +239,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunEngineTests))]
         public static void Engine_UsePublicKey()
         {
@@ -253,6 +266,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunTpmTssTests))]
         public static void Engine_OpenExistingTPMPrivateKey()
         {
@@ -270,6 +284,7 @@ namespace System.Security.Cryptography.Tests
             Assert.False(ecdsaPri.VerifyData(data, badSignature, HashAlgorithmName.SHA256));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunProviderEcDsaTests))]
         public static void Provider_TPM2ECDSA()
         {
@@ -308,6 +323,7 @@ namespace System.Security.Cryptography.Tests
             Assert.ThrowsAny<CryptographicException>(() => ecdsaPri.ExportParameters(includePrivateParameters: true));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunProviderEcDsaTests))]
         public static void Provider_TPM2ECDSA_ExportParameters()
         {
@@ -323,6 +339,7 @@ namespace System.Security.Cryptography.Tests
             Assert.True(ecdsaPub.VerifyData(data, signature, HashAlgorithmName.SHA256));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunProviderEcDsaTests))]
         public static void Provider_TPM2ECDSA_ExportExplicitParameters()
         {
@@ -338,6 +355,7 @@ namespace System.Security.Cryptography.Tests
             Assert.True(ecdsaPub.VerifyData(data, signature, HashAlgorithmName.SHA256));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunProviderEcDhTests))]
         public static void Provider_TPM2ECDH()
         {
@@ -375,6 +393,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalTheory(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunProviderRsaTests))]
         [MemberData(nameof(OpenSslNamedKeysHelpers.RSASignaturePaddingValues), MemberType = typeof(OpenSslNamedKeysHelpers))]
         public static void Provider_TPM2SignRsa(RSASignaturePadding signaturePadding)
@@ -416,6 +435,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalTheory(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunProviderRsaTests))]
         [InlineData(RSAEncryptionPaddingMode.Pkcs1)]
         [InlineData(RSAEncryptionPaddingMode.Oaep)]
@@ -471,6 +491,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/129339")]
         [ConditionalFact(typeof(OpenSslNamedKeysHelpers), nameof(OpenSslNamedKeysHelpers.ShouldRunProviderRsaTests))]
         public static void Provider_TPM2DecryptRsa_ExportParameters()
         {


### PR DESCRIPTION
This adds an `ActiveIssue` to all functional members of `OpenSslNamedKeysTests` because they are very likely the source of memory corruption that is showing in #129339.

Disable the tests for now so that CI is stable while permanent fixes are investigated.