### PR TITLE
[wasm] Fix reflection invoke of R2R-compiled methods

### DIFF
--- a/src/coreclr/vm/wasm/calldescrworkerwasm.cpp
+++ b/src/coreclr/vm/wasm/calldescrworkerwasm.cpp
@@ -38,5 +38,18 @@ extern "C" void STDCALL CallDescrWorkerInternal(CallDescrData* pCallDescrData)
         retBuff = &pCallDescrData->returnValue;
     }
 
-    ExecuteInterpretedMethodWithArgs((TADDR)targetIp, args, argsSize, retBuff, (PCODE)&CallDescrWorkerInternal);
+    if (targetIp == NULL)
+    {
+        // The target has no interpreter code because it is R2R (native Wasm) compiled.
+        // Dispatch to the native entry point via the interpreter-to-R2R thunk, mirroring
+        // ExecuteInterpretedMethodWithArgs_PortableEntryPoint_Complex. Calling the
+        // interpreter with a NULL target would not execute the method and would leave the
+        // return buffer aliasing the incoming arguments.
+        ManagedMethodParam param = { pMethod, args, (int8_t*)retBuff, (PCODE)NULL, NULL };
+        InvokeManagedMethod(&param);
+    }
+    else
+    {
+        ExecuteInterpretedMethodWithArgs((TADDR)targetIp, args, argsSize, retBuff, (PCODE)&CallDescrWorkerInternal);
+    }
 }


### PR DESCRIPTION
On wasm, `CallDescrWorkerInternal` (the reflection / dynamic-invoke path) only
dispatched to interpreted targets. For an R2R (native wasm) compiled method,
`GetInterpreterCode()` stays null even after `DoPrestub`, so it called
`ExecuteInterpretedMethodWithArgs` with a null target: the method never executed
and the return buffer was left aliasing the incoming arguments. As a result,
reflection `Invoke` of any value-returning R2R method returned the first argument
(or first struct field) instead of the real return value.

Dispatch through `InvokeManagedMethod` (the interpreter-to-R2R thunk) when there is
no interpreter code, mirroring
`ExecuteInterpretedMethodWithArgs_PortableEntryPoint_Complex`.

Fixes `InterlockedTest.TestCompareExchangeUnextended` (which invokes the target via
reflection) and, more broadly, all value-returning reflection invocations of R2R
methods on wasm. Validated against a standalone repro and the JIT_r test group.
