### PR TITLE
Fix Android NativeAOT test crypto JNI export

### DIFF
--- a/eng/testing/tests.android.targets
+++ b/eng/testing/tests.android.targets
@@ -28,6 +28,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <_SuppressNativeLibEventSourceWarning>true</_SuppressNativeLibEventSourceWarning>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TestNativeAOT)' == 'true'">
+    <!-- Android test APKs link the crypto archive directly; keep the Java native trust-manager callback visible. -->
+    <IlcArg Include="--export-dynamic-symbol:Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate" />
+    <LinkerArg Include="-Wl,-u,Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate" />
+  </ItemGroup>
 
   <!-- Target that kicks off the whole test build and run flow -->
   <Target Name="BundleTestAndroidApp" DependsOnTargets="$(BundleTestAndroidAppDependsOn)" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -611,10 +611,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security\tests\UnitTests\System.Net.Security.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.IO.FileSystem.Tests\DisabledFileLockingTests\System.IO.FileSystem.DisabledFileLocking.Tests.csproj" />
 
-    <!-- https://github.com/dotnet/runtime/issues/120959 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Requests\tests\System.Net.Requests.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
-
     <SmokeTestProject Include="$(RepoRoot)src\tests\FunctionalTests\Android\Device_Emulator\NativeAOT\*.Test.csproj"/>
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Globalization.Tests\System.Globalization.Tests.csproj" />
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Security.Cryptography\tests\System.Security.Cryptography.Tests.csproj" />


### PR DESCRIPTION
Fix Android NativeAOT test APK packaging so the Android crypto trust-manager JNI callback is both retained and exported from the final app shared library.

This also removes the issue 120959 Android NativeAOT test exclusions for `System.Net.Requests.Tests` and `System.Net.WebSockets.Client.Tests`.

For customer Android NativeAOT apps, the proper fix lives in dotnet/android’s NativeAOT packaging/linking path: it already models `libSystem.Security.Cryptography.Native.Android.a` with `jniOnLoadName: AndroidCryptoNative_InitLibraryOnLoad` and `SymbolsToPreserve` for `Java_net_dot_android_crypto_DotnetProxyTrustManager_verifyRemoteCertificate`; the Android workload should flow that metadata into the final app link/export. This runtime change is scoped to runtime test APK packaging only.

> [!NOTE]
> This pull request description was created with assistance from GitHub Copilot.