### PR TITLE
[release/10.0] Fix TypeLoadException in GetMarshalAs when SafeArray has zero-length user-defined type name

### DIFF
--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -123,7 +123,6 @@ FCFuncStart(gMetaDataImport)
     FCFuncElement("GetFieldMarshal", MetaDataImport::GetFieldMarshal)
     FCFuncElement("GetPInvokeMap", MetaDataImport::GetPInvokeMap)
     FCFuncElement("IsValidToken", MetaDataImport::IsValidToken)
-    FCFuncElement("GetMarshalAs", MetaDataImport::GetMarshalAs)
 FCFuncEnd()
 
 FCFuncStart(gSignatureNative)

--- a/src/coreclr/vm/managedmdimport.cpp
+++ b/src/coreclr/vm/managedmdimport.cpp
@@ -12,20 +12,29 @@
 //
 extern BOOL ParseNativeTypeInfo(NativeTypeParamInfo* pInfo, PCCOR_SIGNATURE pvNativeType, ULONG cbNativeType);
 
-FCIMPL11(FC_BOOL_RET, MetaDataImport::GetMarshalAs,
+extern "C" BOOL QCALLTYPE MetadataImport_GetMarshalAs(
     BYTE*   pvNativeType,
     ULONG   cbNativeType,
     INT32*  unmanagedType,
     INT32*  safeArraySubType,
     LPUTF8* safeArrayUserDefinedSubType,
+    INT32*  safeArrayUserDefinedSubTypeLength,
     INT32*  arraySubType,
     INT32*  sizeParamIndex,
     INT32*  sizeConst,
     LPUTF8* marshalType,
+    INT32*  marshalTypeLength,
     LPUTF8* marshalCookie,
+    INT32*  marshalCookieLength,
     INT32*  iidParamIndex)
 {
-    FCALL_CONTRACT;
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
 
     NativeTypeParamInfo info{};
 
@@ -37,7 +46,7 @@ FCIMPL11(FC_BOOL_RET, MetaDataImport::GetMarshalAs,
     ZeroMemory(&info, sizeof(info));
     if (!ParseNativeTypeInfo(&info, pvNativeType, cbNativeType))
     {
-        FC_RETURN_BOOL(FALSE);
+        return FALSE;
     }
 
     *unmanagedType = info.m_NativeType;
@@ -51,21 +60,24 @@ FCIMPL11(FC_BOOL_RET, MetaDataImport::GetMarshalAs,
     *safeArraySubType = info.m_SafeArrayElementVT;
 
     *safeArrayUserDefinedSubType = info.m_strSafeArrayUserDefTypeName;
+    *safeArrayUserDefinedSubTypeLength = info.m_cSafeArrayUserDefTypeNameBytes;
 #else
     *iidParamIndex = 0;
 
     *safeArraySubType = VT_EMPTY;
 
     *safeArrayUserDefinedSubType = NULL;
+    *safeArrayUserDefinedSubTypeLength = 0;
 #endif
 
     *marshalType = info.m_strCMMarshalerTypeName;
+    *marshalTypeLength = info.m_cCMMarshalerTypeNameBytes;
 
     *marshalCookie = info.m_strCMCookie;
+    *marshalCookieLength = info.m_cCMCookieStrBytes;
 
-    FC_RETURN_BOOL(TRUE);
+    return TRUE;
 }
-FCIMPLEND
 
 FCIMPL1(IMDInternalImport*, MetaDataImport::GetMetadataImport, ReflectModuleBaseObject * pModuleUNSAFE)
 {

--- a/src/coreclr/vm/managedmdimport.hpp
+++ b/src/coreclr/vm/managedmdimport.hpp
@@ -54,20 +54,23 @@ public:
     static FCDECL3(HRESULT, GetSigOfMethodDef, IMDInternalImport* pScope, mdToken tk, ConstArray* pMarshalInfo);
     static FCDECL3(HRESULT, GetFieldMarshal, IMDInternalImport* pScope, mdToken tk, ConstArray* pMarshalInfo);
     static FCDECL2(FC_BOOL_RET, IsValidToken, IMDInternalImport* pScope, mdToken tk);
-
-    static FCDECL11(FC_BOOL_RET, GetMarshalAs,
-        BYTE*   pvNativeType,
-        ULONG   cbNativeType,
-        INT32*  unmanagedType,
-        INT32*  safeArraySubType,
-        LPUTF8* safeArrayUserDefinedSubType,
-        INT32*  arraySubType,
-        INT32*  sizeParamIndex,
-        INT32*  sizeConst,
-        LPUTF8* marshalType,
-        LPUTF8* marshalCookie,
-        INT32*  iidParamIndex);
 };
+
+extern "C" BOOL QCALLTYPE MetadataImport_GetMarshalAs(
+    BYTE*   pvNativeType,
+    ULONG   cbNativeType,
+    INT32*  unmanagedType,
+    INT32*  safeArraySubType,
+    LPUTF8* safeArrayUserDefinedSubType,
+    INT32*  safeArrayUserDefinedSubTypeLength,
+    INT32*  arraySubType,
+    INT32*  sizeParamIndex,
+    INT32*  sizeConst,
+    LPUTF8* marshalType,
+    INT32*  marshalTypeLength,
+    LPUTF8* marshalCookie,
+    INT32*  marshalCookieLength,
+    INT32*  iidParamIndex);
 
 extern "C" void QCALLTYPE MetadataImport_Enum(
     IMDInternalImport* pScope,

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -206,7 +206,6 @@ BOOL ParseNativeTypeInfo(NativeTypeParamInfo* pParamInfo,
 
                 pParamInfo->m_strSafeArrayUserDefTypeName = (LPUTF8)pvNativeType;
                 pParamInfo->m_cSafeArrayUserDefTypeNameBytes = strLen;
-                _ASSERTE((ULONG)(pvNativeType + strLen - pvNativeTypeStart) == cbNativeType);
             }
             break;
 
@@ -304,7 +303,6 @@ BOOL ParseNativeTypeInfo(NativeTypeParamInfo* pParamInfo,
 
             pParamInfo->m_strCMCookie = (LPUTF8)pvNativeType;
             pParamInfo->m_cCMCookieStrBytes = strLen;
-            _ASSERTE((ULONG)(pvNativeType + strLen - pvNativeTypeStart) == cbNativeType);
             break;
 
         default:

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -413,6 +413,7 @@ static const Entry s_QCall[] =
     DllImportEntry(Monitor_TryEnter_Slowpath)
     DllImportEntry(Monitor_Exit_Slowpath)
     DllImportEntry(MetadataImport_Enum)
+    DllImportEntry(MetadataImport_GetMarshalAs)
     DllImportEntry(ReflectionInvocation_RunClassConstructor)
     DllImportEntry(ReflectionInvocation_RunModuleConstructor)
     DllImportEntry(ReflectionInvocation_CompileMethod)

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/MarshalAsAttributeTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/MarshalAsAttributeTests.cs
@@ -1,6 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
 using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
@@ -11,7 +18,7 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData((UnmanagedType)(-1))]
         [InlineData(UnmanagedType.HString)]
         [InlineData((UnmanagedType)int.MaxValue)]
-        public void Ctor_UmanagedTye(UnmanagedType unmanagedType)
+        public void Ctor_UnmanagedType(UnmanagedType unmanagedType)
         {
             var attribute = new MarshalAsAttribute(unmanagedType);
             Assert.Equal(unmanagedType, attribute.Value);
@@ -25,6 +32,93 @@ namespace System.Runtime.InteropServices.Tests
         {
             var attribute = new MarshalAsAttribute(umanagedType);
             Assert.Equal((UnmanagedType)umanagedType, attribute.Value);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltInComEnabled), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        public void SafeArrayParameter_ZeroLengthUserDefinedSubType_DoesNotThrow()
+        {
+            byte[] peBytes = BuildPEWithSafeArrayMarshalBlob();
+
+            AssemblyLoadContext alc = new(nameof(SafeArrayParameter_ZeroLengthUserDefinedSubType_DoesNotThrow), isCollectible: true);
+            try
+            {
+                using MemoryStream peStream = new(peBytes);
+                Assembly asm = alc.LoadFromStream(peStream);
+                Type iface = asm.GetType("TestInterface")!;
+                MethodInfo method = iface.GetMethod("TestMethod")!;
+                ParameterInfo param = method.GetParameters()[0];
+
+                // Must not throw TypeLoadException.
+                _ = param.GetCustomAttributes(false);
+
+                MarshalAsAttribute? attr = (MarshalAsAttribute?)Attribute.GetCustomAttribute(param, typeof(MarshalAsAttribute));
+                Assert.NotNull(attr);
+                Assert.Equal(UnmanagedType.SafeArray, attr.Value);
+                Assert.Null(attr.SafeArrayUserDefinedSubType);
+            }
+            finally
+            {
+                alc.Unload();
+            }
+        }
+
+        /// <summary>
+        /// Creates a PE whose parameter has a FieldMarshal blob that
+        /// reproduces the native bug: NATIVE_TYPE_SAFEARRAY (0x1D),
+        /// VT_DISPATCH (0x09), zero-length string (0x00), followed by
+        /// poison byte 'X' (0x58) and null terminator (0x00).
+        /// Without the native fix the FCALL returns a dangling pointer
+        /// into the poison byte region causing TypeLoadException.
+        /// </summary>
+        private static byte[] BuildPEWithSafeArrayMarshalBlob()
+        {
+            PersistedAssemblyBuilder ab = new(
+                new AssemblyName("SafeArrayTestAsm"), typeof(object).Assembly);
+            ModuleBuilder mod = ab.DefineDynamicModule("SafeArrayTestAsm.dll");
+            TypeBuilder td = mod.DefineType("TestInterface",
+                TypeAttributes.Interface | TypeAttributes.Abstract | TypeAttributes.Public);
+
+            MethodBuilder md = td.DefineMethod("TestMethod",
+                MethodAttributes.Public | MethodAttributes.Abstract |
+                MethodAttributes.Virtual | MethodAttributes.NewSlot |
+                MethodAttributes.HideBySig,
+                typeof(void), new[] { typeof(object[]) });
+
+            md.DefineParameter(1, ParameterAttributes.HasFieldMarshal, "args");
+            td.CreateType();
+
+            MetadataBuilder mdb = ab.GenerateMetadata(out BlobBuilder ilBlob, out _);
+
+            // This is the only parameter defined on the only method, so it
+            // occupies row 1 in the Param table. PersistedAssemblyBuilder
+            // emits parameters in definition order deterministically.
+            const int paramRowNumber = 1;
+
+            // Blob bytes:
+            //   0x1D  NATIVE_TYPE_SAFEARRAY
+            //   0x09  VT_DISPATCH
+            //   0x00  compressed string length 0
+            //   0x58  'X' poison (not consumed by parser)
+            //   0x00  null terminator
+            BlobBuilder marshalBlob = new();
+            marshalBlob.WriteByte(0x1D);
+            marshalBlob.WriteByte(0x09);
+            marshalBlob.WriteByte(0x00);
+            marshalBlob.WriteByte(0x58);
+            marshalBlob.WriteByte(0x00);
+            mdb.AddMarshallingDescriptor(
+                MetadataTokens.ParameterHandle(paramRowNumber),
+                mdb.GetOrAddBlob(marshalBlob));
+
+            ManagedPEBuilder pe = new(
+                PEHeaderBuilder.CreateLibraryHeader(),
+                new MetadataRootBuilder(mdb),
+                ilBlob,
+                flags: CorFlags.ILOnly);
+
+            BlobBuilder output = new();
+            pe.Serialize(output);
+            return output.ToArray();
         }
     }
 }


### PR DESCRIPTION
Backport of #124408 to release/10.0

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Customer reported in https://github.com/dotnet/runtime/issues/124346. Getting the `CustomAttributes` of a `ParameterInfo` throws `TypeLoadException` when consuming tlbimp-generated COM interop assemblies (e.g. the `Interop.MFilesAPI` NuGet package).

A backport to .NET 10.0 was requested in https://github.com/dotnet/runtime/issues/129889. This is already fixed in .NET 11.

`MetadataImport.GetMarshalAs` returned raw byte pointers to managed code without associated lengths. When a `MarshalAs` blob contains `NATIVE_TYPE_SAFEARRAY` with a zero-length user-defined type name (common in tlbimp-generated COM interop assemblies), the managed side used `CreateReadOnlySpanFromNullTerminated` to read these pointers, but the strings in the metadata blob are length-prefixed and NOT null-terminated, so this read garbage memory, producing a garbled string that failed type resolution with `TypeLoadException`.

The fix passes string byte counts alongside the raw pointers, converts `GetMarshalAs` from an FCALL to a QCall, removes overly strict asserts that forbade trailing bytes (which ECMA-335 permits and tlbimp produces), and adds a regression test.

Fixes https://github.com/dotnet/runtime/issues/124346
Fixes https://github.com/dotnet/runtime/issues/129889

## Regression

- [x] Yes
- [ ] No

Regression from commit a3dc1337 (.NET 9), which switched `GetMarshalAs` from returning managed strings to returning raw byte pointers.

## Testing

Automated regression test added (`MarshalAsAttributeTests.cs`) that builds a PE via `PersistedAssemblyBuilder` with a FieldMarshal blob reproducing the dangling pointer read.

## Risk

Low. Scoped to metadata blob parsing in `GetMarshalAs`; the bounded-span reads and assert removals only affect the SAFEARRAY/CUSTOMMARSHALER decoding paths, and the change is covered by a new regression test.
