### PR TITLE
Fix R2R GC ref map mismatch for unboxing stubs

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -117,10 +117,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder(factory, relocsOnly);
             dataBuilder.AddSymbol(this);
 
-            // Optimize some of the fixups into a more compact form
+            // Optimize some of the fixups into a more compact form.
+            // The compact token forms cannot carry signature flags, so instantiating and unboxing
+            // stubs must use the full method signature.
             ReadyToRunFixupKind fixupKind = _fixupKind;
             bool optimized = false;
-            if (_method.Method.IsPrimaryMethodDesc() && !IsInstantiatingStub
+            if (_method.Method.IsPrimaryMethodDesc() && !IsInstantiatingStub && !_method.Unboxing
                 && _method.ConstrainedType == null && fixupKind == ReadyToRunFixupKind.MethodEntry)
             {
                 if (!_method.Method.HasInstantiation && !_method.Method.OwningType.HasInstantiation && !_method.Method.OwningType.IsArray)


### PR DESCRIPTION
Fixes #129778 - The test is now passing in the manual CI run.

## Problem

A checked/debug build hits the assert

```
GC ref map mismatch detected for method: System.Int32::ToString
  Runtime GC ref map: I(00)
Crossgen2 GC ref map: R(00)
```

when a boxed value type is dispatched through an unboxing stub in a ReadyToRun image compiled in a Large Version Bubble. The repro is `box int; tail. callvirt System.Object::ToString()` (test `JIT/Regression/JitBlue/DevDiv_754566`), which only asserts when `System.Private.CoreLib` is in the version bubble.

## Root cause

In `MethodFixupSignature.GetData`, crossgen2 optimizes `MethodEntry` fixups on primary, non-instantiating, non-constrained methods into a compact `MethodEntry_DefToken` / `MethodEntry_RefToken` form that emits **only a token**. That compact form has no flag bits, so it cannot carry `READYTORUN_METHOD_SIG_UnboxingStub`.

For an unboxing stub this produces an inconsistency:

- The GC ref map node reads the same signature's `IsUnboxingStub` (`== _method.Unboxing == true`) and emits a full GC **ref (R)** for the boxed object reference.
- At load time the runtime decodes the flagless token as the **non-unboxing** entry and computes an **interior pointer (I)**.

`R != I` → the GC ref map check asserts. The interior result is also the unsafe one — calling the non-unboxing entry with a full object reference would be incorrect — so crossgen2's `R` is the correct value and the dropped flag is the bug.

The existing guard already excluded instantiating stubs (`!IsInstantiatingStub`) for exactly this reason but did not exclude unboxing stubs.

## Fix

Add `&& !_method.Unboxing` to the compact-token optimization guard so unboxing stubs fall through to the full `EmitMethodSignature` path, which writes the `UnboxingStub` flag. The common, non-unboxing case is unchanged and still uses the compact token form (no size/perf regression).

## Validation

- Reproduced the assert with `crossgen2 --inputbubble` (exit 134); without LVB the bug is latent and the test passes.
- With the fix, the native (shipping) crossgen2 recompiles the image and the test runs to **exit 100 / `=== PASSED ===`**.
- `R2RDump` confirms the `Int32.ToString()` import cell now carries `[UNBOX] ... (METHOD_ENTRY)`, while ordinary calls (`Program.Test`, `String.Concat`, `Console.WriteLine`) still use the compact `METHOD_ENTRY_DEF_TOKEN` / `METHOD_ENTRY_REF_TOKEN` form.

> [!NOTE]
> This PR description was drafted with GitHub Copilot.
