### PR TITLE
Use indirect field access for types spanning multiple inexact compilation units

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -3095,6 +3095,25 @@ namespace Internal.JitInterface
                 }
                 // ENCODE_NONE
             }
+            else if (_compilation.CompilationModuleGroup.TypeLayoutCompilationUnits(pMT).HasMultipleInexactCompilationUnits)
+            {
+                PreventRecursiveFieldInlinesOutsideVersionBubble(field, callerMethod);
+
+                // The layout of this type spans multiple inexact compilation units (assemblies that version
+                // with the current compilation but whose grouping into composite images is not fixed at
+                // compile time). When that is the case the offset of this field relative to its base class is
+                // unknowable: depending on whether those modules are ultimately bound as a single composite
+                // image or as individual assemblies, the runtime may either insert alignment before this
+                // type's fields or back-fill them into the base type's trailing alignment padding. Neither the
+                // relative ENCODE_FIELD_BASE_OFFSET encoding nor a baked absolute offset (with a relative
+                // field-offset verification) is valid for both layouts, so fall back to an indirect,
+                // runtime-resolved field offset, which is correct regardless of how the modules are grouped.
+
+                // ENCODE_FIELD_OFFSET
+                pResult->offset = 0;
+                pResult->fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INSTANCE_WITH_BASE;
+                pResult->fieldLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.FieldOffset(ComputeFieldWithToken(field, ref pResolvedToken)));
+            }
             else if (_compilation.IsInheritanceChainLayoutFixedInCurrentVersionBubble(pMT.BaseType))
             {
                 if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout && !callerMethod.IsNonVersionable() && (pResult->offset <= FieldFixupSignature.MaxCheckableOffset))


### PR DESCRIPTION
Fixes #128968 - The test passes in the manual CI run.

## Problem

In crossgen2-composite Large Version Bubble (LVB) R2R test legs (compiled with `--verify-type-and-field-layout`), the runtime hits a `Verify_FieldOffset` failfast, e.g.:

```
Assert failure: Verify_FieldOffset 'UnixConsoleStream._useReadLine' Field offset 8!=-6(actual) || baseOffset 0!=0(actual)
  File: .../src/coreclr/vm/jitinterface.cpp:14549
```

## Root cause

This is a cross-module layout divergence between crossgen2 and the runtime:

- When a reference type's layout chain spans **2+ inexact compilation units** (assemblies that version with the current compilation but whose grouping into composite images is not fixed at compile time), crossgen2 conservatively **aligns** the derived type's fields after the cross-compilation-unit base.
- At runtime, those framework modules can instead bind into a **single composite image**, where the runtime **back-fills** the derived type's fields into the base type's trailing alignment padding.

The two layouts disagree, so a baked relative offset (`ENCODE_FIELD_BASE_OFFSET`) or absolute offset with a relative field-offset verification is invalid for one of them — producing the failfast (and, with verification off, an incorrect memory access).

This reproduces for types like `UnixConsoleStream._useReadLine` (`System.Console` + corelib) and `XmlJsonReader._complexTextMode` (`System.Private.DataContractSerialization` + `System.Private.Xml` + corelib).

## Fix

In `EncodeFieldBaseOffset`, when `TypeLayoutCompilationUnits(pMT).HasMultipleInexactCompilationUnits` is true, route field access to an **indirect, runtime-resolved field offset** (`ENCODE_FIELD_OFFSET` via `SymbolNodeFactory.FieldOffset`). This is correct regardless of how the modules are ultimately grouped and emits no layout-verification fixup. The new branch is placed before the `IsInheritanceChainLayoutFixedInCurrentVersionBubble` branch, which would otherwise bake a wrong offset for these types.

## Validation

Validated end-to-end against a composite framework image (`framework-r2r.dll`) plus a separately-compiled test composite, the exact configuration that triggered the failure:

- `binarytrees-6` (writes to Console -> `UnixConsoleStream`): passed, no assert.
- `JsonBenchmarks` Serialize/Deserialize (`DataContractJsonSerializer` -> `XmlJsonReader`): passed, no assert.
- `strace` confirmed both `framework-r2r.dll` and the patched test `composite-r2r.dll` are loaded in-process during the run (not a JIT fallback).

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
