### PR TITLE
Fix debug build of libraries tests

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
Without this change there's error:

```
/home/runtime/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs(29,158): error CS0103: The name 'RuntimeInformation' does not exist in the current context [/home/runtime/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj::TargetFramework=net11.0-unix]
```

This is introduced in https://github.com/dotnet/runtime/pull/129479