### PR TITLE
Clean up S.S.AccessControl

### DIFF
--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
@@ -54,8 +54,6 @@ namespace System.Security.AccessControl
 
     public abstract class GenericAce
     {
-        // The 'byte' type is used to accommodate user-defined,
-        // as well as well-known ACE types.
         private readonly AceType _type;
         private AceFlags _flags;
         internal ushort _indexInAcl;
@@ -1020,6 +1018,7 @@ namespace System.Security.AccessControl
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } SYSTEM_ALARM_CALLBACK_ACE, *PSYSTEM_ALARM_CALLBACK_ACE;
+
     public sealed class CommonAce : QualifiedAce
     {
         // The constructor computes the type of this ACE and passes the rest
@@ -1300,6 +1299,7 @@ namespace System.Security.AccessControl
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } SYSTEM_ALARM_CALLBACK_OBJECT_ACE, *PSYSTEM_ALARM_CALLBACK_OBJECT_ACE;
+
     [Flags]
     public enum ObjectAceFlags
     {

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
@@ -1,13 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*============================================================
-**
-** Classes:  Access Control Entry (ACE) family of classes
-**
-**
-===========================================================*/
-
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -16,12 +9,8 @@ using System.Security.Principal;
 
 namespace System.Security.AccessControl
 {
-    //
     // Predefined ACE types
     // Anything else is considered user-defined
-    //
-
-
     public enum AceType : byte
     {
         AccessAllowed = 0x00,
@@ -44,14 +33,10 @@ namespace System.Security.AccessControl
         MaxDefinedAceType = SystemAlarmCallbackObject,
     }
 
-    //
     // Predefined ACE flags
     // The inheritance and auditing flags are stored in the
     // same field - this is to follow Windows ACE design
-    //
-
     [Flags]
-
     public enum AceFlags : byte
     {
         None = 0x00,
@@ -67,47 +52,25 @@ namespace System.Security.AccessControl
         AuditFlags = SuccessfulAccess | FailedAccess,
     }
 
-
     public abstract class GenericAce
     {
-        #region Private Members
-
-        //
         // The 'byte' type is used to accommodate user-defined,
         // as well as well-known ACE types.
-        //
-
         private readonly AceType _type;
         private AceFlags _flags;
         internal ushort _indexInAcl;
-        #endregion
 
-        #region Internal Constants
-
-        //
         // Length of the ACE header in binary form
-        //
-
         internal const int HeaderLength = 4;
 
-        #endregion
-
-        #region Internal Methods
-
-        //
         // Format of the ACE header from ntseapi.h
-        //
         // typedef struct _ACE_HEADER {
         //     UCHAR AceType;
         //     UCHAR AceFlags;
         //     USHORT AceSize;
         // } ACE_HEADER;
-        //
 
-        //
         // Marshal the ACE header into the given array starting at the given offset
-        //
-
         internal void MarshalHeader(byte[] binaryForm, int offset)
         {
             ArgumentNullException.ThrowIfNull(binaryForm);
@@ -117,21 +80,15 @@ namespace System.Security.AccessControl
             ArgumentOutOfRangeException.ThrowIfNegative(offset);
             if (binaryForm.Length - offset < BinaryLength)
             {
-                //
                 // The buffer will not fit the header
-                //
-
                 throw new ArgumentOutOfRangeException(
                     nameof(binaryForm),
                     SR.ArgumentOutOfRange_ArrayTooSmall);
             }
             else if (Length > ushort.MaxValue)
             {
-                //
                 // Only have two bytes to store the length in.
                 // Indicates a bug in the implementation, not in user's code.
-                //
-
                 Debug.Fail("Length > ushort.MaxValue");
                 // Replacing SystemException with InvalidOperationException. It's not a perfect fit,
                 // but it's the best exception type available to indicate a failure because
@@ -145,29 +102,15 @@ namespace System.Security.AccessControl
             binaryForm[offset + 3] = (byte)(Length >> 8);
         }
 
-        #endregion
-
-        #region Constructors
-
         internal GenericAce(AceType type, AceFlags flags)
         {
-            //
             // Store the values passed in;
             // do not make any checks - anything is valid here
-            //
-
             _type = type;
             _flags = flags;
         }
 
-        #endregion
-
-        #region Static Methods
-
-        //
         // These mapper routines convert audit type flags to ACE flags and vice versa
-        //
-
         internal static AceFlags AceFlagsFromAuditFlags(AuditFlags auditFlags)
         {
             AceFlags flags = AceFlags.None;
@@ -192,10 +135,7 @@ namespace System.Security.AccessControl
             return flags;
         }
 
-        //
         // These mapper routines convert inheritance type flags to ACE flags and vice versa
-        //
-
         internal static AceFlags AceFlagsFromInheritanceFlags(InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags)
         {
             AceFlags flags = AceFlags.None;
@@ -210,10 +150,7 @@ namespace System.Security.AccessControl
                 flags |= AceFlags.ObjectInherit;
             }
 
-            //
             // Propagation flags are meaningless without inheritance flags
-            //
-
             if (flags != 0)
             {
                 if ((propagationFlags & PropagationFlags.NoPropagateInherit) != 0)
@@ -230,10 +167,7 @@ namespace System.Security.AccessControl
             return flags;
         }
 
-        //
         // Sanity-check the ACE header (used by the unmarshaling logic)
-        //
-
         internal static void VerifyHeader(byte[] binaryForm, int offset)
         {
             ArgumentNullException.ThrowIfNull(binaryForm);
@@ -241,41 +175,29 @@ namespace System.Security.AccessControl
             ArgumentOutOfRangeException.ThrowIfNegative(offset);
             if (binaryForm.Length - offset < HeaderLength)
             {
-                //
                 // We expect at least the ACE header ( 4 bytes )
-                //
-
                 throw new ArgumentOutOfRangeException(
                     nameof(binaryForm),
                     SR.ArgumentOutOfRange_ArrayTooSmall);
             }
             else if ((binaryForm[offset + 3] << 8) + (binaryForm[offset + 2] << 0) > binaryForm.Length - offset)
             {
-                //
                 // Reported length of ACE ought to be no longer than the
                 // length of the buffer passed in
-                //
-
                 throw new ArgumentOutOfRangeException(
                     nameof(binaryForm),
                     SR.ArgumentOutOfRange_ArrayTooSmall);
             }
         }
 
-        //
         // Instantiates the most-derived ACE type based on the binary
         // representation of an ACE
-        //
-
         public static GenericAce CreateFromBinaryForm(byte[] binaryForm, int offset)
         {
             GenericAce result;
             AceType type;
 
-            //
             // Sanity check the header
-            //
-
             VerifyHeader(binaryForm, offset);
 
             type = (AceType)binaryForm[offset];
@@ -357,16 +279,11 @@ namespace System.Security.AccessControl
                 result = new CustomAce(type, flags, opaque);
             }
 
-            //
             // As a final check, confirm that the advertised ACE header length
             // was the actual parsed length
-            //
-
             if (((!(result is ObjectAce)) && ((binaryForm[offset + 2] << 0) + (binaryForm[offset + 3] << 8) != result.BinaryLength))
-                //
                 // This is needed because object aces created through ADSI have the advertised ACE length
                 // greater than the actual length by 32 (bug in ADSI).
-                //
                 || ((result is ObjectAce) && ((binaryForm[offset + 2] << 0) + (binaryForm[offset + 3] << 8) != result.BinaryLength) && (((binaryForm[offset + 2] << 0) + (binaryForm[offset + 3] << 8) - 32) != result.BinaryLength)))
             {
                 goto InvalidParameter;
@@ -381,16 +298,9 @@ namespace System.Security.AccessControl
                 nameof(binaryForm));
         }
 
-        #endregion
-
-        #region Public Properties
-
-        //
         // Returns the numeric type of the ACE
         // Since not all ACE types are known, this
         // property returns a byte value.
-        //
-
         public AceType AceType
         {
             get
@@ -399,11 +309,8 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Sets and retrieves the flags associated with the ACE
         // No checks are performed when setting the flags.
-        //
-
         public AceFlags AceFlags
         {
             get
@@ -421,7 +328,7 @@ namespace System.Security.AccessControl
         {
             get
             {
-                return ((this.AceFlags & AceFlags.Inherited) != 0);
+                return ((AceFlags & AceFlags.Inherited) != 0);
             }
         }
 
@@ -431,12 +338,12 @@ namespace System.Security.AccessControl
             {
                 InheritanceFlags flags = 0;
 
-                if ((this.AceFlags & AceFlags.ContainerInherit) != 0)
+                if ((AceFlags & AceFlags.ContainerInherit) != 0)
                 {
                     flags |= InheritanceFlags.ContainerInherit;
                 }
 
-                if ((this.AceFlags & AceFlags.ObjectInherit) != 0)
+                if ((AceFlags & AceFlags.ObjectInherit) != 0)
                 {
                     flags |= InheritanceFlags.ObjectInherit;
                 }
@@ -451,12 +358,12 @@ namespace System.Security.AccessControl
             {
                 PropagationFlags flags = 0;
 
-                if ((this.AceFlags & AceFlags.InheritOnly) != 0)
+                if ((AceFlags & AceFlags.InheritOnly) != 0)
                 {
                     flags |= PropagationFlags.InheritOnly;
                 }
 
-                if ((this.AceFlags & AceFlags.NoPropagateInherit) != 0)
+                if ((AceFlags & AceFlags.NoPropagateInherit) != 0)
                 {
                     flags |= PropagationFlags.NoPropagateInherit;
                 }
@@ -471,12 +378,12 @@ namespace System.Security.AccessControl
             {
                 AuditFlags flags = 0;
 
-                if ((this.AceFlags & AceFlags.SuccessfulAccess) != 0)
+                if ((AceFlags & AceFlags.SuccessfulAccess) != 0)
                 {
                     flags |= AuditFlags.Success;
                 }
 
-                if ((this.AceFlags & AceFlags.FailedAccess) != 0)
+                if ((AceFlags & AceFlags.FailedAccess) != 0)
                 {
                     flags |= AuditFlags.Failure;
                 }
@@ -485,37 +392,21 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // The value returned is really an unsigned short
         // A signed type is used for CLS compliance
-        //
-
         public abstract int BinaryLength { get; }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Copies the binary representation of the ACE into a given array
         // starting at the given offset.
-        //
-
         public abstract void GetBinaryForm(byte[] binaryForm, int offset);
 
-        //
         // Cloning is performed by calling the from-binary static factory method
         // on the binary representation of the ACE.
         // Make this routine virtual if any leaf ACE class were to ever become
         // unsealed.
-        //
-
         public GenericAce Copy()
         {
-            //
             // Allocate an array big enough to hold the binary representation of the ACE
-            //
-
             byte[] binaryForm = new byte[BinaryLength];
 
             GetBinaryForm(binaryForm, 0);
@@ -532,13 +423,13 @@ namespace System.Security.AccessControl
                 return false;
             }
 
-            if (this.AceType != ace.AceType ||
-                this.AceFlags != ace.AceFlags)
+            if (AceType != ace.AceType ||
+                AceFlags != ace.AceFlags)
             {
                 return false;
             }
 
-            int thisLength = this.BinaryLength;
+            int thisLength = BinaryLength;
 
             if (thisLength != ace.BinaryLength)
             {
@@ -546,7 +437,7 @@ namespace System.Security.AccessControl
             }
 
             byte[] array1 = new byte[thisLength];
-            this.GetBinaryForm(array1, 0);
+            GetBinaryForm(array1, 0);
 
             byte[] array2 = new byte[thisLength];
             ace.GetBinaryForm(array2, 0);
@@ -561,12 +452,9 @@ namespace System.Security.AccessControl
             GetBinaryForm(array, 0);
             int result = 0, i = 0;
 
-            //
             // For purposes of hash code computation,
             // treat the ACE as an array of ints (fortunately, its length is divisible by 4)
             // and simply XOR all these ints together
-            //
-
             while (i < binaryLength)
             {
                 int increment = ((int)array[i]) +
@@ -604,61 +492,30 @@ namespace System.Security.AccessControl
         {
             return !(left == right);
         }
-        #endregion
     }
 
-    //
     // ACEs fall into two broad categories: known and user-defined
-    //
-
-    //
     // Every known ACE type contains an access mask and a SID
-    //
-
-
     public abstract class KnownAce : GenericAce
     {
-        #region Private Members
-
-        //
         // All known ACE types contain an access mask and a SID
-        //
-
         private int _accessMask;
         private SecurityIdentifier _sid;
 
-        #endregion
-
-        #region Internal Constants
-
         internal const int AccessMaskLength = 4;
-
-        #endregion
-
-        #region Constructors
 
         internal KnownAce(AceType type, AceFlags flags, int accessMask, SecurityIdentifier securityIdentifier)
             : base(type, flags)
         {
             ArgumentNullException.ThrowIfNull(securityIdentifier);
 
-            //
             // The values are set by invoking the properties.
-            //
-
             AccessMask = accessMask;
             SecurityIdentifier = securityIdentifier;
         }
 
-        #endregion
-
-        #region Public Properties
-
-        //
         // Sets and retrieves the access mask associated with this ACE.
         // The access mask can be any 32-bit value.
-        //
-
         public int AccessMask
         {
             get
@@ -672,12 +529,9 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Sets and retrieves the SID associated with this ACE.
         // The SID can not be null, but can otherwise be any valid
         // security identifier.
-        //
-
         public SecurityIdentifier SecurityIdentifier
         {
             get
@@ -691,40 +545,19 @@ namespace System.Security.AccessControl
                 _sid = value;
             }
         }
-        #endregion
     }
 
-    //
     // User-defined ACEs are ACE types we don't recognize.
     // They contain a standard ACE header followed by a binary blob.
-    //
-
-
     public sealed class CustomAce : GenericAce
     {
-        #region Private Members
-
-        //
         // Opaque data is what follows the ACE header.
         // It is not interpreted by any code except that which
         // understands the ACE type.
-        //
-
         private byte[]? _opaque;
 
-        #endregion
-
-        #region Public Constants
-
-        //
         // Returns the maximum allowed length of opaque data
-        //
-
         public static readonly int MaxOpaqueLength = ushort.MaxValue - HeaderLength;
-
-        #endregion
-
-        #region Constructors
 
         public CustomAce(AceType type, AceFlags flags, byte[]? opaque)
             : base(type, flags)
@@ -739,14 +572,7 @@ namespace System.Security.AccessControl
             SetOpaque(opaque);
         }
 
-        #endregion
-
-        #region Public Properties
-
-        //
         // Returns the length of the opaque blob
-        //
-
         public int OpaqueLength
         {
             get
@@ -762,11 +588,8 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Returns the length of the binary representation of this ACE
         // The value returned is really an unsigned short
-        //
-
         public /* sealed */ override int BinaryLength
         {
             get
@@ -775,15 +598,8 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Methods to set and retrieve the opaque portion of the ACE
         // Important: the caller is given the actual (not cloned) copy of the data
-        //
-
         public byte[]? GetOpaque()
         {
             return _opaque;
@@ -810,24 +626,15 @@ namespace System.Security.AccessControl
             _opaque = opaque;
         }
 
-        //
         // Copies the binary representation of the ACE into a given array
         // starting at the given offset.
-        //
-
         public /* sealed */ override void GetBinaryForm(byte[] binaryForm, int offset)
         {
-            //
             // Populate the header
-            //
-
             MarshalHeader(binaryForm, offset);
             offset += HeaderLength;
 
-            //
             // Header is followed by the opaque data
-            //
-
             if (OpaqueLength != 0)
             {
                 if (OpaqueLength > MaxOpaqueLength)
@@ -842,18 +649,11 @@ namespace System.Security.AccessControl
                 GetOpaque()!.CopyTo(binaryForm, offset);
             }
         }
-        #endregion
     }
 
-    //
     // Known ACE types fall into two categories: compound and qualified
-    //
-
-    //
     // Compound ACEs ...
-    //
     // Tne in-memory structure of a compound ACE is as follows:
-    //
     // typedef struct _COMPOUND_ACCESS_ALLOWED_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -861,44 +661,23 @@ namespace System.Security.AccessControl
     //     USHORT Reserved;
     //     ULONG SidStart;
     // } COMPOUND_ACCESS_ALLOWED_ACE;
-    //
-
-
     public enum CompoundAceType
     {
         Impersonation = 0x01,
     }
 
-
     public sealed class CompoundAce : KnownAce
     {
-        #region Private Members
-
         private CompoundAceType _compoundAceType;
 
-        #endregion
-
-        #region Private Constants
-
         private const int AceTypeLength = 4; // including 2 reserved bytes
-
-        #endregion
-
-        #region Constructors
 
         public CompoundAce(AceFlags flags, int accessMask, CompoundAceType compoundAceType, SecurityIdentifier sid)
             : base(AceType.AccessAllowedCompound, flags, accessMask, sid)
         {
-            //
             // The compound ACE type value is deliberately not validated
-            //
-
             _compoundAceType = compoundAceType;
         }
-
-        #endregion
-
-        #region Static Parser
 
         internal static bool ParseBinaryForm(
             byte[] binaryForm,
@@ -907,16 +686,10 @@ namespace System.Security.AccessControl
             out CompoundAceType compoundAceType,
             [NotNullWhen(true)] out SecurityIdentifier? sid)
         {
-            //
             // Verify the ACE header
-            //
-
             VerifyHeader(binaryForm, offset);
 
-            //
             // Verify the length field
-            //
-
             if (binaryForm.Length - offset < HeaderLength + AccessMaskLength + AceTypeLength + SecurityIdentifier.MinBinaryLength)
             {
                 goto InvalidParameter;
@@ -925,10 +698,7 @@ namespace System.Security.AccessControl
             int baseOffset = offset + HeaderLength;
             int offsetLocal = 0;
 
-            //
             // The access mask is stored in big-endian format
-            //
-
             accessMask =
                 unchecked((int)(
                 (((uint)binaryForm[baseOffset + 0]) << 0) +
@@ -945,10 +715,7 @@ namespace System.Security.AccessControl
 
             offsetLocal += AceTypeLength; // Skipping over the two reserved bits
 
-            //
             // The access mask is followed by the SID
-            //
-
             sid = new SecurityIdentifier(binaryForm, baseOffset + offsetLocal);
 
             return true;
@@ -961,10 +728,6 @@ namespace System.Security.AccessControl
 
             return false;
         }
-
-        #endregion
-
-        #region Public Properties
 
         public CompoundAceType CompoundAceType
         {
@@ -987,29 +750,17 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Copies the binary representation of the ACE into a given array
         // starting at the given offset.
-        //
-
         public override void GetBinaryForm(byte[] binaryForm, int offset)
         {
-            //
             // Populate the header
-            //
-
             MarshalHeader(binaryForm, offset);
 
             int baseOffset = offset + HeaderLength;
             int offsetLocal = 0;
 
-            //
             // Store the access mask in the big-endian format
-            //
             unchecked
             {
                 binaryForm[baseOffset + 0] = (byte)(AccessMask >> 0);
@@ -1020,10 +771,7 @@ namespace System.Security.AccessControl
 
             offsetLocal += AccessMaskLength;
 
-            //
             // Store the compound ace type and the two reserved bytes
-            //
-
             binaryForm[baseOffset + offsetLocal + 0] = (byte)((ushort)CompoundAceType >> 0);
             binaryForm[baseOffset + offsetLocal + 1] = (byte)((ushort)CompoundAceType >> 8);
             binaryForm[baseOffset + offsetLocal + 2] = 0;
@@ -1031,25 +779,17 @@ namespace System.Security.AccessControl
 
             offsetLocal += AceTypeLength;
 
-            //
             // Store the SID
-            //
-
             SecurityIdentifier.GetBinaryForm(binaryForm, baseOffset + offsetLocal);
         }
-        #endregion
     }
 
-    //
     // Qualified ACEs are always one of:
     //     - AccessAllowed
     //     - AccessDenied
     //     - SystemAudit
     //     - SystemAlarm
     // and may optionally support callback data
-    //
-
-
     public enum AceQualifier
     {
         AccessAllowed = 0x0,
@@ -1058,25 +798,15 @@ namespace System.Security.AccessControl
         SystemAlarm = 0x3,
     }
 
-
     public abstract class QualifiedAce : KnownAce
     {
-        #region Private Members
-
         private readonly bool _isCallback;
         private readonly AceQualifier _qualifier;
         private byte[]? _opaque;
 
-        #endregion
-
-        #region Private Methods
-
         private static AceQualifier QualifierFromType(AceType type, out bool isCallback)
         {
-            //
             // Better performance might be achieved by using a hard-coded table
-            //
-
             switch (type)
             {
                 case AceType.AccessAllowed:
@@ -1145,10 +875,7 @@ namespace System.Security.AccessControl
 
                 default:
 
-                    //
                     // Indicates a bug in the implementation, not in user's code
-                    //
-
                     Debug.Fail("Invalid ACE type");
                     // Replacing SystemException with InvalidOperationException. It's not a perfect fit,
                     // but it's the best exception type available to indicate a failure because
@@ -1157,10 +884,6 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Constructors
-
         internal QualifiedAce(AceType type, AceFlags flags, int accessMask, SecurityIdentifier sid, byte[]? opaque)
             : base(type, flags, accessMask, sid)
         {
@@ -1168,17 +891,10 @@ namespace System.Security.AccessControl
             SetOpaque(opaque);
         }
 
-        #endregion
-
-        #region Public Properties
-
-        //
         // Returns the qualifier associated with this ACE
         // Qualifier is determined at object creation time and
         // can not be changed since doing so would change the ACE type
         // which is in itself an immutable property
-        //
-
         public AceQualifier AceQualifier
         {
             get
@@ -1187,13 +903,10 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Returns 'true' if this ACE type supports resource
         // manager-specific callback data.
         // This property is determined at object creation time
         // and can not be changed.
-        //
-
         public bool IsCallback
         {
             get
@@ -1202,17 +915,11 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // ACE types that support opaque data must also specify the maximum
         // allowed length of such data
-        //
-
         internal abstract int MaxOpaqueLengthInternal { get; }
 
-        //
         // Returns the length of opaque blob
-        //
-
         public int OpaqueLength
         {
             get
@@ -1228,15 +935,8 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Methods to set and retrieve the opaque portion of the ACE
         // NOTE: the caller is given the actual (not cloned) copy of the data
-        //
-
         public byte[]? GetOpaque()
         {
             return _opaque;
@@ -1262,95 +962,68 @@ namespace System.Security.AccessControl
 
             _opaque = opaque;
         }
-        #endregion
     }
 
-    //
     // The following eight classes are boilerplate, differing only by their ACE type
     // and support for callbacks
     // Thus their implementation will derive from the same class: CommonAce
-    //
     // typedef struct _ACCESS_ALLOWED_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     // } ACCESS_ALLOWED_ACE;
-    //
     // typedef struct _ACCESS_DENIED_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     // } ACCESS_DENIED_ACE;
-    //
     // typedef struct _SYSTEM_AUDIT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     // } SYSTEM_AUDIT_ACE;
-    //
     // typedef struct _SYSTEM_ALARM_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     // } SYSTEM_ALARM_ACE;
-    //
     // typedef struct _ACCESS_ALLOWED_CALLBACK_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } ACCESS_ALLOWED_CALLBACK_ACE, *PACCESS_ALLOWED_CALLBACK_ACE;
-    //
     // typedef struct _ACCESS_DENIED_CALLBACK_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } ACCESS_DENIED_CALLBACK_ACE, *PACCESS_DENIED_CALLBACK_ACE;
-    //
     // typedef struct _SYSTEM_AUDIT_CALLBACK_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } SYSTEM_AUDIT_CALLBACK_ACE, *PSYSTEM_AUDIT_CALLBACK_ACE;
-    //
     // typedef struct _SYSTEM_ALARM_CALLBACK_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } SYSTEM_ALARM_CALLBACK_ACE, *PSYSTEM_ALARM_CALLBACK_ACE;
-    //
-
-
     public sealed class CommonAce : QualifiedAce
     {
-        #region Constructors
-
-        //
         // The constructor computes the type of this ACE and passes the rest
         // to the base class constructor
-        //
-
         public CommonAce(AceFlags flags, AceQualifier qualifier, int accessMask, SecurityIdentifier sid, bool isCallback, byte[]? opaque)
             : base(TypeFromQualifier(isCallback, qualifier), flags, accessMask, sid, opaque)
         {
         }
 
-        #endregion
-
-        #region Private Static Methods
-
-        //
         // Based on the is-callback and qualifier information,
         // computes the numerical type of the ACE
-        //
-
         private static AceType TypeFromQualifier(bool isCallback, AceQualifier qualifier) =>
-            //
             // Might benefit from replacing this with a static hard-coded table
-            //
             qualifier switch
             {
                 AceQualifier.AccessAllowed => isCallback ? AceType.AccessAllowedCallback : AceType.AccessAllowed,
@@ -1360,15 +1033,8 @@ namespace System.Security.AccessControl
                 _ => throw new ArgumentOutOfRangeException(nameof(qualifier), SR.ArgumentOutOfRange_Enum),
             };
 
-        #endregion
-
-        #region Static Parser
-
-        //
         // Called by GenericAce.CreateFromBinaryForm to parse the binary
         // form of the common ACE and extract the useful pieces.
-        //
-
         internal static bool ParseBinaryForm(
             byte[] binaryForm,
             int offset,
@@ -1378,25 +1044,16 @@ namespace System.Security.AccessControl
             out bool isCallback,
             out byte[]? opaque)
         {
-            //
             // Verify the ACE header
-            //
-
             VerifyHeader(binaryForm, offset);
 
-            //
             // Verify the length field
-            //
-
             if (binaryForm.Length - offset < HeaderLength + AccessMaskLength + SecurityIdentifier.MinBinaryLength)
             {
                 goto InvalidParameter;
             }
 
-            //
             // Identify callback ACE types
-            //
-
             AceType type = (AceType)binaryForm[offset];
 
             if (type == AceType.AccessAllowed ||
@@ -1418,10 +1075,7 @@ namespace System.Security.AccessControl
                 goto InvalidParameter;
             }
 
-            //
             // Compute the qualifier from the ACE type
-            //
-
             if (type == AceType.AccessAllowed ||
                 type == AceType.AccessAllowedCallback)
             {
@@ -1450,10 +1104,7 @@ namespace System.Security.AccessControl
             int baseOffset = offset + HeaderLength;
             int offsetLocal = 0;
 
-            //
             // The access mask is stored in big-endian format
-            //
-
             accessMask =
                 (int)(
                 (((uint)binaryForm[baseOffset + 0]) << 0) +
@@ -1463,16 +1114,10 @@ namespace System.Security.AccessControl
 
             offsetLocal += AccessMaskLength;
 
-            //
             // The access mask is followed by the SID
-            //
-
             sid = new SecurityIdentifier(binaryForm, baseOffset + offsetLocal);
 
-            //
             // The rest of the blob is occupied by opaque callback data, if such is supported
-            //
-
             opaque = null;
 
             int aceLength = (binaryForm[offset + 3] << 8) + (binaryForm[offset + 2] << 0);
@@ -1507,10 +1152,6 @@ namespace System.Security.AccessControl
             return false;
         }
 
-        #endregion
-
-        #region Public Properties
-
         public /* sealed */ override int BinaryLength
         {
             get
@@ -1529,30 +1170,17 @@ namespace System.Security.AccessControl
             get { return MaxOpaqueLength(IsCallback); }
         }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Copies the binary representation of the ACE into a given array
         // starting at the given offset.
-        //
-
         public /* sealed */ override void GetBinaryForm(byte[] binaryForm, int offset)
         {
-            //
             // Populate the header
-            //
-
             MarshalHeader(binaryForm, offset);
 
             int baseOffset = offset + HeaderLength;
             int offsetLocal = 0;
 
-            //
             // Store the access mask in the big-endian format
-            //
-
             unchecked
             {
                 binaryForm[baseOffset + 0] = (byte)(AccessMask >> 0);
@@ -1563,17 +1191,11 @@ namespace System.Security.AccessControl
 
             offsetLocal += AccessMaskLength;
 
-            //
             // Store the SID
-            //
-
             SecurityIdentifier.GetBinaryForm(binaryForm, baseOffset + offsetLocal);
             offsetLocal += SecurityIdentifier.BinaryLength;
 
-            //
             // Finally, if opaque is supported, store it
-            //
-
             if (GetOpaque() != null)
             {
                 if (OpaqueLength > MaxOpaqueLengthInternal)
@@ -1588,14 +1210,11 @@ namespace System.Security.AccessControl
                 GetOpaque()!.CopyTo(binaryForm, baseOffset + offsetLocal);
             }
         }
-        #endregion
     }
 
-    //
     // The following eight classes are boilerplate, differing only by their ACE type
     // and support for opaque data
     // Thus their implementation will derive from the same class: ObjectAce
-    //
     // typedef struct _ACCESS_ALLOWED_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1604,7 +1223,6 @@ namespace System.Security.AccessControl
     //     GUID InheritedObjectType;
     //     ULONG SidStart;
     // } ACCESS_ALLOWED_OBJECT_ACE, *PACCESS_ALLOWED_OBJECT_ACE;
-    //
     // typedef struct _ACCESS_DENIED_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1613,7 +1231,6 @@ namespace System.Security.AccessControl
     //     GUID InheritedObjectType;
     //     ULONG SidStart;
     // } ACCESS_DENIED_OBJECT_ACE, *PACCESS_DENIED_OBJECT_ACE;
-    //
     // typedef struct _SYSTEM_AUDIT_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1622,7 +1239,6 @@ namespace System.Security.AccessControl
     //     GUID InheritedObjectType;
     //     ULONG SidStart;
     // } SYSTEM_AUDIT_OBJECT_ACE, *PSYSTEM_AUDIT_OBJECT_ACE;
-    //
     // typedef struct _SYSTEM_ALARM_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1631,7 +1247,6 @@ namespace System.Security.AccessControl
     //     GUID InheritedObjectType;
     //     ULONG SidStart;
     // } SYSTEM_ALARM_OBJECT_ACE, *PSYSTEM_ALARM_OBJECT_ACE;
-    //
     // typedef struct _ACCESS_ALLOWED_CALLBACK_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1641,7 +1256,6 @@ namespace System.Security.AccessControl
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } ACCESS_ALLOWED_CALLBACK_OBJECT_ACE, *PACCESS_ALLOWED_CALLBACK_OBJECT_ACE;
-    //
     // typedef struct _ACCESS_DENIED_CALLBACK_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1651,7 +1265,6 @@ namespace System.Security.AccessControl
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } ACCESS_DENIED_CALLBACK_OBJECT_ACE, *PACCESS_DENIED_CALLBACK_OBJECT_ACE;
-    //
     // typedef struct _SYSTEM_AUDIT_CALLBACK_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1661,7 +1274,6 @@ namespace System.Security.AccessControl
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } SYSTEM_AUDIT_CALLBACK_OBJECT_ACE, *PSYSTEM_AUDIT_CALLBACK_OBJECT_ACE;
-    //
     // typedef struct _SYSTEM_ALARM_CALLBACK_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1671,10 +1283,7 @@ namespace System.Security.AccessControl
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } SYSTEM_ALARM_CALLBACK_OBJECT_ACE, *PSYSTEM_ALARM_CALLBACK_OBJECT_ACE;
-    //
-
     [Flags]
-
     public enum ObjectAceFlags
     {
         None = 0x00,
@@ -1682,21 +1291,14 @@ namespace System.Security.AccessControl
         InheritedObjectAceTypePresent = 0x02,
     }
 
-
     public sealed class ObjectAce : QualifiedAce
     {
-        #region Private Members and Constants
-
         private ObjectAceFlags _objectFlags;
         private Guid _objectAceType;
         private Guid _inheritedObjectAceType;
 
         private const int ObjectFlagsLength = 4;
         private const int GuidLength = 16;
-
-        #endregion
-
-        #region Constructors
 
         public ObjectAce(AceFlags aceFlags, AceQualifier qualifier, int accessMask, SecurityIdentifier sid, ObjectAceFlags flags, Guid type, Guid inheritedType, bool isCallback, byte[]? opaque)
             : base(TypeFromQualifier(isCallback, qualifier), aceFlags, accessMask, sid, opaque)
@@ -1706,21 +1308,14 @@ namespace System.Security.AccessControl
             _inheritedObjectAceType = inheritedType;
         }
 
-        #endregion
-
-        #region Private Methods
-
-        //
         // The following access mask bits in object aces may refer to an objectType that
         // identifies the property set, property, extended right, or type of child object to which the ACE applies
-        //
         //    ADS_RIGHT_DS_CREATE_CHILD = 0x1,
         //    ADS_RIGHT_DS_DELETE_CHILD = 0x2,
         //    ADS_RIGHT_DS_SELF = 0x8,
         //    ADS_RIGHT_DS_READ_PROP = 0x10,
         //    ADS_RIGHT_DS_WRITE_PROP = 0x20,
         //    ADS_RIGHT_DS_CONTROL_ACCESS = 0x100
-        //
         internal const int AccessMaskWithObjectType = 0x1 | 0x2 | 0x8 | 0x10 | 0x20 | 0x100;
 
         private static AceType TypeFromQualifier(bool isCallback, AceQualifier qualifier) =>
@@ -1733,10 +1328,8 @@ namespace System.Security.AccessControl
                 _ => throw new ArgumentOutOfRangeException(nameof(qualifier), SR.ArgumentOutOfRange_Enum),
             };
 
-        //
         // This method checks if the objectType matches with the specified object type
         // (Either both do not have an object type or they have the same object type)
-        //
         internal bool ObjectTypesMatch(ObjectAceFlags objectFlags, Guid objectType)
         {
             if ((ObjectAceFlags & ObjectAceFlags.ObjectAceTypePresent) != (objectFlags & ObjectAceFlags.ObjectAceTypePresent))
@@ -1753,10 +1346,8 @@ namespace System.Security.AccessControl
             return true;
         }
 
-        //
         // This method checks if the inheritedObjectType matches with the specified inherited object type
         // (Either both do not have an inherited object type or they have the same inherited object type)
-        //
         internal bool InheritedObjectTypesMatch(ObjectAceFlags objectFlags, Guid inheritedObjectType)
         {
             if ((ObjectAceFlags & ObjectAceFlags.InheritedObjectAceTypePresent) != (objectFlags & ObjectAceFlags.InheritedObjectAceTypePresent))
@@ -1773,15 +1364,8 @@ namespace System.Security.AccessControl
             return true;
         }
 
-        #endregion
-
-        #region Static Parser
-
-        //
         // Called by GenericAce.CreateFromBinaryForm to parse the binary form
         // of the object ACE and extract the useful pieces
-        //
-
         internal static bool ParseBinaryForm(
             byte[] binaryForm,
             int offset,
@@ -1796,25 +1380,16 @@ namespace System.Security.AccessControl
         {
             byte[] guidArray = new byte[GuidLength];
 
-            //
             // Verify the ACE header
-            //
-
             VerifyHeader(binaryForm, offset);
 
-            //
             // Verify the length field
-            //
-
             if (binaryForm.Length - offset < HeaderLength + AccessMaskLength + ObjectFlagsLength + SecurityIdentifier.MinBinaryLength)
             {
                 goto InvalidParameter;
             }
 
-            //
             // Identify callback ACE types
-            //
-
             AceType type = (AceType)binaryForm[offset];
 
             if (type == AceType.AccessAllowedObject ||
@@ -1836,10 +1411,7 @@ namespace System.Security.AccessControl
                 goto InvalidParameter;
             }
 
-            //
             // Compute the qualifier from the ACE type
-            //
-
             if (type == AceType.AccessAllowedObject ||
                 type == AceType.AccessAllowedCallbackObject)
             {
@@ -1973,14 +1545,7 @@ namespace System.Security.AccessControl
             return false;
         }
 
-        #endregion
-
-        #region Public Properties
-
-        //
         // Returns the object flags field of this ACE
-        //
-
         public ObjectAceFlags ObjectAceFlags
         {
             get
@@ -1994,10 +1559,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Allows querying and setting the object type GUID for this ACE
-        //
-
         public Guid ObjectAceType
         {
             get
@@ -2011,11 +1573,8 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Allows querying and setting the inherited object type
         // GUID for this ACE
-        //
-
         public Guid InheritedObjectAceType
         {
             get
@@ -2033,10 +1592,7 @@ namespace System.Security.AccessControl
         {
             get
             {
-                //
                 // The GUIDs may or may not be present depending on the object flags
-                //
-
                 int GuidLengths =
                     ((_objectFlags & ObjectAceFlags.ObjectAceTypePresent) != 0 ? GuidLength : 0) +
                     ((_objectFlags & ObjectAceFlags.InheritedObjectAceTypePresent) != 0 ? GuidLength : 0);
@@ -2055,29 +1611,17 @@ namespace System.Security.AccessControl
             get { return MaxOpaqueLength(IsCallback); }
         }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Copies the binary representation of the ACE into a given array
         // starting at the given offset.
-        //
-
         public /* sealed */ override void GetBinaryForm(byte[] binaryForm, int offset)
         {
-            //
             // Populate the header
-            //
-
             MarshalHeader(binaryForm, offset);
 
             int baseOffset = offset + HeaderLength;
             int offsetLocal = 0;
 
-            //
             // Store the access mask in the big-endian format
-            //
             unchecked
             {
                 binaryForm[baseOffset + 0] = (byte)(AccessMask >> 0);
@@ -2088,10 +1632,7 @@ namespace System.Security.AccessControl
 
             offsetLocal += AccessMaskLength;
 
-            //
             // Store the object flags in the big-endian format
-            //
-
             binaryForm[baseOffset + offsetLocal + 0] = (byte)(((uint)ObjectAceFlags) >> 0);
             binaryForm[baseOffset + offsetLocal + 1] = (byte)(((uint)ObjectAceFlags) >> 8);
             binaryForm[baseOffset + offsetLocal + 2] = (byte)(((uint)ObjectAceFlags) >> 16);
@@ -2099,10 +1640,7 @@ namespace System.Security.AccessControl
 
             offsetLocal += ObjectFlagsLength;
 
-            //
             // Store the object type GUIDs if present
-            //
-
             if ((ObjectAceFlags & ObjectAceFlags.ObjectAceTypePresent) != 0)
             {
                 ObjectAceType.ToByteArray().CopyTo(binaryForm, baseOffset + offsetLocal);
@@ -2115,17 +1653,11 @@ namespace System.Security.AccessControl
                 offsetLocal += GuidLength;
             }
 
-            //
             // Store the SID
-            //
-
             SecurityIdentifier.GetBinaryForm(binaryForm, baseOffset + offsetLocal);
             offsetLocal += SecurityIdentifier.BinaryLength;
 
-            //
             // Finally, if opaque is supported, store it
-            //
-
             if (GetOpaque() != null)
             {
                 if (OpaqueLength > MaxOpaqueLengthInternal)
@@ -2140,6 +1672,5 @@ namespace System.Security.AccessControl
                 GetOpaque()!.CopyTo(binaryForm, baseOffset + offsetLocal);
             }
         }
-        #endregion
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
@@ -64,6 +64,7 @@ namespace System.Security.AccessControl
         internal const int HeaderLength = 4;
 
         // Format of the ACE header from ntseapi.h
+        //
         // typedef struct _ACE_HEADER {
         //     UCHAR AceType;
         //     UCHAR AceFlags;
@@ -967,44 +968,52 @@ namespace System.Security.AccessControl
     // The following eight classes are boilerplate, differing only by their ACE type
     // and support for callbacks
     // Thus their implementation will derive from the same class: CommonAce
+    //
     // typedef struct _ACCESS_ALLOWED_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     // } ACCESS_ALLOWED_ACE;
+    //
     // typedef struct _ACCESS_DENIED_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     // } ACCESS_DENIED_ACE;
+    //
     // typedef struct _SYSTEM_AUDIT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     // } SYSTEM_AUDIT_ACE;
+    //
     // typedef struct _SYSTEM_ALARM_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     // } SYSTEM_ALARM_ACE;
+    //
     // typedef struct _ACCESS_ALLOWED_CALLBACK_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } ACCESS_ALLOWED_CALLBACK_ACE, *PACCESS_ALLOWED_CALLBACK_ACE;
+    //
     // typedef struct _ACCESS_DENIED_CALLBACK_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } ACCESS_DENIED_CALLBACK_ACE, *PACCESS_DENIED_CALLBACK_ACE;
+    //
     // typedef struct _SYSTEM_AUDIT_CALLBACK_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } SYSTEM_AUDIT_CALLBACK_ACE, *PSYSTEM_AUDIT_CALLBACK_ACE;
+    //
     // typedef struct _SYSTEM_ALARM_CALLBACK_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1215,6 +1224,7 @@ namespace System.Security.AccessControl
     // The following eight classes are boilerplate, differing only by their ACE type
     // and support for opaque data
     // Thus their implementation will derive from the same class: ObjectAce
+    //
     // typedef struct _ACCESS_ALLOWED_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1223,6 +1233,7 @@ namespace System.Security.AccessControl
     //     GUID InheritedObjectType;
     //     ULONG SidStart;
     // } ACCESS_ALLOWED_OBJECT_ACE, *PACCESS_ALLOWED_OBJECT_ACE;
+    //
     // typedef struct _ACCESS_DENIED_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1231,6 +1242,7 @@ namespace System.Security.AccessControl
     //     GUID InheritedObjectType;
     //     ULONG SidStart;
     // } ACCESS_DENIED_OBJECT_ACE, *PACCESS_DENIED_OBJECT_ACE;
+    //
     // typedef struct _SYSTEM_AUDIT_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1239,6 +1251,7 @@ namespace System.Security.AccessControl
     //     GUID InheritedObjectType;
     //     ULONG SidStart;
     // } SYSTEM_AUDIT_OBJECT_ACE, *PSYSTEM_AUDIT_OBJECT_ACE;
+    //
     // typedef struct _SYSTEM_ALARM_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1247,6 +1260,7 @@ namespace System.Security.AccessControl
     //     GUID InheritedObjectType;
     //     ULONG SidStart;
     // } SYSTEM_ALARM_OBJECT_ACE, *PSYSTEM_ALARM_OBJECT_ACE;
+    //
     // typedef struct _ACCESS_ALLOWED_CALLBACK_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1256,6 +1270,7 @@ namespace System.Security.AccessControl
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } ACCESS_ALLOWED_CALLBACK_OBJECT_ACE, *PACCESS_ALLOWED_CALLBACK_OBJECT_ACE;
+    //
     // typedef struct _ACCESS_DENIED_CALLBACK_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1265,6 +1280,7 @@ namespace System.Security.AccessControl
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } ACCESS_DENIED_CALLBACK_OBJECT_ACE, *PACCESS_DENIED_CALLBACK_OBJECT_ACE;
+    //
     // typedef struct _SYSTEM_AUDIT_CALLBACK_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1274,6 +1290,7 @@ namespace System.Security.AccessControl
     //     ULONG SidStart;
     //     // Opaque resource manager specific data
     // } SYSTEM_AUDIT_CALLBACK_OBJECT_ACE, *PSYSTEM_AUDIT_CALLBACK_OBJECT_ACE;
+    //
     // typedef struct _SYSTEM_ALARM_CALLBACK_OBJECT_ACE {
     //     ACE_HEADER Header;
     //     ACCESS_MASK Mask;
@@ -1310,6 +1327,7 @@ namespace System.Security.AccessControl
 
         // The following access mask bits in object aces may refer to an objectType that
         // identifies the property set, property, extended right, or type of child object to which the ACE applies
+        //
         //    ADS_RIGHT_DS_CREATE_CHILD = 0x1,
         //    ADS_RIGHT_DS_DELETE_CHILD = 0x2,
         //    ADS_RIGHT_DS_SELF = 0x8,

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
@@ -74,6 +74,7 @@ namespace System.Security.AccessControl
         //  Define an ACL and the ACE format.  The structure of an ACL header
         //  followed by one or more ACEs.  Pictorally the structure of an ACL header
         //  is as follows:
+        //
         //       3 3 2 2 2 2 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1
         //       1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
         //      +-------------------------------+---------------+---------------+
@@ -654,6 +655,7 @@ namespace System.Security.AccessControl
         //    LessThan if ace1 < ace2
         //    EqualTo if ace1 == ace2
         //    GreaterThan if ace1 > ace2
+        //
         // The order is:
         //        - explicit Access Denied ACEs
         //          [regular aces first, then object aces]
@@ -704,6 +706,7 @@ namespace System.Security.AccessControl
         //    LessThan if ace1 < ace2
         //    EqualTo if ace1 == ace2
         //    GreaterThan if ace1 > ace2
+        //
         // The order is:
         //        - explicit audit or alarm ACEs
         //        - explicit audit or alarm object ACEs
@@ -1086,9 +1089,12 @@ namespace System.Security.AccessControl
             {
                 // If the aces have access bits in common which refer to object types
                 // then we follow these rules:
+                //
                 //       Remove    No OT    OT = A        OT = B
                 // Existing
+                //
                 //   No OT          Remove   Invalid        Invalid
+                //
                 //   OT = A        Remove   Remove      Nothing Common
                 if (ace is ObjectAce objectAce)
                 {
@@ -1128,9 +1134,12 @@ namespace System.Security.AccessControl
             {
                 // If the aces have inheritance bits in common
                 // then we follow these rules:
+                //
                 //       Remove    No IOT    IOT = A        IOT = B
                 // Existing
+                //
                 //   No IOT          Remove   Invalid        Invalid
+                //
                 //   IOT = A        Remove   Remove      Nothing Common
                 if (ace is ObjectAce objectAce)
                 {
@@ -1226,6 +1235,7 @@ namespace System.Security.AccessControl
             }
 
             // The modification algorithm proceeds in stages
+            //
             // Stage 1: if flags match, add to the access mask
             if (ace.AceFlags == newAce.AceFlags)
             {

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
@@ -1,13 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*============================================================
-**
-** Classes:  Access Control List (ACL) family of classes
-**
-**
-===========================================================*/
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -19,23 +12,11 @@ namespace System.Security.AccessControl
 {
     public sealed class AceEnumerator : IEnumerator
     {
-        #region Private Members
-
-        //
         // Current enumeration index
-        //
-
         private int _current;
 
-        //
         // Parent collection
-        //
-
         private readonly GenericAcl _acl;
-
-        #endregion
-
-        #region Constructors
 
         internal AceEnumerator(GenericAcl collection)
         {
@@ -44,10 +25,6 @@ namespace System.Security.AccessControl
             _acl = collection;
             Reset();
         }
-
-        #endregion
-
-        #region IEnumerator Interface
 
         object IEnumerator.Current
         {
@@ -80,43 +57,23 @@ namespace System.Security.AccessControl
             _current = -1;
         }
 
-        #endregion
     }
-
 
     public abstract class GenericAcl : ICollection
     {
-        #region Constructors
-
         protected GenericAcl()
         { }
 
-        #endregion
-
-        #region Public Constants
-
-        //
         // ACL revisions
-        //
-
         public static readonly byte AclRevision = 2;
         public static readonly byte AclRevisionDS = 4;
 
-        //
         // Maximum length of a binary representation of the ACL
-        //
-
         public static readonly int MaxBinaryLength = ushort.MaxValue;
 
-        #endregion
-
-        #region Protected Members
-
-        //
         //  Define an ACL and the ACE format.  The structure of an ACL header
         //  followed by one or more ACEs.  Pictorally the structure of an ACL header
         //  is as follows:
-        //
         //       3 3 2 2 2 2 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1
         //       1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
         //      +-------------------------------+---------------+---------------+
@@ -124,45 +81,19 @@ namespace System.Security.AccessControl
         //      +-------------------------------+---------------+---------------+
         //      |              Sbz2             |           AceCount            |
         //      +-------------------------------+-------------------------------+
-        //
-
         internal const int HeaderLength = 8;
 
-        #endregion
-
-        #region Public Properties
-
-        //
         // Returns the revision of the ACL
-        //
-
         public abstract byte Revision { get; }
 
-        //
         // Returns the length of the binary representation of the ACL
-        //
-
         public abstract int BinaryLength { get; }
 
-        //
         // Retrieves the ACE at a specified index
-        //
-
         public abstract GenericAce this[int index] { get; set; }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Returns the binary representation of the ACL
-        //
-
         public abstract void GetBinaryForm(byte[] binaryForm, int offset);
-
-        #endregion
-
-        #region ICollection Implementation
 
         void ICollection.CopyTo(Array array, int index)
         {
@@ -202,10 +133,6 @@ namespace System.Security.AccessControl
             get { return this; }
         }
 
-        #endregion
-
-        #region IEnumerable Implementation
-
         IEnumerator IEnumerable.GetEnumerator()
         {
             return new AceEnumerator(this);
@@ -216,20 +143,12 @@ namespace System.Security.AccessControl
             return (AceEnumerator)((IEnumerable)this).GetEnumerator();
         }
 
-        #endregion
     }
-
 
     public sealed class RawAcl : GenericAcl
     {
-        #region Private Members
-
         private byte _revision;
         private List<GenericAce> _aces;
-
-        #endregion
-
-        #region Private Methods
 
         private static void VerifyHeader(byte[] binaryForm, int offset, out byte revision, out int count, out int length)
         {
@@ -239,10 +158,7 @@ namespace System.Security.AccessControl
 
             if (binaryForm.Length - offset < HeaderLength)
             {
-                //
                 // We expect at least the ACL header
-                //
-
                 goto InvalidParameter;
             }
 
@@ -252,11 +168,8 @@ namespace System.Security.AccessControl
 
             if (length > binaryForm.Length - offset)
             {
-                //
                 // Reported length of ACL ought to be no longer than the
                 // length of the buffer passed in
-                //
-
                 goto InvalidParameter;
             }
 
@@ -296,16 +209,10 @@ namespace System.Security.AccessControl
         {
             int count, length;
 
-            //
             // Verify the header and extract interesting header info
-            //
-
             VerifyHeader(binaryForm, offset, out _revision, out count, out length);
 
-            //
             // Remember how far ahead the binary form should end (for later verification)
-            //
-
             length += offset;
 
             offset += HeaderLength;
@@ -321,10 +228,7 @@ namespace System.Security.AccessControl
 
                 if (binaryLength + aceLength > MaxBinaryLength)
                 {
-                    //
                     // The ACE was too long - it would overflow the ACL maximum length
-                    //
-
                     throw new ArgumentException(SR.ArgumentException_InvalidAclBinaryForm, nameof(binaryForm));
                 }
 
@@ -332,11 +236,8 @@ namespace System.Security.AccessControl
 
                 if (aceLength % 4 != 0)
                 {
-                    //
                     // This indicates a bug in one of the ACE classes.
                     // Binary length of an ace must ALWAYS be divisible by 4.
-                    //
-
                     Debug.Fail("aceLength % 4 != 0");
                     // Replacing SystemException with InvalidOperationException. This code path
                     // indicates a bad ACE, but I don't know of a great exception to represent that.
@@ -349,12 +250,10 @@ namespace System.Security.AccessControl
 
                 if (_revision == AclRevisionDS)
                 {
-                    //
                     // Increment the offset by the advertised length rather than the
                     // actual binary length. (Ideally these two should match, but for
                     // object aces created through ADSI, the actual length is 32 bytes
                     // less than the allocated size of the ACE. This is a bug in ADSI.)
-                    //
                     offset += (binaryForm[offset + 2] << 0) + (binaryForm[offset + 3] << 8);
                 }
                 else
@@ -362,10 +261,7 @@ namespace System.Security.AccessControl
                     offset += aceLength;
                 }
 
-                //
                 // Verify that no more than the advertised length of the ACL was consumed
-                //
-
                 if (offset > length)
                 {
                     goto InvalidParameter;
@@ -381,14 +277,7 @@ namespace System.Security.AccessControl
                 nameof(binaryForm));
         }
 
-        #endregion
-
-        #region Constructors
-
-        //
         // Creates an empty ACL
-        //
-
         public RawAcl(byte revision, int capacity)
             : base()
         {
@@ -396,42 +285,26 @@ namespace System.Security.AccessControl
             _aces = new List<GenericAce>(capacity);
         }
 
-        //
         // Creates an ACL from its binary representation
-        //
-
         public RawAcl(byte[] binaryForm, int offset)
             : base()
         {
             SetBinaryForm(binaryForm, offset);
         }
 
-        #endregion
-
-        #region Public Properties
-
-        //
         // Returns the revision of the ACL
-        //
-
         public override byte Revision
         {
             get { return _revision; }
         }
 
-        //
         // Returns the number of ACEs in the ACL
-        //
-
         public override int Count
         {
             get { return _aces.Count; }
         }
 
-        //
         // Returns the length of the binary representation of the ACL
-        //
-
         public override int BinaryLength
         {
             get
@@ -448,20 +321,10 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Returns the binary representation of the ACL
-        //
-
         public override void GetBinaryForm(byte[] binaryForm, int offset)
         {
-            //
             // Populate the header
-            //
-
             MarshalHeader(binaryForm, offset);
             offset += HeaderLength;
 
@@ -475,11 +338,8 @@ namespace System.Security.AccessControl
 
                 if (aceLength % 4 != 0)
                 {
-                    //
                     // This indicates a bug in one of the ACE classes.
                     // Binary length of an ace must ALWAYS be divisible by 4.
-                    //
-
                     Debug.Fail("aceLength % 4 != 0");
                     // Replacing SystemException with InvalidOperationException. This code path
                     // indicates a bad ACE, but I don't know of a great exception to represent that.
@@ -492,12 +352,9 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Return an ACE at a particular index
         // The ACE is not cloned prior to returning, enabling the caller
         // to modify the ACE in place (a potentially dangerous operation)
-        //
-
         public override GenericAce this[int index]
         {
             get
@@ -511,11 +368,8 @@ namespace System.Security.AccessControl
 
                 if (value.BinaryLength % 4 != 0)
                 {
-                    //
                     // This indicates a bug in one of the ACE classes.
                     // Binary length of an ace must ALWAYS be divisible by 4.
-                    //
-
                     Debug.Fail("aceLength % 4 != 0");
                     // Replacing SystemException with InvalidOperationException. This code path
                     // indicates a bad ACE, but I don't know of a great exception to represent that.
@@ -535,10 +389,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Adds an ACE at the specified index
-        //
-
         public void InsertAce(int index, GenericAce ace)
         {
             ArgumentNullException.ThrowIfNull(ace);
@@ -551,22 +402,16 @@ namespace System.Security.AccessControl
             _aces.Insert(index, ace);
         }
 
-        //
         // Removes an ACE at the specified index
-        //
-
         public void RemoveAce(int index)
         {
             _aces.RemoveAt(index);
         }
 
-        #endregion
     }
-
 
     public abstract class CommonAcl : GenericAcl
     {
-        #region Add/Remove Logic Support
 
         [Flags]
         private enum AF    // ACE flags
@@ -601,12 +446,9 @@ namespace System.Security.AccessControl
                 afToPm[i] = PM.Invalid;
             }
 
-            //
             // This table specifies what effect various combinations of inheritance bits
             // have on how ACEs are inherited onto child objects
             // Important: Not all combinations of inheritance bits are valid
-            //
-
             afToPm[(int)(   0   |   0   |   0   |   0   )] = PM.F |   0   |   0   |   0   |     0;
             afToPm[(int)(   0   | AF.OI |   0   |   0   )] = PM.F |   0   | PM.CO |   0   | PM.GO;
             afToPm[(int)(   0   | AF.OI |   0   | AF.NP )] = PM.F |   0   | PM.CO |   0   |     0;
@@ -633,13 +475,10 @@ namespace System.Security.AccessControl
                 pmToAf[i] = AF.Invalid;
             }
 
-            //
             // This table is a reverse lookup table of the AFtoPM table
             // Given how inheritance is applied to child objects and containers,
             // it helps figure out whether that pattern is expressible using
             // the four ACE inheritance bits
-            //
-
             pmToAf[(int)( PM.F |   0   |   0   |   0   |   0   )] =    0   |   0   |   0   |     0;
             pmToAf[(int)( PM.F |   0   | PM.CO |   0   | PM.GO )] =    0   | AF.OI |   0   |     0;
             pmToAf[(int)( PM.F |   0   | PM.CO |   0   |   0   )] =    0   | AF.OI |   0   | AF.NP;
@@ -657,10 +496,7 @@ namespace System.Security.AccessControl
             return pmToAf;
         }
 
-        //
         // Canonicalizes AceFlags into a form that the mapping tables understand
-        //
-
         private static AF AFFromAceFlags(AceFlags aceFlags, bool isDS)
         {
             AF af = 0;
@@ -670,10 +506,8 @@ namespace System.Security.AccessControl
                 af |= AF.CI;
             }
 
-            //
             // ObjectInherit applies only to regular aces not object aces
             // so it can be ignored in the object aces case
-            //
             if ((!isDS) && ((aceFlags & AceFlags.ObjectInherit) != 0))
             {
                 af |= AF.OI;
@@ -692,10 +526,7 @@ namespace System.Security.AccessControl
             return af;
         }
 
-        //
         // Converts lookup table representation of AceFlags into the "public" form
-        //
-
         private static AceFlags AceFlagsFromAF(AF af, bool isDS)
         {
             AceFlags aceFlags = 0;
@@ -705,10 +536,8 @@ namespace System.Security.AccessControl
                 aceFlags |= AceFlags.ContainerInherit;
             }
 
-            //
             // ObjectInherit applies only to regular aces not object aces
             // so it can be ignored in the object aces case
-            //
             if ((!isDS) && ((af & AF.OI) != 0))
             {
                 aceFlags |= AceFlags.ObjectInherit;
@@ -727,10 +556,7 @@ namespace System.Security.AccessControl
             return aceFlags;
         }
 
-        //
         // Implements the merge of inheritance bits during the 'ADD' operation
-        //
-
         private static bool MergeInheritanceBits(AceFlags left, AceFlags right, bool isDS, out AceFlags result)
         {
             result = 0;
@@ -779,11 +605,8 @@ namespace System.Security.AccessControl
             PM resultPM;
             unchecked { resultPM = leftPM & ~rightPM; }
 
-            //
             // If the resulting propagation matrix is zero,
             // communicate back the fact that removal is "total"
-            //
-
             if (resultPM == 0)
             {
                 total = true;
@@ -803,24 +626,13 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Private Members
-
         private readonly RawAcl _acl;
         private bool _isDirty;
         private readonly bool _isCanonical;
         private readonly bool _isContainer;
 
-        //
         // To distinguish between a directory object acl and other common acls.
-        //
-
         private readonly bool _isDS;
-
-        #endregion
-
-        #region Private Methods
 
         private void CanonicalizeIfNecessary()
         {
@@ -838,12 +650,10 @@ namespace System.Security.AccessControl
             GreaterThan,
         }
 
-        //
         // Compares two discretionary ACEs and returns
         //    LessThan if ace1 < ace2
         //    EqualTo if ace1 == ace2
         //    GreaterThan if ace1 > ace2
-        //
         // The order is:
         //        - explicit Access Denied ACEs
         //          [regular aces first, then object aces]
@@ -851,8 +661,6 @@ namespace System.Security.AccessControl
         //          [regular aces first, then object aces]
         //        - inherited ACEs (in the original order )
         //        - user-defined ACEs (in the original order )
-        //
-
         private static int DaclAcePriority(GenericAce ace)
         {
             int result;
@@ -860,10 +668,7 @@ namespace System.Security.AccessControl
 
             if ((ace.AceFlags & AceFlags.Inherited) != 0)
             {
-                //
                 // inherited aces are at the end as a group
-                //
-
                 result = 2 * ushort.MaxValue + ace._indexInAcl;
             }
             else if (type == AceType.AccessDenied ||
@@ -888,28 +693,22 @@ namespace System.Security.AccessControl
             }
             else
             {
-                //
                 // custom aces are at the second group
-                //
                 result = ushort.MaxValue + ace._indexInAcl;
             }
 
             return result;
         }
 
-        //
         // Compares two system ACEs and returns
         //    LessThan if ace1 < ace2
         //    EqualTo if ace1 == ace2
         //    GreaterThan if ace1 > ace2
-        //
         // The order is:
         //        - explicit audit or alarm ACEs
         //        - explicit audit or alarm object ACEs
         //        - inherited ACEs (in the original order )
         //        - user-defined ACEs (in the original order )
-        //
-
         private static int SaclAcePriority(GenericAce ace)
         {
             int result;
@@ -1032,12 +831,9 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Inspects the ACE, modifies it by stripping away unnecessary or
         // meaningless flags.
         // Returns 'true' if the ACE should remain in the ACL, 'false' otherwise
-        //
-
         private bool InspectAce(ref GenericAce ace, bool isDacl)
         {
             const AceFlags AuditFlags =
@@ -1050,10 +846,7 @@ namespace System.Security.AccessControl
                 AceFlags.NoPropagateInherit |
                 AceFlags.InheritOnly;
 
-            //
             // Any ACE without at least one bit set in the access mask can be removed
-            //
-
             KnownAce? knownAce = ace as KnownAce;
 
             if (knownAce != null)
@@ -1066,15 +859,12 @@ namespace System.Security.AccessControl
 
             if (!IsContainer)
             {
-                //
                 // On a leaf object ACL, inheritance bits are meaningless.
                 // Specifically, an ACE marked "inherit-only" will never participate
                 // in access control and can be removed.
                 // Similarly, an ACE marked "container-inherit", "no-propagate-inherit"
                 // or "object-inherit" can have those bits cleared since they carry
                 // no meaning.
-                //
-
                 if ((ace.AceFlags & AceFlags.InheritOnly) != 0)
                 {
                     return false;
@@ -1087,11 +877,8 @@ namespace System.Security.AccessControl
             }
             else
             {
-                //
                 // Without either "container inherit" or "object inherit" to go with it,
                 // the InheritOnly bit is meaningless and the entire ACE can be removed.
-                //
-
                 if (((ace.AceFlags & AceFlags.InheritOnly) != 0) &&
                     ((ace.AceFlags & AceFlags.ContainerInherit) == 0) &&
                     ((ace.AceFlags & AceFlags.ObjectInherit) == 0))
@@ -1099,10 +886,8 @@ namespace System.Security.AccessControl
                     return false;
                 }
 
-                //
                 // Without either "container inherit" or "object inherit" to go with it,
                 // the NoPropagateInherit bit is meaningless and can be turned off.
-                //
                 if (((ace.AceFlags & AceFlags.NoPropagateInherit) != 0) &&
                     ((ace.AceFlags & AceFlags.ContainerInherit) == 0) &&
                     ((ace.AceFlags & AceFlags.ObjectInherit) == 0))
@@ -1115,18 +900,12 @@ namespace System.Security.AccessControl
 
             if (isDacl)
             {
-                //
                 // There is no place for audit flags on a DACL
-                //
-
                 unchecked { ace.AceFlags &= ~AuditFlags; }
 
                 if (qualifiedAce != null)
                 {
-                    //
                     // Qualified ACEs in a DACL must be allow or deny ACEs
-                    //
-
                     if (qualifiedAce.AceQualifier != AceQualifier.AccessAllowed &&
                         qualifiedAce.AceQualifier != AceQualifier.AccessDenied)
                     {
@@ -1136,20 +915,14 @@ namespace System.Security.AccessControl
             }
             else
             {
-                //
                 // On a SACL, any ACE that does not specify Success or Failure
                 // flags can be removed
-                //
-
                 if ((ace.AceFlags & AuditFlags) == 0)
                 {
                     return false;
                 }
 
-                //
                 // Qualified ACEs in a SACL must be audit ACEs
-                //
-
                 if (qualifiedAce != null)
                 {
                     if (qualifiedAce.AceQualifier != AceQualifier.SystemAudit)
@@ -1161,17 +934,11 @@ namespace System.Security.AccessControl
             return true;
         }
 
-        //
         // Strips meaningless flags from ACEs, removes meaningless ACEs
-        //
-
         private void RemoveMeaninglessAcesAndFlags(bool isDacl)
         {
-            //
             // Be warned: do NOT use the Count property because it has
             // side-effect of calling canonicalization.
-            //
-
             for (int i = _acl.Count - 1; i >= 0; i--)
             {
                 GenericAce ace = _acl[i];
@@ -1183,19 +950,13 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Converts the ACL to its canonical form
-        //
-
         private void Canonicalize(bool compact, bool isDacl)
         {
-            //
             // for quick sort to work, we must not allow the ace's indexes - which are constantly
             // changing during sorting - to influence our element's sorting order value. For
             // that purpose, we fix the ace's _indexInAcl here and use it for creating the
             // ace's sorting order value.
-            //
-
             for (ushort aclIndex = 0; aclIndex < _acl.Count; aclIndex++)
             {
                 _acl[aclIndex]._indexInAcl = aclIndex;
@@ -1229,10 +990,8 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // This method determines whether the object type and inherited object type from the original ace
         // should be retained or not based on access mask and aceflags for a given split
-        //
         private static void GetObjectTypesForSplit(ObjectAce originalAce, int accessMask, AceFlags aceFlags, out ObjectAceFlags objectFlags, out Guid objectType, out Guid inheritedObjectType)
         {
 
@@ -1240,9 +999,7 @@ namespace System.Security.AccessControl
             objectType = Guid.Empty;
             inheritedObjectType = Guid.Empty;
 
-            //
             // We should retain the object type if the access mask for this split contains any bits that refer to object type
-            //
             if ((accessMask & ObjectAce.AccessMaskWithObjectType) != 0)
             {
                 // keep the original ace's object flags and object type
@@ -1250,9 +1007,7 @@ namespace System.Security.AccessControl
                 objectFlags |= originalAce.ObjectAceFlags & ObjectAceFlags.ObjectAceTypePresent;
             }
 
-            //
             // We should retain the inherited object type if the aceflags for this contains inheritance (ContainerInherit)
-            //
             if ((aceFlags & AceFlags.ContainerInherit) != 0)
             {
                 // keep the original ace's object flags and object type
@@ -1279,13 +1034,10 @@ namespace System.Security.AccessControl
 
         private static bool AccessMasksAreMergeable(QualifiedAce ace, QualifiedAce newAce)
         {
-            //
             // The access masks are mergeable in any of the following conditions
             // 1. Object types match
             // 2. (Object types do not match) The existing ace does not have an object type and
             //     already contains all the bits of the new ace which refer to the object type
-            //
-
             if (ObjectTypesMatch(ace, newAce))
             {
                 // case 1
@@ -1305,13 +1057,10 @@ namespace System.Security.AccessControl
 
         private static bool AceFlagsAreMergeable(QualifiedAce ace, QualifiedAce newAce)
         {
-            //
             // The ace flags can be considered for merge in any of the following conditions
             // 1. Inherited object types match
             // 2. (Inherited object types do not match) The existing ace does not have an inherited object type and
             //     already contains all the bits of the new ace
-            //
-
             if (InheritedObjectTypesMatch(ace, newAce))
             {
                 // case 1
@@ -1322,11 +1071,8 @@ namespace System.Security.AccessControl
             if ((objectFlags & ObjectAceFlags.InheritedObjectAceTypePresent) == 0)
             {
                 // case 2
-
-                //
                 // This method is called only when the access masks of the two aces are already confirmed to be exact matches
                 // therefore the second condition of case 2 is already verified
-                //
                 Debug.Assert((ace.AccessMask & newAce.AccessMask) == newAce.AccessMask, "AceFlagsAreMergeable:: AccessMask of existing ace does not contain all access bits of new ace.");
                 return true;
             }
@@ -1338,37 +1084,25 @@ namespace System.Security.AccessControl
         {
             if ((ace.AccessMask & accessMask & ObjectAce.AccessMaskWithObjectType) != 0)
             {
-
-                //
                 // If the aces have access bits in common which refer to object types
                 // then we follow these rules:
-                //
                 //       Remove    No OT    OT = A        OT = B
                 // Existing
-                //
                 //   No OT          Remove   Invalid        Invalid
-                //
                 //   OT = A        Remove   Remove      Nothing Common
-                //
-
-
                 if (ace is ObjectAce objectAce)
                 {
-                    //
                     // if what we are trying to remove has an object type
                     // but the existing ace does not then this is an invalid case
-                    //
                     if (((objectFlags & ObjectAceFlags.ObjectAceTypePresent) != 0) &&
                         ((objectAce.ObjectAceFlags & ObjectAceFlags.ObjectAceTypePresent) == 0))
                     {
                         return false;
                     }
 
-                    //
                     // if what we are trying to remove has no object type or
                     // if object types match (since at this point we have ensured that both have object types present)
                     // then we have common access bits with object type
-                    //
                     bool commonAccessBitsWithObjectTypeExist = ((objectFlags & ObjectAceFlags.ObjectAceTypePresent) == 0) ||
                                                                                     objectAce.ObjectTypesMatch(objectFlags, objectType);
                     if (!commonAccessBitsWithObjectTypeExist)
@@ -1392,36 +1126,24 @@ namespace System.Security.AccessControl
         {
             if (((ace.AceFlags & AceFlags.ContainerInherit) != 0) && ((aceFlags & AceFlags.ContainerInherit) != 0))
             {
-
-                //
                 // If the aces have inheritance bits in common
                 // then we follow these rules:
-                //
                 //       Remove    No IOT    IOT = A        IOT = B
                 // Existing
-                //
                 //   No IOT          Remove   Invalid        Invalid
-                //
                 //   IOT = A        Remove   Remove      Nothing Common
-                //
-
-
                 if (ace is ObjectAce objectAce)
                 {
-                    //
                     // if what we are trying to remove has an inherited object type
                     // but the existing ace does not then this is an invalid case
-                    //
                     if (((objectFlags & ObjectAceFlags.InheritedObjectAceTypePresent) != 0) &&
                         ((objectAce.ObjectAceFlags & ObjectAceFlags.InheritedObjectAceTypePresent) == 0))
                     {
                         return false;
                     }
 
-                    //
                     // if what we are trying to remove has no inherited object type or
                     // if inherited object types match then we have common inheritance flags
-                    //
                     bool commonInheritanceFlagsExist = ((objectFlags & ObjectAceFlags.InheritedObjectAceTypePresent) == 0) ||
                                                                        objectAce.InheritedObjectTypesMatch(objectFlags, inheritedObjectType);
                     if (!commonInheritanceFlagsExist)
@@ -1456,19 +1178,13 @@ namespace System.Security.AccessControl
 
         private static bool AcesAreMergeable(QualifiedAce ace, QualifiedAce newAce)
         {
-            //
             // Only interested in ACEs with the specified type
-            //
-
             if (ace.AceType != newAce.AceType)
             {
                 return false;
             }
 
-            //
             // Only interested in explicit (non-inherited) ACEs
-            //
-
             if ((ace.AceFlags & AceFlags.Inherited) != 0)
             {
                 return false;
@@ -1479,28 +1195,19 @@ namespace System.Security.AccessControl
                 return false;
             }
 
-            //
             // Only interested in ACEs with the specified qualifier
-            //
-
             if (ace.AceQualifier != newAce.AceQualifier)
             {
                 return false;
             }
 
-            //
             // Only interested in ACEs with the specified SID
-            //
-
             if (ace.SecurityIdentifier != newAce.SecurityIdentifier)
             {
                 return false;
             }
 
-            //
             // Only interested in ACEs with the specified callback data
-            //
-
             if (!AceOpaquesMatch(ace, newAce))
             {
                 return false;
@@ -1509,27 +1216,17 @@ namespace System.Security.AccessControl
             return true;
         }
 
-        //
         // Merge routine for qualified ACEs
-        //
-
         private bool MergeAces(ref QualifiedAce ace, QualifiedAce newAce)
         {
-            //
             // Check whether the ACEs are potentially mergeable
-            //
-
             if (!AcesAreMergeable(ace, newAce))
             {
                 return false;
             }
 
-            //
             // The modification algorithm proceeds in stages
-            //
             // Stage 1: if flags match, add to the access mask
-            //
-
             if (ace.AceFlags == newAce.AceFlags)
             {
                 if (ace is ObjectAce || newAce is ObjectAce)
@@ -1552,13 +1249,8 @@ namespace System.Security.AccessControl
                 }
             }
 
-
-
-            //
             // Stage 2: Audit flags can be combined if the rest of the
             //          flags (both access mask and inheritance) match
-            //
-
             if (((ace.AceFlags & AceFlags.InheritanceFlags) == (newAce.AceFlags & AceFlags.InheritanceFlags)) &&
                 (ace.AccessMask == newAce.AccessMask))
             {
@@ -1580,20 +1272,14 @@ namespace System.Security.AccessControl
 
             }
 
-            //
             // Stage 3: Inheritance flags can be combined in some cases
             //          provided access mask and audit bits are the same
-            //
-
             if (((ace.AceFlags & AceFlags.AuditFlags) == (newAce.AceFlags & AceFlags.AuditFlags)) &&
                 (ace.AccessMask == newAce.AccessMask))
             {
                 AceFlags merged;
 
-                //
                 // See whether the inheritance bits can be merged
-                //
-
                 if ((ace is ObjectAce) || (newAce is ObjectAce))
                 {
                     // object types need to match (for access mask equality) and inheritance flags need additional DS specific logic
@@ -1622,31 +1308,22 @@ namespace System.Security.AccessControl
             return false;
         }
 
-        //
         // Returns 'true' if the ACL is in canonical order; 'false' otherwise
-        //
-
         private bool CanonicalCheck(bool isDacl)
         {
             if (isDacl)
             {
-                //
                 // DACL canonical order:
                 //   Explicit Deny - Explicit Allow - Inherited
-                //
-
                 const int AccessDenied = 0;
                 const int AccessAllowed = 1;
                 const int Inherited = 2;
 
                 int currentStage = AccessDenied;
 
-                //
                 // In this loop, do NOT use 'Count' as upper bound of the loop,
                 // since doing so will canonicalize the ACL invalidating the result
                 // of this check!
-                //
-
                 for (int i = 0; i < _acl.Count; i++)
                 {
                     int aceStage;
@@ -1663,10 +1340,7 @@ namespace System.Security.AccessControl
 
                         if (qualifiedAce == null)
                         {
-                            //
                             // Explicit ACE is not recognized - this is not a canonical ACL
-                            //
-
                             return false;
                         }
 
@@ -1680,10 +1354,7 @@ namespace System.Security.AccessControl
                         }
                         else
                         {
-                            //
                             // Only allow and deny ACEs are allowed here
-                            //
-
                             Debug.Fail("Audit and alarm ACEs must have been stripped by remove-meaningless logic");
                             return false;
                         }
@@ -1701,22 +1372,16 @@ namespace System.Security.AccessControl
             }
             else
             {
-                //
                 // SACL canonical order:
                 //   Explicit - Inherited
-                //
-
                 const int Explicit = 0;
                 const int Inherited = 1;
 
                 int currentStage = Explicit;
 
-                //
                 // In this loop, do NOT use 'Count' as upper bound of the loop,
                 // since doing so will canonicalize the ACL invalidating the result
                 // of this check!
-                //
-
                 for (int i = 0; i < _acl.Count; i++)
                 {
                     int aceStage;
@@ -1725,11 +1390,8 @@ namespace System.Security.AccessControl
 
                     if (ace == null)
                     {
-                        //
                         // <markpu-9/19/2004> Afraid to yank this statement now
                         // for fear of destabilization, so adding an assert instead
-                        //
-
                         Debug.Assert(ace != null, "How did a null ACE end up in a SACL?");
                         continue;
                     }
@@ -1744,10 +1406,7 @@ namespace System.Security.AccessControl
 
                         if (qualifiedAce == null)
                         {
-                            //
                             // Explicit ACE is not recognized - this is not a canonical ACL
-                            //
-
                             return false;
                         }
 
@@ -1758,10 +1417,7 @@ namespace System.Security.AccessControl
                         }
                         else
                         {
-                            //
                             // Only audit and alarm ACEs are allowed here
-                            //
-
                             Debug.Fail("Allow and deny ACEs must have been stripped by remove-meaningless logic");
                             return false;
                         }
@@ -1789,14 +1445,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Constructors
-
-        //
         // Creates an empty ACL
-        //
-
         internal CommonAcl(bool isContainer, bool isDS, byte revision, int capacity)
             : base()
         {
@@ -1806,14 +1455,11 @@ namespace System.Security.AccessControl
             _isCanonical = true; // since it is empty
         }
 
-        //
         // Creates an ACL from a raw ACL
         // - 'trusted' (internal) callers get to pass the raw ACL
         //   that this object will take ownership of
         // - 'untrusted' callers are handled by creating a local
         //   copy of the ACL passed in
-        //
-
         internal CommonAcl(bool isContainer, bool isDS, RawAcl rawAcl, bool trusted, bool isDacl)
             : base()
         {
@@ -1824,34 +1470,22 @@ namespace System.Security.AccessControl
 
             if (trusted)
             {
-                //
                 // In the trusted case, we take over ownership of the ACL passed in
-                //
-
                 _acl = rawAcl;
 
                 RemoveMeaninglessAcesAndFlags(isDacl);
             }
             else
             {
-                //
                 // In the untrusted case, we create our own raw ACL to keep the ACEs in
-                //
-
                 _acl = new RawAcl(rawAcl.Revision, rawAcl.Count);
 
                 for (int i = 0; i < rawAcl.Count; i++)
                 {
-                    //
                     // Clone each ACE prior to putting it in
-                    //
-
                     GenericAce ace = rawAcl[i].Copy();
 
-                    //
                     // Avoid inserting meaningless ACEs
-                    //
-
                     if (InspectAce(ref ace, isDacl))
                     {
                         _acl.InsertAce(_acl.Count, ace);
@@ -1859,16 +1493,10 @@ namespace System.Security.AccessControl
                 }
             }
 
-            //
             // See whether the ACL is canonical to begin with
-            //
-
             if (CanonicalCheck(isDacl))
             {
-                //
                 // Sort and compact the array
-                //
-
                 Canonicalize(true, isDacl);
 
                 _isCanonical = true;
@@ -1879,18 +1507,10 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Internal Properties
-
         internal RawAcl RawAcl
         {
             get { return _acl; }
         }
-
-        #endregion
-
-        #region Protected Methods
 
         internal static void CheckAccessType(AccessControlType accessType)
         {
@@ -1907,10 +1527,7 @@ namespace System.Security.AccessControl
         {
             if (IsContainer)
             {
-                //
                 // Supplying propagation flags without inheritance flags is illegal
-                //
-
                 if (inheritanceFlags == InheritanceFlags.None &&
                     propagationFlags != PropagationFlags.None)
                 {
@@ -1935,10 +1552,7 @@ namespace System.Security.AccessControl
             return;
         }
 
-        //
         // Helper function behind all the AddXXX methods for qualified aces
-        //
-
         internal void AddQualifiedAce(SecurityIdentifier sid, AceQualifier qualifier, int accessMask, AceFlags flags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
             ArgumentNullException.ThrowIfNull(sid);
@@ -1973,19 +1587,13 @@ namespace System.Security.AccessControl
                 newAce = new ObjectAce(flags, qualifier, accessMask, sid, objectFlags, objectType, inheritedObjectType, false, null);
             }
 
-            //
             // Make sure the new ACE wouldn't be meaningless before proceeding
-            //
-
             if (!InspectAce(ref newAce, this is DiscretionaryAcl))
             {
                 return;
             }
 
-            //
             // See if the new ACE can be merged with any of the existing ones
-            //
-
             for (int i = 0; i < Count; i++)
             {
                 QualifiedAce? ace = _acl[i] as QualifiedAce;
@@ -2002,10 +1610,7 @@ namespace System.Security.AccessControl
                 }
             }
 
-            //
             // Couldn't modify any existing entry, so add a new one
-            //
-
             if (!aceMerged)
             {
                 _acl.InsertAce(_acl.Count, newAce);
@@ -2015,10 +1620,7 @@ namespace System.Security.AccessControl
             OnAclModificationTried();
         }
 
-        //
         // Helper function behind all the SetXXX methods
-        //
-
         internal void SetQualifiedAce(SecurityIdentifier sid, AceQualifier qualifier, int accessMask, AceFlags flags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
             ArgumentNullException.ThrowIfNull(sid);
@@ -2051,10 +1653,7 @@ namespace System.Security.AccessControl
                 newAce = new ObjectAce(flags, qualifier, accessMask, sid, objectFlags, objectType, inheritedObjectType, false, null);
             }
 
-            //
             // Make sure the new ACE wouldn't be meaningless before proceeding
-            //
-
             if (!InspectAce(ref newAce, this is DiscretionaryAcl))
             {
                 return;
@@ -2064,69 +1663,45 @@ namespace System.Security.AccessControl
             {
                 QualifiedAce? ace = _acl[i] as QualifiedAce;
 
-                //
                 // Not a qualified ACE - keep going
-                //
-
                 if (ace == null)
                 {
                     continue;
                 }
 
-                //
                 // Only interested in explicit (non-inherited) ACEs
-                //
-
                 if ((ace.AceFlags & AceFlags.Inherited) != 0)
                 {
                     continue;
                 }
 
-                //
                 // Only interested in ACEs with the specified qualifier
-                //
-
                 if (ace.AceQualifier != qualifier)
                 {
                     continue;
                 }
 
-                //
                 // Only interested in ACEs with the specified SID
-                //
-
                 if (ace.SecurityIdentifier != sid)
                 {
                     continue;
                 }
 
-                //
                 // This ACE corresponds to the SID and qualifier in question - remove it
-                //
-
                 _acl.RemoveAce(i);
                 i--;
             }
 
-            //
             // As a final step, add the ACE we want.
             // Add it at the end - we'll re-canonicalize later.
-            //
-
             _acl.InsertAce(_acl.Count, newAce);
 
-            //
             // To aid the efficiency of batch operations, recanonicalize this later
-            //
-
             _isDirty = true;
             OnAclModificationTried();
         }
 
-        //
         // Helper function behind all the RemoveXXX methods
-        //
-
         internal bool RemoveQualifiedAces(SecurityIdentifier sid, AceQualifier qualifier, int accessMask, AceFlags flags, bool saclSemantics, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
             if (accessMask == 0)
@@ -2148,31 +1723,22 @@ namespace System.Security.AccessControl
 
             ThrowIfNotCanonical();
 
-
-            //
             // Two passes are made.
             // During the first pass, no changes are made to the ACL,
             // the ACEs are simply evaluated to ascertain that the operation
             // can succeed.
             // If everything is kosher, the second pass is the one that makes changes.
-            //
-
             bool evaluationPass = true;
             bool removePossible = true; // unless proven otherwise
 
-            //
             // Needed for DS acls to keep track of the original access mask specified for removal
-            //
             int originalAccessMask = accessMask;
             AceFlags originalFlags = flags;
 
-            //
             // It is possible that the removal will result in an overflow exception
             // because more ACEs get inserted.
             // Save the current state of the object and revert to it later if
             // and exception is thrown.
-            //
-
             byte[] recovery = new byte[BinaryLength];
             GetBinaryForm(recovery, 0);
 
@@ -2184,49 +1750,33 @@ namespace System.Security.AccessControl
                 {
                     QualifiedAce? ace = _acl[i] as QualifiedAce;
 
-                    //
                     // Not a qualified ACE - keep going
-                    //
-
                     if (ace == null)
                     {
                         continue;
                     }
 
-                    //
                     // Only interested in explicit (non-inherited) ACEs
-                    //
-
                     if ((ace.AceFlags & AceFlags.Inherited) != 0)
                     {
                         continue;
                     }
 
-                    //
                     // Only interested in ACEs with the specified qualifier
-                    //
-
                     if (ace.AceQualifier != qualifier)
                     {
                         continue;
                     }
 
-                    //
                     // Only interested in ACEs with the specified SID
-                    //
-
                     if (ace.SecurityIdentifier != sid)
                     {
                         continue;
                     }
 
-                    //
                     // If access masks have nothing in common, skip the whole exercise
-                    //
-
                     if (IsDS)
                     {
-                        //
                         // incase of directory aces, if the access mask of the
                         // existing and new ace have any bits in common that need
                         // an object type, then we need to perform some checks on the
@@ -2234,7 +1784,6 @@ namespace System.Security.AccessControl
                         // by the object type they cannot be determined to be common without
                         // inspecting the object type. It is possible that the same bits may be set but
                         // the object types are different in which case they are really not common bits.
-                        //
                         accessMask = originalAccessMask;
                         bool objectTypesConflict = !GetAccessMaskForRemoval(ace, objectFlags, objectType, ref accessMask);
 
@@ -2244,14 +1793,12 @@ namespace System.Security.AccessControl
                             continue;
                         }
 
-                        //
                         // incase of directory aces, if the existing and new ace are being inherited,
                         // then we need to perform some checks on the
                         // inherited object types in the two aces. Since inheritance is further qualified
                         // by the inherited object type the inheritance flags cannot be determined to be common without
                         // inspecting the inherited object type. It is possible that both aces may be further inherited but if
                         // the inherited object types are different the inheritance may not be common.
-                        //
                         flags = originalFlags;
                         bool inheritedObjectTypesConflict = !GetInheritanceFlagsForRemoval(ace, objectFlags, inheritedObjectType, ref flags);
 
@@ -2262,10 +1809,8 @@ namespace System.Security.AccessControl
                             continue;
                         }
 
-                        //
                         // if the ace being removed referred only to child types and child types among existing ace and
                         // ace being removed are not common then there is nothing in common between these aces (skip)
-                        //
                         if (((originalFlags & AceFlags.ContainerInherit) != 0) && ((originalFlags & AceFlags.InheritOnly) != 0) && ((flags & AceFlags.ContainerInherit) == 0))
                         {
                             continue;
@@ -2273,10 +1818,8 @@ namespace System.Security.AccessControl
 
                         if (objectTypesConflict || inheritedObjectTypesConflict)
                         {
-                            //
                             // if we reached this stage, then we've found something common between the two aces.
                             // But since there is a conflict between the object types (or inherited object types), the remove is not possible
-                            //
                             removePossible = false;
                             break;
                         }
@@ -2289,59 +1832,41 @@ namespace System.Security.AccessControl
                         }
                     }
 
-                    //
                     // If audit flags on a SACL have nothing in common,
                     // skip the whole exercise
-                    //
-
                     if (saclSemantics &&
                         ((ace.AceFlags & flags & AceFlags.AuditFlags) == 0))
                     {
                         continue;
                     }
 
-                    //
                     // See if the ACE needs to be split into several
                     // To illustrate with an example, consider this equation:
                     //            From: CI OI    NP SA FA R W
                     //          Remove:    OI IO NP SA    R
-                    //
                     // PermissionSplit: CI OI    NP SA FA   W   // remove R
                     //   AuditingSplit: CI OI    NP    FA R     // remove SA
                     //      MergeSplit: CI OI    NP SA    R     // ready for merge
                     //          Remove:    OI IO NP SA    R     // same audit and perm flags as merge split
-                    //
                     //          Result: CI OI    NP SA FA   W   // PermissionSplit
                     //                  CI OI    NP    FA R     // AuditingSplit
                     //                  CI       NP SA    R     // Result of perm removal
-                    //
-
-                    //
                     // Example for DS acls (when removal is possible)
-                    //
                     // From: CI(Guid) LC CC(Guid)
                     // Remove: CI IO LC
-                    //
                     // PermissionSplit: CI(Guid) CC(Guid) // Remove GR
                     //        MergeSplit: CI(Guid) LC // Ready for merge
                     //           Remove: CI IO LC // Removal is possible since we are trying to remove inheritance for
                     //                                            all child types when it exists for one specific child type
-                    //
                     //              Result: CI(Guid) CC(Guid) // PermissionSplit
                     //                         LC // Result of perm removal
-                    //
-                    //
                     // Example for DS acls (when removal is NOT possible)
-                    //
                     // From: CI GR CC(Guid)
                     // Remove: CI(Guid) IO LC
-                    //
                     // PermissionSplit: CI CC(Guid) // Remove GR
                     //        MergeSplit: CI LC // Ready for merge
                     //           Remove: CI(Guid) IO CC // Removal is not possible since we are trying to remove
                     //                                                     inheritance for a specific child type when it exists for all child types
-                    //
-
                     // Permission split settings
                     AceFlags ps_AceFlags = 0;
                     int ps_AccessMask = 0;
@@ -2367,66 +1892,43 @@ namespace System.Security.AccessControl
                     AceFlags mergeResultFlags = 0;
                     bool mergeRemoveTotal = false;
 
-                    //
                     // First compute the permission split
-                    //
-
                     ps_AceFlags = ace.AceFlags;
                     unchecked { ps_AccessMask = ace.AccessMask & ~accessMask; }
 
                     if (ace is ObjectAce oAce)
                     {
-                        //
                         // determine what should be the object/inherited object types on the permission split
-                        //
                         GetObjectTypesForSplit(oAce, ps_AccessMask /* access mask for this split */, ps_AceFlags /* flags remain the same */, out ps_ObjectAceFlags, out ps_ObjectAceType, out ps_InheritedObjectAceType);
                     }
 
-                    //
                     // Next, for SACLs only, compute the auditing split
-                    //
-
                     if (saclSemantics)
                     {
-                        //
                         // This operation can set the audit bits region
                         // of ACE flags to zero;
                         // This case will be handled later
-                        //
-
                         unchecked { as_AceFlags = ace.AceFlags & ~(flags & AceFlags.AuditFlags); }
 
-                        //
                         // The result of this evaluation is guaranteed
                         // not to be zero by now
-                        //
-
                         as_AccessMask = (ace.AccessMask & accessMask);
 
                         if (ace is ObjectAce objAce)
                         {
-                            //
                             // determine what should be the object/inherited object types on the audit split
-                            //
                             GetObjectTypesForSplit(objAce, as_AccessMask /* access mask for this split */, as_AceFlags /* flags remain the same for inheritance */, out as_ObjectAceFlags, out as_ObjectAceType, out as_InheritedObjectAceType);
                         }
                     }
 
-                    //
                     // Finally, compute the merge split
-                    //
-
                     ms_AceFlags = (ace.AceFlags & AceFlags.InheritanceFlags) | (flags & ace.AceFlags & AceFlags.AuditFlags);
                     ms_AccessMask = (ace.AccessMask & accessMask);
 
-
-                    //
                     // Now is the time to obtain the result of applying the remove
                     // operation to the merge split
                     // Skipping this step for SACLs where the merge split step
                     // produced no auditing flags
-                    //
-
                     if (!saclSemantics ||
                         ((ms_AceFlags & AceFlags.AuditFlags) != 0))
                     {
@@ -2442,30 +1944,22 @@ namespace System.Security.AccessControl
 
                             if (ace is ObjectAce objAce)
                             {
-                                //
                                 // determine what should be the object/inherited object types on the merge split
-                                //
                                 GetObjectTypesForSplit(objAce, ms_AccessMask /* access mask for this split */, mergeResultFlags /* flags for this split */, out ms_ObjectAceFlags, out ms_ObjectAceType, out ms_InheritedObjectAceType);
                             }
                         }
                     }
 
-                    //
                     // If this is no longer an evaluation, go ahead and make the changes
-                    //
-
                     if (!evaluationPass)
                     {
                         QualifiedAce newAce;
 
-                        //
                         // Modify the existing ACE in-place if it has any access
                         // mask bits left, otherwise simply remove it
                         // However, if for an object ace we are removing the object type
                         // then we should really remove this ace and add a new one since
                         // we would be changing the size of this ace
-                        //
-
                         if (ps_AccessMask != 0)
                         {
                             if ((ace is ObjectAce) &&
@@ -2497,10 +1991,7 @@ namespace System.Security.AccessControl
                             i--; // keep the array index honest
                         }
 
-                        //
                         // On a SACL, the result of the auditing split must be recorded
-                        //
-
                         if (saclSemantics && ((as_AceFlags & AceFlags.AuditFlags) != 0))
                         {
                             if (ace is CommonAce)
@@ -2517,11 +2008,8 @@ namespace System.Security.AccessControl
                             _acl.InsertAce(i, newAce);
                         }
 
-                        //
                         // If there are interesting bits left over from a remove, store them
                         // as a separate ACE
-                        //
-
                         if (!mergeRemoveTotal)
                         {
                             if (ace is CommonAce)
@@ -2542,20 +2030,14 @@ namespace System.Security.AccessControl
             }
             catch (OverflowException)
             {
-                //
                 // Oops, overflow means that the ACL became too big.
                 // Inform the caller that the remove was not possible.
-                //
-
                 _acl.SetBinaryForm(recovery, 0);
                 return false;
             }
 
-            //
             // Finished evaluating the possibility of a remove.
             // If it looks like it's doable, go ahead and do it.
-            //
-
             if (evaluationPass && removePossible)
             {
                 evaluationPass = false;
@@ -2592,55 +2074,37 @@ namespace System.Security.AccessControl
             {
                 QualifiedAce? ace = _acl[i] as QualifiedAce;
 
-                //
                 // Not a qualified ACE - keep going
-                //
-
                 if (ace == null)
                 {
                     continue;
                 }
 
-                //
                 // Only interested in explicit (non-inherited) ACEs
-                //
-
                 if ((ace.AceFlags & AceFlags.Inherited) != 0)
                 {
                     continue;
                 }
 
-                //
                 // Only interested in ACEs with the specified qualifier
-                //
-
                 if (ace.AceQualifier != qualifier)
                 {
                     continue;
                 }
 
-                //
                 // Only interested in ACEs with the specified SID
-                //
-
                 if (ace.SecurityIdentifier != sid)
                 {
                     continue;
                 }
 
-                //
                 // Only interested in exact ACE flag matches
-                //
-
                 if (ace.AceFlags != flags)
                 {
                     continue;
                 }
 
-                //
                 // Only interested in exact access mask matches
-                //
-
                 if (ace.AccessMask != accessMask)
                 {
                     continue;
@@ -2648,17 +2112,11 @@ namespace System.Security.AccessControl
 
                 if (IsDS)
                 {
-                    //
                     // Incase of object aces, only interested in ACEs which match in their
                     // objectType and inheritedObjectType
-                    //
-
                     if ((ace is ObjectAce objectAce) && (objectFlags != ObjectAceFlags.None))
                     {
-                        //
                         // both are object aces, so must match in object type and inherited object type
-                        //
-
                         if ((!objectAce.ObjectTypesMatch(objectFlags, objectType))
                             || (!objectAce.InheritedObjectTypesMatch(objectFlags, inheritedObjectType)))
                         {
@@ -2672,10 +2130,7 @@ namespace System.Security.AccessControl
                     }
                 }
 
-                //
                 // Got our exact match; now remove it
-                //
-
                 _acl.RemoveAce(i);
                 i--; // keep the array index honest
             }
@@ -2685,23 +2140,14 @@ namespace System.Security.AccessControl
         internal virtual void OnAclModificationTried()
         {
         }
-        #endregion
 
-        #region Public Properties
-
-        //
         // Returns the revision of the ACL
-        //
-
         public sealed override byte Revision
         {
             get { return _acl.Revision; }
         }
 
-        //
         // Returns the number of ACEs in the ACL
-        //
-
         public sealed override int Count
         {
             get
@@ -2711,10 +2157,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Returns the length of the binary representation of the ACL
-        //
-
         public sealed override int BinaryLength
         {
             get
@@ -2724,10 +2167,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Returns 'true' if the ACL was canonical at creation time
-        //
-
         public bool IsCanonical
         {
             get { return _isCanonical; }
@@ -2743,26 +2183,16 @@ namespace System.Security.AccessControl
             get { return _isDS; }
         }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Returns the binary representation of the ACL
-        //
-
         public sealed override void GetBinaryForm(byte[] binaryForm, int offset)
         {
             CanonicalizeIfNecessary();
             _acl.GetBinaryForm(binaryForm, offset);
         }
 
-        //
         // Retrieves the ACE at a given index inside the ACL
         // Since the caller can modify the ACE it receives,
         // clone the ACE prior to returning it to the caller
-        //
-
         public sealed override GenericAce this[int index]
         {
             get
@@ -2781,11 +2211,8 @@ namespace System.Security.AccessControl
         {
             ThrowIfNotCanonical();
 
-            //
             // Iterating backwards as an optimization - all inherited ACEs
             // are usually in the back of the ACL
-            //
-
             for (int i = _acl.Count - 1; i >= 0; i--)
             {
                 GenericAce ace = _acl[i];
@@ -2808,28 +2235,19 @@ namespace System.Security.AccessControl
             {
                 KnownAce? ace = _acl[i] as KnownAce;
 
-                //
                 // Skip over unknown ACEs
-                //
-
                 if (ace == null)
                 {
                     continue;
                 }
 
-                //
                 // Skip over inherited ACEs
-                //
-
                 if ((ace.AceFlags & AceFlags.Inherited) != 0)
                 {
                     continue;
                 }
 
-                //
                 // SID matches - ACE is out
-                //
-
                 if (ace.SecurityIdentifier == sid)
                 {
                     _acl.RemoveAce(i);
@@ -2838,18 +2256,11 @@ namespace System.Security.AccessControl
             OnAclModificationTried();
         }
 
-        #endregion
     }
-
 
     public sealed class SystemAcl : CommonAcl
     {
-        #region Constructors
-
-        //
         // Creates an empty ACL
-        //
-
         public SystemAcl(bool isContainer, bool isDS, int capacity)
             : this(isContainer, isDS, isDS ? AclRevisionDS : AclRevision, capacity)
         {
@@ -2860,29 +2271,19 @@ namespace System.Security.AccessControl
         {
         }
 
-        //
         // Creates an ACL from a given raw ACL
         // after canonicalizing it
-        //
-
         public SystemAcl(bool isContainer, bool isDS, RawAcl rawAcl)
             : this(isContainer, isDS, rawAcl, false)
         {
         }
 
-        //
         // Internal version - if 'trusted' is true,
         // takes ownership of the given raw ACL
-        //
-
         internal SystemAcl(bool isContainer, bool isDS, RawAcl rawAcl, bool trusted)
             : base(isContainer, isDS, rawAcl, trusted, false)
         {
         }
-
-        #endregion
-
-        #region Public Methods
 
         public void AddAudit(AuditFlags auditFlags, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags)
         {
@@ -2913,9 +2314,7 @@ namespace System.Security.AccessControl
 
         public void AddAudit(AuditFlags auditFlags, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
-            //
             // This is valid only for DS Acls
-            //
             if (!IsDS)
             {
                 throw new InvalidOperationException(
@@ -2933,9 +2332,7 @@ namespace System.Security.AccessControl
 
         public void SetAudit(AuditFlags auditFlags, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
-            //
             // This is valid only for DS Acls
-            //
             if (!IsDS)
             {
                 throw new InvalidOperationException(
@@ -2953,9 +2350,7 @@ namespace System.Security.AccessControl
 
         public bool RemoveAudit(AuditFlags auditFlags, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
-            //
             // This is valid only for DS Acls
-            //
             if (!IsDS)
             {
                 throw new InvalidOperationException(
@@ -2972,9 +2367,7 @@ namespace System.Security.AccessControl
 
         public void RemoveAuditSpecific(AuditFlags auditFlags, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
-            //
             // This is valid only for DS Acls
-            //
             if (!IsDS)
             {
                 throw new InvalidOperationException(
@@ -2984,23 +2377,14 @@ namespace System.Security.AccessControl
             RemoveQualifiedAcesSpecific(sid, AceQualifier.SystemAudit, accessMask, GenericAce.AceFlagsFromAuditFlags(auditFlags) | GenericAce.AceFlagsFromInheritanceFlags(inheritanceFlags, propagationFlags), objectFlags, objectType, inheritedObjectType);
         }
 
-        #endregion
     }
-
 
     public sealed class DiscretionaryAcl : CommonAcl
     {
-        #region
         private static readonly SecurityIdentifier _sidEveryone = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
         private bool everyOneFullAccessForNullDacl;
-        #endregion
 
-        #region Constructors
-
-        //
         // Creates an empty ACL
-        //
-
         public DiscretionaryAcl(bool isContainer, bool isDS, int capacity)
             : this(isContainer, isDS, isDS ? AclRevisionDS : AclRevision, capacity)
         {
@@ -3011,29 +2395,19 @@ namespace System.Security.AccessControl
         {
         }
 
-        //
         // Creates an ACL from a given raw ACL
         // after canonicalizing it
-        //
-
         public DiscretionaryAcl(bool isContainer, bool isDS, RawAcl? rawAcl)
             : this(isContainer, isDS, rawAcl, false)
         {
         }
 
-        //
         // Internal version - if 'trusted' is true,
         // takes ownership of the given raw ACL
-        //
-
         internal DiscretionaryAcl(bool isContainer, bool isDS, RawAcl? rawAcl, bool trusted)
             : base(isContainer, isDS, rawAcl ?? new RawAcl(isDS ? AclRevisionDS : AclRevision, 0), trusted, true)
         {
         }
-
-        #endregion
-
-        #region Public Methods
 
         public void AddAccess(AccessControlType accessType, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags)
         {
@@ -3072,9 +2446,7 @@ namespace System.Security.AccessControl
 
         public void AddAccess(AccessControlType accessType, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
-            //
             // This is valid only for DS Acls
-            //
             if (!IsDS)
             {
                 throw new InvalidOperationException(
@@ -3094,9 +2466,7 @@ namespace System.Security.AccessControl
 
         public void SetAccess(AccessControlType accessType, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
-            //
             // This is valid only for DS Acls
-            //
             if (!IsDS)
             {
                 throw new InvalidOperationException(
@@ -3116,9 +2486,7 @@ namespace System.Security.AccessControl
 
         public bool RemoveAccess(AccessControlType accessType, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
-            //
             // This is valid only for DS Acls
-            //
             if (!IsDS)
             {
                 throw new InvalidOperationException(
@@ -3137,9 +2505,7 @@ namespace System.Security.AccessControl
 
         public void RemoveAccessSpecific(AccessControlType accessType, SecurityIdentifier sid, int accessMask, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, ObjectAceFlags objectFlags, Guid objectType, Guid inheritedObjectType)
         {
-            //
             // This is valid only for DS Acls
-            //
             if (!IsDS)
             {
                 throw new InvalidOperationException(
@@ -3151,26 +2517,18 @@ namespace System.Security.AccessControl
             RemoveQualifiedAcesSpecific(sid, accessType == AccessControlType.Allow ? AceQualifier.AccessAllowed : AceQualifier.AccessDenied, accessMask, GenericAce.AceFlagsFromInheritanceFlags(inheritanceFlags, propagationFlags), objectFlags, objectType, inheritedObjectType);
         }
 
-        #endregion
-
-        #region internals and privates
-
-        //
         // DACL's "allow everyone full access may be created to replace a null DACL because managed
         // access control does not want to leave null DACLs around. But we need to remember this MACL
         // created ACE when the DACL is modified, we can remove it to match the same native semantics of
         // a null DACL.
-        //
         internal bool EveryOneFullAccessForNullDacl
         {
             get { return everyOneFullAccessForNullDacl; }
             set { everyOneFullAccessForNullDacl = value; }
         }
 
-        //
         // As soon as you tried successfully to modified the ACL, the internally created allow every one full access ACL is materialized
         // because in native world, a NULL dacl can't be operated on.
-        //
         internal override void OnAclModificationTried()
         {
             everyOneFullAccessForNullDacl = false;
@@ -3197,6 +2555,5 @@ namespace System.Security.AccessControl
             dcl.everyOneFullAccessForNullDacl = true;
             return dcl;
         }
-        #endregion
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
@@ -1854,29 +1854,39 @@ namespace System.Security.AccessControl
                     // To illustrate with an example, consider this equation:
                     //            From: CI OI    NP SA FA R W
                     //          Remove:    OI IO NP SA    R
+                    //
                     // PermissionSplit: CI OI    NP SA FA   W   // remove R
                     //   AuditingSplit: CI OI    NP    FA R     // remove SA
                     //      MergeSplit: CI OI    NP SA    R     // ready for merge
                     //          Remove:    OI IO NP SA    R     // same audit and perm flags as merge split
+                    //
                     //          Result: CI OI    NP SA FA   W   // PermissionSplit
                     //                  CI OI    NP    FA R     // AuditingSplit
                     //                  CI       NP SA    R     // Result of perm removal
+                    //
                     // Example for DS acls (when removal is possible)
+                    //
                     // From: CI(Guid) LC CC(Guid)
                     // Remove: CI IO LC
+                    //
                     // PermissionSplit: CI(Guid) CC(Guid) // Remove GR
                     //        MergeSplit: CI(Guid) LC // Ready for merge
                     //           Remove: CI IO LC // Removal is possible since we are trying to remove inheritance for
                     //                                            all child types when it exists for one specific child type
+                    //
                     //              Result: CI(Guid) CC(Guid) // PermissionSplit
                     //                         LC // Result of perm removal
+                    //
                     // Example for DS acls (when removal is NOT possible)
+                    //
                     // From: CI GR CC(Guid)
                     // Remove: CI(Guid) IO LC
+                    //
                     // PermissionSplit: CI CC(Guid) // Remove GR
                     //        MergeSplit: CI LC // Ready for merge
                     //           Remove: CI(Guid) IO CC // Removal is not possible since we are trying to remove
                     //                                                     inheritance for a specific child type when it exists for all child types
+
                     // Permission split settings
                     AceFlags ps_AceFlags = 0;
                     int ps_AccessMask = 0;

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/CommonObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/CommonObjectSecurity.cs
@@ -1,13 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*============================================================
-**
-** Classes:  Common Object Security class
-**
-**
-===========================================================*/
-
 using System;
 using System.Collections;
 using System.Diagnostics;
@@ -20,8 +13,6 @@ namespace System.Security.AccessControl
 {
     public abstract class CommonObjectSecurity : ObjectSecurity
     {
-        #region Constructors
-
         protected CommonObjectSecurity(bool isContainer)
             : base(isContainer, false)
         {
@@ -32,10 +23,7 @@ namespace System.Security.AccessControl
         {
         }
 
-        #endregion
-
-        #region Private Methods
-        // Ported from NDP\clr\src\BCL\System\Security\Principal\SID.cs since we can't access System.Security.Principal.IdentityReference's internals
+        // Ported from desktop code since we can't access System.Security.Principal.IdentityReference's internals.
         private static bool IsValidTargetTypeStatic(Type targetType)
         {
             if (targetType == typeof(NTAccount))
@@ -52,7 +40,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        private AuthorizationRuleCollection GetRules(bool access, bool includeExplicit, bool includeInherited, System.Type targetType)
+        private AuthorizationRuleCollection GetRules(bool access, bool includeExplicit, bool includeInherited, Type targetType)
         {
             ReadLock();
 
@@ -86,9 +74,7 @@ namespace System.Security.AccessControl
 
                 if (acl == null)
                 {
-                    //
                     // The required ACL was not present; return an empty collection.
-                    //
                     return result;
                 }
 
@@ -100,7 +86,6 @@ namespace System.Security.AccessControl
 
                     for (int i = 0; i < acl.Count; i++)
                     {
-                        //
                         // Calling the indexer on a common ACL results in cloning,
                         // (which would not be the case if we were to use the internal RawAcl property)
                         // but also ensures that the resulting order of ACEs is proper
@@ -108,7 +93,6 @@ namespace System.Security.AccessControl
                         // the canonical order could be ascertained just once.
                         // A better way would be to have an internal method that would canonicalize the ACL
                         // and call it once, then use the RawAcl.
-                        //
                         CommonAce? ace = acl[i] as CommonAce;
                         if (AceNeedsTranslation(ace, access, includeExplicit, includeInherited))
                         {
@@ -122,7 +106,6 @@ namespace System.Security.AccessControl
                 int targetIndex = 0;
                 for (int i = 0; i < acl.Count; i++)
                 {
-                    //
                     // Calling the indexer on a common ACL results in cloning,
                     // (which would not be the case if we were to use the internal RawAcl property)
                     // but also ensures that the resulting order of ACEs is proper
@@ -130,8 +113,6 @@ namespace System.Security.AccessControl
                     // the canonical order could be ascertained just once.
                     // A better way would be to have an internal method that would canonicalize the ACL
                     // and call it once, then use the RawAcl.
-                    //
-
                     CommonAce? ace = acl[i] as CommonAce;
                     if (AceNeedsTranslation(ace, access, includeExplicit, includeInherited))
                     {
@@ -185,10 +166,7 @@ namespace System.Security.AccessControl
         {
             if (ace == null)
             {
-                //
                 // Only consider common ACEs
-                //
-
                 return false;
             }
 
@@ -219,9 +197,7 @@ namespace System.Security.AccessControl
             return false;
         }
 
-        //
         // Modifies the DACL
-        //
         protected override bool ModifyAccess(AccessControlModification modification, AccessRule rule, out bool modified)
         {
             ArgumentNullException.ThrowIfNull(rule);
@@ -345,10 +321,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Modifies the SACL
-        //
-
         protected override bool ModifyAudit(AccessControlModification modification, AuditRule rule, out bool modified)
         {
             ArgumentNullException.ThrowIfNull(rule);
@@ -420,14 +393,6 @@ namespace System.Security.AccessControl
                 WriteUnlock();
             }
         }
-
-        #endregion
-
-        #region Protected Methods
-
-        #endregion
-
-        #region Public Methods
 
         protected void AddAccessRule(AccessRule rule)
         {
@@ -624,15 +589,14 @@ namespace System.Security.AccessControl
             }
         }
 
-        public AuthorizationRuleCollection GetAccessRules(bool includeExplicit, bool includeInherited, System.Type targetType)
+        public AuthorizationRuleCollection GetAccessRules(bool includeExplicit, bool includeInherited, Type targetType)
         {
             return GetRules(true, includeExplicit, includeInherited, targetType);
         }
 
-        public AuthorizationRuleCollection GetAuditRules(bool includeExplicit, bool includeInherited, System.Type targetType)
+        public AuthorizationRuleCollection GetAuditRules(bool includeExplicit, bool includeInherited, Type targetType)
         {
             return GetRules(false, includeExplicit, includeInherited, targetType);
         }
-        #endregion
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Enums.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Enums.cs
@@ -38,7 +38,6 @@ namespace System.Security.AccessControl
         SystemAcl = 0x00000008,
     }
 
-
     public enum ResourceType
     {
         Unknown = 0x00,

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -1,13 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*============================================================
-**
-** Classes:  NativeObjectSecurity class
-**
-**
-===========================================================*/
-
 using System;
 using System.Collections;
 using System.Diagnostics;
@@ -23,8 +16,6 @@ namespace System.Security.AccessControl
 {
     public abstract class NativeObjectSecurity : CommonObjectSecurity
     {
-        #region Private Members
-
         private readonly ResourceType _resourceType;
         private readonly ExceptionFromErrorCode? _exceptionFromErrorCode;
         private readonly object? _exceptionContext;
@@ -33,17 +24,7 @@ namespace System.Security.AccessControl
         private readonly uint UnprotectedDiscretionaryAcl = 0x20000000;
         private readonly uint UnprotectedSystemAcl = 0x10000000;
 
-
-
-        #endregion
-
-        #region Delegates
-
         protected internal delegate System.Exception? ExceptionFromErrorCode(int errorCode, string? name, SafeHandle? handle, object? context);
-
-        #endregion
-
-        #region Constructors
 
         protected NativeObjectSecurity(bool isContainer, ResourceType resourceType)
             : base(isContainer)
@@ -89,10 +70,6 @@ namespace System.Security.AccessControl
             : this(isContainer, resourceType, handle, includeSections, null, null)
         {
         }
-
-        #endregion
-
-        #region Private Methods
 
         private static CommonSecurityDescriptor CreateInternal(ResourceType resourceType, bool isContainer, string? name, SafeHandle? handle, AccessControlSections includeSections, bool createByName, ExceptionFromErrorCode? exceptionFromErrorCode, object? exceptionContext)
         {
@@ -174,10 +151,7 @@ namespace System.Security.AccessControl
             return new CommonSecurityDescriptor(isContainer, false /* isDS */, rawSD!, true);
         }
 
-        //
         // Attempts to persist the security descriptor onto the object
-        //
-
         private void Persist(string? name, SafeHandle? handle, AccessControlSections includeSections, object? exceptionContext)
         {
             WriteLock();
@@ -253,10 +227,7 @@ namespace System.Security.AccessControl
 
                 if (securityInfo == 0)
                 {
-                    //
                     // Nothing to persist
-                    //
-
                     return;
                 }
 
@@ -311,15 +282,12 @@ namespace System.Security.AccessControl
                     throw exception;
                 }
 
-                //
                 // Everything goes well, let us clean the modified flags.
                 // We are in proper write lock, so just go ahead
-                //
-
-                this.OwnerModified = false;
-                this.GroupModified = false;
-                this.AccessRulesModified = false;
-                this.AuditRulesModified = false;
+                OwnerModified = false;
+                GroupModified = false;
+                AccessRulesModified = false;
+                AuditRulesModified = false;
             }
             finally
             {
@@ -327,17 +295,9 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Protected Methods
-
-        //
         // Persists the changes made to the object
         // by calling the underlying Windows API
-        //
         // This overloaded method takes a name of an existing object
-        //
-
         protected sealed override void Persist(string name, AccessControlSections includeSections)
         {
             Persist(name, includeSections, _exceptionContext);
@@ -350,12 +310,9 @@ namespace System.Security.AccessControl
             Persist(name, null, includeSections, exceptionContext);
         }
 
-        //
         // Persists the changes made to the object
         // by calling the underlying Windows API
-        //
         // This overloaded method takes a handle to an existing object
-        //
         protected sealed override void Persist(SafeHandle handle, AccessControlSections includeSections)
         {
             Persist(handle, includeSections, _exceptionContext);
@@ -367,6 +324,5 @@ namespace System.Security.AccessControl
 
             Persist(null, handle, includeSections, exceptionContext);
         }
-        #endregion
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -297,6 +297,7 @@ namespace System.Security.AccessControl
 
         // Persists the changes made to the object
         // by calling the underlying Windows API
+        //
         // This overloaded method takes a name of an existing object
         protected sealed override void Persist(string name, AccessControlSections includeSections)
         {
@@ -312,6 +313,7 @@ namespace System.Security.AccessControl
 
         // Persists the changes made to the object
         // by calling the underlying Windows API
+        //
         // This overloaded method takes a handle to an existing object
         protected sealed override void Persist(SafeHandle handle, AccessControlSections includeSections)
         {

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
@@ -243,6 +243,7 @@ namespace System.Security.AccessControl
         }
 
         // Persists the changes made to the object
+        //
         // This overloaded method takes a name of an existing object
         protected virtual void Persist(string name, AccessControlSections includeSections)
         {
@@ -285,6 +286,7 @@ namespace System.Security.AccessControl
         }
 
         // Persists the changes made to the object
+        //
         // This overloaded method takes a handle to an existing object
         protected virtual void Persist(SafeHandle handle, AccessControlSections includeSections)
         {

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
@@ -1,13 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*============================================================
-**
-** Classes:  Object Security family of classes
-**
-**
-===========================================================*/
-
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -16,7 +9,6 @@ using System.Threading;
 
 namespace System.Security.AccessControl
 {
-
     public enum AccessControlModification
     {
         Add = 0,
@@ -26,12 +18,8 @@ namespace System.Security.AccessControl
         RemoveAll = 4,
         RemoveSpecific = 5,
     }
-
-
     public abstract class ObjectSecurity
     {
-        #region Private Members
-
         private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
         internal readonly CommonSecurityDescriptor _securityDescriptor = null!;
@@ -55,10 +43,6 @@ namespace System.Security.AccessControl
             ControlFlags.DiscretionaryAclAutoInherited |
             ControlFlags.DiscretionaryAclProtected;
 
-        #endregion
-
-        #region Constructors
-
         protected ObjectSecurity()
         {
         }
@@ -78,10 +62,6 @@ namespace System.Security.AccessControl
 
             _securityDescriptor = securityDescriptor;
         }
-
-        #endregion
-
-        #region Private methods
 
         private void UpdateWithNewSecurityDescriptor(RawSecurityDescriptor newOne, AccessControlSections includeSections)
         {
@@ -134,10 +114,6 @@ namespace System.Security.AccessControl
                     (ControlFlags)((newOne.ControlFlags | daclFlag) & DACL_CONTROL_FLAGS));
             }
         }
-
-        #endregion
-
-        #region Protected Properties and Methods
 
         /// <summary>
         /// Gets the security descriptor for this instance.
@@ -266,22 +242,16 @@ namespace System.Security.AccessControl
             get { return _securityDescriptor.IsDS; }
         }
 
-        //
         // Persists the changes made to the object
-        //
         // This overloaded method takes a name of an existing object
-        //
-
         protected virtual void Persist(string name, AccessControlSections includeSections)
         {
             throw NotImplemented.ByDesign;
         }
 
-        //
         // if Persist (by name) is implemented, then this function will also try to enable take ownership
         // privilege while persisting if the enableOwnershipPrivilege is true.
         // Integrators can override it if this is not desired.
-        //
         protected virtual void Persist(bool enableOwnershipPrivilege, string name, AccessControlSections includeSections)
         {
             Privilege? ownerPrivilege = null;
@@ -314,25 +284,14 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Persists the changes made to the object
-        //
         // This overloaded method takes a handle to an existing object
-        //
-
         protected virtual void Persist(SafeHandle handle, AccessControlSections includeSections)
         {
             throw NotImplemented.ByDesign;
         }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Sets and retrieves the owner of this object
-        //
-
         public IdentityReference? GetOwner(System.Type targetType)
         {
             ReadLock();
@@ -369,10 +328,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Sets and retrieves the group of this object
-        //
-
         public IdentityReference? GetGroup(System.Type targetType)
         {
             ReadLock();
@@ -645,7 +601,7 @@ namespace System.Security.AccessControl
         {
             ArgumentNullException.ThrowIfNull(rule);
 
-            if (!this.AccessRuleType.IsAssignableFrom(rule.GetType()))
+            if (!AccessRuleType.IsAssignableFrom(rule.GetType()))
             {
                 throw new ArgumentException(
                     SR.AccessControl_InvalidAccessRuleType,
@@ -668,7 +624,7 @@ namespace System.Security.AccessControl
         {
             ArgumentNullException.ThrowIfNull(rule);
 
-            if (!this.AuditRuleType.IsAssignableFrom(rule.GetType()))
+            if (!AuditRuleType.IsAssignableFrom(rule.GetType()))
             {
                 throw new ArgumentException(
                     SR.AccessControl_InvalidAuditRuleType,
@@ -690,6 +646,5 @@ namespace System.Security.AccessControl
         public abstract AccessRule AccessRuleFactory(IdentityReference identityReference, int accessMask, bool isInherited, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, AccessControlType type);
 
         public abstract AuditRule AuditRuleFactory(IdentityReference identityReference, int accessMask, bool isInherited, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, AuditFlags flags);
-        #endregion
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurityT.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurityT.cs
@@ -1,16 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*============================================================
-**
-** Class:  ObjectSecurity
-**
-** Purpose: Generic Managed ACL wrapper
-**
-** Date:  February 7, 2007
-**
-===========================================================*/
-
 using System;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
@@ -21,11 +11,7 @@ namespace System.Security.AccessControl
 {
     public class AccessRule<T> : AccessRule where T : struct
     {
-        #region Constructors
-        //
         // Constructors for creating access rules for file objects
-        //
-
         public AccessRule(
             IdentityReference identity,
             T rights,
@@ -52,10 +38,7 @@ namespace System.Security.AccessControl
                 type)
         { }
 
-        //
         // Constructor for creating access rules for folder objects
-        //
-
         public AccessRule(
             IdentityReference identity,
             T rights,
@@ -86,11 +69,8 @@ namespace System.Security.AccessControl
                 type)
         { }
 
-        //
         // Internal constructor to be called by public constructors
         // and the access rule factory methods of ObjectSecurity
-        //
-
         internal AccessRule(
             IdentityReference identity,
             int accessMask,
@@ -107,22 +87,14 @@ namespace System.Security.AccessControl
                 type)
         { }
 
-        #endregion
-
-        #region Public properties
-
         public T Rights
         {
             get { return (T)(object)base.AccessMask; }
         }
-        #endregion
     }
-
 
     public class AuditRule<T> : AuditRule where T : struct
     {
-        #region Constructors
-
         public AuditRule(
             IdentityReference identity,
             T rights,
@@ -198,22 +170,14 @@ namespace System.Security.AccessControl
         {
         }
 
-        #endregion
-
-        #region Public properties
-
         public T Rights
         {
             get { return (T)(object)base.AccessMask; }
         }
-        #endregion
     }
-
 
     public abstract class ObjectSecurity<T> : NativeObjectSecurity where T : struct
     {
-        #region Constructors
-
         protected ObjectSecurity(bool isContainer, ResourceType resourceType)
             : base(isContainer, resourceType, null, null)
         { }
@@ -233,9 +197,6 @@ namespace System.Security.AccessControl
         protected ObjectSecurity(bool isContainer, ResourceType resourceType, SafeHandle? safeHandle, AccessControlSections includeSections, ExceptionFromErrorCode? exceptionFromErrorCode, object? exceptionContext)
             : base(isContainer, resourceType, safeHandle, includeSections, exceptionFromErrorCode, exceptionContext)
         { }
-
-        #endregion
-        #region Factories
 
         public override AccessRule AccessRuleFactory(
             IdentityReference identityReference,
@@ -271,9 +232,6 @@ namespace System.Security.AccessControl
                 flags);
         }
 
-        #endregion
-        #region Private Methods
-
         private AccessControlSections GetAccessControlSectionsFromChanges()
         {
             AccessControlSections persistRules = AccessControlSections.None;
@@ -295,9 +253,6 @@ namespace System.Security.AccessControl
             }
             return persistRules;
         }
-
-        #endregion
-        #region Protected Methods
 
         // Use this in your own Persist after you have demanded any appropriate CAS permissions.
         // Note that you will want your version to be internal and use a specialized Safe Handle.
@@ -334,9 +289,6 @@ namespace System.Security.AccessControl
                 WriteUnlock();
             }
         }
-
-        #endregion
-        #region Public Methods
 
         // Override these if you need to do some custom bit remapping to hide any
         // complexity from the user.
@@ -395,9 +347,6 @@ namespace System.Security.AccessControl
             base.RemoveAuditRuleSpecific(rule);
         }
 
-        #endregion
-        #region some overrides
-
         public override Type AccessRightType
         {
             get { return typeof(T); }
@@ -412,6 +361,5 @@ namespace System.Security.AccessControl
         {
             get { return typeof(AuditRule<T>); }
         }
-        #endregion
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
@@ -28,12 +28,12 @@ namespace System.Security.AccessControl
         private static readonly Dictionary<string, Luid> s_luids = new Dictionary<string, Luid>();
         private static readonly ReaderWriterLockSlim s_privilegeLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
-        private bool needToRevert;
-        private bool initialState;
-        private bool stateWasChanged;
-        private Luid luid;
+        private bool _needToRevert;
+        private bool _initialState;
+        private bool _stateWasChanged;
+        private Luid _luid;
         private readonly Thread _currentThread = Thread.CurrentThread;
-        private TlsContents? tlsContents;
+        private TlsContents? _tlsContents;
 
         public const string CreateToken = "SeCreateTokenPrivilege";
         public const string AssignPrimaryToken = "SeAssignPrimaryTokenPrivilege";
@@ -140,13 +140,13 @@ namespace System.Security.AccessControl
 
         private sealed class TlsContents : IDisposable
         {
-            private bool disposed;
-            private int referenceCount = 1;
-            private SafeTokenHandle? threadHandle = new SafeTokenHandle(IntPtr.Zero);
-            private readonly bool isImpersonating;
+            private bool _disposed;
+            private int _referenceCount = 1;
+            private SafeTokenHandle? _threadHandle = new SafeTokenHandle(IntPtr.Zero);
+            private readonly bool _isImpersonating;
 
-            private static SafeTokenHandle processHandle = new SafeTokenHandle(IntPtr.Zero);
-            private static readonly object syncRoot = new object();
+            private static SafeTokenHandle s_processHandle = new SafeTokenHandle(IntPtr.Zero);
+            private static readonly object s_syncRoot = new object();
 
             public TlsContents()
             {
@@ -154,11 +154,11 @@ namespace System.Security.AccessControl
                 int cachingError = 0;
                 bool success = true;
 
-                if (processHandle.IsInvalid)
+                if (s_processHandle.IsInvalid)
                 {
-                    lock (syncRoot)
+                    lock (s_syncRoot)
                     {
-                        if (processHandle.IsInvalid)
+                        if (s_processHandle.IsInvalid)
                         {
                             SafeTokenHandle localProcessHandle;
                             if (!Interop.Advapi32.OpenProcessToken(
@@ -169,7 +169,7 @@ namespace System.Security.AccessControl
                                 cachingError = Marshal.GetLastPInvokeError();
                                 success = false;
                             }
-                            processHandle = localProcessHandle;
+                            s_processHandle = localProcessHandle;
                         }
                     }
                 }
@@ -178,36 +178,36 @@ namespace System.Security.AccessControl
                 {
                     // Open the thread token; if there is no thread token, get one from
                     // the process token by impersonating self.
-                    SafeTokenHandle? threadHandleBefore = threadHandle;
+                    SafeTokenHandle? threadHandleBefore = _threadHandle;
                     error = OpenThreadToken(
                                   TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges,
                                   WinSecurityContext.Process,
-                                  out threadHandle);
+                                  out _threadHandle);
                     unchecked { error &= ~(int)0x80070000; }
 
                     if (error != 0)
                     {
                         if (success)
                         {
-                            threadHandle = threadHandleBefore;
+                            _threadHandle = threadHandleBefore;
 
                             if (error != Interop.Errors.ERROR_NO_TOKEN)
                             {
                                 success = false;
                             }
 
-                            System.Diagnostics.Debug.Assert(!isImpersonating, "Incorrect isImpersonating state");
+                            System.Diagnostics.Debug.Assert(!_isImpersonating, "Incorrect isImpersonating state");
 
                             if (success)
                             {
                                 error = 0;
                                 if (!Interop.Advapi32.DuplicateTokenEx(
-                                                processHandle,
+                                                s_processHandle,
                                                 TokenAccessLevels.Impersonate | TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges,
                                                 IntPtr.Zero,
                                                 Interop.Advapi32.SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation,
                                                 System.Security.Principal.TokenType.TokenImpersonation,
-                                                ref threadHandle))
+                                                ref _threadHandle))
                                 {
                                     error = Marshal.GetLastPInvokeError();
                                     success = false;
@@ -216,7 +216,7 @@ namespace System.Security.AccessControl
 
                             if (success)
                             {
-                                error = SetThreadToken(threadHandle);
+                                error = SetThreadToken(_threadHandle);
                                 unchecked { error &= ~(int)0x80070000; }
 
                                 if (error != 0)
@@ -227,7 +227,7 @@ namespace System.Security.AccessControl
 
                             if (success)
                             {
-                                isImpersonating = true;
+                                _isImpersonating = true;
                             }
                         }
                         else
@@ -266,7 +266,7 @@ namespace System.Security.AccessControl
 
             ~TlsContents()
             {
-                if (!disposed)
+                if (!_disposed)
                 {
                     Dispose(false);
                 }
@@ -280,33 +280,33 @@ namespace System.Security.AccessControl
 
             private void Dispose(bool disposing)
             {
-                if (disposed) return;
+                if (_disposed) return;
 
                 if (disposing)
                 {
-                    if (threadHandle != null)
+                    if (_threadHandle != null)
                     {
-                        threadHandle.Dispose();
-                        threadHandle = null!;
+                        _threadHandle.Dispose();
+                        _threadHandle = null!;
                     }
                 }
 
-                if (isImpersonating)
+                if (_isImpersonating)
                 {
                     Interop.Advapi32.RevertToSelf();
                 }
 
-                disposed = true;
+                _disposed = true;
             }
 
             public void IncrementReferenceCount()
             {
-                referenceCount++;
+                _referenceCount++;
             }
 
             public int DecrementReferenceCount()
             {
-                int result = --referenceCount;
+                int result = --_referenceCount;
 
                 if (result == 0)
                 {
@@ -318,20 +318,20 @@ namespace System.Security.AccessControl
 
             public int ReferenceCountValue
             {
-                get { return referenceCount; }
+                get { return _referenceCount; }
             }
 
             public SafeTokenHandle ThreadHandle
             {
                 get
                 {
-                    return threadHandle!;
+                    return _threadHandle!;
                 }
             }
 
             public bool IsImpersonating
             {
-                get { return isImpersonating; }
+                get { return _isImpersonating; }
             }
         }
 
@@ -339,15 +339,15 @@ namespace System.Security.AccessControl
         {
             ArgumentNullException.ThrowIfNull(privilegeName);
 
-            luid = LuidFromPrivilege(privilegeName);
+            _luid = LuidFromPrivilege(privilegeName);
         }
 
         // Finalizer simply ensures that the privilege was not leaked
         ~Privilege()
         {
-            System.Diagnostics.Debug.Assert(!needToRevert, "Must revert privileges that you alter!");
+            System.Diagnostics.Debug.Assert(!_needToRevert, "Must revert privileges that you alter!");
 
-            if (needToRevert)
+            if (_needToRevert)
             {
                 Revert();
             }
@@ -360,7 +360,7 @@ namespace System.Security.AccessControl
 
         public bool NeedToRevert
         {
-            get { return needToRevert; }
+            get { return _needToRevert; }
         }
 
         private unsafe void ToggleState(bool enable)
@@ -374,7 +374,7 @@ namespace System.Security.AccessControl
             }
 
             // This privilege was already altered and needs to be reverted before it can be altered again
-            if (needToRevert)
+            if (_needToRevert)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_MustRevertPrivilege);
             }
@@ -382,21 +382,21 @@ namespace System.Security.AccessControl
             try
             {
                 // Retrieve TLS state
-                tlsContents = t_tlsSlotData;
+                _tlsContents = t_tlsSlotData;
 
-                if (tlsContents == null)
+                if (_tlsContents == null)
                 {
-                    tlsContents = new TlsContents();
-                    t_tlsSlotData = tlsContents;
+                    _tlsContents = new TlsContents();
+                    t_tlsSlotData = _tlsContents;
                 }
                 else
                 {
-                    tlsContents.IncrementReferenceCount();
+                    _tlsContents.IncrementReferenceCount();
                 }
 
                 Interop.Advapi32.TOKEN_PRIVILEGE newState;
                 newState.PrivilegeCount = 1;
-                newState.Privileges.Luid = luid;
+                newState.Privileges.Luid = _luid;
                 newState.Privileges.Attributes = enable ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED;
 
                 Interop.Advapi32.TOKEN_PRIVILEGE previousState = default;
@@ -404,7 +404,7 @@ namespace System.Security.AccessControl
 
                 // Place the new privilege on the thread token and remember the previous state.
                 if (!Interop.Advapi32.AdjustTokenPrivileges(
-                                  tlsContents.ThreadHandle,
+                                  _tlsContents.ThreadHandle,
                                   false,
                                   &newState,
                                   (uint)sizeof(Interop.Advapi32.TOKEN_PRIVILEGE),
@@ -420,18 +420,18 @@ namespace System.Security.AccessControl
                 else
                 {
                     // This is the initial state that revert will have to go back to
-                    initialState = ((previousState.Privileges.Attributes & Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED) != 0);
+                    _initialState = ((previousState.Privileges.Attributes & Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED) != 0);
 
                     // Remember whether state has changed at all
-                    stateWasChanged = (initialState != enable);
+                    _stateWasChanged = (_initialState != enable);
 
                     // If we had to impersonate, or if the privilege state changed we'll need to revert
-                    needToRevert = tlsContents.IsImpersonating || stateWasChanged;
+                    _needToRevert = _tlsContents.IsImpersonating || _stateWasChanged;
                 }
             }
             finally
             {
-                if (!needToRevert)
+                if (!_needToRevert)
                 {
                     Reset();
                 }
@@ -439,7 +439,7 @@ namespace System.Security.AccessControl
 
             if (error == Interop.Errors.ERROR_NOT_ALL_ASSIGNED)
             {
-                throw new PrivilegeNotHeldException(s_privileges[luid]);
+                throw new PrivilegeNotHeldException(s_privileges[_luid]);
             }
             if (error == Interop.Errors.ERROR_NOT_ENOUGH_MEMORY)
             {
@@ -477,17 +477,17 @@ namespace System.Security.AccessControl
             {
                 // Only call AdjustTokenPrivileges if we're not going to be reverting to self,
                 // on this Revert, since doing the latter obliterates the thread token anyway
-                if (stateWasChanged &&
-                    (tlsContents!.ReferenceCountValue > 1 ||
-                      !tlsContents.IsImpersonating))
+                if (_stateWasChanged &&
+                    (_tlsContents!.ReferenceCountValue > 1 ||
+                      !_tlsContents.IsImpersonating))
                 {
                     Interop.Advapi32.TOKEN_PRIVILEGE newState;
                     newState.PrivilegeCount = 1;
-                    newState.Privileges.Luid = luid;
-                    newState.Privileges.Attributes = (initialState ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED);
+                    newState.Privileges.Luid = _luid;
+                    newState.Privileges.Attributes = (_initialState ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED);
 
                     if (!Interop.Advapi32.AdjustTokenPrivileges(
-                                      tlsContents.ThreadHandle,
+                                      _tlsContents.ThreadHandle,
                                       false,
                                       &newState,
                                       0,
@@ -524,15 +524,15 @@ namespace System.Security.AccessControl
 
         private void Reset()
         {
-            stateWasChanged = false;
-            initialState = false;
-            needToRevert = false;
+            _stateWasChanged = false;
+            _initialState = false;
+            _needToRevert = false;
 
-            if (tlsContents != null)
+            if (_tlsContents != null)
             {
-                if (0 == tlsContents.DecrementReferenceCount())
+                if (0 == _tlsContents.DecrementReferenceCount())
                 {
-                    tlsContents = null;
+                    _tlsContents = null;
                     t_tlsSlotData = null;
                 }
             }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
@@ -24,15 +24,15 @@ namespace System.Security.AccessControl
     {
         [ThreadStatic]
         private static TlsContents? t_tlsSlotData;
-        private static readonly Dictionary<Luid, string> privileges = new Dictionary<Luid, string>();
-        private static readonly Dictionary<string, Luid> luids = new Dictionary<string, Luid>();
-        private static readonly ReaderWriterLockSlim privilegeLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+        private static readonly Dictionary<Luid, string> s_privileges = new Dictionary<Luid, string>();
+        private static readonly Dictionary<string, Luid> s_luids = new Dictionary<string, Luid>();
+        private static readonly ReaderWriterLockSlim s_privilegeLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
         private bool needToRevert;
         private bool initialState;
         private bool stateWasChanged;
         private Luid luid;
-        private readonly Thread currentThread = Thread.CurrentThread;
+        private readonly Thread _currentThread = Thread.CurrentThread;
         private TlsContents? tlsContents;
 
         public const string CreateToken = "SeCreateTokenPrivilege";
@@ -68,32 +68,26 @@ namespace System.Security.AccessControl
         public const string TrustedCredentialManagerAccess = "SeTrustedCredManAccessPrivilege";
         public const string ReserveProcessor = "SeReserveProcessorPrivilege";
 
-        //
         // This routine is a wrapper around a hashtable containing mappings
         // of privilege names to LUIDs
-        //
-
         private static Luid LuidFromPrivilege(string privilege)
         {
             Luid luid;
             luid.LowPart = 0;
             luid.HighPart = 0;
 
-            //
             // Look up the privilege LUID inside the cache
-            //
-
             try
             {
-                privilegeLock.EnterReadLock();
+                s_privilegeLock.EnterReadLock();
 
-                if (luids.TryGetValue(privilege, out luid))
+                if (s_luids.TryGetValue(privilege, out luid))
                 {
-                    privilegeLock.ExitReadLock();
+                    s_privilegeLock.ExitReadLock();
                 }
                 else
                 {
-                    privilegeLock.ExitReadLock();
+                    s_privilegeLock.ExitReadLock();
 
                     if (!Interop.Advapi32.LookupPrivilegeValue(null, privilege, out luid))
                     {
@@ -120,24 +114,24 @@ namespace System.Security.AccessControl
                         }
                     }
 
-                    privilegeLock.EnterWriteLock();
+                    s_privilegeLock.EnterWriteLock();
                 }
             }
             finally
             {
-                if (privilegeLock.IsReadLockHeld)
+                if (s_privilegeLock.IsReadLockHeld)
                 {
-                    privilegeLock.ExitReadLock();
+                    s_privilegeLock.ExitReadLock();
                 }
 
-                if (privilegeLock.IsWriteLockHeld)
+                if (s_privilegeLock.IsWriteLockHeld)
                 {
-                    if (luids.TryAdd(privilege, luid))
+                    if (s_luids.TryAdd(privilege, luid))
                     {
-                        privileges[luid] = privilege;
+                        s_privileges[luid] = privilege;
                     }
 
-                    privilegeLock.ExitWriteLock();
+                    s_privilegeLock.ExitWriteLock();
                 }
             }
 
@@ -153,8 +147,6 @@ namespace System.Security.AccessControl
 
             private static SafeTokenHandle processHandle = new SafeTokenHandle(IntPtr.Zero);
             private static readonly object syncRoot = new object();
-
-            #region Constructor and Finalizer
 
             public TlsContents()
             {
@@ -184,30 +176,27 @@ namespace System.Security.AccessControl
 
                 try
                 {
-                    //
                     // Open the thread token; if there is no thread token, get one from
                     // the process token by impersonating self.
-                    //
-
-                    SafeTokenHandle? threadHandleBefore = this.threadHandle;
+                    SafeTokenHandle? threadHandleBefore = threadHandle;
                     error = OpenThreadToken(
                                   TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges,
                                   WinSecurityContext.Process,
-                                  out this.threadHandle);
+                                  out threadHandle);
                     unchecked { error &= ~(int)0x80070000; }
 
                     if (error != 0)
                     {
                         if (success)
                         {
-                            this.threadHandle = threadHandleBefore;
+                            threadHandle = threadHandleBefore;
 
                             if (error != Interop.Errors.ERROR_NO_TOKEN)
                             {
                                 success = false;
                             }
 
-                            System.Diagnostics.Debug.Assert(!this.isImpersonating, "Incorrect isImpersonating state");
+                            System.Diagnostics.Debug.Assert(!isImpersonating, "Incorrect isImpersonating state");
 
                             if (success)
                             {
@@ -218,7 +207,7 @@ namespace System.Security.AccessControl
                                                 IntPtr.Zero,
                                                 Interop.Advapi32.SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation,
                                                 System.Security.Principal.TokenType.TokenImpersonation,
-                                                ref this.threadHandle))
+                                                ref threadHandle))
                                 {
                                     error = Marshal.GetLastPInvokeError();
                                     success = false;
@@ -227,7 +216,7 @@ namespace System.Security.AccessControl
 
                             if (success)
                             {
-                                error = SetThreadToken(this.threadHandle);
+                                error = SetThreadToken(threadHandle);
                                 unchecked { error &= ~(int)0x80070000; }
 
                                 if (error != 0)
@@ -238,7 +227,7 @@ namespace System.Security.AccessControl
 
                             if (success)
                             {
-                                this.isImpersonating = true;
+                                isImpersonating = true;
                             }
                         }
                         else
@@ -277,14 +266,11 @@ namespace System.Security.AccessControl
 
             ~TlsContents()
             {
-                if (!this.disposed)
+                if (!disposed)
                 {
                     Dispose(false);
                 }
             }
-            #endregion
-
-            #region IDisposable implementation
 
             public void Dispose()
             {
@@ -294,36 +280,33 @@ namespace System.Security.AccessControl
 
             private void Dispose(bool disposing)
             {
-                if (this.disposed) return;
+                if (disposed) return;
 
                 if (disposing)
                 {
-                    if (this.threadHandle != null)
+                    if (threadHandle != null)
                     {
-                        this.threadHandle.Dispose();
-                        this.threadHandle = null!;
+                        threadHandle.Dispose();
+                        threadHandle = null!;
                     }
                 }
 
-                if (this.isImpersonating)
+                if (isImpersonating)
                 {
                     Interop.Advapi32.RevertToSelf();
                 }
 
-                this.disposed = true;
+                disposed = true;
             }
-            #endregion
-
-            #region Reference Counting
 
             public void IncrementReferenceCount()
             {
-                this.referenceCount++;
+                referenceCount++;
             }
 
             public int DecrementReferenceCount()
             {
-                int result = --this.referenceCount;
+                int result = --referenceCount;
 
                 if (result == 0)
                 {
@@ -335,118 +318,93 @@ namespace System.Security.AccessControl
 
             public int ReferenceCountValue
             {
-                get { return this.referenceCount; }
+                get { return referenceCount; }
             }
-            #endregion
-
-            #region Properties
 
             public SafeTokenHandle ThreadHandle
             {
                 get
                 {
-                    return this.threadHandle!;
+                    return threadHandle!;
                 }
             }
 
             public bool IsImpersonating
             {
-                get { return this.isImpersonating; }
+                get { return isImpersonating; }
             }
-            #endregion
         }
-
-        #region Constructors
 
         public Privilege(string privilegeName)
         {
             ArgumentNullException.ThrowIfNull(privilegeName);
 
-            this.luid = LuidFromPrivilege(privilegeName);
+            luid = LuidFromPrivilege(privilegeName);
         }
-        #endregion
 
-        //
         // Finalizer simply ensures that the privilege was not leaked
-        //
-
         ~Privilege()
         {
-            System.Diagnostics.Debug.Assert(!this.needToRevert, "Must revert privileges that you alter!");
+            System.Diagnostics.Debug.Assert(!needToRevert, "Must revert privileges that you alter!");
 
-            if (this.needToRevert)
+            if (needToRevert)
             {
                 Revert();
             }
         }
 
-        #region Public interface
         public void Enable()
         {
-            this.ToggleState(true);
+            ToggleState(true);
         }
 
         public bool NeedToRevert
         {
-            get { return this.needToRevert; }
+            get { return needToRevert; }
         }
-
-        #endregion
 
         private unsafe void ToggleState(bool enable)
         {
             int error = 0;
 
-            //
             // All privilege operations must take place on the same thread
-            //
-
-            if (!this.currentThread.Equals(Thread.CurrentThread))
+            if (!_currentThread.Equals(Thread.CurrentThread))
             {
                 throw new InvalidOperationException(SR.InvalidOperation_MustBeSameThread);
             }
 
-            //
             // This privilege was already altered and needs to be reverted before it can be altered again
-            //
-
-            if (this.needToRevert)
+            if (needToRevert)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_MustRevertPrivilege);
             }
 
             try
             {
-                //
                 // Retrieve TLS state
-                //
+                tlsContents = t_tlsSlotData;
 
-                this.tlsContents = t_tlsSlotData;
-
-                if (this.tlsContents == null)
+                if (tlsContents == null)
                 {
-                    this.tlsContents = new TlsContents();
-                    t_tlsSlotData = this.tlsContents;
+                    tlsContents = new TlsContents();
+                    t_tlsSlotData = tlsContents;
                 }
                 else
                 {
-                    this.tlsContents.IncrementReferenceCount();
+                    tlsContents.IncrementReferenceCount();
                 }
 
                 Interop.Advapi32.TOKEN_PRIVILEGE newState;
                 newState.PrivilegeCount = 1;
-                newState.Privileges.Luid = this.luid;
+                newState.Privileges.Luid = luid;
                 newState.Privileges.Attributes = enable ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED;
 
                 Interop.Advapi32.TOKEN_PRIVILEGE previousState = default;
                 uint previousSize = 0;
 
-                //
                 // Place the new privilege on the thread token and remember the previous state.
-                //
-
                 if (!Interop.Advapi32.AdjustTokenPrivileges(
-                                  this.tlsContents.ThreadHandle,
+                                  tlsContents.ThreadHandle,
                                   false,
                                   &newState,
                                   (uint)sizeof(Interop.Advapi32.TOKEN_PRIVILEGE),
@@ -461,36 +419,27 @@ namespace System.Security.AccessControl
                 }
                 else
                 {
-                    //
                     // This is the initial state that revert will have to go back to
-                    //
+                    initialState = ((previousState.Privileges.Attributes & Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED) != 0);
 
-                    this.initialState = ((previousState.Privileges.Attributes & Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED) != 0);
-
-                    //
                     // Remember whether state has changed at all
-                    //
+                    stateWasChanged = (initialState != enable);
 
-                    this.stateWasChanged = (this.initialState != enable);
-
-                    //
                     // If we had to impersonate, or if the privilege state changed we'll need to revert
-                    //
-
-                    this.needToRevert = this.tlsContents.IsImpersonating || this.stateWasChanged;
+                    needToRevert = tlsContents.IsImpersonating || stateWasChanged;
                 }
             }
             finally
             {
-                if (!this.needToRevert)
+                if (!needToRevert)
                 {
-                    this.Reset();
+                    Reset();
                 }
             }
 
             if (error == Interop.Errors.ERROR_NOT_ALL_ASSIGNED)
             {
-                throw new PrivilegeNotHeldException(privileges[this.luid]);
+                throw new PrivilegeNotHeldException(s_privileges[luid]);
             }
             if (error == Interop.Errors.ERROR_NOT_ENOUGH_MEMORY)
             {
@@ -512,12 +461,12 @@ namespace System.Security.AccessControl
         {
             int error = 0;
 
-            if (!this.currentThread.Equals(Thread.CurrentThread))
+            if (!_currentThread.Equals(Thread.CurrentThread))
             {
                 throw new InvalidOperationException(SR.InvalidOperation_MustBeSameThread);
             }
 
-            if (!this.NeedToRevert)
+            if (!NeedToRevert)
             {
                 return;
             }
@@ -526,22 +475,19 @@ namespace System.Security.AccessControl
 
             try
             {
-                //
                 // Only call AdjustTokenPrivileges if we're not going to be reverting to self,
                 // on this Revert, since doing the latter obliterates the thread token anyway
-                //
-
-                if (this.stateWasChanged &&
-                    (this.tlsContents!.ReferenceCountValue > 1 ||
-                      !this.tlsContents.IsImpersonating))
+                if (stateWasChanged &&
+                    (tlsContents!.ReferenceCountValue > 1 ||
+                      !tlsContents.IsImpersonating))
                 {
                     Interop.Advapi32.TOKEN_PRIVILEGE newState;
                     newState.PrivilegeCount = 1;
-                    newState.Privileges.Luid = this.luid;
-                    newState.Privileges.Attributes = (this.initialState ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED);
+                    newState.Privileges.Luid = luid;
+                    newState.Privileges.Attributes = (initialState ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED);
 
                     if (!Interop.Advapi32.AdjustTokenPrivileges(
-                                      this.tlsContents.ThreadHandle,
+                                      tlsContents.ThreadHandle,
                                       false,
                                       &newState,
                                       0,
@@ -557,7 +503,7 @@ namespace System.Security.AccessControl
             {
                 if (success)
                 {
-                    this.Reset();
+                    Reset();
                 }
             }
 
@@ -578,15 +524,15 @@ namespace System.Security.AccessControl
 
         private void Reset()
         {
-            this.stateWasChanged = false;
-            this.initialState = false;
-            this.needToRevert = false;
+            stateWasChanged = false;
+            initialState = false;
+            needToRevert = false;
 
-            if (this.tlsContents != null)
+            if (tlsContents != null)
             {
-                if (0 == this.tlsContents.DecrementReferenceCount())
+                if (0 == tlsContents.DecrementReferenceCount())
                 {
-                    this.tlsContents = null;
+                    tlsContents = null;
                     t_tlsSlotData = null;
                 }
             }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Rules.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Rules.cs
@@ -8,27 +8,19 @@ using System.Security.Principal;
 
 namespace System.Security.AccessControl
 {
-
     public enum AccessControlType
     {
         Allow = 0,
         Deny = 1,
     }
 
-
     public abstract class AuthorizationRule
     {
-        #region Private Members
-
         private readonly IdentityReference _identity;
         private readonly int _accessMask;
         private readonly bool _isInherited;
         private readonly InheritanceFlags _inheritanceFlags;
         private readonly PropagationFlags _propagationFlags;
-
-        #endregion
-
-        #region Constructors
 
         protected internal AuthorizationRule(
             IdentityReference identity,
@@ -78,10 +70,6 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Properties
-
         public IdentityReference IdentityReference
         {
             get { return _identity; }
@@ -107,19 +95,11 @@ namespace System.Security.AccessControl
             get { return _propagationFlags; }
         }
 
-        #endregion
     }
-
 
     public abstract class AccessRule : AuthorizationRule
     {
-        #region Private Methods
-
         private readonly AccessControlType _type;
-
-        #endregion
-
-        #region Constructors
 
         protected AccessRule(
             IdentityReference identity,
@@ -151,30 +131,18 @@ namespace System.Security.AccessControl
             _type = type;
         }
 
-        #endregion
-
-        #region Properties
-
         public AccessControlType AccessControlType
         {
             get { return _type; }
         }
 
-        #endregion
     }
-
 
     public abstract class ObjectAccessRule : AccessRule
     {
-        #region Private Members
-
         private readonly Guid _objectType;
         private readonly Guid _inheritedObjectType;
         private readonly ObjectAceFlags _objectFlags = ObjectAceFlags.None;
-
-        #endregion
-
-        #region Constructors
 
         protected ObjectAccessRule(IdentityReference identity, int accessMask, bool isInherited, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, Guid objectType, Guid inheritedObjectType, AccessControlType type)
             : base(identity, accessMask, isInherited, inheritanceFlags, propagationFlags, type)
@@ -200,10 +168,6 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Properties
-
         public Guid ObjectType
         {
             get { return _objectType; }
@@ -219,19 +183,11 @@ namespace System.Security.AccessControl
             get { return _objectFlags; }
         }
 
-        #endregion
     }
-
 
     public abstract class AuditRule : AuthorizationRule
     {
-        #region Private Members
-
         private readonly AuditFlags _flags;
-
-        #endregion
-
-        #region Constructors
 
         protected AuditRule(
             IdentityReference identity,
@@ -254,30 +210,18 @@ namespace System.Security.AccessControl
             _flags = auditFlags;
         }
 
-        #endregion
-
-        #region Public Properties
-
         public AuditFlags AuditFlags
         {
             get { return _flags; }
         }
 
-        #endregion
     }
-
 
     public abstract class ObjectAuditRule : AuditRule
     {
-        #region Private Members
-
         private readonly Guid _objectType;
         private readonly Guid _inheritedObjectType;
         private readonly ObjectAceFlags _objectFlags = ObjectAceFlags.None;
-
-        #endregion
-
-        #region Constructors
 
         protected ObjectAuditRule(IdentityReference identity, int accessMask, bool isInherited, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, Guid objectType, Guid inheritedObjectType, AuditFlags auditFlags)
             : base(identity, accessMask, isInherited, inheritanceFlags, propagationFlags, auditFlags)
@@ -304,10 +248,6 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Public Properties
-
         public Guid ObjectType
         {
             get { return _objectType; }
@@ -323,47 +263,29 @@ namespace System.Security.AccessControl
             get { return _objectFlags; }
         }
 
-
-        #endregion
     }
-
 
     public sealed class AuthorizationRuleCollection : ReadOnlyCollectionBase
     {
-        #region Constructors
-
         public AuthorizationRuleCollection()
             : base()
         {
         }
-
-        #endregion
-
-        #region Public methods
 
         public void AddRule(AuthorizationRule? rule)
         {
             InnerList.Add(rule);
         }
 
-        #endregion
-
-        #region ICollection Members
-
         public void CopyTo(AuthorizationRule[] rules, int index)
         {
-            ((ICollection)this).CopyTo(rules, index);
+            InnerList.CopyTo(rules, index);
         }
-
-        #endregion
-
-        #region Public properties
 
         public AuthorizationRule? this[int index]
         {
             get { return InnerList[index] as AuthorizationRule; }
         }
 
-        #endregion
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
@@ -239,7 +239,7 @@ namespace System.Security.AccessControl
 
             offset += HeaderLength;
 
-            // Marhsal the Owner SID into place
+            // Marshal the Owner SID into place
             if (Owner != null)
             {
                 MarshalInt(binaryForm, ownerOffset, offset - originalOffset);

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
@@ -1,13 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*============================================================
-**
-** Classes:  Security Descriptor family of classes
-**
-**
-===========================================================*/
-
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -20,7 +13,6 @@ using Microsoft.Win32;
 namespace System.Security.AccessControl
 {
     [Flags]
-
     public enum ControlFlags
     {
         None = 0x0000,
@@ -44,11 +36,7 @@ namespace System.Security.AccessControl
 
     public abstract class GenericSecurityDescriptor
     {
-        #region Protected Members
-
-        //
         // Pictorially the structure of a security descriptor is as follows:
-        //
         //       3 3 2 2 2 2 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1
         //       1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
         //      +---------------------------------------------------------------+
@@ -62,22 +50,13 @@ namespace System.Security.AccessControl
         //      +---------------------------------------------------------------+
         //      |                            Dacl                               |
         //      +---------------------------------------------------------------+
-        //
-
         internal const int HeaderLength = 20;
         internal const int OwnerFoundAt = 4;
         internal const int GroupFoundAt = 8;
         internal const int SaclFoundAt = 12;
         internal const int DaclFoundAt = 16;
 
-        #endregion
-
-        #region Private Methods
-
-        //
         // Stores an integer in big-endian format into an array at a given offset
-        //
-
         private static void MarshalInt(byte[] binaryForm, int offset, int number)
         {
             binaryForm[offset + 0] = (byte)(number >> 0);
@@ -86,10 +65,7 @@ namespace System.Security.AccessControl
             binaryForm[offset + 3] = (byte)(number >> 24);
         }
 
-        //
         // Retrieves an integer stored in big-endian format at a given offset in an array
-        //
-
         internal static int UnmarshalInt(byte[] binaryForm, int offset)
         {
             return (int)(
@@ -99,22 +75,11 @@ namespace System.Security.AccessControl
                 (binaryForm[offset + 3] << 24));
         }
 
-        #endregion
-
-        #region Constructors
-
         internal GenericSecurityDescriptor()
         { }
 
-        #endregion
-
-        #region Protected Properties
-
-        //
         // Marshaling logic requires calling into the derived
         // class to obtain pointers to SACL and DACL
-        //
-
         internal abstract GenericAcl? GenericSacl { get; }
         internal abstract GenericAcl? GenericDacl { get; }
         private bool IsCraftedAefaDacl
@@ -124,10 +89,6 @@ namespace System.Security.AccessControl
                 return (GenericDacl is DiscretionaryAcl dacl) && dacl.EveryOneFullAccessForNullDacl;
             }
         }
-
-        #endregion
-
-        #region Public Properties
 
         public static bool IsSddlConversionSupported()
         {
@@ -139,29 +100,17 @@ namespace System.Security.AccessControl
             get { return 1; }
         }
 
-        //
         // Allows retrieving and setting the control bits for this security descriptor
-        //
-
         public abstract ControlFlags ControlFlags { get; }
 
-        //
         // Allows retrieving and setting the owner SID for this security descriptor
-        //
-
         public abstract SecurityIdentifier? Owner { get; set; }
 
-        //
         // Allows retrieving and setting the group SID for this security descriptor
-        //
-
         public abstract SecurityIdentifier? Group { get; set; }
 
-        //
         // Retrieves the length of the binary representation
         // of the security descriptor
-        //
-
         public int BinaryLength
         {
             get
@@ -194,14 +143,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        #endregion
-
-        #region Public Methods
-
-        //
         // Converts the security descriptor to its SDDL form
-        //
-
         public string GetSddlForm(AccessControlSections includeSections)
         {
             byte[] binaryForm = new byte[BinaryLength];
@@ -237,10 +179,7 @@ namespace System.Security.AccessControl
             if (error == Interop.Errors.ERROR_INVALID_PARAMETER ||
                 error == Interop.Errors.ERROR_UNKNOWN_REVISION)
             {
-                //
                 // Indicates that the marshaling logic in GetBinaryForm is busted
-                //
-
                 Debug.Fail("binaryForm produced invalid output");
                 throw new InvalidOperationException();
             }
@@ -253,10 +192,7 @@ namespace System.Security.AccessControl
             return resultSddl!;
         }
 
-        //
         // Converts the security descriptor to its binary form
-        //
-
         public void GetBinaryForm(byte[] binaryForm, int offset)
         {
             ArgumentNullException.ThrowIfNull(binaryForm);
@@ -270,18 +206,12 @@ namespace System.Security.AccessControl
                     SR.ArgumentOutOfRange_ArrayTooSmall);
             }
 
-            //
             // the offset will grow as we go for each additional field (owner, group,
             // acl, etc) being written. But for each of such fields, we must use the
             // original offset as passed in, not the growing offset
-            //
-
             int originalOffset = offset;
 
-            //
             // Populate the header
-            //
-
             byte rmControl =
                 ((this is RawSecurityDescriptor rsd) &&
                  ((ControlFlags & ControlFlags.RMControlValid) != 0)) ? (rsd.ResourceManagerControl) : (byte)0;
@@ -298,10 +228,7 @@ namespace System.Security.AccessControl
             binaryForm[offset + 2] = unchecked((byte)((int)materializedControlFlags >> 0));
             binaryForm[offset + 3] = (byte)((int)materializedControlFlags >> 8);
 
-            //
             // Compute offsets at which owner, group, SACL and DACL are stored
-            //
-
             int ownerOffset, groupOffset, saclOffset, daclOffset;
 
             ownerOffset = offset + OwnerFoundAt;
@@ -311,10 +238,7 @@ namespace System.Security.AccessControl
 
             offset += HeaderLength;
 
-            //
             // Marhsal the Owner SID into place
-            //
-
             if (Owner != null)
             {
                 MarshalInt(binaryForm, ownerOffset, offset - originalOffset);
@@ -323,17 +247,11 @@ namespace System.Security.AccessControl
             }
             else
             {
-                //
                 // If Owner SID is null, store 0 in the offset field
-                //
-
                 MarshalInt(binaryForm, ownerOffset, 0);
             }
 
-            //
             // Marshal the Group SID into place
-            //
-
             if (Group != null)
             {
                 MarshalInt(binaryForm, groupOffset, offset - originalOffset);
@@ -342,17 +260,11 @@ namespace System.Security.AccessControl
             }
             else
             {
-                //
                 // If Group SID is null, store 0 in the offset field
-                //
-
                 MarshalInt(binaryForm, groupOffset, 0);
             }
 
-            //
             // Marshal the SACL into place, if present
-            //
-
             if ((ControlFlags & ControlFlags.SystemAclPresent) != 0 &&
                 GenericSacl != null)
             {
@@ -362,17 +274,11 @@ namespace System.Security.AccessControl
             }
             else
             {
-                //
                 // If SACL is null or not present, store 0 in the offset field
-                //
-
                 MarshalInt(binaryForm, saclOffset, 0);
             }
 
-            //
             // Marshal the DACL into place, if present
-            //
-
             if ((ControlFlags & ControlFlags.DiscretionaryAclPresent) != 0 &&
                 GenericDacl != null && !IsCraftedAefaDacl)
             {
@@ -381,31 +287,20 @@ namespace System.Security.AccessControl
             }
             else
             {
-                //
                 // If DACL is null or not present, store 0 in the offset field
-                //
-
                 MarshalInt(binaryForm, daclOffset, 0);
             }
         }
-        #endregion
     }
-
 
     public sealed class RawSecurityDescriptor : GenericSecurityDescriptor
     {
-        #region Private Members
-
         private SecurityIdentifier? _owner;
         private SecurityIdentifier? _group;
         private ControlFlags _flags;
         private RawAcl? _sacl;
         private RawAcl? _dacl;
         private byte _rmControl; // the not-so-reserved SBZ1 field
-
-        #endregion
-
-        #region Protected Properties
 
         internal override GenericAcl? GenericSacl
         {
@@ -417,10 +312,6 @@ namespace System.Security.AccessControl
             get { return _dacl; }
         }
 
-        #endregion
-
-        #region Private methods
-
         private void CreateFromParts(ControlFlags flags, SecurityIdentifier? owner, SecurityIdentifier? group, RawAcl? systemAcl, RawAcl? discretionaryAcl)
         {
             SetFlags(flags);
@@ -431,49 +322,30 @@ namespace System.Security.AccessControl
             ResourceManagerControl = 0;
         }
 
-        #endregion
-
-        #region Constructors
-
-        //
         // Creates a security descriptor explicitly
-        //
-
         public RawSecurityDescriptor(ControlFlags flags, SecurityIdentifier? owner, SecurityIdentifier? group, RawAcl? systemAcl, RawAcl? discretionaryAcl)
             : base()
         {
             CreateFromParts(flags, owner, group, systemAcl, discretionaryAcl);
         }
 
-        //
         // Creates a security descriptor from an SDDL string
-        //
-
         public RawSecurityDescriptor(string sddlForm)
             : this(BinaryFormFromSddlForm(sddlForm), 0)
         {
         }
 
-        //
         // Creates a security descriptor from its binary representation
         // Important: the representation must be in self-relative format
-        //
-
         public RawSecurityDescriptor(byte[] binaryForm, int offset)
             : base()
         {
             ArgumentNullException.ThrowIfNull(binaryForm);
 
-            //
             // The array passed in must be valid
-            //
-
             ArgumentOutOfRangeException.ThrowIfNegative(offset);
 
-            //
             // At least make sure the header is in place
-            //
-
             if (binaryForm.Length - offset < HeaderLength)
             {
                 throw new ArgumentOutOfRangeException(
@@ -481,38 +353,25 @@ namespace System.Security.AccessControl
                     SR.ArgumentOutOfRange_ArrayTooSmall);
             }
 
-            //
             // We only understand revision-1 security descriptors
-            //
-
             if (binaryForm[offset + 0] != Revision)
             {
                 throw new ArgumentOutOfRangeException(nameof(binaryForm),
                      SR.AccessControl_InvalidSecurityDescriptorRevision);
             }
 
-
             ControlFlags flags;
             SecurityIdentifier? owner, group;
             RawAcl? sacl, dacl;
             byte rmControl;
 
-            //
             // Extract the ResourceManagerControl field
-            //
-
             rmControl = binaryForm[offset + 1];
 
-            //
             // Extract the control flags
-            //
-
             flags = (ControlFlags)((binaryForm[offset + 2] << 0) + (binaryForm[offset + 3] << 8));
 
-            //
             // Make sure that the input is in self-relative format
-            //
-
             if ((flags & ControlFlags.SelfRelative) == 0)
             {
                 throw new ArgumentException(
@@ -520,10 +379,7 @@ namespace System.Security.AccessControl
                     nameof(binaryForm));
             }
 
-            //
             // Extract the owner SID
-            //
-
             int ownerOffset = UnmarshalInt(binaryForm, offset + OwnerFoundAt);
 
             if (ownerOffset != 0)
@@ -535,10 +391,7 @@ namespace System.Security.AccessControl
                 owner = null;
             }
 
-            //
             // Extract the group SID
-            //
-
             int groupOffset = UnmarshalInt(binaryForm, offset + GroupFoundAt);
 
             if (groupOffset != 0)
@@ -550,10 +403,7 @@ namespace System.Security.AccessControl
                 group = null;
             }
 
-            //
             // Extract the SACL
-            //
-
             int saclOffset = UnmarshalInt(binaryForm, offset + SaclFoundAt);
 
             if (((flags & ControlFlags.SystemAclPresent) != 0) &&
@@ -566,10 +416,7 @@ namespace System.Security.AccessControl
                 sacl = null;
             }
 
-            //
             // Extract the DACL
-            //
-
             int daclOffset = UnmarshalInt(binaryForm, offset + DaclFoundAt);
 
             if (((flags & ControlFlags.DiscretionaryAclPresent) != 0) &&
@@ -582,26 +429,16 @@ namespace System.Security.AccessControl
                 dacl = null;
             }
 
-            //
             // Create the resulting security descriptor
-            //
-
             CreateFromParts(flags, owner, group, sacl, dacl);
 
-            //
             // In the offchance that the flags indicate that the rmControl
             // field is meaningful, remember what was there.
-            //
-
             if ((flags & ControlFlags.RMControlValid) != 0)
             {
                 ResourceManagerControl = rmControl;
             }
         }
-
-        #endregion
-
-        #region Static Methods
 
         private static byte[] BinaryFormFromSddlForm(string sddlForm)
         {
@@ -650,17 +487,12 @@ namespace System.Security.AccessControl
 
                 binaryForm = new byte[byteArraySize];
 
-                //
                 // Extract the data from the returned pointer
-                //
-
                 Marshal.Copy(byteArray, binaryForm, 0, (int)byteArraySize);
             }
             finally
             {
-                //
                 // Now is a good time to get rid of the returned pointer
-                //
                 if (byteArray != IntPtr.Zero)
                 {
                     Marshal.FreeHGlobal(byteArray);
@@ -670,17 +502,10 @@ namespace System.Security.AccessControl
             return binaryForm;
         }
 
-        #endregion
-
-        #region Public Properties
-
-        //
         // Allows retrieving the control bits for this security descriptor
         // Important: Special checks must be applied when setting flags and not
         // all flags can be set (for instance, we only deal with self-relative
         // security descriptors), thus flags can be set through other methods.
-        //
-
         public override ControlFlags ControlFlags
         {
             get
@@ -689,10 +514,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Allows retrieving and setting the owner SID for this security descriptor
-        //
-
         public override SecurityIdentifier? Owner
         {
             get
@@ -706,10 +528,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Allows retrieving and setting the group SID for this security descriptor
-        //
-
         public override SecurityIdentifier? Group
         {
             get
@@ -723,10 +542,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Allows retrieving and setting the SACL for this security descriptor
-        //
-
         public RawAcl? SystemAcl
         {
             get
@@ -740,10 +556,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Allows retrieving and setting the DACL for this security descriptor
-        //
-
         public RawAcl? DiscretionaryAcl
         {
             get
@@ -757,13 +570,10 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // CORNER CASE (LEGACY)
         // The ostensibly "reserved" field in the Security Descriptor header
         // can in fact be used by obscure resource managers which in this
         // case must set the RMControlValid flag.
-        //
-
         public byte ResourceManagerControl
         {
             get
@@ -777,38 +587,22 @@ namespace System.Security.AccessControl
             }
         }
 
-
-        #endregion
-
-        #region Public Methods
-
         public void SetFlags(ControlFlags flags)
         {
-            //
             // We can not deal with non-self-relative descriptors
             // so just forget about it
-            //
-
             _flags = (flags | ControlFlags.SelfRelative);
         }
-        #endregion
     }
-
 
     public sealed class CommonSecurityDescriptor : GenericSecurityDescriptor
     {
-        #region Private Members
-
         private bool _isContainer;
         private bool _isDS;
         private RawSecurityDescriptor _rawSd;
         private SystemAcl? _sacl;
         private DiscretionaryAcl? _dacl;
 
-
-        #endregion
-
-        #region Private Methods
         [MemberNotNull(nameof(_rawSd))]
         private void CreateFromParts(bool isContainer, bool isDS, ControlFlags flags, SecurityIdentifier? owner, SecurityIdentifier? group, SystemAcl? systemAcl, DiscretionaryAcl? discretionaryAcl)
         {
@@ -858,28 +652,16 @@ namespace System.Security.AccessControl
 
             _sacl = systemAcl;
 
-            //
             // Replace null DACL with an allow-all for everyone DACL
-            //
-
-            //
             // to conform to native behavior, we will add allow everyone ace for DACL
-            //
-
             discretionaryAcl ??= DiscretionaryAcl.CreateAllowEveryoneFullAccess(_isDS, _isContainer);
 
             _dacl = discretionaryAcl;
 
-            //
             // DACL is never null. So always set the flag bit on
-            //
-
             ControlFlags actualFlags = flags | ControlFlags.DiscretionaryAclPresent;
 
-            //
             // Keep SACL and the flag bit in sync.
-            //
-
             if (systemAcl == null)
             {
                 unchecked { actualFlags &= ~(ControlFlags.SystemAclPresent); }
@@ -892,14 +674,7 @@ namespace System.Security.AccessControl
             _rawSd = new RawSecurityDescriptor(actualFlags, owner, group, systemAcl?.RawAcl, discretionaryAcl.RawAcl);
         }
 
-        #endregion
-
-        #region Constructors
-
-        //
         // Creates a security descriptor explicitly
-        //
-
         public CommonSecurityDescriptor(bool isContainer, bool isDS, ControlFlags flags, SecurityIdentifier? owner, SecurityIdentifier? group, SystemAcl? systemAcl, DiscretionaryAcl? discretionaryAcl)
         {
             CreateFromParts(isContainer, isDS, flags, owner, group, systemAcl, discretionaryAcl);
@@ -929,27 +704,17 @@ namespace System.Security.AccessControl
                 rawSecurityDescriptor.DiscretionaryAcl == null ? null : new DiscretionaryAcl(isContainer, isDS, rawSecurityDescriptor.DiscretionaryAcl, trusted));
         }
 
-        //
         // Create a security descriptor from an SDDL string
-        //
-
         public CommonSecurityDescriptor(bool isContainer, bool isDS, string sddlForm)
             : this(isContainer, isDS, new RawSecurityDescriptor(sddlForm), true)
         {
         }
 
-        //
         // Create a security descriptor from its binary representation
-        //
-
         public CommonSecurityDescriptor(bool isContainer, bool isDS, byte[] binaryForm, int offset)
             : this(isContainer, isDS, new RawSecurityDescriptor(binaryForm, offset), true)
         {
         }
-
-        #endregion
-
-        #region Protected Properties
 
         internal sealed override GenericAcl? GenericSacl
         {
@@ -961,10 +726,6 @@ namespace System.Security.AccessControl
             get { return _dacl; }
         }
 
-        #endregion
-
-        #region Public Properties
-
         public bool IsContainer
         {
             get { return _isContainer; }
@@ -975,11 +736,7 @@ namespace System.Security.AccessControl
             get { return _isDS; }
         }
 
-
-        //
         // Allows retrieving the control bits for this security descriptor
-        //
-
         public override ControlFlags ControlFlags
         {
             get
@@ -988,10 +745,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Allows retrieving and setting the owner SID for this security descriptor
-        //
-
         public override SecurityIdentifier? Owner
         {
             get
@@ -1005,10 +759,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Allows retrieving and setting the group SID for this security descriptor
-        //
-
         public override SecurityIdentifier? Group
         {
             get
@@ -1022,7 +773,6 @@ namespace System.Security.AccessControl
             }
         }
 
-
         public SystemAcl? SystemAcl
         {
             get
@@ -1034,19 +784,19 @@ namespace System.Security.AccessControl
             {
                 if (value != null)
                 {
-                    if (value.IsContainer != this.IsContainer)
+                    if (value.IsContainer != IsContainer)
                     {
                         throw new ArgumentException(
-                            this.IsContainer ?
+                            IsContainer ?
                                 SR.AccessControl_MustSpecifyContainerAcl :
                                 SR.AccessControl_MustSpecifyLeafObjectAcl,
                             nameof(value));
                     }
 
-                    if (value.IsDS != this.IsDS)
+                    if (value.IsDS != IsDS)
                     {
                         throw new ArgumentException(
-                            this.IsDS ?
+                            IsDS ?
                                 SR.AccessControl_MustSpecifyDirectoryObjectAcl :
                                 SR.AccessControl_MustSpecifyNonDirectoryObjectAcl,
                             nameof(value));
@@ -1068,10 +818,7 @@ namespace System.Security.AccessControl
             }
         }
 
-        //
         // Allows retrieving and setting the DACL for this security descriptor
-        //
-
         public DiscretionaryAcl? DiscretionaryAcl
         {
             get
@@ -1083,29 +830,26 @@ namespace System.Security.AccessControl
             {
                 if (value != null)
                 {
-                    if (value.IsContainer != this.IsContainer)
+                    if (value.IsContainer != IsContainer)
                     {
                         throw new ArgumentException(
-                            this.IsContainer ?
+                            IsContainer ?
                                 SR.AccessControl_MustSpecifyContainerAcl :
                                 SR.AccessControl_MustSpecifyLeafObjectAcl,
                             nameof(value));
                     }
 
-                    if (value.IsDS != this.IsDS)
+                    if (value.IsDS != IsDS)
                     {
                         throw new ArgumentException(
-                            this.IsDS ?
+                            IsDS ?
                                 SR.AccessControl_MustSpecifyDirectoryObjectAcl :
                                 SR.AccessControl_MustSpecifyNonDirectoryObjectAcl,
                             nameof(value));
                     }
                 }
 
-                //
                 // NULL DACLs are replaced with allow everyone full access DACLs.
-                //
-
                 if (value == null)
                 {
                     _dacl = DiscretionaryAcl.CreateAllowEveryoneFullAccess(IsDS, IsContainer);
@@ -1129,10 +873,6 @@ namespace System.Security.AccessControl
         {
             get { return (DiscretionaryAcl == null || DiscretionaryAcl.IsCanonical); }
         }
-
-        #endregion
-
-        #region Public Methods
 
         public void SetSystemAclProtection(bool isProtected, bool preserveInheritance)
         {
@@ -1188,31 +928,25 @@ namespace System.Security.AccessControl
 
         public void AddDiscretionaryAcl(byte revision, int trusted)
         {
-            this.DiscretionaryAcl = new DiscretionaryAcl(this.IsContainer, this.IsDS, revision, trusted);
-            this.AddControlFlags(ControlFlags.DiscretionaryAclPresent);
+            DiscretionaryAcl = new DiscretionaryAcl(IsContainer, IsDS, revision, trusted);
+            AddControlFlags(ControlFlags.DiscretionaryAclPresent);
         }
 
         public void AddSystemAcl(byte revision, int trusted)
         {
-            this.SystemAcl = new SystemAcl(this.IsContainer, this.IsDS, revision, trusted);
-            this.AddControlFlags(ControlFlags.SystemAclPresent);
+            SystemAcl = new SystemAcl(IsContainer, IsDS, revision, trusted);
+            AddControlFlags(ControlFlags.SystemAclPresent);
         }
 
-        #endregion
-
-        #region internal Methods
         internal void UpdateControlFlags(ControlFlags flagsToUpdate, ControlFlags newFlags)
         {
             ControlFlags finalFlags = newFlags | (_rawSd.ControlFlags & (~flagsToUpdate));
             _rawSd.SetFlags(finalFlags);
         }
 
-        //
         // These two add/remove method must be called with great care (and thus it is internal)
         // The caller is responsible for keeping the SaclPresent and DaclPresent bits in sync
         // with the actual SACL and DACL.
-        //
-
         internal void AddControlFlags(ControlFlags flags)
         {
             _rawSd.SetFlags(_rawSd.ControlFlags | flags);
@@ -1241,6 +975,5 @@ namespace System.Security.AccessControl
                 return (_rawSd.ControlFlags & ControlFlags.DiscretionaryAclPresent) != 0;
             }
         }
-        #endregion
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
@@ -37,6 +37,7 @@ namespace System.Security.AccessControl
     public abstract class GenericSecurityDescriptor
     {
         // Pictorially the structure of a security descriptor is as follows:
+        //
         //       3 3 2 2 2 2 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1
         //       1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
         //      +---------------------------------------------------------------+

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Win32.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Win32.cs
@@ -16,10 +16,7 @@ namespace System.Security.AccessControl
 {
     internal static class Win32
     {
-        //
         // Wrapper around advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW
-        //
-
         internal static int ConvertSdToSddl(
             byte[] binaryForm,
             int requestedRevision,
@@ -36,16 +33,10 @@ namespace System.Security.AccessControl
                 goto Error;
             }
 
-            //
             // Extract data from the returned pointer
-            //
-
             resultSddl = Marshal.PtrToStringUni(ByteArray)!;
 
-            //
             // Now is a good time to get rid of the returned pointer
-            //
-
             Marshal.FreeHGlobal(ByteArray);
 
             return 0;
@@ -62,10 +53,7 @@ namespace System.Security.AccessControl
             return errorCode;
         }
 
-        //
         // Wrapper around advapi32.GetSecurityInfo
-        //
-
         internal static unsafe int GetSecurityInfo(
             ResourceType resourceType,
             string? name,
@@ -143,10 +131,8 @@ namespace System.Security.AccessControl
 
                 if (errorCode == Interop.Errors.ERROR_SUCCESS && IntPtr.Zero.Equals(ByteArray))
                 {
-                    //
                     // This means that the object doesn't have a security descriptor. And thus we throw
                     // a specific exception for the caller to catch and handle properly.
-                    //
                     throw new InvalidOperationException(SR.InvalidOperation_NoSecurityDescriptor);
                 }
                 else if (errorCode == Interop.Errors.ERROR_NOT_ALL_ASSIGNED ||
@@ -176,10 +162,7 @@ namespace System.Security.AccessControl
                 privilege?.Revert();
             }
 
-            //
             // Extract data from the returned pointer
-            //
-
             uint Length = Interop.Advapi32.GetSecurityDescriptorLength(ByteArray);
 
             byte[] BinaryForm = new byte[Length];
@@ -202,10 +185,7 @@ namespace System.Security.AccessControl
             return errorCode;
         }
 
-        //
         // Wrapper around advapi32.SetNamedSecurityInfoW and advapi32.SetSecurityInfo
-        //
-
         internal static int SetSecurityInfo(
             ResourceType type,
             string? name,
@@ -251,11 +231,8 @@ namespace System.Security.AccessControl
 
             if ((securityInformation & SecurityInfos.SystemAcl) != 0)
             {
-                //
                 // Enable security privilege if trying to set a SACL.
                 // Note: even setting it by handle needs this privilege enabled!
-                //
-
                 securityPrivilege = new Privilege(Privilege.Security);
             }
 


### PR DESCRIPTION
When S.S.AccessControl was ported much of it had a lot of code style that does not fit with the current coding standards.

- Removed old `#region` / `#endregion` blocks.
- Removed decorative banner comments and empty `//` separator lines.
- Tightened comment spacing so comments sit directly above the code they describe.
- Removed redundant `this.` qualifiers.
- Renamed a few private fields in `Privilege.cs` to match current field naming conventions.
- Collapsed excessive blank lines left by the cleanup.

A lot of the cleanup mentioned in https://github.com/dotnet/runtime/issues/15934#issuecomment-276526094 has already happened organically due to various analyzers and code fixers.

There should be no functional changes.

Fixes #15934