### PR TITLE
[release/9.0-staging] Fix assembly labels on MacOS X64 to be LOCAL_LABEL

### DIFF
--- a/src/coreclr/vm/amd64/Context.S
+++ b/src/coreclr/vm/amd64/Context.S
@@ -21,7 +21,7 @@ NESTED_ENTRY ClrRestoreNonvolatileContextWorker, _TEXT, NoHandler
         mov     r11, rsi
 
         test    byte ptr [r10 + OFFSETOF__CONTEXT__ContextFlags], CONTEXT_INTEGER
-        je      Done_Restore_CONTEXT_INTEGER
+        je      LOCAL_LABEL(Done_Restore_CONTEXT_INTEGER)
         mov     rbx, [r10 + OFFSETOF__CONTEXT__Rbx]
         mov     rcx, [r10 + OFFSETOF__CONTEXT__Rcx]
         mov     rdx, [r10 + OFFSETOF__CONTEXT__Rdx]
@@ -34,25 +34,25 @@ NESTED_ENTRY ClrRestoreNonvolatileContextWorker, _TEXT, NoHandler
         mov     r13, [r10 + OFFSETOF__CONTEXT__R13]
         mov     r14, [r10 + OFFSETOF__CONTEXT__R14]
         mov     r15, [r10 + OFFSETOF__CONTEXT__R15]
-    Done_Restore_CONTEXT_INTEGER:
+    LOCAL_LABEL(Done_Restore_CONTEXT_INTEGER):
     
         test    byte ptr [r10 + OFFSETOF__CONTEXT__ContextFlags], CONTEXT_CONTROL
-        je      Done_Restore_CONTEXT_CONTROL
+        je      LOCAL_LABEL(Done_Restore_CONTEXT_CONTROL)
 
         test    r11, r11
-        je      No_Ssp_Update
+        je      LOCAL_LABEL(No_Ssp_Update)
         rdsspq  rax
         sub     r11, rax
         shr     r11, 3
         // the incsspq instruction uses only the lowest 8 bits of the argument, so we need to loop in case the increment is larger than 255
         mov     rax, 255
-    Update_Loop:
+    LOCAL_LABEL(Update_Loop):
         cmp     r11, rax
         cmovb   rax, r11
         incsspq rax
         sub     r11, rax
-        ja      Update_Loop
-    No_Ssp_Update:
+        ja      LOCAL_LABEL(Update_Loop)
+    LOCAL_LABEL(No_Ssp_Update):
 
         // When user-mode shadow stacks are enabled, and for example the intent is to continue execution in managed code after
         // exception handling, iret and ret can't be used because their shadow stack enforcement would not allow that transition,
@@ -61,7 +61,7 @@ NESTED_ENTRY ClrRestoreNonvolatileContextWorker, _TEXT, NoHandler
         mov     rax, [r10 + OFFSETOF__CONTEXT__Rip]
         mov     rsp, [r10 + OFFSETOF__CONTEXT__Rsp]
         jmp     rax
-    Done_Restore_CONTEXT_CONTROL:
+    LOCAL_LABEL(Done_Restore_CONTEXT_CONTROL):
     
         // The function was not asked to restore the control registers so we return back to the caller
         pop     rbp

--- a/src/coreclr/vm/amd64/virtualcallstubamd64.S
+++ b/src/coreclr/vm/amd64/virtualcallstubamd64.S
@@ -55,31 +55,31 @@ LEAF_ENTRY ResolveWorkerChainLookupAsmStub, _TEXT
         mov     rax, BACKPATCH_FLAG  // First we check if r11 has the BACKPATCH_FLAG set
         and     rax, r11             // Set the flags based on (BACKPATCH_FLAG and r11)
         pop     rax                  // pop the pointer to the ResolveCacheElem from the top of stack (leaving the flags unchanged)
-        jnz     Fail_RWCLAS          // If the BACKPATCH_FLAGS is set we will go directly to the ResolveWorkerAsmStub
+        jnz     LOCAL_LABEL(Fail_RWCLAS)          // If the BACKPATCH_FLAGS is set we will go directly to the ResolveWorkerAsmStub
 
-MainLoop_RWCLAS:
+LOCAL_LABEL(MainLoop_RWCLAS):
         mov     rax, [rax+0x18]   // get the next entry in the chain (don't bother checking the first entry again)
         test    rax,rax          // test if we hit a terminating NULL
-        jz      Fail_RWCLAS
+        jz      LOCAL_LABEL(Fail_RWCLAS)
 
         cmp    rdx, [rax+0x00]    // compare our MT with the one in the ResolveCacheElem
-        jne    MainLoop_RWCLAS
+        jne    LOCAL_LABEL(MainLoop_RWCLAS)
         cmp    r10, [rax+0x08]    // compare our DispatchToken with one in the ResolveCacheElem
-        jne    MainLoop_RWCLAS
-Success_RWCLAS:
+        jne    LOCAL_LABEL(MainLoop_RWCLAS)
+LOCAL_LABEL(Success_RWCLAS):
         PREPARE_EXTERNAL_VAR CHAIN_SUCCESS_COUNTER, rdx
         sub    qword ptr [rdx],1 // decrement success counter
-        jl     Promote_RWCLAS
+        jl     LOCAL_LABEL(Promote_RWCLAS)
         mov    rax, [rax+0x10]    // get the ImplTarget
         pop    rdx
         jmp    rax
 
-Promote_RWCLAS:                  // Move this entry to head position of the chain
+LOCAL_LABEL(Promote_RWCLAS):                  // Move this entry to head position of the chain
         // be quick to reset the counter so we don't get a bunch of contending threads
         mov    qword ptr [rdx], INITIAL_SUCCESS_COUNT
         or     r11, PROMOTE_CHAIN_FLAG
         mov    r10, rax          // We pass the ResolveCacheElem to ResolveWorkerAsmStub instead of the DispatchToken
-Fail_RWCLAS:
+LOCAL_LABEL(Fail_RWCLAS):
         pop    rdx               // Restore the original saved rdx value
         push   r10               // pass the DispatchToken or ResolveCacheElem to promote to ResolveWorkerAsmStub
 


### PR DESCRIPTION
Backport of #129531 to release/9.0-staging.

/cc @davidwrighton

## Customer Impact

- [ ] Customer reported
- [x] Found internally

Without this fix, macOS x64 assembly labels can be emitted as ordinary symbols instead of local labels. That can let the linker carve up functions incorrectly, leading to incorrect runtime behavior.

## Regression

- [ ] Yes
- [x] No

No known recent regression; this fixes existing assembly label authoring for macOS x64.

## Testing

This backport changes `src/coreclr/vm/amd64/Context.S` and `src/coreclr/vm/amd64/virtualcallstubamd64.S`. No new test was added because this is an assembly-label/linker-behavior fix. The source PR and this backport PR rely on CI coverage for the affected release branch.

## Risk

Low. The change is limited to converting internal assembly labels and branches to LOCAL_LABEL(...) in macOS x64 CoreCLR assembly code, preserving control flow while avoiding externally visible labels.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is elease/X.0-staging, not elease/X.0.

## Package authoring no longer needed in .NET 9

**IMPORTANT**: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.

> [!NOTE]
> This PR description was generated by GitHub Copilot.