### PR TITLE
[cDAC] Fix IsSharedByGenericInstantiations for non-shared canonical MTs

### DIFF
--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -326,8 +326,9 @@ internal partial struct RuntimeTypeSystem_1
     internal enum WFLAGS_LOW : uint
     {
         GenericsMask = 0x00000030,
-        GenericsMask_NonGeneric = 0x00000000,   // no instantiation
-        GenericsMask_TypicalInstantiation = 0x00000030,   // the type instantiated at its formal parameters, e.g. List<T>
+        GenericsMask_NonGeneric = 0x00000000,            // no instantiation
+        GenericsMask_SharedInst = 0x00000020,            // shared instantiation, e.g. List<__Canon> or List<MyValueType<__Canon>>
+        GenericsMask_TypicalInstantiation = 0x00000030,  // the type instantiated at its formal parameters, e.g. List<T>
 
         StringArrayValues = GenericsMask_NonGeneric,
     }
@@ -402,6 +403,7 @@ internal partial struct RuntimeTypeSystem_1
         public bool IsDynamicStatics => GetFlag(WFLAGS2_ENUM.DynamicStatics) != 0;
         public bool IsTrackedReferenceWithFinalizer => GetFlag(WFLAGS_HIGH.IsTrackedReferenceWithFinalizer) != 0;
         public bool IsGenericTypeDefinition => TestFlagWithMask(WFLAGS_LOW.GenericsMask, WFLAGS_LOW.GenericsMask_TypicalInstantiation);
+        public bool IsSharedByGenericInstantiations => TestFlagWithMask(WFLAGS_LOW.GenericsMask, WFLAGS_LOW.GenericsMask_SharedInst);
     }
 
     [Flags]
@@ -1837,7 +1839,7 @@ Determining where a shared generic method obtains its generic context:
                 return true;
         }
         MethodTable mt = _methodTables[md.MethodTable];
-        return mt.IsCanonMT && mt.Flags.HasInstantiation;
+        return mt.Flags.IsSharedByGenericInstantiations;
     }
 ```
 

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -3701,7 +3701,7 @@ private:
         // AS YOU ADD NEW FLAGS PLEASE CONSIDER WHETHER Generics::NewInstantiation NEEDS
         // TO BE UPDATED IN ORDER TO ENSURE THAT METHODTABLES DUPLICATED FOR GENERIC INSTANTIATIONS
         // CARRY THE CORECT FLAGS.
-        // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of enum_flag_GenericsMask, enum_flag_GenericsMask_NonGeneric, and enum_flag_GenericsMask_TypicalInst.
+        // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of enum_flag_GenericsMask, enum_flag_GenericsMask_NonGeneric, enum_flag_GenericsMask_SharedInst, and enum_flag_GenericsMask_TypicalInst.
 
         // We are overloading the low 2 bytes of m_dwFlags to be a component size for Strings
         // and Arrays and some set of flags which we can be assured are of a specified state

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -1435,7 +1435,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
         // Check class-level sharing: canonical MethodTable with generic instantiation
         MethodTable mt = GetOrCreateMethodTable(methodDesc);
-        return mt.IsCanonMT && mt.Flags.HasInstantiation;
+        return mt.Flags.IsSharedByGenericInstantiations;
     }
 
     private bool IsAbstract(MethodDesc methodDesc)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodTableFlags_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodTableFlags_1.cs
@@ -22,8 +22,9 @@ internal struct MethodTableFlags_1
     internal enum WFLAGS_LOW : uint
     {
         GenericsMask = 0x00000030,
-        GenericsMask_NonGeneric = 0x00000000,   // no instantiation
-        GenericsMask_TypicalInstantiation = 0x00000030,   // the type instantiated at its formal parameters, e.g. List<T>
+        GenericsMask_NonGeneric = 0x00000000,            // no instantiation
+        GenericsMask_SharedInst = 0x00000020,            // shared instantiation, e.g. List<__Canon> or List<MyValueType<__Canon>>
+        GenericsMask_TypicalInstantiation = 0x00000030,  // the type instantiated at its formal parameters, e.g. List<T>
 
         StringArrayValues =
             GenericsMask_NonGeneric |
@@ -108,6 +109,7 @@ internal struct MethodTableFlags_1
     public bool IsTrackedReferenceWithFinalizer => GetFlag(WFLAGS_HIGH.IsTrackedReferenceWithFinalizer) != 0;
     public bool IsDynamicStatics => GetFlag(WFLAGS2_ENUM.DynamicStatics) != 0;
     public bool IsGenericTypeDefinition => TestFlagWithMask(WFLAGS_LOW.GenericsMask, WFLAGS_LOW.GenericsMask_TypicalInstantiation);
+    public bool IsSharedByGenericInstantiations => TestFlagWithMask(WFLAGS_LOW.GenericsMask, WFLAGS_LOW.GenericsMask_SharedInst);
     public bool ContainsGenericVariables => GetFlag(WFLAGS_HIGH.ContainsGenericVariables) != 0;
 
     internal static EEClassOrCanonMTBits GetEEClassOrCanonMTBits(TargetPointer eeClassOrCanonMTPtr)


### PR DESCRIPTION
The cDAC's `IsSharedByGenericInstantiations` fell back to `IsCanonMT && HasInstantiation`, which is too permissive: a value-type generic instantiation like `ArraySortHelper<int>` is its own canonical MT (value-type instantiations don't share with `__Canon`), so the check returned `true` and `GetGenericContextLoc` reported `InstArgMethodTable` for methods that don't actually need an inst arg.

This mirrors the runtime's `MethodTable::IsSharedByGenericInstantiations` (`methodtable.inl:1044`): `GenericsMask` bits == `enum_flag_GenericsMask_SharedInst`. The cDAC's `MethodTableFlags_1` was missing the `SharedInst` (`0x20`) value of the `GenericsMask` bits; this adds it (the `GenericInst` `0x10` value is not used by the contract so left out per usual cDAC convention) and uses it directly.

Methods now correctly classified (previously reported a spurious `TYPE_PARAM`):
- `ArraySortHelper<int>.cctor()` / `.CreateArraySortHelper()`
- `ArraySortHelper<ulong>.cctor()` / `.CreateArraySortHelper()`
- `ReadOnlySpan<char>.ToString()`
- `Dictionary.CollectionsMarshalHelper.GetValueRefOrAddDefault(...)`

Also updates `docs/design/datacontracts/RuntimeTypeSystem.md` to reflect the new flag value and the simplified implementation, and the `[cDAC] [RuntimeTypeSystem]` dependency comment in `src/coreclr/vm/methodtable.h`.

Surfaced by the cdacstress `ArgIterator` sub-check (`DOTNET_CdacStress=0x201`).

> [!NOTE]
> This PR description was authored with assistance from GitHub Copilot.
