### PR TITLE
[wasm R2R] Align 8-byte stack locals and keep frames 16-aligned

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -5753,7 +5753,9 @@ int Compiler::lvaAllocLocalAndSetVirtualOffset(unsigned lclNum, unsigned size, i
     noway_assert(lclNum != BAD_VAR_NUM);
 
     LclVarDsc* lcl = lvaGetDesc(lclNum);
-#ifdef TARGET_64BIT
+#if defined(TARGET_64BIT) || defined(TARGET_WASM)
+    // Align >=8 byte locals to 8 bytes.
+    //
     // Before final frame layout, assume the worst case, that every >=8 byte local will need
     // maximum padding to be aligned. This is because we generate code based on the stack offset
     // computed during tentative frame layout. These offsets cannot get bigger during final
@@ -5825,7 +5827,7 @@ int Compiler::lvaAllocLocalAndSetVirtualOffset(unsigned lclNum, unsigned size, i
         }
 #endif
     }
-#endif // TARGET_64BIT
+#endif // TARGET_64BIT || TARGET_WASM
 
     /* Reserve space on the stack by bumping the frame size */
 
@@ -6046,8 +6048,17 @@ void Compiler::lvaAlignFrame()
         }
     }
 #elif defined(TARGET_WASM)
-    // TODO-WASM: decide what the stack alignment strategy should be. In the native ABI, the alignment is 16, but that
-    // may be suboptimal for the managed ABI, since it may imply zeroing the padding slots.
+    // Keep the stack aligned to STACK_ALIGN.
+    if ((compLclFrameSize % STACK_ALIGN) != 0)
+    {
+        lvaIncrementFrameSize(STACK_ALIGN - (compLclFrameSize % STACK_ALIGN));
+    }
+    else if (lvaDoneFrameLayout != FINAL_FRAME_LAYOUT)
+    {
+        // Reserve a full STACK_ALIGN so the offsets computed now are upper bounds.
+        lvaIncrementFrameSize(STACK_ALIGN);
+    }
+    assert((compLclFrameSize % STACK_ALIGN) == 0);
 #else
     NYI("TARGET specific lvaAlignFrame");
 #endif


### PR DESCRIPTION
Fixes #129802.

## Problem

On the WebAssembly **CoreCLR + ReadyToRun (crossgen2-wasm)** configuration, 64-bit
JS interop values (`long`/`BigInt`, `double`, `DateTime`, `Int52`) were corrupted
crossing the managed↔JS boundary: `corrupted = (original & 0xFFFFFFFF) << 32`. The JS
side reads/writes these slots through the 8-byte `HEAP64`/`HEAPF64` typed-array views
(`addr >>> 3`), which require 8-byte alignment; the marshaler buffer was landing at a
`4-mod-8` address, so the view addressed the wrong word.

## Root cause

wasm is `TARGET_WASM32` (4-byte pointers) and does not define `TARGET_64BIT`, so:

- The per-local 8-byte alignment padding in `lvaAllocLocalAndSetVirtualOffset` was gated
  on `TARGET_64BIT` and compiled out, leaving 8-byte stack locals only 4-byte aligned.
- `lvaAlignFrame` was a no-op for wasm, so the frame size was only 4-byte aligned. Since
  the shadow stack pointer is threaded through calls (`calleeSP = callerSP - frameSize`),
  a single `4-mod-8`-sized frame drifts every deeper frame — and every `stackalloc`'d
  marshaler buffer — out of 8-byte alignment.

## Fix

- Enable the existing 8-byte-local alignment for `TARGET_WASM`.
- Round `compLclFrameSize` up to `STACK_ALIGN` in `lvaAlignFrame` for wasm so the shadow
  SP stays aligned across calls.

## Validation

- The wasm cross-JIT rebuilds clean.
- crossgen2-wasm `JitDump` of a method with the marshaler pattern (address-taken `long` +
  `stackalloc Span`) confirms every 8-byte local now lands at an 8-aligned frame offset
  and the frame size is a multiple of 16 (the `Pad … size=8` events only fire from the
  newly enabled code block).
- A `JSImport` `BigInt`/`double` echo repro passes on the interpreter (matching the
  issue's interpreter baseline).

A black-box R2R pass/fail is best covered by the existing
`System.Runtime.InteropServices.JavaScript.UnitTests` suite on the coreclr-wasm-R2R lane.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot and reviewed before posting.
