### PR TITLE
[ci-scan] Add superpmi-diffs and Fuzzlyn pipelines to CI failure scan

### DIFF
--- a/.github/workflows/ci-failure-scan.md
+++ b/.github/workflows/ci-failure-scan.md
@@ -154,8 +154,10 @@ For each row in the pipeline table below:
 | runtime-coreclr pgo | 144 | |
 | runtime-coreclr libraries-pgo | 145 | |
 | gc-standalone | 146 | ADO name differs from display name |
+| runtime-coreclr superpmi-diffs | 152 | |
 | runtime-coreclr superpmi-replay | 150 | |
 | runtime-coreclr superpmi-asmdiffs-checked-release | 153 | |
+| Fuzzlyn | 149 | |
 | runtime-coreclr jit-cfg | 155 | Control flow guard |
 | runtime-coreclr jitstress-random | 159 | Stress mode value comes from logs |
 | runtime-coreclr libraries-jitstress-random | 160 | Stress mode value comes from logs |


### PR DESCRIPTION
Adds two outer-loop AzDO pipelines that were missing from the `ci-failure-scan` walk-through table so their `main` failures get triaged into Known Build Errors:

| Pipeline | Definition ID |
|----------|---------------|
| runtime-coreclr superpmi-diffs | 152 |
| Fuzzlyn | 149 |

`runtime-coreclr superpmi-replay` (150) and `runtime-coreclr superpmi-asmdiffs-checked-release` (153) are already present in the table, so no change was needed for those.

Definition IDs verified against the dnceng-public AzDO build-definition API. The pipeline table is runtime-imported prose, so no `.lock.yml` recompilation is required.

> [!NOTE]
> This PR was generated with assistance from GitHub Copilot.
