### PR TITLE
JIT/wasm: more EH related fixes

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -226,6 +226,7 @@ protected:
     void                       ensureCurrentFuncIsUnwindable();
     void                       genEmitIf(WasmValueType blockType = WasmValueType::Invalid);
     void                       genEmitEndIf();
+    void                       genEmitFunctionEnd();
 #endif
 
     void genEmitStartBlock(BasicBlock* block);

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -226,7 +226,7 @@ protected:
     void                       ensureCurrentFuncIsUnwindable();
     void                       genEmitIf(WasmValueType blockType = WasmValueType::Invalid);
     void                       genEmitEndIf();
-    void                       genEmitFunctionEnd();
+    void                       genEmitFunctionEnd(bool emitTerminalUnreachable = true);
 #endif
 
     void genEmitStartBlock(BasicBlock* block);

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -809,6 +809,21 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
 
         case BBJ_THROW:
         {
+#if defined(TARGET_WASM)
+            // Wasm validator needs an `unreachable` after the throw so the
+            // fall-through stack is polymorphic.
+            //
+            GetEmitter()->emitIns(INS_unreachable);
+
+            // At function/funclet end, close open intervals and emit `end`
+            // (we've already emitted the terminating `unreachable` above).
+            //
+            if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+            {
+                genEmitFunctionEnd(/* emitTerminalUnreachable */ false);
+            }
+#else  // !TARGET_WASM
+
             // If we have a throw at the end of a function or funclet, we need to emit another instruction
             // afterwards to help the OS unwinder determine the correct context during unwind.
             // We insert an unexecuted breakpoint instruction in several situations
@@ -840,23 +855,7 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
                     }
                 }
             }
-
-#if defined(TARGET_WASM)
-            // For wasm, every BBJ_THROW must be followed by `unreachable` so the
-            // wasm validator treats the subsequent stack as polymorphic; otherwise
-            // a normal-flow fall-through through this block would fail validation
-            // (the throw helper is a regular call from the validator's perspective).
-            //
-            GetEmitter()->emitIns(INS_unreachable);
-
-            // If this is the last block of the function or funclet, close any
-            // still-open intervals and emit the function-body terminator.
-            //
-            if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
-            {
-                genEmitFunctionEnd();
-            }
-#endif // defined(TARGET_WASM)
+#endif // !TARGET_WASM
 
             break;
         }

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -842,7 +842,14 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
             }
 
 #if defined(TARGET_WASM)
-            // For wasm the last instruction in a function or funclet must be end.
+            // For wasm, every BBJ_THROW must be followed by `unreachable` so the
+            // wasm validator treats the subsequent stack as polymorphic; otherwise
+            // a normal-flow fall-through through this block would fail validation
+            // (the throw helper is a regular call from the validator's perspective).
+            //
+            GetEmitter()->emitIns(INS_unreachable);
+
+            // The last instruction in a wasm function or funclet must be end.
             //
             if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
             {

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -849,11 +849,12 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
             //
             GetEmitter()->emitIns(INS_unreachable);
 
-            // The last instruction in a wasm function or funclet must be end.
+            // If this is the last block of the function or funclet, close any
+            // still-open intervals and emit the function-body terminator.
             //
             if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
             {
-                GetEmitter()->emitIns(INS_end);
+                genEmitFunctionEnd();
             }
 #endif // defined(TARGET_WASM)
 
@@ -916,21 +917,13 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
 #endif // FEATURE_LOOP_ALIGN
 
 #if defined(TARGET_WASM)
-            // The last instruction in a wasm function or funclet must be end.
-            // BBJ_ALWAYS that targets a backedge (e.g., an infinite loop tail) can
-            // be the last block emitted; close any still-open wasm intervals
-            // (loop/block), mark the implicit return as unreachable so it matches
-            // any return type, and emit the function-body terminator.
+            // If this BBJ_ALWAYS is the last block of the function or funclet
+            // (e.g., backedge of an infinite loop), close any still-open
+            // wasm intervals and emit the function-body terminator.
             //
             if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
             {
-                while (!wasmControlFlowStack->Empty())
-                {
-                    GetEmitter()->emitIns(INS_end);
-                    wasmControlFlowStack->Pop();
-                }
-                GetEmitter()->emitIns(INS_unreachable);
-                GetEmitter()->emitIns(INS_end);
+                genEmitFunctionEnd();
             }
 #endif // defined(TARGET_WASM)
 

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -914,6 +914,26 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
 #if FEATURE_LOOP_ALIGN
             SetLoopAlignBackEdge(block, block->GetTarget());
 #endif // FEATURE_LOOP_ALIGN
+
+#if defined(TARGET_WASM)
+            // The last instruction in a wasm function or funclet must be end.
+            // BBJ_ALWAYS that targets a backedge (e.g., an infinite loop tail) can
+            // be the last block emitted; close any still-open wasm intervals
+            // (loop/block), mark the implicit return as unreachable so it matches
+            // any return type, and emit the function-body terminator.
+            //
+            if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+            {
+                while (!wasmControlFlowStack->Empty())
+                {
+                    GetEmitter()->emitIns(INS_end);
+                    wasmControlFlowStack->Pop();
+                }
+                GetEmitter()->emitIns(INS_unreachable);
+                GetEmitter()->emitIns(INS_end);
+            }
+#endif // defined(TARGET_WASM)
+
             break;
 
         case BBJ_COND:

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -571,6 +571,18 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
     //
     while (!wasmControlFlowStack->Empty() && (wasmControlFlowStack->Top()->End() == cursor))
     {
+        WasmInterval* const topInterval = wasmControlFlowStack->Top();
+
+        // The [exnref]-wrapper is only meant to be reached via catch_ref; any
+        // normal-flow fall-through into its `end` would fail to provide the
+        // required [exnref]. Emit `unreachable` right before the wrapper's end
+        // so the fall-through path is polymorphic.
+        //
+        if (topInterval->IsExnRefWrapper())
+        {
+            instGen(INS_unreachable);
+        }
+
         instGen(INS_end);
         WasmInterval* interval = wasmControlFlowStack->Pop();
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -619,16 +619,30 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
                 assert(jTrue->OperIs(GT_WASM_JEXCEPT));
 
                 // try_table uses void result sig; the paired [exnref]-wrapper
-                // just outside it provides the depth-0 target for catch_ref.
+                // provides the catch_ref target. Find its depth on the control
+                // flow stack: any plain Blocks emitted between the wrapper and
+                // this try_table sit inside the wrapper and shift its index.
                 //
                 GetEmitter()->emitIns_Ty_I(INS_try_table, WasmValueType::Invalid, 1);
 
-                // One catch clause targeting the wrapper at depth 0. The true
-                // target of GT_WASM_JEXCEPT is passed only for disasm readability.
+                int const stackHeight  = wasmControlFlowStack->Height();
+                unsigned  wrapperDepth = UINT_MAX;
+                for (int i = 0; i < stackHeight; i++)
+                {
+                    if (wasmControlFlowStack->Top(i)->IsExnRefWrapper())
+                    {
+                        wrapperDepth = (unsigned)i;
+                        break;
+                    }
+                }
+                assert(wrapperDepth != UINT_MAX);
+
+                // One catch clause targeting the wrapper. The true target of
+                // GT_WASM_JEXCEPT is passed only for disasm readability.
                 //
                 assert(block->GetFalseTarget() == block->Next());
                 BasicBlock* const target = block->GetTrueTarget();
-                GetEmitter()->emitIns_J(INS_catch_ref, EA_4BYTE, 0, target);
+                GetEmitter()->emitIns_J(INS_catch_ref, EA_4BYTE, wrapperDepth, target);
             }
             else
             {

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -703,6 +703,49 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
 }
 
 //------------------------------------------------------------------------
+// genEmitFunctionEnd: close any still-open wasm control flow intervals at the
+//   end of a function or funclet and emit the function-body terminator.
+//
+// Notes:
+//   Mirrors the per-interval bookkeeping done by genEmitStartBlock when
+//   popping intervals: Try needs a trailing `unreachable`, ExnRefWrapper
+//   needs a preceding `unreachable` and a trailing `local.set` of the
+//   per-funclet exnref local. After all intervals are closed, an extra
+//   `unreachable` makes the implicit return polymorphic so it matches any
+//   function-return signature, then `end` terminates the function body.
+//
+void CodeGen::genEmitFunctionEnd()
+{
+    while (!wasmControlFlowStack->Empty())
+    {
+        WasmInterval* const topInterval = wasmControlFlowStack->Top();
+
+        if (topInterval->IsExnRefWrapper())
+        {
+            instGen(INS_unreachable);
+        }
+
+        instGen(INS_end);
+        WasmInterval* interval = wasmControlFlowStack->Pop();
+
+        if (interval->IsTry())
+        {
+            instGen(INS_unreachable);
+        }
+
+        if (interval->IsExnRefWrapper())
+        {
+            unsigned const exnRefIdx = m_compiler->funCurrentFunc()->funWasmExnRefLocalIndex;
+            assert(exnRefIdx != UINT_MAX);
+            GetEmitter()->emitIns_I(INS_local_set, EA_PTRSIZE, exnRefIdx);
+        }
+    }
+
+    instGen(INS_unreachable);
+    instGen(INS_end);
+}
+
+//------------------------------------------------------------------------
 // WasmProduceReg: Produce a register and update liveness for an emitted node.
 //
 // Wrapper over "genProduceReg". Does two additional things:

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -703,18 +703,20 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
 }
 
 //------------------------------------------------------------------------
-// genEmitFunctionEnd: close any still-open wasm control flow intervals at the
-//   end of a function or funclet and emit the function-body terminator.
+// genEmitFunctionEnd: close still-open control flow intervals and emit the
+//   function-body terminator.
+//
+// Arguments:
+//   emitTerminalUnreachable - if true, emit `unreachable` before the closing
+//     `end` so the implicit return is polymorphic. Callers that have already
+//     emitted a terminator (e.g. BBJ_THROW) pass false.
 //
 // Notes:
-//   Mirrors the per-interval bookkeeping done by genEmitStartBlock when
-//   popping intervals: Try needs a trailing `unreachable`, ExnRefWrapper
-//   needs a preceding `unreachable` and a trailing `local.set` of the
-//   per-funclet exnref local. After all intervals are closed, an extra
-//   `unreachable` makes the implicit return polymorphic so it matches any
-//   function-return signature, then `end` terminates the function body.
+//   Per-interval bookkeeping mirrors genEmitStartBlock: Try needs a trailing
+//   `unreachable`; ExnRefWrapper needs a preceding `unreachable` and a
+//   trailing `local.set` of the per-funclet exnref local.
 //
-void CodeGen::genEmitFunctionEnd()
+void CodeGen::genEmitFunctionEnd(bool emitTerminalUnreachable)
 {
     while (!wasmControlFlowStack->Empty())
     {
@@ -741,7 +743,10 @@ void CodeGen::genEmitFunctionEnd()
         }
     }
 
-    instGen(INS_unreachable);
+    if (emitTerminalUnreachable)
+    {
+        instGen(INS_unreachable);
+    }
     instGen(INS_end);
 }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2354,6 +2354,11 @@ class FlowGraphTryRegion
     // region to some descendant region.
     jitstd::vector<FlowEdge*> m_entryEdges;
 
+    // In-try blocks that have no flow-graph predecessors. The wasm DFS will not
+    // reach them via normal succs, so they are surfaced as fake successors of
+    // the try entry by FgWasm::VisitWasmSuccs.
+    jitstd::vector<BasicBlock*> m_unreachableBlocks;
+
     bool m_requiresRuntimeResumption;
     bool m_hasSideEntry;
 
@@ -2394,6 +2399,11 @@ public:
     const jitstd::vector<FlowEdge*>& EntryEdges() const
     {
         return m_entryEdges;
+    }
+
+    const jitstd::vector<BasicBlock*>& UnreachableBlocks() const
+    {
+        return m_unreachableBlocks;
     }
 
     // True if resumption from a catch in this or in an enclosed

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2986,7 +2986,12 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             // block (later we can refine this to something like: blocks that have calls
             // or will inspire calls during codegen).
             //
-            if (!block->isEmpty())
+            // Also refresh BBJ_CALLFINALLY blocks: the implicit call_indirect to the
+            // finally funclet is emitted at codegen time and the runtime EH walker
+            // would otherwise see the stale try-region virtualIP and re-dispatch the
+            // same finally during unwind.
+            //
+            if (!block->isEmpty() || block->KindIs(BBJ_CALLFINALLY))
             {
                 updateVirtualIPOnFrame(func, block);
             }

--- a/src/coreclr/jit/fgwasm.h
+++ b/src/coreclr/jit/fgwasm.h
@@ -437,6 +437,30 @@ BasicBlockVisit FgWasm::VisitWasmSuccs(Compiler* comp, BasicBlock* block, TFunc 
         }
     }
 
+    // Inject any unreachable in-try blocks as successors of the try entry, so
+    // wasm DFS visits them and the layout pass keeps them inside the try region.
+    //
+    if (comp->bbIsTryBeg(block))
+    {
+        EHblkDsc* const HBtab = comp->ehGetBlockTryDsc(block);
+
+        for (BasicBlock* const tb : comp->Blocks(HBtab->ebdTryBeg, HBtab->ebdTryLast))
+        {
+            if ((tb == block) || (tb->bbPreds != nullptr))
+            {
+                continue;
+            }
+            // Skip throw helpers (handled above) and blocks not in the same
+            // EH region as the try entry (inner try or different handler).
+            //
+            if (tb->HasFlag(BBF_THROW_HELPER) || !BasicBlock::sameEHRegion(tb, block))
+            {
+                continue;
+            }
+            RETURN_ON_ABORT(func(tb));
+        }
+    }
+
     switch (block->GetKind())
     {
             // Funclet returns have no successors

--- a/src/coreclr/jit/fgwasm.h
+++ b/src/coreclr/jit/fgwasm.h
@@ -440,24 +440,15 @@ BasicBlockVisit FgWasm::VisitWasmSuccs(Compiler* comp, BasicBlock* block, TFunc 
     // Inject any unreachable in-try blocks as successors of the try entry, so
     // wasm DFS visits them and the layout pass keeps them inside the try region.
     //
-    if (comp->bbIsTryBeg(block))
+    if (comp->bbIsTryBeg(block) && (comp->fgTryRegions != nullptr))
     {
-        EHblkDsc* const HBtab = comp->ehGetBlockTryDsc(block);
-
-        for (BasicBlock* const tb : comp->Blocks(HBtab->ebdTryBeg, HBtab->ebdTryLast))
+        FlowGraphTryRegion* const region = comp->fgTryRegions->GetTryRegionByHeader(block);
+        if (region != nullptr)
         {
-            if ((tb == block) || (tb->bbPreds != nullptr))
+            for (BasicBlock* const tb : region->UnreachableBlocks())
             {
-                continue;
+                RETURN_ON_ABORT(func(tb));
             }
-            // Skip throw helpers (handled above) and blocks not in the same
-            // EH region as the try entry (inner try or different handler).
-            //
-            if (tb->HasFlag(BBF_THROW_HELPER) || !BasicBlock::sameEHRegion(tb, block))
-            {
-                continue;
-            }
-            RETURN_ON_ABORT(func(tb));
         }
     }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -7859,13 +7859,15 @@ FlowGraphTryRegions* FlowGraphTryRegions::Build(Compiler* comp, FlowGraphDfsTree
             FlowGraphTryRegion* region = regions->m_tryRegions[dsc->ebdID];
             assert(region != nullptr);
 
-            // Track in-try blocks that won't be reached by the DFS so wasm
-            // codegen can attach them as fake successors of the try entry.
+            // In-try blocks with no flow-graph preds won't be reached by the
+            // DFS; track them so wasm codegen can attach them as fake
+            // successors of the try entry. Their DFS index is meaningless,
+            // so skip the rest of the per-block work.
             //
-            bool isUnreachable = (dfsTree != nullptr) ? !dfsTree->Contains(block) : (block->bbPreds == nullptr);
-            if (isUnreachable && (block != dsc->ebdTryBeg) && !block->HasFlag(BBF_THROW_HELPER))
+            if ((block != dsc->ebdTryBeg) && (block->bbPreds == nullptr) && !block->HasFlag(BBF_THROW_HELPER))
             {
                 region->m_unreachableBlocks.push_back(block);
+                continue;
             }
 
             // A block may be in more than one region, so walk up the ancestor chain

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -7769,6 +7769,7 @@ FlowGraphTryRegion::FlowGraphTryRegion(EHblkDsc* ehDsc, FlowGraphTryRegions* reg
     , m_ehDsc(ehDsc)
     , m_blocks(BitVecOps::UninitVal())
     , m_entryEdges(regions->GetCompiler()->getAllocator(CMK_BasicBlock))
+    , m_unreachableBlocks(regions->GetCompiler()->getAllocator(CMK_BasicBlock))
     , m_requiresRuntimeResumption(false)
     , m_hasSideEntry(false)
 {
@@ -7857,6 +7858,15 @@ FlowGraphTryRegions* FlowGraphTryRegions::Build(Compiler* comp, FlowGraphDfsTree
         {
             FlowGraphTryRegion* region = regions->m_tryRegions[dsc->ebdID];
             assert(region != nullptr);
+
+            // Track in-try blocks that won't be reached by the DFS so wasm
+            // codegen can attach them as fake successors of the try entry.
+            //
+            bool isUnreachable = (dfsTree != nullptr) ? !dfsTree->Contains(block) : (block->bbPreds == nullptr);
+            if (isUnreachable && (block != dsc->ebdTryBeg) && !block->HasFlag(BBF_THROW_HELPER))
+            {
+                region->m_unreachableBlocks.push_back(block);
+            }
 
             // A block may be in more than one region, so walk up the ancestor chain
             // adding the postorder number to each.

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -7859,12 +7859,15 @@ FlowGraphTryRegions* FlowGraphTryRegions::Build(Compiler* comp, FlowGraphDfsTree
             FlowGraphTryRegion* region = regions->m_tryRegions[dsc->ebdID];
             assert(region != nullptr);
 
-            // In-try blocks with no flow-graph preds won't be reached by the
-            // DFS; track them so wasm codegen can attach them as fake
-            // successors of the try entry. Their DFS index is meaningless,
-            // so skip the rest of the per-block work.
+            // In-try blocks that won't be reached by the DFS need to be tracked
+            // so wasm codegen can attach them as fake successors of the try
+            // entry. Use DFS membership when available; otherwise fall back to
+            // pred-less as a conservative heuristic. When truly unreachable,
+            // skip the rest of the per-block work (the block's DFS index is
+            // meaningless and would corrupt the region's bit set).
             //
-            if ((block != dsc->ebdTryBeg) && (block->bbPreds == nullptr) && !block->HasFlag(BBF_THROW_HELPER))
+            bool isUnreachable = (dfsTree != nullptr) ? !dfsTree->Contains(block) : (block->bbPreds == nullptr);
+            if (isUnreachable && (block != dsc->ebdTryBeg) && !block->HasFlag(BBF_THROW_HELPER))
             {
                 region->m_unreachableBlocks.push_back(block);
                 continue;


### PR DESCRIPTION
Fix remaining Pri1 validation errors.

* Inject unreachable in-try blocks as successors of the try entry in VisitWasmSuccs
* Handle methods with return values that never return via appropriate `unreachable`
* Likewise emit `unreachable` in a few more cases where we do not have fall through and might have type mismatches
* Compute depth of the exnref wrapper block rather than assuming it is always at top of stack
* Ensure we emit a VIP when we transition from a try to a callfinally

Fixes #129743.