### PR TITLE
Fix VerificationException when marshalling non-blittable struct arrays in trimmed apps

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -9,6 +9,19 @@
     <!-- Accessed via native code. -->
     <type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
 
+    <!-- Referenced by name from the IL-stub generator in native code and used as constrained
+         TMarshaler type arguments the trimmer cannot see. -->
+    <type fullname="System.StubHelpers.DateMarshaler" />
+    <type fullname="System.StubHelpers.StructureMarshaler`1" />
+    <type fullname="System.StubHelpers.BlittableArrayMarshaler`1" />
+    <type fullname="System.StubHelpers.AnsiCharArrayMarshaler`2" />
+    <type fullname="System.StubHelpers.LayoutClassMarshaler`1" />
+    <type fullname="System.StubHelpers.VariantBoolMarshaler" />
+    <type fullname="System.StubHelpers.BoolMarshaler`1" />
+    <type fullname="System.StubHelpers.LPWSTRMarshaler" />
+    <type fullname="System.StubHelpers.LPSTRArrayElementMarshaler`2" />
+    <type fullname="System.StubHelpers.BSTRArrayElementMarshaler" />
+
     <!-- GetActualImplementationForArrayGenericIListOrIReadOnlyListMethod depends on slots of these interfaces not changing -->
     <type fullname="System.Collections.Generic.IEnumerable`1" />
     <type fullname="System.Collections.Generic.ICollection`1" />


### PR DESCRIPTION
## Description

Right now, any trimmed app that marshals an array of a non-blittable struct crashes with a `VerificationException`. The biggest impact is that `net11.0-android` Release build fails to start, since Android's startup marshals a `JniNativeMethodRegistration[]`. The cause is that the runtime generates the array-marshalling code at runtime, referencing helper types like `StructureMarshaler<T>` by name from native code. The trimmer can't see those references, so it strips the interface implementations those helpers rely on, and the constraint check blows up at runtime.

Fixes #128027