### PR TITLE
Fix IsKnownNonNull assert for SIMD base addresses

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1619,8 +1619,8 @@ bool ValueNumStore::IsKnownNonNull(ValueNum vn)
         return false;
     }
 
-    // The base address of an indirection can be a SIMD value (e.g. SVE GatherVector, a vector
-    // of addresses), which is never known non-null here. Assert added in #129447.
+    // Ignore corner cases like a SIMD value - SIMD could be a base address of an indirection
+    // (e.g. SVE GatherVector, a vector of addresses).
     var_types vnType = TypeOfVN(vn);
     if ((vnType != TYP_I_IMPL) && (vnType != TYP_REF) && (vnType != TYP_BYREF))
     {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1619,10 +1619,10 @@ bool ValueNumStore::IsKnownNonNull(ValueNum vn)
         return false;
     }
 
-    // The base address of an indirection can be a SIMD value for certain implicit indirs,
-    // e.g. the SVE GatherVector API (a vector of addresses). Such VNs are never known to be
-    // non-null here, and the offset-peeling logic below only applies to pointer-like VNs.
-    if ((TypeOfVN(vn) != TYP_I_IMPL) && (TypeOfVN(vn) != TYP_REF) && (TypeOfVN(vn) != TYP_BYREF))
+    // The base address of an indirection can be a SIMD value (e.g. SVE GatherVector, a vector
+    // of addresses), which is never known non-null here. Assert added in #129447.
+    var_types vnType = TypeOfVN(vn);
+    if ((vnType != TYP_I_IMPL) && (vnType != TYP_REF) && (vnType != TYP_BYREF))
     {
         return false;
     }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1619,7 +1619,13 @@ bool ValueNumStore::IsKnownNonNull(ValueNum vn)
         return false;
     }
 
-    assert((TypeOfVN(vn) == TYP_I_IMPL) || (TypeOfVN(vn) == TYP_REF) || (TypeOfVN(vn) == TYP_BYREF));
+    // The base address of an indirection can be a SIMD value for certain implicit indirs,
+    // e.g. the SVE GatherVector API (a vector of addresses). Such VNs are never known to be
+    // non-null here, and the offset-peeling logic below only applies to pointer-like VNs.
+    if ((TypeOfVN(vn) != TYP_I_IMPL) && (TypeOfVN(vn) != TYP_REF) && (TypeOfVN(vn) != TYP_BYREF))
+    {
+        return false;
+    }
 
     target_ssize_t offset;
     PeelOffsets(&vn, &offset);


### PR DESCRIPTION
Fixes #129738.

I added this assert in https://github.com/dotnet/runtime/pull/129447, but it turns out we can visit that functions for SIMD values as addresses (e.g. via `fgValueNumberIndirNullCheckExceptions` calls it with a SIMD base address (SVE gather/scatter).