### PR TITLE
[browser][coreCLR] idempotent lazy download of dll/pdb

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/LazyLoadingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/LazyLoadingTests.cs
@@ -51,6 +51,29 @@ public class LazyLoadingTests : WasmTemplateTestsBase
     }
 
     [Fact]
+    public async Task LoadLazyAssemblyTwiceIsIdempotent()
+    {
+        // Regression test for the lazy loader rewriting an asset's virtualPath in place while
+        // fetching it, which broke the lookup (and dedup) on a subsequent load of the same
+        // assembly - e.g. when Blazor fires OnNavigate more than once - and surfaced as
+        // "<assembly> must be marked with 'BlazorWebAssemblyLazyLoad' item group ...".
+        Configuration config = Configuration.Debug;
+        ProjectInfo info = CopyTestAsset(config, false, TestAsset.WasmBasicTestApp, "LazyLoadingTests");
+        BuildProject(info, config, new BuildOptions(ExtraMSBuildArgs: "-p:TestLazyLoading=true"));
+
+        RunResult result = await RunForBuildWithDotnetRun(new BrowserRunOptions(
+            config,
+            TestScenario: "LazyLoadingTest",
+            BrowserQueryString: new NameValueCollection { { "loadLazyAssemblyTwice", "true" } }
+        ));
+
+        Assert.True(result.TestOutput.Any(m => m.Contains("firstJsonLoad=true")), "The first lazy load should report that it loaded the assembly");
+        Assert.True(result.TestOutput.Any(m => m.Contains("secondJsonLoad=false")), "The second lazy load of the same assembly should be an idempotent no-op");
+        Assert.True(result.TestOutput.Any(m => m.Contains("FirstName")), "The lazy loading test didn't emit expected message with JSON");
+        Assert.False(result.ConsoleOutput.Any(m => m.Contains("must be marked with 'BlazorWebAssemblyLazyLoad'")), "Reloading an already-loaded lazy assembly must not throw the 'must be marked' error");
+    }
+
+    [Fact]
     public async Task FailOnMissingLazyAssembly()
     {
         Configuration config = Configuration.Debug;

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -270,7 +270,15 @@ try {
                         break;
                 }
 
-                await INTERNAL.loadLazyAssembly(`Json${lazyAssemblyExtension}`);
+                const firstJsonLoad = await INTERNAL.loadLazyAssembly(`Json${lazyAssemblyExtension}`);
+                testOutput(`firstJsonLoad=${firstJsonLoad}`);
+                if (params.get("loadLazyAssemblyTwice") === "true") {
+                    // Regression test: loading the same lazy assembly a second time must be an
+                    // idempotent no-op (returns false) and must not throw
+                    // "must be marked with 'BlazorWebAssemblyLazyLoad'".
+                    const secondJsonLoad = await INTERNAL.loadLazyAssembly(`Json${lazyAssemblyExtension}`);
+                    testOutput(`secondJsonLoad=${secondJsonLoad}`);
+                }
                 exports.LazyLoadingTest.Run();
                 await INTERNAL.loadLazyAssembly(`LazyLibrary${lazyAssemblyExtension}`);
                 const { LazyLibrary } = await getAssemblyExports("LazyLibrary");

--- a/src/native/libs/Common/JavaScript/loader/assets.ts
+++ b/src/native/libs/Common/JavaScript/loader/assets.ts
@@ -261,6 +261,10 @@ export async function fetchSatelliteAssemblies(culturesToLoad: string[]): Promis
     await Promise.all(promises);
 }
 
+function lazyAssetFileName(virtualPath: string): string {
+    return virtualPath.substring(virtualPath.lastIndexOf("/") + 1);
+}
+
 export async function fetchLazyAssembly(assemblyNameToLoad: string): Promise<boolean> {
     const lazyAssemblies = loaderConfig.resources?.lazyAssembly;
     if (!lazyAssemblies) {
@@ -273,12 +277,17 @@ export async function fetchLazyAssembly(assemblyNameToLoad: string): Promise<boo
     else if (assemblyNameToLoad.endsWith(".wasm"))
         assemblyNameWithoutExtension = assemblyNameToLoad.substring(0, assemblyNameToLoad.length - 5);
 
+    if (loadedLazyAssemblies.has(assemblyNameWithoutExtension)) {
+        return false;
+    }
+
     const assemblyNameToLoadDll = assemblyNameWithoutExtension + ".dll";
     const assemblyNameToLoadWasm = assemblyNameWithoutExtension + ".wasm";
 
     let dllAsset: AssemblyAsset | null = null;
     for (const asset of lazyAssemblies) {
-        if (asset.virtualPath === assemblyNameToLoadDll || asset.virtualPath === assemblyNameToLoadWasm) {
+        const fileName = lazyAssetFileName(asset.virtualPath);
+        if (fileName === assemblyNameToLoadDll || fileName === assemblyNameToLoadWasm) {
             dllAsset = asset;
             break;
         }
@@ -288,12 +297,8 @@ export async function fetchLazyAssembly(assemblyNameToLoad: string): Promise<boo
         throw new Error(`${assemblyNameToLoad} must be marked with 'BlazorWebAssemblyLazyLoad' item group in your project file to allow lazy-loading.`);
     }
 
-    if (loadedLazyAssemblies.has(dllAsset.virtualPath)) {
-        return false;
-    }
-
     await fetchAssembly(dllAsset);
-    loadedLazyAssemblies.add(dllAsset.virtualPath);
+    loadedLazyAssemblies.add(assemblyNameWithoutExtension);
 
     if (loaderConfig.debugLevel !== 0) {
         const pdbNameToLoad = assemblyNameWithoutExtension + ".pdb";
@@ -301,7 +306,7 @@ export async function fetchLazyAssembly(assemblyNameToLoad: string): Promise<boo
         let pdbAssetToLoad: AssemblyAsset | undefined;
         if (pdbAssets) {
             for (const pdbAsset of pdbAssets) {
-                if (pdbAsset.virtualPath === pdbNameToLoad) {
+                if (lazyAssetFileName(pdbAsset.virtualPath) === pdbNameToLoad) {
                     pdbAssetToLoad = pdbAsset;
                     break;
                 }
@@ -309,7 +314,7 @@ export async function fetchLazyAssembly(assemblyNameToLoad: string): Promise<boo
         }
         if (!pdbAssetToLoad) {
             for (const lazyAsset of lazyAssemblies) {
-                if (lazyAsset.virtualPath === pdbNameToLoad) {
+                if (lazyAssetFileName(lazyAsset.virtualPath) === pdbNameToLoad) {
                     pdbAssetToLoad = lazyAsset as AssemblyAsset;
                     break;
                 }


### PR DESCRIPTION
## Summary

Loading the same lazy assembly more than once (e.g. when Blazor fires `OnNavigate`
repeatedly) incorrectly threw:

```
<assembly> must be marked with 'BlazorWebAssemblyLazyLoad' item group in your project file to allow lazy-loading.
```

even though the assembly *was* correctly marked and had already been loaded once.
This change makes a repeated `loadLazyAssembly` call an idempotent no-op that
returns `false`, and adds a regression test.

## Root cause

The lazy loader matched and de-duplicated assets using the asset's `virtualPath`
field. However, `fetchAssembly` calls `normalizeVirtualPath`, which **mutates
`asset.virtualPath` in place** — it rewrites the `.wasm` extension to `.dll` and
prefixes the path with the app base (and culture). The `lazyAssembly` resources
array holds references to those same asset objects.

As a result, after the first successful load:

1. The asset's `virtualPath` no longer equals the bare `Json.dll` / `Json.wasm`
   name the lookup compared against, so the second call failed to find the asset.
2. The dedup set (`loadedLazyAssemblies`) stored the already-rewritten path, so
   the early-return guard never matched on the second call either.

With the asset "not found," the loader fell through to the
`must be marked with 'BlazorWebAssemblyLazyLoad'` error path.

## Changes

### `src/native/libs/Common/JavaScript/loader/assets.ts`

- Added a small `lazyAssetFileName(virtualPath)` helper that extracts just the
  file name (the segment after the last `/`), so asset matching is robust to the
  in-place normalization that prefixes the path.
- Matching of the DLL/WASM asset and the PDB asset now compares the **file name**
  rather than the full `virtualPath`.
- De-duplication now keys off the stable `assemblyNameWithoutExtension` instead of
  the mutable `virtualPath`, and the dedup check is moved **before** the asset
  lookup so a repeated load short-circuits to `return false` immediately.

### `src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js`

- Captures and reports the boolean result of `loadLazyAssembly` (`firstJsonLoad`).
- When the `loadLazyAssemblyTwice=true` query string is set, loads the same lazy
  assembly a second time and reports `secondJsonLoad`, exercising the idempotent
  path.

### `src/mono/wasm/Wasm.Build.Tests/LazyLoadingTests.cs`

- Added `LoadLazyAssemblyTwiceIsIdempotent`, a regression test that:
  - asserts the first load returns `true`,
  - asserts the second load of the same assembly returns `false` (idempotent no-op),
  - asserts the test still produces its expected JSON output, and
  - asserts the `must be marked with 'BlazorWebAssemblyLazyLoad'` error is **not**
    emitted to the console.

## Testing

Added `LoadLazyAssemblyTwiceIsIdempotent` to `Wasm.Build.Tests`, which reproduces
the failure without the fix and passes with it.
