### PR TITLE
Limit osx-x64 CoreCLR_Libraries PR builds

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -349,8 +349,7 @@ extends:
                   displayName: Build Assets
             condition: >-
               or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
       #


### PR DESCRIPTION
## Summary
- limit the osx-x64 release CoreCLR_Libraries PR build to installer-related changes
- keep the build running for non-PR rolling builds

## Context
The osx-x64 release CoreCLR_Libraries build exists for the osx-x64 installer build/test dependency path, so PR builds only need it when installer tests can run.

> [!NOTE]
> This PR description was created by GitHub Copilot.