### PR TITLE
Root DotNetRuntimeContractDescriptor export against linker GC in NativeAOT

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -391,6 +391,14 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-exported_symbols_list /dev/null" Condition="'$(OutputType)' == 'exe' and '$(_IsApplePlatform)' == 'true' and '$(ExportsFile)' == ''" />
       <CustomLinkerArg Include="-Wl,--version-script=&quot;$(ExportsFile)&quot;" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(ExportsFile)' != ''" />
       <CustomLinkerArg Include="-Wl,--export-dynamic" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(ExportsFile)' != ''" />
+      <!-- Root the cDAC contract descriptor export against linker dead code stripping. The export
+           args above merely set the symbol's visibility if it survives; unlike DotNetRuntimeDebugHeader
+           (referenced by PopulateDebugHeaders) the descriptor is a pure data symbol with no other
+           references, so without an explicit -u it is stripped. Windows .def EXPORTS already roots it.
+           Mirrors the apphost's -Wl,-u,DotNetRuntimeContractDescriptor (with the underscore-prefixed
+           name on Apple). -->
+      <CustomLinkerArg Include="-Wl,-u,_DotNetRuntimeContractDescriptor" Condition="'$(_IsApplePlatform)' == 'true' and '$(DebuggerSupport)' != 'false'" />
+      <CustomLinkerArg Include="-Wl,-u,DotNetRuntimeContractDescriptor" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(_targetOS)' != 'browser' and '$(DebuggerSupport)' != 'false'" />
       <CustomLinkerArg Include="-Wl,-dead_strip" Condition="'$(_IsApplePlatform)' == 'true'" />
       <CustomLinkerArg Include="@(LinkerArg)" />
     </ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -391,13 +391,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-exported_symbols_list /dev/null" Condition="'$(OutputType)' == 'exe' and '$(_IsApplePlatform)' == 'true' and '$(ExportsFile)' == ''" />
       <CustomLinkerArg Include="-Wl,--version-script=&quot;$(ExportsFile)&quot;" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(ExportsFile)' != ''" />
       <CustomLinkerArg Include="-Wl,--export-dynamic" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(ExportsFile)' != ''" />
-      <!-- Root the cDAC contract descriptor export against linker dead code stripping. The export
-           args above merely set the symbol's visibility if it survives; unlike DotNetRuntimeDebugHeader
-           (referenced by PopulateDebugHeaders) the descriptor is a pure data symbol with no other
-           references, so without an explicit -u it is stripped. Windows .def EXPORTS already roots it.
-           Mirrors the apphost's -Wl,-u,DotNetRuntimeContractDescriptor (with the underscore-prefixed
-           name on Apple). -->
-      <CustomLinkerArg Include="-Wl,-u,_DotNetRuntimeContractDescriptor" Condition="'$(_IsApplePlatform)' == 'true' and '$(DebuggerSupport)' != 'false'" />
       <CustomLinkerArg Include="-Wl,-u,DotNetRuntimeContractDescriptor" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(_targetOS)' != 'browser' and '$(DebuggerSupport)' != 'false'" />
       <CustomLinkerArg Include="-Wl,-dead_strip" Condition="'$(_IsApplePlatform)' == 'true'" />
       <CustomLinkerArg Include="@(LinkerArg)" />


### PR DESCRIPTION
## Summary

On **Linux/ELF**, a NativeAOT binary strips the `DotNetRuntimeContractDescriptor` symbol entirely -- it is present in neither `.dynsym` nor `.symtab` (confirmed with `readelf`). As a result the cDAC's contract-descriptor discovery (`GetExportSymbolAddress("DotNetRuntimeContractDescriptor")`) returns nothing on Linux and contract-based data access is impossible. On Windows the symbol is exported correctly (`dumpbin /exports`).

This is a Linux/ELF-only linker issue: ILC asks for the export on every platform, but on ELF the request is not strong enough to survive the link's `--gc-sections`.

## Root cause

ILC asks for the export on every platform via `--export-dynamic-symbol`, realized per-platform by `ExportsFileWriter`:

| Platform | Export mechanism | Roots the symbol vs `--gc-sections`? |
|----------|------------------|--------------------------------------|
| Windows  | `.def` `EXPORTS` | **Yes** -- PE exports are GC roots |
| Apple    | `-exported_symbols_list` (+ `-dead_strip`) | **Yes** -- listed symbols are kept |
| **Linux**| version script `global:` (+ `--export-dynamic`) | **No** -- only sets visibility/binding *if the symbol survives*; does not keep its section |

`DotNetRuntimeContractDescriptor` is a pure data symbol with no other references in the image (unlike `DotNetRuntimeDebugHeader`, which is written by `PopulateDebugHeaders()` at startup and so stays alive on its own). On ELF, `--gc-sections` collects it before the version script / `--export-dynamic` can export it, and it vanishes from the binary.

CoreCLR already solved this exact problem for the single-file apphost by force-keeping the same symbol with `-Wl,-u,DotNetRuntimeContractDescriptor` in `src/native/corehost/apphost/static/CMakeLists.txt`. NativeAOT did not do the equivalent. (The apphost needs its own `-u` because it does not use an exports file; NativeAOT does, which is why only ELF -- not Apple -- is affected here.)

## Fix

Root the exported contract descriptor against linker dead-code stripping on ELF in the `LinkNative` target of `Microsoft.NETCore.Native.targets`, mirroring the apphost:

```xml
<CustomLinkerArg Include="-Wl,-u,DotNetRuntimeContractDescriptor"
                 Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(_targetOS)' != 'browser' and '$(DebuggerSupport)' != 'false'" />
```

- **ELF** (non-win, non-Apple, non-browser): `-Wl,-u,DotNetRuntimeContractDescriptor` forces the symbol as an undefined reference at link start, making its section a GC root so it survives `--gc-sections` and is then exported by the version script + `--export-dynamic`.
- **Windows** and **Apple** are excluded: `.def` EXPORTS and `-exported_symbols_list` respectively already root the symbol.

Gated on `DebuggerSupport != false`, matching the existing `--export-dynamic-symbol` request. The `-u` only affects *retention*; the existing `--export-dynamic-symbol:` IlcArgs still drive export *visibility*.

## Validation

1. Build a NativeAOT console app for `linux-x64`/`linux-arm64` with default `DebuggerSupport`.
2. `readelf -W --dyn-syms <app> | grep DotNetRuntimeContractDescriptor` -> now **present**.
3. Confirm cDAC/SOS `GetExportSymbolAddress("DotNetRuntimeContractDescriptor")` resolves on a Linux dump.
4. Regression: Windows/Apple exports unchanged; an app built with `DebuggerSupport=false` still omits the symbol.

> [!NOTE]
> This PR description was generated with assistance from GitHub Copilot.
