### PR TITLE
Use common helper to decide runtime lookups for code pointers

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1456,15 +1456,11 @@ namespace Internal.JitInterface
 
                 if (pResult->exactContextNeedsRuntimeLookup)
                 {
-                    MethodDesc caller = HandleToObject(callerHandle);
-
-                    pResult->codePointerOrStubLookup.lookupKind.needsRuntimeLookup = true;
-                    pResult->codePointerOrStubLookup.runtimeLookup.indirections = CORINFO.USEHELPER;
-                    pResult->codePointerOrStubLookup.runtimeLookup.helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_GENERIC_HANDLE;
-                    pResult->codePointerOrStubLookup.lookupKind.runtimeLookupKind = GetGenericRuntimeLookupKind(caller);
-                    object helperArg = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
-                    ISymbolNode helper = GetGenericLookupHelper(pResult->codePointerOrStubLookup.lookupKind.runtimeLookupKind, ReadyToRunHelperId.MethodEntry, caller, helperArg);
-                    pResult->codePointerOrStubLookup.runtimeLookup.helperEntryPoint = CreateConstLookupToSymbol(helper);
+                    ComputeLookup(ref pResolvedToken,
+                        GetRuntimeDeterminedObjectForToken(ref pResolvedToken),
+                        ReadyToRunHelperId.MethodEntry,
+                        HandleToObject(callerHandle),
+                        ref pResult->codePointerOrStubLookup);
                 }
                 else
                 {


### PR DESCRIPTION
Instead of always using R2R helper, decide the appropriate lookup strategy with the shared helper.