### PR TITLE
Fix W3CPropagatorcompliance against W3C Trace Context Level 2

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -60,6 +60,12 @@ namespace System.Diagnostics
             {
                 traceId = null;
             }
+            else if (traceId!.Length > TraceParentCoreLength)
+            {
+                // For future versions, ignore unknown extension fields and keep the W3C core parent id that Activity can consume.
+                // https://www.w3.org/TR/trace-context-2/#versioning-of-traceparent
+                traceId = traceId.Substring(0, TraceParentCoreLength);
+            }
 
             getter(carrier, TraceState, out string? traceStateValue, out _);
             traceState = ValidateTraceState(traceStateValue);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -16,6 +16,7 @@ namespace System.Diagnostics
         private const int MaxBaggageEntriesToEmit = 64;     // Suggested by W3C specs
         private const int MaxBaggageEncodedLength = 8192;   // Suggested by W3C specs
         private const int MaxTraceStateEncodedLength = 256; // Suggested by W3C specs
+        private const int TraceParentCoreLength = 55;
 
         private const char Equal = '=';
         private const char Percent = '%';
@@ -542,7 +543,7 @@ namespace System.Diagnostics
         // Example 00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01
         private static bool IsInvalidTraceParent(string? traceParent)
         {
-            if (traceParent is null || traceParent.Length < 55)
+            if (traceParent is null || traceParent.Length < TraceParentCoreLength)
             {
                 return true;
             }
@@ -555,7 +556,7 @@ namespace System.Diagnostics
             if (traceParent[0] == '0' && traceParent[1] == '0')
             {
                 // version 00 should have exactly 55 characters
-                if (traceParent.Length != 55)
+                if (traceParent.Length != TraceParentCoreLength)
                 {
                     return true; // invalid length for version 00
                 }
@@ -567,7 +568,7 @@ namespace System.Diagnostics
                 //      o Parse trace-id (from the first dash through the next 32 characters). Vendors MUST check that the 32 characters are hex, and that they are followed by a dash (-).
                 //      o Parse parent-id (from the second dash at the 35th position through the next 16 characters). Vendors MUST check that the 16 characters are hex and followed by a dash.
                 //      o Parse the sampled bit of flags (2 characters from the third dash). Vendors MUST check that the 2 characters are either the end of the string or a dash.
-                if (traceParent.Length > 55 && traceParent[55] != '-')
+                if (traceParent.Length > TraceParentCoreLength && traceParent[TraceParentCoreLength] != '-')
                 {
                     return true; // invalid format for version other than 00
                 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -13,9 +13,9 @@ namespace System.Diagnostics
     {
         internal static DistributedContextPropagator Instance { get; } = new W3CPropagator();
 
-        private const int MaxBaggageEntriesToEmit = 64;     // Suggested by W3C specs
-        private const int MaxBaggageEncodedLength = 8192;   // Suggested by W3C specs
-        private const int MaxTraceStateEncodedLength = 512; // Suggested by W3C specs
+        private const int MaxBaggageEntriesToEmit = 64;
+        private const int MaxBaggageEncodedLength = 8192;
+        private const int MaxTraceStateEncodedLength = 512;
         private const int MaxTraceStateKeyLength = 256;
         private const int MaxTraceStateValueLength = 256;
         private const int MaxTraceStateEntries = 32;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -209,11 +209,6 @@ namespace System.Diagnostics
                 vsb.Append(Equal);
                 vsb.Append(value);
 
-                if (vsb.Length > MaxTraceStateEncodedLength)
-                {
-                    return null;
-                }
-
                 if (commaIndex < 0)
                 {
                     break;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -13,6 +13,7 @@ namespace System.Diagnostics
     {
         internal static DistributedContextPropagator Instance { get; } = new W3CPropagator();
 
+        // W3C Baggage propagation limits: https://www.w3.org/TR/baggage/#limits
         private const int MaxBaggageEntriesToEmit = 64;
         private const int MaxBaggageEncodedLength = 8192;
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -15,8 +15,9 @@ namespace System.Diagnostics
 
         private const int MaxBaggageEntriesToEmit = 64;     // Suggested by W3C specs
         private const int MaxBaggageEncodedLength = 8192;   // Suggested by W3C specs
-        private const int MaxTraceStateEncodedLength = 256; // Suggested by W3C specs
+        private const int MaxTraceStateEncodedLength = 512; // Suggested by W3C specs
         private const int MaxTraceStateValueLength = 256;
+        private const int MaxTraceStateEntries = 32;
         private const int TraceParentCoreLength = 55;
 
         private const char Equal = '=';
@@ -137,67 +138,73 @@ namespace System.Diagnostics
             return baggageList != null;
         }
 
-        // list  = list-member 0*31( OWS "," OWS list-member )
+        // https://www.w3.org/TR/trace-context-2/#tracestate-header
+        // list        = list-member 0*31( OWS "," OWS list-member )
         // list-member = (key "=" value) / OWS
-        //
-        // key = ( lcalpha / DIGIT ) 0*255 ( keychar )
-        // keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/" / "@"
-        // lcalpha    = %x61-7A ; a-z
-        // DIGIT     = %x30-39 ; 0-9
-        //
-        // value    = 0*255(chr) nblk-chr
-        // nblk-chr = %x21-2B / %x2D-3C / %x3E-7E
-        // chr      = %x20 / nblk-chr
-
+        // key         = ( lcalpha / DIGIT ) 0*255 ( keychar )
+        // keychar     = lcalpha / DIGIT / "_" / "-"/ "*" / "/" / "@"
+        // lcalpha     = %x61-7A ; a-z
+        // DIGIT       = %x30-39 ; 0-9
+        // value       = 0*255(chr) nblk-chr
+        // nblk-chr    = %x21-2B / %x2D-3C / %x3E-7E
+        // chr         = %x20 / nblk-chr
         internal static string? ValidateTraceState(string? traceState)
         {
             if (string.IsNullOrEmpty(traceState))
             {
-                return null; // invalid format
+                return null;
             }
 
-            int processed = 0;
+            int entries = 0;
+            using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[256]);
 
-            while (processed < traceState.Length)
+            ReadOnlySpan<char> traceStateSpan = traceState;
+            do
             {
-                ReadOnlySpan<char> traceStateSpan = traceState.AsSpan(processed);
                 int commaIndex = traceStateSpan.IndexOf(Comma);
                 ReadOnlySpan<char> entry = commaIndex >= 0 ? traceStateSpan.Slice(0, commaIndex) : traceStateSpan;
-                int delta = entry.Length + (commaIndex >= 0 ? 1 : 0); // +1 for the comma
+                traceStateSpan = commaIndex >= 0 ? traceStateSpan.Slice(commaIndex + 1) : ReadOnlySpan<char>.Empty;
 
-                if (processed + delta > MaxTraceStateEncodedLength)
+                entry = Trim(entry);
+                if (entry.IsEmpty)
                 {
-                    break; // entry exceeds max length
+                    continue;
+                }
+
+                if (++entries > MaxTraceStateEntries)
+                {
+                    return null;
                 }
 
                 int equalIndex = entry.IndexOf(Equal);
                 if (equalIndex <= 0 || equalIndex >= entry.Length - 1)
                 {
-                    break; // invalid format
+                    return null;
                 }
 
-                if (IsInvalidTraceStateKey(Trim(entry.Slice(0, equalIndex))) || IsInvalidTraceStateValue(TrimSpaceOnly(entry.Slice(equalIndex + 1))))
+                ReadOnlySpan<char> key = entry.Slice(0, equalIndex);
+                ReadOnlySpan<char> value = entry.Slice(equalIndex + 1);
+                if (IsInvalidTraceStateKey(key) || IsInvalidTraceStateValue(value))
                 {
-                    break; // entry exceeds max length or invalid key/value, skip the whole trace state entries.
+                    return null;
                 }
 
-                processed += delta;
-            }
-
-            if (processed > 0)
-            {
-                if (traceState[processed - 1] == Comma)
+                if (vsb.Length > 0)
                 {
-                    processed--; // remove the last comma
+                    vsb.Append(Comma);
                 }
 
-                if (processed > 0)
+                vsb.Append(key);
+                vsb.Append(Equal);
+                vsb.Append(value);
+
+                if (vsb.Length > MaxTraceStateEncodedLength)
                 {
-                    return processed >= traceState.Length ? traceState : traceState.AsSpan(0, processed).ToString();
+                    return null;
                 }
-            }
+            } while (traceStateSpan.Length > 0);
 
-            return null;
+            return vsb.Length > 0 ? vsb.ToString() : null;
         }
 
         internal static void InjectTraceState(string traceState, object? carrier, PropagatorSetterCallback setter)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -165,7 +165,7 @@ namespace System.Diagnostics
             using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[MaxTraceStateEncodedLength]);
 
             ReadOnlySpan<char> traceStateSpan = traceState;
-            do
+            while (true)
             {
                 int commaIndex = traceStateSpan.IndexOf(Comma);
                 ReadOnlySpan<char> entry = commaIndex >= 0 ? traceStateSpan.Slice(0, commaIndex) : traceStateSpan;
@@ -179,6 +179,11 @@ namespace System.Diagnostics
                 entry = Trim(entry);
                 if (entry.IsEmpty)
                 {
+                    if (commaIndex < 0)
+                    {
+                        break;
+                    }
+
                     continue;
                 }
 
@@ -208,7 +213,12 @@ namespace System.Diagnostics
                 {
                     return null;
                 }
-            } while (traceStateSpan.Length > 0);
+
+                if (commaIndex < 0)
+                {
+                    break;
+                }
+            }
 
             return vsb.Length > 0 ? vsb.ToString() : null;
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -156,6 +156,11 @@ namespace System.Diagnostics
                 return null;
             }
 
+            if (traceState.Length > MaxTraceStateEncodedLength)
+            {
+                return null;
+            }
+
             int entries = 0;
             using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[256]);
 
@@ -166,15 +171,15 @@ namespace System.Diagnostics
                 ReadOnlySpan<char> entry = commaIndex >= 0 ? traceStateSpan.Slice(0, commaIndex) : traceStateSpan;
                 traceStateSpan = commaIndex >= 0 ? traceStateSpan.Slice(commaIndex + 1) : ReadOnlySpan<char>.Empty;
 
+                if (++entries > MaxTraceStateEntries)
+                {
+                    return null;
+                }
+
                 entry = Trim(entry);
                 if (entry.IsEmpty)
                 {
                     continue;
-                }
-
-                if (++entries > MaxTraceStateEntries)
-                {
-                    return null;
                 }
 
                 int equalIndex = entry.IndexOf(Equal);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -162,7 +162,7 @@ namespace System.Diagnostics
             }
 
             int entries = 0;
-            using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[MaxTraceStateEncodedLength]);
+            using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[traceState.Length]);
 
             ReadOnlySpan<char> traceStateSpan = traceState;
             while (true)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -16,6 +16,7 @@ namespace System.Diagnostics
         private const int MaxBaggageEntriesToEmit = 64;     // Suggested by W3C specs
         private const int MaxBaggageEncodedLength = 8192;   // Suggested by W3C specs
         private const int MaxTraceStateEncodedLength = 512; // Suggested by W3C specs
+        private const int MaxTraceStateKeyLength = 256;
         private const int MaxTraceStateValueLength = 256;
         private const int MaxTraceStateEntries = 32;
         private const int TraceParentCoreLength = 55;
@@ -436,6 +437,7 @@ namespace System.Diagnostics
         // Key has to start with a lowercase letter or digit
         private static bool IsInvalidTraceStateKey(ReadOnlySpan<char> key) =>
             key.IsEmpty ||
+            key.Length > MaxTraceStateKeyLength ||
             ((uint)('z' - key[0]) > (uint)('z' - 'a') && (uint)('9' - key[0]) > (uint)('9' - '0')) ||
             key.ContainsAnyExcept(s_validTraceStateKeyChars);
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -59,8 +59,11 @@ namespace System.Diagnostics
             if (IsInvalidTraceParent(traceId))
             {
                 traceId = null;
+                traceState = null;
+                return;
             }
-            else if (traceId!.Length > TraceParentCoreLength)
+
+            if (traceId!.Length > TraceParentCoreLength)
             {
                 // For future versions, ignore unknown extension fields and keep the W3C core parent id that Activity can consume.
                 // https://www.w3.org/TR/trace-context-2/#versioning-of-traceparent

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -16,6 +16,7 @@ namespace System.Diagnostics
         private const int MaxBaggageEntriesToEmit = 64;     // Suggested by W3C specs
         private const int MaxBaggageEncodedLength = 8192;   // Suggested by W3C specs
         private const int MaxTraceStateEncodedLength = 256; // Suggested by W3C specs
+        private const int MaxTraceStateValueLength = 256;
         private const int TraceParentCoreLength = 55;
 
         private const char Equal = '=';
@@ -431,12 +432,15 @@ namespace System.Diagnostics
             ((uint)('z' - key[0]) > (uint)('z' - 'a') && (uint)('9' - key[0]) > (uint)('9' - '0')) ||
             key.ContainsAnyExcept(s_validTraceStateKeyChars);
 
-        // value    = 0 * 255(chr) nblk-chr
-        // nblk-chr = % x21 - 2B / % x2D - 3C / % x3E - 7E
-        // chr      = % x20 / nblk-chr
-        private static readonly SearchValues<char> s_validTraceStateValueChars = SearchValues.Create("!\"#$%&'()*+-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~");
+        // https://www.w3.org/TR/trace-context-2/#value
+        // value    = 0*255(chr) nblk-chr
+        // nblk-chr = %x21-2B / %x2D-3C / %x3E-7E
+        // chr      = %x20 / nblk-chr
+        private static readonly SearchValues<char> s_validTraceStateValueChars = SearchValues.Create(" !\"#$%&'()*+-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~");
 
-        private static bool IsInvalidTraceStateValue(ReadOnlySpan<char> value) => value.IsEmpty || value.ContainsAnyExcept(s_validTraceStateValueChars);
+        private static bool IsInvalidTraceStateValue(ReadOnlySpan<char> value) =>
+            value.IsEmpty || value.Length > MaxTraceStateValueLength || value[value.Length - 1] == Space ||
+            value.ContainsAnyExcept(s_validTraceStateValueChars);
 
         // baggage-string =  list-member 0*179( OWS "," OWS list-member )
         // list-member    =  key OWS "=" OWS value *( OWS ";" OWS property )

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -15,6 +15,8 @@ namespace System.Diagnostics
 
         private const int MaxBaggageEntriesToEmit = 64;
         private const int MaxBaggageEncodedLength = 8192;
+
+        // W3C Trace Context tracestate limits: https://www.w3.org/TR/trace-context-2/#tracestate-limits
         private const int MaxTraceStateEncodedLength = 512;
         private const int MaxTraceStateKeyLength = 256;
         private const int MaxTraceStateValueLength = 256;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -158,13 +158,8 @@ namespace System.Diagnostics
                 return null;
             }
 
-            if (traceState.Length > MaxTraceStateEncodedLength)
-            {
-                return null;
-            }
-
             int entries = 0;
-            using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[traceState.Length]);
+            using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[Math.Min(traceState.Length, MaxTraceStateEncodedLength)]);
 
             ReadOnlySpan<char> traceStateSpan = traceState;
             while (true)
@@ -175,7 +170,7 @@ namespace System.Diagnostics
 
                 if (++entries > MaxTraceStateEntries)
                 {
-                    return null;
+                    break;
                 }
 
                 entry = Trim(entry);
@@ -200,6 +195,12 @@ namespace System.Diagnostics
                 if (IsInvalidTraceStateKey(key) || IsInvalidTraceStateValue(value))
                 {
                     return null;
+                }
+
+                int nextLength = vsb.Length + entry.Length + (vsb.Length > 0 ? 1 : 0);
+                if (nextLength > MaxTraceStateEncodedLength)
+                {
+                    break;
                 }
 
                 if (vsb.Length > 0)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -162,7 +162,7 @@ namespace System.Diagnostics
             }
 
             int entries = 0;
-            using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[256]);
+            using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[MaxTraceStateEncodedLength]);
 
             ReadOnlySpan<char> traceStateSpan = traceState;
             do

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -42,6 +42,14 @@ namespace System.Diagnostics.Tests
             // valid trace state, the key can have digits https://www.w3.org/TR/trace-context-2/#key
             yield return new object[] { "123@456=1", "123@456=1", null, null, null }; // trace state key has to start with lowercase or digit
 
+            // valid trace state, the key can contain at signs after the first character
+            yield return new object[] { "foo@=1", "foo@=1", null, null, null };
+            yield return new object[] { "foo@@bar=1", "foo@@bar=1", null, null, null };
+            yield return new object[] { "foo@bar@baz=1", "foo@bar@baz=1", null, null, null };
+
+            // invalid trace state, the key cannot start with an at sign
+            yield return new object[] { "@vendor=1", null, null, null, null };
+
             // Tabs are only allowed as optional whitespace around list members. The whole trace state is discarded when a member is invalid.
             yield return new object[] { "start=1, end=\t1", null, null, null, null };
 
@@ -51,11 +59,11 @@ namespace System.Diagnostics.Tests
             // Optional whitespace around trace state list members
             yield return new object[] { " start=1 \t, \tend=1 ", "start=1,end=1", null, null, null };
 
-            // trace state longer than the max combined length limit
-            yield return new object[] { $"a={new string('a', 255)},b={new string('b', 255)}", null, null, null, null }; // trace state length max is 512
+            // trace state key longer than the max limit
+            yield return new object[] { $"{new string('a', 257)}=1", null, null, null, null }; // trace state key length max is 256
 
-            // trace state equal the max combined length limit
-            yield return new object[] { $"a={new string('a', 254)},b={new string('b', 253)}", $"a={new string('a', 254)},b={new string('b', 253)}", null, null, null }; // trace state length max is 512
+            // trace state equal the max
+            yield return new object[] { $"{new string('a', 256)}=1", $"{new string('a', 256)}=1", null, null, null }; // trace state key length max is 256
 
             // Invalid baggage key.
             yield return new object[] { null, null, new[]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -63,6 +63,15 @@ namespace System.Diagnostics.Tests
             yield return new object[] { $"{new string(' ', 252)}state=1{new string(' ', 253)}", "state=1", null, null, null };
             yield return new object[] { $"{new string(' ', 253)}state=1{new string(' ', 253)}", null, null, null, null };
 
+            // Trace state raw length is limited to 512 characters.
+            yield return new object[] { $"{new string('a', 256)}={new string('b', 255)}", $"{new string('a', 256)}={new string('b', 255)}", null, null, null };
+            yield return new object[] { $"{new string('a', 256)}={new string('b', 256)}", null, null, null, null };
+
+            string traceStateWith32Members = string.Join(",", Enumerable.Range(0, 32).Select(i => $"k{i}=v"));
+            string traceStateWith33Members = string.Join(",", Enumerable.Range(0, 33).Select(i => $"k{i}=v"));
+            yield return new object[] { traceStateWith32Members, traceStateWith32Members, null, null, null };
+            yield return new object[] { traceStateWith33Members, null, null, null, null };
+
             // Empty and whitespace-only trace state list members are allowed, but they count toward the list-member limit.
             yield return new object[] { $"{string.Join(",", Enumerable.Repeat(" ", 31))},state=1", "state=1", null, null, null };
             yield return new object[] { $"{string.Join(",", Enumerable.Repeat(" ", 32))},state=1", null, null, null, null };

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -75,6 +75,11 @@ namespace System.Diagnostics.Tests
             // Empty and whitespace-only trace state list members are allowed, but they count toward the list-member limit.
             yield return new object[] { $"{string.Join(",", Enumerable.Repeat(" ", 31))},state=1", "state=1", null, null, null };
             yield return new object[] { $"{string.Join(",", Enumerable.Repeat(" ", 32))},state=1", null, null, null, null };
+            yield return new object[] { "state=1,", "state=1", null, null, null };
+
+            string traceStateWith31Members = string.Join(",", Enumerable.Range(0, 31).Select(i => $"k{i}=v"));
+            yield return new object[] { $"{traceStateWith31Members},", traceStateWith31Members, null, null, null };
+            yield return new object[] { $"{traceStateWith32Members},", null, null, null, null };
 
             // trace state key longer than the max limit
             yield return new object[] { $"{new string('a', 257)}=1", null, null, null, null }; // trace state key length max is 256

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -401,6 +401,23 @@ namespace System.Diagnostics.Tests
             Assert.Equal(isValid, traceId is not null);
         }
 
+        [Fact]
+        public void ValidateTraceIdAndStateExtractionTrimsFutureVersionTraceParentExtensions()
+        {
+            s_w3cPropagator.ExtractTraceIdAndState(null, (object carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
+            {
+                fieldValues = null;
+                fieldValue = null;
+
+                if (fieldName == PropagatorTests.TraceParent)
+                {
+                    fieldValue = "cc-12345678901234567890123456789012-1234567890123456-01-what-the-future-will-be-like";
+                }
+            }, out string? traceId, out _);
+
+            Assert.Equal("cc-12345678901234567890123456789012-1234567890123456-01", traceId);
+        }
+
         private static string? EncodeBaggage(IEnumerable<KeyValuePair<string, string>> baggageEntries)
         {
             Activity? current = Activity.Current;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -59,18 +59,20 @@ namespace System.Diagnostics.Tests
             // Optional whitespace around trace state list members
             yield return new object[] { " start=1 \t, \tend=1 ", "start=1,end=1", null, null, null };
 
-            // Trace state raw length includes optional whitespace, even when the propagated value is normalized.
+            // Trace state optional whitespace is not propagated.
             yield return new object[] { $"{new string(' ', 252)}state=1{new string(' ', 253)}", "state=1", null, null, null };
-            yield return new object[] { $"{new string(' ', 253)}state=1{new string(' ', 253)}", null, null, null, null };
+            yield return new object[] { $"{new string(' ', 253)}state=1{new string(' ', 253)}", "state=1", null, null, null };
 
-            // Trace state raw length is limited to 512 characters.
-            yield return new object[] { $"{new string('a', 256)}={new string('b', 255)}", $"{new string('a', 256)}={new string('b', 255)}", null, null, null };
+            // Trace state propagation is limited to 512 characters and truncates whole entries from the end.
+            string traceStateWith512Chars = $"{new string('a', 256)}={new string('b', 255)}";
+            yield return new object[] { traceStateWith512Chars, traceStateWith512Chars, null, null, null };
+            yield return new object[] { $"{traceStateWith512Chars},c=d", traceStateWith512Chars, null, null, null };
             yield return new object[] { $"{new string('a', 256)}={new string('b', 256)}", null, null, null, null };
 
             string traceStateWith32Members = string.Join(",", Enumerable.Range(0, 32).Select(i => $"k{i}=v"));
             string traceStateWith33Members = string.Join(",", Enumerable.Range(0, 33).Select(i => $"k{i}=v"));
             yield return new object[] { traceStateWith32Members, traceStateWith32Members, null, null, null };
-            yield return new object[] { traceStateWith33Members, null, null, null, null };
+            yield return new object[] { traceStateWith33Members, traceStateWith32Members, null, null, null };
 
             // Empty and whitespace-only trace state list members are allowed, but they count toward the list-member limit.
             yield return new object[] { $"{string.Join(",", Enumerable.Repeat(" ", 31))},state=1", "state=1", null, null, null };
@@ -79,7 +81,7 @@ namespace System.Diagnostics.Tests
 
             string traceStateWith31Members = string.Join(",", Enumerable.Range(0, 31).Select(i => $"k{i}=v"));
             yield return new object[] { $"{traceStateWith31Members},", traceStateWith31Members, null, null, null };
-            yield return new object[] { $"{traceStateWith32Members},", null, null, null, null };
+            yield return new object[] { $"{traceStateWith32Members},", traceStateWith32Members, null, null, null };
 
             // trace state key longer than the max limit
             yield return new object[] { $"{new string('a', 257)}=1", null, null, null, null }; // trace state key length max is 256

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -483,6 +483,23 @@ namespace System.Diagnostics.Tests
             Assert.Equal("cc-12345678901234567890123456789012-1234567890123456-01", traceId);
         }
 
+        [Fact]
+        public void ValidateTraceIdAndStateExtractionRejectsFutureVersionTraceParentWithInvalidExtensionSeparator()
+        {
+            s_w3cPropagator.ExtractTraceIdAndState(null, (object carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
+            {
+                fieldValues = null;
+                fieldValue = null;
+
+                if (fieldName == PropagatorTests.TraceParent)
+                {
+                    fieldValue = "cc-12345678901234567890123456789012-1234567890123456-01.what-the-future-will-be-like";
+                }
+            }, out string? traceId, out string? traceState);
+
+            Assert.Null(traceId);
+        }
+
         private static string? EncodeBaggage(IEnumerable<KeyValuePair<string, string>> baggageEntries)
         {
             Activity? current = Activity.Current;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -42,17 +42,20 @@ namespace System.Diagnostics.Tests
             // valid trace state, the key can have digits https://www.w3.org/TR/trace-context-2/#key
             yield return new object[] { "123@456=1", "123@456=1", null, null, null }; // trace state key has to start with lowercase or digit
 
-            // Tabs is not allowed in trace state values. use only the valid entry
-            yield return new object[] { "start=1, end=\t1", "start=1", null, null, null }; // trace state key has to start with lowercase or digit
+            // Tabs are only allowed as optional whitespace around list members. The whole trace state is discarded when a member is invalid.
+            yield return new object[] { "start=1, end=\t1", null, null, null, null };
 
             // multiple trace states
-            yield return new object[] { "start=1, end=1", "start=1, end=1", null, null, null }; // trace state key has to start with lowercase or digit
+            yield return new object[] { "start=1, end=1", "start=1,end=1", null, null, null }; // trace state key has to start with lowercase or digit
 
-            // trace state longer than the max limit
-            yield return new object[] { $"{new string('a', 255)}=1", null, null, null, null }; // trace state length max is 256
+            // Optional whitespace around trace state list members
+            yield return new object[] { " start=1 \t, \tend=1 ", "start=1,end=1", null, null, null };
 
-            // trace state equal the max
-            yield return new object[] { $"{new string('a', 254)}=1", $"{new string('a', 254)}=1", null, null, null }; // trace state length max is 256
+            // trace state longer than the max combined length limit
+            yield return new object[] { $"a={new string('a', 255)},b={new string('b', 255)}", null, null, null, null }; // trace state length max is 512
+
+            // trace state equal the max combined length limit
+            yield return new object[] { $"a={new string('a', 254)},b={new string('b', 253)}", $"a={new string('a', 254)},b={new string('b', 253)}", null, null, null }; // trace state length max is 512
 
             // Invalid baggage key.
             yield return new object[] { null, null, new[]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -30,6 +30,9 @@ namespace System.Diagnostics.Tests
             // Simple case
             yield return new object[] { "state=1", "state=1", new[] { new KeyValuePair<string, string>("b1", "v1") }, "b1 = v1", new[] { new KeyValuePair<string, string>("b1", "v1") } };
 
+            // Trace state value can contain spaces.
+            yield return new object[] { "state=a b", "state=a b", null, null, null };
+
             // Invalid trace state
             yield return new object[] { "PassThroughW3CState=1", null, null, null, null }; // trace state key has to be lowercase or digit
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -54,7 +54,7 @@ namespace System.Diagnostics.Tests
             yield return new object[] { "start=1, end=\t1", null, null, null, null };
 
             // multiple trace states
-            yield return new object[] { "start=1, end=1", "start=1,end=1", null, null, null }; // trace state key has to start with lowercase or digit
+            yield return new object[] { "start=1, end=1", "start=1,end=1", null, null, null };
 
             // Optional whitespace around trace state list members
             yield return new object[] { " start=1 \t, \tend=1 ", "start=1,end=1", null, null, null };

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -401,6 +401,33 @@ namespace System.Diagnostics.Tests
             Assert.Equal(isValid, traceId is not null);
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("00-00000000000000000000000000000000-b9c7c989f97918e1-01")]
+        public void ValidateTraceIdAndStateExtractionDiscardsTraceStateWithInvalidTraceParent(string? traceParent)
+        {
+            s_w3cPropagator.ExtractTraceIdAndState(null, (object carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
+            {
+                fieldValues = null;
+                fieldValue = null;
+
+                if (fieldName == PropagatorTests.TraceParent)
+                {
+                    fieldValue = traceParent;
+                    return;
+                }
+
+                if (fieldName == PropagatorTests.TraceState)
+                {
+                    fieldValue = "foo=1";
+                    return;
+                }
+            }, out string? traceId, out string? traceState);
+
+            Assert.Null(traceId);
+            Assert.Null(traceState);
+        }
+
         [Fact]
         public void ValidateTraceIdAndStateExtractionTrimsFutureVersionTraceParentExtensions()
         {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -59,6 +59,14 @@ namespace System.Diagnostics.Tests
             // Optional whitespace around trace state list members
             yield return new object[] { " start=1 \t, \tend=1 ", "start=1,end=1", null, null, null };
 
+            // Trace state raw length includes optional whitespace, even when the propagated value is normalized.
+            yield return new object[] { $"{new string(' ', 252)}state=1{new string(' ', 253)}", "state=1", null, null, null };
+            yield return new object[] { $"{new string(' ', 253)}state=1{new string(' ', 253)}", null, null, null, null };
+
+            // Empty and whitespace-only trace state list members are allowed, but they count toward the list-member limit.
+            yield return new object[] { $"{string.Join(",", Enumerable.Repeat(" ", 31))},state=1", "state=1", null, null, null };
+            yield return new object[] { $"{string.Join(",", Enumerable.Repeat(" ", 32))},state=1", null, null, null, null };
+
             // trace state key longer than the max limit
             yield return new object[] { $"{new string('a', 257)}=1", null, null, null, null }; // trace state key length max is 256
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -495,7 +495,7 @@ namespace System.Diagnostics.Tests
                 {
                     fieldValue = "cc-12345678901234567890123456789012-1234567890123456-01.what-the-future-will-be-like";
                 }
-            }, out string? traceId, out string? traceState);
+            }, out string? traceId, out string? _);
 
             Assert.Null(traceId);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/129413

Does not bring strange behavior for key names described under https://github.com/w3c/trace-context/pull/583. Technically it is not fully compliant with the officail tests suite, but also it does not bring any regression in this topic.
I hope it will be addressed under W3C, if not, we can make a follow ups.

If needed, I can add the full python suite here based on https://github.com/Kielek/runtime/commit/9f88d19ffa843faf7a29c258ac2b77795f88bea9, but I think that existing C# coverage is more than enough.

I have tried to made the commit granular, it might be easier to review it once by one, instead of all at once.