### PR TITLE
Bump timeout for runtime-interpreter build job

### DIFF
--- a/eng/pipelines/coreclr/interpreter.yml
+++ b/eng/pipelines/coreclr/interpreter.yml
@@ -35,6 +35,7 @@ extends:
           - osx_arm64
           jobParameters:
             buildArgs: -s clr+libs -c $(_BuildConfig) -lc Release
+            timeoutInMinutes: 120
             postBuildSteps:
               - template: /eng/pipelines/coreclr/templates/build-native-test-assets-step.yml
               - template: /eng/pipelines/common/upload-artifact-step.yml
@@ -63,7 +64,7 @@ extends:
           testGroup: outerloop
 
       #
-      # Checked JIT test runs
+      # Checked Interpreter test runs
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:


### PR DESCRIPTION
Product build job takes longer than the default of 60minutes on windows-arm64, which is likely slower hardware. For the runtime pipeline, the timeout for coreclr build jobs is set to 120 so let's do the same for the interpreter pipeline.