### PR TITLE
[r2r] Include generic type instantiations from GenericLookupSignature for discovery of virtual methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -1546,4 +1546,32 @@ public class R2RTestSuites
             Assert.True(R2RAssert.HasCompiledMethod(reader, "ITest7`1<int>", "ITest7Base.Test7Method", out diag, ["int"]), diag);
         }
     }
+
+    [Fact]
+    public void VirtualMethodGenericsGenericLookup()
+    {
+        var genericLookupLib = new CompiledAssembly
+        {
+            AssemblyName = nameof(VirtualMethodGenericsGenericLookup),
+            SourceResourceNames = ["VirtualMethodGenerics/GenericLookup.cs"],
+        };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(VirtualMethodGenericsGenericLookup),
+            [
+                new(nameof(VirtualMethodGenericsGenericLookup), [new CrossgenAssembly(genericLookupLib)])
+                {
+                    Validate = Validate,
+                },
+            ]));
+
+        static void Validate(ReadyToRunReader reader)
+        {
+            string diag;
+
+            // The generic type instantiation is reached only through a GenericLookupSignature
+            // fixup, so its virtual method must still be discovered and compiled.
+            Assert.True(R2RAssert.HasCompiledMethod(reader, "TestA`2<__Canon,int>", "TestMethod", out diag), diag);
+        }
+    }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/VirtualMethodGenerics/GenericLookup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/VirtualMethodGenerics/GenericLookup.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Virtual method discovery for a generic type instantiation that is only ever
+// reached through a GenericLookupSignature fixup.
+//
+// When compiling the shared TestB<__Canon, int>.TestCreate, the instance of
+// TestA<T, int> is obtained through a generic dictionary lookup (a
+// GenericLookupSignature fixup referencing TestA<__Canon, int>) rather than via
+// a TypeFixupSignature. The virtual TestMethod on TestA<__Canon, int> must still
+// be discovered and compiled.
+
+public class TestA<T, U>
+{
+    public virtual void TestMethod(T item) => Console.WriteLine($"{item} / {typeof(U)}");
+}
+
+public class TestB<T, U>
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public TestA<T, U> TestCreate() => new TestA<T, U>();
+}
+
+static class GenericLookupTests
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static TestB<T, U> CreateTestB<T, U>() => new TestB<T, U>();
+
+    static void Run()
+    {
+        TestB<string, int> obj = CreateTestB<string, int>();
+        obj.TestCreate().TestMethod("hello");
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -133,10 +133,30 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             DependencyList dependencies = null;
+
             if (_fixupKind == ReadyToRunFixupKind.TypeHandle)
             {
                 TypeFixupSignature.AddDependenciesForAsyncStateMachineBox(ref dependencies, factory, _typeArgument);
+
+                // In shared generic code, newobj uses a generic dictionary lookup for the type handle
+                // rather than a direct READYTORUN_FIXUP_TypeHandle (TypeFixupSignature). Mirror the
+                // creation of InheritedVirtualMethodsNode as it is done in TypeFixupSignature, so we
+                // scan the virtual methods on this type for dependency analysis.
+                if (_typeArgument != null)
+                {
+                    TypeDesc canonType = _typeArgument.ConvertToCanonForm(CanonicalFormKind.Specific);
+                    if (!canonType.IsGenericDefinition &&
+                        !canonType.IsInterface &&
+                        canonType.IsDefType &&
+                        (factory.CompilationCurrentPhase == 0) &&
+                        factory.CompilationModuleGroup.VersionsWithType(canonType))
+                    {
+                        dependencies ??= new DependencyList();
+                        dependencies.Add(factory.InheritedVirtualMethods(canonType), "Generic lookup type discovery for virtual dispatch");
+                    }
+                }
             }
+
             return dependencies;
         }
 


### PR DESCRIPTION
Normally, we detect the usage of a type in the application via the TypeFixupSignature and then we use this type to determine which virtual methods on the type need compilation (via supporting GVMDependenciesNode and VirtualMethodUseNode).

Consider the following scenario:

```
public class TestA<T, U>
{
    public virtual void TestMethod(T item) => Console.WriteLine($"{item} / {typeof(U)}");
}

public class TestB<T, U>
{
    public TestA<T, U> TestCreate() => new TestA<T, U>();
}

TestB<string, int> obj = new TestB<string, int>();
obj.TestCreate().TestMethod("hello");
```

When compiling `TestB<Canon,int32>.TestCreate` we need to create an instance of `TestA<T,int32>`. Because we are compiling a shared version we need to embed a call to a generic lookup helper in order to obtain the actual T. This is done with a GenericLookupSignature fixup, which contains the type `TestA<Canon,int32>` that needs resolving. When creating this node, we add the InheritedVirtualMethodsNode as a dependency which facilitates discovery of virtual methods on this type.

Fixes perf on linq sorting, ex: `LinqBenchmarks.Order00LinqMethodX` (~20x improvement)