### PR TITLE
JIT: mark R2R direct-call target loads as non-faulting

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6324,7 +6324,8 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
 #ifdef DEBUG
                 cellAddr->AsIntCon()->SetTargetHandle((size_t)call->gtCallMethHnd);
 #endif
-                GenTree* indir = Ind(cellAddr);
+                // The cell holds a function pointer that is never null.
+                GenTree* indir = m_compiler->gtNewIndir(TYP_I_IMPL, cellAddr, GTF_IND_NONFAULTING);
                 result         = indir;
             }
             break;

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -105,7 +105,8 @@ void Lowering::LowerPEPCall(GenTreeCall* call)
 
     BlockRange().Remove(controlExpr);
     BlockRange().InsertBefore(call, controlExpr);
-    GenTree* target = Ind(controlExpr);
+    // The PEP local holds a function pointer that is never null.
+    GenTree* target = m_compiler->gtNewIndir(TYP_I_IMPL, controlExpr, GTF_IND_NONFAULTING);
     BlockRange().InsertBefore(call, target);
 
     call->gtControlExpr = target;


### PR DESCRIPTION
The two indirections introduced by LowerDirectCall (IAT_PVALUE) and LowerPEPCall load function pointers from R2R fixup slots / PEP locals that are guaranteed never null.