### PR TITLE
Add support for new R2RIncompatible flag for runtime tests

### DIFF
--- a/docs/workflow/ci/disabling-tests.md
+++ b/docs/workflow/ci/disabling-tests.md
@@ -75,6 +75,7 @@ and inserting a property in a `<PropertyGroup>`, as follows:
 - Prevent a test from running when testing ildasm/ilasm round-tripping: add `<IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>`
 - Prevent a test assembly from being passed to the Mono AOT compiler: add `<MonoAotIncompatible>true</MonoAotIncompatible>`
 - Prevent a test from being passed to CrossGen2: add `<CrossGenTest>false</CrossGenTest>`
+- Prevent a test from running in ReadyToRun (R2R) test legs: add `<R2RIncompatible>true</R2RIncompatible>`
 - Prevent a test from being passed to the NativeAOT ILCompiler and run under NativeAOT: add `<NativeAotIncompatible>true</NativeAotIncompatible>`
 
 When one of the following settings is already required for a given test, the following settings can also be set in the project file instead of via XUnit attributes. They should not be the only reason a test is marked as `<RequiresProcessIsolation>true</RequiresProcessIsolation>`, however.

--- a/docs/workflow/testing/coreclr/test-configuration.md
+++ b/docs/workflow/testing/coreclr/test-configuration.md
@@ -63,6 +63,8 @@ Therefore the managed portion of each test **must not contain**:
     * `<AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>`
 * When `CrossGenTest` is set to false, this test is not run with standard R2R compilation even if running an R2R test pass.
     * `<CrossGenTest>false</CrossGenTest>`
+* Exclude test from ReadyToRun (R2R) test runs by adding the following to the csproj:
+    * `<R2RIncompatible>true</R2RIncompatible>`
 * Add NuGet references by updating the following [test project](https://github.com/dotnet/runtime/blob/main/src/tests/Common/test_dependencies/test_dependencies.csproj).
 * Any System.Private.CoreLib types and methods used by tests must be available for building on all platforms.
 This means there must be enough implementation for the C# compiler to find the referenced types and methods. Unsupported target platforms

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -42,7 +42,15 @@ WARNING:   When setting properties based on their current state (for example:
     <Error Text="Setting both AlwaysUseCrossGen2 to true and CrossGenTest to false is non-sensical" Condition="'$(CrossGenTest)' == 'false' and '$(AlwaysUseCrossGen2)' == 'true'"/>
 
     <PropertyGroup>
-      <CrossgenBashScript Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(CrossGenTest)' != 'false'">
+      <CrossgenBashScript Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(R2RIncompatible)' == 'true'">
+        <![CDATA[
+if [ ! -z ${RunCrossGen2+x} ]%3B then
+  echo SKIPPING EXECUTION BECAUSE the test is incompatible with ReadyToRun
+  exit 0
+fi
+        ]]>
+      </CrossgenBashScript>
+      <CrossgenBashScript Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(CrossGenTest)' != 'false' and '$(R2RIncompatible)' != 'true'">
         <![CDATA[
 
 if [ "$(AlwaysUseCrossGen2)" == "true" ]; then
@@ -229,7 +237,16 @@ fi
 
   <Target Name="GetCrossgenBatchScript">
     <PropertyGroup>
-      <CrossgenBatchScript Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(CrossGenTest)' != 'false'">
+      <CrossgenBatchScript Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(R2RIncompatible)' == 'true'">
+        <![CDATA[
+IF NOT "%RunCrossGen2%"=="" (
+  ECHO SKIPPING EXECUTION BECAUSE the test is incompatible with ReadyToRun
+  popd
+  Exit /b 0
+)
+        ]]>
+      </CrossgenBatchScript>
+      <CrossgenBatchScript Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(CrossGenTest)' != 'false' and '$(R2RIncompatible)' != 'true'">
         <![CDATA[
 
 if /i "$(AlwaysUseCrossGen2)" == "true" (

--- a/src/tests/Loader/SystemCoreLibDirectory/SystemCoreLibDirectory.csproj
+++ b/src/tests/Loader/SystemCoreLibDirectory/SystemCoreLibDirectory.csproj
@@ -6,7 +6,7 @@
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
     <!-- Loading SPCL from a separate directory is incompatible with R2R composite mode
          because the composite image won't be found beside the redirected assembly. -->
-    <CrossGenTest>false</CrossGenTest>
+    <R2RIncompatible>true</R2RIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SystemCoreLibDirectory.cs" />


### PR DESCRIPTION
The existing CrossGenTest doesn't prevent the test from running in R2R pipelines. Instead it just disables the compilation of the test with R2R. The framework can still be compiled with R2R. As with the other such configuration, this property requires `RequiresProcessIsolation` so that the test runs in standalone mode, with the specific bits for test R2R compilation included in the test execution script. This change makes the test execution skip if RunCrossGen2 is set, which is the flag set by the testing infrastructure when running the crossgen2 pipelines.

This properly disables src/tests/Loader/SystemCoreLibDirectory/SystemCoreLibDirectory.csproj

The previous attempt to disable the test in https://github.com/dotnet/runtime/pull/129178, was wrong because it misinterpreted the behavior of `CrossGenTest`.

https://github.com/dotnet/runtime/issues/129046