### PR TITLE
Pass correct search path to DllImportResolver for default flags on Mono

### DIFF
--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -440,7 +440,7 @@ static MonoDl* native_handle_lookup_wrapper (gpointer handle)
 }
 
 static MonoDl *
-netcore_resolve_with_dll_import_resolver (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, const char *scope, guint32 flags, MonoError *error)
+netcore_resolve_with_dll_import_resolver (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, const char *scope, gboolean user_specified_flags, guint32 flags, MonoError *error)
 {
 	MonoDl *result = NULL;
 	gpointer lib = NULL;
@@ -476,7 +476,7 @@ netcore_resolve_with_dll_import_resolver (MonoAssemblyLoadContext *alc, MonoAsse
 	goto_if_nok (error, leave);
 
 	gboolean has_search_flags;
-	has_search_flags = flags != 0 ? TRUE : FALSE;
+	has_search_flags = user_specified_flags;
 	gpointer args [5];
 	args [0] = MONO_HANDLE_RAW (scope_handle);
 	args [1] = MONO_HANDLE_RAW (assembly_handle);
@@ -493,12 +493,12 @@ leave:
 }
 
 static MonoDl *
-netcore_resolve_with_dll_import_resolver_nofail (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, const char *scope, guint32 flags)
+netcore_resolve_with_dll_import_resolver_nofail (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, const char *scope, gboolean user_specified_flags, guint32 flags)
 {
 	MonoDl *result = NULL;
 	ERROR_DECL (error);
 
-	result = netcore_resolve_with_dll_import_resolver (alc, assembly, scope, flags, error);
+	result = netcore_resolve_with_dll_import_resolver (alc, assembly, scope, user_specified_flags, flags, error);
 	if (!is_ok (error))
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT, "Error while invoking ALC DllImportResolver(\"%s\") delegate: '%s'", scope, mono_error_get_message (error));
 
@@ -703,7 +703,7 @@ netcore_lookup_native_library (MonoAssemblyLoadContext *alc, MonoImage *image, c
 		goto leave;
 	}
 
-	module = (MonoDl *)netcore_resolve_with_dll_import_resolver_nofail (alc, assembly, scope, flags);
+	module = (MonoDl *)netcore_resolve_with_dll_import_resolver_nofail (alc, assembly, scope, user_specified_flags, flags);
 	if (module) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT, "Native library found via DllImportResolver: '%s'.", scope);
 		goto add_to_alc_cache;

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -141,6 +141,31 @@ public class DllImportSearchPathsTest
         Assert.Equal(3, sum);
         Console.WriteLine("NativeLibraryWithDependency.Sum returned {0}", sum);
     }
+
+    [Fact]
+    public static void DllImportResolver_SearchPathMatchesAttributes()
+    {
+        DllImportSearchPath? observedSearchPath = null;
+        NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), (libraryName, assembly, searchPath) =>
+        {
+            if (libraryName == SearchPathPInvoke.LibraryName)
+                observedSearchPath = searchPath;
+
+            return IntPtr.Zero;
+        });
+
+        Assert.Throws<DllNotFoundException>(() => SearchPathPInvoke.AssemblyDirectory());
+        Assert.Equal(DllImportSearchPath.AssemblyDirectory, observedSearchPath);
+
+        Assert.Throws<DllNotFoundException>(() => SearchPathPInvoke.System32());
+        Assert.Equal(DllImportSearchPath.System32, observedSearchPath);
+
+        Assert.Throws<DllNotFoundException>(() => SearchPathPInvoke.LegacyBehavior());
+        Assert.Equal(DllImportSearchPath.LegacyBehavior, observedSearchPath);
+
+        Assert.Throws<DllNotFoundException>(() => SearchPathPInvoke.NoFlags());
+        Assert.Null(observedSearchPath);
+    }
 }
 
 public class NativeLibraryPInvoke
@@ -219,4 +244,25 @@ public class NativeLibraryWithDependency
     [DllImport(nameof(NativeLibraryWithDependency))]
     [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32)]
     static extern int CallDependencySum(int a, int b);
+}
+
+public class SearchPathPInvoke
+{
+    // Routed through the registered DllImportResolver, then fails the built-in search.
+    internal const string LibraryName = "DoesNotExist";
+
+    [DllImport(LibraryName)]
+    public static extern void NoFlags();
+
+    [DllImport(LibraryName)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+    public static extern void AssemblyDirectory();
+
+    [DllImport(LibraryName)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    public static extern void System32();
+
+    [DllImport(LibraryName)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+    public static extern void LegacyBehavior();
 }


### PR DESCRIPTION
On Mono, when no search flags are user-specified, `lookup_pinvoke_call_impl` defaults the flags to `DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY` for the built-in probing logic. `netcore_resolve_with_dll_import_resolver` then derived whether to report search flags to the resolver from `flags != 0`, so the explicit `AssemblyDirectory` value was passed to the resolver instead of `null`. The expected `DllImportResolver` contract is that `searchPath` is the attribute value, or `null` when neither the P/Invoke nor the assembly has the attribute.

After #114756, specifying only `AssemblyDirectory` meant only assembly directory. This means that when a resolver that forwards the (wrongly non-null) `AssemblyDirectory` to `NativeLibrary.Load`, it no longer does the default search (bare `dlopen`/`LoadLibrary`).

This change passes the `user_specified_flags` value through to the resolver invocation and uses it for "has search flags", so the resolver receives the attribute value or `null` for non-user-specified.

cc @dotnet/appmodel @AaronRobinsonMSFT 

See #129798. We should backport to 10.

> [!NOTE]
> This pull request was created with GitHub Copilot.
