### PR TITLE
[wasm] Enable Vector128 fast paths on Wasm via PackedSimd: hex/Guid, UTF-8, SearchValues, Teddy, Adler32/XXH3

### DIFF
--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -96,9 +96,10 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         internal static (Vector128<byte>, Vector128<byte>) AsciiToHexVector128(Vector128<byte> src, Vector128<byte> hexMap)
         {
-            Debug.Assert(Ssse3.IsSupported || AdvSimd.Arm64.IsSupported);
+            Debug.Assert(Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported);
 
             // The algorithm is simple: a single srcVec (contains the whole 16b Guid) is converted
             // into nibbles and then, via hexMap, converted into a HEX representation via
@@ -115,6 +116,7 @@ namespace System
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static void EncodeTo_Vector128<TChar>(ReadOnlySpan<byte> source, Span<TChar> destination, Casing casing)
         {
             Debug.Assert(source.Length >= (Vector128<TChar>.Count / 2));
@@ -187,7 +189,7 @@ namespace System
             Debug.Assert(utf8Destination.Length >= (source.Length * 2));
 
 #if SYSTEM_PRIVATE_CORELIB
-            if ((AdvSimd.Arm64.IsSupported || Ssse3.IsSupported) && (source.Length >= (Vector128<byte>.Count / 2)))
+            if ((AdvSimd.Arm64.IsSupported || Ssse3.IsSupported || PackedSimd.IsSupported) && (source.Length >= (Vector128<byte>.Count / 2)))
             {
                 EncodeTo_Vector128(source, utf8Destination, casing);
                 return;
@@ -204,7 +206,7 @@ namespace System
             Debug.Assert(destination.Length >= (source.Length * 2));
 
 #if SYSTEM_PRIVATE_CORELIB
-            if ((AdvSimd.Arm64.IsSupported || Ssse3.IsSupported) && (source.Length >= (Vector128<ushort>.Count / 2)))
+            if ((AdvSimd.Arm64.IsSupported || Ssse3.IsSupported || PackedSimd.IsSupported) && (source.Length >= (Vector128<ushort>.Count / 2)))
             {
                 EncodeTo_Vector128(source, Unsafe.BitCast<Span<char>, Span<ushort>>(destination), casing);
                 return;

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Adler32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Adler32.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 #if NET
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -299,6 +300,23 @@ namespace System.IO.Hashing
                         Vector128<ushort> wprod2 = AdvSimd.MultiplyWideningLower(bytes2.GetLower(), tap2.AsByte().GetLower());
                         wprod2 = AdvSimd.MultiplyWideningUpperAndAdd(wprod2, bytes2, tap2.AsByte());
                         vs2 = AdvSimd.AddPairwiseWideningAndAdd(vs2, wprod2);
+                    }
+                    else if (PackedSimd.IsSupported)
+                    {
+                        // Widening byte sum: each byte -> ushort pair sum -> uint pair sum, then accumulate into vs1.
+                        // Because weights are all positive (1-32), unsigned byte * unsigned byte multiply is valid for vs2.
+                        Vector128<ushort> sumPairs1 = PackedSimd.AddPairwiseWidening(bytes1);
+                        Vector128<ushort> sumPairs2 = PackedSimd.AddPairwiseWidening(bytes2);
+                        vs1 += PackedSimd.AddPairwiseWidening(sumPairs1) + PackedSimd.AddPairwiseWidening(sumPairs2);
+
+                        // bytes * weights -> 8 ushorts low + 8 ushorts high, sum pairwise to 4 uints + 4 uints.
+                        Vector128<ushort> wprod1Lo = PackedSimd.MultiplyWideningLower(bytes1, tap1.AsByte());
+                        Vector128<ushort> wprod1Hi = PackedSimd.MultiplyWideningUpper(bytes1, tap1.AsByte());
+                        vs2 += PackedSimd.AddPairwiseWidening(wprod1Lo) + PackedSimd.AddPairwiseWidening(wprod1Hi);
+
+                        Vector128<ushort> wprod2Lo = PackedSimd.MultiplyWideningLower(bytes2, tap2.AsByte());
+                        Vector128<ushort> wprod2Hi = PackedSimd.MultiplyWideningUpper(bytes2, tap2.AsByte());
+                        vs2 += PackedSimd.AddPairwiseWidening(wprod2Lo) + PackedSimd.AddPairwiseWidening(wprod2Hi);
                     }
                     else
                     {

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 #if NET
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -702,12 +703,25 @@ namespace System.IO.Hashing
                 Vector64<uint> sourceHigh = Vector128.Shuffle(source, Vector128.Create(1u, 3, 0, 0)).GetLower();
                 return AdvSimd.MultiplyWideningLower(sourceLow, sourceHigh);
             }
+            else if (Sse2.IsSupported)
+            {
+                Vector128<uint> sourceLow = Vector128.Shuffle(source, Vector128.Create(1u, 0, 3, 0));
+                return Sse2.Multiply(source, sourceLow);
+            }
+            else if (PackedSimd.IsSupported)
+            {
+                // PackedSimd.MultiplyWideningLower (i64x2.extmul_low_i32x4_u) does
+                // result[i] = (ulong)a[i] * (ulong)b[i] for i in {0, 1}.
+                // We need { source[0]*source[1], source[2]*source[3] } to match the Sse2/AdvSimd paths,
+                // so first move the even lanes into one operand and the odd lanes into the other.
+                Vector128<uint> evens = Vector128.Shuffle(source, Vector128.Create(0u, 2, 0, 0));
+                Vector128<uint> odds = Vector128.Shuffle(source, Vector128.Create(1u, 3, 0, 0));
+                return PackedSimd.MultiplyWideningLower(evens, odds);
+            }
             else
             {
                 Vector128<uint> sourceLow = Vector128.Shuffle(source, Vector128.Create(1u, 0, 3, 0));
-                return Sse2.IsSupported ?
-                    Sse2.Multiply(source, sourceLow) :
-                    (source & Vector128.Create(~0u, 0u, ~0u, 0u)).AsUInt64() * (sourceLow & Vector128.Create(~0u, 0u, ~0u, 0u)).AsUInt64();
+                return (source & Vector128.Create(~0u, 0u, ~0u, 0u)).AsUInt64() * (sourceLow & Vector128.Create(~0u, 0u, ~0u, 0u)).AsUInt64();
             }
         }
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 using System.Runtime.Versioning;
 using System.Text;
@@ -1345,7 +1346,7 @@ namespace System
                 }
                 flags >>= 8;
 
-                if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian)
+                if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) && BitConverter.IsLittleEndian)
                 {
                     // Vectorized implementation for D, N, P and B formats:
                     // [{|(]dddddddd[-]dddd[-]dddd[-]dddd[-]dddddddddddd[}|)]
@@ -1513,9 +1514,10 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static (Vector128<byte>, Vector128<byte>, Vector128<byte>) FormatGuidVector128Utf8(Guid value, bool useDashes)
         {
-            Debug.Assert((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian);
+            Debug.Assert((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) && BitConverter.IsLittleEndian);
             // Vectorized implementation for D, N, P and B formats:
             // [{|(]dddddddd[-]dddd[-]dddd[-]dddd[-]dddddddddddd[}|)]
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -4388,33 +4388,47 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         internal static Vector128<byte> UnpackLow(Vector128<byte> left, Vector128<byte> right)
         {
             if (Sse2.IsSupported)
             {
                 return Sse2.UnpackLow(left, right);
             }
-            else if (!AdvSimd.Arm64.IsSupported)
+            else if (AdvSimd.Arm64.IsSupported)
             {
-                ThrowHelper.ThrowNotSupportedException();
+                return AdvSimd.Arm64.ZipLow(left, right);
             }
-            return AdvSimd.Arm64.ZipLow(left, right);
+            else if (PackedSimd.IsSupported)
+            {
+                return PackedSimd.Shuffle(left, right,
+                    Vector128.Create((byte)0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23));
+            }
+            ThrowHelper.ThrowNotSupportedException();
+            return default;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         internal static Vector128<byte> UnpackHigh(Vector128<byte> left, Vector128<byte> right)
         {
             if (Sse2.IsSupported)
             {
                 return Sse2.UnpackHigh(left, right);
             }
-            else if (!AdvSimd.Arm64.IsSupported)
+            else if (AdvSimd.Arm64.IsSupported)
             {
-                ThrowHelper.ThrowNotSupportedException();
+                return AdvSimd.Arm64.ZipHigh(left, right);
             }
-            return AdvSimd.Arm64.ZipHigh(left, right);
+            else if (PackedSimd.IsSupported)
+            {
+                return PackedSimd.Shuffle(left, right,
+                    Vector128.Create((byte)8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31));
+            }
+            ThrowHelper.ThrowNotSupportedException();
+            return default;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -4401,8 +4401,14 @@ namespace System.Runtime.Intrinsics
             }
             else if (PackedSimd.IsSupported)
             {
-                return PackedSimd.Shuffle(left, right,
-                    Vector128.Create((byte)0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23));
+                // Compose with two ShuffleNative (PackedSimd.Swizzle, which clamps indices >= 16 to 0)
+                // plus OR. PackedSimd.Shuffle (two-vector i8x16.shuffle) would require constant lane
+                // indices and is impractical to call portably from generic code paths.
+                Vector128<byte> leftPart = Vector128.ShuffleNative(left,
+                    Vector128.Create((byte)0, 0xFF, 1, 0xFF, 2, 0xFF, 3, 0xFF, 4, 0xFF, 5, 0xFF, 6, 0xFF, 7, 0xFF));
+                Vector128<byte> rightPart = Vector128.ShuffleNative(right,
+                    Vector128.Create((byte)0xFF, 0, 0xFF, 1, 0xFF, 2, 0xFF, 3, 0xFF, 4, 0xFF, 5, 0xFF, 6, 0xFF, 7));
+                return leftPart | rightPart;
             }
             ThrowHelper.ThrowNotSupportedException();
             return default;
@@ -4424,8 +4430,11 @@ namespace System.Runtime.Intrinsics
             }
             else if (PackedSimd.IsSupported)
             {
-                return PackedSimd.Shuffle(left, right,
-                    Vector128.Create((byte)8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31));
+                Vector128<byte> leftPart = Vector128.ShuffleNative(left,
+                    Vector128.Create((byte)8, 0xFF, 9, 0xFF, 10, 0xFF, 11, 0xFF, 12, 0xFF, 13, 0xFF, 14, 0xFF, 15, 0xFF));
+                Vector128<byte> rightPart = Vector128.ShuffleNative(right,
+                    Vector128.Create((byte)0xFF, 8, 0xFF, 9, 0xFF, 10, 0xFF, 11, 0xFF, 12, 0xFF, 13, 0xFF, 14, 0xFF, 15));
+                return leftPart | rightPart;
             }
             ThrowHelper.ThrowNotSupportedException();
             return default;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -4401,12 +4401,15 @@ namespace System.Runtime.Intrinsics
             }
             else if (PackedSimd.IsSupported)
             {
-                // Compose with two ShuffleNative (PackedSimd.Swizzle, which clamps indices >= 16 to 0)
-                // plus OR. PackedSimd.Shuffle (two-vector i8x16.shuffle) would require constant lane
-                // indices and is impractical to call portably from generic code paths.
-                Vector128<byte> leftPart = Vector128.ShuffleNative(left,
+                // Compose with two PackedSimd.Swizzle calls (clamp out-of-range to 0) plus OR.
+                // We call PackedSimd.Swizzle directly rather than Vector128.ShuffleNative because
+                // the latter goes through a Ssse3 -> AdvSimd.Arm64 -> PackedSimd dispatcher chain
+                // that the Mono SIMD intrinsic recognizer doesn't always lower cleanly.
+                // PackedSimd.Shuffle (two-vector i8x16.shuffle) requires constant lane indices
+                // and is impractical to call portably from generic code paths.
+                Vector128<byte> leftPart = PackedSimd.Swizzle(left,
                     Vector128.Create((byte)0, 0xFF, 1, 0xFF, 2, 0xFF, 3, 0xFF, 4, 0xFF, 5, 0xFF, 6, 0xFF, 7, 0xFF));
-                Vector128<byte> rightPart = Vector128.ShuffleNative(right,
+                Vector128<byte> rightPart = PackedSimd.Swizzle(right,
                     Vector128.Create((byte)0xFF, 0, 0xFF, 1, 0xFF, 2, 0xFF, 3, 0xFF, 4, 0xFF, 5, 0xFF, 6, 0xFF, 7));
                 return leftPart | rightPart;
             }
@@ -4430,9 +4433,9 @@ namespace System.Runtime.Intrinsics
             }
             else if (PackedSimd.IsSupported)
             {
-                Vector128<byte> leftPart = Vector128.ShuffleNative(left,
+                Vector128<byte> leftPart = PackedSimd.Swizzle(left,
                     Vector128.Create((byte)8, 0xFF, 9, 0xFF, 10, 0xFF, 11, 0xFF, 12, 0xFF, 13, 0xFF, 14, 0xFF, 15, 0xFF));
-                Vector128<byte> rightPart = Vector128.ShuffleNative(right,
+                Vector128<byte> rightPart = PackedSimd.Swizzle(right,
                     Vector128.Create((byte)0xFF, 8, 0xFF, 9, 0xFF, 10, 0xFF, 11, 0xFF, 12, 0xFF, 13, 0xFF, 14, 0xFF, 15));
                 return leftPart | rightPart;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -80,7 +80,7 @@ namespace System.Buffers
         [BypassReadyToRun]
         private static void SetCharBit(ref uint charMap, byte value)
         {
-            if (Sse41.IsSupported || AdvSimd.Arm64.IsSupported)
+            if (Sse41.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported)
             {
                 Unsafe.Add(ref Unsafe.As<uint, byte>(ref charMap), value & VectorizedIndexMask) |= (byte)(1u << (value >> VectorizedIndexShift));
             }
@@ -92,7 +92,7 @@ namespace System.Buffers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [BypassReadyToRun]
-        private static bool IsCharBitSet(ref uint charMap, byte value) => Sse41.IsSupported || AdvSimd.Arm64.IsSupported
+        private static bool IsCharBitSet(ref uint charMap, byte value) => Sse41.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported
             ? (Unsafe.Add(ref Unsafe.As<uint, byte>(ref charMap), value & VectorizedIndexMask) & (1u << (value >> VectorizedIndexShift))) != 0
             : (Unsafe.Add(ref charMap, value & PortableIndexMask) & (1u << (value >> PortableIndexShift))) != 0;
 
@@ -220,6 +220,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static Vector128<byte> ContainsMask16Chars(Vector128<byte> charMapLower, Vector128<byte> charMapUpper, ref char searchSpace)
         {
             Vector128<ushort> source0 = Vector128.LoadUnsafe(ref searchSpace);
@@ -237,6 +238,11 @@ namespace System.Buffers
             {
                 sourceLower = AdvSimd.Arm64.UnzipEven(source0.AsByte(), source1.AsByte());
                 sourceUpper = AdvSimd.Arm64.UnzipOdd(source0.AsByte(), source1.AsByte());
+            }
+            else if (PackedSimd.IsSupported)
+            {
+                sourceLower = PackedSimd.ConvertNarrowingSaturateUnsigned((source0 & Vector128.Create((ushort)255)).AsInt16(), (source1 & Vector128.Create((ushort)255)).AsInt16());
+                sourceUpper = PackedSimd.ConvertNarrowingSaturateUnsigned((source0 >>> 8).AsInt16(), (source1 >>> 8).AsInt16());
             }
             else
             {
@@ -392,7 +398,7 @@ namespace System.Buffers
         internal static int IndexOfAny<TUseFastContains>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
             where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
-            if ((Sse41.IsSupported || AdvSimd.Arm64.IsSupported) && searchSpaceLength >= 16)
+            if ((Sse41.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) && searchSpaceLength >= 16)
             {
                 return Vector512.IsHardwareAccelerated && Avx512Vbmi.VL.IsSupported
                     ? IndexOfAnyVectorizedAvx512<TUseFastContains>(ref searchSpace, searchSpaceLength, ref state)
@@ -406,7 +412,7 @@ namespace System.Buffers
         internal static int LastIndexOfAny<TUseFastContains>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
             where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
-            if ((Sse41.IsSupported || AdvSimd.Arm64.IsSupported) && searchSpaceLength >= 16)
+            if ((Sse41.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) && searchSpaceLength >= 16)
             {
                 return Vector512.IsHardwareAccelerated && Avx512Vbmi.VL.IsSupported
                     ? LastIndexOfAnyVectorizedAvx512<TUseFastContains>(ref searchSpace, searchSpaceLength, ref state)
@@ -501,10 +507,11 @@ namespace System.Buffers
 
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(Sse41))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static int IndexOfAnyVectorized<TUseFastContains>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
             where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
-            Debug.Assert(Sse41.IsSupported || AdvSimd.Arm64.IsSupported);
+            Debug.Assert(Sse41.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported);
             Debug.Assert(searchSpaceLength >= 16);
 
             ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
@@ -679,10 +686,11 @@ namespace System.Buffers
 
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(Sse41))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static int LastIndexOfAnyVectorized<TUseFastContains>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
             where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
-            Debug.Assert(Sse41.IsSupported || AdvSimd.Arm64.IsSupported);
+            Debug.Assert(Sse41.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported);
             Debug.Assert(searchSpaceLength >= 16);
 
             ref char cur = ref Unsafe.Add(ref searchSpace, searchSpaceLength);

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/AsciiStringSearchValuesTeddyBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/AsciiStringSearchValuesTeddyBase.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 using static System.Buffers.StringSearchValuesHelper;
 using static System.Buffers.TeddyHelper;
@@ -150,6 +151,7 @@ namespace System.Buffers
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         protected int IndexOfAnyN2(ReadOnlySpan<char> span)
         {
             // The behavior of the rest of the function remains the same if Avx2 or Avx512BW aren't supported
@@ -170,6 +172,7 @@ namespace System.Buffers
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         protected int IndexOfAnyN3(ReadOnlySpan<char> span)
         {
             // The behavior of the rest of the function remains the same if Avx2 or Avx512BW aren't supported
@@ -190,6 +193,7 @@ namespace System.Buffers
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private int IndexOfAnyN2Vector128(ReadOnlySpan<char> span)
         {
             // See comments in 'IndexOfAnyN3Vector128' below.
@@ -350,6 +354,7 @@ namespace System.Buffers
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private int IndexOfAnyN3Vector128(ReadOnlySpan<char> span)
         {
             // We can't process inputs shorter than 18 characters in a vectorized manner here.

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
@@ -369,11 +369,13 @@ namespace System.Buffers
             }
             else if (PackedSimd.IsSupported)
             {
-                // ShuffleNative lowers to PackedSimd.Swizzle which clamps out-of-range
-                // indices (>= 16) to 0, so we can compose the two halves with an OR.
-                Vector128<byte> leftPart = Vector128.ShuffleNative(left,
+                // Call PackedSimd.Swizzle directly (i8x16.swizzle) rather than through
+                // Vector128.ShuffleNative's dispatcher chain, which the Mono SIMD intrinsic
+                // recognizer doesn't always lower cleanly. Swizzle clamps out-of-range
+                // indices (>= 16) to 0 so we can compose the two halves with OR.
+                Vector128<byte> leftPart = PackedSimd.Swizzle(left,
                     Vector128.Create((byte)15, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF));
-                Vector128<byte> rightPart = Vector128.ShuffleNative(right,
+                Vector128<byte> rightPart = PackedSimd.Swizzle(right,
                     Vector128.Create((byte)0xFF, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14));
                 return leftPart | rightPart;
             }
@@ -407,9 +409,9 @@ namespace System.Buffers
             }
             else if (PackedSimd.IsSupported)
             {
-                Vector128<byte> leftPart = Vector128.ShuffleNative(left,
+                Vector128<byte> leftPart = PackedSimd.Swizzle(left,
                     Vector128.Create((byte)14, 15, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF));
-                Vector128<byte> rightPart = Vector128.ShuffleNative(right,
+                Vector128<byte> rightPart = PackedSimd.Swizzle(right,
                     Vector128.Create((byte)0xFF, 0xFF, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13));
                 return leftPart | rightPart;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
@@ -4,6 +4,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
@@ -17,6 +18,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         public static (Vector128<byte> Result, Vector128<byte> Prev0) ProcessInputN2(
             Vector128<byte> input,
             Vector128<byte> prev0,
@@ -90,6 +92,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         public static (Vector128<byte> Result, Vector128<byte> Prev0, Vector128<byte> Prev1) ProcessInputN3(
             Vector128<byte> input,
             Vector128<byte> prev0, Vector128<byte> prev1,
@@ -216,6 +219,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         public static Vector128<byte> LoadAndPack16AsciiChars(ref char source)
         {
             Vector128<ushort> source0 = Vector128.LoadUnsafe(ref source);
@@ -228,6 +232,10 @@ namespace System.Buffers
             else if (AdvSimd.Arm64.IsSupported)
             {
                 return AdvSimd.Arm64.UnzipEven(source0.AsByte(), source1.AsByte());
+            }
+            else if (PackedSimd.IsSupported)
+            {
+                return PackedSimd.ConvertNarrowingSaturateUnsigned(source0.AsInt16(), source1.AsInt16());
             }
             else
             {
@@ -276,10 +284,13 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static (Vector128<byte> Low, Vector128<byte> High) GetNibbles(Vector128<byte> input)
         {
             // 'low' is not strictly correct here, but we take advantage of Ssse3.Shuffle's behavior
-            // of doing an implicit 'AND 0xF' in order to skip the redundant AND.
+            // of doing an implicit 'AND 0xF' in order to skip the redundant AND. PackedSimd.Swizzle
+            // and AdvSimd's table lookup return 0 for indices >= 16 (instead of masking the low 4
+            // bits), so they need the explicit AND.
             Vector128<byte> low = Ssse3.IsSupported
                 ? input
                 : input & Vector128.Create((byte)0xF);
@@ -316,6 +327,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static Vector128<byte> Shuffle(Vector128<byte> maskLow, Vector128<byte> maskHigh, Vector128<byte> low, Vector128<byte> high)
         {
             return SearchValues.ShuffleNativeModified(maskLow, low) & Vector128.ShuffleNative(maskHigh, high);
@@ -338,6 +350,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static Vector128<byte> RightShift1(Vector128<byte> left, Vector128<byte> right)
         {
             // Given input vectors like
@@ -354,6 +367,16 @@ namespace System.Buffers
             {
                 return AdvSimd.ExtractVector128(left, right, 15);
             }
+            else if (PackedSimd.IsSupported)
+            {
+                // ShuffleNative lowers to PackedSimd.Swizzle which clamps out-of-range
+                // indices (>= 16) to 0, so we can compose the two halves with an OR.
+                Vector128<byte> leftPart = Vector128.ShuffleNative(left,
+                    Vector128.Create((byte)15, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF));
+                Vector128<byte> rightPart = Vector128.ShuffleNative(right,
+                    Vector128.Create((byte)0xFF, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14));
+                return leftPart | rightPart;
+            }
             else
             {
                 // We explicitly recheck each IsSupported query to ensure that the trimmer can see which paths are live/dead
@@ -365,6 +388,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static Vector128<byte> RightShift2(Vector128<byte> left, Vector128<byte> right)
         {
             // Given input vectors like
@@ -380,6 +404,14 @@ namespace System.Buffers
             else if (AdvSimd.IsSupported)
             {
                 return AdvSimd.ExtractVector128(left, right, 14);
+            }
+            else if (PackedSimd.IsSupported)
+            {
+                Vector128<byte> leftPart = Vector128.ShuffleNative(left,
+                    Vector128.Create((byte)14, 15, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF));
+                Vector128<byte> rightPart = Vector128.ShuffleNative(right,
+                    Vector128.Create((byte)0xFF, 0xFF, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13));
+                return leftPart | rightPart;
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValues.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 using System.Text;
 using System.Text.Unicode;
@@ -128,7 +129,7 @@ namespace System.Buffers
                 return CreateForSingleValue(values[0], uniqueValues, ignoreCase, allAscii, asciiLettersOnly);
             }
 
-            if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) &&
+            if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) &&
                 TryGetTeddyAcceleratedValues(values, uniqueValues, ignoreCase, allAscii, asciiLettersOnly, nonAsciiAffectedByCaseConversion, minLength) is { } searchValues)
             {
                 return searchValues;
@@ -198,7 +199,7 @@ namespace System.Buffers
 
             int n = minLength == 2 ? 2 : 3;
 
-            if (Ssse3.IsSupported)
+            if (Ssse3.IsSupported || PackedSimd.IsSupported)
             {
                 foreach (string value in values)
                 {
@@ -206,8 +207,9 @@ namespace System.Buffers
                     {
                         // If we let null chars through here, Teddy would still work correctly, but it
                         // would hit more false positives that the verification step would have to rule out.
-                        // While we could flow a generic flag like Ssse3AndWasmHandleZeroInNeedle through,
-                        // we expect such values to be rare enough that introducing more code is not worth it.
+                        // Ssse3.PackUnsignedSaturate and PackedSimd.ConvertNarrowingSaturateUnsigned both
+                        // treat negative signed-16 values as 0, so we filter out null-containing needles
+                        // for both to avoid that source of false positives.
                         return null;
                     }
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 #if NET
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -884,7 +885,7 @@ namespace System.Text.Unicode
 #if NET
             Vector128<short> nonAsciiUtf16DataMask;
 
-            if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian))
+            if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || (PackedSimd.IsSupported && BitConverter.IsLittleEndian))
             {
                 nonAsciiUtf16DataMask = Vector128.Create(unchecked((short)0xFF80)); // mask of non-ASCII bits in a UTF-16 char
             }
@@ -944,7 +945,7 @@ namespace System.Text.Unicode
                     uint minElementsRemaining = (uint)Math.Min(inputCharsRemaining, outputBytesRemaining);
 
 #if NET
-                    if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian))
+                    if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || (PackedSimd.IsSupported && BitConverter.IsLittleEndian))
                     {
                         // Try reading and writing 8 elements per iteration.
                         uint maxIters = minElementsRemaining / 8;
@@ -982,6 +983,17 @@ namespace System.Text.Unicode
                                 // narrow and write
                                 Sse2.StoreScalar((ulong*)pOutputBuffer /* unaligned */, Sse2.PackUnsignedSaturate(utf16Data, utf16Data).AsUInt64());
                             }
+                            else if (PackedSimd.IsSupported)
+                            {
+                                if ((utf16Data & nonAsciiUtf16DataMask) != Vector128<short>.Zero)
+                                {
+                                    goto LoopTerminatedDueToNonAsciiDataInVectorLocal;
+                                }
+
+                                // narrow and write low 8 bytes
+                                Vector128<byte> narrowed = PackedSimd.ConvertNarrowingSaturateUnsigned(utf16Data, utf16Data);
+                                Unsafe.WriteUnaligned<ulong>(pOutputBuffer, narrowed.AsUInt64().ToScalar());
+                            }
                             else
                             {
                                 // We explicitly recheck each IsSupported query to ensure that the trimmer can see which paths are live/dead
@@ -1014,6 +1026,11 @@ namespace System.Text.Unicode
                             else if (Sse2.IsSupported)
                             {
                                 Unsafe.WriteUnaligned(pOutputBuffer, Sse2.ConvertToUInt32(Sse2.PackUnsignedSaturate(utf16Data, utf16Data).AsUInt32()));
+                            }
+                            else if (PackedSimd.IsSupported)
+                            {
+                                Vector128<byte> narrowed = PackedSimd.ConvertNarrowingSaturateUnsigned(utf16Data, utf16Data);
+                                Unsafe.WriteUnaligned<uint>(pOutputBuffer, narrowed.AsUInt32().ToScalar());
                             }
                             else
                             {
@@ -1057,6 +1074,11 @@ namespace System.Text.Unicode
                             else if (Sse2.IsSupported)
                             {
                                 Unsafe.WriteUnaligned(pOutputBuffer, Sse2.ConvertToUInt32(Sse2.PackUnsignedSaturate(utf16Data, utf16Data).AsUInt32()));
+                            }
+                            else if (PackedSimd.IsSupported)
+                            {
+                                Vector128<byte> narrowed = PackedSimd.ConvertNarrowingSaturateUnsigned(utf16Data, utf16Data);
+                                Unsafe.WriteUnaligned<uint>(pOutputBuffer, narrowed.AsUInt32().ToScalar());
                             }
                             else
                             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -885,7 +885,7 @@ namespace System.Text.Unicode
 #if NET
             Vector128<short> nonAsciiUtf16DataMask;
 
-            if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || (PackedSimd.IsSupported && BitConverter.IsLittleEndian))
+            if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || PackedSimd.IsSupported)
             {
                 nonAsciiUtf16DataMask = Vector128.Create(unchecked((short)0xFF80)); // mask of non-ASCII bits in a UTF-16 char
             }
@@ -945,7 +945,7 @@ namespace System.Text.Unicode
                     uint minElementsRemaining = (uint)Math.Min(inputCharsRemaining, outputBytesRemaining);
 
 #if NET
-                    if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || (PackedSimd.IsSupported && BitConverter.IsLittleEndian))
+                    if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || PackedSimd.IsSupported)
                     {
                         // Try reading and writing 8 elements per iteration.
                         uint maxIters = minElementsRemaining / 8;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -190,8 +190,8 @@ namespace System.Text.Unicode
 
 #if NET
                     LoopTerminatedEarlyDueToNonAsciiData:
-                        // x86 can only be little endian, while ARM can be big or little endian
-                        // so if we reached this label we need to check both combinations are supported
+                        // x86 and Wasm can only be little endian, while ARM can be big or little endian,
+                        // so if we reached this label we need to check the LE-restricted combinations as well.
                         Debug.Assert((AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || Sse2.IsSupported || PackedSimd.IsSupported);
 
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 #if NET
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -158,6 +159,15 @@ namespace System.Text.Unicode
                                         goto LoopTerminatedEarlyDueToNonAsciiData;
                                     }
                                 }
+                                else if (PackedSimd.IsSupported)
+                                {
+                                    uint mask = Vector128.LoadUnsafe(ref *pInputBuffer).ExtractMostSignificantBits();
+                                    if (mask != 0)
+                                    {
+                                        trailingZeroCount = (nuint)BitOperations.TrailingZeroCount(mask);
+                                        goto LoopTerminatedEarlyDueToNonAsciiData;
+                                    }
+                                }
                                 else
 #endif
                                 {
@@ -182,7 +192,7 @@ namespace System.Text.Unicode
                     LoopTerminatedEarlyDueToNonAsciiData:
                         // x86 can only be little endian, while ARM can be big or little endian
                         // so if we reached this label we need to check both combinations are supported
-                        Debug.Assert((AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || Sse2.IsSupported);
+                        Debug.Assert((AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || Sse2.IsSupported || PackedSimd.IsSupported);
 
 
                         // The 'mask' value will have a 0 bit for each ASCII byte we saw and a 1 bit


### PR DESCRIPTION
Enable several `Vector128` fast paths in CoreLib and `System.IO.Hashing` on browser-wasm by adding a `PackedSimd.IsSupported` branch alongside the existing `Sse2`/`Ssse3`/`AdvSimd.Arm64` gates. Before these changes, the SIMD code paths were unreachable on Wasm even though the wasm runtime supports PackedSimd (the test pipeline default sets `WasmEnableSIMD=true`).

## Scope and commits

| # | Commit | Area |
|---|--------|------|
| 1 | `c69998277eb` `0e99f4a194c` | Add Wasm `PackedSimd` path to `Vector128.UnpackLow/UnpackHigh` (composed from two `PackedSimd.Swizzle` calls + OR; the two-vector `PackedSimd.Shuffle` requires constant lane indices and is impractical from generic code). |
| 2 | `3dc956b6465` | Enable Vector128 hex/Guid format fast path on Wasm — widen the gates on `HexConverter.AsciiToHexVector128`, `HexConverter.EncodeToUtf8/Utf16`, `HexConverter.EncodeTo_Vector128`, and `Guid.FormatGuidVector128Utf8`. Bodies were already portable (`Vector128.ShuffleNative`, `Vector128.UnpackLow/High`, constant-index `Vector128.Shuffle`). |
| 3 | `061b22bffcf` `2543702633` | Vectorize `Utf8Utility.Validation` ASCII fast path on Wasm — add a `PackedSimd` branch alongside `AdvSimd.Arm64`/`Sse2` in the inner ASCII-scan loop of `GetPointerToFirstInvalidChar`, using portable `Vector128.LoadUnsafe` + `ExtractMostSignificantBits`. |
| 4 | `da08d905c6e` | Vectorize `Utf8Utility.Transcoding` ASCII fast path on Wasm — the 8-char narrow-store loop and the two 4-char tail stores, using `PackedSimd.ConvertNarrowingSaturateUnsigned`. |
| 5 | `2caa5e25997` `0e99f4a194c` | Enable Teddy multi-string search on Wasm — `TeddyHelper.LoadAndPack16AsciiChars`, `GetNibbles`, two-table `Shuffle`, `RightShift1/RightShift2` (composed from two `PackedSimd.Swizzle` calls + OR), plus the `StringSearchValues.CreateFromNormalizedValues` entry gate and `AsciiStringSearchValuesTeddyBase.IndexOfAnyN2/N3` `[CompExactlyDependsOn]`. |
| 6 | `819c9fe3960` | Enable `ProbabilisticMap` vectorized `SearchValues<char>` on Wasm. Subtle because the bitmap **layout itself** branches on the gate (`SetCharBit`/`IsCharBitSet`, marked `[BypassReadyToRun]`). Widens the layout choice, `ContainsMask16Chars` (new PackedSimd narrowing branch), the `IndexOfAny`/`LastIndexOfAny` entry dispatcher, and the worker `[CompExactlyDependsOn]` attributes consistently. |
| 7 | `80522ca629b` | `Adler32.UpdateVector128` and `XxHashShared.MultiplyWideningLower`: replace the portable `Vector128.Widen + multiply + add` sequences with `PackedSimd.AddPairwiseWidening` + `MultiplyWideningLower/Upper` and `PackedSimd.MultiplyWideningLower` (`i64x2.extmul_low_i32x4_u`). Already vectorized on Wasm via the generic else branch; this turns 3–5 ops/iter into 1. |

## Test results

Validated end-to-end with `WasmEnableSIMD=true` (the browser-wasm test pipeline default).

| Suite | Host arm64 | browser-wasm (V8 v15) | Coverage |
|------|-----------|------------------------|----------|
| `System.Runtime.Tests` | 69,714 / 69,714 ✅ | 67,835 / 67,835 ✅ | Guid format/parse |
| `System.Runtime.Extensions.Tests` | 8,350 / 8,350 ✅ | 8,224 / 8,224 ✅ | `Convert.ToHexString`/`FromHexString` |
| `System.Memory.Tests` | 52,906 / 52,906 ✅ | 52,249 / 52,249 ✅ | UTF-8 validation/transcoding, Ascii, `SearchValues<string>` (Teddy), `SearchValues<char>` (ProbabilisticMap), `SpanHelpers` |
| `System.IO.Hashing.Tests` | 4,196 / 4,196 ✅ | 4,196 / 4,196 ✅ | Adler32, XxHash (lane-order is checked end-to-end via the hash output bytes — a swap would corrupt every hash) |

The original push exposed two AOT-only failure modes in browser-wasm Helix legs:
1. `PackedSimd.Shuffle` (two-vector `i8x16.shuffle`) requires compile-time-constant lane indices; Mono AOT can't fold a `Vector128.Create(...)` operand and throws `PlatformNotSupportedException`. Fixed in `c69998277eb` → `0e99f4a194c` by composing with single-vector `PackedSimd.Swizzle` + OR.
2. The same pattern was originally applied in `TeddyHelper.RightShift1/RightShift2` via `Vector128.ShuffleNative` (a dispatcher with an `Ssse3 → AdvSimd.Arm64 → PackedSimd` if/else chain). The Mono SIMD intrinsic recognizer doesn't always lower that chain cleanly for less-traveled paths — the safer pattern is to call `PackedSimd.Swizzle` directly under the `PackedSimd.IsSupported` branch. Applied consistently in `0e99f4a194c`.

## Files changed
- `src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs`
- `src/libraries/Common/src/System/HexConverter.cs`
- `src/libraries/System.Private.CoreLib/src/System/Guid.cs`
- `src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs`
- `src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs`
- `src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs`
- `src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValues.cs`
- `src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/AsciiStringSearchValuesTeddyBase.cs`
- `src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs`
- `src/libraries/System.IO.Hashing/src/System/IO/Hashing/Adler32.cs`
- `src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs`

## Not in this PR
- `Base64DecoderHelper` / `Base64EncoderHelper` — need `pmaddubsw` and `pmulhuw` analogs composed from `MultiplyWideningLower/Upper` + `AddPairwiseWidening` or `Dot`, with careful 8-short lane preservation. Worth a dedicated follow-up with benchmarks.

> [!NOTE]
> This PR description and the commits in this branch were drafted with AI/Copilot assistance.
