### PR TITLE
Use SearchValues to scan for characters to escape with default Json options

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -52,13 +52,36 @@ namespace System.Text.Json
 
         private static bool NeedsEscapingNoBoundsCheck(char value) => AllowList[value] == 0;
 
+#if NET
+        // The characters allowed by AllowList, used to vectorize the default (no custom encoder) escaping
+        // scan directly instead of routing through System.Text.Encodings.Web.
+        private static readonly SearchValues<byte> s_allowedBytes = SearchValues.Create(
+            " !#$%()*,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{|}~"u8);
+        private static readonly SearchValues<char> s_allowedChars = SearchValues.Create(
+            " !#$%()*,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{|}~");
+#endif
+
         public static int NeedsEscaping(ReadOnlySpan<byte> value, JavaScriptEncoder? encoder)
         {
+#if NET
+            if (encoder is null)
+            {
+                return value.IndexOfAnyExcept(s_allowedBytes);
+            }
+#endif
+
             return (encoder ?? JavaScriptEncoder.Default).FindFirstCharacterToEncodeUtf8(value);
         }
 
         public static int NeedsEscaping(ReadOnlySpan<char> value, JavaScriptEncoder? encoder)
         {
+#if NET
+            if (encoder is null)
+            {
+                return value.IndexOfAnyExcept(s_allowedChars);
+            }
+#endif
+
             // Some implementations of JavaScriptEncoder.FindFirstCharacterToEncode may not accept
             // null pointers and guard against that. Hence, check up-front to return -1.
             if (value.IsEmpty)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -19,6 +19,8 @@ namespace System.Text.Json
         // and exclude characters that need to be escaped by adding a backslash: '\n', '\r', '\t', '\\', '\b', '\f'
         //
         // non-zero = allowed, 0 = disallowed
+        // This exactly matches the set used by JavaScriptEncoder.Default.
+        // SearchValues instances below also represent the same ASCII set, validated to match in the debug static ctor below.
         public const int LastAsciiCharacter = 0x7F;
         private static ReadOnlySpan<byte> AllowList => // byte.MaxValue + 1
         [
@@ -68,6 +70,7 @@ namespace System.Text.Json
 #if NET
         // The characters allowed by AllowList, used to vectorize the default (no custom encoder) escaping
         // scan directly instead of routing through System.Text.Encodings.Web.
+        // Validated to match the AllowList and JavaScriptEncoder.Default in the static ctor above.
         private static readonly SearchValues<byte> s_allowedBytes = SearchValues.Create(
             " !#$%()*,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{|}~"u8);
         private static readonly SearchValues<char> s_allowedChars = SearchValues.Create(

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -64,7 +64,7 @@ namespace System.Text.Json
         public static int NeedsEscaping(ReadOnlySpan<byte> value, JavaScriptEncoder? encoder)
         {
 #if NET
-            if (encoder is null)
+            if (encoder is null || ReferenceEquals(encoder, JavaScriptEncoder.Default))
             {
                 return value.IndexOfAnyExcept(s_allowedBytes);
             }
@@ -76,7 +76,7 @@ namespace System.Text.Json
         public static int NeedsEscaping(ReadOnlySpan<char> value, JavaScriptEncoder? encoder)
         {
 #if NET
-            if (encoder is null)
+            if (encoder is null || ReferenceEquals(encoder, JavaScriptEncoder.Default))
             {
                 return value.IndexOfAnyExcept(s_allowedChars);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -42,6 +42,19 @@ namespace System.Text.Json
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+00F0..U+00FF
         ];
 
+#if DEBUG && NET
+        static JsonWriterHelper()
+        {
+            for (int i = 0; i < 128; i++)
+            {
+                bool needsEscaping = AllowList[i] == 0;
+                Debug.Assert(needsEscaping == JavaScriptEncoder.Default.WillEncode(i));
+                Debug.Assert(needsEscaping == !s_allowedBytes.Contains((byte)i));
+                Debug.Assert(needsEscaping == !s_allowedChars.Contains((char)i));
+            }
+        }
+#endif
+
 #if NET
         private const string HexFormatString = "X4";
 #endif

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
@@ -4,7 +4,6 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 
 namespace System.Text.Json
@@ -304,7 +303,7 @@ namespace System.Text.Json
 
         internal static unsafe T WriteString<T>(ReadOnlySpan<byte> utf8Value, WriteCallback<T> writeCallback)
         {
-            int firstByteToEscape = JsonWriterHelper.NeedsEscaping(utf8Value, JavaScriptEncoder.Default);
+            int firstByteToEscape = JsonWriterHelper.NeedsEscaping(utf8Value, encoder: null);
 
             if (firstByteToEscape == -1)
             {
@@ -353,7 +352,7 @@ namespace System.Text.Json
                     }
 
                     escapedValue[0] = JsonConstants.Quote;
-                    JsonWriterHelper.EscapeString(utf8Value, escapedValue.Slice(1), firstByteToEscape, JavaScriptEncoder.Default, out int written);
+                    JsonWriterHelper.EscapeString(utf8Value, escapedValue.Slice(1), firstByteToEscape, encoder: null, out int written);
                     escapedValue[1 + written] = JsonConstants.Quote;
 
                     return writeCallback(escapedValue.Slice(0, written + 2));


### PR DESCRIPTION
Helps avoid some indirection in the common case.
A couple small improvements: https://github.com/EgorBot/Benchmarks/issues/268#issuecomment-4784727774, https://github.com/dotnet/runtime/pull/129781#issuecomment-4785067304