### PR TITLE
Reject SAFEARRAY to IntPtr[] marshalling with mismatched native element size

### DIFF
--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -2062,6 +2062,17 @@ MethodDesc* GetInstantiatedSafeArrayMethod(BinderMethodID methodId, VARTYPE vt, 
     TypeHandle thElementType = GetElementTypeForSafeArrayVarType(vt, pElementMT);
     TypeHandle thMarshalerType(GetMarshalerMTForSafeArrayVarType(vt, pElementMT, bHeterogeneous, bNativeDataValid));
 
+    // When the managed element type is IntPtr/UIntPtr, the blittable array marshaler copies
+    // sizeof(IntPtr) bytes per element with a bulk memmove. The native SAFEARRAY element size
+    // (e.g. 4 bytes for VT_I4/VT_INT/VT_UI4/VT_UINT) can differ from the pointer size (e.g. 8 bytes
+    // on a 64-bit process), in which case the copy length would not match the native element size.
+    // Reject the mismatch as a type mismatch instead of performing a mismatched copy.
+    if ((thElementType == TypeHandle(CoreLibBinder::GetClass(CLASS__INTPTR)) || thElementType == TypeHandle(CoreLibBinder::GetClass(CLASS__UINTPTR)))
+        && sizeof(void*) != OleVariant::GetElementSizeForVarType(vt, pElementMT))
+    {
+        COMPlusThrow(kSafeArrayTypeMismatchException);
+    }
+
     TypeHandle thArgs[2] = { thElementType, thMarshalerType };
 
     return MethodDesc::FindOrCreateAssociatedMethodDesc(

--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -1986,6 +1986,20 @@ namespace
         }
     }
 
+    // Returns the IntPtr/UIntPtr element TypeHandle for a pointer-sized SAFEARRAY element, rejecting
+    // the case where the managed pointer size does not match the native SAFEARRAY element size. The
+    // blittable array marshaler copies sizeof(void*) bytes per element, so an 8-byte IntPtr does
+    // not match a 4-byte VT_I4/VT_INT/VT_UI4/VT_UINT element on a 64-bit process.
+    TypeHandle GetPointerSizedElementTypeForSafeArrayVarType(VARTYPE vt, MethodTable* pPointerMT)
+    {
+        STANDARD_VM_CONTRACT;
+
+        if (sizeof(void*) != OleVariant::GetElementSizeForVarType(vt, NULL))
+            COMPlusThrow(kSafeArrayTypeMismatchException);
+
+        return TypeHandle(pPointerMT);
+    }
+
     // Returns the element TypeHandle for a given VARTYPE and element MethodTable.
     TypeHandle GetElementTypeForSafeArrayVarType(VARTYPE vt, MethodTable* pElementMT)
     {
@@ -2005,20 +2019,20 @@ namespace
         case VT_INT:
         case VT_ERROR:
             if (pElementMT == CoreLibBinder::GetClass(CLASS__INTPTR))
-                return TypeHandle(CoreLibBinder::GetClass(CLASS__INTPTR));
+                return GetPointerSizedElementTypeForSafeArrayVarType(vt, CoreLibBinder::GetClass(CLASS__INTPTR));
             return TypeHandle(CoreLibBinder::GetClass(CLASS__INT32));
         case VT_UI4:
         case VT_UINT:
             if (pElementMT == CoreLibBinder::GetClass(CLASS__UINTPTR))
-                return TypeHandle(CoreLibBinder::GetClass(CLASS__UINTPTR));
+                return GetPointerSizedElementTypeForSafeArrayVarType(vt, CoreLibBinder::GetClass(CLASS__UINTPTR));
             return TypeHandle(CoreLibBinder::GetClass(CLASS__UINT32));
         case VT_I8:
             if (pElementMT == CoreLibBinder::GetClass(CLASS__INTPTR))
-                return TypeHandle(CoreLibBinder::GetClass(CLASS__INTPTR));
+                return GetPointerSizedElementTypeForSafeArrayVarType(vt, CoreLibBinder::GetClass(CLASS__INTPTR));
             return TypeHandle(CoreLibBinder::GetClass(CLASS__INT64));
         case VT_UI8:
             if (pElementMT == CoreLibBinder::GetClass(CLASS__UINTPTR))
-                return TypeHandle(CoreLibBinder::GetClass(CLASS__UINTPTR));
+                return GetPointerSizedElementTypeForSafeArrayVarType(vt, CoreLibBinder::GetClass(CLASS__UINTPTR));
             return TypeHandle(CoreLibBinder::GetClass(CLASS__UINT64));
         case VT_R4:         return TypeHandle(CoreLibBinder::GetClass(CLASS__SINGLE));
         case VT_R8:         return TypeHandle(CoreLibBinder::GetClass(CLASS__DOUBLE));
@@ -2061,17 +2075,6 @@ MethodDesc* GetInstantiatedSafeArrayMethod(BinderMethodID methodId, VARTYPE vt, 
 
     TypeHandle thElementType = GetElementTypeForSafeArrayVarType(vt, pElementMT);
     TypeHandle thMarshalerType(GetMarshalerMTForSafeArrayVarType(vt, pElementMT, bHeterogeneous, bNativeDataValid));
-
-    // When the managed element type is IntPtr/UIntPtr, the blittable array marshaler copies
-    // sizeof(IntPtr) bytes per element with a bulk memmove. The native SAFEARRAY element size
-    // (e.g. 4 bytes for VT_I4/VT_INT/VT_UI4/VT_UINT) can differ from the pointer size (e.g. 8 bytes
-    // on a 64-bit process), in which case the copy length would not match the native element size.
-    // Reject the mismatch as a type mismatch instead of performing a mismatched copy.
-    if ((thElementType == TypeHandle(CoreLibBinder::GetClass(CLASS__INTPTR)) || thElementType == TypeHandle(CoreLibBinder::GetClass(CLASS__UINTPTR)))
-        && sizeof(void*) != OleVariant::GetElementSizeForVarType(vt, pElementMT))
-    {
-        COMPlusThrow(kSafeArrayTypeMismatchException);
-    }
 
     TypeHandle thArgs[2] = { thElementType, thMarshalerType };
 

--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -2019,20 +2019,20 @@ namespace
         case VT_INT:
         case VT_ERROR:
             if (pElementMT == CoreLibBinder::GetClass(CLASS__INTPTR))
-                return GetPointerSizedElementTypeForSafeArrayVarType(vt, CoreLibBinder::GetClass(CLASS__INTPTR));
+                return GetPointerSizedElementTypeForSafeArrayVarType(vt, pElementMT);
             return TypeHandle(CoreLibBinder::GetClass(CLASS__INT32));
         case VT_UI4:
         case VT_UINT:
             if (pElementMT == CoreLibBinder::GetClass(CLASS__UINTPTR))
-                return GetPointerSizedElementTypeForSafeArrayVarType(vt, CoreLibBinder::GetClass(CLASS__UINTPTR));
+                return GetPointerSizedElementTypeForSafeArrayVarType(vt, pElementMT);
             return TypeHandle(CoreLibBinder::GetClass(CLASS__UINT32));
         case VT_I8:
             if (pElementMT == CoreLibBinder::GetClass(CLASS__INTPTR))
-                return GetPointerSizedElementTypeForSafeArrayVarType(vt, CoreLibBinder::GetClass(CLASS__INTPTR));
+                return GetPointerSizedElementTypeForSafeArrayVarType(vt, pElementMT);
             return TypeHandle(CoreLibBinder::GetClass(CLASS__INT64));
         case VT_UI8:
             if (pElementMT == CoreLibBinder::GetClass(CLASS__UINTPTR))
-                return GetPointerSizedElementTypeForSafeArrayVarType(vt, CoreLibBinder::GetClass(CLASS__UINTPTR));
+                return GetPointerSizedElementTypeForSafeArrayVarType(vt, pElementMT);
             return TypeHandle(CoreLibBinder::GetClass(CLASS__UINT64));
         case VT_R4:         return TypeHandle(CoreLibBinder::GetClass(CLASS__SINGLE));
         case VT_R8:         return TypeHandle(CoreLibBinder::GetClass(CLASS__DOUBLE));

--- a/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.cs
+++ b/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.cs
@@ -181,6 +181,17 @@ public class SafeArrayMarshallingTest
         SafeArrayNative.Verify2DStringSafeArray(result, rows, cols);
     }
 
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsBuiltInComEnabled), nameof(TestLibrary.PlatformDetection.Is64BitProcess))]
+    [SkipOnMono("Requires COM support")]
+    public static void IntPtrArray_MismatchedNativeElementSize()
+    {
+        // Native VT_I4 SAFEARRAY (4-byte elements) -> managed IntPtr[,] (8-byte elements).
+        Assert.Throws<SafeArrayTypeMismatchException>(() => SafeArrayNative.Create2DIntSafeArrayAsIntPtr(2, 2, out _));
+
+        // Managed IntPtr[,] (8-byte elements) -> native VT_I4 SAFEARRAY (4-byte elements).
+        Assert.Throws<SafeArrayTypeMismatchException>(() => SafeArrayNative.Verify2DIntSafeArrayAsIntPtr(new IntPtr[2, 2], 2, 2));
+    }
+
     private static bool XorArray(bool[] values)
     {
         bool retVal = false;
@@ -325,6 +336,22 @@ class SafeArrayNative
     [DllImport(nameof(SafeArrayNative), PreserveSig = false)]
     public static extern void Verify2DIntSafeArray(
         [MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_I4)] int[,] array,
+        int rows,
+        int cols
+    );
+
+    // Deliberately mismatched declarations on 64-bit - the managed element type is IntPtr (8 bytes)
+    // while the native SAFEARRAY element size is 4 bytes.
+    [DllImport(nameof(SafeArrayNative), PreserveSig = false, EntryPoint = "Create2DIntSafeArray")]
+    public static extern void Create2DIntSafeArrayAsIntPtr(
+        int rows,
+        int cols,
+        [MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_I4)] out IntPtr[,] result
+    );
+
+    [DllImport(nameof(SafeArrayNative), PreserveSig = false, EntryPoint = "Verify2DIntSafeArray")]
+    public static extern void Verify2DIntSafeArrayAsIntPtr(
+        [MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_I4)] IntPtr[,] array,
         int rows,
         int cols
     );

--- a/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.cs
+++ b/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.cs
@@ -183,8 +183,7 @@ public class SafeArrayMarshallingTest
 
     [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsBuiltInComEnabled), nameof(TestLibrary.PlatformDetection.Is64BitProcess))]
     [SkipOnMono("Requires COM support")]
-    public static void IntPtrArray_MismatchedNativeElementSize()
-    {
+    public static void MultidimensionalIntPtrArray_MismatchedNativeElementSize()
         // Native VT_I4 SAFEARRAY (4-byte elements) -> managed IntPtr[,] (8-byte elements).
         Assert.Throws<SafeArrayTypeMismatchException>(() => SafeArrayNative.Create2DIntSafeArrayAsIntPtr(2, 2, out _));
 

--- a/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.cs
+++ b/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.cs
@@ -184,6 +184,7 @@ public class SafeArrayMarshallingTest
     [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsBuiltInComEnabled), nameof(TestLibrary.PlatformDetection.Is64BitProcess))]
     [SkipOnMono("Requires COM support")]
     public static void MultidimensionalIntPtrArray_MismatchedNativeElementSize()
+    {
         // Native VT_I4 SAFEARRAY (4-byte elements) -> managed IntPtr[,] (8-byte elements).
         Assert.Throws<SafeArrayTypeMismatchException>(() => SafeArrayNative.Create2DIntSafeArrayAsIntPtr(2, 2, out _));
 


### PR DESCRIPTION
When marshalling a SAFEARRAY as a `IntPtr`/`UIntPtr` array, we could end up going past the length of the array if the element size is less than the pointer size.

Reject the element size mismatch with `SafeArrayTypeMismatchException`

> [!NOTE]
> This pull request was authored with assistance from GitHub Copilot.
