### PR TITLE
Add DacMode-based SOS test legs to runtime-diagnostics pipeline

### DIFF
--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -37,8 +37,7 @@ parameters:
   templateContext: ''
   disableComponentGovernance: ''
   liveRuntimeDir: ''
-  useCdac: false
-  noFallback: false
+  dacMode: ''
   classFilter: ''
   methodFilter: ''
   testInterpreter: false
@@ -91,8 +90,7 @@ jobs:
 
       - _TestArgs: '-test'
       - _Cross: ''
-      - _CdacArgs: ''
-      - _NoFallbackArgs: ''
+      - _DacModeArgs: ''
       - _ClassFilterArgs: ''
       - _MethodFilterArgs: ''
       - _TestInterpreterArgs: ''
@@ -108,11 +106,13 @@ jobs:
       - ${{ if or(eq(parameters.buildOnly, 'true'), eq(parameters.isCodeQLRun, 'true')) }}:
         - _TestArgs: ''
 
-      - ${{ if eq(parameters.useCdac, 'true') }}:
-        - _CdacArgs: '-useCdac'
-
-      - ${{ if eq(parameters.noFallback, 'true') }}:
-        - _NoFallbackArgs: '-noFallback'
+      # Selects which DAC/cDAC SOS loads (see DacMode in dotnet/diagnostics SOSRunner). The cdac mode
+      # additionally overlays the runtime-under-test's own cDAC next to sos.dll; the freshly built cDAC is
+      # downloaded by sos-test-leg.yml into artifacts/cdac and passed via -cdacPath.
+      - ${{ if eq(parameters.dacMode, 'cdac') }}:
+        - _DacModeArgs: '-dacMode cdac -cdacPath $(Build.SourcesDirectory)/artifacts/cdac/mscordaccore_universal.dll'
+      - ${{ elseif ne(parameters.dacMode, '') }}:
+        - _DacModeArgs: '-dacMode ${{ parameters.dacMode }}'
 
       - ${{ if ne(parameters.classFilter, '') }}:
         - _ClassFilterArgs: '-classfilter ${{ parameters.classFilter }}'
@@ -215,8 +215,7 @@ jobs:
           -configuration ${{ parameters.buildConfig }}
           -architecture ${{ parameters.archType }}
           -privatebuild
-          $(_CdacArgs)
-          $(_NoFallbackArgs)
+          $(_DacModeArgs)
           $(_TestInterpreterArgs)
           -liveRuntimeDir ${{ parameters.liveRuntimeDir }}
           $(_TestArgs)

--- a/eng/pipelines/diagnostics/sos-test-leg.yml
+++ b/eng/pipelines/diagnostics/sos-test-leg.yml
@@ -1,7 +1,7 @@
 # sos-test-leg.yml -- wraps the matrix + job + dep + artifact download +
 # standard postBuildSteps pattern used by the SOS-style test legs (cDAC,
-# cDAC_no_fallback, DAC) that run on windows_x64. Each of those legs only
-# differs in its `name`, `useCdac`, and `noFallback` value.
+# cDAC_fallback, cDAC_verify, DAC) that run on windows_x64. Each of those legs
+# only differs in its `name` and `dacMode` value.
 #
 # AzDO tasks workaround:
 #   PublishTestResults v2.270.0 garbles parameterized xUnit test names
@@ -11,12 +11,9 @@
 parameters:
 - name: name
   type: string
-- name: useCdac
-  type: boolean
-  default: false
-- name: noFallback
-  type: boolean
-  default: false
+- name: dacMode
+  type: string
+  default: ''
 
 jobs:
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -30,8 +27,7 @@ jobs:
         value: false
     jobParameters:
       name: ${{ parameters.name }}
-      useCdac: ${{ parameters.useCdac }}
-      noFallback: ${{ parameters.noFallback }}
+      dacMode: ${{ parameters.dacMode }}
       testInterpreter: true
       methodFilter: SOS*
       isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -46,6 +42,17 @@ jobs:
           artifactFileName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr$(archiveExtension)
           unpackFolder: $(Build.SourcesDirectory)/artifacts/runtime
           displayName: 'Runtime Build Artifacts'
+      # The cdac leg exercises the runtime-under-test's own cDAC through SOS's standard cDAC hosting.
+      # SOS resolves the cDAC from next to sos.dll, which is the copy restored from a referenced runtime
+      # package -- not the runtime being tested. Download the freshly built cDAC so the build can overlay
+      # it (see -cdacPath in runtime-diag-job.yml / eng/build.* in dotnet/diagnostics).
+      - ${{ if eq(parameters.dacMode, 'cdac') }}:
+        - template: /eng/pipelines/common/download-artifact-step.yml
+          parameters:
+            artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_cdac
+            artifactFileName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_cdac$(archiveExtension)
+            unpackFolder: $(Build.SourcesDirectory)/artifacts/cdac
+            displayName: 'cDAC Build Artifacts'
       postBuildSteps:
       - task: PublishTestResults@2
         inputs:

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -3,8 +3,8 @@
 # Pipeline overview:
 #
 #   SOSTests           windows_x64 Release. One shared coreclr+libs build (-c Debug
-#                      -rc release -lc release -clrinterpreter) consumed by 3 SOS
-#                      legs that run on top of it: cDAC, cDAC_no_fallback, DAC.
+#                      -rc release -lc release -clrinterpreter) consumed by 4 SOS
+#                      legs that run on top of it: cDAC, cDAC_fallback, cDAC_verify, DAC.
 #                      Each leg sets testInterpreter: true so interpreter coverage
 #                      is exercised inline (no separate Interpreter leg).
 #
@@ -146,24 +146,48 @@ extends:
                 tarCompression: $(tarCompression)
                 artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
                 displayName: Build Assets
+            # The cDAC (mscordaccore_universal) is built by tools.cdac but is not part of the shared
+            # framework (testhost), so upload it separately for the cDAC-only SOS leg to consume.
+            - powershell: |
+                $cdacDir = Get-ChildItem -Directory -Path "$(Build.SourcesDirectory)\artifacts\bin\mscordaccore_universal\*\win-$(archType)\publish" | Select-Object -ExpandProperty FullName -First 1
+                Write-Host "##vso[task.setvariable variable=cdacDir]$cdacDir"
+              displayName: 'Set Path to cDAC Artifacts'
+            - template: /eng/pipelines/common/upload-artifact-step.yml
+              parameters:
+                rootFolder: $(cdacDir)
+                includeRootFolder: false
+                archiveType: $(archiveType)
+                archiveExtension: $(archiveExtension)
+                tarCompression: $(tarCompression)
+                artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_cdac
+                displayName: cDAC Assets
 
       # SOS test legs: each depends on the shared build above. Differ only in
-      # name (artifact namespace) and the cDAC fallback flags.
+      # name (artifact namespace) and the cDAC/DAC load mode.
+
+      # cDAC: the runtime-under-test's own standalone cDAC (mscordaccore_universal) loaded through SOS's
+      # standard cDAC hosting path (overlaying the freshly built cDAC next to sos.dll).
       - template: /eng/pipelines/diagnostics/sos-test-leg.yml
         parameters:
           name: cDAC
-          useCdac: true
+          dacMode: cdac
+
+      # cDAC_fallback / cDAC_verify: the in-box DAC hosts the cDAC contract reader, with per-API fallback
+      # to the legacy DAC (fallback) or no fallback but still verifying against it (verify).
+      - template: /eng/pipelines/diagnostics/sos-test-leg.yml
+        parameters:
+          name: cDAC_fallback
+          dacMode: cdacfallback
 
       - template: /eng/pipelines/diagnostics/sos-test-leg.yml
         parameters:
-          name: cDAC_no_fallback
-          useCdac: true
-          noFallback: true
+          name: cDAC_verify
+          dacMode: cdacverify
 
       - template: /eng/pipelines/diagnostics/sos-test-leg.yml
         parameters:
           name: DAC
-          useCdac: false
+          dacMode: dac
 
     # ----------------------------------------------------------------------
     # cDAC managed-side unit tests + DataGenerator tests. Standalone, no


### PR DESCRIPTION
Replaces the `useCdac`/`noFallback` booleans in the SOS test legs with a single `dacMode` parameter and adds a 4th leg. The shared windows_x64 build now uploads the freshly built cDAC (`mscordaccore_universal`) as a separate artifact for the `cdac` leg to consume.

SOS legs (windows_x64 Release, `testInterpreter`):
- **cDAC** -- `dacMode cdac` -- standalone cDAC via SOS (downloads + overlays the built cDAC next to sos.dll)
- **cDAC_fallback** -- `dacMode cdacfallback` -- in-box DAC hosts cDAC, with fallback
- **cDAC_verify** -- `dacMode cdacverify` -- in-box DAC hosts cDAC, no fallback (verifies)
- **DAC** -- `dacMode dac` -- legacy DAC only

Depends on the `DacMode` support added in dotnet/diagnostics#5901. To exercise it before that merges, queue `runtime-diagnostics` with `diagnosticsBranch` pointing at the diagnostics PR's merge ref.

Sample run: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1481626&view=logs&j=d359ac0d-403b-5f4f-9a78-93671d33ea9d