### PR TITLE
[interp] Send CreateThread debugger event from the interpreter

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -8886,6 +8886,40 @@ void Debugger::ThreadStarted(Thread* pRuntimeThread)
 }
 
 
+void Debugger::SendCreateThreadAtInterpreterEntry(Thread *pRuntimeThread)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_TRIGGERS;
+        MODE_ANY;
+        PRECONDITION(pRuntimeThread != NULL);
+        PRECONDITION(pRuntimeThread == g_pEEInterface->GetThread());
+    }
+    CONTRACTL_END;
+
+    if (CORDBUnrecoverableError(this))
+        return;
+
+    if (!CORDebuggerAttached())
+        return;
+
+    {
+        GCX_PREEMP();
+        PollWaitingForHelper();
+    }
+
+    SENDIPCEVENT_BEGIN(this, pRuntimeThread);
+
+    if (CORDebuggerAttached())
+    {
+        ThreadStarted(pRuntimeThread);
+    }
+
+    SENDIPCEVENT_END;
+}
+
+
 //---------------------------------------------------------------------------------------
 //
 // DetachThread is called by Runtime threads when they are completing

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -1925,6 +1925,7 @@ public:
 
     void ThreadCreated(Thread* pRuntimeThread);
     void ThreadStarted(Thread* pRuntimeThread);
+    void SendCreateThreadAtInterpreterEntry(Thread* pRuntimeThread);
     void DetachThread(Thread *pRuntimeThread);
 
     BOOL SuspendComplete(bool isEESuspendedForGC = false);

--- a/src/coreclr/vm/dbginterface.h
+++ b/src/coreclr/vm/dbginterface.h
@@ -380,6 +380,8 @@ public:
     virtual void ExternalMethodFixupNextStep(PCODE address) = 0;
     virtual void ProcessAnyPendingEvals(Thread* pThread) = 0;
 
+    virtual void SendCreateThreadAtInterpreterEntry(Thread* pRuntimeThread) = 0;
+
 #endif //DACCESS_COMPILE
 };
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -6558,7 +6558,7 @@ InterpThreadContext* Thread::GetOrCreateInterpThreadContext()
     CONTRACTL
     {
         THROWS;
-        GC_NOTRIGGER;
+        GC_TRIGGERS;
         MODE_ANY;
     }
     CONTRACTL_END;
@@ -6566,6 +6566,13 @@ InterpThreadContext* Thread::GetOrCreateInterpThreadContext()
     if (m_pInterpThreadContext == nullptr)
     {
         m_pInterpThreadContext = new InterpThreadContext();
+
+#ifdef DEBUGGING_SUPPORTED
+        if (CORDebuggerAttached() && g_pDebugInterface != NULL)
+        {
+            g_pDebugInterface->SendCreateThreadAtInterpreterEntry(this);
+        }
+#endif // DEBUGGING_SUPPORTED
     }
 
     return m_pInterpThreadContext;


### PR DESCRIPTION
## Description

When debugging interpreted code, breakpoints stop the process but there are no locals. The cause is that the interpreter never sends the managed `CreateThread` event, so the it has no `ICorDebugThread` for the thread. For JIT, the VM only calls `ThreadCreated`, and the event itself is pulled lazily by `DebuggerThreadStarter` via the trace-call mechanism when the thread hits its first managed instruction. 

This change has the interpreter notify the thread directly the first time it runs interpreted code under a debugger. A new per-thread `TSNC_DebuggerThreadStartSent` flag guards the event to at most once per thread. `InterpExecMethod` calls a new `Debugger::SendCreateThreadAtInterpreterEntry`, which establishes the required `SENDIPCEVENT_BEGIN/END` context and then invokes the existing `ThreadStarted`.