### PR TITLE
Add AssemblyLoadContext.SetAssemblyLocationOverride

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -519,7 +519,7 @@ namespace System.Reflection
                 RuntimeAssembly runtimeAssembly = this;
                 GetLocation(new QCallAssembly(ref runtimeAssembly), new StringHandleOnStack(ref location));
 
-                return location!;
+                return AssemblyLoadContext.ResolveAssemblyLocation(this, location!);
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ThunkedApis.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ThunkedApis.cs
@@ -63,7 +63,7 @@ namespace System.Reflection.Runtime.Assemblies
         {
             get
             {
-                return string.Empty;
+                return System.Runtime.Loader.AssemblyLoadContext.ResolveAssemblyLocation(this, string.Empty);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -4053,7 +4053,7 @@
     <value>Use of ResourceManager for custom types is disabled. Set the MSBuild Property CustomResourceTypesSupport to true in order to enable it.</value>
   </data>
   <data name="InvalidOperation_AssemblyLocationOverrideAlreadySet" xml:space="preserve">
-    <value>The assembly location override has already been set and can only be set once.</value>
+    <value>Attempt to update previously set assembly location override.</value>
   </data>
   <data name="InvalidOperation_AssemblyNotEditable" xml:space="preserve">
     <value>The assembly can not be edited or changed.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -4052,6 +4052,9 @@
   <data name="ResourceManager_ReflectionNotAllowed" xml:space="preserve">
     <value>Use of ResourceManager for custom types is disabled. Set the MSBuild Property CustomResourceTypesSupport to true in order to enable it.</value>
   </data>
+  <data name="InvalidOperation_AssemblyLocationOverrideAlreadySet" xml:space="preserve">
+    <value>The assembly location override has already been set and can only be set once.</value>
+  </data>
   <data name="InvalidOperation_AssemblyNotEditable" xml:space="preserve">
     <value>The assembly can not be edited or changed.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -4053,7 +4053,7 @@
     <value>Use of ResourceManager for custom types is disabled. Set the MSBuild Property CustomResourceTypesSupport to true in order to enable it.</value>
   </data>
   <data name="InvalidOperation_AssemblyLocationOverrideAlreadySet" xml:space="preserve">
-    <value>Attempt to update previously set assembly location override.</value>
+    <value>The assembly location override has already been set.</value>
   </data>
   <data name="InvalidOperation_AssemblyNotEditable" xml:space="preserve">
     <value>The assembly can not be edited or changed.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -315,7 +315,10 @@ namespace System.Runtime.Loader
         /// <summary>
         /// Sets a process-wide callback that overrides the value returned by <see cref="Assembly.Location"/>.
         /// </summary>
-        /// <remarks>The callback can only be set once for the lifetime of the process.</remarks>
+        /// <remarks>
+        /// The callback can only be set once for the lifetime of the process. The callback should not
+        /// call <see cref="Assembly.Location"/> on the provided assembly to avoid recursion.
+        /// </remarks>
         /// <param name="locationOverride">
         /// A callback that receives an <see cref="Assembly"/> and the location the runtime computed for it, and
         /// returns the value that <see cref="Assembly.Location"/> should report.
@@ -342,7 +345,8 @@ namespace System.Runtime.Loader
                 return originalLocation;
             }
 
-            return locationOverride(assembly, originalLocation);
+            // A callback that returns null falls back to the original location, since Assembly.Location is non-nullable.
+            return locationOverride(assembly, originalLocation) ?? originalLocation;
         }
 
         // Custom AssemblyLoadContext implementations can override this

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -309,6 +309,43 @@ namespace System.Runtime.Loader
             return AssemblyName.GetAssemblyName(assemblyPath);
         }
 
+        // Callback that, when set, can override the value returned by Assembly.Location.
+        private static Func<Assembly, string, string>? s_assemblyLocationOverride;
+
+        /// <summary>
+        /// Sets a process-wide callback that overrides the value returned by <see cref="Assembly.Location"/>.
+        /// </summary>
+        /// <remarks>The callback can only be set once for the lifetime of the process.</remarks>
+        /// <param name="locationOverride">
+        /// A callback that receives an <see cref="Assembly"/> and the location the runtime computed for it, and
+        /// returns the value that <see cref="Assembly.Location"/> should report.
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="locationOverride"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException">The location override has already been set.</exception>
+        public static void SetAssemblyLocationOverride(Func<Assembly, string, string> locationOverride)
+        {
+            ArgumentNullException.ThrowIfNull(locationOverride);
+
+            if (Interlocked.CompareExchange(ref s_assemblyLocationOverride, locationOverride, null) is not null)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_AssemblyLocationOverrideAlreadySet);
+            }
+        }
+
+        // Applies the location override callback (if any) to the location the runtime computed for the assembly.
+        // Called from each runtime's RuntimeAssembly.Location implementation.
+        internal static string ResolveAssemblyLocation(Assembly assembly, string originalLocation)
+        {
+            Func<Assembly, string, string>? locationOverride = s_assemblyLocationOverride;
+            if (locationOverride is null)
+            {
+                return originalLocation;
+            }
+
+            // A callback that returns null falls back to the original location, since Assembly.Location is non-nullable.
+            return locationOverride(assembly, originalLocation) ?? originalLocation;
+        }
+
         // Custom AssemblyLoadContext implementations can override this
         // method to perform custom processing and use one of the protected
         // helpers above to load the assembly.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -342,8 +342,7 @@ namespace System.Runtime.Loader
                 return originalLocation;
             }
 
-            // A callback that returns null falls back to the original location, since Assembly.Location is non-nullable.
-            return locationOverride(assembly, originalLocation) ?? originalLocation;
+            return locationOverride(assembly, originalLocation);
         }
 
         // Custom AssemblyLoadContext implementations can override this

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -345,8 +345,7 @@ namespace System.Runtime.Loader
                 return originalLocation;
             }
 
-            // A callback that returns null falls back to the original location, since Assembly.Location is non-nullable.
-            return locationOverride(assembly, originalLocation) ?? originalLocation;
+            return locationOverride(assembly, originalLocation);
         }
 
         // Custom AssemblyLoadContext implementations can override this

--- a/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.cs
+++ b/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.cs
@@ -87,6 +87,7 @@ namespace System.Runtime.Loader
         public System.Reflection.Assembly LoadFromStream(System.IO.Stream assembly, System.IO.Stream? assemblySymbols) { throw null; }
         protected virtual System.IntPtr LoadUnmanagedDll(string unmanagedDllName) { throw null; }
         protected System.IntPtr LoadUnmanagedDllFromPath(string unmanagedDllPath) { throw null; }
+        public static void SetAssemblyLocationOverride(System.Func<System.Reflection.Assembly, string, string> locationOverride) { }
         public void SetProfileOptimizationRoot(string directoryPath) { }
         public void StartProfileOptimization(string? profile) { }
         public override string ToString() { throw null; }

--- a/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -418,6 +418,63 @@ namespace System.Runtime.Loader.Tests
             }).Dispose();
         }
 
+        [Fact]
+        public static void SetAssemblyLocationOverride_NullArgument_Throws()
+        {
+            // The null check happens before any global state is mutated, so this is safe to run in-process.
+            AssertExtensions.Throws<ArgumentNullException>("locationOverride", () => AssemblyLoadContext.SetAssemblyLocationOverride(null));
+        }
+
+        [ConditionalFact(typeof(AssemblyLoadContextTest), nameof(IsRemoteExecutorSupportedAndAssemblyLoadingSupported))]
+        public static void SetAssemblyLocationOverride_OverridesLocationForStreamLoadedAssembly()
+        {
+            // The override is process-wide and set-once, so it must run in its own process.
+            RemoteExecutor.Invoke(static () =>
+            {
+                // Override the location only for assemblies the runtime reports no location for (e.g. loaded
+                // from a stream / memory). Embed the assembly name so we also verify the Assembly argument.
+                AssemblyLoadContext.SetAssemblyLocationOverride(
+                    static (assembly, location) => string.IsNullOrEmpty(location) ? $"/overridden/{assembly.GetName().Name}.dll" : location);
+
+                string asmPath = ExtractEmbeddedAssembly("System.Runtime.Loader.Tests.AssemblyVersion1");
+                try
+                {
+                    // Loading from a stream means the runtime has no location, so the override kicks in.
+                    var streamAlc = new AssemblyLoadContext("LocationOverride_Stream", isCollectible: true);
+                    Assembly streamLoaded;
+                    using (FileStream fs = File.OpenRead(asmPath))
+                    {
+                        streamLoaded = streamAlc.LoadFromStream(fs);
+                    }
+                    Assert.Equal($"/overridden/{streamLoaded.GetName().Name}.dll", streamLoaded.Location);
+
+                    // The same assembly loaded from a path (into a separate context) has a real location,
+                    // so the callback leaves it untouched.
+                    var pathAlc = new AssemblyLoadContext("LocationOverride_Path", isCollectible: true);
+                    Assembly fileLoaded = pathAlc.LoadFromAssemblyPath(asmPath);
+                    Assert.False(string.IsNullOrEmpty(fileLoaded.Location));
+                    Assert.DoesNotContain("/overridden/", fileLoaded.Location);
+                }
+                finally
+                {
+                    try { File.Delete(asmPath); } catch { }
+                }
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(AssemblyLoadContextTest), nameof(IsRemoteExecutorSupportedAndAssemblyLoadingSupported))]
+        public static void SetAssemblyLocationOverride_CalledTwice_Throws()
+        {
+            RemoteExecutor.Invoke(static () =>
+            {
+                AssemblyLoadContext.SetAssemblyLocationOverride(static (assembly, location) => location);
+                Assert.Throws<InvalidOperationException>(
+                    () => AssemblyLoadContext.SetAssemblyLocationOverride(static (assembly, location) => location));
+            }).Dispose();
+        }
+
+        private static bool IsRemoteExecutorSupportedAndAssemblyLoadingSupported => RemoteExecutor.IsSupported && PlatformDetection.IsAssemblyLoadingSupported;
+
         private static bool IsRemoteExecutorSupportedAndCoreCLR => RemoteExecutor.IsSupported && PlatformDetection.IsAssemblyLoadingSupported && PlatformDetection.IsCoreCLR;
 
         private static string ExtractEmbeddedAssembly(string name)

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -131,7 +131,7 @@ namespace System.Reflection
 
         public override string ImageRuntimeVersion => GetInfo(AssemblyInfoKind.ImageRuntimeVersion)!;
 
-        public override string Location => GetInfo(AssemblyInfoKind.Location)!;
+        public override string Location => AssemblyLoadContext.ResolveAssemblyLocation(this, GetInfo(AssemblyInfoKind.Location)!);
 
         // TODO: consider a dedicated icall instead
         public override bool IsCollectible => AssemblyLoadContext.GetLoadContext((Assembly)this)!.IsCollectible;


### PR DESCRIPTION
Adds a static, set-once callback that overrides the value returned by Assembly.Location. The callback is stored in the shared AssemblyLoadContext and applied by RuntimeAssembly.Location on CoreCLR, Mono, and NativeAOT.

Updates the System.Runtime.Loader reference assembly and adds tests covering the override, the set-once guard, and null handling.

Fix #127097