### PR TITLE
JIT/wasm: bail R2R for calls passing 16-byte SIMD by value

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2790,6 +2790,13 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
             assert(seg.IsPassedInRegister());
             WasmValueType wvt = WasmRegToType(seg.GetRegister());
             assert(wvt < WasmValueType::Count);
+            if (wvt == WasmValueType::V128)
+            {
+                // Passing a 16-byte SIMD value by value through a call is not yet correctly
+                // implemented: the argument is materialized as an i32 (by-ref) while the call
+                // signature requires v128, producing an invalid module. Bail for now.
+                NYI_WASM_SIMD("SIMD16 call argument");
+            }
             typeStack.Push((CorInfoWasmType)emitter::GetWasmValueTypeCode(wvt));
         }
     }


### PR DESCRIPTION
On wasm, building a `call_indirect` signature emits `v128` for a 16-byte SIMD
(`Vector128`/`Vector<T>`) argument passed by value, but codegen materializes that
argument as an `i32` (a by-ref pointer) — so the pushed value (`local.get` of an
`i32`) doesn't match the `v128` the signature requires, and the whole module fails
`WebAssembly.Module()` validation (`call_indirect[N] expected type v128, found
local.get of type i32`).

This blocks R2R compilation of `System.Private.CoreLib` (59 SIMD methods —
`Vector128.Shuffle`/`Round`, `Vector<T>.Equals`, the `ISimdVector` *WhereAllBitsSet*
helpers, etc. — all fail identically).

Until the SIMD-by-value call ABI is implemented, mark such methods
R2R-unsupported via `NYI_WASM_SIMD` (consistent with the existing
`SIMD16 local load` bail), so they fall back to the interpreter and the module
validates. With this change `System.Private.CoreLib.wasm` validates cleanly
(0 invalid functions, was 59).
