### PR TITLE
Use managed NTLM on RHEL 8 to fix NegotiateAuthentication test failures

### DIFF
--- a/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
@@ -19,7 +19,8 @@ namespace System.Net.Security.Tests
     public class NegotiateAuthenticationTests
     {
         // Ubuntu 24 and 26 ship with broekn gss-ntlmssp 1.2
-        private static bool UseManagedNtlm => PlatformDetection.IsUbuntu24 || PlatformDetection.IsUbuntu26 || PlatformDetection.IsOpenSUSE16;
+        // RHEL 8 ships gss-ntlmssp 1.2 built against OpenSSL 1.1 which produces broken NTLM responses
+        private static bool UseManagedNtlm => PlatformDetection.IsUbuntu24 || PlatformDetection.IsUbuntu26 || PlatformDetection.IsOpenSUSE16 || (PlatformDetection.IsRedHatFamily && !PlatformDetection.IsOpenSsl3);
         private static bool IsNtlmAvailable => UseManagedNtlm || Capability.IsNtlmInstalled() || OperatingSystem.IsAndroid() || OperatingSystem.IsTvOS();
         private static bool IsNtlmUnavailable => !IsNtlmAvailable;
 


### PR DESCRIPTION
## Summary

RHEL 8 ships `gss-ntlmssp 1.2.0` built against OpenSSL 1.1.1. Unlike RHEL 9/10 (which use OpenSSL 3.x), this combination causes gssntlmssp to fail when producing NTLM Type 3 (Authenticate) messages, `GetOutgoingBlob` returns `GenericFailure` when processing a server challenge.

This is the same class of issue already handled for Ubuntu 24/26 and openSUSE 16 (which ship a broken `gss-ntlmssp 1.2`). The fix adds RHEL 8 to the `UseManagedNtlm` condition using `PlatformDetection.IsRedHatFamily && !PlatformDetection.IsOpenSsl3`, which enables the managed NTLM implementation only on RHEL versions with OpenSSL < 3 (i.e., RHEL 8). RHEL 9 and 10 (OpenSSL 3.x) are unaffected.

## Verification

Tested on a RHEL 8.10 s390x machine (`gssntlmssp-1.2.0-1.el8_8`, OpenSSL 1.1.1k):

- **Without managed NTLM**: Client Negotiate succeeds, but processing the server challenge returns `GenericFailure` — gssntlmssp cannot produce an Authenticate message.
- **With managed NTLM** (`DOTNET_System_Net_Security_UseManagedNtlm=1`): Full NTLM handshake completes successfully — valid Type 3 message (356 bytes, `status=Completed`).

This resolves 11 NegotiateAuthentication test failures seen in CI on RHEL 8.