### PR TITLE
Handle conflicting assertions in GetRangeFromAssertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2314,12 +2314,24 @@ void Compiler::optMapComplementary(AssertionIndex assertionIndex, AssertionIndex
     optComplementaryAssertionMap[index]          = assertionIndex;
 }
 
-/*****************************************************************************
- *
- *  Given an assertion index, return the assertion index of the complementary
- *  assertion or 0 if one does not exist.
- */
-AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex)
+//------------------------------------------------------------------------
+// optFindComplementary: Find the assertion that is the logical negation of the given assertion.
+//
+// Arguments:
+//    assertIndex - the assertion to find the complementary of
+//    allowScan   - when false, only the cached complementary map is consulted (an O(1) lookup) and
+//                  the O(n) fallback scan over the assertion table is skipped
+//
+// Return Value:
+//    The index of the complementary assertion (e.g. "X != c" for "X == c"), or NO_ASSERTION_INDEX
+//    if none exists (or none is cached, when allowScan is false).
+//
+// Notes:
+//    Passing allowScan = false suits throughput-sensitive callers that only care about complements
+//    registered up front (e.g. the two assertions created for the two edges of a JTRUE). Returning
+//    NO_ASSERTION_INDEX early is always safe for such callers.
+//
+AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex, bool allowScan)
 {
     if (assertIndex == NO_ASSERTION_INDEX)
     {
@@ -2337,6 +2349,11 @@ AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex)
     if (index != NO_ASSERTION_INDEX && index <= optAssertionCount)
     {
         return index;
+    }
+
+    if (!allowScan)
+    {
+        return NO_ASSERTION_INDEX;
     }
 
     for (AssertionIndex index = 1; index <= optAssertionCount; ++index)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9098,7 +9098,7 @@ public:
     AssertionInfo  optCreateJTrueBoundsAssertion(GenTree* tree);
     AssertionInfo  optAssertionGenJtrue(GenTree* tree);
     AssertionIndex optCreateJtrueAssertions(GenTree* op1, GenTree* op2, bool equals);
-    AssertionIndex optFindComplementary(AssertionIndex assertionIndex);
+    AssertionIndex optFindComplementary(AssertionIndex assertionIndex, bool allowScan = true);
     void           optMapComplementary(AssertionIndex assertionIndex, AssertionIndex index);
 
     ValueNum optConservativeNormalVN(const GenTree* tree);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -938,7 +938,31 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
     }
 
     Range phiRange = Range(Limit(Limit::keUndef));
-    auto  visitor  = [comp, vnType, &phiRange, &budget, visited](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
+    auto  visitor  = [comp, vnType, &phiRange, &budget, visited, assertions](ValueNum  reachingVN,
+                                                                           ASSERT_TP reachingAssertions) {
+        // If this phi-predecessor edge asserts the negation of something known at the use site
+        // (i.e. its edge assertions contain the complementary of a use-site assertion), control
+        // cannot reach the use from this edge, so its value can't be the phi's value here. Skip it
+        // instead of widening the merged range. This narrows a phi whose definitions are correlated
+        // with a condition that is re-tested at the use site, e.g. "if (c) a = X; else a = Y; ...
+        // if (c) use(a);".
+        if (!BitVecOps::MayBeUninit(assertions) && !BitVecOps::MayBeUninit(reachingAssertions) &&
+            !BitVecOps::IsEmpty(comp->apTraits, reachingAssertions))
+        {
+            BitVecOps::Iter useIter(comp->apTraits, assertions);
+            unsigned        useIndex = 0;
+            while (useIter.NextElem(&useIndex))
+            {
+                const AssertionIndex complementary = comp->optFindComplementary(GetAssertionIndex(useIndex),
+                                                                                  /* allowScan */ false);
+                if ((complementary != NO_ASSERTION_INDEX) &&
+                    BitVecOps::IsMember(comp->apTraits, reachingAssertions, complementary - 1))
+                {
+                    return Compiler::AssertVisit::Continue;
+                }
+            }
+        }
+
         // call GetRangeFromAssertionsWorker for each reaching VN using reachingAssertions
         Range edgeRange = GetRangeFromType(vnType);
 


### PR DESCRIPTION
If a phi-predecessor edge asserts the negation of something known at the use site (i.e. its edge assertions contain the complementary of a use-site assertion), control cannot reach the use from this edge, so its value can't be the phi's value here. Skip it instead of widening the merged range.

Example:

```cs
 int handler;
 if (cmd == Open)       handler = 1;
 else if (cmd == Close) handler = 2;
 else if (alt == Retry) handler = 3;
 else                   handler = 0;        // fallback
 ...
 if (alt == Retry) 
     return handler == 0 ? Fallback() : Run(handler);  // handler is always 3 when alt == Retry
```
