### PR TITLE
Allow exact devirtualization for value-type variant instantiations in ilc

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2287,7 +2287,17 @@ namespace Internal.JitInterface
         private int getExactClasses(CORINFO_CLASS_STRUCT_* baseType, int maxExactClasses, CORINFO_CLASS_STRUCT_** exactClsRet)
         {
             MetadataType type = HandleToObject(baseType) as MetadataType;
-            if (type == null || type.HasVariance)
+            if (type == null)
+            {
+                return -1;
+            }
+
+            // Variance can make types not in the implementor list compatible with 'type',
+            // so reporting an exact class set would be unsound. This only happens through
+            // reference conversions of the variant arguments, so it's still safe when every
+            // variant argument is a value type (e.g. the contravariant IEqualityComparer<int>
+            // used by Dictionary<int, int>).
+            if (type.HasVariance && HasVariantReferenceTypeArgument(type))
             {
                 return -1;
             }
@@ -2324,6 +2334,22 @@ namespace Internal.JitInterface
 
             Debug.Assert(index <= maxExactClasses);
             return index;
+        }
+
+        private static bool HasVariantReferenceTypeArgument(MetadataType type)
+        {
+            Instantiation typeInstantiation = type.Instantiation;
+            Instantiation genericParameters = type.GetTypeDefinition().Instantiation;
+            for (int i = 0; i < genericParameters.Length; i++)
+            {
+                if (((GenericParameterDesc)genericParameters[i]).Variance != GenericVariance.None
+                    && typeInstantiation[i].IsGCPointer)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private bool getStaticFieldContent(CORINFO_FIELD_STRUCT_* fieldHandle, byte* buffer, int bufferSize, int valueOffset, bool ignoreMovableObjects)


### PR DESCRIPTION
Dictionary<int,int>'s getter regressed slightly in .NET 11 NativeAOT (see semi-related #129895).

PR #123476 made getExactClasses bail for any variant type to avoid unsoundly folding variant casts (e.g. Action<string> vs Action<object>). That guard is slightly over-broad: variance is only relevant for reference types and can be ignored for ValueType type arguments.

This regressed exact devirtualization of the contravariant IEqualityComparer<T> calls in Dictionary<TKey, TValue>.FindValue for value-type keys, inflating the method and slowing the hot path.

We can tighten the condition for bailing early and do so only when a variant generic parameter is instantiated with a reference type.