### PR TITLE
Fix build break in System.Net.Security TestConfiguration after OpenBSD port (#129479)

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
## Problem

PR #129479 (Port System.Net.Security to OpenBSD) merged to `main` on 2026-06-18 and reintroduced uses of `RuntimeInformation.IsOSPlatform(OSPlatform.Create("OPENBSD"))` in `src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs` (lines 29-30) without adding the corresponding `using System.Runtime.InteropServices;` directive.

The `using` had been removed previously because #124555 (Remove Windows 7 support code from System.Net.Security) had cleaned up the only references that needed it.

As a result, `main` HEAD currently fails to build with:

```
TestConfiguration.cs(29,158): error CS0103: The name 'RuntimeInformation' does not exist in the current context
TestConfiguration.cs(29,190): error CS0103: The name 'OSPlatform' does not exist in the current context
TestConfiguration.cs(30,158): error CS0103: The name 'RuntimeInformation' does not exist in the current context
TestConfiguration.cs(30,190): error CS0103: The name 'OSPlatform' does not exist in the current context
```

This breaks every open PR's CI as soon as it merges in the latest `main` (e.g. observed on the codeflow PR #129454 across 21 build legs).

#129479's own CI had these same 4 errors prior to merge (build [1467260](https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_build/results?buildId=1467260)), but the PR was admin-merged.

## Fix

Add `using System.Runtime.InteropServices;` to `TestConfiguration.cs`. One-line fix.

> [!NOTE]
> This comment was AI/Copilot-generated.
