### PR TITLE
JIT: fix opt-repeat divide-by-zero miscompile (#129386)

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4147,9 +4147,8 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions,
     // is location-dependent (derived from a dominating assertion rather than from the
     // operand's own value), the divide is only safe at this position, so CSE/loop hoisting
     // must not move it above the check that justified the flag. Pin it with an ordering
-    // side effect in that case (see https://github.com/dotnet/runtime/issues/129386). A
-    // value-based proof (e.g. a constant non-zero divisor) holds everywhere, so such a
-    // divide stays freely movable and is not pinned.
+    // side effect in that case. A value-based proof (e.g. a constant non-zero divisor)
+    // holds everywhere, so such a divide stays freely movable and is not pinned.
     const bool byZeroNeedsPin   = op2IsNotZero && !op2->IsNeverZero();
     const bool overflowNeedsPin = (op1IsNotNegative || op2IsNotNegative) &&
                                   !op1->IsNeverNegative(this) && !op2->IsNeverNegative(this);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4149,9 +4149,9 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions,
     // must not move it above the check that justified the flag. Pin it with an ordering
     // side effect in that case. A value-based proof (e.g. a constant non-zero divisor)
     // holds everywhere, so such a divide stays freely movable and is not pinned.
-    const bool byZeroNeedsPin   = op2IsNotZero && !op2->IsNeverZero();
-    const bool overflowNeedsPin = (op1IsNotNegative || op2IsNotNegative) &&
-                                  !op1->IsNeverNegative(this) && !op2->IsNeverNegative(this);
+    const bool byZeroNeedsPin = op2IsNotZero && !op2->IsNeverZero();
+    const bool overflowNeedsPin =
+        (op1IsNotNegative || op2IsNotNegative) && !op1->IsNeverNegative(this) && !op2->IsNeverNegative(this);
     if (byZeroNeedsPin || overflowNeedsPin)
     {
         tree->SetHasOrderingSideEffect();

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4150,8 +4150,10 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions,
     // side effect in that case. A value-based proof (e.g. a constant non-zero divisor)
     // holds everywhere, so such a divide stays freely movable and is not pinned.
     const bool byZeroNeedsPin = op2IsNotZero && !op2->IsNeverZero();
-    const bool overflowNeedsPin =
-        (op1IsNotNegative || op2IsNotNegative) && !op1->IsNeverNegative(this) && !op2->IsNeverNegative(this);
+    // Overflow (ArithmeticException) is only possible for signed div/mod, so only those need
+    // pinning for an assertion-based no-overflow proof.
+    const bool overflowNeedsPin = tree->OperIs(GT_DIV, GT_MOD) && (op1IsNotNegative || op2IsNotNegative) &&
+                                  !op1->IsNeverNegative(this) && !op2->IsNeverNegative(this);
     if (byZeroNeedsPin || overflowNeedsPin)
     {
         tree->SetHasOrderingSideEffect();

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4131,7 +4131,7 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions,
 
     if (op2IsNotZero)
     {
-        JITDUMP("Divisor for DIV/MOD is proven to be never negative...\n")
+        JITDUMP("Divisor for DIV/MOD is proven to be never zero...\n")
         tree->gtFlags |= GTF_DIV_MOD_NO_BY_ZERO;
         changed = true;
     }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4143,12 +4143,17 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions,
         changed = true;
     }
 
-    // GTF_DIV_MOD_NO_BY_ZERO/GTF_DIV_MOD_NO_OVERFLOW make the divide appear non-throwing,
-    // which would otherwise let CSE/loop hoisting move it above the dominating check that
-    // proved the divisor safe (the flag is only valid at this node's location). Pin the
-    // node with an ordering side effect so it cannot be reordered above that check, even
-    // across opt-repeat iterations (see https://github.com/dotnet/runtime/issues/129386).
-    if ((tree->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)) != 0)
+    // The no-throw flags above make the divide look non-throwing. When the safety proof
+    // is location-dependent (derived from a dominating assertion rather than from the
+    // operand's own value), the divide is only safe at this position, so CSE/loop hoisting
+    // must not move it above the check that justified the flag. Pin it with an ordering
+    // side effect in that case (see https://github.com/dotnet/runtime/issues/129386). A
+    // value-based proof (e.g. a constant non-zero divisor) holds everywhere, so such a
+    // divide stays freely movable and is not pinned.
+    const bool byZeroNeedsPin   = op2IsNotZero && !op2->IsNeverZero();
+    const bool overflowNeedsPin = (op1IsNotNegative || op2IsNotNegative) &&
+                                  !op1->IsNeverNegative(this) && !op2->IsNeverNegative(this);
+    if (byZeroNeedsPin || overflowNeedsPin)
     {
         tree->SetHasOrderingSideEffect();
     }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4143,6 +4143,16 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions,
         changed = true;
     }
 
+    // GTF_DIV_MOD_NO_BY_ZERO/GTF_DIV_MOD_NO_OVERFLOW make the divide appear non-throwing,
+    // which would otherwise let CSE/loop hoisting move it above the dominating check that
+    // proved the divisor safe (the flag is only valid at this node's location). Pin the
+    // node with an ordering side effect so it cannot be reordered above that check, even
+    // across opt-repeat iterations (see https://github.com/dotnet/runtime/issues/129386).
+    if ((tree->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)) != 0)
+    {
+        tree->SetHasOrderingSideEffect();
+    }
+
     return changed ? optAssertionProp_Update(tree, tree, stmt) : nullptr;
 }
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4129,34 +4129,20 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions,
         changed = true;
     }
 
-    if (op2IsNotZero)
+    if (op2IsNotZero && ((tree->gtFlags & GTF_DIV_MOD_NO_BY_ZERO) == 0))
     {
-        JITDUMP("Divisor for DIV/MOD is proven to be never zero...\n")
+        JITDUMP("Divisor for DIV/MOD is proven to be never negative...\n")
         tree->gtFlags |= GTF_DIV_MOD_NO_BY_ZERO;
+        tree->SetHasOrderingSideEffect();
         changed = true;
     }
 
-    if (op1IsNotNegative || op2IsNotNegative)
+    if ((op1IsNotNegative || op2IsNotNegative) && ((tree->gtFlags & GTF_DIV_MOD_NO_OVERFLOW) == 0))
     {
         JITDUMP("DIV/MOD is proven to never overflow...\n")
         tree->gtFlags |= GTF_DIV_MOD_NO_OVERFLOW;
-        changed = true;
-    }
-
-    // The no-throw flags above make the divide look non-throwing. When the safety proof
-    // is location-dependent (derived from a dominating assertion rather than from the
-    // operand's own value), the divide is only safe at this position, so CSE/loop hoisting
-    // must not move it above the check that justified the flag. Pin it with an ordering
-    // side effect in that case. A value-based proof (e.g. a constant non-zero divisor)
-    // holds everywhere, so such a divide stays freely movable and is not pinned.
-    const bool byZeroNeedsPin = op2IsNotZero && !op2->IsNeverZero();
-    // Overflow (ArithmeticException) is only possible for signed div/mod, so only those need
-    // pinning for an assertion-based no-overflow proof.
-    const bool overflowNeedsPin = tree->OperIs(GT_DIV, GT_MOD) && (op1IsNotNegative || op2IsNotNegative) &&
-                                  !op1->IsNeverNegative(this) && !op2->IsNeverNegative(this);
-    if (byZeroNeedsPin || overflowNeedsPin)
-    {
         tree->SetHasOrderingSideEffect();
+        changed = true;
     }
 
     return changed ? optAssertionProp_Update(tree, tree, stmt) : nullptr;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5822,35 +5822,11 @@ void Compiler::ResetOptAnnotations()
     {
         for (Statement* const stmt : block->Statements())
         {
-            bool clearedDivModFlags = false;
             for (GenTree* const tree : stmt->TreeList())
             {
                 tree->ClearVN();
                 tree->ClearAssertion();
                 tree->gtCSEnum = NO_CSE;
-
-                // GTF_DIV_MOD_NO_BY_ZERO and GTF_DIV_MOD_NO_OVERFLOW are flow-sensitive
-                // annotations set by assertion propagation once a dominating check proves
-                // the divisor safe at the node's location. They are "set once" facts that
-                // become stale when we re-run the optimizer, and must not be observed by
-                // the next iteration's (flow-insensitive) value numbering: doing so would
-                // let VN model the divide as non-throwing and allow CSE/loop hoisting to
-                // move it above the check that justified the flag (see
-                // https://github.com/dotnet/runtime/issues/129386). Clear them here so each
-                // iteration's assertion propagation re-derives them from scratch.
-                if (tree->OperIs(GT_DIV, GT_UDIV, GT_MOD, GT_UMOD) &&
-                    ((tree->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)) != 0))
-                {
-                    tree->gtFlags &= ~(GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW);
-                    clearedDivModFlags = true;
-                }
-            }
-
-            // Clearing the no-throw flags above can make a divide throwing again, so
-            // recompute the statement's side effects to restore GTF_EXCEPT consistency.
-            if (clearedDivModFlags)
-            {
-                gtUpdateStmtSideEffects(stmt);
             }
         }
     }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5822,11 +5822,35 @@ void Compiler::ResetOptAnnotations()
     {
         for (Statement* const stmt : block->Statements())
         {
+            bool clearedDivModFlags = false;
             for (GenTree* const tree : stmt->TreeList())
             {
                 tree->ClearVN();
                 tree->ClearAssertion();
                 tree->gtCSEnum = NO_CSE;
+
+                // GTF_DIV_MOD_NO_BY_ZERO and GTF_DIV_MOD_NO_OVERFLOW are flow-sensitive
+                // annotations set by assertion propagation once a dominating check proves
+                // the divisor safe at the node's location. They are "set once" facts that
+                // become stale when we re-run the optimizer, and must not be observed by
+                // the next iteration's (flow-insensitive) value numbering: doing so would
+                // let VN model the divide as non-throwing and allow CSE/loop hoisting to
+                // move it above the check that justified the flag (see
+                // https://github.com/dotnet/runtime/issues/129386). Clear them here so each
+                // iteration's assertion propagation re-derives them from scratch.
+                if (tree->OperIs(GT_DIV, GT_UDIV, GT_MOD, GT_UMOD) &&
+                    ((tree->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)) != 0))
+                {
+                    tree->gtFlags &= ~(GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW);
+                    clearedDivModFlags = true;
+                }
+            }
+
+            // Clearing the no-throw flags above can make a divide throwing again, so
+            // recompute the statement's side effects to restore GTF_EXCEPT consistency.
+            if (clearedDivModFlags)
+            {
+                gtUpdateStmtSideEffects(stmt);
             }
         }
     }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8801,10 +8801,11 @@ bool GenTree::OperSupportsOrderingSideEffect() const
         case GT_LOCKADD:
         case GT_CMPXCHG:
         case GT_MEMORYBARRIER:
-        // DIV/UDIV/MOD/UMOD support an ordering side effect so that, once assertion propagation
-        // proves the divide cannot throw (GTF_DIV_MOD_NO_BY_ZERO/GTF_DIV_MOD_NO_OVERFLOW)
-        // and the node would otherwise look movable, it stays pinned below the dominating
-        // check that justified the flag.
+        // DIV/UDIV/MOD/UMOD support an ordering side effect so that, once assertion
+        // propagation proves the divide cannot throw (GTF_DIV_MOD_NO_BY_ZERO for any of
+        // them, plus GTF_DIV_MOD_NO_OVERFLOW for the signed ones) and the node would
+        // otherwise look movable, it stays pinned below the dominating check that
+        // justified the flag.
         case GT_DIV:
         case GT_UDIV:
         case GT_MOD:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8801,7 +8801,7 @@ bool GenTree::OperSupportsOrderingSideEffect() const
         case GT_LOCKADD:
         case GT_CMPXCHG:
         case GT_MEMORYBARRIER:
-        // DIV/MOD support an ordering side effect so that, once assertion propagation
+        // DIV/UDIV/MOD/UMOD support an ordering side effect so that, once assertion propagation
         // proves the divide cannot throw (GTF_DIV_MOD_NO_BY_ZERO/GTF_DIV_MOD_NO_OVERFLOW)
         // and the node would otherwise look movable, it stays pinned below the dominating
         // check that justified the flag.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8801,6 +8801,14 @@ bool GenTree::OperSupportsOrderingSideEffect() const
         case GT_LOCKADD:
         case GT_CMPXCHG:
         case GT_MEMORYBARRIER:
+        // DIV/MOD support an ordering side effect so that, once assertion propagation
+        // proves the divide cannot throw (GTF_DIV_MOD_NO_BY_ZERO/GTF_DIV_MOD_NO_OVERFLOW)
+        // and the node would otherwise look movable, it stays pinned below the dominating
+        // check that justified the flag (see https://github.com/dotnet/runtime/issues/129386).
+        case GT_DIV:
+        case GT_UDIV:
+        case GT_MOD:
+        case GT_UMOD:
         case GT_CATCH_ARG:
         case GT_ASYNC_CONTINUATION:
         case GT_RETURN_SUSPEND:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8804,7 +8804,7 @@ bool GenTree::OperSupportsOrderingSideEffect() const
         // DIV/MOD support an ordering side effect so that, once assertion propagation
         // proves the divide cannot throw (GTF_DIV_MOD_NO_BY_ZERO/GTF_DIV_MOD_NO_OVERFLOW)
         // and the node would otherwise look movable, it stays pinned below the dominating
-        // check that justified the flag (see https://github.com/dotnet/runtime/issues/129386).
+        // check that justified the flag.
         case GT_DIV:
         case GT_UDIV:
         case GT_MOD:

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129386/Runtime_129386.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129386/Runtime_129386.cs
@@ -6,10 +6,10 @@
 // flow-sensitive GTF_DIV_MOD_NO_BY_ZERO flag (set by assertion propagation under
 // a dominating zero-check). CSE/loop-hoisting then moved the division into the
 // loop preheader, above the dominating check, where it executed unconditionally
-// and divided by zero. The fix clears these stale flow-sensitive flags
-// (GTF_DIV_MOD_NO_BY_ZERO / GTF_DIV_MOD_NO_OVERFLOW) between opt-repeat iterations
-// in ResetOptAnnotations, so a later value-numbering pass no longer sees the
-// divide as non-throwing and cannot hoist it above its guard.
+// and divided by zero. The fix marks the divide with an ordering side effect
+// (GTF_ORDER_SIDEEFF) when assertion propagation proves it non-throwing, so it
+// stays pinned below the dominating check and cannot be reordered/hoisted above
+// its guard even though it now looks non-throwing.
 
 using System;
 using System.Numerics;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129386/Runtime_129386.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129386/Runtime_129386.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Under JitOptRepeat (STRESS_OPT_REPEAT), a second value-numbering + CSE round
+// could observe a divide whose DivideByZeroException had been suppressed by the
+// flow-sensitive GTF_DIV_MOD_NO_BY_ZERO flag (set by assertion propagation under
+// a dominating zero-check). CSE/loop-hoisting then moved the division into the
+// loop preheader, above the dominating check, where it executed unconditionally
+// and divided by zero. The division's exception must be modeled from value-based
+// information only, so it is not hoisted above the check that proves it safe.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_129386
+{
+    private static volatile uint s_inputP0 = 0u;
+    private static volatile uint s_inputP1 = 0xFFFFFFFFu;
+    private static int[] s_trace = new int[64];
+    private static int s_traceLen = 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static uint Fn30000002142(uint p0, uint p1)
+    {
+        unchecked
+        {
+            uint v1 = 0, v3 = 0, v4 = 0, v5 = 0, v7 = 0, v11 = 0, v13 = 0, v14 = 0, v19 = 0,
+                 v22 = 0, v23 = 0, v24 = 0, v25 = 0, v33 = 0, v35 = 0, v39 = 0, v42 = 0,
+                 v50 = 0, v51 = 0, v58 = 0, v61 = 0, v63 = 0, v66 = 0, v67 = 0, v68 = 0,
+                 v69 = 0, v71 = 0, v72 = 0, v73 = 0, v74 = 0, v75 = 0, v78 = 0, v80 = 0,
+                 v82 = 0, v83 = 0, v84 = 0, v85 = 0, v86 = 0, v87 = 0, v88 = 0, v93 = 0,
+                 v119 = 0, v120 = 0, v121 = 0, v123 = 0, v124 = 0;
+            int v6 = 0, v10 = 0, v17 = 0, v21 = 0, v26 = 0, v70 = 0, v76 = 0, v77 = 0,
+                v79 = 0, v81 = 0, v118 = 0, v122 = 0;
+
+        b0:
+            v6 = (0u < p0) ? 1 : 0;
+            if (v6 != 0) goto b1;
+            goto b3;
+        b1:
+            v10 = BitOperations.IsPow2(v7) ? 1 : 0;
+            v11 = (uint)v10;
+            v14 = v13 - 0x000D3403u;
+            v17 = (v14 > v4) ? 1 : 0;
+            if (v17 != 0) goto b2;
+            goto b10;
+        b2:
+            s_trace[s_traceLen++] = 2;
+            v19 = v5 % p0;
+            v21 = (p0 <= v11) ? 1 : 0;
+            if (v21 != 0) goto b10;
+            goto b11;
+        b3:
+            v22 = v14 - 0x000CBA13u;
+            v23 = v11 | 0xFFFC3D1Au;
+            v24 = v4 & v22;
+            v25 = 0u & v1;
+            v26 = (v24 > p0) ? 1 : 0;
+            if (v26 != 0) goto b10;
+            goto b12;
+        b10:
+            s_trace[s_traceLen++] = 10;
+            v66 = v51 >>> (int)v61;
+            v67 = v58 - 0x0004A8B9u;
+            v68 = Math.Max(0xFFFA3E09u, 0xFFFFFFFDu);
+            v69 = v33 - v50;
+            v70 = BitOperations.PopCount(0xFFFBC8AAu);
+            v71 = (uint)v70;
+            v72 = v4 | 0x00004D11u;
+            goto b19;
+        b11:
+            s_trace[s_traceLen++] = 11;
+            v73 = v51 + 0x000003E8u;
+            v74 = BitOperations.RotateRight(v39, (int)v42);
+            v75 = 0xFFFAF3CAu + v58;
+            v76 = (v68 == v19) ? 1 : 0;
+            if (v76 != 0) goto b13;
+            goto b0;
+        b12:
+            s_trace[s_traceLen++] = 12;
+            v77 = (v4 < v23) ? 1 : 0;
+            v78 = (uint)v77;
+            v79 = (v35 <= 0x000B9492u) ? 1 : 0;
+            v80 = (uint)v79;
+            v81 = BitOperations.TrailingZeroCount(0xFFFFFFFFu);
+            v82 = (uint)v81;
+            return v82;
+        b13:
+            s_trace[s_traceLen++] = 13;
+            v83 = ~v23;
+            v84 = v25 + v1;
+            v85 = Math.Max(0x80000000u, p1);
+            v86 = 0xFFFF5264u % v84;
+            v87 = p0 & 0xFFFFFFF9u;
+            v88 = ~p0;
+            goto b2;
+        b19:
+            s_trace[s_traceLen++] = 19;
+            v118 = (v83 <= 0x000BF458u) ? 1 : 0;
+            v119 = (uint)v118;
+            v120 = 0x0000001Fu * v93;
+            v121 = ~v75;
+            v122 = BitOperations.Log2(v24);
+            v123 = (uint)v122;
+            v124 = v63 + v3;
+            return v124;
+        }
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        // With p0 == 0 the source-correct path is b0 -> b3 -> b12 -> return 0;
+        // block b2 (which evaluates 'v5 % p0', a divide-by-zero) is unreachable.
+        // The miscompile produced a DivideByZeroException instead.
+        uint result = Fn30000002142(s_inputP0, s_inputP1);
+        return result == 0 ? 100 : 101;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129386/Runtime_129386.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129386/Runtime_129386.cs
@@ -6,8 +6,10 @@
 // flow-sensitive GTF_DIV_MOD_NO_BY_ZERO flag (set by assertion propagation under
 // a dominating zero-check). CSE/loop-hoisting then moved the division into the
 // loop preheader, above the dominating check, where it executed unconditionally
-// and divided by zero. The division's exception must be modeled from value-based
-// information only, so it is not hoisted above the check that proves it safe.
+// and divided by zero. The fix clears these stale flow-sensitive flags
+// (GTF_DIV_MOD_NO_BY_ZERO / GTF_DIV_MOD_NO_OVERFLOW) between opt-repeat iterations
+// in ResetOptAnnotations, so a later value-numbering pass no longer sees the
+// divide as non-throwing and cannot hoist it above its guard.
 
 using System;
 using System.Numerics;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129386/Runtime_129386.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129386/Runtime_129386.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitEnableOptRepeat" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitOptRepeat" Value="Fn30000002142" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitOptRepeatCount" Value="2" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
> [!NOTE]
> This PR (code and description) was generated with AI assistance (GitHub Copilot CLI), reviewed by @JulieLeeMSFT.

Fixes #129386.

## Summary

Under `JitOptRepeat` / `STRESS_OPT_REPEAT`, the JIT could silently miscompile an integer divide, taking a wrong-direction branch into an unreachable `% 0` path and throwing `DivideByZeroException` (default FullOpts/MinOpts return the correct result).

## Root cause

`GTF_DIV_MOD_NO_BY_ZERO` (and the sibling `GTF_DIV_MOD_NO_OVERFLOW`) are **flow-sensitive** annotations that `optAssertionProp_ModDiv` sets on a divide once a dominating check proves the divisor safe *at that node''s location*.

Once the flag is set, `OperExceptions` reports the divide as non-throwing and `GTF_EXCEPT` is cleared, so the node now looks **pure / freely movable**. A later optimization iteration re-runs **(flow-insensitive) value numbering** and CSE / loop hoisting then moves the loop-invariant `0 % p0` into the loop **preheader**, above the dominating `p0 == 0` guard, where it executes unconditionally and throws.

Confirmed from `JitDump`: the divide''s value number carries `DivideByZeroExc` on the first VN pass but not on the repeat pass, after which CSE places the def in the preheader and the guard is folded.

## Fix

When `optAssertionProp_ModDiv` proves a divide non-throwing and sets `GTF_DIV_MOD_NO_BY_ZERO` / `GTF_DIV_MOD_NO_OVERFLOW`, also mark the node with **`GTF_ORDER_SIDEEFF`** (`GenTree::SetHasOrderingSideEffect`). This is the same mechanism the JIT already uses elsewhere for proven-safe-but-must-not-move nodes (bounds checks, indirs, null checks): the divide still benefits from the codegen check elision, but it is pinned in place so CSE / loop hoisting cannot reorder it above the dominating check that justified the flag — even though it now looks non-throwing, and even across opt-repeat iterations. The pin is applied **only when the no-throw proof is location-dependent** (derived from a dominating assertion). A value-based proof (e.g. a constant non-zero divisor) holds everywhere, so such a divide is left freely movable and is not pinned.

`GT_DIV` / `GT_UDIV` / `GT_MOD` / `GT_UMOD` are added to `GenTree::OperSupportsOrderingSideEffect()` so they can carry the flag. `OperExceptions`, code generation, and `StackLevelSetter` are unchanged and stay mutually consistent.

## Testing

- New regression test `src/tests/JIT/Regression/JitBlue/Runtime_129386` (runs the repro under `JitOptRepeat`). It **fails without** the fix (`DivideByZeroException`, exit 101) and **passes with** it (exit 100). Verified on x64 Checked by building the JIT with and without the assertion-prop change.

---

<details>
<summary>History of earlier approaches (superseded)</summary>

**Attempt 1 — `OperExceptions` value-based + codegen reads the flag (superseded).**
Made `GenTree::OperExceptions` model divide-by-zero from value-based info only (ignoring `GTF_DIV_MOD_NO_BY_ZERO`), and had the arm64/loongarch64/riscv64/wasm code generators consult `GTF_DIV_MOD_NO_BY_ZERO` directly to keep eliding the runtime check. This fixed the miscompile but was the wrong shape:
- It created a split-brain oracle: `StackLevelSetter` still used `OperExceptions` and would reserve an `SCK_DIV_BY_ZERO` throw-helper block that codegen never jumps to (dead block). *(Flagged by the automated review.)*
- It did not address the parallel `GTF_DIV_MOD_NO_OVERFLOW` risk for signed div/mod overflow. *(Also flagged by the automated review.)*
- It scattered flag handling across five files.

**Attempt 2 — clear the stale flags in `ResetOptAnnotations` (superseded).**
Cleared `GTF_DIV_MOD_NO_BY_ZERO` / `GTF_DIV_MOD_NO_OVERFLOW` on div/mod nodes between opt-repeat iterations (alongside the existing VN/assertion/CSE reset), recomputing statement side effects afterward. This fixed the miscompile and kept all consumers consistent, but per review feedback (@EgorBo) it treated the symptom at the opt-repeat reset point rather than the cause: the right fix is for *whoever sets the no-throw flag* to also add `GTF_ORDER_SIDEEFF`, which is how the same class of "proven safe, must not reorder" problem is handled everywhere else. Replaced by the current approach.

</details>
