### PR TITLE
[JSON] Fix source generator serializing null byte[] as empty string

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -1783,21 +1783,21 @@ namespace System.Text.Json.SourceGeneration
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}Value({valueExpr}.ToString());");
                     }
-                    else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
-                    {
-                        // byte[] is a nullable reference type; emit an explicit null check so that null values
-                        // serialize as 'null' rather than an empty Base64 string, matching reflection behavior.
-                        writer.WriteLine($$"""
-                            if ({{valueExpr}} is null)
-                            {
-                                writer.WriteNullValue();
-                            }
-                            else
-                            {
-                                writer.{{primitiveWriterMethod}}Value({{valueExpr}});
-                            }
-                            """);
-                    }
+else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
+{
+    // byte[] is a nullable reference type; emit an explicit null check so that null values
+    // serialize as 'null' rather than an empty Base64 string, matching reflection behavior.
+    writer.WriteLine($$"""
+        if ({{valueExpr}} is byte[] __byteArray)
+        {
+            writer.{{primitiveWriterMethod}}Value(__byteArray);
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+        """);
+}
                     else
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}Value({valueExpr});");
@@ -1824,21 +1824,21 @@ namespace System.Text.Json.SourceGeneration
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}({propertyNameExpr}, {valueExpr}.ToString());");
                     }
-                    else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
-                    {
-                        // byte[] is a nullable reference type; emit an explicit null check so that null values
-                        // serialize as 'null' rather than an empty Base64 string, matching reflection behavior.
-                        writer.WriteLine($$"""
-                            if ({{valueExpr}} is null)
-                            {
-                                writer.WriteNull({{propertyNameExpr}});
-                            }
-                            else
-                            {
-                                writer.{{primitiveWriterMethod}}({{propertyNameExpr}}, {{valueExpr}});
-                            }
-                            """);
-                    }
+else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
+{
+    // byte[] is a nullable reference type; emit an explicit null check so that null values
+    // serialize as 'null' rather than an empty Base64 string, matching reflection behavior.
+    writer.WriteLine($$"""
+        if ({{valueExpr}} is byte[] __byteArray)
+        {
+            writer.{{primitiveWriterMethod}}({{propertyNameExpr}}, __byteArray);
+        }
+        else
+        {
+            writer.WriteNull({{propertyNameExpr}});
+        }
+        """);
+}
                     else
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}({propertyNameExpr}, {valueExpr});");

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -1793,8 +1793,6 @@ namespace System.Text.Json.SourceGeneration
                     }
                     else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
                     {
-                        // byte[] is a reference type but WriteBase64StringValue accepts ReadOnlySpan<byte>,
-                        // which silently maps null to an empty value. Route through a helper that preserves null.
                         writer.WriteLine($"{ByteArrayValueWriterMethodName}(writer, {valueExpr});");
                         _emitByteArrayValueHelper = true;
                     }
@@ -1826,8 +1824,6 @@ namespace System.Text.Json.SourceGeneration
                     }
                     else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
                     {
-                        // byte[] is a reference type but WriteBase64String accepts ReadOnlySpan<byte>,
-                        // which silently maps null to an empty value. Route through a helper that preserves null.
                         writer.WriteLine($"writer.WritePropertyName({propertyNameExpr});");
                         writer.WriteLine($"{ByteArrayValueWriterMethodName}(writer, {valueExpr});");
                         _emitByteArrayValueHelper = true;

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -1783,21 +1783,21 @@ namespace System.Text.Json.SourceGeneration
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}Value({valueExpr}.ToString());");
                     }
-else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
-{
-    // byte[] is a nullable reference type; emit an explicit null check so that null values
-    // serialize as 'null' rather than an empty Base64 string, matching reflection behavior.
-    writer.WriteLine($$"""
-        if ({{valueExpr}} is byte[] __byteArray)
-        {
-            writer.{{primitiveWriterMethod}}Value(__byteArray);
-        }
-        else
-        {
-            writer.WriteNullValue();
-        }
-        """);
-}
+                    else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
+                    {
+                        // byte[] is a reference type but WriteBase64StringValue accepts ReadOnlySpan<byte>,
+                        // which loses null information. Emit an explicit null check to match reflection behavior.
+                        writer.WriteLine($$"""
+                            if ({{valueExpr}} is not null)
+                            {
+                                writer.{{primitiveWriterMethod}}Value({{valueExpr}});
+                            }
+                            else
+                            {
+                                writer.WriteNullValue();
+                            }
+                            """);
+                    }
                     else
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}Value({valueExpr});");
@@ -1824,21 +1824,21 @@ else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}({propertyNameExpr}, {valueExpr}.ToString());");
                     }
-else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
-{
-    // byte[] is a nullable reference type; emit an explicit null check so that null values
-    // serialize as 'null' rather than an empty Base64 string, matching reflection behavior.
-    writer.WriteLine($$"""
-        if ({{valueExpr}} is byte[] __byteArray)
-        {
-            writer.{{primitiveWriterMethod}}({{propertyNameExpr}}, __byteArray);
-        }
-        else
-        {
-            writer.WriteNull({{propertyNameExpr}});
-        }
-        """);
-}
+                    else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
+                    {
+                        // byte[] is a reference type but WriteBase64String accepts ReadOnlySpan<byte>,
+                        // which loses null information. Emit an explicit null check to match reflection behavior.
+                        writer.WriteLine($$"""
+                            if ({{valueExpr}} is not null)
+                            {
+                                writer.{{primitiveWriterMethod}}({{propertyNameExpr}}, {{valueExpr}});
+                            }
+                            else
+                            {
+                                writer.WriteNull({{propertyNameExpr}});
+                            }
+                            """);
+                    }
                     else
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}({propertyNameExpr}, {valueExpr});");

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -1783,6 +1783,21 @@ namespace System.Text.Json.SourceGeneration
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}Value({valueExpr}.ToString());");
                     }
+                    else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
+                    {
+                        // byte[] is a nullable reference type; emit an explicit null check so that null values
+                        // serialize as 'null' rather than an empty Base64 string, matching reflection behavior.
+                        writer.WriteLine($$"""
+                            if ({{valueExpr}} is null)
+                            {
+                                writer.WriteNullValue();
+                            }
+                            else
+                            {
+                                writer.{{primitiveWriterMethod}}Value({{valueExpr}});
+                            }
+                            """);
+                    }
                     else
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}Value({valueExpr});");
@@ -1808,6 +1823,21 @@ namespace System.Text.Json.SourceGeneration
                     if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.Char)
                     {
                         writer.WriteLine($"writer.{primitiveWriterMethod}({propertyNameExpr}, {valueExpr}.ToString());");
+                    }
+                    else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
+                    {
+                        // byte[] is a nullable reference type; emit an explicit null check so that null values
+                        // serialize as 'null' rather than an empty Base64 string, matching reflection behavior.
+                        writer.WriteLine($$"""
+                            if ({{valueExpr}} is null)
+                            {
+                                writer.WriteNull({{propertyNameExpr}});
+                            }
+                            else
+                            {
+                                writer.{{primitiveWriterMethod}}({{propertyNameExpr}}, {{valueExpr}});
+                            }
+                            """);
                     }
                     else
                     {

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -36,7 +36,6 @@ namespace System.Text.Json.SourceGeneration
             private const string JsonSerializerOptionsTypeRef = "global::System.Text.Json.JsonSerializerOptions";
             private const string JsonSerializerContextTypeRef = "global::System.Text.Json.Serialization.JsonSerializerContext";
             private const string Utf8JsonWriterTypeRef = "global::System.Text.Json.Utf8JsonWriter";
-            private const string ByteArrayValueWriterMethodName = "WriteByteArrayValue";
             private const string JsonCommentHandlingTypeRef = "global::System.Text.Json.JsonCommentHandling";
             private const string JsonConverterTypeRef = "global::System.Text.Json.Serialization.JsonConverter";
             private const string JsonConverterFactoryTypeRef = "global::System.Text.Json.Serialization.JsonConverterFactory";
@@ -61,6 +60,8 @@ namespace System.Text.Json.SourceGeneration
             private const string JsonUnionInfoValuesTypeRef = "global::System.Text.Json.Serialization.Metadata.JsonUnionInfoValues";
             private const string ReferenceHandlerTypeRef = "global::System.Text.Json.Serialization.ReferenceHandler";
             private const string EmptyTypeArray = "global::System.Array.Empty<global::System.Type>()";
+
+            private const string ByteArrayValueWriterMethodName = "WriteByteArrayValue";
 
             /// <summary>
             /// Contains an index from TypeRef to TypeGenerationSpec for the current ContextGenerationSpec.

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -36,6 +36,7 @@ namespace System.Text.Json.SourceGeneration
             private const string JsonSerializerOptionsTypeRef = "global::System.Text.Json.JsonSerializerOptions";
             private const string JsonSerializerContextTypeRef = "global::System.Text.Json.Serialization.JsonSerializerContext";
             private const string Utf8JsonWriterTypeRef = "global::System.Text.Json.Utf8JsonWriter";
+            private const string ByteArrayValueWriterMethodName = "WriteByteArrayValue";
             private const string JsonCommentHandlingTypeRef = "global::System.Text.Json.JsonCommentHandling";
             private const string JsonConverterTypeRef = "global::System.Text.Json.Serialization.JsonConverter";
             private const string JsonConverterFactoryTypeRef = "global::System.Text.Json.Serialization.JsonConverterFactory";
@@ -85,6 +86,12 @@ namespace System.Text.Json.SourceGeneration
             private bool _emitValueTypeSetterDelegate;
 
             /// <summary>
+            /// Indicates that the fast-path serializer writes a <see cref="byte"/> array value,
+            /// requiring the on-demand byte[] writer helper to be emitted on the context.
+            /// </summary>
+            private bool _emitByteArrayValueHelper;
+
+            /// <summary>
             /// The SourceText emit implementation filled by the individual Roslyn versions.
             /// </summary>
             private partial void AddSource(string hintName, SourceText sourceText);
@@ -112,7 +119,7 @@ namespace System.Text.Json.SourceGeneration
                 string contextName = contextGenerationSpec.ContextType.Name;
 
                 // Add root context implementation.
-                AddSource($"{contextName}.g.cs", GetRootJsonContextImplementation(contextGenerationSpec, _emitGetConverterForNullablePropertyMethod, _emitValueTypeSetterDelegate));
+                AddSource($"{contextName}.g.cs", GetRootJsonContextImplementation(contextGenerationSpec, _emitGetConverterForNullablePropertyMethod, _emitValueTypeSetterDelegate, _emitByteArrayValueHelper));
 
                 // Add GetJsonTypeInfo override implementation.
                 AddSource($"{contextName}.GetJsonTypeInfo.g.cs", GetGetTypeInfoImplementation(contextGenerationSpec));
@@ -122,6 +129,7 @@ namespace System.Text.Json.SourceGeneration
 
                 _emitGetConverterForNullablePropertyMethod = false;
                 _emitValueTypeSetterDelegate = false;
+                _emitByteArrayValueHelper = false;
                 _propertyNames.Clear();
                 _typeIndex.Clear();
             }
@@ -1775,7 +1783,7 @@ namespace System.Text.Json.SourceGeneration
                 }
             }
 
-            private static void GenerateSerializeValueStatement(SourceWriter writer, TypeGenerationSpec typeSpec, string valueExpr)
+            private void GenerateSerializeValueStatement(SourceWriter writer, TypeGenerationSpec typeSpec, string valueExpr)
             {
                 if (GetPrimitiveWriterMethod(typeSpec) is string primitiveWriterMethod)
                 {
@@ -1786,17 +1794,9 @@ namespace System.Text.Json.SourceGeneration
                     else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
                     {
                         // byte[] is a reference type but WriteBase64StringValue accepts ReadOnlySpan<byte>,
-                        // which loses null information. Emit an explicit null check to match reflection behavior.
-                        writer.WriteLine($$"""
-                            if ({{valueExpr}} is not null)
-                            {
-                                writer.{{primitiveWriterMethod}}Value({{valueExpr}});
-                            }
-                            else
-                            {
-                                writer.WriteNullValue();
-                            }
-                            """);
+                        // which silently maps null to an empty value. Route through a helper that preserves null.
+                        writer.WriteLine($"{ByteArrayValueWriterMethodName}(writer, {valueExpr});");
+                        _emitByteArrayValueHelper = true;
                     }
                     else
                     {
@@ -1816,7 +1816,7 @@ namespace System.Text.Json.SourceGeneration
                 }
             }
 
-            private static void GenerateSerializePropertyStatement(SourceWriter writer, TypeGenerationSpec typeSpec, string propertyNameExpr, string valueExpr)
+            private void GenerateSerializePropertyStatement(SourceWriter writer, TypeGenerationSpec typeSpec, string propertyNameExpr, string valueExpr)
             {
                 if (GetPrimitiveWriterMethod(typeSpec) is string primitiveWriterMethod)
                 {
@@ -1827,17 +1827,10 @@ namespace System.Text.Json.SourceGeneration
                     else if (typeSpec.PrimitiveTypeKind is JsonPrimitiveTypeKind.ByteArray)
                     {
                         // byte[] is a reference type but WriteBase64String accepts ReadOnlySpan<byte>,
-                        // which loses null information. Emit an explicit null check to match reflection behavior.
-                        writer.WriteLine($$"""
-                            if ({{valueExpr}} is not null)
-                            {
-                                writer.{{primitiveWriterMethod}}({{propertyNameExpr}}, {{valueExpr}});
-                            }
-                            else
-                            {
-                                writer.WriteNull({{propertyNameExpr}});
-                            }
-                            """);
+                        // which silently maps null to an empty value. Route through a helper that preserves null.
+                        writer.WriteLine($"writer.WritePropertyName({propertyNameExpr});");
+                        writer.WriteLine($"{ByteArrayValueWriterMethodName}(writer, {valueExpr});");
+                        _emitByteArrayValueHelper = true;
                     }
                     else
                     {
@@ -1922,7 +1915,7 @@ namespace System.Text.Json.SourceGeneration
                     """);
             }
 
-            private static SourceText GetRootJsonContextImplementation(ContextGenerationSpec contextSpec, bool emitGetConverterForNullablePropertyMethod, bool emitValueTypeSetterDelegate)
+            private static SourceText GetRootJsonContextImplementation(ContextGenerationSpec contextSpec, bool emitGetConverterForNullablePropertyMethod, bool emitValueTypeSetterDelegate, bool emitByteArrayValueHelper)
             {
                 string contextTypeRef = contextSpec.ContextType.FullyQualifiedName;
                 string contextTypeName = contextSpec.ContextType.Name;
@@ -1975,6 +1968,24 @@ namespace System.Text.Json.SourceGeneration
                     """);
 
                 writer.WriteLine();
+
+                if (emitByteArrayValueHelper)
+                {
+                    writer.WriteLine($$"""
+                        private static void {{ByteArrayValueWriterMethodName}}({{Utf8JsonWriterTypeRef}} writer, byte[]? value)
+                        {
+                            if (value is null)
+                            {
+                                writer.WriteNullValue();
+                            }
+                            else
+                            {
+                                writer.WriteBase64StringValue(value);
+                            }
+                        }
+                        """);
+                    writer.WriteLine();
+                }
 
                 GenerateConverterHelpers(writer, emitGetConverterForNullablePropertyMethod);
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -1164,5 +1164,42 @@ namespace System.Text.Json.SourceGeneration.Tests
         internal partial class NestedGenericConverterContext : JsonSerializerContext
         {
         }
+
+        public class ClassWithMultipleByteArrayProperties
+        {
+            public byte[]? Data1 { get; set; }
+            public byte[]? Data2 { get; set; }
+            public byte[]? Data3 { get; set; }
+        }
+
+        [JsonSerializable(typeof(ClassWithMultipleByteArrayProperties))]
+        internal partial class MultipleByteArrayContext : JsonSerializerContext
+        {
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 1, 2, 3 }, new byte[] { 4, 5, 6 }, null)]
+        [InlineData(null, new byte[] { 4, 5, 6 }, new byte[] { 7, 8, 9 })]
+        [InlineData(null, null, null)]
+        public static void ClassWithMultipleByteArrayProperties_Roundtrip(byte[]? data1, byte[]? data2, byte[]? data3)
+        {
+            var value = new ClassWithMultipleByteArrayProperties
+            {
+                Data1 = data1,
+                Data2 = data2,
+                Data3 = data3,
+            };
+
+            string json = JsonSerializer.Serialize(value, MultipleByteArrayContext.Default.ClassWithMultipleByteArrayProperties);
+
+            if (data1 is null) Assert.Contains("\"Data1\":null", json);
+            if (data2 is null) Assert.Contains("\"Data2\":null", json);
+            if (data3 is null) Assert.Contains("\"Data3\":null", json);
+
+            ClassWithMultipleByteArrayProperties deserialized = JsonSerializer.Deserialize(json, MultipleByteArrayContext.Default.ClassWithMultipleByteArrayProperties);
+            Assert.Equal(value.Data1, deserialized.Data1);
+            Assert.Equal(value.Data2, deserialized.Data2);
+            Assert.Equal(value.Data3, deserialized.Data3);
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -873,6 +873,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             {
                 Uri = new Uri("http://contoso.com"),
                 Array = new int[] { 42 },
+                ByteArray = new byte[] { 1, 2, 3 },
                 Poco = new ClassWithNullableProperties.MyPoco(),
 
                 NullableUri = new Uri("http://contoso.com"),
@@ -889,6 +890,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 
                 Assert.Equal(expected.Uri, actual.Uri);
                 Assert.Equal(expected.Array, actual.Array);
+                Assert.Equal(expected.ByteArray, actual.ByteArray);
                 Assert.Equal(expected.Poco, actual.Poco);
 
                 Assert.Equal(expected.NullableUri, actual.NullableUri);
@@ -943,6 +945,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             public Uri? Uri { get; set; }
             public int[]? Array { get; set; }
+            public byte[]? ByteArray { get; set; }
             public MyPoco? Poco { get; set; }
 
             public Uri? NullableUri { get; set; }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -886,6 +886,12 @@ namespace System.Text.Json.SourceGeneration.Tests
             void RunTest(ClassWithNullableProperties expected)
             {
                 string json = JsonSerializer.Serialize(expected, DefaultContext.ClassWithNullableProperties);
+
+                if (expected.ByteArray is null)
+                {
+                    Assert.Contains("\"ByteArray\":null", json);
+                }
+
                 ClassWithNullableProperties actual = JsonSerializer.Deserialize(json, DefaultContext.ClassWithNullableProperties);
 
                 Assert.Equal(expected.Uri, actual.Uri);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
@@ -455,6 +455,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             {
                 Uri = new Uri("http://contoso.com"),
                 Array = new int[] { 42 },
+                ByteArray = new byte[] { 1, 2, 3 },
                 Poco = new ClassWithNullableProperties.MyPoco(),
 
                 NullableUri = new Uri("http://contoso.com"),
@@ -471,6 +472,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 
                 Assert.Equal(expected.Uri, actual.Uri);
                 Assert.Equal(expected.Array, actual.Array);
+                Assert.Equal(expected.ByteArray, actual.ByteArray);
                 Assert.Equal(expected.Poco, actual.Poco);
 
                 Assert.Equal(expected.NullableUri, actual.NullableUri);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
@@ -468,6 +468,12 @@ namespace System.Text.Json.SourceGeneration.Tests
             void RunTest(ClassWithNullableProperties expected)
             {
                 string json = JsonSerializer.Serialize(expected, DefaultContext.ClassWithNullableProperties);
+
+                if (expected.ByteArray is null)
+                {
+                    Assert.Contains("\"ByteArray\":null", json);
+                }
+
                 ClassWithNullableProperties actual = JsonSerializer.Deserialize(json, ((ITestContext)MetadataWithPerTypeAttributeContext.Default).ClassWithNullableProperties);
 
                 Assert.Equal(expected.Uri, actual.Uri);


### PR DESCRIPTION
Fixes #129833

# Description

The System.Text.Json source generator's fast path serialized a null `byte[]` as an empty string (`""`) instead of `null`, diverging from the reflection-based `ByteArrayConverter`.

This happens because the emitted `writer.WriteBase64String(value)` implicitly converts the null `byte[]` to a `ReadOnlySpan<byte>`, where null and empty are indistinguishable. Unlike `WriteString`/`WriteStringValue` (which take `string?` and null-check internally), there is no `WriteBase64String` overload accepting a nullable `byte[]` — a span can't carry null — so the check can't live in the writer call and must be emitted by the generator, mirroring what `ByteArrayConverter.Write` already does.

The fix adds an explicit null check in the fast-path serialization helpers for `JsonPrimitiveTypeKind.ByteArray`, so null `byte[]` serializes as `null` for both object properties and collection elements.

# Testing

Extended `ClassWithNullableProperties_Roundtrip` to cover `byte[]` — the existing all-null case now exercises the regression (with the bug, a null `byte[]` serialized to `""` round-trips back to an empty array, not null). Runs across the reflection, metadata, and serialization (fast-path) contexts.
