### PR TITLE
[cDac] Fix failing cDac test on OSX

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/TargetFieldExtensions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/TargetFieldExtensions.cs
@@ -212,8 +212,12 @@ public static class TargetFieldExtensions
     [Conditional("DEBUG")]
     private static void AssertPointerType(Target.FieldInfo field, string fieldName)
     {
+        // Managed types express raw pointers as IntPtr/UIntPtr, which the contract descriptor
+        // reports as "nint"/"nuint" (there is no way to mark a managed field as "pointer").
+        // Accept those in addition to "pointer" so pointer-valued fields on managed types can be
+        // read via ReadPointer, which reads the value unsigned at full pointer width.
         Debug.Assert(
-            field.TypeName is null or "" or "pointer",
+            field.TypeName is null or "" or "pointer" or "nint" or "nuint",
             $"Type mismatch reading field '{fieldName}': declared as '{field.TypeName}', expected pointer");
     }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/TargetFieldExtensions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/TargetFieldExtensions.cs
@@ -212,8 +212,8 @@ public static class TargetFieldExtensions
     [Conditional("DEBUG")]
     private static void AssertPointerType(Target.FieldInfo field, string fieldName)
     {
-        // Managed types express raw pointers as IntPtr/UIntPtr, which the contract descriptor
-        // reports as "nint"/"nuint" (there is no way to mark a managed field as "pointer").
+        // Managed field signatures report IntPtr/UIntPtr as native ints, which the contract descriptor maps to
+        // "nint"/"nuint" (as distinct from raw pointer element types which map to "pointer").
         // Accept those in addition to "pointer" so pointer-valued fields on managed types can be
         // read via ReadPointer, which reads the value unsigned at full pointer width.
         Debug.Assert(

--- a/src/native/managed/cdac/tests/UnitTests/ObjectiveCMarshalTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ObjectiveCMarshalTests.cs
@@ -71,12 +71,14 @@ public class ObjectiveCMarshalTests
         };
 
         // Register ObjcTrackingInformation type with a single pointer-sized _memory field at offset 0.
+        // The managed _memory field is an IntPtr, so the contract descriptor reports its type as "nint";
+        // model that here so the pointer read path is validated against the real descriptor type.
         var trackingInfoType = new Target.TypeInfo
         {
             Size = (uint)helpers.PointerSize,
             Fields = new Dictionary<string, Target.FieldInfo>
             {
-                ["_memory"] = new Target.FieldInfo { Offset = 0 }
+                ["_memory"] = new Target.FieldInfo { Offset = 0, TypeName = "nint" }
             }
         };
 


### PR DESCRIPTION
Fixes failing OSX cDac test.  I think this is a regression from #128961.

This pull request updates the handling of pointer types in managed code to better align with how .NET expresses raw pointers. The main change is to allow fields typed as `IntPtr`/`UIntPtr` (reported as `"nint"`/`"nuint"`) to be treated as pointers by the contract reader, improving compatibility and correctness when reading pointer-sized fields.

Improvements to pointer type handling:

* Updated `AssertPointerType` in `TargetFieldExtensions.cs` to accept `"nint"` and `"nuint"` as valid pointer type names, in addition to `"pointer"`, enabling proper handling of managed fields typed as `IntPtr`/`UIntPtr`.

Test and contract descriptor alignment:

* Modified the test contract for the `_memory` field in `ObjectiveCMarshalTests.cs` to explicitly set its type as `"nint"`, ensuring that the pointer read path is validated against the real managed contract descriptor.