### PR TITLE
Allow the GcInfoDumper to report scratch registers at safe points (DECODE_NO_VALIDATION)

### DIFF
--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -1584,8 +1584,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */
@@ -1692,8 +1694,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */
@@ -1795,8 +1799,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */
@@ -1935,8 +1941,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */
@@ -2059,8 +2067,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */


### PR DESCRIPTION
A checked/debug build can hit  _ASSERTE(flags & ActiveStackFrame) in TGcInfoDecoder<...>::ReportRegisterToGC when the  GcInfoDumper  is used to dump a method whose GC info reports a scratch register live at a safe point. This is reachable today through SOS's gcinfo, e.g. AMD64 GC info reporting rax live at a partially interruptible safe point. GcInfoDumper::EnumerateStateChanges constructs its decoder with DECODE_NO_VALIDATION and calls  EnumerateLiveSlots(&regdisp, /*reportScratchSlots*/ true, flags | NoReportUntracked, ...). At safe points it deliberately sets flags = 0 (not ActiveStackFrame ) but still asks for scratch slots, because the dumper's job is to display every encoded slot at every offset - it is not performing a real stackwalk. The assert was written for the real-GC contract (scratch registers are only valid on the active/leaf frame) and does not account for the dumper's explicit  DECODE_NO_VALIDATION mode.