### PR TITLE
Avoid publishing interpreter frame with invalid IP

### DIFF
--- a/src/coreclr/inc/volatile.h
+++ b/src/coreclr/inc/volatile.h
@@ -59,8 +59,6 @@
 
 #include "staticcontract.h"
 
-#include <atomic>
-
 //
 // This code is extremely compiler- and CPU-specific, and will need to be altered to
 // support new compilers and/or CPUs.  Here we enforce that we can only compile using
@@ -325,18 +323,6 @@ void VolatileLoadBarrier()
 #else
     VOLATILE_MEMORY_BARRIER();
 #endif
-}
-
-//
-// Compiler reordering barrier. Prevents the compiler from moving memory accesses across this
-// point. It emits no instructions and provides no CPU or cross-thread ordering; use it only to
-// order accesses with respect to asynchronous interruption on the SAME thread, such as a signal
-// or hardware-exception handler.
-//
-inline
-void CompilerBarrier()
-{
-    std::atomic_signal_fence(std::memory_order_acq_rel);
 }
 
 //

--- a/src/coreclr/inc/volatile.h
+++ b/src/coreclr/inc/volatile.h
@@ -59,6 +59,8 @@
 
 #include "staticcontract.h"
 
+#include <atomic>
+
 //
 // This code is extremely compiler- and CPU-specific, and will need to be altered to
 // support new compilers and/or CPUs.  Here we enforce that we can only compile using
@@ -323,6 +325,18 @@ void VolatileLoadBarrier()
 #else
     VOLATILE_MEMORY_BARRIER();
 #endif
+}
+
+//
+// Compiler reordering barrier. Prevents the compiler from moving memory accesses across this
+// point. It emits no instructions and provides no CPU or cross-thread ordering; use it only to
+// order accesses with respect to asynchronous interruption on the SAME thread, such as a signal
+// or hardware-exception handler.
+//
+inline
+void CompilerBarrier()
+{
+    std::atomic_signal_fence(std::memory_order_acq_rel);
 }
 
 //

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3360,8 +3360,11 @@ SWITCH_OPCODE:
                                 if (!pChildFrame)
                                 {
                                     pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
-                                    pChildFrame->pNext = NULL;
-                                    pFrame->pNext = pChildFrame;
+                                    // We make sure that a new frame can't be seen with invalid ip/next when a stack
+                                    // overflow is triggered at a location outside of our control.
+                                    VolatileStoreWithoutBarrier(&pChildFrame->ip, (const int32_t*)nullptr);
+                                    VolatileStoreWithoutBarrier(&pChildFrame->pNext, (InterpMethodContextFrame*)nullptr);
+                                    VolatileStoreWithoutBarrier(&pFrame->pNext, pChildFrame);
                                 }
                                 pChildFrame->ReInit(pFrame, targetIp, returnValueAddress, LOCAL_VAR_ADDR(callArgsOffset, int8_t));
                                 pFrame = pChildFrame;
@@ -3463,8 +3466,11 @@ CALL_INTERP_METHOD:
                             if (!pChildFrame)
                             {
                                 pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
-                                pChildFrame->pNext = NULL;
-                                pFrame->pNext = pChildFrame;
+                                // We make sure that a new frame can't be seen with invalid ip/next when a stack
+                                // overflow is triggered at a location outside of our control.
+                                VolatileStoreWithoutBarrier(&pChildFrame->ip, (const int32_t*)nullptr);
+                                VolatileStoreWithoutBarrier(&pChildFrame->pNext, (InterpMethodContextFrame*)nullptr);
+                                VolatileStoreWithoutBarrier(&pFrame->pNext, pChildFrame);
                             }
                             pChildFrame->ReInit(pFrame, targetIp, returnValueAddress, callArgsAddress);
                             pFrame = pChildFrame;
@@ -4296,8 +4302,11 @@ do                                                                      \
                         if (!pChildFrame)
                         {
                             pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
-                            pChildFrame->pNext = NULL;
-                            pFrame->pNext = pChildFrame;
+                            // We make sure that a new frame can't be seen with invalid ip/next when a stack
+                            // overflow is triggered at a location outside of our control.
+                            VolatileStoreWithoutBarrier(&pChildFrame->ip, (const int32_t*)nullptr);
+                            VolatileStoreWithoutBarrier(&pChildFrame->pNext, (InterpMethodContextFrame*)nullptr);
+                            VolatileStoreWithoutBarrier(&pFrame->pNext, pChildFrame);
                         }
                         // Set the frame to the same values as the caller frame.
                         pChildFrame->ReInit(pFrame, pFrame->startIp, pFrame->pRetVal, pFrame->pStack);

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -23,6 +23,16 @@ extern "C" void SamplingProfiler_OnSamplepoint();
 // for numeric_limits
 #include <limits>
 #include <functional>
+#include <atomic>
+
+// Compiler reordering barrier. Prevents the compiler from moving memory accesses across this
+// point. It emits no instructions and provides no CPU or cross-thread ordering; use it only to
+// order accesses with respect to asynchronous interruption on the SAME thread, such as a stack
+// overflow or other hardware-exception handler.
+static inline void CompilerBarrier()
+{
+    std::atomic_signal_fence(std::memory_order_acq_rel);
+}
 
 struct InterpDispatchCacheEntry
 {

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3362,9 +3362,10 @@ SWITCH_OPCODE:
                                     pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
                                     // We make sure that a new frame can't be seen with invalid ip/next when a stack
                                     // overflow is triggered at a location outside of our control.
-                                    VolatileStoreWithoutBarrier(&pChildFrame->ip, (const int32_t*)nullptr);
-                                    VolatileStoreWithoutBarrier(&pChildFrame->pNext, (InterpMethodContextFrame*)nullptr);
-                                    VolatileStoreWithoutBarrier(&pFrame->pNext, pChildFrame);
+                                    pChildFrame->ip = NULL;
+                                    pChildFrame->pNext = NULL;
+                                    CompilerBarrier();
+                                    pFrame->pNext = pChildFrame;
                                 }
                                 pChildFrame->ReInit(pFrame, targetIp, returnValueAddress, LOCAL_VAR_ADDR(callArgsOffset, int8_t));
                                 pFrame = pChildFrame;
@@ -3468,9 +3469,10 @@ CALL_INTERP_METHOD:
                                 pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
                                 // We make sure that a new frame can't be seen with invalid ip/next when a stack
                                 // overflow is triggered at a location outside of our control.
-                                VolatileStoreWithoutBarrier(&pChildFrame->ip, (const int32_t*)nullptr);
-                                VolatileStoreWithoutBarrier(&pChildFrame->pNext, (InterpMethodContextFrame*)nullptr);
-                                VolatileStoreWithoutBarrier(&pFrame->pNext, pChildFrame);
+                                pChildFrame->ip = NULL;
+                                pChildFrame->pNext = NULL;
+                                CompilerBarrier();
+                                pFrame->pNext = pChildFrame;
                             }
                             pChildFrame->ReInit(pFrame, targetIp, returnValueAddress, callArgsAddress);
                             pFrame = pChildFrame;
@@ -4304,9 +4306,10 @@ do                                                                      \
                             pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
                             // We make sure that a new frame can't be seen with invalid ip/next when a stack
                             // overflow is triggered at a location outside of our control.
-                            VolatileStoreWithoutBarrier(&pChildFrame->ip, (const int32_t*)nullptr);
-                            VolatileStoreWithoutBarrier(&pChildFrame->pNext, (InterpMethodContextFrame*)nullptr);
-                            VolatileStoreWithoutBarrier(&pFrame->pNext, pChildFrame);
+                            pChildFrame->ip = NULL;
+                            pChildFrame->pNext = NULL;
+                            CompilerBarrier();
+                            pFrame->pNext = pChildFrame;
                         }
                         // Set the frame to the same values as the caller frame.
                         pChildFrame->ReInit(pFrame, pFrame->startIp, pFrame->pRetVal, pFrame->pStack);


### PR DESCRIPTION
When we need to obtain a new `InterpMethodContextFrame` for called method execution, we try to obtain a preallocated one from the list. If there is none, then we just allocate a new one with `alloca` and initialize the fields, including the `ip` to 0 initially. The problem is that the compiler is free to reorder this initialization in whichever way it considers optimal. If a stack overflow gets triggered at some point during execution (at a location that we don't normally expect), the unwinder might actually observe a pushed interp frame that has a non-null junk ip. We fix this by making sure the ip is properly zeroed before we publish the new interpreter frame on the list. Order is achieved just via compiler barriers.

Should fix `stackoverflowtester` on win-arm64.
```
"Assert failure(PID 46068 [0x0000b3f4], Thread: 46860 [0xb70c]): m_crawl.GetCodeInfo()->IsValid()"

CORECLR! StackFrameIterator::NextRaw + 0x764 (0x00007ff8`157b6e04)"
CORECLR! StackFrameIterator::Filter + 0xBD4 (0x00007ff8`157b57b4)"
CORECLR! StackFrameIterator::Init + 0x258 (0x00007ff8`157b60d8)"
CORECLR! Thread::StackWalkFramesEx + 0x178 (0x00007ff8`157b7e78)"
CORECLR! Thread::StackWalkFrames + 0x1A8 (0x00007ff8`157b7cd8)"
CORECLR! LogCallstackForLogWorker + 0x19C (0x00007ff8`1585139c)"
CORECLR! LogStackOverflowStackTraceThread + 0x10 (0x00007ff8`15851fe0)"
KERNEL32! BaseThreadInitThunk + 0x40 (0x00007ff8`8f128740)"
<no module>! <no symbol> + 0x0 (0x392cfff8`8fe64594)"
    File: D:\a\_work\1\s\src\coreclr\vm\stackwalk.cpp:2306"
    Image: C:\h\w\BD470A90\p\corerun.exe"
```