### PR TITLE
JIT: ensure magic divisors are always marked DONT_CSE for all targets

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -10464,7 +10464,12 @@ bool GenTreeOp::UsesDivideByConstOptimized(Compiler* comp)
             // x / -1 can't be optimized because INT_MIN / -1 is required to throw an exception.
             return false;
         }
-        else if (isPow2(divisorValue))
+        // Match the lowering acceptance for absolute value: lowering's TryLowerConstIntDivOrMod
+        // turns negative pow2 divisors into shift+neg and negative non-pow2 divisors into
+        // signed magic-divide sequences, both of which require the divisor be a literal.
+        size_t absDivisorValue = (divisorValue == SSIZE_T_MIN) ? static_cast<size_t>(divisorValue)
+                                                               : static_cast<size_t>(std::abs(divisorValue));
+        if (isPow2(absDivisorValue))
         {
             return true;
         }
@@ -10514,7 +10519,9 @@ bool GenTreeOp::UsesDivideByConstOptimized(Compiler* comp)
 
 // TODO-ARM-CQ: Currently there's no GT_MULHI for ARM32
 #if defined(TARGET_XARCH) || defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-    if (!comp->opts.MinOpts() && ((divisorValue >= 3) || !isSignedDivide))
+    // For signed divides also accept negative magic divisors (e.g. -3, -5); lowering generates
+    // a reciprocal-multiply sequence for those, see TryLowerConstIntDivOrMod.
+    if (!comp->opts.MinOpts() && (!isSignedDivide || (divisorValue >= 3) || (divisorValue <= -3)))
     {
         // All checks pass we can perform the division operation using a reciprocal multiply.
         return true;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11396,6 +11396,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree, bool* optAssertionPropD
                 DEBUG_DESTROY_NODE(tree);
                 return op1;
             }
+            tree->AsOp()->CheckDivideByConstOptimized(this);
             break;
 
         case GT_UDIV:


### PR DESCRIPTION
`fgMorphSmpOpOptional` calls `CheckDivideByConstOptimized` for `GT_UDIV`/`GT_UMOD` but the corresponding `case GT_DIV:` arm only checks for `val / 1` and breaks. Signed integer divides with a constant divisor reach lowering without `GTF_DONT_CSE` on the divisor.

Magic-divide expansion in `LowerSignedDivOrMod` -> `TryLowerConstIntDivOrMod` bails at `if (!divisor->IsCnsIntOrI()) return false;` and falls back to `idiv` if CSE has rewritten the divisor to a `LCL_VAR`.

This is latent on x64 because the default `JitConstCSE` setting disables most integer-constant CSE there, so a full SPMI sweep on x64 shows zero asm diffs. It is observable on ARM64/RISC-V where constant CSE is enabled, and would also surface immediately on x64 if `JitConstCSE` is ever broadened.

Signed `GT_MOD` is already covered: `fgMorphModToSubMulDiv` transforms `a % b` into `a - (a / b) * b` and calls `CheckDivideByConstOptimized` on the inner `DIV`.

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot.
