### PR TITLE
Add warning for duplicate assembly references with same simple name and different versions

### DIFF
--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -28,13 +28,13 @@ namespace System.CommandLine
         public static string[] ValidOS { get; } = ["windows", "linux", "freebsd", "openbsd", "osx", "maccatalyst", "ios", "iossimulator", "tvos", "tvossimulator", "android", "browser", "wasi"];
         public static string[] ValidArchitectures { get; } = ["arm", "armel", "arm64", "x86", "x64", "riscv64", "loongarch64", "wasm"];
 
-        public static Dictionary<string, string> BuildPathDictionary(IReadOnlyList<Token> tokens, bool strict)
+        public static Dictionary<string, string> BuildPathDictionary(IReadOnlyList<Token> tokens, bool strict, Action<string, string, string> onDuplicateDropped = null)
         {
             Dictionary<string, string> dictionary = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (Token token in tokens)
             {
-                AppendExpandedPaths(dictionary, token.Value, strict);
+                AppendExpandedPaths(dictionary, token.Value, strict, onDuplicateDropped);
             }
 
             return dictionary;
@@ -366,7 +366,7 @@ namespace System.CommandLine
         }
 
         // Helper to create a collection of paths unique in their simple names.
-        private static void AppendExpandedPaths(Dictionary<string, string> dictionary, string pattern, bool strict)
+        private static void AppendExpandedPaths(Dictionary<string, string> dictionary, string pattern, bool strict, Action<string, string, string> onDuplicateDropped = null)
         {
             bool empty = true;
             string directoryName = Path.GetDirectoryName(pattern);
@@ -389,6 +389,12 @@ namespace System.CommandLine
                         {
                             throw new CommandLineException("Multiple input files matching same simple name " +
                                 fullFileName + " " + otherFullFileName);
+                        }
+                        else
+                        {
+                            // The earlier file (otherFullFileName) wins binding; this one is dropped. Notify
+                            // the caller so it can warn if the files are genuinely different.
+                            onDuplicateDropped?.Invoke(simpleName, otherFullFileName, fullFileName);
                         }
                     }
                     else

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/ReferenceConflict/ConflictingApp.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/ReferenceConflict/ConflictingApp.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+public static class App
+{
+    public static int Main() => Lib.GetValue();
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/ReferenceConflict/ConflictingLibV1.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/ReferenceConflict/ConflictingLibV1.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+[assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
+
+public static class Lib
+{
+    public static int GetValue() => 1;
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/ReferenceConflict/ConflictingLibV2.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/ReferenceConflict/ConflictingLibV2.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+[assembly: System.Reflection.AssemblyVersion("2.0.0.0")]
+
+public static class Lib
+{
+    public static int GetValue() => 2;
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/ReferenceVersionConflictTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/ReferenceVersionConflictTests.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using ILCompiler.ReadyToRun.Tests.TestCasesRunner;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILCompiler.ReadyToRun.Tests.TestCases;
+
+/// <summary>
+/// Tests that crossgen2 warns when the same assembly simple name is passed as a reference
+/// more than once with different versions/identity. crossgen2 silently binds to the first
+/// such reference, which can produce R2R code that throws MissingMethodException at runtime.
+/// </summary>
+public class ReferenceVersionConflictTests
+{
+    private const string LibAssemblyName = "ConflictingLib";
+
+    private readonly ITestOutputHelper _output;
+
+    public ReferenceVersionConflictTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void WarnsWhenReferencesHaveDifferentVersions()
+    {
+        // Two builds of the same assembly name with different versions (and thus different MVIDs),
+        // emitted to separate subdirectories so they coexist on disk.
+        var libV1 = new CompiledAssembly
+        {
+            AssemblyName = LibAssemblyName,
+            SourceResourceNames = ["ReferenceConflict/ConflictingLibV1.cs"],
+            OutputSubdirectory = "v1",
+        };
+        var libV2 = new CompiledAssembly
+        {
+            AssemblyName = LibAssemblyName,
+            SourceResourceNames = ["ReferenceConflict/ConflictingLibV2.cs"],
+            OutputSubdirectory = "v2",
+        };
+        var app = new CompiledAssembly
+        {
+            AssemblyName = "ConflictingApp",
+            SourceResourceNames = ["ReferenceConflict/ConflictingApp.cs"],
+            References = [libV1],
+        };
+
+        // Pass v1 first so it is the binding winner (matching what the app was built against),
+        // and v2 second as the dropped, conflicting reference.
+        var cgApp = new CrossgenAssembly(app);
+        var cgLibV1 = new CrossgenAssembly(libV1) { Kind = Crossgen2InputKind.Reference };
+        var cgLibV2 = new CrossgenAssembly(libV2) { Kind = Crossgen2InputKind.Reference };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(WarnsWhenReferencesHaveDifferentVersions),
+            [new CrossgenCompilation(app.AssemblyName, [cgApp, cgLibV1, cgLibV2]) { ValidateResult = ValidateWarns }]));
+
+        static void ValidateWarns(R2RCompilationResult result)
+        {
+            string output = result.StandardOutput + result.StandardError;
+            // The conflict is a warning, not an error: crossgen2 still produces an image.
+            Assert.True(result.Success, $"crossgen2 should succeed with a warning:\n{output}");
+            // The "warning:" prefix is what the SDK's RunReadyToRunCompiler task scans for
+            // (case-insensitively) to surface R2R compiler warnings, so assert it explicitly.
+            Assert.Contains("warning:", output, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(LibAssemblyName, output);
+            Assert.Contains("1.0.0.0", output);
+            Assert.Contains("2.0.0.0", output);
+        }
+    }
+
+    [Fact]
+    public void DoesNotWarnWhenReferencesAreIdentical()
+    {
+        // Two builds of the same source. Deterministic compilation yields identical MVID and
+        // version, so passing both as references (from different paths) must not warn.
+        var libA = new CompiledAssembly
+        {
+            AssemblyName = LibAssemblyName,
+            SourceResourceNames = ["ReferenceConflict/ConflictingLibV1.cs"],
+            OutputSubdirectory = "a",
+        };
+        var libB = new CompiledAssembly
+        {
+            AssemblyName = LibAssemblyName,
+            SourceResourceNames = ["ReferenceConflict/ConflictingLibV1.cs"],
+            OutputSubdirectory = "b",
+        };
+        var app = new CompiledAssembly
+        {
+            AssemblyName = "ConflictingApp",
+            SourceResourceNames = ["ReferenceConflict/ConflictingApp.cs"],
+            References = [libA],
+        };
+
+        var cgApp = new CrossgenAssembly(app);
+        var cgLibA = new CrossgenAssembly(libA) { Kind = Crossgen2InputKind.Reference };
+        var cgLibB = new CrossgenAssembly(libB) { Kind = Crossgen2InputKind.Reference };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(DoesNotWarnWhenReferencesAreIdentical),
+            [new CrossgenCompilation(app.AssemblyName, [cgApp, cgLibA, cgLibB]) { ValidateResult = ValidateNoWarning }]));
+
+        static void ValidateNoWarning(R2RCompilationResult result)
+        {
+            string output = result.StandardOutput + result.StandardError;
+            Assert.True(result.Success, $"crossgen2 should succeed:\n{output}");
+            Assert.DoesNotContain("warning:", output, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestCaseCompiler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestCaseCompiler.cs
@@ -87,6 +87,10 @@ internal sealed class R2RTestCaseCompiler
             new CSharpCompilationOptions(outputKind)
                 .WithOptimizationLevel(OptimizationLevel.Release)
                 .WithAllowUnsafe(true)
+                // Deterministic emit makes the module MVID a function of the inputs, so compiling
+                // identical sources twice yields byte-identical assemblies. Tests rely on this to
+                // produce same-identity (no conflict) vs. different-identity references.
+                .WithDeterministic(true)
                 .WithNullableContextOptions(NullableContextOptions.Enable));
 
         EmitResult result = compilation.Emit(outputPath);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestRunner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestRunner.cs
@@ -33,8 +33,16 @@ internal sealed class CompiledAssembly
     /// </summary>
     public List<CompiledAssembly> References { get; init; } = new();
 
+    /// <summary>
+    /// Optional subdirectory under the per-test <c>IL/</c> output folder. Use this to disambiguate
+    /// the output path when several assemblies share the same <see cref="AssemblyName"/> (for example
+    /// two versions of one assembly built for a reference-conflict test). Defaults to none, placing
+    /// the assembly directly under <c>IL/</c>.
+    /// </summary>
+    public string? OutputSubdirectory { get; init; }
+
     private string? _outputDir = null;
-    public string FilePath => _outputDir != null ? Path.Combine(_outputDir, "IL", AssemblyName + ".dll")
+    public string FilePath => _outputDir != null ? Path.Combine(_outputDir, "IL", OutputSubdirectory ?? "", AssemblyName + ".dll")
         : throw new InvalidOperationException("Output directory not set");
 
     public void SetOutputDir(string outputDir)
@@ -93,6 +101,14 @@ internal sealed class CrossgenCompilation(string name, List<CrossgenAssembly> as
     /// Optional validator for this compilation's R2R output image.
     /// </summary>
     public Action<ReadyToRunReader>? Validate { get; init; }
+
+    /// <summary>
+    /// Optional validator for this compilation's crossgen2 result (exit code and console output).
+    /// Use this to assert on diagnostics crossgen2 writes to stdout/stderr (e.g. warnings), as
+    /// opposed to <see cref="Validate"/> which inspects the emitted R2R image. When set, the runner
+    /// does not auto-assert success, so the validator fully owns result validation.
+    /// </summary>
+    public Action<R2RCompilationResult>? ValidateResult { get; init; }
 
     public string Name => name;
 
@@ -201,7 +217,7 @@ internal sealed class R2RTestRunner
         try
         {
             // Step 1: Compile all assemblies with Roslyn in order
-            var assemblyPaths = CompileAllAssemblies(assembliesToCompile);
+            CompileAllAssemblies(assembliesToCompile);
 
             // Step 2: Run each crossgen2 compilation and validate
             var driver = new R2RDriver(_output, _paths);
@@ -209,11 +225,21 @@ internal sealed class R2RTestRunner
 
             foreach(var compilation in testCase.Compilations)
             {
-                string outputPath = RunCrossgenCompilation(
-                    testCase.Name, compilation, driver, compilation.FilePath, refPaths, assemblyPaths);
+                R2RCompilationResult result = RunCrossgenCompilation(
+                    testCase.Name, compilation, driver, refPaths);
 
-                if (compilation.Validate is not null)
+                if (compilation.ValidateResult is not null)
                 {
+                    _output.WriteLine($"  Validating crossgen2 result (exit code {result.ExitCode})");
+                    compilation.ValidateResult(result);
+                }
+
+                // Only inspect the emitted image when the compilation actually produced one. A test
+                // may legitimately pair ValidateResult with an expected failure (no image written),
+                // in which case there is nothing to read here.
+                if (compilation.Validate is not null && result.Success)
+                {
+                    string outputPath = compilation.FilePath;
                     Assert.True(File.Exists(outputPath), $"R2R image not found: {outputPath}");
                     _output.WriteLine($"  Validating R2R image: {outputPath}");
                     var reader = new ReadyToRunReader(new SimpleAssemblyResolver(_paths), outputPath);
@@ -266,14 +292,13 @@ internal sealed class R2RTestRunner
         }
     }
 
-    private static string RunCrossgenCompilation(
+    private static R2RCompilationResult RunCrossgenCompilation(
         string testName,
         CrossgenCompilation compilation,
         R2RDriver driver,
-        string outputFile,
-        List<string> refPaths,
-        Dictionary<string, string> assemblyPaths)
+        List<string> refPaths)
     {
+        string outputFile = compilation.FilePath;
         var args = new List<string>();
 
         var inputFiles = new List<string>();
@@ -281,10 +306,9 @@ internal sealed class R2RTestRunner
         foreach (var asm in compilation.Assemblies)
         {
             var ilAssemblyName = asm.ILAssembly.AssemblyName;
-            Assert.True(assemblyPaths.ContainsKey(ilAssemblyName),
-                $"Assembly '{ilAssemblyName}' not found in compiled assemblies.");
-
             string ilPath = asm.ILAssembly.FilePath;
+            Assert.True(File.Exists(ilPath),
+                $"Compiled assembly '{ilAssemblyName}' not found at '{ilPath}'.");
 
             if (asm.Kind == Crossgen2InputKind.InputAssembly)
             {
@@ -320,10 +344,16 @@ internal sealed class R2RTestRunner
         args.Add($"--out");
         args.Add($"{outputFile}");
         var result = driver.Compile(args);
-        Assert.True(result.Success,
-            $"crossgen2 failed for '{testName}':\n{result.StandardError}\n{result.StandardOutput}");
 
-        return outputFile;
+        // When a test provides its own result validator it fully owns success/failure checking
+        // (e.g. asserting a warning was emitted while the compilation still succeeds).
+        if (compilation.ValidateResult is null)
+        {
+            Assert.True(result.Success,
+                $"crossgen2 failed for '{testName}':\n{result.StandardError}\n{result.StandardOutput}");
+        }
+
+        return result;
     }
 
     private static void AddRefArgs(List<string> args, List<string> refPaths)

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -21,7 +21,7 @@ namespace ILCompiler
         public Option<Dictionary<string, string>> UnrootedInputFilePaths { get; } =
             new("--unrooted-input-file-paths", "-u") { CustomParser = result => Helpers.BuildPathDictionary(result.Tokens, true), DefaultValueFactory = result => Helpers.BuildPathDictionary(result.Tokens, true), Description = SR.UnrootedInputFilesToCompile };
         public Option<Dictionary<string, string>> ReferenceFilePaths { get; } =
-            new("--reference", "-r") { CustomParser = result => Helpers.BuildPathDictionary(result.Tokens, false), DefaultValueFactory = result => Helpers.BuildPathDictionary(result.Tokens, false), Description = SR.ReferenceFiles };
+            new("--reference", "-r") { CustomParser = result => Helpers.BuildPathDictionary(result.Tokens, false, ReferenceConflictWarning.WarnIfConflictingVersions), DefaultValueFactory = result => Helpers.BuildPathDictionary(result.Tokens, false, ReferenceConflictWarning.WarnIfConflictingVersions), Description = SR.ReferenceFiles };
         public Option<string> InstructionSet { get; } =
             new("--instruction-set") { Description = SR.InstructionSets };
         public Option<int> MaxVectorTBitWidth { get; } =

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -354,6 +354,9 @@
   <data name="WarningOverridingOptimize" xml:space="preserve">
     <value>Warning: -Od overrides other optimization options</value>
   </data>
+  <data name="WarningConflictingReferenceVersions" xml:space="preserve">
+    <value>Warning: multiple versions of assembly '{0}' were passed as references: '{1}' (version {2}) and '{3}' (version {4}). '{1}' will be used.</value>
+  </data>
   <data name="CallChainProfileFile" xml:space="preserve">
     <value>Json file(s) for predictive profile guided optimization</value>
   </data>

--- a/src/coreclr/tools/aot/crossgen2/ReferenceConflictWarning.cs
+++ b/src/coreclr/tools/aot/crossgen2/ReferenceConflictWarning.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Diagnoses conflicting <c>--reference</c> inputs. crossgen2 keeps only the first reference
+    /// seen for a given assembly simple name; a later reference with the same simple name is dropped
+    /// and the type system binds against the first one. When the dropped file is a genuinely different
+    /// assembly (different module MVID or assembly version) this can produce R2R code that throws
+    /// <see cref="MissingMethodException"/> or otherwise fails at runtime, so we warn.
+    /// </summary>
+    internal static class ReferenceConflictWarning
+    {
+        /// <summary>
+        /// Callback compatible with <c>Helpers.BuildPathDictionary</c>'s duplicate notification:
+        /// (simple name, kept path, dropped path). Warns when the dropped reference is a different
+        /// assembly than the one crossgen2 will bind to. Best effort: never throws.
+        /// </summary>
+        public static void WarnIfConflictingVersions(string simpleName, string keptPath, string droppedPath)
+        {
+            // Cheap path equality skips the common case of the same file matched by overlapping
+            // patterns; genuinely different files are compared by assembly identity below.
+            if (string.Equals(keptPath, droppedPath, StringComparison.Ordinal))
+                return;
+
+            if (!TryGetAssemblyIdentity(keptPath, out Version keptVersion, out Guid keptMvid)
+                || !TryGetAssemblyIdentity(droppedPath, out Version droppedVersion, out Guid droppedMvid))
+            {
+                // If either file cannot be read as an assembly, stay silent and let the real load
+                // path report any genuine error.
+                return;
+            }
+
+            // Identical copies of one assembly share an MVID and version; only warn when the dropped
+            // file is genuinely a different assembly.
+            if (keptMvid != droppedMvid || keptVersion != droppedVersion)
+            {
+                Console.WriteLine(string.Format(SR.WarningConflictingReferenceVersions,
+                    simpleName, keptPath, keptVersion, droppedPath, droppedVersion));
+            }
+        }
+
+        private static bool TryGetAssemblyIdentity(string filePath, out Version version, out Guid mvid)
+        {
+            version = null;
+            mvid = Guid.Empty;
+
+            try
+            {
+                using FileStream stream = File.OpenRead(filePath);
+                using PEReader peReader = new PEReader(stream);
+                if (!peReader.HasMetadata)
+                    return false;
+
+                MetadataReader reader = peReader.GetMetadataReader();
+                if (!reader.IsAssembly)
+                    return false;
+
+                version = reader.GetAssemblyDefinition().Version;
+                mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
+                return true;
+            }
+            catch
+            {
+                // Best effort: a malformed or inaccessible reference must never fail the compilation here.
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes dotnet/runtime#114513. When two --reference files share a simple name but resolve to different assemblies (differing module MVID or assembly version), crossgen2 silently selects the first one with no diagnostic.

Detect the conflict at the dictionary-insertion site in the shared command-line helper: when a non-strict simple-name collision drops a reference, compare the dropped file against the binding winner by MVID and version and emit a warning. The check is opt-in via a new parameter so only crossgen2's --reference participates; input files, inputbubbleref, ILCompiler, and ILVerify are unchanged. Identical copies of one assembly (same MVID and version) stay silent to avoid false positives on overlapping reference globs.

Add ILCompiler.ReadyToRun.Tests regression coverage for both the conflicting-version (warns) and identical-copy (no warning) cases.