### PR TITLE
Wasm R2R: implement support for resume after catch

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -553,13 +553,32 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
 {
     const unsigned cursor = getBlockIndex(block);
 
-    // Pop control flow intervals that end here (at most two, block and/or loop)
-    // and emit wasm END instructions for them.
+    // Pop control flow intervals that end here and emit wasm END instructions for them.
     //
     while (!wasmControlFlowStack->Empty() && (wasmControlFlowStack->Top()->End() == cursor))
     {
         instGen(INS_end);
         WasmInterval* interval = wasmControlFlowStack->Pop();
+
+        // After a TRY's `end`, emit `unreachable` so the rest of its
+        // [exnref]-wrapper body is polymorphic — try_table itself uses void
+        // result sig, so without this the wrapper's `end` would not validate
+        // against its [exnref] sig.
+        //
+        if (interval->IsTry())
+        {
+            instGen(INS_unreachable);
+        }
+
+        // Stash the [exnref] that catch_ref pushed onto the wrapper's `end`
+        // into the per-funclet local so any later throw_ref can reload it.
+        //
+        if (interval->IsExnRefWrapper())
+        {
+            unsigned const exnRefIdx = m_compiler->funCurrentFunc()->funWasmExnRefLocalIndex;
+            assert(exnRefIdx != UINT_MAX);
+            GetEmitter()->emitIns_I(INS_local_set, EA_PTRSIZE, exnRefIdx);
+        }
     }
 
     // Push control flow for intervals that start here or earlier, and emit
@@ -585,52 +604,22 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
                 GenTree* const jTrue      = blockRange.LastNode();
                 assert(jTrue->OperIs(GT_WASM_JEXCEPT));
 
-                // Empty stack sig, one catch clause
+                // try_table uses void result sig; the paired [exnref]-wrapper
+                // just outside it provides the depth-0 target for catch_ref.
                 //
                 GetEmitter()->emitIns_Ty_I(INS_try_table, WasmValueType::Invalid, 1);
 
-                // Post-catch continuation dispatch block is the true target.
-                // False target should be the next block.
+                // One catch clause targeting the wrapper at depth 0. The true
+                // target of GT_WASM_JEXCEPT is passed only for disasm readability.
                 //
                 assert(block->GetFalseTarget() == block->Next());
                 BasicBlock* const target = block->GetTrueTarget();
-                unsigned          depth  = findTargetDepth(target);
-                GetEmitter()->emitIns_J(INS_catch_ref, EA_4BYTE, depth, target);
+                GetEmitter()->emitIns_J(INS_catch_ref, EA_4BYTE, 0, target);
             }
             else
             {
                 assert(interval->IsBlock());
-
-                bool isTryWrapper = false;
-
-#if FALSE
-                // TODO-WASM: block sig when we emit catch_ref
-
-                // If this interval exactly wraps a try, it represents the branch to the
-                // catch handlers. We need to emit an exnref block sig
-                //
-                // (TODO, perhaps ... detect this earlier and make it an interval property)
-                if ((wasmCursor + 1) < m_compiler->fgWasmIntervals->size())
-                {
-                    WasmInterval* nextInterval = m_compiler->fgWasmIntervals->at(wasmCursor + 1);
-                    if (nextInterval->IsTry())
-                    {
-                        // we should always see a wrapping block because of the
-                        // control flow added by fgWasmEhFlow
-                        //
-                        if ((nextInterval->Start() == interval->Start()) && (nextInterval->End() == interval->End()))
-                        {
-                            isTryWrapper = true;
-                        }
-                        else
-                        {
-                            assert(!"Expected block to wrap the try");
-                        }
-                    }
-                }
-#endif
-
-                if (isTryWrapper)
+                if (interval->IsExnRefWrapper())
                 {
                     GetEmitter()->emitIns_BlockTy(INS_block, WasmValueType::ExnRef);
                 }
@@ -906,9 +895,13 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             break;
 
         case GT_WASM_THROW_REF:
-            // TODO-WASM: enable when we emit catch_ref instead of catch_all
-            // GetEmitter()->emitIns(INS_throw_ref);
-            GetEmitter()->emitIns(INS_unreachable);
+            // Reload and rethrow the exnref stashed at the catch_ref landing.
+            {
+                unsigned const exnRefIdx = m_compiler->funCurrentFunc()->funWasmExnRefLocalIndex;
+                assert(exnRefIdx != UINT_MAX);
+                GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, exnRefIdx);
+                GetEmitter()->emitIns(INS_throw_ref);
+            }
             break;
 
         case GT_CATCH_ARG:

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1775,6 +1775,7 @@ struct FuncInfoDsc
 
     jitstd::vector<WasmLocalsDecl>* funWasmLocalDecls;
     unsigned funWasmFrameSize;
+    unsigned funWasmExnRefLocalIndex = UINT_MAX;
     bool needsUnwindableFrame;
     emitLocation* startLoc;
     emitLocation* endLoc;
@@ -4257,6 +4258,7 @@ public:
     unsigned lvaWasmVirtualIP = BAD_VAR_NUM; // Wasm virtual IP slot
     unsigned lvaWasmFunctionIndex = BAD_VAR_NUM; // Wasm function index slot
     unsigned lvaWasmResumeIP = BAD_VAR_NUM; // Wasm catch resumption IP slot
+
 #endif // defined(TARGET_WASM)
 
     unsigned lvaInlinedPInvokeFrameVar = BAD_VAR_NUM; // variable representing the InlinedCallFrame

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -715,9 +715,8 @@ unsigned emitter::instrDesc::idCodeSize() const
         {
             // no opcode, this is part of a try_table
 
-            size = 1; // catch kind
-            // TODO-WASM: tag index
-            // size += PADDED_RELOC_SIZE;                 // catch type tag
+            size = 1;                                  // catch kind
+            size += PADDED_RELOC_SIZE;                 // catch type tag (RtlRestoreContext tag index)
             size += SizeOfULEB128(emitGetInsSC(this)); // control flow stack offset
             break;
         }
@@ -1040,11 +1039,16 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         }
         case IF_CATCH_DECL:
         {
-            // TODO-WASM: this should be Kind 1: catch_ref with type tag
-            uint8_t catchKind = 2;
+            // Kind 1: catch_ref with type tag. The tag is the well-known
+            // CoreCLR RtlRestoreContext exception tag exported by the runtime;
+            // crossgen2's WasmObjectWriter resolves this reloc to the tag index
+            // of the module's imported `rtlRestoreContextTag`.
+            uint8_t catchKind = 1;
             dst += emitOutputByte(dst, catchKind);
-            // TODO-WASM: figure out how to get proper tag index here
-            // dst += emitOutputPaddedReloc(dst);
+
+            emitRecordRelocation(dst, emitCodeBlock, CorInfoReloc::WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB);
+            dst += emitOutputPaddedReloc(dst);
+
             dst += emitOutputULEB128(dst, (int64_t)emitGetInsSC(id));
             break;
         }
@@ -1335,8 +1339,8 @@ void emitter::emitDispIns(
 
         case IF_CATCH_DECL:
         {
-            // TODO: catch type
-            // target label
+            // catch_ref RtlRestoreContextTag, depth
+            printf(" RtlRestoreContextTag");
             dispJumpTargetIfAny();
         }
         break;

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -1362,6 +1362,14 @@ PhaseStatus Compiler::fgWasmControlFlow()
             unsigned            endCursor   = cursor + tryRegion->NumBlocks();
             WasmInterval* const tryInterval = WasmInterval::NewTry(this, block, initialLayout[endCursor]);
             fgWasmIntervals->push_back(tryInterval);
+
+            // Pair the TRY with a same-range [exnref]-wrapper Block so
+            // `catch_ref TAG 0` from inside try_table has a valid target.
+            // The sort tiebreaker places the wrapper just outside the TRY.
+            //
+            WasmInterval* const wrapperInterval =
+                WasmInterval::NewExnRefWrapper(this, block, initialLayout[endCursor]);
+            fgWasmIntervals->push_back(wrapperInterval);
         }
 
         // Now see where block branches to...
@@ -1619,7 +1627,18 @@ PhaseStatus Compiler::fgWasmControlFlow()
             return i1->IsBlock();
         }
 
-        // Either both are blocks or both are trys.
+        // Order regular blocks before ExnRef-wrapper blocks so the wrapper
+        // sits immediately outside its paired TRY (depth 0 from catch_ref).
+        //
+        if (i1->IsBlock())
+        {
+            if (i1->IsExnRefWrapper() != i2->IsExnRefWrapper())
+            {
+                return i2->IsExnRefWrapper();
+            }
+        }
+
+        // Either both are (regular or wrapper) blocks, or both are trys.
         //
         return false;
     };

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -1367,8 +1367,7 @@ PhaseStatus Compiler::fgWasmControlFlow()
             // `catch_ref TAG 0` from inside try_table has a valid target.
             // The sort tiebreaker places the wrapper just outside the TRY.
             //
-            WasmInterval* const wrapperInterval =
-                WasmInterval::NewExnRefWrapper(this, block, initialLayout[endCursor]);
+            WasmInterval* const wrapperInterval = WasmInterval::NewExnRefWrapper(this, block, initialLayout[endCursor]);
             fgWasmIntervals->push_back(wrapperInterval);
         }
 

--- a/src/coreclr/jit/fgwasm.h
+++ b/src/coreclr/jit/fgwasm.h
@@ -143,6 +143,9 @@ private:
     // kind of interval
     Kind m_kind;
 
+    // True if this is an ExnRef-result wrapper paired with a TRY (Block-kind).
+    bool m_isExnRefWrapper;
+
 public:
 
     WasmInterval(unsigned start, unsigned end, Kind kind)
@@ -151,6 +154,7 @@ public:
         , m_end(end)
         , m_chainEnd(end)
         , m_kind(kind)
+        , m_isExnRefWrapper(false)
     {
         m_chain = this;
     }
@@ -205,6 +209,13 @@ public:
         return m_kind == Kind::Try;
     }
 
+    // True if this Block-kind interval is the [exnref]-result wrapper paired with a TRY.
+    //
+    bool IsExnRefWrapper() const
+    {
+        return m_isExnRefWrapper;
+    }
+
     void SetChain(WasmInterval* c)
     {
         m_chain       = c;
@@ -231,6 +242,16 @@ public:
             new (comp, CMK_WasmCfgLowering) WasmInterval(start->bbPreorderNum, end->bbPreorderNum, Kind::Try);
         return result;
     }
+
+    // Construct the [exnref]-result wrapper paired with a TRY.
+    //
+    static WasmInterval* NewExnRefWrapper(Compiler* comp, BasicBlock* start, BasicBlock* end)
+    {
+        WasmInterval* result =
+            new (comp, CMK_WasmCfgLowering) WasmInterval(start->bbPreorderNum, end->bbPreorderNum, Kind::Block);
+        result->m_isExnRefWrapper = true;
+        return result;
+    }
 #ifdef DEBUG
     void Dump(bool chainExtent = false)
     {
@@ -245,6 +266,10 @@ public:
             else if (m_kind == Kind::Try)
             {
                 printf("T");
+            }
+            else if (m_isExnRefWrapper)
+            {
+                printf("X");
             }
         }
 
@@ -264,7 +289,7 @@ public:
         switch (m_kind)
         {
             case Kind::Block:
-                return "Block";
+                return m_isExnRefWrapper ? "ExnRefWrapper" : "Block";
             case Kind::Loop:
                 return "Loop";
             case Kind::Try:

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3150,6 +3150,7 @@ PhaseStatus Compiler::fgCreateFunclets()
 #endif
 #ifdef TARGET_WASM
         funcInfo[i].funWasmLocalDecls = nullptr;
+        funcInfo[i].funWasmExnRefLocalIndex = UINT_MAX;
 #endif
     }
 #endif
@@ -7903,7 +7904,15 @@ FlowGraphTryRegions* FlowGraphTryRegions::Build(Compiler* comp, FlowGraphDfsTree
 
                         region->AddEntryEdge(edge);
                         region->SetHasSideEntry();
-                        regions->SetHasMultipleEntryTryRegions();
+
+                        // Only try/catch regions need to be reshaped into single-entry form for
+                        // Wasm codegen (they will be lowered to a wasm try_table). Try/fault and
+                        // try/finally are emitted differently and tolerate multi-entry.
+                        //
+                        if (dsc->HasCatchHandler())
+                        {
+                            regions->SetHasMultipleEntryTryRegions();
+                        }
                         continue;
                     }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3149,7 +3149,7 @@ PhaseStatus Compiler::fgCreateFunclets()
         funcInfo[i].funFramePointerReg = REG_NA;
 #endif
 #ifdef TARGET_WASM
-        funcInfo[i].funWasmLocalDecls = nullptr;
+        funcInfo[i].funWasmLocalDecls       = nullptr;
         funcInfo[i].funWasmExnRefLocalIndex = UINT_MAX;
 #endif
     }

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -1170,6 +1170,16 @@ void WasmRegAlloc::ResolveReferences()
                 decls->push_back({type, physRegs.DeclaredCount});
             }
         }
+
+        // Allocate the per-funclet exnref local used to relay caught exceptions
+        // from the catch_ref landing to any throw_ref rethrow site in this function.
+        //
+        if (m_compiler->lvaWasmResumeIP != BAD_VAR_NUM)
+        {
+            assert(funcInfo->funWasmExnRefLocalIndex == UINT_MAX);
+            funcInfo->funWasmExnRefLocalIndex = indexBase;
+            decls->push_back({WasmValueType::ExnRef, 1});
+        }
     }
 
     // Set all lcl var assignments to the main method's allocations.

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -1038,7 +1038,7 @@ namespace ILCompiler.ObjectWriter
         public const int RtlRestoreContextTagIndex = 0;
 
         private static readonly WasmFuncType RtlRestoreContextTagSignature = new(
-            new([WasmValueType.I32, WasmValueType.I32]),
+            new([]),
             new([]));
 
         private WasmImport[] CreateDefaultGlobalImports()

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -494,28 +494,24 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 
 size_t CallDescrWorkerInternalReturnAddressOffset = 0;
 
-// File-local WebAssembly exception tag used only by RtlRestoreContext.
+// File-local WebAssembly exception tag used only by RtlRestoreContext. Carries
+// no payload; the resume IP is communicated via the JIT-managed resumeIP local.
 asm(".globl __coreclr_wasm_rtlrestorecontext_tag\n"
-    ".tagtype __coreclr_wasm_rtlrestorecontext_tag i32, i32\n"
+    ".tagtype __coreclr_wasm_rtlrestorecontext_tag\n"
     "__coreclr_wasm_rtlrestorecontext_tag:\n");
 
-__attribute__((naked)) void ThrowRtlRestoreContextTag(uint32_t ip, uint32_t sp)
+__attribute__((naked)) void ThrowRtlRestoreContextTag()
 {
-    asm("local.get 0\n"
-        "local.get 1\n"
-        "throw __coreclr_wasm_rtlrestorecontext_tag\n"
+    asm("throw __coreclr_wasm_rtlrestorecontext_tag\n"
         "unreachable\n" ::);
 }
 
 VOID PALAPI RtlRestoreContext(IN PCONTEXT ContextRecord, IN PEXCEPTION_RECORD ExceptionRecord)
 {
+    UNREFERENCED_PARAMETER(ContextRecord);
     UNREFERENCED_PARAMETER(ExceptionRecord);
 
-    uint32_t ip = (uint32_t)GetIP(ContextRecord);
-    uint32_t sp = (uint32_t)GetSP(ContextRecord);
-
-    // Tag payload order: first ip, then sp.
-    ThrowRtlRestoreContextTag(ip, sp);
+    ThrowRtlRestoreContextTag();
 
     __builtin_unreachable();
 }


### PR DESCRIPTION
Pair each try_table with an exnref-typed wrapper block, using a per-funclet exnref local to carry the caught exception. Also simplify the RtlRestoreContext tag to ()->() and stop marking try-fault funclets as multi-entry.