### PR TITLE
JIT: only skip loop inversion when the IV test is the bottom test

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1955,8 +1955,7 @@ bool Compiler::optTryInvertWhileLoop(FlowGraphNaturalLoop* loop)
 
         if (isExitingCondLatch(latch) && isIvTest(latch))
         {
-            JITDUMP("No loop-inversion for " FMT_LP "; IV-test latch " FMT_BB
-                    " already makes it bottom-tested\n",
+            JITDUMP("No loop-inversion for " FMT_LP "; IV-test latch " FMT_BB " already makes it bottom-tested\n",
                     loop->GetIndex(), latch->bbNum);
             return false;
         }
@@ -1968,8 +1967,8 @@ bool Compiler::optTryInvertWhileLoop(FlowGraphNaturalLoop* loop)
                 BasicBlock* const pred = predEdge->getSourceBlock();
                 if (loop->ContainsBlock(pred) && isExitingCondLatch(pred) && isIvTest(pred))
                 {
-                    JITDUMP("No loop-inversion for " FMT_LP "; IV-test predecessor " FMT_BB " of canonical latch "
-                            FMT_BB " already makes it bottom-tested\n",
+                    JITDUMP("No loop-inversion for " FMT_LP "; IV-test predecessor " FMT_BB
+                            " of canonical latch " FMT_BB " already makes it bottom-tested\n",
                             loop->GetIndex(), pred->bbNum, latch->bbNum);
                     return false;
                 }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1903,14 +1903,16 @@ bool Compiler::optTryInvertWhileLoop(FlowGraphNaturalLoop* loop)
     }
 
     // There may be multiple exits, and one of the other exits may also be a
-    // latch. That latch could be preferable to leave (for example because it
-    // is an IV test). The general BBJ_COND-latch-that-exits check below
-    // subsumes the IV-test case.
-
-    // If the loop is already bottom-tested (has a BBJ_COND latch that exits the loop),
-    // there is no need to invert. Also handle the canonical multi-backedge case, where
-    // optCanonicalizeBackedges has installed a BBJ_ALWAYS latch whose in-loop predecessors
-    // are the original bottom tests.
+    // latch. So avoid inversion if the loop is already bottom-tested.
+    //
+    // We check for two cases:
+    //  1. The latch itself is a BBJ_COND that exits the loop, AND the latch is
+    //     the recognized IV test (so the latch BBJ_COND determines loop
+    //     continuation, not a body-internal early exit that happens to feed the
+    //     back-edge).
+    //  2. The latch is a BBJ_ALWAYS (installed by optCanonicalizeBackedges for
+    //     loops with originally multiple backedges) and one of its in-loop
+    //     predecessors is the recognized IV test BBJ_COND that exits the loop.
     //
     auto isExitingCondLatch = [&](BasicBlock* block) -> bool {
         if ((block == condBlock) || !block->KindIs(BBJ_COND))
@@ -1927,13 +1929,34 @@ bool Compiler::optTryInvertWhileLoop(FlowGraphNaturalLoop* loop)
         return false;
     };
 
+    // Only run AnalyzeIteration when we see a back-edge that could
+    // qualify for the bail-out (i.e. its source block, or an in-loop predecessor
+    // of a BBJ_ALWAYS canonical latch, is a candidate for being the IV test).
+    //
+    NaturalLoopIterInfo iterInfo;
+    bool                analyzedIteration = false;
+    BasicBlock*         ivTestBlock       = nullptr;
+
+    auto isIvTest = [&](BasicBlock* candidate) -> bool {
+        if (!analyzedIteration)
+        {
+            analyzedIteration = true;
+            if (loop->AnalyzeIteration(&iterInfo))
+            {
+                ivTestBlock = iterInfo.TestBlock;
+            }
+        }
+        return (ivTestBlock != nullptr) && (candidate == ivTestBlock);
+    };
+
     for (FlowEdge* const backEdge : loop->BackEdges())
     {
         BasicBlock* const latch = backEdge->getSourceBlock();
 
-        if (isExitingCondLatch(latch))
+        if (isExitingCondLatch(latch) && isIvTest(latch))
         {
-            JITDUMP("No loop-inversion for " FMT_LP "; latch " FMT_BB " already makes it bottom-tested\n",
+            JITDUMP("No loop-inversion for " FMT_LP "; IV-test latch " FMT_BB
+                    " already makes it bottom-tested\n",
                     loop->GetIndex(), latch->bbNum);
             return false;
         }
@@ -1943,10 +1966,10 @@ bool Compiler::optTryInvertWhileLoop(FlowGraphNaturalLoop* loop)
             for (FlowEdge* const predEdge : latch->PredEdges())
             {
                 BasicBlock* const pred = predEdge->getSourceBlock();
-                if (loop->ContainsBlock(pred) && isExitingCondLatch(pred))
+                if (loop->ContainsBlock(pred) && isExitingCondLatch(pred) && isIvTest(pred))
                 {
-                    JITDUMP("No loop-inversion for " FMT_LP "; predecessor " FMT_BB " of canonical latch " FMT_BB
-                            " already makes it bottom-tested\n",
+                    JITDUMP("No loop-inversion for " FMT_LP "; IV-test predecessor " FMT_BB " of canonical latch "
+                            FMT_BB " already makes it bottom-tested\n",
                             loop->GetIndex(), pred->bbNum, latch->bbNum);
                     return false;
                 }


### PR DESCRIPTION
The bail-out added in #128459 fires for any BBJ_COND latch (or BBJ_COND predecessor of a canonical BBJ_ALWAYS latch) that exits the loop. That block may be an unrelated early-exit and not the loop's continuation test — for example, `Dictionary<TKey,TValue>+Enumerator.MoveNext`'s body has an early-exit BBJ_COND (`if (entry.next >= -1) return true;`) while the actual loop continuation is the top-tested `_index < _count` check in the header. The current predicate falsely classifies that shape as "already bottom-tested" and skips a beneficial inversion.

Restrict the bail-out to the case where the recognized IV test (from `AnalyzeIteration`) is at that latch / predecessor position. `AnalyzeIteration` is called lazily so only loops that match the structural shape pay the cost.

### Fixes the Dictionary regression reported in #128910

`System.Collections.Generic.Dictionary`2+Enumerator[int,int]:MoveNext` codegen:

| | code size | instructions | PerfScore |
|---|---|---|---|
| Pre-#128459 (target) | **129 bytes** | 43 | 105.38 |
| Post-#128459 (regressed) | 114 bytes | 38 | 114.88 |
| **With this fix** | **129 bytes** | **43** | **105.38** ✓ |

BDN `IterateForEach<Int32>.Dictionary(Size: 512)` on AMD Zen 3 (3 interleaved rounds, mean of 3):
- current main: 501.9 ns
- with fix: **490.1 ns (−2.4%)**

The Viper lab is Zen 4 where the regression is +6%; the fix restores byte-identical pre-#128459 codegen, so the lab perf should fully recover.

### SPMI impact

| Collection | Code size | PerfScore overall | PerfScore on diffs | TP (release) |
|---|---:|---:|---:|---:|
| benchmarks.run_pgo | +0.18% | −0.04% | −1.07% | +0.46% |
| aspnet2.run | +0.09% | +0.07% | −0.77% | +0.28% |
| libraries.pmi | +0.07% | −0.02% | −0.79% | +0.11% |

~1,600 methods get inversion re-enabled. TP cost mostly comes from running the actual inversion phase on those methods; the lazy `AnalyzeIteration` call itself is a small fraction.

### Original target of #128459

The Perf_Encoding regression that #128459 fixed (`Utf8Utility.GetPointerToFirstInvalidByte` on arm64) has a true bottom-tested IV-controlled loop where `AnalyzeIteration` recognizes the latch as the IV test, so this refined predicate still bails out there.

> [!NOTE]
> This PR description was drafted with assistance from GitHub Copilot CLI.
