### PR TITLE
Remove unneeded message printed in case of Tizen build

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -160,8 +160,6 @@ if(TIZEN)
     find_toolchain_dir("${CROSS_ROOTFS}/usr/lib64/gcc/${TIZEN_TOOLCHAIN}")
   endif()
 
-  message(STATUS "TIZEN_TOOLCHAIN_PATH set to: ${TIZEN_TOOLCHAIN_PATH}")
-
   include_directories(SYSTEM ${TIZEN_TOOLCHAIN_PATH}/include/c++)
   include_directories(SYSTEM ${TIZEN_TOOLCHAIN_PATH}/include/c++/${TIZEN_TOOLCHAIN})
 endif()


### PR DESCRIPTION
Without this change output of `cmake -P eng/native/output-toolchain-info.cmake` is not in xml format, and this breaks build of src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj

```
/home/runtime/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj(74,5): error MSB4018: The "XmlPeek" task failed unexpectedly. /home/runtime/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj(74,5): error MSB4018: System.NullReferenceException: Object reference not set to an instance of an object.
/home/runtime/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj(74,5): error MSB4018:    at Microsoft.Build.Tasks.XmlPeek.Execute()
/home/runtime/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj(74,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(TaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
    0 Warning(s)
    1 Error(s)
```