### PR TITLE
Disable OpenBSD execute-only for NativeAOT stubs

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -278,6 +278,8 @@ The .NET Foundation licenses this file to you under the MIT license.
            indirect branches (e.g. switch jump tables) to non-endbr64 targets fault with SIGILL.
            Opt out of branch-target CFI enforcement via the PT_OPENBSD_NOBTCFI program header. -->
       <LinkerArg Include="-Wl,-z,nobtcfi" Condition="'$(_targetOS)' == 'openbsd'" />
+      <!-- Opt out of OpenBSD's execute-only text so NativeAOT can read its own stub bytes (RhGetCodeTarget). -->
+      <LinkerArg Include="-Wl,--no-execute-only" Condition="'$(_targetOS)' == 'openbsd'" />
       <!-- this workaround can be deleted once the minimum supported glibc version
            (runtime's official build machine's glibc version) is at least 2.33
            see https://github.com/bminor/glibc/commit/99468ed45f5a58f584bab60364af937eb6f8afda -->
@@ -286,8 +288,10 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-L&quot;$(SysRoot)/usr/local/lib&quot; -lgssapi_krb5" Condition="'$(_targetOS)' == 'freebsd'" />
       <!-- FreeBSD's inotify is an installed package and not found in default libraries  -->
       <LinkerArg Include="-L&quot;$(SysRoot)/usr/local/lib&quot; -linotify" Condition="'$(_targetOS)' == 'freebsd'" />
-      <!-- OpenBSD's GSSAPI is provided by the Heimdal package. -->
-      <LinkerArg Include="-L&quot;$(SysRoot)/usr/local/heimdal/lib&quot; -l:libgssapi.so.9.0" Condition="'$(_targetOS)' == 'openbsd'" />
+      <!-- OpenBSD's GSSAPI is provided by the Heimdal package, which ships only a versioned shared object. -->
+      <LinkerArg Include="-L&quot;$(SysRoot)/usr/local/heimdal/lib&quot; -l:libgssapi.so.9.0 -Wl,-rpath,/usr/local/heimdal/lib" Condition="'$(_targetOS)' == 'openbsd'" />
+      <!-- OpenBSD's inotify is the libinotify port, which ships only a versioned shared object. -->
+      <LinkerArg Include="-L&quot;$(SysRoot)/usr/local/lib/inotify&quot; -l:libinotify.so.4.0 -Wl,-rpath,/usr/local/lib/inotify" Condition="'$(_targetOS)' == 'openbsd'" />
       <LinkerArg Include="@(ExtraLinkerArg->'-Wl,%(Identity)')" />
       <LinkerArg Include="@(NativeFramework->'-framework %(Identity)')" Condition="'$(_IsApplePlatform)' == 'true'" />
       <LinkerArg Include="-Wl,--eh-frame-hdr" Condition="'$(_IsApplePlatform)' != 'true'" />


### PR DESCRIPTION
The process was immediately terminating at startup; used AI to figure out that binary header having execute flag was causing the issue. `--no-execute-only` for the rescue.

```sh
am11@foo:~$ uname -a
OpenBSD foo.mshome.net 7.8 GENERIC.MP#54 amd64

am11@foo:~/projects/api1$ ~/projects/runtime/.dotnet/dotnet new webapiaot -n api1 && cd $_
am11@foo:~/projects/api1$ ~/projects/runtime/.dotnet/dotnet publish -p:PublishAot=true -o dist
am11@foo:~/projects/api1$ dist/api1
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://localhost:5000
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
info: Microsoft.Hosting.Lifetime[0]
      Content root path: /home/am11/projects/api1

# on second terminal
am11@foo:~$ curl -sSL http://localhost:5000/todos | jq
[
  {
    "id": 1,
    "title": "Walk the dog",
    "dueBy": null,
    "isComplete": false
  },
  {
    "id": 2,
    "title": "Do the dishes",
    "dueBy": "2026-06-22",
    "isComplete": false
  },
  {
    "id": 3,
    "title": "Do the laundry",
    "dueBy": "2026-06-23",
    "isComplete": false
  },
  {
    "id": 4,
    "title": "Clean the bathroom",
    "dueBy": null,
    "isComplete": false
  },
  {
    "id": 5,
    "title": "Clean the car",
    "dueBy": "2026-06-24",
    "isComplete": false
  }
]
```

Contributes to https://github.com/dotnet/runtime/issues/124911.