### PR TITLE
Locate crossgen2 by $(CoreCLRConfiguration) in ILCompiler.ReadyToRun.Tests

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
@@ -21,7 +21,14 @@
 
   <ItemGroup>
     <ProjectReference Include="../ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj" />
-    <ProjectReference Include="../crossgen2/crossgen2_inbuild.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../crossgen2/crossgen2_inbuild.csproj" ReferenceOutputAssembly="false">
+      <!-- crossgen2 is a CoreCLR artifact, so publish it in the CoreCLR configuration. This keeps it
+           alongside the other CoreCLR artifacts the test consumes (System.Private.CoreLib, the JITs)
+           even when this test project is built in a different configuration than CoreCLR was (e.g.
+           CoreCLR built Release via 'clr -rc release', but the test built/run as Debug). Mirrors the
+           CoreLib SetConfiguration pattern in eng/references.targets. -->
+      <SetConfiguration Condition="'$(Configuration)' != '$(CoreCLRConfiguration)'">Configuration=$(CoreCLRConfiguration)</SetConfiguration>
+    </ProjectReference>
   </ItemGroup>
 
   <!-- HACK: We run runtime.proj inline to build the wasm JIT and then Copy it directly into
@@ -57,7 +64,7 @@
       <_WasmJitCrossHostArchSubdir Condition="'$(_BuildJitsCrossArch)' == 'true'">$(BuildArchitecture)/</_WasmJitCrossHostArchSubdir>
       <_WasmJitFileName>$(HostLibPrefix)clrjit_universal_wasm_$(BuildArchitecture)$(HostLibSuffix)</_WasmJitFileName>
       <_WasmJitSourcePath>$(CoreCLRArtifactsPath)$(_WasmJitCrossHostArchSubdir)$(_WasmJitFileName)</_WasmJitSourcePath>
-      <_Crossgen2InbuildPublishDir>$(RuntimeBinDir)$(BuildArchitecture)/crossgen2/</_Crossgen2InbuildPublishDir>
+      <_Crossgen2InbuildPublishDir>$(CoreCLRArtifactsPath)$(BuildArchitecture)/crossgen2/</_Crossgen2InbuildPublishDir>
     </PropertyGroup>
     <Copy SourceFiles="$(_WasmJitSourcePath)"
           DestinationFolder="$(_Crossgen2InbuildPublishDir)"
@@ -74,7 +81,7 @@
   <!-- Pass build-time paths to test runtime via RuntimeHostConfigurationOption -->
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="R2RTest.Crossgen2Dir">
-      <Value>$(RuntimeBinDir)/$(BuildArchitecture)/crossgen2</Value>
+      <Value>$(CoreCLRArtifactsPath)/$(BuildArchitecture)/crossgen2</Value>
     </RuntimeHostConfigurationOption>
     <RuntimeHostConfigurationOption Include="R2RTest.RuntimePackDir">
       <Value>$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</Value>


### PR DESCRIPTION
The ILCompiler.ReadyToRun.Tests project resolved crossgen2 and the copied JIT via `$(RuntimeBinDir)`, which is keyed on the test project's own `$(Configuration)`, while the sibling CoreCLR artifacts it sits next to (System.Private.CoreLib, the JITs) are keyed on `$(CoreCLRConfiguration)` via `$(CoreCLRArtifactsPath)`. These agree in CI (Configuration=CoreCLRConfiguration) but diverge in dev builds where `clr` is built in `Release`, and test is run in the default Debug config.

Align all the crossgen2 config/location on $(CoreCLRConfiguration):
- The crossgen2_inbuild ProjectReference now sets Configuration to `$(CoreCLRConfiguration)`, so crossgen2 publishes under the CoreCLR config.
- The wasm JIT copy destination and the R2RTest.Crossgen2Dir runtime option now use `$(CoreCLRArtifactsPath)` instead of `$(RuntimeBinDir)`.

In CI this is a no-op (Configuration == CoreCLRConfiguration). For dev builds it lets the test find crossgen2 without forcing the test project to be built in the same configuration as CoreCLR.