### PR TITLE
[browser] Wasm boot JSON: touch a stamp, not the boot JSON itself (fix #129280)

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -708,7 +708,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     DependsOnTargets="_WriteWasmBootJsonBuildPropertyStamp"
     Condition="'$(WasmBuildingForNestedPublish)' != 'true'"
     Inputs="@(IntermediateAssembly);@(WasmStaticWebAsset);@(_WasmJsModuleCandidatesForBuild);@(_WasmFilesToIncludeInFileSystemStaticWebAsset);@(_WasmJsConfigStaticWebAsset);@(_WasmDotnetJsForBuild);@(WasmBootConfigExtension);$(ProjectRuntimeConfigFilePath);$(MSBuildProjectFullPath);$(MSBuildThisFileFullPath);$(_WebAssemblySdkTasksAssembly);$(IntermediateOutputPath)wasm-bootjson-build.stamp"
-    Outputs="$(_WasmBuildBootJsonPath)">
+    Outputs="$(IntermediateOutputPath)wasm-bootjson-build.complete.stamp">
 
     <GenerateWasmBootJson
       AssemblyPath="@(IntermediateAssembly)"
@@ -748,12 +748,20 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <FileWrites Include="$(_WasmBuildBootJsonPath)" />
+      <FileWrites Include="$(IntermediateOutputPath)wasm-bootjson-build.complete.stamp" />
     </ItemGroup>
 
-    <!-- The GenerateWasmBootJson task uses content comparison and preserves old timestamps when
-         the output content is unchanged. Touch the output so MSBuild's Inputs/Outputs check
-         sees a current timestamp and can correctly skip this target on subsequent builds. -->
-    <Touch Files="$(_WasmBuildBootJsonPath)" />
+    <!-- The GenerateWasmBootJson task uses content comparison and preserves old timestamps
+         when the output content is unchanged. We need a current timestamp on something for
+         MSBuild's Inputs/Outputs check to correctly skip this target on subsequent builds,
+         but we must NOT touch $(_WasmBuildBootJsonPath) itself: that file is a source for the
+         StaticWebAssets compression pipeline (GZipCompress/BrotliCompress) and the copy-to-
+         output target (_BuildCopyStaticWebAssetsPreserveNewest). Bumping its timestamp on every
+         build defeats their incrementality checks and breaks `dotnet build -question` (see
+         dotnet/runtime#129280, dotnet/runtime#124729, dotnet/aspnetcore#63207).
+         Touch a separate stamp file that is the target's Outputs= so MSBuild sees a current
+         output timestamp without affecting downstream consumers of the boot JSON. -->
+    <Touch Files="$(IntermediateOutputPath)wasm-bootjson-build.complete.stamp" AlwaysCreate="true" />
   </Target>
 
   <!-- Define the boot config file as a static web asset and create endpoints.
@@ -1180,7 +1188,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GeneratePublishWasmBootJson"
     DependsOnTargets="_WriteWasmPublishBootJsonPropertyStamp"
     Inputs="@(IntermediateAssembly);@(_WasmPublishAsset);@(_WasmJsModuleCandidatesForPublish);@(_WasmPublishConfigFile);@(_WasmDotnetJsForPublish);@(WasmBootConfigExtension);$(ProjectRuntimeConfigFilePath);$(MSBuildProjectFullPath);$(MSBuildThisFileFullPath);$(_WebAssemblySdkTasksAssembly);$(IntermediateOutputPath)wasm-bootjson-publish.stamp"
-    Outputs="$(IntermediateOutputPath)$(_WasmPublishBootConfigFileName)">
+    Outputs="$(IntermediateOutputPath)wasm-bootjson-publish.complete.stamp">
 
     <GenerateWasmBootJson
       AssemblyPath="@(IntermediateAssembly)"
@@ -1220,12 +1228,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <FileWrites Include="$([MSBuild]::NormalizePath($(IntermediateOutputPath), $(_WasmPublishBootConfigFileName)))" />
+      <FileWrites Include="$(IntermediateOutputPath)wasm-bootjson-publish.complete.stamp" />
     </ItemGroup>
 
-    <!-- The GenerateWasmBootJson task uses content comparison and preserves old timestamps when
-         the output content is unchanged. Touch the output so MSBuild's Inputs/Outputs check
-         sees a current timestamp and can correctly skip this target on subsequent builds. -->
-    <Touch Files="$(IntermediateOutputPath)$(_WasmPublishBootConfigFileName)" />
+    <!-- See _WriteBuildWasmBootJsonFile for rationale: touch a separate stamp file rather than
+         the boot JSON itself to avoid cascading mtime bumps into downstream StaticWebAssets
+         compression / copy targets. -->
+    <Touch Files="$(IntermediateOutputPath)wasm-bootjson-publish.complete.stamp" AlwaysCreate="true" />
 
   </Target>
 

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -773,6 +773,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- Track boot JSON for clean operations even when _WriteBuildWasmBootJsonFile was skipped -->
       <FileWrites Include="$(_WasmBuildBootJsonPath)" />
+      <!-- Track the completion stamp here too: when _WriteBuildWasmBootJsonFile is skipped on
+           incremental builds, its in-body FileWrites entries aren't populated. Without this,
+           `dotnet clean` would leave the stamp behind and the next build would (correctly)
+           see it as up-to-date even though the boot JSON was just cleaned. -->
+      <FileWrites Include="$(IntermediateOutputPath)wasm-bootjson-build.complete.stamp" />
       <_WasmBuildBootConfigCandidate
         Include="$(_WasmBuildBootJsonPath)"
         RelativePath="_framework/$(_WasmBootConfigFileName)" />
@@ -1092,6 +1097,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- Track boot JSON for clean operations even when GeneratePublishWasmBootJson was skipped -->
       <FileWrites Include="$(IntermediateOutputPath)$(_WasmPublishBootConfigFileName)" />
+      <!-- Track the completion stamp here too: see _GenerateBuildWasmBootJson for rationale. -->
+      <FileWrites Include="$(IntermediateOutputPath)wasm-bootjson-publish.complete.stamp" />
       <_WasmPublishBootConfigCandidate
         Include="$([MSBuild]::NormalizePath($(IntermediateOutputPath), $(_WasmPublishBootConfigFileName)))"
         RelativePath="_framework/$(_WasmBootConfigFileName)" />


### PR DESCRIPTION
## Problem

`Wasm.Build.Tests.WasmTemplateTests.TypeScriptDefinitionsCopiedToWwwrootOnBuild(config: Debug, emitTypeScriptDts: True)` fails its `dotnet build -question` rebuild check with:

```
MSBUILD : error : Building target "_BuildCopyStaticWebAssetsPreserveNewest" partially,
because some output files are out of date with respect to their input files.
[_BuildStaticWebAssetsPreserveNewest:
  Input  = obj\Debug\net11.0\compressed\{hash}-{0}-{fp}-{fp}.gz,
  Output = bin\Debug\net11.0\wwwroot\_framework\dotnet.{fp}.js.gz]
Input file is newer than output file.
```

This is the same family of bug as #129280 (different surface: upstream variant where MSBuild flags `_WriteBuildWasmBootJsonFile` itself as stale; ours is the downstream cascade through compression).

## Root cause

Binlog analysis:
1. `_WriteBuildWasmBootJsonFile` runs `GenerateWasmBootJson` (uses `ArtifactWriter.PersistFileIfChanged`, preserves old mtime on unchanged content) followed by `<Touch Files="$(_WasmBuildBootJsonPath)" />` (added in #125367 to keep MSBuild's I/O check on this target happy).
2. `$(_WasmBuildBootJsonPath)` — `obj/{cfg}/{tfm}/dotnet.js` — is also a source for the StaticWebAssets compression pipeline (`GenerateBuildCompressedStaticWebAssets` → `GZipCompress`).
3. `GZipCompress.cs` skips when `input.mtime < output.mtime` (strict `<`). When `Touch` lands close enough in time to the `.gz` write (or any subsequent target re-stamps dotnet.js), equal/newer mtimes send the next build's compression task down the re-compress path.
4. Re-compression on build #2 bumps `obj/.../{0}.gz` mtime past `bin/.../dotnet.{fp}.js.gz` (which was copied during build #1 and isn't touched since), so `_BuildCopyStaticWebAssetsPreserveNewest` reports its input newer than its output. `-question` fails.

This is a regression of #118637 (Aug 2025, *"Override boot config only when the content changes"*), which fixed the exact same `_BuildCopyStaticWebAssetsPreserveNewest` symptom in dotnet/aspnetcore#63207 by introducing `ArtifactWriter.PersistFileIfChanged`. PR #125367's `<Touch>` undid that protection.

## Fix

Touch a separate `wasm-bootjson-{build,publish}.complete.stamp` file rather than the boot JSON itself, and use the stamp as the target's `Outputs=`. MSBuild's incrementality check on the boot-JSON target stays correct (its declared output has a current mtime after every successful run), while the boot JSON's mtime remains content-derived — preserving #118637's invariant for downstream consumers.

Applied to both:
- `_WriteBuildWasmBootJsonFile` (build)
- `GeneratePublishWasmBootJson` (publish)

Both have identical shape and the same downstream consumers (StaticWebAssets compression / Copy targets).

## What's not fixed here

- `_ConvertBuildDllsToWebcil` (line 431) uses the same `<Touch>` pattern but on per-item-batched `@(_WasmConvertedWebcilOutputs)`. It is *probably* exposed to the same cascade for the webcil files; not addressed here pending a per-item analysis.
- Defense-in-depth in `dotnet/sdk`: `GZipCompress`/`BrotliCompress` `<` mtime check could become `<=` to harden the entire StaticWebAssets pipeline against this class of cascade. Worth a separate dotnet/sdk PR.

## Verification

- Reproduces on `dotnet/runtime` PR #129454 build https://dev.azure.com/dnceng-public/public/_build/results?buildId=1470806 (`browser-wasm windows Release WasmBuildTests`, workitem `WBT-NoWebcil-MONO-ST-Wasm.Build.Tests.WasmTemplateTests`).
- The WBT theory case `TypeScriptDefinitionsCopiedToWwwrootOnBuild(Debug|Release, emitTypeScriptDts:True)` exercises the `dotnet build -question` second-build check that this fix addresses.

Fixes #129280

> [!NOTE]
> This pull request was created with the assistance of GitHub Copilot.
