### PR TITLE
Preserve integer context for interpreter in DAC fallback stackwalks

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5544,7 +5544,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread,
                         UpdateContextFromRegDisp(&tmpRd, &tmpContext);
                         CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
                         pContextBuffer->ContextFlags = DT_CONTEXT_CONTROL
-    #if defined(TARGET_AMD64) || defined(TARGET_ARM) || defined(TARGET_ARM64)
+    #if defined(TARGET_AMD64) || defined(TARGET_ARM) || defined(FEATURE_INTERPRETER)
                                                     | DT_CONTEXT_INTEGER
     #endif
                         ;

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5544,10 +5544,17 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread,
                         UpdateContextFromRegDisp(&tmpRd, &tmpContext);
                         CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
                         pContextBuffer->ContextFlags = DT_CONTEXT_CONTROL
-    #if defined(TARGET_AMD64) || defined(TARGET_ARM) || defined(FEATURE_INTERPRETER)
+    #if defined(TARGET_AMD64) || defined(TARGET_ARM)
                                                     | DT_CONTEXT_INTEGER
     #endif
                         ;
+#ifdef FEATURE_INTERPRETER
+                        EECodeInfo codeInfo(GetIP(&tmpContext));
+                        if (codeInfo.IsInterpretedCode())
+                        {
+                            pContextBuffer->ContextFlags |= DT_CONTEXT_INTEGER;
+                        }
+#endif // FEATURE_INTERPRETER
                         return S_OK;
                     }
                     frame = frame->Next();

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5544,7 +5544,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread,
                         UpdateContextFromRegDisp(&tmpRd, &tmpContext);
                         CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
                         pContextBuffer->ContextFlags = DT_CONTEXT_CONTROL
-    #if defined(TARGET_AMD64) || defined(TARGET_ARM)
+    #if defined(TARGET_AMD64) || defined(TARGET_ARM) || defined(TARGET_ARM64)
                                                     | DT_CONTEXT_INTEGER
     #endif
                         ;


### PR DESCRIPTION
Fixes an ARM64 DAC fallback context issue hit by remote debugging when ShimRemoteDataTarget::GetThreadContext  returns  E_NOTIMPL .

In that case, DAC synthesizes a context from explicit frames. The fallback already advertises integer registers on AMD64 and ARM, but not ARM64. For ARM64 interpreter stackwalks this causes  CORDbgCopyThreadContext  to skip  X0 , even though the fallback context has populated it. Later,  StackFrameIterator::ResetRegDisp  expects  X0  to identify the owning  InterpreterFrame , sees  0 , and can assert/crash.

This change includes  DT_CONTEXT_INTEGER  for the interpreter in the fallback context flags, preserving  X0  consistently with the other architectures.