### PR TITLE
Entirely defer to SearchValues in OptimizedInboxTextEncoder

### DIFF
--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/AllowedBmpCodePointsBitmap.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/AllowedBmpCodePointsBitmap.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Unicode;
 
 #if NET
+using System.Buffers;
 using System.Numerics;
 #endif
 
@@ -122,5 +123,48 @@ namespace System.Text.Encodings.Web
             index = value >> 5;
             offset = (int)value & 0x1F;
         }
+
+#if NET
+        /// <summary>
+        /// Creates a <see cref="SearchValues{Char}"/> containing every <see cref="char"/> currently in the allow list.
+        /// </summary>
+        public readonly SearchValues<char> CreateSearchValues()
+        {
+            // Rather than probing all 64K code points individually, scan the bitmap one DWORD at a time and
+            // use a vectorized search to quickly skip over runs of all-disallowed (zero) DWORDs.
+            char[] allowedChars = ArrayPool<char>.Shared.Rent(64 * 1024);
+            int count = 0;
+
+            fixed (uint* pBitmap = Bitmap)
+            {
+                ReadOnlySpan<uint> bitmap = new ReadOnlySpan<uint>(pBitmap, BitmapLengthInDWords);
+
+                int dwordIndex = 0;
+                int next;
+                while ((next = bitmap.IndexOfAnyExcept(0u)) >= 0)
+                {
+                    dwordIndex += next;
+                    bitmap = bitmap.Slice(next);
+
+                    uint dword = bitmap[0];
+                    int charBase = dwordIndex * 32;
+                    do
+                    {
+                        int bit = BitOperations.TrailingZeroCount(dword);
+                        allowedChars[count++] = (char)(charBase + bit);
+                        dword &= dword - 1; // clear the lowest set bit
+                    }
+                    while (dword != 0);
+
+                    dwordIndex++;
+                    bitmap = bitmap.Slice(1);
+                }
+            }
+
+            SearchValues<char> result = SearchValues.Create(allowedChars.AsSpan(0, count));
+            ArrayPool<char>.Shared.Return(allowedChars);
+            return result;
+        }
+#endif
     }
 }

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/OptimizedInboxTextEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/OptimizedInboxTextEncoder.cs
@@ -24,7 +24,7 @@ namespace System.Text.Encodings.Web
 
 #if NET
         private readonly SearchValues<byte> _allowedAsciiBytes;
-        private readonly SearchValues<char> _allowedAsciiChars;
+        private readonly SearchValues<char> _allowedChars;
 #endif
 
         internal unsafe OptimizedInboxTextEncoder(
@@ -70,22 +70,23 @@ namespace System.Text.Encodings.Web
 
 #if NET
             // Create the SearchValues instances for vectorized fast paths.
+            // _allowedAsciiBytes is used by the UTF-8 path, which decodes any non-ASCII bytes manually.
             Span<byte> allowedAsciiBytes = stackalloc byte[128];
-            Span<char> allowedAsciiChars = stackalloc char[128];
             int allowedAsciiCount = 0;
 
             for (int i = 0; i < 128; i++)
             {
                 if (_allowedBmpCodePoints.IsCharAllowed((char)i))
                 {
-                    allowedAsciiBytes[allowedAsciiCount] = (byte)i;
-                    allowedAsciiChars[allowedAsciiCount] = (char)i;
-                    allowedAsciiCount++;
+                    allowedAsciiBytes[allowedAsciiCount++] = (byte)i;
                 }
             }
 
             _allowedAsciiBytes = SearchValues.Create(allowedAsciiBytes.Slice(0, allowedAsciiCount));
-            _allowedAsciiChars = SearchValues.Create(allowedAsciiChars.Slice(0, allowedAsciiCount));
+
+            // _allowedChars covers the entire allowed BMP range. SearchValues.Create picks an implementation
+            // that uses a vectorized ASCII fast-path and a scalar fallback for the rest of the BMP.
+            _allowedChars = _allowedBmpCodePoints.CreateSearchValues();
 #endif
         }
 
@@ -394,61 +395,36 @@ namespace System.Text.Encodings.Web
 
         public int GetIndexOfFirstCharToEncode(ReadOnlySpan<char> data)
         {
-            int asciiCharsSkipped = 0;
-
 #if NET
-            // First, try calling the SIMD-enabled version.
-            // The SIMD-enabled version handles only ASCII characters.
-            if (data.Length >= 8)
-            {
-                asciiCharsSkipped = data.IndexOfAnyExcept(_allowedAsciiChars);
+            return data.IndexOfAnyExcept(_allowedChars);
+#else
+            _AssertThisNotNull(); // hoist "this != null" check out of hot loop below
 
-                if ((uint)asciiCharsSkipped >= (uint)data.Length || char.IsAscii(data[asciiCharsSkipped]))
-                {
-                    // We either processed the whole span (in which case asciiCharsSkipped is -1), or we've found a disallowed ASCII char.
-                    return asciiCharsSkipped;
-                }
+            int idx = 0;
+
+            // unroll the loop 8x
+            while (data.Length >= 8)
+            {
+                if (!_allowedBmpCodePoints.IsCharAllowed(data[0])) { return idx; }
+                if (!_allowedBmpCodePoints.IsCharAllowed(data[1])) { return idx + 1; }
+                if (!_allowedBmpCodePoints.IsCharAllowed(data[2])) { return idx + 2; }
+                if (!_allowedBmpCodePoints.IsCharAllowed(data[3])) { return idx + 3; }
+                if (!_allowedBmpCodePoints.IsCharAllowed(data[4])) { return idx + 4; }
+                if (!_allowedBmpCodePoints.IsCharAllowed(data[5])) { return idx + 5; }
+                if (!_allowedBmpCodePoints.IsCharAllowed(data[6])) { return idx + 6; }
+                if (!_allowedBmpCodePoints.IsCharAllowed(data[7])) { return idx + 7; }
+                idx += 8;
+                data = data.Slice(8);
             }
+
+            foreach (char c in data)
+            {
+                if (!_allowedBmpCodePoints.IsCharAllowed(c)) { return idx; }
+                idx++;
+            }
+
+            return -1;
 #endif
-
-            int idx = asciiCharsSkipped;
-
-            // If there's any leftover data, try consuming it now.
-
-            if ((uint)idx < (uint)data.Length)
-            {
-                _AssertThisNotNull(); // hoist "this != null" check out of hot loop below
-
-                // Slicing keeps the indexed accesses below provably in-bounds, so the JIT
-                // elides the bounds checks just as the previous pointer-based loop did.
-                ReadOnlySpan<char> remaining = data.Slice(idx);
-
-                // unroll the loop 8x
-                while (remaining.Length >= 8)
-                {
-                    if (!_allowedBmpCodePoints.IsCharAllowed(remaining[0])) { goto Return; }
-                    if (!_allowedBmpCodePoints.IsCharAllowed(remaining[1])) { idx += 1; goto Return; }
-                    if (!_allowedBmpCodePoints.IsCharAllowed(remaining[2])) { idx += 2; goto Return; }
-                    if (!_allowedBmpCodePoints.IsCharAllowed(remaining[3])) { idx += 3; goto Return; }
-                    if (!_allowedBmpCodePoints.IsCharAllowed(remaining[4])) { idx += 4; goto Return; }
-                    if (!_allowedBmpCodePoints.IsCharAllowed(remaining[5])) { idx += 5; goto Return; }
-                    if (!_allowedBmpCodePoints.IsCharAllowed(remaining[6])) { idx += 6; goto Return; }
-                    if (!_allowedBmpCodePoints.IsCharAllowed(remaining[7])) { idx += 7; goto Return; }
-                    idx += 8;
-                    remaining = remaining.Slice(8);
-                }
-
-                foreach (char c in remaining)
-                {
-                    if (!_allowedBmpCodePoints.IsCharAllowed(c)) { goto Return; }
-                    idx++;
-                }
-            }
-
-        Return:
-
-            Debug.Assert(0 <= idx && idx <= data.Length);
-            return (idx == data.Length) ? -1 : idx;
         }
 
         /// <summary>


### PR DESCRIPTION
Instead of having the SearchValues just for the ASCII fast path with a manual scalar fallback, let's just defer to SearchValues for the whole input.
For ASCII-only sets of allowed chars, we'll just have one method call that handles everything.
For mixed ASCII and non-ASCII, we'll get the [`ProbabilisticWithAsciiCharSearchValues`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs) implementation that still uses an ASCII fast path, and for `IndexOfAnyExcept` then falls back to a scalar loop with perfect hash lookups.

The fallback logic in the encoder is still there for Framework targets.

The fallback in `ProbabilisticWithAsciiCharSearchValues` doesn't use unrolling as I haven't seen it meaningfully improve things in the past. Let's see what perf looks like