### PR TITLE
[wasm] Restore TARGET_WASM short-circuit in VirtualUnwindCallFrame

### DIFF
--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -421,6 +421,17 @@ PCODE Thread::VirtualUnwindCallFrame(T_CONTEXT* pContext,
                                         EECodeInfo * pCodeInfo /*= NULL*/
                                         ARM64_ARG(TADDR * pSpForPacSign /*= NULL*/))
 {
+#ifdef TARGET_WASM
+    // Interpreter-only WASM has no R2R unwind info to walk and no
+    // RtlVirtualUnwind equivalent. EH stack-walking on WASM proceeds through
+    // the explicit Frame chain (Thread::GetFrame()), so this overload should
+    // never be reached on the interpreter-only path. PR #128423 (Use Virtual
+    // IPs in R2R format) removed the original short-circuit assuming all WASM
+    // use-cases now have R2R unwind info, which is not true for the
+    // interpreter-only WASI build.
+    _ASSERTE(!"VirtualUnwindCallFrame is not supported on WebAssembly");
+    return 0;
+#else
     CONTRACTL
     {
         NOTHROW;
@@ -568,6 +579,7 @@ PCODE Thread::VirtualUnwindCallFrame(T_CONTEXT* pContext,
 #endif // !DACCESS_COMPILE
 
     return uControlPc;
+#endif // TARGET_WASM
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -425,10 +425,7 @@ PCODE Thread::VirtualUnwindCallFrame(T_CONTEXT* pContext,
     // Interpreter-only WASM has no R2R unwind info to walk and no
     // RtlVirtualUnwind equivalent. EH stack-walking on WASM proceeds through
     // the explicit Frame chain (Thread::GetFrame()), so this overload should
-    // never be reached on the interpreter-only path. PR #128423 (Use Virtual
-    // IPs in R2R format) removed the original short-circuit assuming all WASM
-    // use-cases now have R2R unwind info, which is not true for the
-    // interpreter-only WASI build.
+    // never be reached on the interpreter-only path.
     _ASSERTE(!"VirtualUnwindCallFrame is not supported on WebAssembly");
     return 0;
 #else

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -422,13 +422,18 @@ PCODE Thread::VirtualUnwindCallFrame(T_CONTEXT* pContext,
                                         ARM64_ARG(TADDR * pSpForPacSign /*= NULL*/))
 {
 #ifdef TARGET_WASM
-    // Interpreter-only WASM has no R2R unwind info to walk and no
-    // RtlVirtualUnwind equivalent. EH stack-walking on WASM proceeds through
-    // the explicit Frame chain (Thread::GetFrame()), so this overload should
-    // never be reached on the interpreter-only path.
-    _ASSERTE(!"VirtualUnwindCallFrame is not supported on WebAssembly");
-    return 0;
-#else
+    // WASM has a custom RtlVirtualUnwind (vm/wasm/helpers.cpp) that handles
+    // R2R-WASM frames keyed by virtual IPs. For interpreter-only WASM (e.g.,
+    // the WASI corerun) there is no R2R unwind info and no virtual IP, so
+    // walking past such a frame is not supported and the call into the body
+    // would corrupt the register display. Fail fast in that case; let R2R
+    // frames flow through the regular path below.
+    if (!ExecutionManager::IsVirtualIP(GetIP(pContext)))
+    {
+        _ASSERTE(!"VirtualUnwindCallFrame: non-virtual-IP context on WebAssembly");
+        return 0;
+    }
+#endif // TARGET_WASM
     CONTRACTL
     {
         NOTHROW;
@@ -576,7 +581,6 @@ PCODE Thread::VirtualUnwindCallFrame(T_CONTEXT* pContext,
 #endif // !DACCESS_COMPILE
 
     return uControlPc;
-#endif // TARGET_WASM
 }
 
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
PR #128423 (Use Virtual IPs in R2R format) removed the TARGET_WASM short-circuit at the top of Thread::VirtualUnwindCallFrame(T_CONTEXT*) on the assumption that all WASM builds now ship R2R unwind info that the function can walk. That is not the case for the interpreter-only WASI corerun: there is no R2R, and the function has no RtlVirtualUnwind equivalent to fall back to.

Restore the assert + early-return-0 (matching the original code from PR #113429) so the function is a hard error instead of corrupting the register display by calling RtlVirtualUnwind on an unrelated context. On WASM EH stack-walking proceeds through the explicit Frame chain (Thread::GetFrame()), so this overload is not reached on the working path; restoring the short-circuit only protects against future bugs that would otherwise show up as silent register-display corruption.

This is defensive and not a fix for the wider interp+EH integration gap on WASI (managed try/catch still aborts in SfiNextWorker at the 'unhandled by runtime' branch; that needs separate work).