### PR TITLE
Batch libraries test Helix work items by compatibility metadata

### DIFF
--- a/eng/testing/DesktopBatchRunner.cmd
+++ b/eng/testing/DesktopBatchRunner.cmd
@@ -1,0 +1,77 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "BATCH_DIR=%CD%"
+set /a SUITE_COUNT=0
+set /a FAIL_COUNT=0
+set "FOUND_ZIP="
+set "PYTHON=%HELIX_PYTHONPATH%"
+if "%PYTHON%"=="" set "PYTHON=python"
+
+if "%HELIX_WORKITEM_UPLOAD_ROOT%"=="" (
+    set "ORIGINAL_UPLOAD_ROOT=%CD%\test-results"
+) else (
+    set "ORIGINAL_UPLOAD_ROOT=%HELIX_WORKITEM_UPLOAD_ROOT%"
+)
+
+echo === DesktopBatchRunner ===
+echo BATCH_DIR=%BATCH_DIR%
+echo ORIGINAL_UPLOAD_ROOT=%ORIGINAL_UPLOAD_ROOT%
+
+for %%z in ("%BATCH_DIR%\*.zip") do (
+    if exist "%%~fz" (
+        set "FOUND_ZIP=1"
+        set "suiteName=%%~nz"
+        set "suiteDir=%BATCH_DIR%\!suiteName!"
+        set "suiteExitCode=0"
+
+        echo.
+        echo ========================= BEGIN !suiteName! =============================
+
+        mkdir "!suiteDir!" >nul 2>nul
+        "%PYTHON%" -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "%%~fz" "!suiteDir!"
+        if !errorlevel! neq 0 (
+            echo ERROR: Failed to extract %%~fz
+            set "suiteExitCode=1"
+        ) else (
+            set "HELIX_WORKITEM_UPLOAD_ROOT=!ORIGINAL_UPLOAD_ROOT!\!suiteName!"
+            mkdir "!HELIX_WORKITEM_UPLOAD_ROOT!" >nul 2>nul
+
+            pushd "!suiteDir!"
+            call RunTests.cmd %*
+            set "suiteExitCode=!errorlevel!"
+            popd
+        )
+
+        rmdir /s /q "!suiteDir!" 2>nul
+
+        set /a SUITE_COUNT+=1
+
+        if !suiteExitCode! neq 0 (
+            set /a FAIL_COUNT+=1
+            echo ----- FAIL !suiteName! - exit code !suiteExitCode! -----
+        ) else (
+            echo ----- PASS !suiteName! -----
+        )
+
+        echo ========================= END !suiteName! ===============================
+    )
+)
+
+set "HELIX_WORKITEM_UPLOAD_ROOT=%ORIGINAL_UPLOAD_ROOT%"
+
+if not defined FOUND_ZIP (
+    echo No .zip files found in %BATCH_DIR%
+    exit /b 1
+)
+
+echo.
+echo === Batch Summary ===
+set /a PASS_COUNT=SUITE_COUNT-FAIL_COUNT
+echo Total: %SUITE_COUNT% ^| Passed: %PASS_COUNT% ^| Failed: %FAIL_COUNT%
+
+if %FAIL_COUNT% neq 0 (
+    exit /b 1
+)
+
+exit /b 0

--- a/eng/testing/DesktopBatchRunner.sh
+++ b/eng/testing/DesktopBatchRunner.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+if [[ -z "${HELIX_WORKITEM_UPLOAD_ROOT:-}" ]]; then
+    ORIGINAL_UPLOAD_ROOT="$PWD/test-results"
+else
+    ORIGINAL_UPLOAD_ROOT="$HELIX_WORKITEM_UPLOAD_ROOT"
+fi
+
+if [[ -n "${HELIX_PYTHONPATH:-}" ]]; then
+    PYTHON_CMD=("$HELIX_PYTHONPATH")
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_CMD=(python3)
+else
+    PYTHON_CMD=(python)
+fi
+
+BATCH_DIR="$PWD"
+SUITE_COUNT=0
+FAIL_COUNT=0
+SUITE_NAMES=()
+SUITE_EXIT_CODES=()
+SUITE_DURATIONS=()
+
+echo "=== DesktopBatchRunner ==="
+echo "BATCH_DIR=$BATCH_DIR"
+echo "ORIGINAL_UPLOAD_ROOT=$ORIGINAL_UPLOAD_ROOT"
+
+for zipFile in "$BATCH_DIR"/*.zip; do
+    if [[ ! -f "$zipFile" ]]; then
+        echo "No .zip files found in $BATCH_DIR"
+        exit 1
+    fi
+
+    suiteName=$(basename "$zipFile" .zip)
+    suiteDir="$BATCH_DIR/$suiteName"
+
+    echo ""
+    echo "========================= BEGIN $suiteName ============================="
+
+    mkdir -p "$suiteDir"
+    "${PYTHON_CMD[@]}" -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$zipFile" "$suiteDir"
+    unzipExitCode=$?
+    if [[ $unzipExitCode -ne 0 ]]; then
+        echo "ERROR: Failed to extract $zipFile (exit code: $unzipExitCode)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        SUITE_NAMES+=("$suiteName")
+        SUITE_EXIT_CODES+=("$unzipExitCode")
+        SUITE_DURATIONS+=("0")
+        SUITE_COUNT=$((SUITE_COUNT + 1))
+        rm -rf "$suiteDir"
+        continue
+    fi
+
+    export HELIX_WORKITEM_UPLOAD_ROOT="$ORIGINAL_UPLOAD_ROOT/$suiteName"
+    mkdir -p "$HELIX_WORKITEM_UPLOAD_ROOT"
+
+    pushd "$suiteDir" >/dev/null
+
+    chmod +x RunTests.sh
+
+    startTime=$(date +%s)
+    ./RunTests.sh "$@"
+    suiteExitCode=$?
+    endTime=$(date +%s)
+
+    popd >/dev/null
+
+    rm -rf "$suiteDir"
+
+    duration=$((endTime - startTime))
+
+    SUITE_NAMES+=("$suiteName")
+    SUITE_EXIT_CODES+=("$suiteExitCode")
+    SUITE_DURATIONS+=("$duration")
+    SUITE_COUNT=$((SUITE_COUNT + 1))
+
+    if [[ $suiteExitCode -ne 0 ]]; then
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        echo "----- FAIL $suiteName - exit code $suiteExitCode - ${duration}s -----"
+    else
+        echo "----- PASS $suiteName - ${duration}s -----"
+    fi
+
+    echo "========================= END $suiteName ==============================="
+done
+
+export HELIX_WORKITEM_UPLOAD_ROOT="$ORIGINAL_UPLOAD_ROOT"
+
+echo ""
+echo "=== Batch Summary ==="
+printf "%-60s %-6s %s\n" "Suite" "Status" "Duration"
+printf "%-60s %-6s %s\n" "-----" "------" "--------"
+
+for i in "${!SUITE_NAMES[@]}"; do
+    if [[ ${SUITE_EXIT_CODES[$i]} -eq 0 ]]; then
+        status="PASS"
+    else
+        status="FAIL"
+    fi
+    printf "%-60s %-6s %ss\n" "${SUITE_NAMES[$i]}" "$status" "${SUITE_DURATIONS[$i]}"
+done
+
+echo ""
+echo "Total: $SUITE_COUNT | Passed: $((SUITE_COUNT - FAIL_COUNT)) | Failed: $FAIL_COUNT"
+
+if [[ $FAIL_COUNT -ne 0 ]]; then
+    exit 1
+fi
+
+exit 0

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -24,8 +24,8 @@
     <ProjectReference Include="$(ToolsProjectRoot)hotreload-delta-gen\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" />
     <ProjectReference Include="$(ToolsProjectRoot)hotreload-delta-gen\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" />
 
-    <!-- HelixTestTasks for batched WASM library tests on Helix -->
-    <ProjectReference Include="$(RepoTasksDir)HelixTestTasks\HelixTestTasks.csproj" Condition="'$(TargetOS)' == 'browser'" />
+    <!-- HelixTestTasks for batched library tests on Helix -->
+    <ProjectReference Include="$(RepoTasksDir)HelixTestTasks\HelixTestTasks.csproj" Condition="'$(TargetOS)' == 'browser' or ('$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true' and '$(BatchLibraryHelixWorkItems)' != 'false')" />
 
     <ProjectReference Include="$(CommonTestPath)AppleTestRunner\AppleTestRunner.csproj" Condition="'$(TargetOS)' == 'maccatalyst' or '$(TargetOS)' == 'ios' or '$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'tvossimulator'"/>
     <ProjectReference Include="$(CommonTestPath)AndroidTestRunner\AndroidTestRunner.csproj" Condition="'$(TargetOS)' == 'android'" />

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -355,10 +355,20 @@
         <TimeoutClass Condition="'$(Scenario)' != '' and '$(Scenario)' != 'normal'">Stress</TimeoutClass>
         <PayloadShape>DesktopRuntime</PayloadShape>
       </_DefaultWorkItems>
+
+      <_BatchCandidateWorkItems Include="@(_DefaultWorkItems)" Condition="'%(_DefaultWorkItems.BatchCompatible)' == 'true'" />
+      <_NonBatchWorkItems Include="@(_DefaultWorkItems)" Condition="'%(_DefaultWorkItems.BatchCompatible)' != 'true'" />
+
+      <HelixWorkItem Include="@(_NonBatchWorkItems -> '$(WorkItemPrefix)%(FileName)')">
+        <PayloadArchive>%(_NonBatchWorkItems.Identity)</PayloadArchive>
+        <Command>$(HelixCommand)</Command>
+        <Timeout>$(_workItemTimeout)</Timeout>
+        <DownloadFilesFromResults Condition=" '$(SuperPmiCollect)' == 'true' ">$(SuperPmiCollectionName).$(SuperPmiCollectionType).$(TargetOS).$(TargetArchitecture).$(Configuration).mch;$(SuperPmiCollectionName).$(SuperPmiCollectionType).$(TargetOS).$(TargetArchitecture).$(Configuration).log</DownloadFilesFromResults>
+      </HelixWorkItem>
     </ItemGroup>
 
-    <GroupWorkItems Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
-                    Items="@(_DefaultWorkItems)"
+    <GroupWorkItems Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != ''"
+                    Items="@(_BatchCandidateWorkItems)"
                     BatchSize="$(MaxTestsPerWorkItem)"
                     LargeThreshold="$(_LibraryHelixBatchLargeThreshold)"
                     CompatibilityMetadataKeys="RunnerType;PlatformFamily;RuntimeFlavor;TargetOS;TargetArchitecture;Scenario;TimeoutClass;PayloadShape"
@@ -366,26 +376,26 @@
       <Output TaskParameter="GroupedItems" ItemName="_BatchGroupedItem" />
     </GroupWorkItems>
 
-    <ItemGroup Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'">
+    <ItemGroup Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != ''">
       <_BatchId Include="@(_BatchGroupedItem -> '%(BatchId)')" />
       <_UniqueBatchId Include="@(_BatchId->Distinct())" />
     </ItemGroup>
 
-    <RemoveDir Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+    <RemoveDir Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != ''"
                Directories="$(IntermediateOutputPath)helix-batches/" />
-    <MakeDir Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+    <MakeDir Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != ''"
              Directories="$(IntermediateOutputPath)helix-batches/batch-%(_UniqueBatchId.Identity)/" />
-    <Copy Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+    <Copy Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != ''"
           SourceFiles="@(_BatchGroupedItem)"
-          DestinationFolder="$(IntermediateOutputPath)helix-batches/batch-%(BatchId)/" />
-    <Copy Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '$(WindowsShell)' == 'true'"
+          DestinationFolder="$(IntermediateOutputPath)helix-batches/batch-%(_BatchGroupedItem.BatchId)/" />
+    <Copy Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != '' and '$(WindowsShell)' == 'true'"
           SourceFiles="$(RepositoryEngineeringDir)testing\DesktopBatchRunner.cmd"
           DestinationFolder="$(IntermediateOutputPath)helix-batches/batch-%(_UniqueBatchId.Identity)/" />
-    <Copy Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '$(WindowsShell)' != 'true'"
+    <Copy Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != '' and '$(WindowsShell)' != 'true'"
           SourceFiles="$(RepositoryEngineeringDir)testing\DesktopBatchRunner.sh"
           DestinationFolder="$(IntermediateOutputPath)helix-batches/batch-%(_UniqueBatchId.Identity)/" />
 
-    <ComputeBatchTimeout Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+    <ComputeBatchTimeout Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != ''"
                          GroupedItems="@(_BatchGroupedItem)"
                          BatchIds="@(_UniqueBatchId)"
                          ItemPrefix="$(WorkItemPrefix)Desktop-"
@@ -393,15 +403,15 @@
       <Output TaskParameter="TimedItems" ItemName="_BatchTimedItem" />
     </ComputeBatchTimeout>
 
-    <ZipDirectory Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+    <ZipDirectory Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != ''"
                   SourceDirectory="%(_BatchTimedItem.BatchDir)"
                   DestinationFile="$(IntermediateOutputPath)helix-batches/%(_BatchTimedItem.Identity).zip"
                   Overwrite="true" />
 
-    <Error Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '$(_BatchHelixCommand)' == ''"
+    <Error Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != '' and '$(_BatchHelixCommand)' == ''"
            Text="BatchLibraryHelixWorkItems requires the structured desktop batch command to be available. A custom HelixCommand cannot be batched by this target." />
 
-    <ItemGroup Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'">
+    <ItemGroup Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '@(_BatchCandidateWorkItems)' != ''">
       <HelixWorkItem Include="@(_BatchTimedItem)">
         <PayloadArchive>$(IntermediateOutputPath)helix-batches/%(Identity).zip</PayloadArchive>
         <Command>$(_BatchHelixCommand)</Command>

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -16,12 +16,22 @@
     <BuildHelixWorkItemsDependsOn>BuildHelixCommand;StageDependenciesForHelix</BuildHelixWorkItemsDependsOn>
     <EnableDefaultBuildHelixWorkItems>true</EnableDefaultBuildHelixWorkItems>
     <HelixDependenciesStagingPath>$([MSBuild]::NormalizeDirectory($(ArtifactsObjDir), 'helix-staging'))</HelixDependenciesStagingPath>
+    <BatchLibraryHelixWorkItems Condition="'$(BatchLibraryHelixWorkItems)' == ''">true</BatchLibraryHelixWorkItems>
+    <MaxTestsPerWorkItem Condition="'$(MaxTestsPerWorkItem)' == ''">20</MaxTestsPerWorkItem>
+    <_LibraryHelixBatchLargeThreshold Condition="'$(_LibraryHelixBatchLargeThreshold)' == ''">52428800</_LibraryHelixBatchLargeThreshold>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)sendtohelix-wasi.targets" Condition="'$(TargetOS)' == 'wasi'" />
   <Import Project="$(MSBuildThisFileDirectory)sendtohelix-browser.targets" Condition="'$(TargetOS)' == 'browser'" />
   <Import Project="$(MSBuildThisFileDirectory)sendtohelix-mobile.targets" Condition="'$(TargetsMobile)' == 'true' and '$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   <Import Project="$(MSBuildThisFileDirectory)sendtohelix-superpmi-collect.targets" Condition="'$(SuperPmiCollect)' == 'true'" />
+
+  <UsingTask TaskName="Microsoft.DotNet.HelixTestTasks.GroupWorkItems"
+             AssemblyFile="$(HelixTestTasksAssemblyPath)"
+             Condition="'$(BatchLibraryHelixWorkItems)' == 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.HelixTestTasks.ComputeBatchTimeout"
+             AssemblyFile="$(HelixTestTasksAssemblyPath)"
+             Condition="'$(BatchLibraryHelixWorkItems)' == 'true'" />
 
   <PropertyGroup Condition="'$(_workItemTimeout)' == ''">
     <!-- Normal jobs have a 30 minute timeout for arm/arm64, and 15 minute timeout otherwise.
@@ -205,24 +215,33 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(HelixCommand)' == ''">
-      <HelixCommand Condition="'$(HelixCommandPrefix)' != '' and '$(WindowsShell)' != 'true'">$(HelixCommandPrefix) &amp;&amp; </HelixCommand>
-      <HelixCommand Condition="'$(HelixCommandPrefix)' != '' and '$(WindowsShell)' == 'true'">$(HelixCommandPrefix) &amp; </HelixCommand>
+      <HelixCommandPrefix Condition="'$(HelixCommandPrefix)' != '' and '$(WindowsShell)' != 'true'">$(HelixCommandPrefix) &amp;&amp;</HelixCommandPrefix>
+      <HelixCommandPrefix Condition="'$(HelixCommandPrefix)' != '' and '$(WindowsShell)' == 'true'">$(HelixCommandPrefix) &amp;</HelixCommandPrefix>
 
-      <HelixCommand Condition="'$(InstallDevCerts)' == 'true' and '$(WindowsShell)' != 'true'">$(HelixCommand) dotnet dev-certs https &amp;&amp; </HelixCommand>
+      <HelixCommandPrefix Condition="'$(InstallDevCerts)' == 'true' and '$(WindowsShell)' != 'true'">$(HelixCommandPrefix) dotnet dev-certs https &amp;&amp;</HelixCommandPrefix>
 
       <!-- on windows `dotnet dev-certs https -trust` shows a dialog, so instead install the certificate with powershell -->
-      <HelixCommand Condition="'$(InstallDevCerts)' == 'true' and '$(WindowsShell)' == 'true'">$(HelixCommand) powershell -command &quot;dotnet dev-certs https --export-path devcerts.pfx --password PLACEHOLDER %3B $pw = ConvertTo-SecureString PLACEHOLDER -AsPlainText -Force %3B Import-PfxCertificate -FilePath devcerts.pfx -Password $pw -CertStoreLocation Cert:\LocalMachine\Root &quot; &amp;&amp; </HelixCommand>
+      <HelixCommandPrefix Condition="'$(InstallDevCerts)' == 'true' and '$(WindowsShell)' == 'true'">$(HelixCommandPrefix) powershell -command &quot;dotnet dev-certs https --export-path devcerts.pfx --password PLACEHOLDER %3B $pw = ConvertTo-SecureString PLACEHOLDER -AsPlainText -Force %3B Import-PfxCertificate -FilePath devcerts.pfx -Password $pw -CertStoreLocation Cert:\LocalMachine\Root &quot; &amp;&amp;</HelixCommandPrefix>
 
       <!--
         For Windows we need to use "call", since the command is going to be called from a batch script created by Helix.
         We "exit /b" at the end of RunTests.cmd. Helix runs some other commands after ours within the batch script,
         so if we don't use "call", then we cause the parent script to exit, and anything after will not be executed.
       -->
-      <HelixCommand Condition="'$(WindowsShell)' == 'true'">$(HelixCommand)call RunTests.cmd</HelixCommand>
-      <HelixCommand Condition="'$(WindowsShell)' == 'true' and '$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixCommand) --runtime-path %HELIX_CORRELATION_PAYLOAD%</HelixCommand>
+      <HelixRunnerEntryPoint Condition="'$(WindowsShell)' == 'true'">call RunTests.cmd</HelixRunnerEntryPoint>
+      <HelixBatchRunnerEntryPoint Condition="'$(WindowsShell)' == 'true'">call DesktopBatchRunner.cmd</HelixBatchRunnerEntryPoint>
+      <HelixRunnerEntryPoint Condition="'$(WindowsShell)' == 'true' and '$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixRunnerEntryPoint) --runtime-path %HELIX_CORRELATION_PAYLOAD%</HelixRunnerEntryPoint>
+      <HelixBatchRunnerEntryPoint Condition="'$(WindowsShell)' == 'true' and '$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixBatchRunnerEntryPoint) --runtime-path %HELIX_CORRELATION_PAYLOAD%</HelixBatchRunnerEntryPoint>
 
-      <HelixCommand Condition="'$(WindowsShell)' != 'true'">$(HelixCommand)./RunTests.sh</HelixCommand>
-      <HelixCommand Condition="'$(WindowsShell)' != 'true' and '$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixCommand) --runtime-path "$HELIX_CORRELATION_PAYLOAD"</HelixCommand>
+      <HelixRunnerEntryPoint Condition="'$(WindowsShell)' != 'true'">./RunTests.sh</HelixRunnerEntryPoint>
+      <HelixBatchRunnerEntryPoint Condition="'$(WindowsShell)' != 'true'">chmod +x DesktopBatchRunner.sh &amp;&amp; ./DesktopBatchRunner.sh</HelixBatchRunnerEntryPoint>
+      <HelixRunnerEntryPoint Condition="'$(WindowsShell)' != 'true' and '$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixRunnerEntryPoint) --runtime-path "$HELIX_CORRELATION_PAYLOAD"</HelixRunnerEntryPoint>
+      <HelixBatchRunnerEntryPoint Condition="'$(WindowsShell)' != 'true' and '$(IncludeHelixCorrelationPayload)' == 'true'">$(HelixBatchRunnerEntryPoint) --runtime-path "$HELIX_CORRELATION_PAYLOAD"</HelixBatchRunnerEntryPoint>
+
+      <HelixCommand Condition="'$(HelixCommandPrefix)' != ''">$(HelixCommandPrefix) </HelixCommand>
+      <HelixCommand>$(HelixCommand)$(HelixRunnerEntryPoint)</HelixCommand>
+      <_BatchHelixCommand Condition="'$(HelixCommandPrefix)' != ''">$(HelixCommandPrefix) </_BatchHelixCommand>
+      <_BatchHelixCommand>$(_BatchHelixCommand)$(HelixBatchRunnerEntryPoint)</_BatchHelixCommand>
     </PropertyGroup>
 
     <!-- FIXME: is this used? -->
@@ -300,7 +319,7 @@
       <HelixCorrelationPayload Condition="$(TargetRuntimeIdentifier.ToLowerInvariant().StartsWith('linux-bionic'))" Include="openssl" Uri="https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/openssl-1.1.1l-beta-1.zip" Destination="openssl" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(EnableDefaultBuildHelixWorkItems)' == 'true'">
+    <ItemGroup Condition="'$(EnableDefaultBuildHelixWorkItems)' == 'true' and '$(BatchLibraryHelixWorkItems)' != 'true'">
       <HelixCorrelationPayload Include="$(HelixCorrelationPayload)"
                                Condition="'$(IncludeHelixCorrelationPayload)' == 'true'"
                                AsArchive="$(HelixCorrelationPayload.EndsWith('.zip'))" />
@@ -312,6 +331,80 @@
         <Command>$(HelixCommand)</Command>
         <Timeout>$(_workItemTimeout)</Timeout>
         <DownloadFilesFromResults Condition=" '$(SuperPmiCollect)' == 'true' ">$(SuperPmiCollectionName).$(SuperPmiCollectionType).$(TargetOS).$(TargetArchitecture).$(Configuration).mch;$(SuperPmiCollectionName).$(SuperPmiCollectionType).$(TargetOS).$(TargetArchitecture).$(Configuration).log</DownloadFilesFromResults>
+      </HelixWorkItem>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(EnableDefaultBuildHelixWorkItems)' == 'true' and '$(BatchLibraryHelixWorkItems)' == 'true'">
+      <HelixCorrelationPayload Include="$(HelixCorrelationPayload)"
+                               Condition="'$(IncludeHelixCorrelationPayload)' == 'true'"
+                               AsArchive="$(HelixCorrelationPayload.EndsWith('.zip'))" />
+
+      <_DefaultWorkItems Include="$(WorkItemArchiveWildCard)" Exclude="$(HelixCorrelationPayload)">
+        <BatchCompatible Condition="'$(Scenario)' == '' or '$(Scenario)' == 'normal'">true</BatchCompatible>
+        <BatchCompatible Condition="'$(Scenario)' != '' and '$(Scenario)' != 'normal'">false</BatchCompatible>
+        <BatchIncompatibilityReason Condition="'%(BatchCompatible)' != 'true'">Scenario=$(Scenario)</BatchIncompatibilityReason>
+        <RunnerType>Desktop</RunnerType>
+        <PlatformFamily Condition="'$(WindowsShell)' == 'true'">Windows</PlatformFamily>
+        <PlatformFamily Condition="'$(WindowsShell)' != 'true'">Unix</PlatformFamily>
+        <RuntimeFlavor>$(RuntimeFlavor)</RuntimeFlavor>
+        <TargetOS>$(TargetOS)</TargetOS>
+        <TargetArchitecture>$(TargetArchitecture)</TargetArchitecture>
+        <Scenario Condition="'$(Scenario)' == ''">normal</Scenario>
+        <Scenario Condition="'$(Scenario)' != ''">$(Scenario)</Scenario>
+        <TimeoutClass Condition="'$(Scenario)' == '' or '$(Scenario)' == 'normal'">Normal</TimeoutClass>
+        <TimeoutClass Condition="'$(Scenario)' != '' and '$(Scenario)' != 'normal'">Stress</TimeoutClass>
+        <PayloadShape>DesktopRuntime</PayloadShape>
+      </_DefaultWorkItems>
+    </ItemGroup>
+
+    <GroupWorkItems Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+                    Items="@(_DefaultWorkItems)"
+                    BatchSize="$(MaxTestsPerWorkItem)"
+                    LargeThreshold="$(_LibraryHelixBatchLargeThreshold)"
+                    CompatibilityMetadataKeys="RunnerType;PlatformFamily;RuntimeFlavor;TargetOS;TargetArchitecture;Scenario;TimeoutClass;PayloadShape"
+                    BatchCompatibleMetadataKey="BatchCompatible">
+      <Output TaskParameter="GroupedItems" ItemName="_BatchGroupedItem" />
+    </GroupWorkItems>
+
+    <ItemGroup Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'">
+      <_BatchId Include="@(_BatchGroupedItem -> '%(BatchId)')" />
+      <_UniqueBatchId Include="@(_BatchId->Distinct())" />
+    </ItemGroup>
+
+    <RemoveDir Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+               Directories="$(IntermediateOutputPath)helix-batches/" />
+    <MakeDir Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+             Directories="$(IntermediateOutputPath)helix-batches/batch-%(_UniqueBatchId.Identity)/" />
+    <Copy Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+          SourceFiles="@(_BatchGroupedItem)"
+          DestinationFolder="$(IntermediateOutputPath)helix-batches/batch-%(BatchId)/" />
+    <Copy Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '$(WindowsShell)' == 'true'"
+          SourceFiles="$(RepositoryEngineeringDir)testing\DesktopBatchRunner.cmd"
+          DestinationFolder="$(IntermediateOutputPath)helix-batches/batch-%(_UniqueBatchId.Identity)/" />
+    <Copy Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '$(WindowsShell)' != 'true'"
+          SourceFiles="$(RepositoryEngineeringDir)testing\DesktopBatchRunner.sh"
+          DestinationFolder="$(IntermediateOutputPath)helix-batches/batch-%(_UniqueBatchId.Identity)/" />
+
+    <ComputeBatchTimeout Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+                         GroupedItems="@(_BatchGroupedItem)"
+                         BatchIds="@(_UniqueBatchId)"
+                         ItemPrefix="$(WorkItemPrefix)Desktop-"
+                         BatchOutputDir="$(IntermediateOutputPath)helix-batches/">
+      <Output TaskParameter="TimedItems" ItemName="_BatchTimedItem" />
+    </ComputeBatchTimeout>
+
+    <ZipDirectory Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'"
+                  SourceDirectory="%(_BatchTimedItem.BatchDir)"
+                  DestinationFile="$(IntermediateOutputPath)helix-batches/%(_BatchTimedItem.Identity).zip"
+                  Overwrite="true" />
+
+    <Error Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true' and '$(_BatchHelixCommand)' == ''"
+           Text="BatchLibraryHelixWorkItems requires the structured desktop batch command to be available. A custom HelixCommand cannot be batched by this target." />
+
+    <ItemGroup Condition="'$(BatchLibraryHelixWorkItems)' == 'true' and '$(EnableDefaultBuildHelixWorkItems)' == 'true'">
+      <HelixWorkItem Include="@(_BatchTimedItem)">
+        <PayloadArchive>$(IntermediateOutputPath)helix-batches/%(Identity).zip</PayloadArchive>
+        <Command>$(_BatchHelixCommand)</Command>
       </HelixWorkItem>
     </ItemGroup>
 

--- a/src/tasks/HelixTestTasks.Tests/GroupWorkItemsTests.cs
+++ b/src/tasks/HelixTestTasks.Tests/GroupWorkItemsTests.cs
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.HelixTestTasks;
+using Xunit;
+
+namespace HelixTestTasks.Tests;
+
+public sealed class GroupWorkItemsTests : IDisposable
+{
+    private readonly string _testDirectory = Path.Combine(AppContext.BaseDirectory, "GroupWorkItemsTests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PreservesGreedyPackingWhenCompatibilityMetadataIsNotConfigured()
+    {
+        ITaskItem[] result = Execute(
+            batchSize: 2,
+            largeThreshold: 1_000,
+            Item("a.zip", 100),
+            Item("b.zip", 50),
+            Item("c.zip", 25));
+
+        Assert.Equal("0", BatchId(result, "a.zip"));
+        Assert.Equal("1", BatchId(result, "b.zip"));
+        Assert.Equal("1", BatchId(result, "c.zip"));
+    }
+
+    [Fact]
+    public void PartitionsSmallItemsByCompatibilityMetadataBeforePacking()
+    {
+        ITaskItem normal1 = Item("normal1.zip", 100, ("Scenario", "normal"));
+        ITaskItem normal2 = Item("normal2.zip", 50, ("Scenario", "normal"));
+        ITaskItem stress1 = Item("stress1.zip", 90, ("Scenario", "stress"));
+        ITaskItem stress2 = Item("stress2.zip", 40, ("Scenario", "stress"));
+
+        ITaskItem[] result = Execute(
+            batchSize: 2,
+            largeThreshold: 1_000,
+            compatibilityMetadataKeys: "Scenario",
+            normal1,
+            normal2,
+            stress1,
+            stress2);
+
+        string[] normalBatchIds = { BatchId(result, "normal1.zip"), BatchId(result, "normal2.zip") };
+        string[] stressBatchIds = { BatchId(result, "stress1.zip"), BatchId(result, "stress2.zip") };
+
+        Assert.Empty(normalBatchIds.Intersect(stressBatchIds));
+    }
+
+    [Fact]
+    public void BatchCompatibleFalseItemsBecomeSoloBatches()
+    {
+        ITaskItem[] result = Execute(
+            batchSize: 2,
+            largeThreshold: 1_000,
+            compatibilityMetadataKeys: "RunnerType",
+            batchCompatibleMetadataKey: "BatchCompatible",
+            Item("one.zip", 100, ("RunnerType", "Desktop"), ("BatchCompatible", "true")),
+            Item("two.zip", 90, ("RunnerType", "Desktop"), ("BatchCompatible", "true")),
+            Item("stress.zip", 80, ("RunnerType", "Desktop"), ("BatchCompatible", "false")));
+
+        Assert.NotEqual(BatchId(result, "stress.zip"), BatchId(result, "one.zip"));
+        Assert.NotEqual(BatchId(result, "stress.zip"), BatchId(result, "two.zip"));
+        Assert.Single(result.Where(item => item.GetMetadata("BatchId") == BatchId(result, "stress.zip")));
+    }
+
+    [Fact]
+    public void LargeItemsKeepNegativeSoloBatchIds()
+    {
+        ITaskItem[] result = Execute(
+            batchSize: 2,
+            largeThreshold: 50,
+            Item("large.zip", 100),
+            Item("small.zip", 10));
+
+        Assert.Equal("-1", BatchId(result, "large.zip"));
+        Assert.Equal("0", BatchId(result, "small.zip"));
+    }
+
+    [Fact]
+    public void MissingCompatibilityMetadataIsSoloBatchedWithoutFailingByDefault()
+    {
+        ITaskItem[] result = Execute(
+            batchSize: 2,
+            largeThreshold: 1_000,
+            compatibilityMetadataKeys: "RunnerType",
+            Item("has-metadata.zip", 100, ("RunnerType", "Desktop")),
+            Item("missing-metadata.zip", 90));
+
+        Assert.NotEqual(BatchId(result, "has-metadata.zip"), BatchId(result, "missing-metadata.zip"));
+    }
+
+    private ITaskItem[] Execute(
+        int batchSize,
+        long largeThreshold,
+        params ITaskItem[] items) =>
+        Execute(batchSize, largeThreshold, compatibilityMetadataKeys: string.Empty, batchCompatibleMetadataKey: string.Empty, items);
+
+    private static ITaskItem[] Execute(
+        int batchSize,
+        long largeThreshold,
+        string compatibilityMetadataKeys,
+        params ITaskItem[] items) =>
+        Execute(batchSize, largeThreshold, compatibilityMetadataKeys, batchCompatibleMetadataKey: string.Empty, items);
+
+    private static ITaskItem[] Execute(
+        int batchSize,
+        long largeThreshold,
+        string compatibilityMetadataKeys,
+        string batchCompatibleMetadataKey,
+        params ITaskItem[] items)
+    {
+        var task = new GroupWorkItems
+        {
+            BuildEngine = new MockBuildEngine(),
+            Items = items,
+            BatchSize = batchSize,
+            LargeThreshold = largeThreshold,
+            CompatibilityMetadataKeys = compatibilityMetadataKeys,
+            BatchCompatibleMetadataKey = batchCompatibleMetadataKey,
+        };
+
+        Assert.True(task.Execute());
+        return task.GroupedItems;
+    }
+
+    private ITaskItem Item(string name, int size, params (string key, string value)[] metadata)
+    {
+        Directory.CreateDirectory(_testDirectory);
+        string path = Path.Combine(_testDirectory, name);
+        File.WriteAllBytes(path, new byte[size]);
+
+        var item = new TaskItem(path);
+        foreach ((string key, string value) in metadata)
+        {
+            item.SetMetadata(key, value);
+        }
+
+        return item;
+    }
+
+    private static string BatchId(IEnumerable<ITaskItem> items, string fileName) =>
+        items.Single(item => Path.GetFileName(item.ItemSpec) == fileName).GetMetadata("BatchId");
+
+    private sealed class MockBuildEngine : IBuildEngine
+    {
+        public bool ContinueOnError => false;
+        public int LineNumberOfTaskNode => 0;
+        public int ColumnNumberOfTaskNode => 0;
+        public string ProjectFileOfTaskNode => string.Empty;
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs) => true;
+        public void LogCustomEvent(CustomBuildEventArgs e) { }
+        public void LogErrorEvent(BuildErrorEventArgs e) { }
+        public void LogMessageEvent(BuildMessageEventArgs e) { }
+        public void LogWarningEvent(BuildWarningEventArgs e) { }
+    }
+}

--- a/src/tasks/HelixTestTasks.Tests/HelixTestTasks.Tests.csproj
+++ b/src/tasks/HelixTestTasks.Tests/HelixTestTasks.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <IsShipping>false</IsShipping>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);NETSDK1023</NoWarn>
+  </PropertyGroup>
+
+  <Import Project="$(RepositoryEngineeringDir)testing\xunit\xunit.props" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+
+    <ProjectReference Include="..\HelixTestTasks\HelixTestTasks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/tasks/HelixTestTasks/GroupWorkItems.cs
+++ b/src/tasks/HelixTestTasks/GroupWorkItems.cs
@@ -62,7 +62,6 @@ public class GroupWorkItems : Task
         int nextBatchId = 0;
         string[] compatibilityKeys = CompatibilityMetadataKeys
             .Split(s_compatibilityMetadataKeySeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        bool hasCompatibilityKeys = compatibilityKeys.Length > 0;
         string batchCompatibleMetadataKey = BatchCompatibleMetadataKey.Trim();
 
         // Separate large items (each gets its own batch)

--- a/src/tasks/HelixTestTasks/GroupWorkItems.cs
+++ b/src/tasks/HelixTestTasks/GroupWorkItems.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -18,12 +19,20 @@ namespace Microsoft.DotNet.HelixTestTasks;
 /// </summary>
 public class GroupWorkItems : Task
 {
+    private static readonly char[] s_compatibilityMetadataKeySeparators = { ';' };
+
     [Required]
     public ITaskItem[] Items { get; set; } = Array.Empty<ITaskItem>();
 
     public int BatchSize { get; set; } = 10;
 
     public long LargeThreshold { get; set; } = 52428800L; // 50 MB
+
+    public string CompatibilityMetadataKeys { get; set; } = string.Empty;
+
+    public string BatchCompatibleMetadataKey { get; set; } = string.Empty;
+
+    public bool StrictCompatibilityMetadata { get; set; }
 
     [Output]
     public ITaskItem[] GroupedItems { get; set; } = Array.Empty<ITaskItem>();
@@ -50,9 +59,15 @@ public class GroupWorkItems : Task
 
         var result = new List<ITaskItem>();
         int negativeBatchId = -1;
+        int nextBatchId = 0;
+        string[] compatibilityKeys = CompatibilityMetadataKeys
+            .Split(s_compatibilityMetadataKeySeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        bool hasCompatibilityKeys = compatibilityKeys.Length > 0;
+        string batchCompatibleMetadataKey = BatchCompatibleMetadataKey.Trim();
 
         // Separate large items (each gets its own batch)
-        var smallItems = new List<(ITaskItem item, long size)>();
+        var partitionedSmallItems = new Dictionary<string, List<(ITaskItem item, long size)>>(StringComparer.Ordinal);
+        var soloSmallItems = new List<(ITaskItem item, long size)>();
         foreach (var entry in itemsWithSize)
         {
             if (entry.size > LargeThreshold)
@@ -64,12 +79,25 @@ public class GroupWorkItems : Task
             }
             else
             {
-                smallItems.Add(entry);
+                if (IsSolo(entry.item, batchCompatibleMetadataKey, compatibilityKeys, out string partitionKey))
+                {
+                    soloSmallItems.Add(entry);
+                }
+                else
+                {
+                    if (!partitionedSmallItems.TryGetValue(partitionKey, out List<(ITaskItem item, long size)>? partitionItems))
+                    {
+                        partitionItems = new List<(ITaskItem item, long size)>();
+                        partitionedSmallItems.Add(partitionKey, partitionItems);
+                    }
+
+                    partitionItems.Add(entry);
+                }
             }
         }
 
         // Greedy bin-packing for small items
-        if (smallItems.Count > 0)
+        foreach (List<(ITaskItem item, long size)> smallItems in partitionedSmallItems.Values)
         {
             int numBatches = Math.Min(BatchSize, smallItems.Count);
             var batchSizes = new long[numBatches];
@@ -88,15 +116,77 @@ public class GroupWorkItems : Task
                 }
                 batchSizes[minIdx] += entry.size;
                 var newItem = new TaskItem(entry.item);
-                newItem.SetMetadata("BatchId", minIdx.ToString());
+                newItem.SetMetadata("BatchId", (nextBatchId + minIdx).ToString());
                 batchAssignments[minIdx].Add(newItem);
             }
 
             for (int i = 0; i < numBatches; i++)
                 result.AddRange(batchAssignments[i]);
+
+            nextBatchId += numBatches;
+        }
+
+        foreach (var entry in soloSmallItems)
+        {
+            var newItem = new TaskItem(entry.item);
+            newItem.SetMetadata("BatchId", nextBatchId.ToString());
+            nextBatchId++;
+            result.Add(newItem);
         }
 
         GroupedItems = result.ToArray();
         return !Log.HasLoggedErrors;
+    }
+
+    private bool IsSolo(ITaskItem item, string batchCompatibleMetadataKey, string[] compatibilityKeys, out string partitionKey)
+    {
+        partitionKey = string.Empty;
+
+        if (!string.IsNullOrEmpty(batchCompatibleMetadataKey))
+        {
+            string batchCompatible = item.GetMetadata(batchCompatibleMetadataKey);
+            if (!string.IsNullOrEmpty(batchCompatible) &&
+                !string.Equals(batchCompatible, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                Log.LogMessage(
+                    MessageImportance.Low,
+                    "Keeping '{0}' in a solo batch because metadata '{1}' is '{2}'.",
+                    item.ItemSpec,
+                    batchCompatibleMetadataKey,
+                    batchCompatible);
+                return true;
+            }
+        }
+
+        if (compatibilityKeys.Length == 0)
+        {
+            return false;
+        }
+
+        string[] values = new string[compatibilityKeys.Length];
+        for (int i = 0; i < compatibilityKeys.Length; i++)
+        {
+            string key = compatibilityKeys[i];
+            string value = item.GetMetadata(key);
+            if (string.IsNullOrEmpty(value))
+            {
+                string message = $"Keeping '{item.ItemSpec}' in a solo batch because required compatibility metadata '{key}' is missing.";
+                if (StrictCompatibilityMetadata)
+                {
+                    Log.LogError(message);
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.High, message);
+                }
+
+                return true;
+            }
+
+            values[i] = value;
+        }
+
+        partitionKey = string.Join('\u001f', compatibilityKeys.Zip(values, static (key, value) => key + "=" + value));
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

Reduces the number of libraries-test Helix work items by **batching multiple test assemblies into a single work item**, cutting per-work-item overhead (queueing, machine provisioning, payload/runtime download) while keeping total test execution time roughly flat.

Today each libraries test assembly is sent to Helix as its own work item, so the fixed per-work-item overhead is paid thousands of times. This change groups compatible desktop libraries work items together and runs them through a structured batch runner.

## How it works

- **`GroupWorkItems` MSBuild task** (`src/tasks/HelixTestTasks/GroupWorkItems.cs`): greedy bin-packs assemblies into batches by file size. Items above a size threshold get their own solo batch. Assemblies are first **partitioned by a compatibility-key tuple** so only co-runnable assemblies share a work item:
  `RunnerType;PlatformFamily;RuntimeFlavor;TargetOS;TargetArchitecture;Scenario;TimeoutClass;PayloadShape`
- **`DesktopBatchRunner.sh` / `.cmd`** (`eng/testing/`): inside a single work item, iterates the batched suites, gives each its own upload root so results don't collide, runs each suite's existing `RunTests` script, and aggregates per-suite exit codes/durations.
- **`sendtohelixhelp.proj`**: composes the desktop batch command from structured runner parts and emits batched work items. Non-batch-compatible (e.g. stress `Scenario`) items are emitted directly so they keep their original runner and timeout instead of flowing through `ComputeBatchTimeout`.
- Unit tests added in `HelixTestTasks.Tests/GroupWorkItemsTests.cs`.

Batching can be disabled via `BatchLibraryHelixWorkItems=false`.

## Validation

A manual pipeline run of this branch showed:
- **~90% fewer libraries Helix work items** vs a comparable `main` run, with total test-execution time roughly flat.
- Work-item efficiency (test-execution time / wall-clock time) improved substantially.
- No new failures observed inside the batched libraries work items.

Opening as **draft** to get full CI coverage and review on the approach.

> [!NOTE]
> This pull request description was drafted with the assistance of GitHub Copilot (AI-generated).
