### PR TITLE
Fix undefined behavior in key_from_id() 

### DIFF
--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -208,7 +208,7 @@ mono_bundled_resources_add (MonoBundledResource **resources_to_bundle, uint32_t 
 static MonoBundledResource *
 bundled_resources_get (const char *id)
 {
-	if (!bundled_resources)
+	if (!bundled_resources || !id)
 		return NULL;
 
 	char key_buffer[1024];

--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -79,7 +79,7 @@ static char *
 key_from_id (const char *id, char *buffer, guint buffer_len)
 {
 	size_t id_length = 0;
-	size_t extension_offset = -1;
+	ssize_t extension_offset = -1;
 	const char *extension = NULL;
 
 	if (id){

--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -75,6 +75,16 @@ bundled_resources_is_known_assembly_extension (const char *ext)
 
 // If a bundled resource has a known assembly extension, we strip the extension from its name
 // This ensures that lookups for foo.dll will work even if the assembly is in a webcil container
+//
+// Arguments:
+//  * id - Name of the resource, not NULL, null-terminated byte string.
+//  * buffer - Data to be written at given target address.
+//  * buffer_len - Length of buffer.
+//
+// Returns:
+// static char * - Pointer to the stripped name of the resource.
+//
+
 static char *
 key_from_id (const char *id, char *buffer, guint buffer_len)
 {
@@ -82,12 +92,12 @@ key_from_id (const char *id, char *buffer, guint buffer_len)
 	ssize_t extension_offset = -1;
 	const char *extension = NULL;
 
-	if (id){
-		id_length = strlen (id);
-		extension = g_memrchr (id, '.', id_length);
-		if (extension)
-			extension_offset = extension - id;
-	}
+	g_assert (id);
+	id_length = strlen (id);
+	extension = g_memrchr (id, '.', id_length);
+	if (extension)
+		extension_offset = extension - id;
+
 	if (!buffer) {
 		// Add space for .dll and null terminator
 		buffer_len = (guint)(id_length + 6);


### PR DESCRIPTION
`key_from_id()` checks for a resource extension but has errors when handling names without extension or when receiving `NULL` instead of string.  

The declaration `size_t extension_offset = -1; ` is incorrect, because size_t is an unsigned type. As a result, `extension_offset >= 0` is always true. This may leads to:
- null pointer deference in `bundled_resources_is_known_assembly_extension (extension)`;
- integer overflow and incorrect results in the expression `extension_offset + 2`.

Additionally, `g_strlcpy` requires a non-null string source string, so `id == NULL` causes UB in `g_strlcpy(buffer, id, ...)`.

There are two ways to call `key_from_id`: in `mono_bundled_resources_add()`, which includes a check via `g_assert (resource_to_bundle->id);` and in `bundled_resources_get()`, which does not perform any checks on the id parameter.

To fix described problems change type of `extension_offset` from `size_t` to  `ssize_t` to properly handle `-1` initial value. This ensures `extension_offset >= 0` accurately reflects whether a file extension was found, avoiding buffer overflow risk. Enforce `id != NULL` via assert in `key_from_id` and add explicit `id != NULL` check in `bundled_resources_get`.

Signed-off-by: Aleksandr Dovydenkov <asd@altlinux.org>
Found by Linux Verification Center (linuxtesting.org) with SVACE.