### PR TITLE
Remove concurrent verify_soh_segment_list call in background_sweep

### DIFF
--- a/src/coreclr/gc/background.cpp
+++ b/src/coreclr/gc/background.cpp
@@ -4114,8 +4114,6 @@ void gc_heap::background_sweep()
                 current_sweep_pos = end;
             }
 
-            verify_soh_segment_list();
-
 #ifdef DOUBLY_LINKED_FL
             while (next_seg && heap_segment_background_allocated (next_seg) == 0)
             {


### PR DESCRIPTION
The removed call site runs inside the concurrent background sweep loop, after restart_EE(), when allocations and SOH segment-list mutations can run on other threads. verify_soh_segment_list assumes stable list topology while it walks generation links, so calling it in this window can observe in-flight updates and report false verification failures. We keep verification at synchronized GC phase boundaries and remove only this racy in-loop invocation.

Close #129723