### PR TITLE
Narrow Mono AOT typeload error cleanup

### DIFF
--- a/src/mono/mono/mini/iltests.il
+++ b/src/mono/mono/mini/iltests.il
@@ -3224,6 +3224,56 @@ L_3:
     IL_000c:  ret
   }
 
+  .class nested private auto ansi beforefieldinit MissingFieldCarrier`1<T>
+      extends [mscorlib]System.Object
+  {
+    .method public hidebysig specialname rtspecialname instance default void .ctor () cil managed
+    {
+      .maxstack 8
+      ldarg.0
+      call instance void object::.ctor()
+      ret
+    }
+  }
+
+  // After lowering the missing-field access into a runtime throw, AOT must also
+  // consume the recoverable metadata error so the later accepted inline does not
+  // trip inline_method()'s cfg->error assert.
+  .method private hidebysig static void missing_field_then_inline<T> () cil managed
+  {
+    .maxstack 8
+    ldnull
+    ldfld !0 class Tests/MissingFieldCarrier`1<!!0>::missing
+    pop
+    ldc.i4.2
+    call int32 Tests::always_inline(int32)
+    pop
+    ret
+  }
+
+  .method public hidebysig static int32 test_0_missing_field_then_inline () cil managed
+  {
+    .maxstack 8
+    .locals init (int32 V_0)
+    .try
+    {
+      call void class Tests::missing_field_then_inline<string> ()
+      ldc.i4.1
+      stloc.0
+      leave.s IL_0011
+    }
+    catch [mscorlib]System.MissingFieldException
+    {
+      pop
+      ldc.i4.0
+      stloc.0
+      leave.s IL_0011
+    }
+
+    IL_0011: ldloc.0
+    ret
+  }
+
   .method public hidebysig static int32 test_104_conv_u_and_string() cil managed
   {
     .maxstack  8

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -10167,9 +10167,14 @@ calli_end:
 				if (!field || CLASS_HAS_FAILURE (klass)) {
 						HANDLE_TYPELOAD_ERROR (cfg, klass);
 
-						// Reached only in AOT. Cannot turn a token into a class. We silence the compilation error
-						// and generate a runtime exception.
-						if (cfg->error->error_code == MONO_ERROR_BAD_IMAGE)
+						/*
+						 * Reached only in AOT. After lowering the field resolution failure into a runtime
+						 * throw, consume the expected recoverable metadata errors as well. Memberref field
+						 * resolution can report MissingField/BadImage directly through cfg->error without
+						 * setting cfg->exception_type, and leaving one of those live lets an accepted inline
+						 * trip the inline_method () cfg->error assert later on.
+						 */
+						if (cfg->error->error_code == MONO_ERROR_BAD_IMAGE || cfg->error->error_code == MONO_ERROR_MISSING_FIELD)
 							clear_cfg_error (cfg);
 
 						// We need to push a dummy value onto the stack, respecting the intended type.


### PR DESCRIPTION
## Summary
- consume the expected recoverable `MissingField` / `BadImage` metadata errors after lowering Mono AOT field-resolution failures into runtime throw IR
- add a direct Mono mini regression in `src/mono/mono/mini/iltests.il` that covers a generic missing-field access followed by a later accepted inline in the same compiled method

## Testing
- `./build.sh mono -os iossimulator -arch arm64 -c Release -rf mono`
- validated manually against the issue sample / reduced repro by replaying the exact failing AOT compiler command and confirming the fixed compiler succeeds where the regressed compiler asserts in `inline_method()`
- local Mono-style regression validation for `src/mono/mono/mini/iltests.il`:
  - `mono iltests.exe --run-only missing_field_then_inline`
  - `mono --aot=full,static iltests.exe`

This doesn't add a CI runnable test as that would require lot of infra which feels a bit too much for servicing change. (I did try, and hitting this is not simple especially with end-to-end test)

Fixes https://github.com/dotnet/runtime/issues/129613.