### PR TITLE
Use `Process.RunAndCaptureText` in src/tests child-process helpers

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/CoreclrTestWrapperLib.cs
@@ -215,12 +215,10 @@ namespace TestLibrary
                 // attempt to use pgrep then
                 var pgrepInfo = new ProcessStartInfo("pgrep");
                 pgrepInfo.RedirectStandardOutput = true;
+                pgrepInfo.RedirectStandardError = true;
                 pgrepInfo.Arguments = $"-P {process.Id}";
 
-                using Process pgrep = Process.Start(pgrepInfo)!;
-
-                string[] pidStrings = pgrep.StandardOutput.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
-                pgrep.WaitForExit();
+                string[] pidStrings = Process.RunAndCaptureText(pgrepInfo).StandardOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
                 childPids = new List<int>();
                 foreach (var pidString in pidStrings)
@@ -568,12 +566,11 @@ namespace TestLibrary
             process.StartInfo.FileName = "cmd.exe";
             process.StartInfo.Arguments = $"/c {command}";
             process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
             process.StartInfo.CreateNoWindow = true;
 
             // Start the process and read the output
-            process.Start();
-            string output = process.StandardOutput.ReadToEnd();
-            process.WaitForExit(100); // wait for 100 ms
+            string output = Process.RunAndCaptureText(process.StartInfo).StandardOutput;
 
             // Output the result
             return output;

--- a/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
+++ b/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
@@ -552,8 +552,12 @@ public class XUnitLogChecker
         };
 
         outputWriter.WriteLine($"Invoking: {startInfo.FileName} {startInfo.Arguments}");
-        ProcessTextOutput result = Process.RunAndCaptureText(startInfo, TimeSpan.FromMilliseconds(DEFAULT_TIMEOUT_MS));
-        if (result.ExitStatus.Canceled)
+        ProcessTextOutput result;
+        try
+        {
+            result = Process.RunAndCaptureText(startInfo, TimeSpan.FromMilliseconds(DEFAULT_TIMEOUT_MS));
+        }
+        catch (TimeoutException)
         {
             outputWriter.WriteLine($"Timedout: '{fileName} {arguments}");
             return false;

--- a/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
+++ b/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
@@ -542,33 +542,25 @@ public class XUnitLogChecker
 
     static bool RunProcess(string fileName, string arguments, TextWriter outputWriter)
     {
-        Process proc = new Process()
+        ProcessStartInfo startInfo = new ProcessStartInfo()
         {
-            StartInfo = new ProcessStartInfo()
-            {
-                FileName = fileName,
-                Arguments = arguments,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-            }
+            FileName = fileName,
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
         };
 
-        outputWriter.WriteLine($"Invoking: {proc.StartInfo.FileName} {proc.StartInfo.Arguments}");
-        proc.Start();
-
-        Task<string> stdOut = proc.StandardOutput.ReadToEndAsync();
-        Task<string> stdErr = proc.StandardError.ReadToEndAsync();
-        if (!proc.WaitForExit(DEFAULT_TIMEOUT_MS))
+        outputWriter.WriteLine($"Invoking: {startInfo.FileName} {startInfo.Arguments}");
+        ProcessTextOutput result = Process.RunAndCaptureText(startInfo, TimeSpan.FromMilliseconds(DEFAULT_TIMEOUT_MS));
+        if (result.ExitStatus.Canceled)
         {
-            proc.Kill(true);
             outputWriter.WriteLine($"Timedout: '{fileName} {arguments}");
             return false;
         }
 
-        Task.WaitAll(stdOut, stdErr);
-        string output = stdOut.Result;
-        string error = stdErr.Result;
+        string output = result.StandardOutput;
+        string error = result.StandardError;
         if (!string.IsNullOrWhiteSpace(output))
         {
             outputWriter.WriteLine($"stdout: {output}");

--- a/src/tests/GC/LargeMemory/memcheck.cs
+++ b/src/tests/GC/LargeMemory/memcheck.cs
@@ -94,13 +94,10 @@ public static class MemCheck {
         ProcessStartInfo startInfo = new ProcessStartInfo(name) {
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
+            RedirectStandardError = true,
             CreateNoWindow = true,
             UseShellExecute = false,
         };
-        using (Process cmd = new Process() { StartInfo = startInfo }) {
-            cmd.Start();
-            cmd.WaitForExit();
-            return cmd.StandardOutput.ReadToEnd();
-        }
+        return Process.RunAndCaptureText(startInfo).StandardOutput;
     }
 }

--- a/src/tests/GC/Stress/Framework/RFLogging.cs
+++ b/src/tests/GC/Stress/Framework/RFLogging.cs
@@ -384,15 +384,12 @@ internal class RFLogging
                     psi.UseShellExecute = false;
                     psi.RedirectStandardOutput = true;
 
-                    Process p = Process.Start(psi);
-                    p.StandardOutput.ReadToEnd();
-                    p.WaitForExit();
-                    if (p.ExitCode != 0)
+                    ProcessTextOutput result = Process.RunAndCaptureText(psi);
+                    if (result.ExitStatus.ExitCode != 0)
                     {
-                        string msg = String.Format("cscript.exe " + Environment.ExpandEnvironmentVariables("//b //nologo %SCRIPTSDIR%\\record.js -i %STRESSID% -a UPDATE_RECORD -s RUNNING\r\nWARNING: Status update did not return success!"), p.ExitCode);
+                        string msg = String.Format("cscript.exe " + Environment.ExpandEnvironmentVariables("//b //nologo %SCRIPTSDIR%\\record.js -i %STRESSID% -a UPDATE_RECORD -s RUNNING\r\nWARNING: Status update did not return success!"), result.ExitStatus.ExitCode);
                         WriteToInstrumentationLog(null, LoggingLevels.UrtFrameworks, msg);
                     }
-                    p.Dispose();
                 }
                 else if (!_noStatusWarningDisplayed)
                 {

--- a/src/tests/GC/Stress/Framework/RFLogging.cs
+++ b/src/tests/GC/Stress/Framework/RFLogging.cs
@@ -383,11 +383,12 @@ internal class RFLogging
                     ProcessStartInfo psi = new ProcessStartInfo("cscript.exe", Environment.ExpandEnvironmentVariables("//b //nologo %SCRIPTSDIR%\\record.js -i %STRESSID% -a UPDATE_RECORD -s RUNNING"));
                     psi.UseShellExecute = false;
                     psi.RedirectStandardOutput = true;
+                    psi.RedirectStandardError = true;
 
                     ProcessTextOutput result = Process.RunAndCaptureText(psi);
                     if (result.ExitStatus.ExitCode != 0)
                     {
-                        string msg = String.Format("cscript.exe " + Environment.ExpandEnvironmentVariables("//b //nologo %SCRIPTSDIR%\\record.js -i %STRESSID% -a UPDATE_RECORD -s RUNNING\r\nWARNING: Status update did not return success!"), result.ExitStatus.ExitCode);
+                        string msg = String.Format("cscript.exe " + Environment.ExpandEnvironmentVariables("//b //nologo %SCRIPTSDIR%\\record.js -i %STRESSID% -a UPDATE_RECORD -s RUNNING\r\nWARNING: Status update did not return success!") + " ExitCode={0}", result.ExitStatus.ExitCode);
                         WriteToInstrumentationLog(null, LoggingLevels.UrtFrameworks, msg);
                     }
                 }

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -1747,15 +1747,12 @@ Thanks for contributing to CLR Stress!
                 psi.UseShellExecute = false;
                 psi.RedirectStandardOutput = true;
 
-                Process p = Process.Start(psi);
-                p.StandardOutput.ReadToEnd();
-                p.WaitForExit();
-                if (p.ExitCode != 0)
+                ProcessTextOutput result = Process.RunAndCaptureText(psi);
+                if (result.ExitStatus.ExitCode != 0)
                 {
                     Console.WriteLine("cscript.exe " + Environment.ExpandEnvironmentVariables("//b //nologo %SCRIPTSDIR%\\record.js -i %STRESSID% -a UPDATE_RECORD -s RUNNING"));
-                    Console.WriteLine("WARNING: Status update did not return success! {0}", p.ExitCode);
+                    Console.WriteLine("WARNING: Status update did not return success! {0}", result.ExitStatus.ExitCode);
                 }
-                p.Dispose();
             }
             else
             {

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -1746,6 +1746,7 @@ Thanks for contributing to CLR Stress!
                 ProcessStartInfo psi = new ProcessStartInfo("cscript.exe", Environment.ExpandEnvironmentVariables(arguments));
                 psi.UseShellExecute = false;
                 psi.RedirectStandardOutput = true;
+                psi.RedirectStandardError = true;
 
                 ProcessTextOutput result = Process.RunAndCaptureText(psi);
                 if (result.ExitStatus.ExitCode != 0)

--- a/src/tests/Loader/PlatformNativeR2R/PlatformNativeR2R.cs
+++ b/src/tests/Loader/PlatformNativeR2R/PlatformNativeR2R.cs
@@ -30,22 +30,18 @@ public class PlatformNativeR2R
             RedirectStandardError = true
         };
 
-        using (Process process = Process.Start(psi))
+        ProcessTextOutput result = Process.RunAndCaptureText(psi);
+
+        string output = result.StandardOutput;
+        if (result.ExitStatus.ExitCode != 0)
         {
-            process.WaitForExit();
-
-            string output = process.StandardOutput.ReadToEnd();
-            if (process.ExitCode != 0)
-            {
-                string stderr = process.StandardError.ReadToEnd();
-                Console.WriteLine($"R2RDump failed with exit code {process.ExitCode}");
-                Console.WriteLine($"stdout: {output}");
-                Console.WriteLine($"stderr: {stderr}");
-                Assert.Fail("R2RDump failed to execute");
-            }
-
-            Assert.True(output.Contains("READYTORUN_FLAG_Component"), "Component assembly should be associated with a platform-native composite image");
-            Assert.True(output.Contains("READYTORUN_FLAG_PlatformNativeImage"), "Component assembly should be associated with a platform-native composite image");
+            Console.WriteLine($"R2RDump failed with exit code {result.ExitStatus.ExitCode}");
+            Console.WriteLine($"stdout: {output}");
+            Console.WriteLine($"stderr: {result.StandardError}");
+            Assert.Fail("R2RDump failed to execute");
         }
+
+        Assert.True(output.Contains("READYTORUN_FLAG_Component"), "Component assembly should be associated with a platform-native composite image");
+        Assert.True(output.Contains("READYTORUN_FLAG_PlatformNativeImage"), "Component assembly should be associated with a platform-native composite image");
     }
 }

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.cs
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.cs
@@ -198,18 +198,10 @@ namespace BinderTracingTests
             };
 
             Console.WriteLine($"[{DateTime.Now:T}] Launching process for {method.Name}...");
-            using (Process p = Process.Start(startInfo))
-            {
-                Console.WriteLine($"Started subprocess '{subprocessName}' with PID {p.Id} for {method.Name}...");
-                p.OutputDataReceived += (_, args) => Console.WriteLine(args.Data);
-                p.BeginOutputReadLine();
-
-                p.ErrorDataReceived += (_, args) => Console.Error.WriteLine(args.Data);
-                p.BeginErrorReadLine();
-
-                p.WaitForExit();
-                return p.ExitCode == 100;
-            }
+            ProcessTextOutput result = Process.RunAndCaptureText(startInfo);
+            Console.Write(result.StandardOutput);
+            Console.Error.Write(result.StandardError);
+            return result.ExitStatus.ExitCode == 100;
         }
 
         private static void ValidateSingleBind(BinderEventListener listener, AssemblyName assemblyName, BindOperation expected)

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.cs
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.cs
@@ -192,16 +192,12 @@ namespace BinderTracingTests
             string subprocessName = Process.GetCurrentProcess().MainModule.FileName;
             var startInfo = new ProcessStartInfo(subprocessName, new[] { Assembly.GetExecutingAssembly().Location, method.Name })
             {
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
+                UseShellExecute = false
             };
 
             Console.WriteLine($"[{DateTime.Now:T}] Launching process for {method.Name}...");
-            ProcessTextOutput result = Process.RunAndCaptureText(startInfo);
-            Console.Write(result.StandardOutput);
-            Console.Error.Write(result.StandardError);
-            return result.ExitStatus.ExitCode == 100;
+            ProcessExitStatus result = Process.Run(startInfo);
+            return result.ExitCode == 100;
         }
 
         private static void ValidateSingleBind(BinderEventListener listener, AssemblyName assemblyName, BindOperation expected)

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -16,43 +16,39 @@ namespace TestStackOverflow
         static void TestStackOverflow(string testName, string testArgs, out List<string> stderrLines)
         {
             Console.WriteLine($"Running {testName} test({testArgs})");
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
+            startInfo.Arguments = $"{Path.Combine(Directory.GetCurrentDirectory(), "..", testName, $"{testName}.dll")} {testArgs}";
+            startInfo.UseShellExecute = false;
+            startInfo.RedirectStandardError = true;
+            startInfo.Environment.Add("DOTNET_DbgEnableMiniDump", "0");
+            startInfo.Environment.Add("DOTNET_LogStackOverflowExit", "1");
+
+            ProcessTextOutput result = Process.RunAndCaptureText(startInfo);
+
             List<string> lines = new List<string>();
-
-            Process testProcess = new Process();
-
-            testProcess.StartInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
-            testProcess.StartInfo.Arguments = $"{Path.Combine(Directory.GetCurrentDirectory(), "..", testName, $"{testName}.dll")} {testArgs}";
-            testProcess.StartInfo.UseShellExecute = false;
-            testProcess.StartInfo.RedirectStandardError = true;
-            testProcess.StartInfo.Environment.Add("DOTNET_DbgEnableMiniDump", "0");
-            testProcess.StartInfo.Environment.Add("DOTNET_LogStackOverflowExit", "1");
             bool endOfStackTrace = false;
-            
-            testProcess.ErrorDataReceived += (sender, line) => 
+            foreach (string rawLine in result.StandardError.Split('\n'))
             {
-                Console.WriteLine($"\"{line.Data}\"");
-                if (!endOfStackTrace && !string.IsNullOrEmpty(line.Data))
+                string data = rawLine.TrimEnd('\r');
+                Console.WriteLine($"\"{data}\"");
+                if (!endOfStackTrace && !string.IsNullOrEmpty(data))
                 {
                     // Store lines only till the end of the stack trace.
                     // In the CI it can also contain lines with createdump info.
-                    if (line.Data.StartsWith("Stack overflow.") ||
-                        line.Data.StartsWith("Repeated ") ||
-                        line.Data.StartsWith("------") ||
-                        line.Data.StartsWith("   at "))
+                    if (data.StartsWith("Stack overflow.") ||
+                        data.StartsWith("Repeated ") ||
+                        data.StartsWith("------") ||
+                        data.StartsWith("   at "))
                     {
-                        lines.Add(line.Data);
+                        lines.Add(data);
                     }
-                    else if (!line.Data.StartsWith("@"))
+                    else if (!data.StartsWith("@"))
                     {
                         endOfStackTrace = true;
                     }
                 }
-            };
-
-            testProcess.Start();
-            testProcess.BeginErrorReadLine();
-            testProcess.WaitForExit();
-            testProcess.CancelErrorRead();
+            }
 
             stderrLines = lines;
 
@@ -66,7 +62,7 @@ namespace TestStackOverflow
                 expectedExitCodes = new int[] { unchecked((int)0xC00000FD), unchecked((int)0x800703E9) };
             }
 
-            if (!Array.Exists(expectedExitCodes, code => testProcess.ExitCode == code))
+            if (!Array.Exists(expectedExitCodes, code => result.ExitStatus.ExitCode == code))
             {
                 string separator = string.Empty;
                 StringBuilder expectedListBuilder = new StringBuilder();
@@ -74,7 +70,7 @@ namespace TestStackOverflow
                     expectedListBuilder.Append($"{separator}0x{code:X8}");
                     separator = " or ";
                 });
-                throw new Exception($"Exit code: 0x{testProcess.ExitCode:X8}, expected {expectedListBuilder.ToString()}");
+                throw new Exception($"Exit code: 0x{result.ExitStatus.ExitCode:X8}, expected {expectedListBuilder.ToString()}");
             }
 
             if (lines[0] != "Stack overflow.")

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -20,6 +20,7 @@ namespace TestStackOverflow
             startInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
             startInfo.Arguments = $"{Path.Combine(Directory.GetCurrentDirectory(), "..", testName, $"{testName}.dll")} {testArgs}";
             startInfo.UseShellExecute = false;
+            startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
             startInfo.Environment.Add("DOTNET_DbgEnableMiniDump", "0");
             startInfo.Environment.Add("DOTNET_LogStackOverflowExit", "1");

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -25,13 +25,18 @@ namespace TestStackOverflow
             startInfo.Environment.Add("DOTNET_DbgEnableMiniDump", "0");
             startInfo.Environment.Add("DOTNET_LogStackOverflowExit", "1");
 
-            ProcessTextOutput result = Process.RunAndCaptureText(startInfo);
+            using Process testProcess = Process.Start(startInfo);
 
             List<string> lines = new List<string>();
             bool endOfStackTrace = false;
-            foreach (string rawLine in result.StandardError.Split('\n'))
+            foreach (ProcessOutputLine line in testProcess.ReadAllLines())
             {
-                string data = rawLine.TrimEnd('\r');
+                if (!line.StandardError)
+                {
+                    continue;
+                }
+
+                string data = line.Content;
                 Console.WriteLine($"\"{data}\"");
                 if (!endOfStackTrace && !string.IsNullOrEmpty(data))
                 {
@@ -51,6 +56,9 @@ namespace TestStackOverflow
                 }
             }
 
+            // A process can close its std handles but keep running.
+            testProcess.WaitForExit();
+
             stderrLines = lines;
 
             int[] expectedExitCodes;
@@ -63,7 +71,7 @@ namespace TestStackOverflow
                 expectedExitCodes = new int[] { unchecked((int)0xC00000FD), unchecked((int)0x800703E9) };
             }
 
-            if (!Array.Exists(expectedExitCodes, code => result.ExitStatus.ExitCode == code))
+            if (!Array.Exists(expectedExitCodes, code => testProcess.ExitCode == code))
             {
                 string separator = string.Empty;
                 StringBuilder expectedListBuilder = new StringBuilder();
@@ -71,7 +79,7 @@ namespace TestStackOverflow
                     expectedListBuilder.Append($"{separator}0x{code:X8}");
                     separator = " or ";
                 });
-                throw new Exception($"Exit code: 0x{result.ExitStatus.ExitCode:X8}, expected {expectedListBuilder.ToString()}");
+                throw new Exception($"Exit code: 0x{testProcess.ExitCode:X8}, expected {expectedListBuilder.ToString()}");
             }
 
             if (lines[0] != "Stack overflow.")

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -20,6 +20,7 @@ namespace TestUnhandledExceptionTester
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
             startInfo.Arguments = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), assembly) + " " + unhandledType;
+            startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
             // Disable creating dump since the target process is expected to fail with an unhandled exception
             startInfo.Environment.Remove("DOTNET_DbgEnableMiniDump");

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -17,29 +17,26 @@ namespace TestUnhandledExceptionTester
     {
         static void RunExternalProcess(string unhandledType, string assembly)
         {
-            List<string> lines = new List<string>();
-
-            Process testProcess = new Process();
-
-            testProcess.StartInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
-            testProcess.StartInfo.Arguments = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), assembly) + " " + unhandledType;
-            testProcess.StartInfo.RedirectStandardError = true;
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
+            startInfo.Arguments = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), assembly) + " " + unhandledType;
+            startInfo.RedirectStandardError = true;
             // Disable creating dump since the target process is expected to fail with an unhandled exception
-            testProcess.StartInfo.Environment.Remove("DOTNET_DbgEnableMiniDump");
-            testProcess.ErrorDataReceived += (sender, line) => 
-            {
-                Console.WriteLine($"\"{line.Data}\"");
-                if (!string.IsNullOrEmpty(line.Data))
-                {
-                    lines.Add(line.Data);
-                }
-            };
+            startInfo.Environment.Remove("DOTNET_DbgEnableMiniDump");
 
-            testProcess.Start();
-            testProcess.BeginErrorReadLine();
-            testProcess.WaitForExit();
+            ProcessTextOutput result = Process.RunAndCaptureText(startInfo);
             Console.WriteLine($"Test process {assembly} with argument {unhandledType} exited");
-            testProcess.CancelErrorRead();
+
+            List<string> lines = new List<string>();
+            foreach (string rawLine in result.StandardError.Split('\n'))
+            {
+                string line = rawLine.TrimEnd('\r');
+                Console.WriteLine($"\"{line}\"");
+                if (!string.IsNullOrEmpty(line))
+                {
+                    lines.Add(line);
+                }
+            }
 
             int[] expectedExitCodes;
             if (TestLibrary.Utilities.IsMonoRuntime)
@@ -72,7 +69,7 @@ namespace TestUnhandledExceptionTester
                 }
             }
 
-            if (!Array.Exists(expectedExitCodes, code => testProcess.ExitCode == code))
+            if (!Array.Exists(expectedExitCodes, code => result.ExitStatus.ExitCode == code))
             {
                 string separator = string.Empty;
                 StringBuilder expectedListBuilder = new StringBuilder();
@@ -81,7 +78,7 @@ namespace TestUnhandledExceptionTester
                     expectedListBuilder.Append($"{separator}0x{code:X8}");
                     separator = " or ";
                 });
-                throw new Exception($"Wrong exit code: 0x{testProcess.ExitCode:X8}, expected {expectedListBuilder}");
+                throw new Exception($"Wrong exit code: 0x{result.ExitStatus.ExitCode:X8}, expected {expectedListBuilder}");
             }
 
             int exceptionStackFrameLine = 1;

--- a/src/tests/nativeaot/AggregateExecutableLibrary/ValidatorExe/ValidatorExe.cs
+++ b/src/tests/nativeaot/AggregateExecutableLibrary/ValidatorExe/ValidatorExe.cs
@@ -16,9 +16,9 @@ ProcessTextOutput result = Process.RunAndCaptureText(new ProcessStartInfo(helloE
 });
 
 string output = result.StandardOutput.Trim();
-string error = result.StandardError.Trim();
 if (result.ExitStatus.ExitCode != 0 || output != "Hello from HelloExe")
 {
+    string error = result.StandardError.Trim();
     Console.Error.WriteLine($"Unexpected HelloExe result. Exit code: {result.ExitStatus.ExitCode}; output: '{output}'; error: '{error}'");
     return 1;
 }

--- a/src/tests/nativeaot/AggregateExecutableLibrary/ValidatorExe/ValidatorExe.cs
+++ b/src/tests/nativeaot/AggregateExecutableLibrary/ValidatorExe/ValidatorExe.cs
@@ -4,32 +4,22 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Threading.Tasks;
 
 string executableExtension = OperatingSystem.IsWindows() ? ".exe" : "";
 string helloExePath = Path.Combine(AppContext.BaseDirectory, $"HelloExe{executableExtension}");
 
-using Process? helloExe = Process.Start(new ProcessStartInfo(helloExePath)
+ProcessTextOutput result = Process.RunAndCaptureText(new ProcessStartInfo(helloExePath)
 {
     RedirectStandardError = true,
     RedirectStandardOutput = true,
     UseShellExecute = false,
 });
 
-if (helloExe is null)
+string output = result.StandardOutput.Trim();
+string error = result.StandardError.Trim();
+if (result.ExitStatus.ExitCode != 0 || output != "Hello from HelloExe")
 {
-    Console.Error.WriteLine($"Failed to start {helloExePath}");
-    return 1;
-}
-
-Task<string> outputTask = helloExe.StandardOutput.ReadToEndAsync();
-Task<string> errorTask = helloExe.StandardError.ReadToEndAsync();
-helloExe.WaitForExit();
-string output = (await outputTask).Trim();
-string error = (await errorTask).Trim();
-if (helloExe.ExitCode != 0 || output != "Hello from HelloExe")
-{
-    Console.Error.WriteLine($"Unexpected HelloExe result. Exit code: {helloExe.ExitCode}; output: '{output}'; error: '{error}'");
+    Console.Error.WriteLine($"Unexpected HelloExe result. Exit code: {result.ExitStatus.ExitCode}; output: '{output}'; error: '{error}'");
     return 1;
 }
 

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -40,7 +40,7 @@ public class Program
             return 3;
         }
 
-        proc = Process.Start(new ProcessStartInfo
+        ProcessTextOutput result = Process.RunAndCaptureText(new ProcessStartInfo
         {
             FileName = llvmDwarfDumpPath,
             Arguments = $"--verify {Environment.ProcessPath}",
@@ -55,9 +55,9 @@ public class Program
         int count = 0;
         bool foundIlCpp = false;
         bool insideIlCpp = false;
-        string line;
-        while ((line = proc.StandardOutput.ReadLine()) != null)
+        foreach (string rawLine in result.StandardOutput.Split('\n'))
         {
+            string line = rawLine.TrimEnd('\r');
             if (line.StartsWith("Verifying unit:"))
             {
                 if (line.EndsWith("\"il.cpp\""))
@@ -87,8 +87,9 @@ public class Program
             // something is off, lets check the StandardError stream
             int errorCount = 0;
             string[] firstFiveErrors = new string[5];
-            while ((line = proc.StandardError.ReadLine()) != null)
+            foreach (string rawLine in result.StandardError.Split('\n'))
             {
+                string line = rawLine.TrimEnd('\r');
                 if (line.Contains("error:"))
                 {
                     if (errorCount < 5) firstFiveErrors[errorCount] = line;
@@ -103,7 +104,6 @@ public class Program
             }
         }
 
-        proc.WaitForExit();
         Console.WriteLine($"Found {count} warnings and errors");
         if (count is not (>= MinWarnings and <= MaxWarnings))
         {

--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -100,27 +100,26 @@ namespace Profiler.Tests
                 FailFastWithMessage("Profiler library not found at expected path: " + profilerPath);
             }
 
-            Process process = new Process();
-            process.StartInfo.FileName = program;
-            process.StartInfo.Arguments = arguments;
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = true;
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.FileName = program;
+            startInfo.Arguments = arguments;
+            startInfo.UseShellExecute = false;
+            startInfo.RedirectStandardOutput = true;
 
             foreach (string key in Environment.GetEnvironmentVariables().Keys)
             {
-                process.StartInfo.EnvironmentVariables[key] = Environment.GetEnvironmentVariable(key);
+                startInfo.EnvironmentVariables[key] = Environment.GetEnvironmentVariable(key);
             }
 
             foreach (string key in envVars.Keys)
             {
-                process.StartInfo.EnvironmentVariables[key] = envVars[key];
+                startInfo.EnvironmentVariables[key] = envVars[key];
             }
 
-            process.Start();
-            ProfileeOutputVerifier verifier = new ProfileeOutputVerifier(process.StandardOutput);
+            ProcessTextOutput result = Process.RunAndCaptureText(startInfo);
+            ProfileeOutputVerifier verifier = new ProfileeOutputVerifier(new StringReader(result.StandardOutput));
 
             verifier.VerifyOutput();
-            process.WaitForExit();
 
             // There are two conditions for profiler tests to pass, the output of the profiled program
             // must contain the phrase "PROFILER TEST PASSES" and the return code must be 100. This is
@@ -131,12 +130,12 @@ namespace Profiler.Tests
             {
                 FailFastWithMessage($"Profiler tests are expected to contain the text '{verifier.SuccessPhrase}' in the console output " +
                     $"of the profilee app to indicate a passing test. Usually it is printed from the Shutdown() method of the profiler implementation. This " +
-                    $"text was not found in the output above. Profilee returned exit code {process.ExitCode}.");
+                    $"text was not found in the output above. Profilee returned exit code {result.ExitStatus.ExitCode}.");
             }
 
-            if (process.ExitCode != 100)
+            if (result.ExitStatus.ExitCode != 100)
             {
-                FailFastWithMessage($"Profilee returned exit code {process.ExitCode} instead of expected exit code 100.");
+                FailFastWithMessage($"Profilee returned exit code {result.ExitStatus.ExitCode} instead of expected exit code 100.");
             }
 
             return 100;
@@ -194,9 +193,9 @@ namespace Profiler.Tests
             private volatile bool _hasPassingOutput;
 
             public string SuccessPhrase = "PROFILER TEST PASSES";
-            private StreamReader standardOutput;
+            private TextReader standardOutput;
 
-            public ProfileeOutputVerifier(StreamReader standardOutput)
+            public ProfileeOutputVerifier(TextReader standardOutput)
             {
                 this.standardOutput = standardOutput;
             }

--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -105,6 +105,7 @@ namespace Profiler.Tests
             startInfo.Arguments = arguments;
             startInfo.UseShellExecute = false;
             startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
 
             foreach (string key in Environment.GetEnvironmentVariables().Keys)
             {

--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -107,11 +107,6 @@ namespace Profiler.Tests
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
 
-            foreach (string key in Environment.GetEnvironmentVariables().Keys)
-            {
-                startInfo.EnvironmentVariables[key] = Environment.GetEnvironmentVariable(key);
-            }
-
             foreach (string key in envVars.Keys)
             {
                 startInfo.EnvironmentVariables[key] = envVars[key];

--- a/src/tests/tracing/userevents/common/UserEventsRequirements.cs
+++ b/src/tests/tracing/userevents/common/UserEventsRequirements.cs
@@ -37,27 +37,25 @@ namespace Tracing.UserEvents.Tests.Common
             checkTracefsStartInfo.RedirectStandardOutput = true;
             checkTracefsStartInfo.RedirectStandardError = true;
 
-            using Process checkTracefs = new() { StartInfo = checkTracefsStartInfo };
-            checkTracefs.OutputDataReceived += (_, e) =>
+            ProcessTextOutput result = Process.RunAndCaptureText(checkTracefsStartInfo);
+            foreach (string rawLine in result.StandardOutput.Split('\n'))
             {
-                if (!string.IsNullOrEmpty(e.Data))
+                string line = rawLine.TrimEnd('\r');
+                if (!string.IsNullOrEmpty(line))
                 {
-                    Console.WriteLine($"[tracefs-check] {e.Data}");
+                    Console.WriteLine($"[tracefs-check] {line}");
                 }
-            };
-            checkTracefs.ErrorDataReceived += (_, e) =>
+            }
+            foreach (string rawLine in result.StandardError.Split('\n'))
             {
-                if (!string.IsNullOrEmpty(e.Data))
+                string line = rawLine.TrimEnd('\r');
+                if (!string.IsNullOrEmpty(line))
                 {
-                    Console.Error.WriteLine($"[tracefs-check] {e.Data}");
+                    Console.Error.WriteLine($"[tracefs-check] {line}");
                 }
-            };
+            }
 
-            checkTracefs.Start();
-            checkTracefs.BeginOutputReadLine();
-            checkTracefs.BeginErrorReadLine();
-            checkTracefs.WaitForExit();
-            if (checkTracefs.ExitCode == 0)
+            if (result.ExitStatus.ExitCode == 0)
             {
                 return true;
             }
@@ -75,27 +73,25 @@ namespace Tracing.UserEvents.Tests.Common
             checkUserEventsDataStartInfo.RedirectStandardOutput = true;
             checkUserEventsDataStartInfo.RedirectStandardError = true;
 
-            using Process checkUserEventsData = new() { StartInfo = checkUserEventsDataStartInfo };
-            checkUserEventsData.OutputDataReceived += (_, e) =>
+            ProcessTextOutput result = Process.RunAndCaptureText(checkUserEventsDataStartInfo);
+            foreach (string rawLine in result.StandardOutput.Split('\n'))
             {
-                if (!string.IsNullOrEmpty(e.Data))
+                string line = rawLine.TrimEnd('\r');
+                if (!string.IsNullOrEmpty(line))
                 {
-                    Console.WriteLine($"[user-events-check] {e.Data}");
+                    Console.WriteLine($"[user-events-check] {line}");
                 }
-            };
-            checkUserEventsData.ErrorDataReceived += (_, e) =>
+            }
+            foreach (string rawLine in result.StandardError.Split('\n'))
             {
-                if (!string.IsNullOrEmpty(e.Data))
+                string line = rawLine.TrimEnd('\r');
+                if (!string.IsNullOrEmpty(line))
                 {
-                    Console.Error.WriteLine($"[user-events-check] {e.Data}");
+                    Console.Error.WriteLine($"[user-events-check] {line}");
                 }
-            };
+            }
 
-            checkUserEventsData.Start();
-            checkUserEventsData.BeginOutputReadLine();
-            checkUserEventsData.BeginErrorReadLine();
-            checkUserEventsData.WaitForExit();
-            if (checkUserEventsData.ExitCode == 0)
+            if (result.ExitStatus.ExitCode == 0)
             {
                 return true;
             }
@@ -113,27 +109,10 @@ namespace Tracing.UserEvents.Tests.Common
             lddStartInfo.RedirectStandardOutput = true;
             lddStartInfo.RedirectStandardError = true;
 
-            using Process lddProcess = new() { StartInfo = lddStartInfo };
-            string? detectedVersionLine = null;
-
-            lddProcess.OutputDataReceived += (_, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data) && detectedVersionLine is null)
-                {
-                    detectedVersionLine = e.Data;
-                }
-            };
-            lddProcess.ErrorDataReceived += (_, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    Console.Error.WriteLine($"[ldd] {e.Data}");
-                }
-            };
-
+            ProcessTextOutput result;
             try
             {
-                lddProcess.Start();
+                result = Process.RunAndCaptureText(lddStartInfo);
             }
             catch (Exception ex)
             {
@@ -141,13 +120,29 @@ namespace Tracing.UserEvents.Tests.Common
                 return false;
             }
 
-            lddProcess.BeginOutputReadLine();
-            lddProcess.BeginErrorReadLine();
-            lddProcess.WaitForExit();
-
-            if (lddProcess.ExitCode != 0)
+            foreach (string rawLine in result.StandardError.Split('\n'))
             {
-                Console.WriteLine($"'ldd --version' exited with code {lddProcess.ExitCode}.");
+                string line = rawLine.TrimEnd('\r');
+                if (!string.IsNullOrEmpty(line))
+                {
+                    Console.Error.WriteLine($"[ldd] {line}");
+                }
+            }
+
+            string? detectedVersionLine = null;
+            foreach (string rawLine in result.StandardOutput.Split('\n'))
+            {
+                string line = rawLine.TrimEnd('\r');
+                if (!string.IsNullOrEmpty(line))
+                {
+                    detectedVersionLine = line;
+                    break;
+                }
+            }
+
+            if (result.ExitStatus.ExitCode != 0)
+            {
+                Console.WriteLine($"'ldd --version' exited with code {result.ExitStatus.ExitCode}.");
                 return false;
             }
 

--- a/src/tests/tracing/userevents/common/UserEventsRequirements.cs
+++ b/src/tests/tracing/userevents/common/UserEventsRequirements.cs
@@ -37,25 +37,28 @@ namespace Tracing.UserEvents.Tests.Common
             checkTracefsStartInfo.RedirectStandardOutput = true;
             checkTracefsStartInfo.RedirectStandardError = true;
 
-            ProcessTextOutput result = Process.RunAndCaptureText(checkTracefsStartInfo);
-            foreach (string rawLine in result.StandardOutput.Split('\n'))
+            using Process process = Process.Start(checkTracefsStartInfo);
+            foreach (ProcessOutputLine line in process.ReadAllLines())
             {
-                string line = rawLine.TrimEnd('\r');
-                if (!string.IsNullOrEmpty(line))
+                if (string.IsNullOrEmpty(line.Content))
                 {
-                    Console.WriteLine($"[tracefs-check] {line}");
+                    continue;
                 }
-            }
-            foreach (string rawLine in result.StandardError.Split('\n'))
-            {
-                string line = rawLine.TrimEnd('\r');
-                if (!string.IsNullOrEmpty(line))
+
+                if (line.StandardError)
                 {
-                    Console.Error.WriteLine($"[tracefs-check] {line}");
+                    Console.Error.WriteLine($"[tracefs-check] {line.Content}");
+                }
+                else
+                {
+                    Console.WriteLine($"[tracefs-check] {line.Content}");
                 }
             }
 
-            if (result.ExitStatus.ExitCode == 0)
+            // A process can close its std handles but keep running.
+            process.WaitForExit();
+
+            if (process.ExitCode == 0)
             {
                 return true;
             }
@@ -73,25 +76,28 @@ namespace Tracing.UserEvents.Tests.Common
             checkUserEventsDataStartInfo.RedirectStandardOutput = true;
             checkUserEventsDataStartInfo.RedirectStandardError = true;
 
-            ProcessTextOutput result = Process.RunAndCaptureText(checkUserEventsDataStartInfo);
-            foreach (string rawLine in result.StandardOutput.Split('\n'))
+            using Process process = Process.Start(checkUserEventsDataStartInfo);
+            foreach (ProcessOutputLine line in process.ReadAllLines())
             {
-                string line = rawLine.TrimEnd('\r');
-                if (!string.IsNullOrEmpty(line))
+                if (string.IsNullOrEmpty(line.Content))
                 {
-                    Console.WriteLine($"[user-events-check] {line}");
+                    continue;
                 }
-            }
-            foreach (string rawLine in result.StandardError.Split('\n'))
-            {
-                string line = rawLine.TrimEnd('\r');
-                if (!string.IsNullOrEmpty(line))
+
+                if (line.StandardError)
                 {
-                    Console.Error.WriteLine($"[user-events-check] {line}");
+                    Console.Error.WriteLine($"[user-events-check] {line.Content}");
+                }
+                else
+                {
+                    Console.WriteLine($"[user-events-check] {line.Content}");
                 }
             }
 
-            if (result.ExitStatus.ExitCode == 0)
+            // A process can close its std handles but keep running.
+            process.WaitForExit();
+
+            if (process.ExitCode == 0)
             {
                 return true;
             }


### PR DESCRIPTION
Adopts the new .NET 11 `Process.RunAndCaptureText` API across `src/tests` C# tests/helpers that followed the "launch a child process, wait for exit, read exit code + full stdout/stderr" pattern (no stdin, no live process control).

Converted:
- `Loader/PlatformNativeR2R/PlatformNativeR2R.cs`
- `nativeaot/AggregateExecutableLibrary/ValidatorExe/ValidatorExe.cs`
- `GC/Stress/Framework/RFLogging.cs` (`WriteToReport`)
- `baseservices/exceptions/unhandled/unhandledTester.cs`
- `baseservices/exceptions/stackoverflow/stackoverflowtester.cs`
- `Loader/binding/tracing/BinderTracingTest.cs`
- `profiler/common/ProfilerTestRunner.cs`
- `nativeaot/SmokeTests/DwarfDump/Program.cs`
- `tracing/userevents/common/UserEventsRequirements.cs`
- `GC/Stress/Framework/ReliabilityFramework.cs` (`AddFailure`)
- `GC/LargeMemory/memcheck.cs` (`RunCommand`)
- `Common/CoreCLRTestLibrary/CoreclrTestWrapperLib.cs` (pgrep + wmic)
- `Common/XUnitLogChecker/XUnitLogChecker.cs` (`RunProcess`)

Call sites that write to stdin, coordinate with a live process (PID/signals/EventPipe), or rely on `sudo`/root process-tree kills were intentionally left unchanged.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.
