### PR TITLE
Fix GC hole when method return is hijacked for GC suspension

### DIFF
--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -4562,12 +4562,23 @@ void Thread::HijackThread(ExecutionState *esb X86_ARG(ReturnKind returnKind) X86
     // not being used to branch execution to.
     hijackedReturnAddress = (PCODE)PacStripPtr((void*)hijackedReturnAddress);
 #endif // TARGET_ARM64
+
+    if (IsCallDescrWorkerInternalReturnAddress(hijackedReturnAddress))
+    {
+        return;
+    }
+#if defined(FEATURE_INTERPRETER) || defined(_DEBUG)
     EECodeInfo codeInfo(hijackedReturnAddress);
     if (!codeInfo.IsValid())
     {
+#ifndef FEATURE_INTERPRETER
+        _ASSERTE(!"Unknown managed code callsite");
+#endif
         STRESS_LOG2(LF_SYNC, LL_INFO100, "Thread::HijackThread(%p): Early out - return address %p is not jitted code.\n", this, (void *)hijackedReturnAddress);
         return;
     }
+#endif // FEATURE_INTERPRETER || _DEBUG
+
 #endif // !TARGET_X86
 
     IS_VALID_CODE_PTR((FARPROC) (TADDR)m_pvHJRetAddr);

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -25,6 +25,7 @@
 #if defined(TARGET_ARM64)
 extern "C" void* PacSignPtr(void* ptr, void* sp);
 extern "C" void* PacAuthPtr(void* ptr, void* sp);
+extern "C" void* PacStripPtr(void* ptr);
 #endif // TARGET_ARM64
 
 bool ThreadSuspend::s_fSuspendRuntimeInProgress = false;
@@ -4548,6 +4549,26 @@ void Thread::HijackThread(ExecutionState *esb X86_ARG(ReturnKind returnKind) X86
 #if defined(TARGET_ARM64)
     m_pSpForPacSign = esb->m_pSpForPacSign;
 #endif
+
+#ifndef TARGET_X86
+    // Except for x86, no registers are scanned as part of the HijackFrame on top of the stack.
+    // This still allows scanning of the return value because the registers in question are
+    // scanned as part of the calling method's roots. The problem arises if we are returning to
+    // the interpreter. The return value is not rooted here but also not yet present on the
+    // interpreter frame to have it detected by the GC.
+    PCODE hijackedReturnAddress = (PCODE)(TADDR)m_pvHJRetAddr;
+#if defined(TARGET_ARM64)
+    // We strip the return address here as it's only used for comparison and
+    // not being used to branch execution to.
+    hijackedReturnAddress = (PCODE)PacStripPtr((void*)hijackedReturnAddress);
+#endif // TARGET_ARM64
+    EECodeInfo codeInfo(hijackedReturnAddress);
+    if (!codeInfo.IsValid())
+    {
+        STRESS_LOG2(LF_SYNC, LL_INFO100, "Thread::HijackThread(%p): Early out - return address %p is not jitted code.\n", this, (void *)hijackedReturnAddress);
+        return;
+    }
+#endif // !TARGET_X86
 
     IS_VALID_CODE_PTR((FARPROC) (TADDR)m_pvHJRetAddr);
     // TODO [DAVBR]: For the full fix for VsWhidbey 450273, the below


### PR DESCRIPTION
Some library test suites running in Interp-JIT mixed configuration displayed a high rate of failure. This turned out to be caused by hijacking the return of a JIT frame that was returning into the interpreter. When the return value is hijacked a new explicit HijackFrame is created, however this frame doesn't produce any roots, it just facilitates reaching the calling frame for which we scan the actual GCInfo. This frame will own and scan the value from the return register from the hijacked frame. The problem arises when the calling method is the interpreter. The interpreter calls compiled methods directly and it has no state of the registers. The first operation that the interpreter does with the return value is to store it on the interpreter stack. However, if the return address is hijacked, we don't enter the interpreter to publish the values to the interpreter stack so the values end up not being scanned at all.

As a fix, we disable hijacking if the return address is not jitted code, with the same pattern used in HandleSuspensionForInterruptedThread, which should be signal safe. HijackFrame actually reports some roots from registers on X86, but adding this for all calling convention specifics on other arches seems like overkill.

Looking at the nature of this failure, the question arises whether this is an interpreter only fix. After some additional investigation, it turns out that at least reflection based method invocation via `MethodBaseInvoker.InterpretedInvoke_Method` -> `RuntimeMethodHandle_InvokeMethod` -> `CallDescrWorkerInternal`. Was able to reliably reproduce this by running with `DOTNET_HeapVerify=1` with forced interpreted invoke on the following sample https://gist.github.com/BrzVlad/debbb230b75a26f31c1b8b670e6e0924. Maybe other callsites could run into the same issue.