### PR TITLE
[cDAC] Add FeatureFlags contract, reduce direct global reads in legacy impl, expand NativeAOT descriptor parity

### DIFF
--- a/docs/design/datacontracts/FeatureFlags.md
+++ b/docs/design/datacontracts/FeatureFlags.md
@@ -1,0 +1,58 @@
+# Contract FeatureFlags
+
+This contract exposes whether optional runtime features are enabled in the target.
+
+## APIs of contract
+
+```csharp
+public enum RuntimeFeature
+{
+    COMInterop,
+    ComWrappers,
+    ObjCMarshal,
+    JavaMarshal,
+    OnStackReplacement,
+    PortableEntrypoints,
+    Webcil,
+}
+
+// Returns true if the target runtime has the given feature enabled.
+// A feature is considered disabled when its global is absent from the
+// target descriptor or present with a zero value.
+bool IsEnabled(RuntimeFeature feature);
+```
+
+## Version 1
+
+Global variables used:
+| Global Name | Type | Purpose |
+| --- | --- | --- |
+| FeatureCOMInterop | uint8 | Present (nonzero) when COM interop is enabled |
+| FeatureComWrappers | uint8 | Present (nonzero) when ComWrappers is enabled |
+| FeatureObjCMarshal | uint8 | Present (nonzero) when Objective-C marshalling is enabled |
+| FeatureJavaMarshal | uint8 | Present (nonzero) when Java marshalling is enabled |
+| FeatureOnStackReplacement | uint8 | Present (nonzero) when on-stack replacement is enabled |
+| FeaturePortableEntrypoints | uint8 | Present (nonzero) when portable entrypoints are enabled |
+| FeatureWebcil | uint8 | Present (nonzero) when Webcil is enabled |
+
+Feature flag globals are **only present in the descriptor when the feature is enabled**. A missing global and a zero-valued global are both treated as "disabled".
+
+```csharp
+bool IsEnabled(RuntimeFeature feature)
+{
+    string? globalName = feature switch
+    {
+        RuntimeFeature.COMInterop           => "FeatureCOMInterop",
+        RuntimeFeature.ComWrappers          => "FeatureComWrappers",
+        RuntimeFeature.ObjCMarshal          => "FeatureObjCMarshal",
+        RuntimeFeature.JavaMarshal          => "FeatureJavaMarshal",
+        RuntimeFeature.OnStackReplacement   => "FeatureOnStackReplacement",
+        RuntimeFeature.PortableEntrypoints  => "FeaturePortableEntrypoints",
+        RuntimeFeature.Webcil               => "FeatureWebcil",
+        _                                   => null,
+    };
+    return globalName is not null
+        && TryReadGlobal<byte>(globalName, out byte? value)
+        && value != 0;
+}
+```

--- a/src/coreclr/nativeaot/Runtime/RuntimeInstance.h
+++ b/src/coreclr/nativeaot/Runtime/RuntimeInstance.h
@@ -20,6 +20,7 @@ class RuntimeInstance
     friend class AsmOffsets;
     friend class Thread;
     friend void PopulateDebugHeaders();
+    friend struct ::cdac_data<RuntimeInstance>;
 
     HANDLE                      m_hPalInstance; // this is the HANDLE passed into DllMain
 
@@ -109,6 +110,13 @@ public:
 };
 typedef DPTR(RuntimeInstance) PTR_RuntimeInstance;
 
+template<> struct cdac_data<RuntimeInstance>
+{
+    static constexpr size_t OsModuleList = offsetof(RuntimeInstance, m_OsModuleList);
+    static constexpr size_t TypeManagerList = offsetof(RuntimeInstance, m_TypeManagerList);
+    static constexpr size_t ManagedCodeStartRange = offsetof(RuntimeInstance, m_pvManagedCodeStartRange);
+    static constexpr size_t ManagedCodeRangeSize = offsetof(RuntimeInstance, m_cbManagedCodeRange);
+};
 
 PTR_RuntimeInstance GetRuntimeInstance();
 

--- a/src/coreclr/nativeaot/Runtime/TypeManager.h
+++ b/src/coreclr/nativeaot/Runtime/TypeManager.h
@@ -6,6 +6,8 @@
 
 class TypeManager
 {
+    friend struct ::cdac_data<TypeManager>;
+
     // NOTE: Part of this layout is a contract with the managed side in TypeManagerHandle.cs
     HANDLE                      m_osModule;
     ReadyToRunHeader *          m_pHeader;
@@ -30,6 +32,12 @@ private:
         int32_t Length;
         void * Start;
     };
+};
+
+template<> struct cdac_data<TypeManager>
+{
+    static constexpr size_t OsModule = offsetof(TypeManager, m_osModule);
+    static constexpr size_t Header = offsetof(TypeManager, m_pHeader);
 };
 
 // TypeManagerHandle represents an AOT module in MRT based runtimes.

--- a/src/coreclr/nativeaot/Runtime/datadescriptor/datadescriptor.h
+++ b/src/coreclr/nativeaot/Runtime/datadescriptor/datadescriptor.h
@@ -11,6 +11,7 @@
 #include "Pal.h"
 #include "holder.h"
 #include "RuntimeInstance.h"
+#include "TypeManager.h"
 #include "regdisplay.h"
 #include "StackFrameIterator.h"
 #include "thread.h"
@@ -23,6 +24,7 @@
 
 GPTR_DECL(MethodTable, g_pFreeObjectEEType);
 GPTR_DECL(StressLog, g_pStressLog);
+GPTR_DECL(RuntimeInstance, g_pTheRuntimeInstance);
 
 // ILC emits a ContractDescriptor named "DotNetManagedContractDescriptor" with
 // managed type layouts. We take its address so datadescriptor.inc can reference

--- a/src/coreclr/nativeaot/Runtime/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/nativeaot/Runtime/datadescriptor/datadescriptor.inc
@@ -106,6 +106,7 @@ CDAC_TYPE_FIELD(StressLog, T_POINTER, Logs, offsetof(StressLog, logs))
 CDAC_TYPE_FIELD(StressLog, T_UINT64, TickFrequency, offsetof(StressLog, tickFrequency))
 CDAC_TYPE_FIELD(StressLog, T_UINT64, StartTimestamp, offsetof(StressLog, startTimeStamp))
 CDAC_TYPE_FIELD(StressLog, T_UINT64, StartTime, offsetof(StressLog, startTime))
+CDAC_TYPE_FIELD(StressLog, T_NUINT, ModuleOffset, offsetof(StressLog, moduleOffset))
 CDAC_TYPE_END(StressLog)
 
 CDAC_TYPE_BEGIN(ThreadStressLog)
@@ -138,6 +139,30 @@ CDAC_TYPE_FIELD(StressMsg, TYPE(StressMsgHeader), Header, 0)
 CDAC_TYPE_FIELD(StressMsg, T_POINTER, Args, offsetof(StressMsg, args))
 CDAC_TYPE_END(StressMsg)
 
+// ========================
+// Loader (RuntimeInstance / TypeManager)
+// ========================
+
+CDAC_TYPE_BEGIN(RuntimeInstance)
+CDAC_TYPE_INDETERMINATE(RuntimeInstance)
+CDAC_TYPE_FIELD(RuntimeInstance, T_POINTER, OsModuleList, cdac_data<RuntimeInstance>::OsModuleList)
+CDAC_TYPE_FIELD(RuntimeInstance, T_POINTER, TypeManagerList, cdac_data<RuntimeInstance>::TypeManagerList)
+CDAC_TYPE_FIELD(RuntimeInstance, T_POINTER, ManagedCodeStartRange, cdac_data<RuntimeInstance>::ManagedCodeStartRange)
+CDAC_TYPE_FIELD(RuntimeInstance, T_UINT32, ManagedCodeRangeSize, cdac_data<RuntimeInstance>::ManagedCodeRangeSize)
+CDAC_TYPE_END(RuntimeInstance)
+
+CDAC_TYPE_BEGIN(TypeManagerEntry)
+CDAC_TYPE_INDETERMINATE(TypeManagerEntry)
+CDAC_TYPE_FIELD(TypeManagerEntry, T_POINTER, Next, offsetof(RuntimeInstance::TypeManagerEntry, m_pNext))
+CDAC_TYPE_FIELD(TypeManagerEntry, T_POINTER, TypeManager, offsetof(RuntimeInstance::TypeManagerEntry, m_pTypeManager))
+CDAC_TYPE_END(TypeManagerEntry)
+
+CDAC_TYPE_BEGIN(TypeManager)
+CDAC_TYPE_INDETERMINATE(TypeManager)
+CDAC_TYPE_FIELD(TypeManager, T_POINTER, OsModule, cdac_data<TypeManager>::OsModule)
+CDAC_TYPE_FIELD(TypeManager, T_POINTER, Header, cdac_data<TypeManager>::Header)
+CDAC_TYPE_END(TypeManager)
+
 CDAC_TYPES_END()
 
 // ========================
@@ -148,14 +173,12 @@ CDAC_GLOBALS_BEGIN()
 
 CDAC_GLOBAL_POINTER(ThreadStore, &ThreadStore::s_pThreadStore)
 
+CDAC_GLOBAL_POINTER(RuntimeInstance, &g_pTheRuntimeInstance)
+
 CDAC_GLOBAL_POINTER(FreeObjectMethodTable, &g_pFreeObjectEEType)
 
 CDAC_GLOBAL_POINTER(GCLowestAddress, &g_lowest_address)
 CDAC_GLOBAL_POINTER(GCHighestAddress, &g_highest_address)
-
-// Thread state flag constants
-CDAC_GLOBAL(ThreadStateFlagAttached, T_UINT32, 0x00000001)
-CDAC_GLOBAL(ThreadStateFlagDetached, T_UINT32, 0x00000002)
 
 // Object contract globals
 #ifdef TARGET_64BIT
@@ -164,13 +187,14 @@ CDAC_GLOBAL(ObjectToMethodTableUnmask, T_UINT8, 7)
 CDAC_GLOBAL(ObjectToMethodTableUnmask, T_UINT8, 3)
 #endif
 
-// StressLog globals (no module table in NativeAOT)
 CDAC_GLOBAL(StressLogEnabled, T_UINT8, 1)
 CDAC_GLOBAL_POINTER(StressLog, &StressLog::theLog)
 CDAC_GLOBAL(StressLogHasModuleTable, T_UINT8, 0)
 CDAC_GLOBAL(StressLogChunkSize, T_UINT32, STRESSLOG_CHUNK_SIZE)
 CDAC_GLOBAL(StressLogValidChunkSig, T_UINT32, 0xCFCFCFCF)
 CDAC_GLOBAL(StressLogMaxMessageSize, T_UINT64, (uint64_t)StressMsg::maxMsgSize)
+
+CDAC_GLOBAL(SOSBreakingChangeVersion, T_UINT8, 5)
 
 #if defined(TARGET_BROWSER)
 #ifdef Browser
@@ -222,10 +246,20 @@ CDAC_GLOBAL(RecommendedReaderVersion, T_UINT32, CDAC_RECOMMENDED_READER_VERSION)
 
 // Contracts: declare which contracts this runtime supports
 CDAC_GLOBAL_CONTRACT(Thread, n1)
-CDAC_GLOBAL_CONTRACT(Exception, c1)
+CDAC_GLOBAL_CONTRACT(Exception, n1)
+CDAC_GLOBAL_CONTRACT(Object, n1)
 CDAC_GLOBAL_CONTRACT(RuntimeTypeSystem, n1)
 CDAC_GLOBAL_CONTRACT(RuntimeInfo, c1)
 CDAC_GLOBAL_CONTRACT(StressLog, c2)
+CDAC_GLOBAL_CONTRACT(Loader, n1)
+CDAC_GLOBAL_CONTRACT(ExecutionManager, n1)
+CDAC_GLOBAL_CONTRACT(SyncBlock, n1)
+CDAC_GLOBAL_CONTRACT(SymbolName, n1)
+CDAC_GLOBAL_CONTRACT(CodeVersions, n1)
+CDAC_GLOBAL_CONTRACT(ReJIT, n1)
+CDAC_GLOBAL_CONTRACT(PrecodeStubs, n1)
+CDAC_GLOBAL_CONTRACT(PlatformMetadata, n1)
+CDAC_GLOBAL_CONTRACT(FeatureFlags, c1)
 
 // Managed type sub-descriptor: ILC emits a ContractDescriptor with managed type layouts
 // that the cDAC reader merges as a sub-descriptor. This provides field offsets for managed

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -1590,33 +1590,21 @@ CDAC_GLOBAL(MethodDescTokenRemainderBitCount, T_UINT8, METHOD_TOKEN_REMAINDER_BI
 
 #if FEATURE_COMINTEROP
 CDAC_GLOBAL(FeatureCOMInterop, T_UINT8, 1)
-#else
-CDAC_GLOBAL(FeatureCOMInterop, T_UINT8, 0)
 #endif
 #if FEATURE_COMWRAPPERS
 CDAC_GLOBAL(FeatureComWrappers, T_UINT8, 1)
-#else
-CDAC_GLOBAL(FeatureComWrappers, T_UINT8, 0)
 #endif
 #if FEATURE_OBJCMARSHAL
 CDAC_GLOBAL(FeatureObjCMarshal, T_UINT8, 1)
-#else
-CDAC_GLOBAL(FeatureObjCMarshal, T_UINT8, 0)
 #endif
 #if FEATURE_JAVAMARSHAL
 CDAC_GLOBAL(FeatureJavaMarshal, T_UINT8, 1)
-#else
-CDAC_GLOBAL(FeatureJavaMarshal, T_UINT8, 0)
 #endif
 #ifdef FEATURE_ON_STACK_REPLACEMENT
 CDAC_GLOBAL(FeatureOnStackReplacement, T_UINT8, 1)
-#else
-CDAC_GLOBAL(FeatureOnStackReplacement, T_UINT8, 0)
 #endif // FEATURE_ON_STACK_REPLACEMENT
 #ifdef FEATURE_WEBCIL
 CDAC_GLOBAL(FeatureWebcil, T_UINT8, 1)
-#else
-CDAC_GLOBAL(FeatureWebcil, T_UINT8, 0)
 #endif
 // See Object::GetGCSafeMethodTable
 #ifdef TARGET_64BIT
@@ -1626,8 +1614,6 @@ CDAC_GLOBAL(ObjectToMethodTableUnmask, T_UINT8, 1 | 1 << 1)
 #endif //TARGET_64BIT
 #ifdef FEATURE_PORTABLE_ENTRYPOINTS
 CDAC_GLOBAL(FeaturePortableEntrypoints, T_UINT8, 1)
-#else
-CDAC_GLOBAL(FeaturePortableEntrypoints, T_UINT8, 0)
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 CDAC_GLOBAL(SOSBreakingChangeVersion, T_UINT8, SOS_BREAKING_CHANGE_VERSION)
 CDAC_GLOBAL(RecommendedReaderVersion, T_UINT32, CDAC_RECOMMENDED_READER_VERSION)
@@ -1754,6 +1740,7 @@ CDAC_GLOBAL_CONTRACT(Notifications, c1)
 CDAC_GLOBAL_CONTRACT(ObjectiveCMarshal, c1)
 #endif // FEATURE_OBJCMARSHAL
 CDAC_GLOBAL_CONTRACT(Object, c1)
+CDAC_GLOBAL_CONTRACT(FeatureFlags, c1)
 CDAC_GLOBAL_CONTRACT(PlatformMetadata, c1)
 CDAC_GLOBAL_CONTRACT(PrecodeStubs, c3)
 #ifdef PROFILING_SUPPORTED

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
@@ -54,6 +54,10 @@ public abstract class ContractRegistry
     /// </summary>
     public virtual IPlatformMetadata PlatformMetadata => GetContract<IPlatformMetadata>();
     /// <summary>
+    /// Gets an instance of the FeatureFlags contract for the target.
+    /// </summary>
+    public virtual IFeatureFlags FeatureFlags => GetContract<IFeatureFlags>();
+    /// <summary>
     /// Gets an instance of the PrecodeStubs contract for the target.
     /// </summary>
     public virtual IPrecodeStubs PrecodeStubs => GetContract<IPrecodeStubs>();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IFeatureFlags.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IFeatureFlags.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+/// <summary>
+/// Feature flags that a runtime may or may not support.
+/// </summary>
+public enum RuntimeFeature
+{
+    COMInterop,
+    ComWrappers,
+    ObjCMarshal,
+    JavaMarshal,
+    OnStackReplacement,
+    PortableEntrypoints,
+    Webcil,
+}
+
+public interface IFeatureFlags : IContract
+{
+    static string IContract.Name { get; } = nameof(FeatureFlags);
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the target runtime has the given feature enabled.
+    /// </summary>
+    bool IsEnabled(RuntimeFeature feature) => throw new NotImplementedException();
+}
+
+public readonly struct FeatureFlags : IFeatureFlags { }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IGC.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IGC.cs
@@ -54,9 +54,9 @@ public readonly struct GCHeapData
     public TargetPointer SavedSweepEphemeralSegment { get; init; } /* Only valid in segment GC builds */
     public TargetPointer SavedSweepEphemeralStart { get; init; } /* Only valid in segment GC builds */
 
-    public TargetPointer InternalRootArray { get; init; }
-    public TargetNUInt InternalRootArrayIndex { get; init; }
-    public bool HeapAnalyzeSuccess { get; init; }
+    public TargetPointer? InternalRootArray { get; init; }
+    public TargetNUInt? InternalRootArrayIndex { get; init; }
+    public bool? HeapAnalyzeSuccess { get; init; }
 
     public IReadOnlyList<TargetNUInt> InterestingData { get; init; }
     public IReadOnlyList<TargetNUInt> CompactReasons { get; init; }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.EEJitManager.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.EEJitManager.cs
@@ -106,7 +106,7 @@ internal partial class ExecutionManagerCore<T> : IExecutionManager
             if (!GetRealCodeHeader(rangeSection, codeStart, out Data.RealCodeHeader? realCodeHeader))
                 return TargetPointer.Null;
 
-            bool featureOnStackReplacement = Target.ReadGlobal<byte>(Constants.Globals.FeatureOnStackReplacement) != 0;
+            bool featureOnStackReplacement = Target.Contracts.FeatureFlags.IsEnabled(RuntimeFeature.OnStackReplacement);
             Data.EEJitManager eeJitManager = Target.ProcessedData.GetOrAdd<Data.EEJitManager>(rangeSection.Data.JitManager);
             if (featureOnStackReplacement || eeJitManager.StoreRichDebugInfo)
                 hasFlagByte = true;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
@@ -284,7 +284,7 @@ internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
 
     TargetPointer IExecutionManager.NonVirtualEntry2MethodDesc(TargetCodePointer entrypoint)
     {
-        if (_target.ReadGlobal<byte>(Constants.Globals.FeaturePortableEntrypoints) != 0)
+        if (_target.Contracts.FeatureFlags.IsEnabled(RuntimeFeature.PortableEntrypoints))
         {
             Data.PortableEntryPoint portableEntryPoint = _target.ProcessedData.GetOrAdd<Data.PortableEntryPoint>(entrypoint.AsTargetPointer);
             return portableEntryPoint.MethodDesc;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/FeatureFlags_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/FeatureFlags_1.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+internal readonly struct FeatureFlags_1 : IFeatureFlags
+{
+    private readonly Target _target;
+
+    public FeatureFlags_1(Target target)
+    {
+        _target = target;
+    }
+
+    bool IFeatureFlags.IsEnabled(RuntimeFeature feature)
+    {
+        string? globalName = feature switch
+        {
+            RuntimeFeature.COMInterop => Constants.Globals.FeatureCOMInterop,
+            RuntimeFeature.ComWrappers => Constants.Globals.FeatureComWrappers,
+            RuntimeFeature.ObjCMarshal => Constants.Globals.FeatureObjCMarshal,
+            RuntimeFeature.JavaMarshal => Constants.Globals.FeatureJavaMarshal,
+            RuntimeFeature.OnStackReplacement => Constants.Globals.FeatureOnStackReplacement,
+            RuntimeFeature.PortableEntrypoints => Constants.Globals.FeaturePortableEntrypoints,
+            RuntimeFeature.Webcil => Constants.Globals.FeatureWebcil,
+            _ => null,
+        };
+        return globalName is not null
+            && _target.TryReadGlobal<byte>(globalName, out byte? value)
+            && value != 0;
+    }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GCHeapWKS.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GCHeapWKS.cs
@@ -28,9 +28,12 @@ internal sealed class GCHeapWKS : IGCHeap
 
         OomData = target.ProcessedData.GetOrAdd<Data.OomHistory>(target.ReadGlobalPointer(Constants.Globals.GCHeapOomData));
 
-        InternalRootArray = target.ReadPointer(target.ReadGlobalPointer(Constants.Globals.GCHeapInternalRootArray));
-        InternalRootArrayIndex = target.ReadNUInt(target.ReadGlobalPointer(Constants.Globals.GCHeapInternalRootArrayIndex));
-        HeapAnalyzeSuccess = target.Read<int>(target.ReadGlobalPointer(Constants.Globals.GCHeapHeapAnalyzeSuccess)) != 0;
+        if (target.TryReadGlobalPointer(Constants.Globals.GCHeapInternalRootArray, out TargetPointer? internalRootArrayPtr))
+            InternalRootArray = target.ReadPointer(internalRootArrayPtr.Value);
+        if (target.TryReadGlobalPointer(Constants.Globals.GCHeapInternalRootArrayIndex, out TargetPointer? internalRootArrayIndexPtr))
+            InternalRootArrayIndex = target.ReadNUInt(internalRootArrayIndexPtr.Value);
+        if (target.TryReadGlobalPointer(Constants.Globals.GCHeapHeapAnalyzeSuccess, out TargetPointer? heapAnalyzeSuccessPtr))
+            HeapAnalyzeSuccess = target.Read<int>(heapAnalyzeSuccessPtr.Value) != 0;
 
         InterestingData = target.ReadGlobalPointer(Constants.Globals.GCHeapInterestingData);
         CompactReasons = target.ReadGlobalPointer(Constants.Globals.GCHeapCompactReasons);
@@ -60,9 +63,9 @@ internal sealed class GCHeapWKS : IGCHeap
 
     public Data.OomHistory OomData { get; }
 
-    public TargetPointer InternalRootArray { get; }
-    public TargetNUInt InternalRootArrayIndex { get; }
-    public bool HeapAnalyzeSuccess { get; }
+    public TargetPointer? InternalRootArray { get; }
+    public TargetNUInt? InternalRootArrayIndex { get; }
+    public bool? HeapAnalyzeSuccess { get; }
 
     public TargetPointer InterestingData { get; }
     public TargetPointer CompactReasons { get; }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GC_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GC_1.cs
@@ -549,11 +549,12 @@ internal struct GC_1 : IGC
             HandleType.Dependent,
             HandleType.WeakInteriorPointer
         ];
-        if (_target.ReadGlobal<byte>(Constants.Globals.FeatureCOMInterop) != 0 || _target.ReadGlobal<byte>(Constants.Globals.FeatureComWrappers) != 0 || _target.ReadGlobal<byte>(Constants.Globals.FeatureObjCMarshal) != 0)
+        IFeatureFlags featureFlags = _target.Contracts.FeatureFlags;
+        if (featureFlags.IsEnabled(RuntimeFeature.COMInterop) || featureFlags.IsEnabled(RuntimeFeature.ComWrappers) || featureFlags.IsEnabled(RuntimeFeature.ObjCMarshal))
         {
             supportedTypes.Add(HandleType.RefCounted);
         }
-        if (_target.ReadGlobal<byte>(Constants.Globals.FeatureJavaMarshal) != 0)
+        if (featureFlags.IsEnabled(RuntimeFeature.JavaMarshal))
         {
             supportedTypes.Add(HandleType.CrossReference);
         }
@@ -662,7 +663,7 @@ internal struct GC_1 : IGC
             handleData.Secondary = 0;
         }
 
-        if (_target.ReadGlobal<byte>(Constants.Globals.FeatureCOMInterop) != 0 && IsRefCounted(type))
+        if (_target.Contracts.FeatureFlags.IsEnabled(RuntimeFeature.COMInterop) && IsRefCounted(type))
         {
             IObject obj = _target.Contracts.Object;
             TargetPointer handle = _target.ReadPointer(handleAddress);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/IGCHeap.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/IGCHeap.cs
@@ -20,9 +20,9 @@ internal interface IGCHeap
 
     Data.OomHistory OomData { get; }
 
-    TargetPointer InternalRootArray { get; }
-    TargetNUInt InternalRootArrayIndex { get; }
-    bool HeapAnalyzeSuccess { get; }
+    TargetPointer? InternalRootArray { get; }
+    TargetNUInt? InternalRootArrayIndex { get; }
+    bool? HeapAnalyzeSuccess { get; }
 
     TargetPointer InterestingData { get; }
     TargetPointer CompactReasons { get; }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/CoreCLRContracts.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/CoreCLRContracts.cs
@@ -46,6 +46,8 @@ public static class CoreCLRContracts
 
         registry.Register<IPlatformMetadata>("c1", static t => new PlatformMetadata_1(t));
 
+        registry.Register<IFeatureFlags>("c1", static t => new FeatureFlags_1(t));
+
         registry.Register<IPrecodeStubs>("c1", static t => new PrecodeStubs_1(t));
         registry.Register<IPrecodeStubs>("c2", static t => new PrecodeStubs_2(t));
         registry.Register<IPrecodeStubs>("c3", static t => new PrecodeStubs_3(t));

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/GC/GCHeapSVR.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/GC/GCHeapSVR.cs
@@ -27,9 +27,9 @@ internal sealed partial class GCHeapSVR : IData<GCHeapSVR>, IGCHeap
 
     [Field] public OomHistory OomData { get; }
 
-    [Field] public TargetPointer InternalRootArray { get; }
-    [Field] public TargetNUInt InternalRootArrayIndex { get; }
-    [Field(UnderlyingBoolType = typeof(int))] public bool HeapAnalyzeSuccess { get; }
+    [Field] public TargetPointer? InternalRootArray { get; }
+    [Field] public TargetNUInt? InternalRootArrayIndex { get; }
+    [Field(UnderlyingBoolType = typeof(int))] public bool? HeapAnalyzeSuccess { get; }
 
     [FieldAddress] public TargetPointer InterestingData { get; }
     [FieldAddress] public TargetPointer CompactReasons { get; }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1894,9 +1894,9 @@ public sealed unsafe partial class SOSDacImpl
             GCHeapData heapData = gc.GetHeapData(addr.ToTargetPointer(_target));
 
             data->heapAddr = addr;
-            data->internal_root_array = heapData.InternalRootArray.ToClrDataAddress(_target);
-            data->internal_root_array_index = heapData.InternalRootArrayIndex.Value;
-            data->heap_analyze_success = heapData.HeapAnalyzeSuccess ? (int)Interop.BOOL.TRUE : (int)Interop.BOOL.FALSE;
+            data->internal_root_array = (heapData.InternalRootArray ?? TargetPointer.Null).ToClrDataAddress(_target);
+            data->internal_root_array_index = (heapData.InternalRootArrayIndex ?? default).Value;
+            data->heap_analyze_success = (heapData.HeapAnalyzeSuccess ?? false) ? (int)Interop.BOOL.TRUE : (int)Interop.BOOL.FALSE;
         }
         catch (System.Exception ex)
         {
@@ -1940,9 +1940,9 @@ public sealed unsafe partial class SOSDacImpl
             GCHeapData heapData = gc.GetHeapData();
 
             data->heapAddr = 0; // Not applicable for static data
-            data->internal_root_array = heapData.InternalRootArray.ToClrDataAddress(_target);
-            data->internal_root_array_index = heapData.InternalRootArrayIndex.Value;
-            data->heap_analyze_success = heapData.HeapAnalyzeSuccess ? (int)Interop.BOOL.TRUE : (int)Interop.BOOL.FALSE;
+            data->internal_root_array = (heapData.InternalRootArray ?? TargetPointer.Null).ToClrDataAddress(_target);
+            data->internal_root_array_index = (heapData.InternalRootArrayIndex ?? default).Value;
+            data->heap_analyze_success = (heapData.HeapAnalyzeSuccess ?? false) ? (int)Interop.BOOL.TRUE : (int)Interop.BOOL.FALSE;
         }
         catch (System.Exception ex)
         {
@@ -3376,7 +3376,7 @@ public sealed unsafe partial class SOSDacImpl
             }
 
             // Populate COM data if this is a COM object
-            if (_target.ReadGlobal<byte>(Constants.Globals.FeatureCOMInterop) != 0
+            if (_target.Contracts.FeatureFlags.IsEnabled(Contracts.RuntimeFeature.COMInterop)
                 && objectContract.GetBuiltInComData(objPtr, out TargetPointer rcw, out TargetPointer ccw, out _))
             {
                 data->RCW = rcw & ~(_rcwMask);
@@ -4995,7 +4995,7 @@ public sealed unsafe partial class SOSDacImpl
 
             *inDCOMProxy = (int)Interop.BOOL.FALSE;
 
-            if (_target.ReadGlobal<byte>(Constants.Globals.FeatureCOMInterop) == 0)
+            if (!_target.Contracts.FeatureFlags.IsEnabled(Contracts.RuntimeFeature.COMInterop))
             {
                 hr = HResults.E_NOTIMPL;
             }
@@ -5228,7 +5228,8 @@ public sealed unsafe partial class SOSDacImpl
     int ISOSDacInterface4.GetClrNotification(ClrDataAddress[] arguments, int count, int* pNeeded)
     {
         int hr = HResults.S_OK;
-        uint MaxClrNotificationArgs = _target.ReadGlobal<uint>(Constants.Globals.MaxClrNotificationArgs);
+        _target.TryReadGlobal<uint>(Constants.Globals.MaxClrNotificationArgs, out uint? maxArgs);
+        uint MaxClrNotificationArgs = maxArgs ?? 0;
         try
         {
             *pNeeded = (int)MaxClrNotificationArgs;


### PR DESCRIPTION
## Summary

This PR reduces direct `ReadGlobal` calls for feature flags in the cDAC legacy implementation and adds parity between CoreCLR and NativeAOT data descriptors.

### Changes

**FeatureFlags contract (new)**
- Add `IFeatureFlags` contract with `IsEnabled(RuntimeFeature)` API
- Add `FeatureFlags_1` implementation: a feature is disabled when its global is absent from the descriptor or present with a zero value
- Feature flag globals in CoreCLR's datadescriptor are now only emitted when the feature is enabled (removed `#else` zero-value branches) for datadescriptor size reduction.
- Declare `FeatureFlags c1` in both CoreCLR and NativeAOT datadescriptors

**Legacy impl cleanup**
- Migrate all `ReadGlobal<byte>(Constants.Globals.FeatureX)` calls in `ExecutionManagerCore`, `GC_1`, and `SOSDacImpl` to use `IFeatureFlags.IsEnabled()`
- Make GC heap-analyze globals optional (`InternalRootArray`, `InternalRootArrayIndex`, `HeapAnalyzeSuccess` are now nullable) to gracefully handle builds where they are absent
- `MaxClrNotificationArgs` reads now use `TryReadGlobal` with a zero fallback for runtimes that don't support CLR notifications

**NativeAOT descriptor parity**
- Add `cdac_data<RuntimeInstance>` and `cdac_data<TypeManager>` specializations exposing module-list offsets
- Add `RuntimeInstance` and `TypeManager` type descriptors and `g_pTheRuntimeInstance` global pointer to NativeAOT datadescriptor
- Add `StressLog.ModuleOffset` field to NativeAOT datadescriptor
- Declare NativeAOT contract parity entries: `Loader`, `ExecutionManager`, `SyncBlock`, `CodeVersions`, `ReJIT`, `PrecodeStubs`, `PlatformMetadata`
- Add `FeatureFlags.md` data contract documentation

> [!NOTE]
> This pull request was created with the assistance of GitHub Copilot.
