### PR TITLE
Surface scheduled outerloop Helix work item failures as warnings

### DIFF
--- a/eng/pipelines/libraries/helix.yml
+++ b/eng/pipelines/libraries/helix.yml
@@ -18,6 +18,10 @@ parameters:
   # partiallySucceeded), this produces a fully successful build. Scheduled builds with
   # always:false set this so that flaky tests don't cause AzDO to re-queue the same commit daily.
   failOnTestFailures: true
+  # When true, failed Helix work items are surfaced as build warnings (visible in the AzDO
+  # timeline) instead of being silently ignored. Intended to be paired with failOnTestFailures:
+  # false so that failures stay visible without failing the build.
+  warnOnTestFailures: false
 
 steps:
   - script: $(_msbuildCommand) $(_warnAsErrorParamHelixOverride) -restore
@@ -33,6 +37,7 @@ steps:
             /p:HelixBuild=$(Build.BuildNumber)
             /p:FailOnWorkItemFailure=${{ parameters.failOnTestFailures }}
             /p:FailOnTestFailure=${{ parameters.failOnTestFailures }}
+            /p:WarnOnHelixTestFailure=${{ parameters.warnOnTestFailures }}
             ${{ parameters.extraHelixArguments }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: Send to Helix

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -54,9 +54,11 @@ extends:
                     testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
                     # On scheduled runs (always:false) don't fail the build on Helix work item or
                     # test failures, so flaky outerloop tests don't keep AzDO re-queueing the same
-                    # commit. The Send to Helix step fully succeeds (not partiallySucceeded).
+                    # commit. The Send to Helix step fully succeeds (not partiallySucceeded). Failed
+                    # work items are still surfaced as warnings in the timeline (warnOnTestFailures).
                     ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
                       failOnTestFailures: false
+                      warnOnTestFailures: true
 
         - ${{ if eq(variables['isRollingBuild'], false) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
@@ -86,9 +88,11 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-                      # Don't fail scheduled builds on Helix work item/test failures (see above).
+                      # Don't fail scheduled builds on Helix work item/test failures; surface them
+                      # as timeline warnings instead (see above).
                       ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
                         failOnTestFailures: false
+                        warnOnTestFailures: true
 
         - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
@@ -114,6 +118,8 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       extraHelixArguments: /p:BuildTargetFramework=net48
-                      # Don't fail scheduled builds on Helix work item/test failures (see above).
+                      # Don't fail scheduled builds on Helix work item/test failures; surface them
+                      # as timeline warnings instead (see above).
                       ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
                         failOnTestFailures: false
+                        warnOnTestFailures: true

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -348,4 +348,20 @@
           DestinationFiles="@(_FilesToStage -> '$(HelixDependenciesStagingPath)\%(DirName)\%(RecursiveDir)%(FileName)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
+
+  <!--
+    When a build sets FailOnWorkItemFailure/FailOnTestFailure to false (e.g. scheduled outerloop runs,
+    which must end up 'succeeded' so AzDO's always:false scheduler doesn't keep re-queueing the same
+    commit) the Helix SDK's CheckHelixJobStatus no longer reports failed work items, which hides them
+    from the build. Setting WarnOnHelixTestFailure=true surfaces each failed work item as a build
+    warning instead, keeping the failures visible in the Azure DevOps timeline without failing the
+    build. The "Send to Helix" step disables warnaserror (see _warnAsErrorParamHelixOverride), so
+    these warnings are not promoted back into build-failing errors.
+  -->
+  <Target Name="WarnOnHelixWorkItemFailure"
+          AfterTargets="CheckHelixJobStatus"
+          Condition="'$(WarnOnHelixTestFailure)' == 'true' and '$(WaitForWorkItemCompletion)' == 'true'">
+    <Warning Condition="'%(CompletedWorkItem.Failed)' == 'true'"
+             Text="Work item %(CompletedWorkItem.WorkItemName) in job %(CompletedWorkItem.JobName) has failed. Failure log: %(CompletedWorkItem.ConsoleOutputUri)" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Problem

PR #129049 made scheduled outerloop builds succeed when only Helix tests fail, by setting `FailOnWorkItemFailure`/`FailOnTestFailure` to `false` on scheduled runs (via the `failOnTestFailures: false` parameter). This stopped AzDO's `always: false` scheduler from re-queueing the same commit day after day.

The side effect: failed Helix work items became **completely invisible** in the Azure DevOps timeline. The `Send to Helix` step is fully green, so there is no signal that work items failed (even though, for flaky outerloop, they almost always do).

## Fix

Surface failed work items as **warnings** instead of silently dropping them. Warnings keep the failures visible in the timeline but do **not** degrade the build below `succeeded` (so the `always: false` re-queue fix from #129049 is preserved).

- **`src/libraries/sendtohelixhelp.proj`**: new `WarnOnHelixWorkItemFailure` target (`AfterTargets=CheckHelixJobStatus`) that emits a `<Warning>` for each failed `@(CompletedWorkItem)` when `WarnOnHelixTestFailure=true`. This mirrors what the Arcade SDK's `CheckHelixJobStatus` would have *errored* on, but as a warning.
- **`eng/pipelines/libraries/helix.yml`**: new `warnOnTestFailures` parameter (default `false`) wired to `/p:WarnOnHelixTestFailure`.
- **`eng/pipelines/libraries/outerloop.yml`**: scheduled runs now set `warnOnTestFailures: true` alongside `failOnTestFailures: false` on all three legs.

No warn-as-error change was needed: the `Send to Helix` step already runs with warnaserror disabled (`_warnAsErrorParamHelixOverride`), so these warnings are not promoted back into build-failing errors.

## Validation

Ran the `runtime-libraries-coreclr outerloop` pipeline (dnceng-public def 125, [build 1472840](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1472840)) with a temporary Manual gate. Multiple CoreCLR_Release legs completed **succeeded** with failed work items surfaced as warnings and **zero errors**, e.g.:

```
src/libraries/sendtohelixhelp.proj(364,5): warning : Work item System.Runtime.Numerics.Tests in job 2e01f1b1-... has failed. Failure log: https://helix.dot.net/api/.../console
```

Legs whose work items all passed produced no such warning, as expected.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
