### PR TITLE
Ship stripped cdac AOT binary and its symbols in the transport package

### DIFF
--- a/src/installer/pkg/projects/Microsoft.DotNet.Cdac.Transport/Microsoft.DotNet.Cdac.Transport.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.Cdac.Transport/Microsoft.DotNet.Cdac.Transport.pkgproj
@@ -5,7 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <File Include="$(DotNetCdacBinDir)$(LibPrefix)mscordaccore_universal$(LibSuffix)">
+    <!--
+      Consume the stripped binary that the runtime-component build installs into the CoreCLR
+      artifacts directory. Using a NativeBinary item (instead of a bare File) lets the packaging
+      infrastructure auto-discover the adjacent symbol file (.so.dbg/.dylib.dwarf/.pdb) and add
+      it to the symbol package.
+    -->
+    <NativeBinary Include="$(CoreCLRArtifactsPath)$(LibPrefix)mscordaccore_universal$(LibSuffix)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <File Include="@(NativeBinary)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsNative>true</IsNative>
     </File>


### PR DESCRIPTION
## Why

On Linux and macOS the `mscordaccore_universal` (cdac AOT) binary shipped in the `Microsoft.DotNet.Cdac.Transport` package was unstripped, and no debug symbols were being added to the symbol packages. Diagnostics tooling consuming this transport package got a fat binary with no separate symbol file.

## Root cause

The package's `<File>` entry pointed at `$(DotNetCdacBinDir)`, the NativeAOT *publish* directory. That output is intentionally unstripped, and there is no symbol file next to it.

The runtime-component build (`src/native/managed/native-library.targets`) already does the right thing: it strips the binary the same way the CoreCLR cmake build does and installs both the stripped library and its symbol file (`.so.dbg` / `.dylib.dwarf` / `.pdb`) into the CoreCLR artifacts directory. Nothing was consuming that stripped output.

## Change

Point the transport package at `$(CoreCLRArtifactsPath)` (where the stripped binary and symbol are installed) instead of the publish directory. Switching the entry from a bare `<File>` to a `<NativeBinary>` item lets the existing packaging infrastructure (`GetSymbolPackageFiles` in `src/installer/pkg/projects/Directory.Build.targets`) auto-discover the adjacent symbol file and add it to the symbol package, matching how `Microsoft.NETCore.DotNetAppHost` and other native packages work.

This is deliberately surgical: the custom cmake-matching strip logic (including the macOS `codesign` step) is left untouched; only the package now consumes the stripped output plus its symbol.

> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.