### PR TITLE
Wasm R2R: emit trailing end after retless BBJ_CALLFINALLY

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3483,6 +3483,14 @@ void CodeGen::genCallFinally(BasicBlock* block)
     if (block->HasFlag(BBF_RETLESS_CALL))
     {
         GetEmitter()->emitIns(INS_unreachable);
+
+        // A retless BBJ_CALLFINALLY can be the last block of a wasm function/funclet;
+        // every wasm function body must end with `end`.
+        //
+        if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+        {
+            GetEmitter()->emitIns(INS_end);
+        }
     }
 }
 


### PR DESCRIPTION
A retless BBJ_CALLFINALLY ending a wasm function/funclet only emits `unreachable` after the indirect call, leaving the body without the required trailing `end` opcode and producing an invalid module (`function body must end with end opcode`). Mirror the BBJ_THROW guard and emit `end` when the block is last or precedes a funclet start.

Fixes #129335.