### PR TITLE
Added async overload of ChangeToken.OnChange

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/ref/Microsoft.Extensions.Primitives.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/ref/Microsoft.Extensions.Primitives.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Extensions.Primitives
     public static partial class ChangeToken
     {
         public static System.IDisposable OnChange(System.Func<Microsoft.Extensions.Primitives.IChangeToken?> changeTokenProducer, System.Action changeTokenConsumer) { throw null; }
+        public static System.IDisposable OnChange(System.Func<Microsoft.Extensions.Primitives.IChangeToken?> changeTokenProducer, System.Func<System.Threading.Tasks.Task> changeTokenConsumer) { throw null; }
         public static System.IDisposable OnChange<TState>(System.Func<Microsoft.Extensions.Primitives.IChangeToken?> changeTokenProducer, System.Action<TState> changeTokenConsumer, TState state) { throw null; }
+        public static System.IDisposable OnChange<TState>(System.Func<Microsoft.Extensions.Primitives.IChangeToken?> changeTokenProducer, System.Func<TState, System.Threading.Tasks.Task> changeTokenConsumer, TState state) { throw null; }
     }
     public partial class CompositeChangeToken : Microsoft.Extensions.Primitives.IChangeToken
     {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Extensions.Primitives
                 else
                 {
                     // Sets can never overlap with other SetDisposable calls so we should never get into this situation
-                    throw new InvalidOperationException("Somebody else set the _disposable field");
+                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_ConcurrentDisposableSet);
                 }
             }
 
@@ -245,7 +245,12 @@ namespace Microsoft.Extensions.Primitives
                 {
                     // The consumer is invoked synchronously here, so that synchronous exceptions from it are propagated
                     // to the code that triggers the change token, just like the sync overload does.
-                    Task consumerTask = _changeTokenConsumer(State) ?? throw new InvalidOperationException("The task returned by changeTokenConsumer must not be null.");
+                    Task consumerTask = _changeTokenConsumer(State);
+
+                    if (consumerTask is null)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_NullConsumerTask);
+                    }
 
                     if (consumerTask.Status == TaskStatus.RanToCompletion)
                     {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Primitives
                 {
                     return;
                 }
-                IDisposable registration = token.RegisterChangeCallback(static s => ((ChangeTokenRegistration<TState>?)s)!.OnChangeTokenFired(), this);
+                IDisposable? registration = token.RegisterChangeCallback(static s => ((ChangeTokenRegistration<TState>?)s)!.OnChangeTokenFired(), this);
                 if (token.HasChanged && token.ActiveChangeCallbacks)
                 {
                     registration?.Dispose();
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.Primitives
                 SetDisposable(registration);
             }
 
-            private void SetDisposable(IDisposable disposable)
+            private void SetDisposable(IDisposable? disposable)
             {
                 // We don't want to transition from _disposedSentinel => anything since it's terminal
                 // but we want to allow going from previously assigned disposable, to another
@@ -151,7 +151,7 @@ namespace Microsoft.Extensions.Primitives
                 // If Dispose was called, then immediately dispose the disposable
                 if (current == _disposedSentinel)
                 {
-                    disposable.Dispose();
+                    disposable?.Dispose();
                     return;
                 }
 
@@ -161,7 +161,7 @@ namespace Microsoft.Extensions.Primitives
                 if (previous == _disposedSentinel)
                 {
                     // The subscription was disposed so we dispose immediately and return
-                    disposable.Dispose();
+                    disposable?.Dispose();
                 }
                 else if (previous == current)
                 {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -132,13 +132,13 @@ namespace Microsoft.Extensions.Primitives
                 {
                     return;
                 }
-                IDisposable registraton = token.RegisterChangeCallback(static s => ((ChangeTokenRegistration<TState>?)s)!.OnChangeTokenFired(), this);
+                IDisposable registration = token.RegisterChangeCallback(static s => ((ChangeTokenRegistration<TState>?)s)!.OnChangeTokenFired(), this);
                 if (token.HasChanged && token.ActiveChangeCallbacks)
                 {
-                    registraton?.Dispose();
+                    registration?.Dispose();
                     return;
                 }
-                SetDisposable(registraton);
+                SetDisposable(registration);
             }
 
             private void SetDisposable(IDisposable disposable)

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -248,6 +248,8 @@ namespace Microsoft.Extensions.Primitives
                     // The consumer is invoked synchronously here, so that synchronous exceptions from it are propagated
                     // to the code that triggers the change token, just like the sync overload does.
                     Task consumerTask = _changeTokenConsumer(State) ?? throw new InvalidOperationException("The task returned by changeTokenConsumer must not be null.");
+
+                    if (consumerTask.Status == TaskStatus.RanToCompletion)
                     {
                         // The common case where the consumer completes synchronously: re-register without allocations.
                         RegisterChangeTokenCallback(token);

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Primitives
 {
@@ -15,8 +16,12 @@ namespace Microsoft.Extensions.Primitives
         /// Registers the <paramref name="changeTokenConsumer"/> action to be called whenever the token produced changes.
         /// </summary>
         /// <param name="changeTokenProducer">Produces the change token.</param>
-        /// <param name="changeTokenConsumer">Action called when the token changes.</param>
-        /// <returns></returns>
+        /// <param name="changeTokenConsumer">Action called when the token changes. The token is re-registered once the action returns.</param>
+        /// <returns>An <see cref="IDisposable"/> that, when disposed, unregisters the consumer.</returns>
+        /// <remarks>
+        /// Exceptions from <paramref name="changeTokenProducer"/> are propagated to the caller of this method or to the code that triggers the change token.
+        /// Exceptions from <paramref name="changeTokenConsumer"/> are propagated to the code that triggers the change token.
+        /// </remarks>
         public static IDisposable OnChange(Func<IChangeToken?> changeTokenProducer, Action changeTokenConsumer)
         {
             if (changeTokenProducer is null)
@@ -28,16 +33,20 @@ namespace Microsoft.Extensions.Primitives
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.changeTokenConsumer);
             }
 
-            return new ChangeTokenRegistration<Action>(changeTokenProducer, callback => callback(), changeTokenConsumer);
+            return new SyncChangeTokenRegistration<Action>(changeTokenProducer, static callback => callback(), changeTokenConsumer);
         }
 
         /// <summary>
         /// Registers the <paramref name="changeTokenConsumer"/> action to be called whenever the token produced changes.
         /// </summary>
         /// <param name="changeTokenProducer">Produces the change token.</param>
-        /// <param name="changeTokenConsumer">Action called when the token changes.</param>
+        /// <param name="changeTokenConsumer">Action called when the token changes. The token is re-registered once the action returns.</param>
         /// <param name="state">state for the consumer.</param>
-        /// <returns></returns>
+        /// <returns>An <see cref="IDisposable"/> that, when disposed, unregisters the consumer.</returns>
+        /// <remarks>
+        /// Exceptions from <paramref name="changeTokenProducer"/> are propagated to the caller of this method or to the code that triggers the change token.
+        /// Exceptions from <paramref name="changeTokenConsumer"/> are propagated to the code that triggers the change token.
+        /// </remarks>
         public static IDisposable OnChange<TState>(Func<IChangeToken?> changeTokenProducer, Action<TState> changeTokenConsumer, TState state)
         {
             if (changeTokenProducer is null)
@@ -49,56 +58,81 @@ namespace Microsoft.Extensions.Primitives
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.changeTokenConsumer);
             }
 
-            return new ChangeTokenRegistration<TState>(changeTokenProducer, changeTokenConsumer, state);
+            return new SyncChangeTokenRegistration<TState>(changeTokenProducer, changeTokenConsumer, state);
         }
 
-        private sealed class ChangeTokenRegistration<TState> : IDisposable
+        /// <summary>
+        /// Registers the <paramref name="changeTokenConsumer"/> function to be called whenever the token produced changes.
+        /// </summary>
+        /// <param name="changeTokenProducer">Produces the change token.</param>
+        /// <param name="changeTokenConsumer">Function called when the token changes. The token is only re-registered once the returned <see cref="Task"/> completes.</param>
+        /// <returns>An <see cref="IDisposable"/> that, when disposed, unregisters the consumer.</returns>
+        /// <remarks>
+        /// Exceptions from <paramref name="changeTokenProducer"/> are propagated to the caller of this method or to the code that triggers the change token.
+        /// Synchronous exceptions from <paramref name="changeTokenConsumer"/> are propagated to the code that triggers the change token.
+        /// Asynchronous exceptions from <paramref name="changeTokenConsumer"/> are left unobserved.
+        /// </remarks>
+        public static IDisposable OnChange(Func<IChangeToken?> changeTokenProducer, Func<Task> changeTokenConsumer)
         {
-            private readonly Func<IChangeToken?> _changeTokenProducer;
-            private readonly Action<TState> _changeTokenConsumer;
-            private readonly TState _state;
+            if (changeTokenProducer is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.changeTokenProducer);
+            }
+            if (changeTokenConsumer is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.changeTokenConsumer);
+            }
+
+            return new AsyncChangeTokenRegistration<Func<Task>>(changeTokenProducer, static callback => callback(), changeTokenConsumer);
+        }
+
+        /// <summary>
+        /// Registers the <paramref name="changeTokenConsumer"/> function to be called whenever the token produced changes.
+        /// </summary>
+        /// <param name="changeTokenProducer">Produces the change token.</param>
+        /// <param name="changeTokenConsumer">Function called when the token changes. The token is only re-registered once the returned <see cref="Task"/> completes.</param>
+        /// <param name="state">state for the consumer.</param>
+        /// <returns>An <see cref="IDisposable"/> that, when disposed, unregisters the consumer.</returns>
+        /// <remarks>
+        /// Exceptions from <paramref name="changeTokenProducer"/> are propagated to the caller of this method or to the code that triggers the change token.
+        /// Synchronous exceptions from <paramref name="changeTokenConsumer"/> are propagated to the code that triggers the change token.
+        /// Asynchronous exceptions from <paramref name="changeTokenConsumer"/> are left unobserved.
+        /// </remarks>
+        public static IDisposable OnChange<TState>(Func<IChangeToken?> changeTokenProducer, Func<TState, Task> changeTokenConsumer, TState state)
+        {
+            if (changeTokenProducer is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.changeTokenProducer);
+            }
+            if (changeTokenConsumer is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.changeTokenConsumer);
+            }
+
+            return new AsyncChangeTokenRegistration<TState>(changeTokenProducer, changeTokenConsumer, state);
+        }
+
+        private abstract class ChangeTokenRegistration<TState>(Func<IChangeToken?> changeTokenProducer, TState state) : IDisposable
+        {
             private IDisposable? _disposable;
 
             private static readonly NoopDisposable _disposedSentinel = new NoopDisposable();
 
-            public ChangeTokenRegistration(Func<IChangeToken?> changeTokenProducer, Action<TState> changeTokenConsumer, TState state)
-            {
-                _changeTokenProducer = changeTokenProducer;
-                _changeTokenConsumer = changeTokenConsumer;
-                _state = state;
+            protected TState State { get; } = state;
 
-                IChangeToken? token = changeTokenProducer();
+            protected void Start() => RegisterChangeTokenCallback(changeTokenProducer());
 
-                RegisterChangeTokenCallback(token);
-            }
+            protected IChangeToken? ProduceToken() => changeTokenProducer();
 
-            private void OnChangeTokenFired()
-            {
-                // The order here is important. We need to take the token and then apply our changes BEFORE
-                // registering. This prevents us from possible having two change updates to process concurrently.
-                //
-                // If the token changes after we take the token, then we'll process the update immediately upon
-                // registering the callback.
-                IChangeToken? token = _changeTokenProducer();
+            protected abstract void OnChangeTokenFired();
 
-                try
-                {
-                    _changeTokenConsumer(_state);
-                }
-                finally
-                {
-                    // We always want to ensure the callback is registered
-                    RegisterChangeTokenCallback(token);
-                }
-            }
-
-            private void RegisterChangeTokenCallback(IChangeToken? token)
+            protected void RegisterChangeTokenCallback(IChangeToken? token)
             {
                 if (token is null)
                 {
                     return;
                 }
-                IDisposable registraton = token.RegisterChangeCallback(s => ((ChangeTokenRegistration<TState>?)s)!.OnChangeTokenFired(), this);
+                IDisposable registraton = token.RegisterChangeCallback(static s => ((ChangeTokenRegistration<TState>?)s)!.OnChangeTokenFired(), this);
                 if (token.HasChanged && token.ActiveChangeCallbacks)
                 {
                     registraton?.Dispose();
@@ -151,6 +185,92 @@ namespace Microsoft.Extensions.Primitives
             {
                 public void Dispose()
                 {
+                }
+            }
+        }
+
+        private sealed class SyncChangeTokenRegistration<TState> : ChangeTokenRegistration<TState>
+        {
+            private readonly Action<TState> _changeTokenConsumer;
+
+            public SyncChangeTokenRegistration(Func<IChangeToken?> changeTokenProducer, Action<TState> changeTokenConsumer, TState state)
+                : base(changeTokenProducer, state)
+            {
+                _changeTokenConsumer = changeTokenConsumer;
+
+                Start();
+            }
+
+            protected override void OnChangeTokenFired()
+            {
+                // The order here is important. We need to take the token and then apply our changes BEFORE
+                // registering. This prevents us from possible having two change updates to process concurrently.
+                //
+                // If the token changes after we take the token, then we'll process the update immediately upon
+                // registering the callback.
+                IChangeToken? token = ProduceToken();
+
+                try
+                {
+                    _changeTokenConsumer(State);
+                }
+                finally
+                {
+                    // We always want to ensure the callback is registered
+                    RegisterChangeTokenCallback(token);
+                }
+            }
+        }
+
+        private sealed class AsyncChangeTokenRegistration<TState> : ChangeTokenRegistration<TState>
+        {
+            private readonly Func<TState, Task> _changeTokenConsumer;
+
+            public AsyncChangeTokenRegistration(Func<IChangeToken?> changeTokenProducer, Func<TState, Task> changeTokenConsumer, TState state)
+                : base(changeTokenProducer, state)
+            {
+                _changeTokenConsumer = changeTokenConsumer;
+
+                Start();
+            }
+
+            protected override void OnChangeTokenFired()
+            {
+                // The order here is important. We need to take the token and then apply our changes BEFORE
+                // registering. This prevents us from possible having two change updates to process concurrently.
+                //
+                // If the token changes after we take the token, then we'll process the update immediately upon
+                // registering the callback once the consumer's task completes.
+                IChangeToken? token = ProduceToken();
+
+                try
+                {
+                    // The consumer is invoked synchronously here, so that synchronous exceptions from it are propagated
+                    // to the code that triggers the change token, just like the sync overload does.
+                    Task consumerTask = _changeTokenConsumer(State);
+
+                    // Asynchronous exceptions can't be propagated without blocking, so they are left unobserved
+                    // (meaning they can be observed only through TaskScheduler.UnobservedTaskException).
+                    _ = AwaitConsumerAndRegisterCallback(consumerTask, token);
+                }
+                catch
+                {
+                    // We always want to ensure the callback is registered, even when the consumer throws synchronously.
+                    RegisterChangeTokenCallback(token);
+                    throw;
+                }
+            }
+
+            private async Task AwaitConsumerAndRegisterCallback(Task consumerTask, IChangeToken? token)
+            {
+                try
+                {
+                    await consumerTask.ConfigureAwait(false);
+                }
+                finally
+                {
+                    // We always want to ensure the callback is registered
+                    RegisterChangeTokenCallback(token);
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -130,6 +130,15 @@ namespace Microsoft.Extensions.Primitives
                 {
                     return;
                 }
+
+                // If the registration has already been disposed, don't register again. This guards re-registration
+                // after disposal: registering on a token that has already changed invokes the callback synchronously, which
+                // would re-run the consumer after disposal.
+                if (Volatile.Read(ref _disposable) == _disposedSentinel)
+                {
+                    return;
+                }
+
                 IDisposable? registration = token.RegisterChangeCallback(static s => ((ChangeTokenRegistration<TState>?)s)!.OnChangeTokenFired(), this);
                 if (token.HasChanged && token.ActiveChangeCallbacks)
                 {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -250,34 +250,36 @@ namespace Microsoft.Extensions.Primitives
                 // registering the callback once the consumer's task completes.
                 IChangeToken? token = ChangeTokenProducer();
 
+                Task consumerTask;
                 try
                 {
                     // The consumer is invoked synchronously here, so that synchronous exceptions from it are propagated
                     // to the code that triggers the change token, just like the sync overload does.
-                    Task consumerTask = _changeTokenConsumer(State);
-
-                    if (consumerTask is null)
-                    {
-                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_NullConsumerTask);
-                    }
-
-                    if (consumerTask.Status == TaskStatus.RanToCompletion)
-                    {
-                        // The common case where the consumer completes synchronously: re-register without allocations.
-                        RegisterChangeTokenCallback(token);
-                    }
-                    else
-                    {
-                        // Asynchronous exceptions can't be propagated without blocking, so they are left unobserved
-                        // (meaning they can be observed only through TaskScheduler.UnobservedTaskException).
-                        _ = AwaitConsumerAndRegisterCallback(consumerTask, token);
-                    }
+                    consumerTask = _changeTokenConsumer(State);
                 }
                 catch
                 {
                     // We always want to ensure the callback is registered, even when the consumer throws synchronously.
                     RegisterChangeTokenCallback(token);
                     throw;
+                }
+
+                if (consumerTask is null)
+                {
+                    RegisterChangeTokenCallback(token);
+                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_NullConsumerTask);
+                }
+
+                if (consumerTask.Status == TaskStatus.RanToCompletion)
+                {
+                    // The common case where the consumer completes synchronously: re-register without allocations.
+                    RegisterChangeTokenCallback(token);
+                }
+                else
+                {
+                    // Asynchronous exceptions can't be propagated without blocking, so they are left unobserved
+                    // (meaning they can be observed only through TaskScheduler.UnobservedTaskException).
+                    _ = AwaitConsumerAndRegisterCallback(consumerTask, token);
                 }
             }
 

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -247,9 +247,7 @@ namespace Microsoft.Extensions.Primitives
                 {
                     // The consumer is invoked synchronously here, so that synchronous exceptions from it are propagated
                     // to the code that triggers the change token, just like the sync overload does.
-                    Task consumerTask = _changeTokenConsumer(State);
-
-                    if (consumerTask.Status == TaskStatus.RanToCompletion)
+                    Task consumerTask = _changeTokenConsumer(State) ?? throw new InvalidOperationException("The task returned by changeTokenConsumer must not be null.");
                     {
                         // The common case where the consumer completes synchronously: re-register without allocations.
                         RegisterChangeTokenCallback(token);

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -249,9 +249,17 @@ namespace Microsoft.Extensions.Primitives
                     // to the code that triggers the change token, just like the sync overload does.
                     Task consumerTask = _changeTokenConsumer(State);
 
-                    // Asynchronous exceptions can't be propagated without blocking, so they are left unobserved
-                    // (meaning they can be observed only through TaskScheduler.UnobservedTaskException).
-                    _ = AwaitConsumerAndRegisterCallback(consumerTask, token);
+                    if (consumerTask.Status == TaskStatus.RanToCompletion)
+                    {
+                        // The common case where the consumer completes synchronously: re-register without allocations.
+                        RegisterChangeTokenCallback(token);
+                    }
+                    else
+                    {
+                        // Asynchronous exceptions can't be propagated without blocking, so they are left unobserved
+                        // (meaning they can be observed only through TaskScheduler.UnobservedTaskException).
+                        _ = AwaitConsumerAndRegisterCallback(consumerTask, token);
+                    }
                 }
                 catch
                 {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -120,9 +120,7 @@ namespace Microsoft.Extensions.Primitives
 
             protected TState State { get; } = state;
 
-            protected void Start() => RegisterChangeTokenCallback(changeTokenProducer());
-
-            protected IChangeToken? ProduceToken() => changeTokenProducer();
+            protected Func<IChangeToken?> ChangeTokenProducer { get; } = changeTokenProducer;
 
             protected abstract void OnChangeTokenFired();
 
@@ -198,7 +196,7 @@ namespace Microsoft.Extensions.Primitives
             {
                 _changeTokenConsumer = changeTokenConsumer;
 
-                Start();
+                RegisterChangeTokenCallback(changeTokenProducer());
             }
 
             protected override void OnChangeTokenFired()
@@ -208,7 +206,7 @@ namespace Microsoft.Extensions.Primitives
                 //
                 // If the token changes after we take the token, then we'll process the update immediately upon
                 // registering the callback.
-                IChangeToken? token = ProduceToken();
+                IChangeToken? token = ChangeTokenProducer();
 
                 try
                 {
@@ -231,7 +229,7 @@ namespace Microsoft.Extensions.Primitives
             {
                 _changeTokenConsumer = changeTokenConsumer;
 
-                Start();
+                RegisterChangeTokenCallback(changeTokenProducer());
             }
 
             protected override void OnChangeTokenFired()
@@ -241,7 +239,7 @@ namespace Microsoft.Extensions.Primitives
                 //
                 // If the token changes after we take the token, then we'll process the update immediately upon
                 // registering the callback once the consumer's task completes.
-                IChangeToken? token = ProduceToken();
+                IChangeToken? token = ChangeTokenProducer();
 
                 try
                 {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/Resources/Strings.resx
@@ -132,4 +132,10 @@
   <data name="Capacity_NotUsedEntirely" xml:space="preserve">
     <value>Entire reserved capacity was not used. Capacity: '{0}', written '{1}'.</value>
   </data>
+  <data name="InvalidOperation_ConcurrentDisposableSet" xml:space="preserve">
+    <value>The change token callback registration was set concurrently, which is not supported.</value>
+  </data>
+  <data name="InvalidOperation_NullConsumerTask" xml:space="preserve">
+    <value>The change token consumer returned a null task.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ThrowHelper.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ThrowHelper.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Extensions.Primitives
                 case ExceptionResource.Capacity_CannotChangeAfterWriteStarted: return SR.Capacity_CannotChangeAfterWriteStarted;
                 case ExceptionResource.Capacity_NotEnough: return SR.Capacity_NotEnough;
                 case ExceptionResource.Capacity_NotUsedEntirely: return SR.Capacity_NotUsedEntirely;
+                case ExceptionResource.InvalidOperation_ConcurrentDisposableSet: return SR.InvalidOperation_ConcurrentDisposableSet;
+                case ExceptionResource.InvalidOperation_NullConsumerTask: return SR.InvalidOperation_NullConsumerTask;
                 default:
                     Debug.Fail($"Unexpected resource {resource}");
                     return "";
@@ -108,6 +110,8 @@ namespace Microsoft.Extensions.Primitives
         Argument_InvalidOffsetLengthStringSegment,
         Capacity_CannotChangeAfterWriteStarted,
         Capacity_NotEnough,
-        Capacity_NotUsedEntirely
+        Capacity_NotUsedEntirely,
+        InvalidOperation_ConcurrentDisposableSet,
+        InvalidOperation_NullConsumerTask
     }
 }

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -254,8 +254,8 @@ namespace Microsoft.Extensions.Primitives
             provider.Changed();
 
             Assert.Equal(1, count);
-            Assert.Equal(2, provider.RegistrationCalls);
-            Assert.Equal(2, provider.DisposeCalls);
+            Assert.Equal(1, provider.RegistrationCalls);
+            Assert.Equal(1, provider.DisposeCalls);
         }
 
         [Fact]
@@ -383,11 +383,104 @@ namespace Microsoft.Extensions.Primitives
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public async Task AsyncDisposeDuringConsumerSuppressesSynchronousReinvocationWhenTokenAlreadyChanged(bool useStateOverload)
+        {
+            var provider = new ResettableChangeTokenProvider();
+            int invocations = 0;
+
+            // Plain (synchronous-continuation) TCS: completing it runs the deferred re-registration inline on the
+            // completing thread. The gate is completed from a thread-pool thread (below) so that, with the product
+            // code's ConfigureAwait(false), that continuation runs synchronously there rather than being posted to
+            // xunit's SynchronizationContext, keeping the test deterministic without arbitrary delays.
+            var gate = new TaskCompletionSource<bool>();
+
+            IDisposable reg;
+            if (useStateOverload)
+            {
+                reg = ChangeToken.OnChange(provider.GetChangeToken, _ =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    return gate.Task;
+                }, new object());
+            }
+            else
+            {
+                reg = ChangeToken.OnChange(provider.GetChangeToken, () =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    return gate.Task;
+                });
+            }
+
+            // The first change starts the consumer; it stays in flight awaiting the gate, so the change token
+            // captured for re-registration is held until the consumer completes.
+            provider.Changed();
+            Assert.Equal(1, invocations);
+
+            // Dispose while the consumer is still in flight.
+            reg.Dispose();
+
+            await Task.Run(() =>
+            {
+                // A change while disposed cancels the captured token, so it is now already changed. Registering a
+                // callback on an already-changed CancellationChangeToken would invoke the callback synchronously.
+                provider.Changed();
+
+                // Completing the consumer drives the deferred re-registration inline on this thread. It must observe
+                // the disposal and skip registering; otherwise registering on the already-changed token invokes the
+                // callback synchronously and re-runs the consumer after Dispose. Completing from a thread-pool thread
+                // (rather than directly here) is required for determinism: with the product code's
+                // ConfigureAwait(false), the continuation runs synchronously on this thread instead of being posted to
+                // xunit's SynchronizationContext, so the (buggy) re-invocation would be observed before the assert.
+                gate.SetResult(true);
+            });
+
+            Assert.Equal(1, invocations);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SyncDisposeAndChangeDuringConsumerSuppressesSynchronousReinvocation(bool useStateOverload)
+        {
+            var provider = new ResettableChangeTokenProvider();
+            int invocations = 0;
+
+            IDisposable reg = null;
+            void Consume()
+            {
+                if (Interlocked.Increment(ref invocations) == 1)
+                {
+                    // Dispose, then change the captured token, so the synchronous re-registration in the consumer's
+                    // finally block would target an already-changed token (which invokes the callback synchronously).
+                    reg.Dispose();
+                    provider.Changed();
+                }
+            }
+
+            reg = useStateOverload
+                ? ChangeToken.OnChange(provider.GetChangeToken, _ => Consume(), new object())
+                : ChangeToken.OnChange(provider.GetChangeToken, Consume);
+
+            provider.Changed();
+
+            // The registration was disposed during the consumer, so the synchronous re-registration must be
+            // suppressed; the consumer must not be invoked again even though the token it would re-register on
+            // has already changed.
+            Assert.Equal(1, invocations);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public async Task DisposingDuringConsumerSuppressesReRegistration(bool useAsyncConsumer)
         {
-            var provider = new ObservableChangeTokenProvider();
+            var provider = new ResettableChangeTokenProvider();
             int invocations = 0;
-            TaskCompletionSource<bool> gate = NewTcs();
+
+            // Plain (synchronous-continuation) TCS so completing it from a thread-pool thread (below) drives the
+            // deferred re-registration inline there rather than posting to xunit's SynchronizationContext.
+            var gate = new TaskCompletionSource<bool>();
 
             // The consumer disposes its own registration mid-invocation. The re-registration that follows the
             // consumer (synchronously for the sync overload, after the returned task completes for the async one)
@@ -419,11 +512,10 @@ namespace Microsoft.Extensions.Primitives
 
             if (useAsyncConsumer)
             {
-                // The async consumer is still in flight, so re-registration is deferred. Arm a signal for it,
-                // then let the consumer complete so the deferred re-registration runs.
-                Task reRegistrationDisposed = provider.ArmRegistrationDisposed();
-                gate.SetResult(true);
-                await reRegistrationDisposed.WaitAsync(TimeSpan.FromSeconds(30));
+                // Complete the in-flight consumer from a thread-pool thread so the deferred re-registration runs
+                // synchronously and completes before the subsequent changes below (the product code awaits with
+                // ConfigureAwait(false)), keeping the test deterministic without arbitrary delays.
+                await Task.Run(() => gate.SetResult(true));
             }
 
             Assert.Equal(1, invocations);
@@ -442,10 +534,13 @@ namespace Microsoft.Extensions.Primitives
         [InlineData(true)]
         public async Task DisposingFromAnotherThreadWhileConsumerExecutingSuppressesReRegistration(bool useAsyncConsumer)
         {
-            var provider = new ObservableChangeTokenProvider();
+            var provider = new ResettableChangeTokenProvider();
             int invocations = 0;
             TaskCompletionSource<bool> started = NewTcs();
-            TaskCompletionSource<bool> gate = NewTcs();
+
+            // Plain (synchronous-continuation) TCS so completing it from a thread-pool thread drives the deferred
+            // re-registration inline there (the product code awaits with ConfigureAwait(false)).
+            var gate = new TaskCompletionSource<bool>();
 
             IDisposable reg;
             if (useAsyncConsumer)
@@ -479,13 +574,10 @@ namespace Microsoft.Extensions.Primitives
             if (useAsyncConsumer)
             {
                 // The change callback already returned (the consumer is in flight via its task), so Dispose does
-                // not block. Dispose from another thread, then let the consumer complete: the deferred
-                // re-registration must observe the disposal instead of arming a live callback.
+                // not block. Dispose from another thread, then complete the consumer from a thread-pool thread so
+                // the deferred re-registration runs synchronously there and must observe the disposal.
                 await Task.Run(reg.Dispose).WaitAsync(TimeSpan.FromSeconds(30));
-
-                Task reRegistrationDisposed = provider.ArmRegistrationDisposed();
-                gate.SetResult(true);
-                await reRegistrationDisposed.WaitAsync(TimeSpan.FromSeconds(30));
+                await Task.Run(() => gate.SetResult(true));
                 await trigger.WaitAsync(TimeSpan.FromSeconds(30));
             }
             else
@@ -736,70 +828,6 @@ namespace Microsoft.Extensions.Primitives
                 var previous = _cts;
                 _cts = new CancellationTokenSource();
                 previous.Cancel();
-            }
-        }
-
-        // A change token provider that signals whenever a registration it produced is disposed, so tests can
-        // deterministically wait for a (possibly deferred) re-registration to complete.
-        public class ObservableChangeTokenProvider
-        {
-            private CancellationTokenSource _cts = new CancellationTokenSource();
-            private TaskCompletionSource<bool> _registrationDisposed = NewTcs();
-
-            public IChangeToken GetChangeToken() => new ObservableChangeToken(_cts.Token, this);
-
-            public void Changed()
-            {
-                var previous = _cts;
-                _cts = new CancellationTokenSource();
-                previous.Cancel();
-            }
-
-            // Arms a fresh signal and returns a task that completes the next time a registration produced by
-            // this provider is disposed.
-            public Task ArmRegistrationDisposed()
-            {
-                var tcs = NewTcs();
-                Volatile.Write(ref _registrationDisposed, tcs);
-                return tcs.Task;
-            }
-
-            private void OnRegistrationDisposed() => Volatile.Read(ref _registrationDisposed).TrySetResult(true);
-
-            private sealed class ObservableChangeToken : IChangeToken
-            {
-                private readonly CancellationChangeToken _inner;
-                private readonly ObservableChangeTokenProvider _owner;
-
-                public ObservableChangeToken(CancellationToken token, ObservableChangeTokenProvider owner)
-                {
-                    _inner = new CancellationChangeToken(token);
-                    _owner = owner;
-                }
-
-                public bool HasChanged => _inner.HasChanged;
-                public bool ActiveChangeCallbacks => _inner.ActiveChangeCallbacks;
-
-                public IDisposable RegisterChangeCallback(Action<object> callback, object state) =>
-                    new SignalingRegistration(_inner.RegisterChangeCallback(callback, state), _owner);
-
-                private sealed class SignalingRegistration : IDisposable
-                {
-                    private readonly IDisposable _inner;
-                    private readonly ObservableChangeTokenProvider _owner;
-
-                    public SignalingRegistration(IDisposable inner, ObservableChangeTokenProvider owner)
-                    {
-                        _inner = inner;
-                        _owner = owner;
-                    }
-
-                    public void Dispose()
-                    {
-                        _inner.Dispose();
-                        _owner.OnRegistrationDisposed();
-                    }
-                }
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -30,6 +30,22 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
+        // A change token whose registration succeeds but whose HasChanged throws.
+        private sealed class ThrowOnHasChangedChangeToken : IChangeToken
+        {
+            public int RegisterCalls { get; private set; }
+
+            public bool ActiveChangeCallbacks => true;
+
+            public bool HasChanged => throw new InvalidTimeZoneException();
+
+            public IDisposable RegisterChangeCallback(Action<object> callback, object state)
+            {
+                RegisterCalls++;
+                return null;
+            }
+        }
+
         [Fact]
         public void HasChangeFiresChange()
         {
@@ -468,6 +484,32 @@ namespace Microsoft.Extensions.Primitives
             // suppressed; the consumer must not be invoked again even though the token it would re-register on
             // has already changed.
             Assert.Equal(1, invocations);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AsyncReRegistrationFailureIsNotRetriedAndPropagates(bool useStateOverload)
+        {
+            var firstToken = new TestChangeToken();
+            var throwingToken = new ThrowOnHasChangedChangeToken();
+            int produced = 0;
+            Func<IChangeToken> producer = () => produced++ == 0 ? firstToken : throwingToken;
+
+            if (useStateOverload)
+            {
+                ChangeToken.OnChange(producer, _ => Task.CompletedTask, new object());
+            }
+            else
+            {
+                ChangeToken.OnChange(producer, () => Task.CompletedTask);
+            }
+
+            // When the token fires, the synchronously-completed consumer triggers re-registration on the next token,
+            // whose HasChanged throws during registration. That exception must propagate to the code that triggers
+            // the change, and re-registration must be attempted exactly once.
+            Assert.Throws<InvalidTimeZoneException>(firstToken.Changed);
+            Assert.Equal(1, throwingToken.RegisterCalls);
         }
 
         [Theory]

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Extensions.Primitives
             Assert.Equal(1, invocations);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task DisposingFromAnotherThreadWhileConsumerExecutingSuppressesReRegistration(bool useAsyncConsumer)

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -380,6 +380,68 @@ namespace Microsoft.Extensions.Primitives
             reg.Dispose();
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DisposingWhileConsumerInFlightSuppressesReRegistration(bool useAsyncConsumer)
+        {
+            var provider = new ObservableChangeTokenProvider();
+            int invocations = 0;
+            TaskCompletionSource<bool> started = NewTcs();
+            TaskCompletionSource<bool> gate = NewTcs();
+
+            IDisposable reg;
+            if (useAsyncConsumer)
+            {
+                reg = ChangeToken.OnChange(provider.GetChangeToken, () =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    started.SetResult(true);
+
+                    // Stay in flight by returning an incomplete task; re-registration is deferred until it completes.
+                    return gate.Task;
+                });
+            }
+            else
+            {
+                reg = ChangeToken.OnChange(provider.GetChangeToken, () =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    started.SetResult(true);
+
+                    // Stay in flight by blocking the triggering thread until the gate is released.
+                    gate.Task.GetAwaiter().GetResult();
+                });
+            }
+
+            // Trigger the change on a background thread: a synchronous consumer blocks the triggering thread
+            // until the gate is released.
+            Task trigger = Task.Run(provider.Changed);
+
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            Assert.Equal(1, invocations);
+
+            // Dispose while the consumer is still in flight. This also disposes the initial registration.
+            reg.Dispose();
+
+            // Arm a signal for the re-registration that happens once the in-flight consumer completes. The
+            // deferred re-registration must observe the disposal and immediately dispose the new registration
+            // instead of arming a live callback.
+            Task reRegistrationDisposed = provider.ArmRegistrationDisposed();
+
+            gate.SetResult(true);
+            await reRegistrationDisposed.WaitAsync(TimeSpan.FromSeconds(30));
+            await trigger.WaitAsync(TimeSpan.FromSeconds(30));
+
+            // Subsequent changes must not invoke the consumer again, because disposal suppressed re-registration.
+            for (int i = 0; i < 5; i++)
+            {
+                provider.Changed();
+            }
+
+            Assert.Equal(1, invocations);
+        }
+
         private static TaskCompletionSource<bool> NewTcs() =>
             new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -606,6 +668,70 @@ namespace Microsoft.Extensions.Primitives
                 var previous = _cts;
                 _cts = new CancellationTokenSource();
                 previous.Cancel();
+            }
+        }
+
+        // A change token provider that signals whenever a registration it produced is disposed, so tests can
+        // deterministically wait for a (possibly deferred) re-registration to complete.
+        public class ObservableChangeTokenProvider
+        {
+            private CancellationTokenSource _cts = new CancellationTokenSource();
+            private TaskCompletionSource<bool> _registrationDisposed = NewTcs();
+
+            public IChangeToken GetChangeToken() => new ObservableChangeToken(_cts.Token, this);
+
+            public void Changed()
+            {
+                var previous = _cts;
+                _cts = new CancellationTokenSource();
+                previous.Cancel();
+            }
+
+            // Arms a fresh signal and returns a task that completes the next time a registration produced by
+            // this provider is disposed.
+            public Task ArmRegistrationDisposed()
+            {
+                var tcs = NewTcs();
+                Volatile.Write(ref _registrationDisposed, tcs);
+                return tcs.Task;
+            }
+
+            private void OnRegistrationDisposed() => Volatile.Read(ref _registrationDisposed).TrySetResult(true);
+
+            private sealed class ObservableChangeToken : IChangeToken
+            {
+                private readonly CancellationChangeToken _inner;
+                private readonly ObservableChangeTokenProvider _owner;
+
+                public ObservableChangeToken(CancellationToken token, ObservableChangeTokenProvider owner)
+                {
+                    _inner = new CancellationChangeToken(token);
+                    _owner = owner;
+                }
+
+                public bool HasChanged => _inner.HasChanged;
+                public bool ActiveChangeCallbacks => _inner.ActiveChangeCallbacks;
+
+                public IDisposable RegisterChangeCallback(Action<object> callback, object state) =>
+                    new SignalingRegistration(_inner.RegisterChangeCallback(callback, state), _owner);
+
+                private sealed class SignalingRegistration : IDisposable
+                {
+                    private readonly IDisposable _inner;
+                    private readonly ObservableChangeTokenProvider _owner;
+
+                    public SignalingRegistration(IDisposable inner, ObservableChangeTokenProvider owner)
+                    {
+                        _inner = inner;
+                        _owner = owner;
+                    }
+
+                    public void Dispose()
+                    {
+                        _inner.Dispose();
+                        _owner.OnRegistrationDisposed();
+                    }
+                }
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -383,7 +383,64 @@ namespace Microsoft.Extensions.Primitives
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task DisposingWhileConsumerInFlightSuppressesReRegistration(bool useAsyncConsumer)
+        public async Task DisposingDuringConsumerSuppressesReRegistration(bool useAsyncConsumer)
+        {
+            var provider = new ObservableChangeTokenProvider();
+            int invocations = 0;
+            TaskCompletionSource<bool> gate = NewTcs();
+
+            // The consumer disposes its own registration mid-invocation. The re-registration that follows the
+            // consumer (synchronously for the sync overload, after the returned task completes for the async one)
+            // must observe the disposal and not arm a live callback. Disposal happens on the thread running the
+            // consumer, so it doesn't block on the in-progress change callback.
+            IDisposable reg = null;
+            if (useAsyncConsumer)
+            {
+                reg = ChangeToken.OnChange(provider.GetChangeToken, () =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    reg.Dispose();
+
+                    // Stay in flight by returning an incomplete task; re-registration is deferred until it completes.
+                    return gate.Task;
+                });
+            }
+            else
+            {
+                reg = ChangeToken.OnChange(provider.GetChangeToken, () =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    reg.Dispose();
+                });
+            }
+
+            // Fire the change. The consumer runs synchronously and disposes itself.
+            provider.Changed();
+
+            if (useAsyncConsumer)
+            {
+                // The async consumer is still in flight, so re-registration is deferred. Arm a signal for it,
+                // then let the consumer complete so the deferred re-registration runs.
+                Task reRegistrationDisposed = provider.ArmRegistrationDisposed();
+                gate.SetResult(true);
+                await reRegistrationDisposed.WaitAsync(TimeSpan.FromSeconds(30));
+            }
+
+            Assert.Equal(1, invocations);
+
+            // Subsequent changes must not invoke the consumer again, because disposal suppressed re-registration.
+            for (int i = 0; i < 5; i++)
+            {
+                provider.Changed();
+            }
+
+            Assert.Equal(1, invocations);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DisposingFromAnotherThreadWhileConsumerExecutingSuppressesReRegistration(bool useAsyncConsumer)
         {
             var provider = new ObservableChangeTokenProvider();
             int invocations = 0;
@@ -414,24 +471,35 @@ namespace Microsoft.Extensions.Primitives
                 });
             }
 
-            // Trigger the change on a background thread: a synchronous consumer blocks the triggering thread
-            // until the gate is released.
+            // A synchronous consumer blocks the triggering thread, so fire the change on a background thread.
             Task trigger = Task.Run(provider.Changed);
-
             await started.Task.WaitAsync(TimeSpan.FromSeconds(30));
             Assert.Equal(1, invocations);
 
-            // Dispose while the consumer is still in flight. This also disposes the initial registration.
-            reg.Dispose();
+            if (useAsyncConsumer)
+            {
+                // The change callback already returned (the consumer is in flight via its task), so Dispose does
+                // not block. Dispose from another thread, then let the consumer complete: the deferred
+                // re-registration must observe the disposal instead of arming a live callback.
+                await Task.Run(reg.Dispose).WaitAsync(TimeSpan.FromSeconds(30));
 
-            // Arm a signal for the re-registration that happens once the in-flight consumer completes. The
-            // deferred re-registration must observe the disposal and immediately dispose the new registration
-            // instead of arming a live callback.
-            Task reRegistrationDisposed = provider.ArmRegistrationDisposed();
+                Task reRegistrationDisposed = provider.ArmRegistrationDisposed();
+                gate.SetResult(true);
+                await reRegistrationDisposed.WaitAsync(TimeSpan.FromSeconds(30));
+                await trigger.WaitAsync(TimeSpan.FromSeconds(30));
+            }
+            else
+            {
+                // The consumer is running on the triggering thread, so Dispose blocks until it returns
+                // (CancellationTokenRegistration.Dispose waits for the in-progress callback). Run it on a
+                // separate thread, then release the consumer so both can complete.
+                Task dispose = Task.Run(reg.Dispose);
+                gate.SetResult(true);
+                await dispose.WaitAsync(TimeSpan.FromSeconds(30));
+                await trigger.WaitAsync(TimeSpan.FromSeconds(30));
+            }
 
-            gate.SetResult(true);
-            await reRegistrationDisposed.WaitAsync(TimeSpan.FromSeconds(30));
-            await trigger.WaitAsync(TimeSpan.FromSeconds(30));
+            Assert.Equal(1, invocations);
 
             // Subsequent changes must not invoke the consumer again, because disposal suppressed re-registration.
             for (int i = 0; i < 5; i++)

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Extensions.Primitives
@@ -45,11 +46,12 @@ namespace Microsoft.Extensions.Primitives
         {
             TestChangeToken token = null;
             var count = 0;
-            ChangeToken.OnChange(() => token = new TestChangeToken(), () =>
+            // The lambda is explicitly typed as Action so it binds to the synchronous overload rather than the Func<Task> one.
+            ChangeToken.OnChange(() => token = new TestChangeToken(), (Action)(() =>
             {
                 count++;
                 throw new Exception();
-            });
+            }));
             Assert.Throws<Exception>(() => token.Changed());
             Assert.Equal(1, count);
             Assert.Throws<Exception>(() => token.Changed());
@@ -75,12 +77,13 @@ namespace Microsoft.Extensions.Primitives
             var count = 0;
             object state = new object();
             object callbackState = null;
-            ChangeToken.OnChange(() => token = new TestChangeToken(), s =>
+            // The lambda is explicitly typed as Action<object> so it binds to the synchronous overload rather than the Func<TState, Task> one.
+            ChangeToken.OnChange(() => token = new TestChangeToken(), (Action<object>)(s =>
             {
                 callbackState = s;
                 count++;
                 throw new Exception();
-            }, state);
+            }), state);
             Assert.Throws<Exception>(() => token.Changed());
             Assert.Equal(1, count);
             Assert.NotNull(callbackState);
@@ -259,6 +262,273 @@ namespace Microsoft.Extensions.Primitives
         public void NullTokenDisposeShouldNotThrow()
         {
             ChangeToken.OnChange(() => null, () => Assert.Fail()).Dispose();
+        }
+
+        [Fact]
+        public void AsyncOnChangeThrowsForNullArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => ChangeToken.OnChange(null, () => Task.CompletedTask));
+            Assert.Throws<ArgumentNullException>(() => ChangeToken.OnChange(() => new TestChangeToken(), (Func<Task>)null));
+            Assert.Throws<ArgumentNullException>(() => ChangeToken.OnChange<object>(null, _ => Task.CompletedTask, null));
+            Assert.Throws<ArgumentNullException>(() => ChangeToken.OnChange<object>(() => new TestChangeToken(), (Func<object, Task>)null, null));
+        }
+
+        [Fact]
+        public void AsyncHasChangeFiresChange()
+        {
+            var provider = new ResettableChangeTokenProvider();
+            int count = 0;
+            ChangeToken.OnChange(provider.GetChangeToken, () =>
+            {
+                count++;
+                return Task.CompletedTask;
+            });
+
+            Assert.Equal(0, count);
+            provider.Changed();
+            Assert.Equal(1, count);
+            provider.Changed();
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
+        public void AsyncHasChangeFiresChangeWithState()
+        {
+            var provider = new ResettableChangeTokenProvider();
+            object state = new object();
+            object callbackState = null;
+            ChangeToken.OnChange(provider.GetChangeToken, s =>
+            {
+                callbackState = s;
+                return Task.CompletedTask;
+            }, state);
+
+            Assert.Null(callbackState);
+            provider.Changed();
+            Assert.Same(state, callbackState);
+        }
+
+        [Fact]
+        public void AsyncDisposingChangeTokenRegistrationDoesNotRaiseConsumerCallback()
+        {
+            var provider = new ResettableChangeTokenProvider();
+            int count = 0;
+            IDisposable reg = ChangeToken.OnChange(provider.GetChangeToken, () =>
+            {
+                count++;
+                return Task.CompletedTask;
+            });
+
+            for (int i = 0; i < 5; i++)
+            {
+                provider.Changed();
+            }
+
+            Assert.Equal(5, count);
+
+            reg.Dispose();
+
+            for (int i = 0; i < 5; i++)
+            {
+                provider.Changed();
+            }
+
+            Assert.Equal(5, count);
+        }
+
+        [Fact]
+        public async Task AsyncDoesNotReregisterUntilConsumerTaskCompletes()
+        {
+            var provider = new ResettableChangeTokenProvider();
+            int invocations = 0;
+            TaskCompletionSource<bool> started = NewTcs();
+            TaskCompletionSource<bool> gate = NewTcs();
+
+            // Plain Task-returning consumer (no async lambda) so no continuation is captured on
+            // xunit's SynchronizationContext, keeping the test isolated from other tests.
+            IDisposable reg = ChangeToken.OnChange(provider.GetChangeToken, () =>
+            {
+                Interlocked.Increment(ref invocations);
+                Volatile.Read(ref started).SetResult(true);
+                return Volatile.Read(ref gate).Task;
+            });
+
+            // First change starts the consumer synchronously; it then blocks awaiting its gate.
+            TaskCompletionSource<bool> firstGate = gate;
+            provider.Changed();
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            Assert.Equal(1, invocations);
+
+            // Arm gates for the next invocation before triggering another change. The consumer re-runs on a
+            // different thread (the awaited gate's continuation), so publish these with Volatile.Write.
+            Volatile.Write(ref started, NewTcs());
+            TaskCompletionSource<bool> secondGate = NewTcs();
+            Volatile.Write(ref gate, secondGate);
+
+            // A change while the consumer is running must not start another invocation, because the
+            // token is only re-registered once the consumer's task completes.
+            provider.Changed();
+            Assert.Equal(1, invocations);
+
+            // Completing the first consumer re-registers and coalesces the pending change into a single invocation.
+            firstGate.SetResult(true);
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            Assert.Equal(2, invocations);
+
+            // Drain the second invocation and unsubscribe.
+            secondGate.SetResult(true);
+            reg.Dispose();
+        }
+
+        private static TaskCompletionSource<bool> NewTcs() =>
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AsyncConsumerSynchronousExceptionPropagatesToProducerAndSubscriptionSurvives(bool useStateOverload)
+        {
+            var provider = new ResettableChangeTokenProvider();
+            int count = 0;
+            object expectedState = new object();
+            object observedState = null;
+
+            Func<Task> faulting = () =>
+            {
+                count++;
+                throw new InvalidTimeZoneException();
+            };
+
+            if (useStateOverload)
+            {
+                ChangeToken.OnChange(provider.GetChangeToken, s =>
+                {
+                    observedState = s;
+                    return faulting();
+                }, expectedState);
+            }
+            else
+            {
+                ChangeToken.OnChange(provider.GetChangeToken, faulting);
+            }
+
+            // A synchronous exception from the consumer is propagated to the code that triggers the change token,
+            // just like the synchronous overload. CancellationTokenSource.Cancel wraps it in an AggregateException.
+            AggregateException ex = Assert.Throws<AggregateException>(provider.Changed);
+            Assert.IsType<InvalidTimeZoneException>(ex.InnerException);
+            Assert.Equal(1, count);
+
+            // The subscription survives a throwing consumer, so a later change invokes (and throws from) it again.
+            Assert.Throws<AggregateException>(provider.Changed);
+            Assert.Equal(2, count);
+
+            if (useStateOverload)
+            {
+                Assert.Same(expectedState, observedState);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AsyncConsumerAsynchronousFaultIsNotPropagatedToProducerAndSubscriptionSurvives(bool useStateOverload)
+        {
+            var provider = new ResettableChangeTokenProvider();
+            int count = 0;
+            object expectedState = new object();
+            object observedState = null;
+
+            Func<Task> faulting = () =>
+            {
+                count++;
+                return Task.FromException(new InvalidTimeZoneException());
+            };
+
+            if (useStateOverload)
+            {
+                ChangeToken.OnChange(provider.GetChangeToken, s =>
+                {
+                    observedState = s;
+                    return faulting();
+                }, expectedState);
+            }
+            else
+            {
+                ChangeToken.OnChange(provider.GetChangeToken, faulting);
+            }
+
+            // An asynchronous fault from the consumer's task cannot be propagated without blocking, so it is left
+            // unobserved (observable only through TaskScheduler.UnobservedTaskException) and is not surfaced to the
+            // code that triggers the change token.
+            provider.Changed();
+            Assert.Equal(1, count);
+
+            // The subscription survives a faulted consumer, so later changes still invoke it.
+            provider.Changed();
+            Assert.Equal(2, count);
+
+            if (useStateOverload)
+            {
+                Assert.Same(expectedState, observedState);
+            }
+        }
+
+        // Subscribes a no-op consumer using each of the four OnChange overloads, selected by index.
+        private static void Subscribe(int overload, Func<IChangeToken> producer)
+        {
+            switch (overload)
+            {
+                case 0:
+                    ChangeToken.OnChange(producer, () => { });
+                    break;
+                case 1:
+                    ChangeToken.OnChange(producer, _ => { }, new object());
+                    break;
+                case 2:
+                    ChangeToken.OnChange(producer, () => Task.CompletedTask);
+                    break;
+                case 3:
+                    ChangeToken.OnChange(producer, _ => Task.CompletedTask, new object());
+                    break;
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void ProducerExceptionDuringInitialRegistrationPropagatesToCaller(int overload)
+        {
+            Func<IChangeToken> producer = () => throw new InvalidTimeZoneException();
+
+            // The producer is invoked while registering, so its exception is propagated to the caller of OnChange.
+            Assert.Throws<InvalidTimeZoneException>(() => Subscribe(overload, producer));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void ProducerExceptionWhenTokenFiresPropagatesToTrigger(int overload)
+        {
+            TestChangeToken token = null;
+            int calls = 0;
+            Func<IChangeToken> producer = () =>
+            {
+                if (calls++ == 0)
+                {
+                    return token = new TestChangeToken();
+                }
+                throw new InvalidTimeZoneException();
+            };
+
+            Subscribe(overload, producer);
+
+            // When the token fires, the producer is invoked again to obtain the next token; its exception is
+            // propagated to the code that triggers the change token.
+            Assert.Throws<InvalidTimeZoneException>(() => token.Changed());
         }
 
         public class TrackableChangeTokenProvider


### PR DESCRIPTION
Fixes #69099.

Adds async (`Func<Task>`) overloads of `ChangeToken.OnChange`, so callers can run asynchronous logic when a change token fires without resorting to `async void` or blocking:

```csharp
public static IDisposable OnChange(Func<IChangeToken?> changeTokenProducer, Func<Task> changeTokenConsumer);
public static IDisposable OnChange<TState>(Func<IChangeToken?> changeTokenProducer, Func<TState, Task> changeTokenConsumer, TState state);
```

These match the shape approved in #69099.

## Behavior

The existing `ChangeTokenRegistration<TState>` is refactored into an abstract base class holding the registration/disposal state machine, with `SyncChangeTokenRegistration` and `AsyncChangeTokenRegistration` subclasses. The synchronous overloads behave exactly as before.

For the async overloads:

- The consumer is invoked synchronously, so **synchronous** exceptions from it are propagated to the code that triggers the change token, just like the synchronous overloads.
- The change token is only re-registered once the returned `Task` completes. Changes that occur while the consumer's task is still in flight are coalesced into a single subsequent invocation.
- **Asynchronous** faults from the consumer's task cannot be propagated without blocking, so they are left unobserved (observable only through `TaskScheduler.UnobservedTaskException`). This is documented in the API remarks.
- When the consumer completes synchronously, re-registration happens without allocating an async state machine.

## Breaking change

This is a source (not binary) breaking change, as called out in the proposal's Risk section: existing code that passes an `async` lambda to `OnChange` previously bound to the `Action` overload (compiling to `async void` / fire-and-forget). With these overloads present, such call sites now bind to the `Func<Task>` overload and re-registration is deferred until the returned task completes. The new behavior is generally more correct. A throwing statement lambda can also become ambiguous between `Action` and `Func<Task>` (CS0121); the two pre-existing tests affected were updated with explicit `(Action)` casts.

## Tests

- Null-argument validation for all four overloads.
- Change firing (with and without state) for the async overloads.
- Disposal stops further consumer invocations.
- Re-registration is deferred until the consumer's task completes (in-flight changes coalesce).
- Synchronous consumer exceptions propagate to the trigger; asynchronous faults do not; the subscription survives both.
- Producer exceptions during initial registration propagate to the caller; producer exceptions when the token fires propagate to the trigger (all four overloads).
- Disposal during a running consumer (both from within the consumer and from another thread) suppresses re-registration. The cross-thread case requires real multithreading and is gated with `[ConditionalTheory(... IsMultithreadingSupported)]`.

> [!NOTE]
> This PR description was generated by GitHub Copilot.
