### PR TITLE
JIT: Elide ldelema covariance check when array type is known exactly

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3996,6 +3996,7 @@ public:
     }
 
     bool gtCanSkipCovariantStoreCheck(GenTree* value, GenTree* array);
+    bool gtCanSkipCovariantLdElemCheck(GenTree* array, CORINFO_CLASS_HANDLE elemClsHnd);
 
     //-------------------------------------------------------------------------
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -36291,6 +36291,63 @@ GenTreeMskCon* Compiler::gtFoldExprConvertVecCnsToMask(GenTreeHWIntrinsic* tree,
 #endif // FEATURE_HW_INTRINSICS
 
 //------------------------------------------------------------------------
+// gtCanSkipCovariantLdElemCheck: see if taking the address of a ref type array
+//    element ("ldelema") can skip the covariant type check.
+//
+// Arguments:
+//    array      -- tree representing the array being indexed
+//    elemClsHnd -- the static element class handle the IL reads (the helper verifies
+//                  that the array's actual element type matches this)
+//
+// Returns:
+//    true if the access does not require a covariant type check.
+//
+// Notes:
+//    The covariant type check verifies that the array's runtime element type equals
+//    "elemClsHnd". This can be skipped when we know the array's type exactly, since then
+//    its element type is exactly "elemClsHnd". (The sealed-element case is already handled
+//    during import.)
+//
+bool Compiler::gtCanSkipCovariantLdElemCheck(GenTree* array, CORINFO_CLASS_HANDLE elemClsHnd)
+{
+    // We should only call this when optimizing.
+    assert(opts.OptimizationEnabled());
+
+    if (elemClsHnd == NO_CLASS_HANDLE)
+    {
+        return false;
+    }
+
+    bool                 arrayIsExact   = false;
+    bool                 arrayIsNonNull = false;
+    CORINFO_CLASS_HANDLE arrayHandle    = gtGetClassHandle(array, &arrayIsExact, &arrayIsNonNull);
+
+    if ((arrayHandle == NO_CLASS_HANDLE) || !arrayIsExact)
+    {
+        return false;
+    }
+
+    // There are some methods in corelib where we're indexing into an array but the IL
+    // doesn't reflect this (see SZArrayHelper). Avoid.
+    if ((info.compCompHnd->getClassAttribs(arrayHandle) & CORINFO_FLG_ARRAY) == 0)
+    {
+        return false;
+    }
+
+    // The runtime element type is exactly the array's (exact) element type. The covariant
+    // check can be skipped only when that equals the static element type the IL reads.
+    CORINFO_CLASS_HANDLE arrayElementHandle = NO_CLASS_HANDLE;
+    if ((info.compCompHnd->getChildType(arrayHandle, &arrayElementHandle) != CORINFO_TYPE_CLASS) ||
+        (arrayElementHandle != elemClsHnd))
+    {
+        return false;
+    }
+
+    JITDUMP("\nldelema of exactly known T[]: skipping covariant type check\n");
+    return true;
+}
+
+//------------------------------------------------------------------------
 // gtCanSkipCovariantStoreCheck: see if storing a ref type value to an array
 //    can skip the array store covariance check.
 //

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6533,6 +6533,69 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         }
     }
 
+    // Morph "ldelema" helper call (array element address with a covariant type check) into a
+    // direct array element address when we can prove the array's element type exactly, making
+    // the covariant type check redundant.
+    // Like the stelem.ref case above, this is done after the arguments are morphed so that constant
+    // propagation has already taken place.
+    if (opts.OptimizationEnabled() && call->IsHelperCallOrUserEquivalent(this, CORINFO_HELP_LDELEMA_REF))
+    {
+        assert(call->gtArgs.CountUserArgs() == 3);
+
+        GenTree* arr     = call->gtArgs.GetUserArgByIndex(0)->GetNode();
+        GenTree* typeArg = call->gtArgs.GetUserArgByIndex(2)->GetNode();
+
+        if (!call->IsHelperCall())
+        {
+            // Convert back to helper call if it wasn't inlined.
+            // Currently, only helper calls are eligible to be direct calls if the target has reached
+            // its final tier. TODO: remove this workaround and convert this user call to direct as well.
+            call->gtCallMethHnd = eeFindHelper(CORINFO_HELP_LDELEMA_REF);
+            call->gtCallType    = CT_HELPER;
+        }
+
+        CORINFO_CLASS_HANDLE elemClsHnd = gtGetHelperArgClassHandle(typeArg);
+        if (gtCanSkipCovariantLdElemCheck(arr, elemClsHnd))
+        {
+            GenTree* index = call->gtArgs.GetUserArgByIndex(1)->GetNode();
+
+            // Either or both of the array and index arguments may have been spilled to temps by `fgMorphArgs`.
+            // Copy the spill trees as well if necessary.
+            GenTree* argSetup = nullptr;
+            for (CallArg& arg : call->gtArgs.EarlyArgs())
+            {
+                if (arg.GetLateNode() == nullptr)
+                {
+                    continue;
+                }
+
+                GenTree* const setupArgNode = arg.GetEarlyNode();
+                assert((setupArgNode != arr) && (setupArgNode != index));
+
+                if (argSetup == nullptr)
+                {
+                    argSetup = setupArgNode;
+                }
+                else
+                {
+                    argSetup = new (this, GT_COMMA) GenTreeOp(GT_COMMA, TYP_VOID, argSetup, setupArgNode);
+                    argSetup->SetMorphed(this);
+                }
+            }
+
+            GenTree* indexAddr = gtNewArrayIndexAddr(arr, index, TYP_REF, elemClsHnd);
+            GenTree* result    = fgMorphTree(indexAddr);
+
+            if (argSetup != nullptr)
+            {
+                result = new (this, GT_COMMA) GenTreeOp(GT_COMMA, result->TypeGet(), argSetup, result);
+                result->SetMorphed(this);
+            }
+
+            return result;
+        }
+    }
+
     if (call->IsNoReturn())
     {
         //

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -15999,18 +15999,20 @@ CORINFO_CLASS_HANDLE ValueNumStore::GetObjectType(ValueNum vn, bool* pIsExact, b
         return NO_CLASS_HANDLE;
     }
 
-    // CastClass/IsInstanceOf/JitNew all have the class handle as the first argument
+    // CastClass/IsInstanceOf/JitNew(Arr) all have the class handle as the first argument
     const VNFunc func = funcApp.GetFunc();
-    if ((func == VNF_CastClass) || (func == VNF_IsInstanceOf) || (func == VNF_JitNew))
+    if ((func == VNF_CastClass) || (func == VNF_IsInstanceOf) || (func == VNF_JitNew) ||
+        (func == VNF_JitNewArr) || (func == VNF_JitNewLclArr))
     {
         ValueNum clsVN = funcApp.GetArg(0);
 
         CORINFO_CLASS_HANDLE clsHandle;
         if (IsVNTypeHandle(clsVN, &clsHandle))
         {
-            // JitNew returns an exact and non-null obj, castclass and isinst do not have this guarantee.
-            *pIsNonNull = func == VNF_JitNew;
-            *pIsExact   = func == VNF_JitNew;
+            // JitNew/JitNewArr return an exact and non-null obj, castclass and isinst do not have this guarantee.
+            const bool isAlloc = (func == VNF_JitNew) || (func == VNF_JitNewArr) || (func == VNF_JitNewLclArr);
+            *pIsNonNull        = isAlloc;
+            *pIsExact          = isAlloc;
             return clsHandle;
         }
     }


### PR DESCRIPTION
CI test for AI fix.

Closes dotnet/runtime#129752