### PR TITLE
[Wasm RyuJit] Add Wasm SIMD NYIs, fix PushArgs assert, fix Async/Try/SCC issue.

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1789,9 +1789,12 @@ void CodeGen::genEmitCallWithCurrentGC(EmitCallParams& params)
     if (retBuf != nullptr)
     {
         GenTree* node = retBuf->GetNode();
-        assert(node->OperIsPutArg());
 
+#if HAS_FIXED_REGISTER_SET
+        assert(node->OperIsPutArg());
         node = node->gtGetOp1()->gtSkipReloadOrCopy();
+#endif
+
         if (!node->OperIs(GT_LCL_ADDR))
         {
             return;

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2441,9 +2441,15 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
 {
     assert(tree->OperIs(GT_LCL_FLD));
     LclVarDsc* varDsc = m_compiler->lvaGetDesc(tree);
+    var_types  type   = tree->TypeGet();
+
+    if (type == TYP_SIMD16)
+    {
+        NYI_WASM_SIMD("SIMD16 local field load");
+    }
 
     GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
-    GetEmitter()->emitIns_S(ins_Load(tree->TypeGet()), emitTypeSize(tree), tree->GetLclNum(), tree->GetLclOffs());
+    GetEmitter()->emitIns_S(ins_Load(type), emitTypeSize(tree), tree->GetLclNum(), tree->GetLclOffs());
     WasmProduceReg(tree);
 }
 
@@ -2465,6 +2471,11 @@ void CodeGen::genCodeForLclVar(GenTreeLclVar* tree)
     if (!varDsc->lvIsRegCandidate())
     {
         var_types type = varDsc->GetRegisterType(tree);
+        if (type == TYP_SIMD16)
+        {
+            NYI_WASM_SIMD("SIMD16 local load");
+        }
+
         GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
         GetEmitter()->emitIns_S(ins_Load(type), emitTypeSize(type), tree->GetLclNum(), 0);
         WasmProduceReg(tree);
@@ -2549,8 +2560,13 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 {
     assert(tree->OperIs(GT_IND));
 
-    var_types   type = tree->TypeGet();
-    instruction ins  = ins_Load(type);
+    var_types type = tree->TypeGet();
+    if (type == TYP_SIMD16)
+    {
+        NYI_WASM_SIMD("SIMD16 indirect load");
+    }
+
+    instruction ins = ins_Load(type);
 
     genConsumeAddress(tree->Addr());
 
@@ -3571,6 +3587,11 @@ void CodeGen::genLoadLocalIntoReg(regNumber targetReg, unsigned lclNum)
 {
     LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
     var_types  type   = varDsc->GetRegisterType();
+    if (type == TYP_SIMD16)
+    {
+        NYI_WASM_SIMD("SIMD16 local load");
+    }
+
     GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
     GetEmitter()->emitIns_S(ins_Load(type), emitTypeSize(type), lclNum, 0);
     GetEmitter()->emitIns_I(INS_local_set, emitTypeSize(type), WasmRegToIndex(targetReg));

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -7982,6 +7982,30 @@ void FlowGraphTryRegions::AddMultipleEntryRegionEdges(ArrayStack<FlowEdge*>& edg
                 // And an edge from method entry to dest.
                 FlowEdge* const entryDestEdge = m_compiler->fgAddRefPred(destBlock, m_compiler->fgFirstBB);
                 edges.Push(entryDestEdge);
+
+                // If the dest is not reachable within the try, then we need to also add
+                // a temporary edge from the try header to the dest to create the SCC.
+                // Since we've pruned away dead blocks, any in-try pred sufficies to establish
+                // reachability.
+                //
+                bool isReachableInTry = false;
+                for (FlowEdge* const predEdge : destBlock->PredEdges())
+                {
+                    BasicBlock* const predBlock = predEdge->getSourceBlock();
+                    if ((predBlock != edge->getSourceBlock()) &&
+                        !predBlock->HasAnyFlag(BBF_ASYNC_RESUMPTION | BBF_CATCH_RESUMPTION) &&
+                        BitVecOps::IsMember(GetBlockBitVecTraits(), region->m_blocks, GetBlockIndex(predBlock)))
+                    {
+                        isReachableInTry = true;
+                        break;
+                    }
+                }
+
+                if (!isReachableInTry)
+                {
+                    FlowEdge* const headerDestEdge = m_compiler->fgAddRefPred(destBlock, headerBlock);
+                    edges.Push(headerDestEdge);
+                }
             }
         }
     }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -7985,16 +7985,13 @@ void FlowGraphTryRegions::AddMultipleEntryRegionEdges(ArrayStack<FlowEdge*>& edg
 
                 // If the dest is not reachable within the try, then we need to also add
                 // a temporary edge from the try header to the dest to create the SCC.
-                // Since we've pruned away dead blocks, any in-try pred sufficies to establish
-                // reachability.
+                // Since we've pruned away dead blocks, any other pred edge suffices to
+                // establish reachability.
                 //
                 bool isReachableInTry = false;
                 for (FlowEdge* const predEdge : destBlock->PredEdges())
                 {
-                    BasicBlock* const predBlock = predEdge->getSourceBlock();
-                    if ((predBlock != edge->getSourceBlock()) &&
-                        !predBlock->HasAnyFlag(BBF_ASYNC_RESUMPTION | BBF_CATCH_RESUMPTION) &&
-                        BitVecOps::IsMember(GetBlockBitVecTraits(), region->m_blocks, GetBlockIndex(predBlock)))
+                    if (predEdge != edge)
                     {
                         isReachableInTry = true;
                         break;

--- a/src/coreclr/jit/layout.h
+++ b/src/coreclr/jit/layout.h
@@ -202,7 +202,7 @@ public:
             case 8:
                 return TYP_LONG;
 #endif
-#ifdef FEATURE_SIMD
+#if defined(FEATURE_SIMD) && !defined(TARGET_WASM)
             // TODO: check TYP_SIMD12 profitability,
             // it will need additional support in `BuildStoreLoc`.
             case 16:


### PR DESCRIPTION
- Report SIMD16 local loads as Wasm SIMD NYIs so R2R compilation can skip them when configured.
- Avoid assuming retbuf call arguments are PUTARG nodes on targets without a fixed register set (Wasm).
- Add temporary bidirectional edges for isolated async try side entries so SCC rewriting can see them. This handles cases where the in-try resumption target is not reachable from the try entry and throws.