### PR TITLE
Fix ValueType.GetHashCode for nested generic field

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ValueType.cs
@@ -141,6 +141,7 @@ namespace System
 
                     case ValueTypeHashCodeStrategy.ValueTypeOverride:
                         Debug.Assert(fieldMT != null);
+                        Debug.Assert(!fieldMT->IsSharedByGenericInstantiations);
                         // Box the field to handle complicated cases like mutable method and shared generic
                         hashCode.Add(RuntimeHelpers.Box(fieldMT, ref Unsafe.AddByteOffset(ref rawData, fieldOffset))?.GetHashCode() ?? 0);
                         break;

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -1918,8 +1918,11 @@ static ValueTypeHashCodeStrategy GetHashCodeStrategy(MethodTable* mt, QCall::Obj
             else
             {
                 // got another value type. Get the type
-                TypeHandle fieldTH = field->GetFieldTypeHandleThrowing();
+                // The type itself may be generic. We need to get the instantiated
+                // type for the field to properly call its method.
+                TypeHandle fieldTH = field->GetExactFieldType(TypeHandle(mt));
                 _ASSERTE(!fieldTH.IsNull());
+                _ASSERTE(!fieldTH.IsSharedByGenericInstantiations());
                 MethodTable* fieldMT = fieldTH.GetMethodTable();
                 if (CanCompareBitsOrUseFastGetHashCode(fieldMT))
                 {

--- a/src/tests/Regressions/coreclr/GitHub_129692/test129692.cs
+++ b/src/tests/Regressions/coreclr/GitHub_129692/test129692.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+internal struct NestedGenericStruct<T>
+{
+    static readonly object StaticField = new object();
+    public T InstanceField;
+
+    public override int GetHashCode()
+    {
+        Assert.NotNull(StaticField);
+        return -InstanceField!.GetHashCode();
+    }
+}
+
+internal struct OuterGenericStruct<T>
+{
+    public T Nested;
+}
+
+public class Program
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        const string str = "129692";
+        var s = new OuterGenericStruct<NestedGenericStruct<string>>
+        {
+            Nested = new NestedGenericStruct<string>
+            {
+                InstanceField = str
+            }
+        };
+        Assert.Equal(HashCode.Combine(typeof(OuterGenericStruct<NestedGenericStruct<string>>).TypeHandle.Value, -str.GetHashCode()), s.GetHashCode());
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_129692/test129692.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_129692/test129692.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test129692.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #129692.

Note: this is not totally a regression. It's an uncovered case while fixing incorrect behavior in #98754.