### PR TITLE
[cDAC] Implement GetILCodeVersionNodeData in DacDbi

### DIFF
--- a/docs/design/datacontracts/CodeVersions.md
+++ b/docs/design/datacontracts/CodeVersions.md
@@ -52,6 +52,10 @@ public virtual TargetPointer GetIL(ILCodeVersionHandle ilCodeVersionHandle);
 // Determines whether an IL code version has default IL
 public virtual bool HasDefaultIL(ILCodeVersionHandle ilCodeVersionHandle);
 
+// Gets the instrumented IL offset mapping for an IL code version, if any.
+// Returns false when the version has no instrumented map.
+public virtual bool TryGetInstrumentedILMap(ILCodeVersionHandle ilCodeVersionHandle, out uint mapEntryCount, out TargetPointer mapEntries);
+
 // Gets the optimization tier for a native code version
 public virtual OptimizationTier GetOptimizationTier(NativeCodeVersionHandle codeVersionHandle);
 ```
@@ -87,6 +91,9 @@ Data descriptors used:
 | ILCodeVersionNode | Next | Pointer to the next `ILCodeVersionNode`|
 | ILCodeVersionNode | RejitState | ReJIT state of the node |
 | ILCodeVersionNode | ILAddress | Address of IL corresponding to `ILCodeVersionNode`|
+| ILCodeVersionNode | InstrumentedILMap | Embedded `InstrumentedILOffsetMapping` describing the instrumented IL offset mapping |
+| InstrumentedILOffsetMapping | Count | Number of instrumented IL offset map entries |
+| InstrumentedILOffsetMapping | Map | Pointer to the array of instrumented IL offset map entries |
 | GCCoverageInfo | SavedCode | Pointer to the GCCover saved code copy, if supported |
 
 The flag indicates that the default version of the code for a method desc is active:
@@ -394,5 +401,23 @@ TargetPointer ICodeVersions.GetIL(ILCodeVersionHandle ilCodeVersionHandle, Targe
 bool ICodeVersions.HasDefaultIL(ILCodeVersionHandle ilCodeVersionHandle)
 {
     return ilCodeVersionHandle.IsExplicit ? AsNode(ilCodeVersionHandle).ILAddress == TargetPointer.Null : true;
+}
+```
+
+### Getting the instrumented IL offset mapping
+```csharp
+bool ICodeVersions.TryGetInstrumentedILMap(ILCodeVersionHandle ilCodeVersionHandle, out uint mapEntryCount, out TargetPointer mapEntries)
+{
+    mapEntryCount = 0;
+    mapEntries = TargetPointer.Null;
+
+    // Synthetic IL code versions have no backing node and therefore no instrumented map.
+    if (!ilCodeVersionHandle.IsExplicit)
+        return false;
+
+    TargetPointer mappingAddress = ilCodeVersionHandle.ILCodeVersionNode + /* ILCodeVersionNode::InstrumentedILMap offset */;
+    mapEntryCount = target.Read<uint>(mappingAddress + /* InstrumentedILOffsetMapping::Count offset */);
+    mapEntries = target.ReadPointer(mappingAddress + /* InstrumentedILOffsetMapping::Map offset */);
+    return true;
 }
 ```

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7165,9 +7165,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetILCodeVersionNodeData(VMPTR_IL
     DD_ENTER_MAY_THROW;
 #ifdef FEATURE_REJIT
     ILCodeVersion ilCode(vmILCodeVersionNode.GetDacPtr());
-    pData->m_state = static_cast<DWORD>(ilCode.GetRejitState());
     pData->m_pbIL = PTR_TO_CORDB_ADDRESS(dac_cast<TADDR>(ilCode.GetIL()));
-    pData->m_dwCodegenFlags = ilCode.GetJitFlags();
     const InstrumentedILOffsetMapping* pMapping = ilCode.GetInstrumentedILMap();
     if (pMapping)
     {

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -1053,7 +1053,7 @@ public:
     ~DebuggerMethodInfo();
 
     // A profiler can remap the IL. We track the "instrumented" IL map here.
-    void SetInstrumentedILMap(COR_IL_MAP * pMap, SIZE_T cEntries);
+    void SetInstrumentedILMap(COR_IL_MAP * pMap, UINT cEntries);
     bool HasInstrumentedILMap() {return m_fHasInstrumentedILMap; }
 
     // TranslateToInstIL will take offOrig, and translate it to the

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1861,7 +1861,7 @@ bool DebuggerMethodInfo::HasMoreRecentEnCVersion()
 /******************************************************************************
  * Updated the instrumented-IL map
  ******************************************************************************/
-void DebuggerMethodInfo::SetInstrumentedILMap(COR_IL_MAP * pMap, SIZE_T cEntries)
+void DebuggerMethodInfo::SetInstrumentedILMap(COR_IL_MAP * pMap, UINT cEntries)
 {
     InstrumentedILOffsetMapping mapping;
     mapping.SetMappingInfo(cEntries, pMap);

--- a/src/coreclr/debug/inc/dacdbistructures.h
+++ b/src/coreclr/debug/inc/dacdbistructures.h
@@ -860,34 +860,9 @@ struct MSLAYOUT DacExceptionCallStackData
     BOOL isLastForeignExceptionFrame;
 };
 
-// These represent the various states a SharedReJitInfo can be in.
-enum DacSharedReJitInfoState
-{
-    // The profiler has requested a ReJit, so we've allocated stuff, but we haven't
-    // called back to the profiler to get any info or indicate that the ReJit has
-    // started. (This Info can be 'reused' for a new ReJit if the
-    // profiler calls RequestReJit again before we transition to the next state.)
-    kStateRequested = 0x00000000,
-
-    // We have asked the profiler about this method via ICorProfilerFunctionControl,
-    // and have thus stored the IL and codegen flags the profiler specified. Can only
-    // transition to kStateReverted from this state.
-    kStateActive = 0x00000001,
-
-    // The methoddef has been reverted, but not freed yet. It (or its instantiations
-    // for generics) *MAY* still be active on the stack someplace or have outstanding
-    // memory references.
-    kStateReverted = 0x00000002,
-
-
-    kStateMask = 0x0000000F,
-};
-
 struct MSLAYOUT DacSharedReJitInfo
 {
-    DWORD          m_state;
     CORDB_ADDRESS  m_pbIL;
-    DWORD          m_dwCodegenFlags;
     ULONG          m_cInstrumentedMapEntries;
     CORDB_ADDRESS  m_rgInstrumentedMapEntries;
 };

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -685,7 +685,7 @@ void ILCodeVersionNode::SetJitFlags(DWORD flags)
     m_jitFlags.Store(flags);
 }
 
-void ILCodeVersionNode::SetInstrumentedILMap(SIZE_T cMap, COR_IL_MAP * rgMap)
+void ILCodeVersionNode::SetInstrumentedILMap(UINT cMap, COR_IL_MAP * rgMap)
 {
     LIMITED_METHOD_CONTRACT;
     _ASSERTE(CodeVersionManager::IsLockOwnedByCurrentThread());
@@ -1028,7 +1028,7 @@ void ILCodeVersion::SetJitFlags(DWORD flags)
     AsNode()->SetJitFlags(flags);
 }
 
-void ILCodeVersion::SetInstrumentedILMap(SIZE_T cMap, COR_IL_MAP * rgMap)
+void ILCodeVersion::SetInstrumentedILMap(UINT cMap, COR_IL_MAP * rgMap)
 {
     LIMITED_METHOD_CONTRACT;
     AsNode()->SetInstrumentedILMap(cMap, rgMap);

--- a/src/coreclr/vm/codeversion.h
+++ b/src/coreclr/vm/codeversion.h
@@ -210,7 +210,7 @@ public:
 #ifndef DACCESS_COMPILE
     void SetIL(COR_ILMETHOD* pIL);
     void SetJitFlags(DWORD flags);
-    void SetInstrumentedILMap(SIZE_T cMap, COR_IL_MAP * rgMap);
+    void SetInstrumentedILMap(UINT cMap, COR_IL_MAP * rgMap);
     HRESULT AddNativeCodeVersion(MethodDesc* pClosedMethodDesc, NativeCodeVersion::OptimizationTier optimizationTier,
         NativeCodeVersion* pNativeCodeVersion, PatchpointInfo* patchpointInfo = NULL, unsigned ilOffset = 0);
     HRESULT GetOrCreateActiveNativeCodeVersion(MethodDesc* pClosedMethodDesc, NativeCodeVersion* pNativeCodeVersion);
@@ -408,7 +408,7 @@ public:
 #ifndef DACCESS_COMPILE
     void SetIL(COR_ILMETHOD* pIL);
     void SetJitFlags(DWORD flags);
-    void SetInstrumentedILMap(SIZE_T cMap, COR_IL_MAP * rgMap);
+    void SetInstrumentedILMap(UINT cMap, COR_IL_MAP * rgMap);
     void SetRejitState(RejitFlags newState);
     void SetEnableReJITCallback(BOOL state);
     void SetNextILVersionNode(ILCodeVersionNode* pNextVersionNode);
@@ -435,6 +435,7 @@ struct cdac_data<ILCodeVersionNode>
     static constexpr size_t Next = offsetof(ILCodeVersionNode, m_pNextILVersionNode);
     static constexpr size_t RejitState = offsetof(ILCodeVersionNode, m_rejitState);
     static constexpr size_t ILAddress = offsetof(ILCodeVersionNode, m_pIL);
+    static constexpr size_t InstrumentedILMap = offsetof(ILCodeVersionNode, m_instrumentedILMap);
     static constexpr size_t Deoptimized = offsetof(ILCodeVersionNode, m_deoptimized);
 };
 

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -1041,8 +1041,15 @@ CDAC_TYPE_FIELD(ILCodeVersionNode, T_NUINT, VersionId, cdac_data<ILCodeVersionNo
 CDAC_TYPE_FIELD(ILCodeVersionNode, T_POINTER, Next, cdac_data<ILCodeVersionNode>::Next)
 CDAC_TYPE_FIELD(ILCodeVersionNode, T_UINT32, RejitState, cdac_data<ILCodeVersionNode>::RejitState)
 CDAC_TYPE_FIELD(ILCodeVersionNode, T_POINTER, ILAddress, cdac_data<ILCodeVersionNode>::ILAddress)
+CDAC_TYPE_FIELD(ILCodeVersionNode, TYPE(InstrumentedILOffsetMapping), InstrumentedILMap, cdac_data<ILCodeVersionNode>::InstrumentedILMap)
 CDAC_TYPE_FIELD(ILCodeVersionNode, T_UINT32, Deoptimized, cdac_data<ILCodeVersionNode>::Deoptimized)
 CDAC_TYPE_END(ILCodeVersionNode)
+
+CDAC_TYPE_BEGIN(InstrumentedILOffsetMapping)
+CDAC_TYPE_INDETERMINATE(InstrumentedILOffsetMapping)
+CDAC_TYPE_FIELD(InstrumentedILOffsetMapping, T_UINT32, Count, cdac_data<InstrumentedILOffsetMapping>::Count)
+CDAC_TYPE_FIELD(InstrumentedILOffsetMapping, T_POINTER, Map, cdac_data<InstrumentedILOffsetMapping>::Map)
+CDAC_TYPE_END(InstrumentedILOffsetMapping)
 #endif // FEATURE_CODE_VERSIONING
 
 #ifdef PROFILING_SUPPORTED

--- a/src/coreclr/vm/ilinstrumentation.cpp
+++ b/src/coreclr/vm/ilinstrumentation.cpp
@@ -63,7 +63,7 @@ void InstrumentedILOffsetMapping::Clear()
 #endif // !DACCESS_COMPILE
 
 #if !defined(DACCESS_COMPILE)
-void InstrumentedILOffsetMapping::SetMappingInfo(SIZE_T cMap, COR_IL_MAP * rgMap)
+void InstrumentedILOffsetMapping::SetMappingInfo(UINT cMap, COR_IL_MAP * rgMap)
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE((cMap == 0) == (rgMap == NULL));
@@ -72,7 +72,7 @@ void InstrumentedILOffsetMapping::SetMappingInfo(SIZE_T cMap, COR_IL_MAP * rgMap
 }
 #endif // !DACCESS_COMPILE
 
-SIZE_T InstrumentedILOffsetMapping::GetCount() const
+UINT InstrumentedILOffsetMapping::GetCount() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
 

--- a/src/coreclr/vm/ilinstrumentation.h
+++ b/src/coreclr/vm/ilinstrumentation.h
@@ -10,6 +10,8 @@
 #ifndef IL_INSTRUMENTATION_H
 #define IL_INSTRUMENTATION_H
 
+#include "cdacdata.h"
+
 // declare an array type of COR_IL_MAP entries
 typedef ArrayDPTR(COR_IL_MAP) ARRAY_PTR_COR_IL_MAP;
 
@@ -34,15 +36,24 @@ public:
     // Release the memory used by the array of COR_IL_MAPs.
     void Clear();
 
-    void SetMappingInfo(SIZE_T cMap, COR_IL_MAP * rgMap);
+    void SetMappingInfo(UINT cMap, COR_IL_MAP * rgMap);
 #endif // !DACCESS_COMPILE
 
-    SIZE_T               GetCount()   const;
+    UINT                 GetCount()   const;
     ARRAY_PTR_COR_IL_MAP GetOffsets() const;
 
 private:
-    SIZE_T               m_cMap;        // the number of elements in m_rgMap
+    UINT                 m_cMap;        // the number of elements in m_rgMap
     ARRAY_PTR_COR_IL_MAP m_rgMap;       // an array of COR_IL_MAPs
+
+    friend struct ::cdac_data<InstrumentedILOffsetMapping>;
+};
+
+template<>
+struct cdac_data<InstrumentedILOffsetMapping>
+{
+    static constexpr size_t Count = offsetof(InstrumentedILOffsetMapping, m_cMap);
+    static constexpr size_t Map = offsetof(InstrumentedILOffsetMapping, m_rgMap);
 };
 
 //---------------------------------------------------------------------------------------

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ICodeVersions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ICodeVersions.cs
@@ -30,6 +30,8 @@ public interface ICodeVersions : IContract
 
     public virtual TargetPointer GetIL(ILCodeVersionHandle ilCodeVersionHandle) => throw new NotImplementedException();
     public virtual bool HasDefaultIL(ILCodeVersionHandle ilCodeVersionHandle) => throw new NotImplementedException();
+    public virtual bool TryGetInstrumentedILMap(ILCodeVersionHandle ilCodeVersionHandle, out uint mapEntryCount, out TargetPointer mapEntries) => throw new NotImplementedException();
+
     public virtual OptimizationTier GetOptimizationTier(NativeCodeVersionHandle codeVersionHandle) => throw new NotImplementedException();
 }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CodeVersions_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CodeVersions_1.cs
@@ -416,6 +416,26 @@ internal readonly partial struct CodeVersions_1 : ICodeVersions
         return iLCodeVersionHandle.IsExplicit ? AsNode(iLCodeVersionHandle).ILAddress == TargetPointer.Null : true;
     }
 
+    bool ICodeVersions.TryGetInstrumentedILMap(ILCodeVersionHandle ilCodeVersionHandle, out uint mapEntryCount, out TargetPointer mapEntries)
+    {
+        mapEntryCount = 0;
+        mapEntries = TargetPointer.Null;
+
+        // ILCodeVersion::GetInstrumentedILMap returns NULL for synthetic versions
+        if (!ilCodeVersionHandle.IsExplicit)
+        {
+            return false;
+        }
+
+        // The InstrumentedILOffsetMapping is embedded within the ILCodeVersionNode.
+        TargetPointer mappingAddress = AsNode(ilCodeVersionHandle).InstrumentedILMap;
+        Data.InstrumentedILOffsetMapping mapping = _target.ProcessedData.GetOrAdd<Data.InstrumentedILOffsetMapping>(mappingAddress);
+
+        mapEntryCount = mapping.Count;
+        mapEntries = mapping.Map;
+        return true;
+    }
+
     OptimizationTier ICodeVersions.GetOptimizationTier(NativeCodeVersionHandle codeVersionHandle)
     {
         if (!codeVersionHandle.Valid)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CodeVersions_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CodeVersions_1.cs
@@ -427,10 +427,7 @@ internal readonly partial struct CodeVersions_1 : ICodeVersions
             return false;
         }
 
-        // The InstrumentedILOffsetMapping is embedded within the ILCodeVersionNode.
-        TargetPointer mappingAddress = AsNode(ilCodeVersionHandle).InstrumentedILMap;
-        Data.InstrumentedILOffsetMapping mapping = _target.ProcessedData.GetOrAdd<Data.InstrumentedILOffsetMapping>(mappingAddress);
-
+        Data.InstrumentedILOffsetMapping mapping = AsNode(ilCodeVersionHandle).InstrumentedILMap;
         mapEntryCount = mapping.Count;
         mapEntries = mapping.Map;
         return true;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ILCodeVersionNode.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ILCodeVersionNode.cs
@@ -11,4 +11,5 @@ internal sealed partial class ILCodeVersionNode : IData<ILCodeVersionNode>
     [Field] public uint RejitState { get; }
     [Field] public TargetPointer ILAddress { get; }
     [Field] public uint Deoptimized { get; }
+    [FieldAddress] public TargetPointer InstrumentedILMap { get; }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ILCodeVersionNode.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ILCodeVersionNode.cs
@@ -11,5 +11,5 @@ internal sealed partial class ILCodeVersionNode : IData<ILCodeVersionNode>
     [Field] public uint RejitState { get; }
     [Field] public TargetPointer ILAddress { get; }
     [Field] public uint Deoptimized { get; }
-    [FieldAddress] public TargetPointer InstrumentedILMap { get; }
+    [Field] public InstrumentedILOffsetMapping InstrumentedILMap { get; }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/InstrumentedILOffsetMapping.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/InstrumentedILOffsetMapping.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+[CdacType(nameof(DataType.InstrumentedILOffsetMapping))]
+internal sealed partial class InstrumentedILOffsetMapping : IData<InstrumentedILOffsetMapping>
+{
+    [Field] public uint Count { get; }
+    [Field] public TargetPointer Map { get; }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
@@ -128,6 +128,7 @@ public enum DataType
     NativeCodeVersionNode,
     ProfControlBlock,
     ILCodeVersionNode,
+    InstrumentedILOffsetMapping,
     ReadyToRunInfo,
     ReadyToRunHeader,
     ReadyToRunSection,

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -4363,7 +4363,8 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         {
             if (pData is null)
                 throw new ArgumentException("Output pointer cannot be null.", nameof(pData));
-            if (_target.Contracts.TryGetContract<IReJIT>(out IReJIT rejit))
+            *pData = default;
+            if (_target.Contracts.TryGetContract<IReJIT>(out _))
             {
                 ICodeVersions codeVersions = _target.Contracts.CodeVersions;
                 ILCodeVersionHandle ilCodeVersion = ILCodeVersionHandle.CreateExplicit(ilCodeVersionNode);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -4357,7 +4357,52 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
     }
 
     public int GetILCodeVersionNodeData(ulong ilCodeVersionNode, DacDbiSharedReJitInfo* pData)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetILCodeVersionNodeData(ilCodeVersionNode, pData) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (pData is null)
+                throw new ArgumentException("Output pointer cannot be null.", nameof(pData));
+            if (_target.Contracts.TryGetContract<IReJIT>(out IReJIT rejit))
+            {
+                ICodeVersions codeVersions = _target.Contracts.CodeVersions;
+                ILCodeVersionHandle ilCodeVersion = ILCodeVersionHandle.CreateExplicit(ilCodeVersionNode);
+
+                pData->pbIL = codeVersions.GetIL(ilCodeVersion).Value;
+                if (codeVersions.TryGetInstrumentedILMap(ilCodeVersion, out uint mapEntryCount, out TargetPointer mapEntries))
+                {
+                    pData->cInstrumentedMapEntries = mapEntryCount;
+                    pData->rgInstrumentedMapEntries = mapEntries.Value;
+                }
+                else
+                {
+                    pData->cInstrumentedMapEntries = 0;
+                    pData->rgInstrumentedMapEntries = 0;
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacy is not null)
+        {
+            DacDbiSharedReJitInfo dataLocal = default;
+            int hrLocal = _legacy.GetILCodeVersionNodeData(ilCodeVersionNode, &dataLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(pData->pbIL == dataLocal.pbIL, $"cDAC: {pData->pbIL:x}, DAC: {dataLocal.pbIL:x}");
+                Debug.Assert(pData->cInstrumentedMapEntries == dataLocal.cInstrumentedMapEntries, $"cDAC: {pData->cInstrumentedMapEntries:x}, DAC: {dataLocal.cInstrumentedMapEntries:x}");
+                Debug.Assert(pData->rgInstrumentedMapEntries == dataLocal.rgInstrumentedMapEntries, $"cDAC: {pData->rgInstrumentedMapEntries:x}, DAC: {dataLocal.rgInstrumentedMapEntries:x}");
+            }
+        }
+#endif
+
+        return hr;
+    }
 
     public int EnableGCNotificationEvents(Interop.BOOL fEnable)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
@@ -95,9 +95,7 @@ public struct DacDbiTypeRefData
 [StructLayout(LayoutKind.Sequential)]
 public struct DacDbiSharedReJitInfo
 {
-    public uint state;
     public ulong pbIL;
-    public uint dwCodegenFlags;
     public uint cInstrumentedMapEntries;
     public ulong rgInstrumentedMapEntries;
 }

--- a/src/native/managed/cdac/tests/UnitTests/CodeVersionsTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/CodeVersionsTests.cs
@@ -140,6 +140,7 @@ public class CodeVersionsTests
             [DataType.NativeCodeVersionNode] = TargetTestHelpers.CreateTypeInfo(builder.NativeCodeVersionNodeLayout),
             [DataType.ILCodeVersioningState] = TargetTestHelpers.CreateTypeInfo(builder.ILCodeVersioningStateLayout),
             [DataType.ILCodeVersionNode] = TargetTestHelpers.CreateTypeInfo(builder.ILCodeVersionNodeLayout),
+            [DataType.InstrumentedILOffsetMapping] = TargetTestHelpers.CreateTypeInfo(builder.InstrumentedILOffsetMappingLayout),
             [DataType.GCCoverageInfo] = TargetTestHelpers.CreateTypeInfo(builder.GCCoverageInfoLayout),
         };
 
@@ -819,5 +820,44 @@ public class CodeVersionsTests
         NativeCodeVersionHandle handle = NativeCodeVersionHandle.CreateSynthetic(methodDescAddress);
         OptimizationTier tier = codeVersions.GetOptimizationTier(handle);
         Assert.Equal(OptimizationTier.OptimizationTierUnknown, tier);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void TryGetInstrumentedILMap_Explicit(MockTarget.Architecture arch)
+    {
+        MockCodeVersions builder = new(arch);
+
+        const uint expectedCount = 3;
+        TargetPointer expectedEntries = new(0x4321_0000);
+        MockILCodeVersionNode ilVersionNode = builder.AddILCodeVersionNode(versionId: 1, /* kStateActive */ 0x00000002);
+        builder.SetInstrumentedILMap(ilVersionNode, expectedCount, expectedEntries.Value);
+
+        var target = CreateTarget(arch, builder);
+        var codeVersions = target.Contracts.CodeVersions;
+
+        ILCodeVersionHandle handle = ILCodeVersionHandle.CreateExplicit(ilVersionNode.Address);
+        bool result = codeVersions.TryGetInstrumentedILMap(handle, out uint mapEntryCount, out TargetPointer mapEntries);
+
+        Assert.True(result);
+        Assert.Equal(expectedCount, mapEntryCount);
+        Assert.Equal(expectedEntries, mapEntries);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void TryGetInstrumentedILMap_Synthetic_ReturnsFalse(MockTarget.Architecture arch)
+    {
+        MockCodeVersions builder = new(arch);
+
+        var target = CreateTarget(arch, builder);
+        var codeVersions = target.Contracts.CodeVersions;
+
+        ILCodeVersionHandle handle = ILCodeVersionHandle.CreateSynthetic(new TargetPointer(0x1a0a_0000), methodDef: 0x06000001);
+        bool result = codeVersions.TryGetInstrumentedILMap(handle, out uint mapEntryCount, out TargetPointer mapEntries);
+
+        Assert.False(result);
+        Assert.Equal(0u, mapEntryCount);
+        Assert.Equal(TargetPointer.Null, mapEntries);
     }
 }

--- a/src/native/managed/cdac/tests/UnitTests/DacDbiImplTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/DacDbiImplTests.cs
@@ -720,6 +720,46 @@ public unsafe class DacDbiImplTests
         Assert.Equal(deoptimized ? Interop.BOOL.TRUE : Interop.BOOL.FALSE, result);
     }
 
+    private delegate void TryGetInstrumentedILMapCallback(ILCodeVersionHandle handle, out uint mapEntryCount, out TargetPointer mapEntries);
+
+    public static IEnumerable<object[]> GetILCodeVersionNodeDataValues()
+    {
+        foreach (object[] stdArch in new MockTarget.StdArch())
+        {
+            // arch, pbIL, hasMap, mapCount, mapEntries
+            yield return [stdArch[0], 0x9000ul, true, 4u, 0xA000ul];
+            yield return [stdArch[0], 0x9000ul, false, 0u, 0ul];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(GetILCodeVersionNodeDataValues))]
+    public void GetILCodeVersionNodeData_FillsData(MockTarget.Architecture arch, ulong pbIL, bool hasMap, uint mapCount, ulong mapEntries)
+    {
+        TargetPointer ilCodeVersionNode = new(0x3000);
+        var ilCodeVersion = ILCodeVersionHandle.CreateExplicit(ilCodeVersionNode);
+
+        var mockCodeVersions = new Mock<ICodeVersions>();
+        mockCodeVersions.Setup(cv => cv.GetIL(ilCodeVersion)).Returns(new TargetPointer(pbIL));
+        mockCodeVersions
+            .Setup(cv => cv.TryGetInstrumentedILMap(ilCodeVersion, out It.Ref<uint>.IsAny, out It.Ref<TargetPointer>.IsAny))
+            .Callback(new TryGetInstrumentedILMapCallback((ILCodeVersionHandle _, out uint count, out TargetPointer entries) =>
+            {
+                count = mapCount;
+                entries = new TargetPointer(mapEntries);
+            }))
+            .Returns(hasMap);
+
+        var dacDbi = CreateDacDbiWithMockContracts(arch, new Mock<ILoader>(), mockCodeVersions, new Mock<IReJIT>());
+
+        DacDbiSharedReJitInfo data;
+        int hr = dacDbi.GetILCodeVersionNodeData(ilCodeVersionNode.Value, &data);
+        Assert.Equal(System.HResults.S_OK, hr);
+        Assert.Equal(pbIL, data.pbIL);
+        Assert.Equal(mapCount, data.cInstrumentedMapEntries);
+        Assert.Equal(mapEntries, data.rgInstrumentedMapEntries);
+    }
+
     private delegate void TryGetLockInfoCallback(TargetPointer syncBlock, out uint owningThreadId, out uint recursion);
 
     public static IEnumerable<object[]> GetThreadOwningMonitorLockData()

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.CodeVersions.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.CodeVersions.cs
@@ -162,7 +162,7 @@ internal sealed class MockILCodeVersionNode : TypedView
             .AddPointerField(NextFieldName)
             .AddUInt32Field(RejitStateFieldName)
             .AddPointerField(ILAddressFieldName)
-            .AddNUIntField(InstrumentedILMapFieldName)
+            .AddUInt32Field(InstrumentedILMapFieldName)
             .AddPointerField(InstrumentedILMapEntriesFieldName)
             .AddUInt32Field(DeoptimizedFieldName)
             .Build<MockILCodeVersionNode>();

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.CodeVersions.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.CodeVersions.cs
@@ -152,6 +152,8 @@ internal sealed class MockILCodeVersionNode : TypedView
     private const string NextFieldName = "Next";
     private const string RejitStateFieldName = "RejitState";
     private const string ILAddressFieldName = "ILAddress";
+    private const string InstrumentedILMapFieldName = "InstrumentedILMap";
+    private const string InstrumentedILMapEntriesFieldName = "InstrumentedILMapEntries";
     private const string DeoptimizedFieldName = "Deoptimized";
 
     public static Layout<MockILCodeVersionNode> CreateLayout(MockTarget.Architecture architecture)
@@ -160,6 +162,8 @@ internal sealed class MockILCodeVersionNode : TypedView
             .AddPointerField(NextFieldName)
             .AddUInt32Field(RejitStateFieldName)
             .AddPointerField(ILAddressFieldName)
+            .AddNUIntField(InstrumentedILMapFieldName)
+            .AddPointerField(InstrumentedILMapEntriesFieldName)
             .AddUInt32Field(DeoptimizedFieldName)
             .Build<MockILCodeVersionNode>();
 
@@ -181,11 +185,41 @@ internal sealed class MockILCodeVersionNode : TypedView
         set => WriteUInt32Field(RejitStateFieldName, value);
     }
 
+    public ulong ILAddress
+    {
+        get => ReadPointerField(ILAddressFieldName);
+        set => WritePointerField(ILAddressFieldName, value);
+    }
+
+    public uint InstrumentedILMapCount
+    {
+        get => ReadUInt32Field(InstrumentedILMapFieldName);
+        set => WriteUInt32Field(InstrumentedILMapFieldName, value);
+    }
+
+    public ulong InstrumentedILMapEntries
+    {
+        get => ReadPointerField(InstrumentedILMapEntriesFieldName);
+        set => WritePointerField(InstrumentedILMapEntriesFieldName, value);
+    }
+
     public uint Deoptimized
     {
         get => ReadUInt32Field(DeoptimizedFieldName);
         set => WriteUInt32Field(DeoptimizedFieldName, value);
     }
+}
+
+internal sealed class MockInstrumentedILOffsetMapping : TypedView
+{
+    private const string CountFieldName = "Count";
+    private const string MapFieldName = "Map";
+
+    public static Layout<MockInstrumentedILOffsetMapping> CreateLayout(MockTarget.Architecture architecture)
+        => new SequentialLayoutBuilder("InstrumentedILOffsetMapping", architecture)
+            .AddUInt32Field(CountFieldName)
+            .AddPointerField(MapFieldName)
+            .Build<MockInstrumentedILOffsetMapping>();
 }
 
 internal sealed class MockGCCoverageInfo : TypedView
@@ -213,6 +247,7 @@ internal sealed class MockCodeVersionsBuilder
     internal Layout<MockNativeCodeVersionNode> NativeCodeVersionNodeLayout { get; }
     internal Layout<MockILCodeVersioningState> ILCodeVersioningStateLayout { get; }
     internal Layout<MockILCodeVersionNode> ILCodeVersionNodeLayout { get; }
+    internal Layout<MockInstrumentedILOffsetMapping> InstrumentedILOffsetMappingLayout { get; }
     internal Layout<MockGCCoverageInfo> GCCoverageInfoLayout { get; }
 
     private readonly MockMemorySpace.BumpAllocator _codeVersionsAllocator;
@@ -244,6 +279,7 @@ internal sealed class MockCodeVersionsBuilder
         NativeCodeVersionNodeLayout = MockNativeCodeVersionNode.CreateLayout(architecture);
         ILCodeVersioningStateLayout = MockILCodeVersioningState.CreateLayout(architecture);
         ILCodeVersionNodeLayout = MockILCodeVersionNode.CreateLayout(architecture);
+        InstrumentedILOffsetMappingLayout = MockInstrumentedILOffsetMapping.CreateLayout(architecture);
         GCCoverageInfoLayout = MockGCCoverageInfo.CreateLayout(architecture);
     }
 
@@ -314,15 +350,23 @@ internal sealed class MockCodeVersionsBuilder
         => ILCodeVersioningStateLayout.Create(
             _codeVersionsAllocator.Allocate((ulong)ILCodeVersioningStateLayout.Size, "ILCodeVersioningState"));
 
-    public MockILCodeVersionNode AddILCodeVersionNode(ulong versionId, uint rejitFlags, bool deoptimized = false)
+    public MockILCodeVersionNode AddILCodeVersionNode(ulong versionId, uint rejitFlags, bool deoptimized = false, ulong ilAddress = 0)
     {
         MockILCodeVersionNode node = ILCodeVersionNodeLayout.Create(
             _codeVersionsAllocator.Allocate((ulong)ILCodeVersionNodeLayout.Size, "ILCodeVersionNode"));
         node.VersionId = versionId;
         node.RejitState = rejitFlags;
         node.Deoptimized = deoptimized ? 1u : 0u;
+        node.ILAddress = ilAddress;
         node.Next = 0;
 
         return node;
+    }
+
+    public void SetInstrumentedILMap(MockILCodeVersionNode node, uint count, ulong entries)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        node.InstrumentedILMapCount = count;
+        node.InstrumentedILMapEntries = entries;
     }
 }

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.ReJIT.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.ReJIT.cs
@@ -92,6 +92,7 @@ internal sealed class MockReJITBuilder
     internal Layout<MockNativeCodeVersionNode> NativeCodeVersionNodeLayout => _codeVersions.NativeCodeVersionNodeLayout;
     internal Layout<MockILCodeVersioningState> ILCodeVersioningStateLayout => _codeVersions.ILCodeVersioningStateLayout;
     internal Layout<MockILCodeVersionNode> ILCodeVersionNodeLayout => _codeVersions.ILCodeVersionNodeLayout;
+    internal Layout<MockInstrumentedILOffsetMapping> InstrumentedILOffsetMappingLayout => _codeVersions.InstrumentedILOffsetMappingLayout;
     internal Layout<MockGCCoverageInfo> GCCoverageInfoLayout => _codeVersions.GCCoverageInfoLayout;
 
     public MockILCodeVersionNode AddExplicitILCodeVersionNode(ulong rejitId, RejitFlags rejitFlags, bool deoptimized = false)

--- a/src/native/managed/cdac/tests/UnitTests/ReJITTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ReJITTests.cs
@@ -24,6 +24,7 @@ public class ReJITTests
             [DataType.NativeCodeVersionNode] = TargetTestHelpers.CreateTypeInfo(rejitBuilder.NativeCodeVersionNodeLayout),
             [DataType.ILCodeVersioningState] = TargetTestHelpers.CreateTypeInfo(rejitBuilder.ILCodeVersioningStateLayout),
             [DataType.ILCodeVersionNode] = TargetTestHelpers.CreateTypeInfo(rejitBuilder.ILCodeVersionNodeLayout),
+            [DataType.InstrumentedILOffsetMapping] = TargetTestHelpers.CreateTypeInfo(rejitBuilder.InstrumentedILOffsetMappingLayout),
             [DataType.GCCoverageInfo] = TargetTestHelpers.CreateTypeInfo(rejitBuilder.GCCoverageInfoLayout),
         };
 


### PR DESCRIPTION
* Making InstrumentedILOffsetMapping m_cMap UINT, it already would fit in a UINT
* Adding API `TryGetInstrumentedILMap(ILCodeVersionHandle ilCodeVersionHandle, out uint mapEntryCount, out TargetPointer mapEntries)`
* Implementing `GetILCodeVersionNodeData`