### PR TITLE
Ignore AppDomain address parameters in ISOSDacInterface

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2429,23 +2429,23 @@ ClrDataAccess::GetAppDomainStoreData(struct DacpAppDomainStoreData *adsData)
 HRESULT
 ClrDataAccess::GetAppDomainData(CLRDATA_ADDRESS addr, struct DacpAppDomainData *appdomainData)
 {
+    // addr is ignored, only one AppDomain exists in CoreCLR.
     SOSDacEnter();
 
-    if (addr == 0)
+    PTR_AppDomain pAppDomain = AppDomain::GetCurrentDomain();
+    if (pAppDomain == NULL)
     {
-        hr = E_INVALIDARG;
+        hr = E_FAIL;
     }
     else
     {
         ZeroMemory(appdomainData, sizeof(DacpAppDomainData));
-        appdomainData->AppDomainPtr = addr;
+        appdomainData->AppDomainPtr = HOST_CDADDR(pAppDomain);
         PTR_LoaderAllocator pLoaderAllocator = SystemDomain::GetGlobalLoaderAllocator();
         appdomainData->pHighFrequencyHeap = HOST_CDADDR(pLoaderAllocator->GetHighFrequencyHeap());
         appdomainData->pLowFrequencyHeap = HOST_CDADDR(pLoaderAllocator->GetLowFrequencyHeap());
         appdomainData->pStubHeap = HOST_CDADDR(pLoaderAllocator->GetStubHeap());
         appdomainData->appDomainStage = STAGE_OPEN;
-
-        PTR_AppDomain pAppDomain = PTR_AppDomain(TO_TADDR(addr));
 
         appdomainData->dwId = DefaultADID;
 
@@ -2550,37 +2550,42 @@ ClrDataAccess::GetFailedAssemblyDisplayName(CLRDATA_ADDRESS assembly, unsigned i
 HRESULT
 ClrDataAccess::GetAssemblyList(CLRDATA_ADDRESS addr, int count, CLRDATA_ADDRESS values[], int *pNeeded)
 {
-    if (addr == (CLRDATA_ADDRESS)NULL)
-        return E_INVALIDARG;
-
+    // addr is ignored, only one AppDomain exists in CoreCLR.
     SOSDacEnter();
 
-    PTR_AppDomain pAppDomain = PTR_AppDomain(TO_TADDR(addr));
-    AppDomain::AssemblyIterator i = pAppDomain->IterateAssembliesEx(
-        (AssemblyIterationFlags)(kIncludeLoading | kIncludeLoaded | kIncludeExecution));
-    CollectibleAssemblyHolder<Assembly *> pAssembly;
-
-    int n = 0;
-    if (values)
+    PTR_AppDomain pAppDomain = AppDomain::GetCurrentDomain();
+    if (pAppDomain == NULL)
     {
-        while (i.Next(pAssembly.This()) && (n < count))
-        {
-            if (pAssembly->IsLoaded())
-            {
-                // Note: DAC doesn't need to keep the assembly alive - see code:CollectibleAssemblyHolder#CAH_DAC
-                values[n++] = HOST_CDADDR(pAssembly.Extract());
-            }
-        }
+        hr = E_FAIL;
     }
     else
     {
-        while (i.Next(pAssembly.This()))
-            if (pAssembly->IsLoaded())
-                n++;
-    }
+        AppDomain::AssemblyIterator i = pAppDomain->IterateAssembliesEx(
+            (AssemblyIterationFlags)(kIncludeLoading | kIncludeLoaded | kIncludeExecution));
+        CollectibleAssemblyHolder<Assembly *> pAssembly;
 
-    if (pNeeded)
-        *pNeeded = n;
+        int n = 0;
+        if (values)
+        {
+            while (i.Next(pAssembly.This()) && (n < count))
+            {
+                if (pAssembly->IsLoaded())
+                {
+                    // Note: DAC doesn't need to keep the assembly alive - see code:CollectibleAssemblyHolder#CAH_DAC
+                    values[n++] = HOST_CDADDR(pAssembly.Extract());
+                }
+            }
+        }
+        else
+        {
+            while (i.Next(pAssembly.This()))
+                if (pAssembly->IsLoaded())
+                    n++;
+        }
+
+        if (pNeeded)
+            *pNeeded = n;
+    }
 
     SOSDacLeave();
     return hr;
@@ -2618,39 +2623,46 @@ ClrDataAccess::GetFailedAssemblyList(CLRDATA_ADDRESS appDomain, int count,
 HRESULT
 ClrDataAccess::GetAppDomainName(CLRDATA_ADDRESS addr, unsigned int count, _Inout_updates_z_(count) WCHAR *name, unsigned int *pNeeded)
 {
+    // addr is ignored, only one AppDomain exists in CoreCLR.
     SOSDacEnter();
 
-    PTR_AppDomain pAppDomain = PTR_AppDomain(TO_TADDR(addr));
-
-    size_t countAsSizeT = count;
-    if (pAppDomain->m_friendlyName.IsValid())
+    PTR_AppDomain pAppDomain = AppDomain::GetCurrentDomain();
+    if (pAppDomain == NULL)
     {
-        LPCWSTR friendlyName = (LPCWSTR)pAppDomain->m_friendlyName;
-        size_t friendlyNameLen = u16_strlen(friendlyName);
-
-        if (pNeeded)
-        {
-            *pNeeded = (unsigned int)(friendlyNameLen + 1);
-        }
-
-        if (name && count > 0)
-        {
-            if (countAsSizeT > (friendlyNameLen + 1))
-            {
-                countAsSizeT = friendlyNameLen + 1;
-            }
-            memcpy(name, friendlyName, countAsSizeT * sizeof(WCHAR));
-            name[countAsSizeT - 1] = 0;
-        }
+        hr = E_FAIL;
     }
     else
     {
-        if (pNeeded)
-            *pNeeded = 1;
-        if (name && count > 0)
-            name[0] = 0;
+        size_t countAsSizeT = count;
+        if (pAppDomain->m_friendlyName.IsValid())
+        {
+            LPCWSTR friendlyName = (LPCWSTR)pAppDomain->m_friendlyName;
+            size_t friendlyNameLen = u16_strlen(friendlyName);
 
-        hr = S_OK;
+            if (pNeeded)
+            {
+                *pNeeded = (unsigned int)(friendlyNameLen + 1);
+            }
+
+            if (name && count > 0)
+            {
+                if (countAsSizeT > (friendlyNameLen + 1))
+                {
+                    countAsSizeT = friendlyNameLen + 1;
+                }
+                memcpy(name, friendlyName, countAsSizeT * sizeof(WCHAR));
+                name[countAsSizeT - 1] = 0;
+            }
+        }
+        else
+        {
+            if (pNeeded)
+                *pNeeded = 1;
+            if (name && count > 0)
+                name[0] = 0;
+
+            hr = S_OK;
+        }
     }
 
     SOSDacLeave();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -108,28 +108,30 @@ public sealed unsafe partial class SOSDacImpl
 
         return hr;
     }
+
+    // addr is ignored, only one AppDomain exists in CoreCLR.
     int ISOSDacInterface.GetAppDomainData(ClrDataAddress addr, DacpAppDomainData* data)
     {
         int hr = HResults.S_OK;
         try
         {
-            if (addr == 0)
-                throw new ArgumentException();
-
             *data = default;
-            data->AppDomainPtr = addr;
             Contracts.ILoader loader = _target.Contracts.Loader;
+            TargetPointer appDomain = loader.GetAppDomain();
+            if (appDomain == TargetPointer.Null)
+                throw new InvalidOperationException();
+
+            data->AppDomainPtr = appDomain.ToClrDataAddress(_target);
             TargetPointer globalLoaderAllocator = loader.GetGlobalLoaderAllocator();
             data->pHighFrequencyHeap = loader.GetHighFrequencyHeap(globalLoaderAllocator).ToClrDataAddress(_target);
             data->pLowFrequencyHeap = loader.GetLowFrequencyHeap(globalLoaderAllocator).ToClrDataAddress(_target);
             data->pStubHeap = loader.GetStubHeap(globalLoaderAllocator).ToClrDataAddress(_target);
             data->appDomainStage = DacpAppDomainDataStage.STAGE_OPEN;
 
-            TargetPointer pAppDomain = addr.ToTargetPointer(_target);
             data->dwId = DefaultAppDomainId;
 
             IEnumerable<Contracts.ModuleHandle> modules = loader.GetModuleHandles(
-                pAppDomain,
+                appDomain,
                 AssemblyIterationFlags.IncludeLoading |
                 AssemblyIterationFlags.IncludeLoaded |
                 AssemblyIterationFlags.IncludeExecution);
@@ -143,7 +145,7 @@ public sealed unsafe partial class SOSDacImpl
             }
 
             IEnumerable<Contracts.ModuleHandle> failedModules = loader.GetModuleHandles(
-                pAppDomain,
+                appDomain,
                 AssemblyIterationFlags.IncludeFailedToLoad);
             data->FailedAssemblyCount = failedModules.Count();
         }
@@ -214,6 +216,7 @@ public sealed unsafe partial class SOSDacImpl
 #endif
         return hr;
     }
+    // addr is ignored -- only one AppDomain exists in CoreCLR.
     int ISOSDacInterface.GetAppDomainName(ClrDataAddress addr, uint count, char* name, uint* pNeeded)
     {
         int hr = HResults.S_OK;
@@ -386,16 +389,17 @@ public sealed unsafe partial class SOSDacImpl
         return hr;
     }
 
+    // addr is ignored, only one AppDomain exists in CoreCLR.
     int ISOSDacInterface.GetAssemblyList(ClrDataAddress addr, int count, [In, MarshalUsing(CountElementName = "count"), Out] ClrDataAddress[]? values, int* pNeeded)
     {
         int hr = HResults.S_OK;
 
         try
         {
-            if (addr == 0)
-                throw new ArgumentException();
-            TargetPointer appDomain = addr.ToTargetPointer(_target);
             ILoader loader = _target.Contracts.Loader;
+            TargetPointer appDomain = loader.GetAppDomain();
+            if (appDomain == TargetPointer.Null)
+                throw new InvalidOperationException();
 
             List<Contracts.ModuleHandle> modules = loader.GetModuleHandles(
                 appDomain,


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from GitHub Copilot.

CoreCLR only has a single AppDomain. The `addr`/`domain` parameters passed to `GetAppDomainData`, `GetAssemblyList`, and `GetAppDomainName` are historical artifacts from the multi-AppDomain era (.NET Framework). These methods now use `AppDomain::GetCurrentDomain()` (DAC) or `ILoader.GetAppDomain()` (cDAC) directly instead of trusting the caller-provided address.

### Changes

**DAC (`request.cpp`):**
- `GetAppDomainData` -- uses `AppDomain::GetCurrentDomain()` instead of casting `addr`
- `GetAssemblyList` -- uses `AppDomain::GetCurrentDomain()` instead of casting `addr`
- `GetAppDomainName` -- uses `AppDomain::GetCurrentDomain()` instead of casting `addr`

**cDAC (`SOSDacImpl.cs`):**
- Same 3 methods use `loader.GetAppDomain()` instead of the input address

All `addr == 0` precondition checks are removed since the parameter is no longer used.

### Testing
All cDAC unit tests pass (2509 passed, 0 failed).

### Follow-up from
dotnet/runtime#129260


Successful runtime-diagnostics run: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1467096&view=results