### PR TITLE
JIT/wasm: Pri-1 R2R codegen fixes (BBJ_CALLFINALLY back-edge, null-check loads)

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2652,6 +2652,16 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 
     genConsumeAddress(tree->Addr());
 
+    // On wasm a load from a null address does not fault, so emit an explicit null check
+    // for faulting loads (mirrors genCodeForStoreInd). Use the same predicate the throw-
+    // helper reservation phase uses (StackLevelSetter), so we never demand an unreserved
+    // throw helper block here.
+    if (((tree->gtFlags & GTF_EXCEPT) != 0) && tree->OperMayThrow(m_compiler))
+    {
+        regNumber addrReg = GetMultiUseOperandReg(tree->Addr());
+        genEmitNullCheck(addrReg);
+    }
+
     // TODO-WASM: Memory barriers
 
     GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), 0);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2652,11 +2652,7 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 
     genConsumeAddress(tree->Addr());
 
-    // On wasm a load from a null address does not fault, so emit an explicit null check
-    // for faulting loads (mirrors genCodeForStoreInd). Use the same predicate the throw-
-    // helper reservation phase uses (StackLevelSetter), so we never demand an unreserved
-    // throw helper block here.
-    if (((tree->gtFlags & GTF_EXCEPT) != 0) && tree->OperMayThrow(m_compiler))
+    if ((tree->gtFlags & GTF_IND_NONFAULTING) == 0)
     {
         regNumber addrReg = GetMultiUseOperandReg(tree->Addr());
         genEmitNullCheck(addrReg);
@@ -3601,23 +3597,13 @@ void CodeGen::genCallFinally(BasicBlock* block)
         return;
     }
 
-    // After call_indirect returns, control falls through to the next wasm instruction.
-    // The paired BBJ_CALLFINALLYRET has no code emitted (see genCodeForBlock), so the
-    // CALLFINALLYRET's continuation must be reached either by fall-through (when it's
-    // the next block in linear order) or by an explicit branch emitted here.
-    //
-    // This is wasm-specific: other targets rely on the native `call`/`ret` to land at
-    // the instruction after the call, and the JIT layout places the CALLFINALLYRET's
-    // continuation immediately after. On wasm the layout may place the continuation
-    // elsewhere (e.g. a loop header reached via back-edge, as produced by a leave from
-    // a catch handler that targets a label outside its enclosing try-finally).
-    //
+    // Branch to the continuation block if it's not the next block.
     assert(block->isBBCallFinallyPair());
     BasicBlock* const callFinallyRet = block->Next();
     assert(callFinallyRet->KindIs(BBJ_CALLFINALLYRET));
     BasicBlock* const continuation = callFinallyRet->GetTarget();
 
-    if (continuation->bbPreorderNum != callFinallyRet->bbPreorderNum + 1)
+    if (continuation != callFinallyRet->Next())
     {
         inst_JMP(EJ_jmp, continuation);
     }

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3587,6 +3587,29 @@ void CodeGen::genCallFinally(BasicBlock* block)
         {
             GetEmitter()->emitIns(INS_end);
         }
+
+        return;
+    }
+
+    // After call_indirect returns, control falls through to the next wasm instruction.
+    // The paired BBJ_CALLFINALLYRET has no code emitted (see genCodeForBlock), so the
+    // CALLFINALLYRET's continuation must be reached either by fall-through (when it's
+    // the next block in linear order) or by an explicit branch emitted here.
+    //
+    // This is wasm-specific: other targets rely on the native `call`/`ret` to land at
+    // the instruction after the call, and the JIT layout places the CALLFINALLYRET's
+    // continuation immediately after. On wasm the layout may place the continuation
+    // elsewhere (e.g. a loop header reached via back-edge, as produced by a leave from
+    // a catch handler that targets a label outside its enclosing try-finally).
+    //
+    assert(block->isBBCallFinallyPair());
+    BasicBlock* const callFinallyRet = block->Next();
+    assert(callFinallyRet->KindIs(BBJ_CALLFINALLYRET));
+    BasicBlock* const continuation = callFinallyRet->GetTarget();
+
+    if (continuation->bbPreorderNum != callFinallyRet->bbPreorderNum + 1)
+    {
+        inst_JMP(EJ_jmp, continuation);
     }
 }
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -458,6 +458,13 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
         return;
     }
 
+    if (indirNode->OperIs(GT_IND) && ((indirNode->gtFlags & GTF_IND_NONFAULTING) == 0))
+    {
+        // On wasm a load from a null address does not fault, so a faulting load needs an
+        // explicit null check, which requires multiple uses of the address operand.
+        SetMultiplyUsed(indirNode->Addr() DEBUGARG("ContainCheckIndir faulting load Addr"));
+    }
+
     // TODO-WASM-CQ: contain suitable LEAs here. Take note of the fact that for this to be correct we must prove the
     // LEA doesn't overflow. It will involve creating a new frontend node to represent "nuw" (offset) addition.
 }

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -460,8 +460,6 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
 
     if (indirNode->OperIs(GT_IND) && ((indirNode->gtFlags & GTF_IND_NONFAULTING) == 0))
     {
-        // On wasm a load from a null address does not fault, so a faulting load needs an
-        // explicit null check, which requires multiple uses of the address operand.
         SetMultiplyUsed(indirNode->Addr() DEBUGARG("ContainCheckIndir faulting load Addr"));
     }
 

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -486,17 +486,9 @@ void WasmRegAlloc::CollectReferencesForNode(GenTree* node)
             CollectReferencesForBinop(node->AsOp());
             break;
 
-        case GT_STOREIND:
-            CollectReferencesForStoreInd(node->AsStoreInd());
-            break;
-
         case GT_IND:
-            if (node->AsIndir()->Addr()->gtLIRFlags & LIR::Flags::MultiplyUsed)
-            {
-                // Faulting loads are null checked on wasm; consume the temporary register
-                // holding the address so it is available for both the check and the load.
-                ConsumeTemporaryRegForOperand(node->AsIndir()->Addr() DEBUGARG("indir load null check"));
-            }
+        case GT_STOREIND:
+            CollectReferencesForIndir(node->AsIndir());
             break;
 
         case GT_STORE_BLK:
@@ -657,15 +649,15 @@ void WasmRegAlloc::CollectReferencesForBinop(GenTreeOp* binopNode)
 }
 
 //------------------------------------------------------------------------
-// CollectReferencesForStoreInd: Collect virtual register references for an indirect store
+// CollectReferencesForIndir: Collect virtual register references for an indirection.
 //
 // Arguments:
-//    node - The GT_STOREIND node
+//    node - The indirection node.
 //
-void WasmRegAlloc::CollectReferencesForStoreInd(GenTreeStoreInd* node)
+void WasmRegAlloc::CollectReferencesForIndir(GenTreeIndir* node)
 {
     GenTree* const addr = node->Addr();
-    ConsumeTemporaryRegForOperand(addr DEBUGARG("storeind null check"));
+    ConsumeTemporaryRegForOperand(addr DEBUGARG("indirection address"));
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -490,6 +490,15 @@ void WasmRegAlloc::CollectReferencesForNode(GenTree* node)
             CollectReferencesForStoreInd(node->AsStoreInd());
             break;
 
+        case GT_IND:
+            if (node->AsIndir()->Addr()->gtLIRFlags & LIR::Flags::MultiplyUsed)
+            {
+                // Faulting loads are null checked on wasm; consume the temporary register
+                // holding the address so it is available for both the check and the load.
+                ConsumeTemporaryRegForOperand(node->AsIndir()->Addr() DEBUGARG("indir load null check"));
+            }
+            break;
+
         case GT_STORE_BLK:
             CollectReferencesForBlockStore(node->AsBlk());
             break;

--- a/src/coreclr/jit/regallocwasm.h
+++ b/src/coreclr/jit/regallocwasm.h
@@ -155,7 +155,7 @@ private:
     void      CollectReferencesForCall(GenTreeCall* callNode);
     void      CollectReferencesForCast(GenTreeOp* castNode);
     void      CollectReferencesForBinop(GenTreeOp* binOpNode);
-    void      CollectReferencesForStoreInd(GenTreeStoreInd* node);
+    void      CollectReferencesForIndir(GenTreeIndir* node);
     void      CollectReferencesForBlockStore(GenTreeBlk* node);
     void      CollectReferencesForLclVar(GenTreeLclVar* lclVar);
     void      CollectReferencesForIndexAddr(GenTreeIndexAddr* indexAddrNode);

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -190,13 +190,49 @@ void StackLevelSetter::ProcessBlock(BasicBlock* block)
 
         if (checkForHelpers)
         {
-            if (((node->gtFlags & GTF_EXCEPT) != 0) && node->OperMayThrow(m_compiler))
+            if (MayUseThrowHelperBlock(node))
             {
                 SetThrowHelperBlocks(node, block);
             }
         }
     }
     assert(currentStackLevel == 0);
+}
+
+//------------------------------------------------------------------------
+// MayUseThrowHelperBlock: Check whether codegen may branch to a throw helper block.
+//
+// Arguments:
+//   node - The node to process.
+//
+// Return Value:
+//   True if the node may branch to a throw helper block.
+//
+bool StackLevelSetter::MayUseThrowHelperBlock(GenTree* node)
+{
+    if (((node->gtFlags & GTF_EXCEPT) != 0) && node->OperMayThrow(m_compiler))
+    {
+        return true;
+    }
+
+#if defined(TARGET_WASM)
+    switch (node->OperGet())
+    {
+        case GT_NULLCHECK:
+        case GT_IND:
+        case GT_STORE_BLK:
+        case GT_STOREIND:
+            return (node->gtFlags & GTF_IND_NONFAULTING) == 0;
+
+        case GT_CALL:
+            return node->AsCall()->NeedsNullCheck();
+
+        default:
+            break;
+    }
+#endif // defined(TARGET_WASM)
+
+    return false;
 }
 
 //------------------------------------------------------------------------
@@ -213,7 +249,7 @@ void StackLevelSetter::ProcessBlock(BasicBlock* block)
 //
 void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
 {
-    assert(node->OperMayThrow(m_compiler));
+    assert(MayUseThrowHelperBlock(node));
 
     // Check that it uses throw block, find its kind, find the block, set level.
     switch (node->OperGet())

--- a/src/coreclr/jit/stacklevelsetter.h
+++ b/src/coreclr/jit/stacklevelsetter.h
@@ -17,6 +17,7 @@ private:
     void ProcessBlocks();
     void ProcessBlock(BasicBlock* block);
 
+    bool MayUseThrowHelperBlock(GenTree* node);
     void SetThrowHelperBlocks(GenTree* node, BasicBlock* block);
     void SetThrowHelperBlock(SpecialCodeKind kind, BasicBlock* block);
 


### PR DESCRIPTION
Two wasm JIT codegen correctness fixes surfaced by the Pri-1 R2R test pass.

**BBJ_CALLFINALLY non-fallthrough back-edge**
`genCodeForBlock` early-returns for `BBJ_CALLFINALLYRET` assuming fall-through to
the next linear block. On wasm the finally is invoked via `call_indirect`, so when
the paired continuation is reached via a back-edge (e.g. a catch leave targeting a
loop header outside the enclosing try/finally) no branch was emitted and control
fell out of the wasm loop, running a cloned finally a second time. Emit a `br` to
the continuation when it is not the next linear block. Fixes the double-finally in
`strswitch_catchrettoinnertry` and similar.

**Null-check faulting GT_IND loads**
On wasm a load from a null address does not fault, so a decoupled array bounds
check read the length from `[null+lenOffset]` as 0 and threw
`IndexOutOfRangeException` instead of `NullReferenceException`. `genCodeForStoreInd`
already emits an explicit null check for faulting stores; do the same for faulting
`GT_IND` loads (lower marks the address multiply-used, regalloc reserves the temp,
codegen emits the check using the same `GTF_EXCEPT && OperMayThrow` predicate the
throw-helper reservation phase uses). Fixes `b42929`, `b41063`, `b31903`,
`b091942`, and the `JitTest_catchfinally_*` array-null tests.
