### PR TITLE
Fix compiled/source-generated lazy loop stack unwinding when giving up at max iteration

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -4095,7 +4095,13 @@ namespace System.Text.RegularExpressions.Generator
                         // to something prior to the lazy loop, then we need to pop off that state here.
                         if (doneLabel == originalDoneLabel)
                         {
-                            EmitAdd(writer, "stackpos", -entriesPerIteration);
+                            // Each iteration of the lazy loop pushed entriesPerIteration values onto the stack, and
+                            // all iterationCount iterations' worth of that state is still on the stack at this point.
+                            // As we're backtracking out of the whole loop, we need to remove all of it.
+                            Debug.Assert(entriesPerIteration >= 1);
+                            writer.WriteLine(entriesPerIteration > 1 ?
+                                $"stackpos -= {iterationCount} * {entriesPerIteration};" :
+                                $"stackpos -= {iterationCount};");
                         }
 
                         if (iterationMayBeEmpty)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -4498,9 +4498,19 @@ namespace System.Text.RegularExpressions
                 // to something prior to the lazy loop, then we need to pop off that state here.
                 if (doneLabel == originalDoneLabel)
                 {
-                    // stackpos -= entriesPerIteration;
+                    // Each iteration of the lazy loop pushed entriesPerIteration values onto the stack, and all
+                    // iterationCount iterations' worth of that state is still on the stack at this point. As we're
+                    // backtracking out of the whole loop, we need to remove all of it.
+
+                    // stackpos -= iterationCount * entriesPerIteration;
+                    Debug.Assert(entriesPerIteration >= 1);
                     Ldloc(stackpos);
-                    Ldc(entriesPerIteration);
+                    Ldloc(iterationCount);
+                    if (entriesPerIteration > 1)
+                    {
+                        Ldc(entriesPerIteration);
+                        Mul();
+                    }
                     Sub();
                     Stloc(stackpos);
                 }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -76,6 +76,16 @@ namespace System.Text.RegularExpressions.Tests
             yield return (@"a{2,}?b", "abc", RegexOptions.None, 0, 3, false, string.Empty);
             yield return (@"a{2,}?b", "aabc", RegexOptions.None, 0, 4, true, "aab");
 
+            // Optional group wrapping a lazy capturing loop followed by a trailing literal. The input drives the lazy
+            // loop to its maximum iteration count and then fails the trailing literal, exercising the loop's give-up
+            // backtracking path, which must unwind every matched iteration's state off the backtracking stack. The
+            // whole expression is optional, so the overall result is a successful empty match.
+            yield return (@"(([0-9]){1,3}?x)?", "123", RegexOptions.None, 0, 3, true, string.Empty);
+            yield return (@"((a+(:c*)?@)?([0-9]|A){1,4}?:)?", "1234", RegexOptions.None, 0, 4, true, string.Empty);
+            yield return (@"((a+(:c*)?@)?([0-9]|A){2,4}?:)?", "1234", RegexOptions.None, 0, 4, true, string.Empty);
+            yield return (@"((a+(:c*)?@)?([0-9]|A){1,4}?:)?", "12:", RegexOptions.None, 0, 3, true, "12:");
+            yield return (@"((a+(:c*)?@)?([0-9]|A){1,4}?:)?", "a@99:", RegexOptions.None, 0, 5, true, "a@99:");
+
             // {,n} is treated as a literal rather than {0,n} as it should be
             yield return (@"a{,3}b", "a{,3}bc", RegexOptions.None, 0, 6, true, "a{,3}b");
             yield return (@"a{,3}b", "aaabc", RegexOptions.None, 0, 5, false, string.Empty);


### PR DESCRIPTION
I threw copilot at it. Effectively a follow-up to #68138 / #97890 to add the `* iterationCount` when updating the `stackpos` in one more location.
E.g. for
https://mihubot.xyz/regex?pattern=%28%28%5B0-9%5D%29%7B1%2C3%7D%3Fx%29%3F&version=10.0
We'll have logic like
```c#
// The lazy loop iteration failed to match.
// more code ...
stackpos -= lazyloop_iteration * 2;
goto LoopIterationNoMatch;

LazyLoopEnd:
// more code ...

// If the upper bound 3 has already been reached,
// don't continue lazily iterating. Instead, backtrack.
if (lazyloop_iteration >= 3)
{
    stackpos -= 2;
    goto LoopIterationNoMatch;
}
```
where now the second block also becomes `stackpos -= lazyloop_iteration * 2`.

----

Fixes #129511

## Summary

The `Compiled` and `[GeneratedRegex]` engines threw `IndexOutOfRangeException` (and in some shapes returned an incorrect match) when backtracking out of a lazy loop that had matched its maximum number of iterations. For example:

```csharp
var pattern = @"((a+(:c*)?@)?([0-9]|A){1,4}?:)?";

new Regex(pattern).Match("1234").Success;                  // interpreter: true (empty match) ✔
new Regex(pattern, RegexOptions.Compiled).Match("1234");   // throws IndexOutOfRangeException ✘
GeneratedRegex().Match("1234");                            // throws IndexOutOfRangeException ✘
```

## Root cause

Each iteration of a (non-single-char) lazy loop pushes `entriesPerIteration` values onto the backtracking stack. `EmitLazy` has two places that unwind that accumulated state when the loop ultimately fails and control returns to the parent:

- The **`iterationFailedLabel`** path (the loop's own child can't match a forced iteration) — already correct since #68138, using `stackpos -= iterationCount * entriesPerIteration`.
- The **`LazyLoopBacktrack` give-up** path (a later construct backtracks in, and the loop has reached its max iteration count / seen an empty iteration) — added later in #97890, but only subtracted **one** iteration's worth: `stackpos -= entriesPerIteration`.

When the loop had matched more than one iteration, the give-up path left stale entries on the backtracking stack. Enclosing constructs then popped those stale values as if they were their own saved state, desyncing every subsequent pop. With enough nesting this drove `stackpos` below zero and indexed the stack out of bounds (`IndexOutOfRangeException` in `TryMatchAtCurrentPosition`); with less nesting it silently produced a wrong match.

## Fix

Make the give-up path unwind **all** matched iterations, matching the already-correct `iterationFailedLabel` path, in both engines:

- `RegexGenerator.Emitter.cs` (source generator): emit `stackpos -= {iterationCount} * {entriesPerIteration};`.
- `RegexCompiler.cs` (compiled): `Ldloc(stackpos); Ldloc(iterationCount); [Ldc(entriesPerIteration); Mul();] Sub(); Stloc(stackpos);`.

This is a follow-up to #68138 — the same correction applied to the second of the two unwind sites. An audit of all other stack-cleanup sites in both engines confirmed they are either absolute `stackpos = startingStackpos` resets (`EmitLoop`/`EmitAtomic`, count-correct by construction) or single-value pops, so no other locations are affected. The interpreter uses a different backtracking mechanism and already produced the correct result.

## Testing

Added cross-engine regression cases to `RegexMatchTests.Match` covering the give-up path, including the issue repro and a minimal `(([0-9]){1,3}?x)?` case whose input reaches the loop's max iteration count. Verified each case throws / returns a wrong result against an unpatched build and passes after the fix. The full `Match` theory passes across the Interpreter, Compiled, NonBacktracking, and SourceGenerated engines.

> [!NOTE]
> This pull request description was generated with the assistance of GitHub Copilot.
