### PR TITLE
[release/9.0] Surface scheduled outerloop Helix work item failures (backport of #129049, #129629)

### DIFF
--- a/eng/pipelines/libraries/helix.yml
+++ b/eng/pipelines/libraries/helix.yml
@@ -16,6 +16,11 @@ parameters:
   SuperPmiCollect: ''
   SuperPmiCollectionType: ''
   SuperPmiCollectionName: ''
+  # When false, Helix work item and test failures do not fail the build, so the "Send to Helix"
+  # step still succeeds. Unlike shouldContinueOnError (which only marks the build as
+  # partiallySucceeded), this produces a fully successful build. Scheduled builds with
+  # always:false set this so that flaky tests don't cause AzDO to re-queue the same commit daily.
+  failOnTestFailures: true
 
 steps:
   - script: $(_msbuildCommand) $(_warnAsErrorParamHelixOverride) -restore
@@ -29,6 +34,8 @@ steps:
             /p:TestScope=${{ parameters.testScope }}
             /p:TestRunNamePrefixSuffix=${{ parameters.testRunNamePrefixSuffix }}
             /p:HelixBuild=$(Build.BuildNumber)
+            /p:FailOnWorkItemFailure=${{ parameters.failOnTestFailures }}
+            /p:FailOnTestFailure=${{ parameters.failOnTestFailures }}
             ${{ parameters.extraHelixArguments }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: Send to Helix

--- a/eng/pipelines/libraries/helix.yml
+++ b/eng/pipelines/libraries/helix.yml
@@ -21,6 +21,10 @@ parameters:
   # partiallySucceeded), this produces a fully successful build. Scheduled builds with
   # always:false set this so that flaky tests don't cause AzDO to re-queue the same commit daily.
   failOnTestFailures: true
+  # When true, failed Helix work items are surfaced as build warnings (visible in the AzDO
+  # timeline) instead of being silently ignored. Intended to be paired with failOnTestFailures:
+  # false so that failures stay visible without failing the build.
+  warnOnTestFailures: false
 
 steps:
   - script: $(_msbuildCommand) $(_warnAsErrorParamHelixOverride) -restore
@@ -36,6 +40,7 @@ steps:
             /p:HelixBuild=$(Build.BuildNumber)
             /p:FailOnWorkItemFailure=${{ parameters.failOnTestFailures }}
             /p:FailOnTestFailure=${{ parameters.failOnTestFailures }}
+            /p:WarnOnHelixTestFailure=${{ parameters.warnOnTestFailures }}
             ${{ parameters.extraHelixArguments }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: Send to Helix

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -52,6 +52,11 @@ extends:
                     testScope: outerloop
                     creator: dotnet-bot
                     testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+                    # On scheduled runs (always:false) don't fail the build on Helix work item or
+                    # test failures, so flaky outerloop tests don't keep AzDO re-queueing the same
+                    # commit. The Send to Helix step fully succeeds (not partiallySucceeded).
+                    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+                      failOnTestFailures: false
 
         - ${{ if eq(variables['isRollingBuild'], false) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
@@ -81,6 +86,9 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+                      # Don't fail scheduled builds on Helix work item/test failures (see above).
+                      ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+                        failOnTestFailures: false
 
         - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
@@ -106,3 +114,6 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       extraHelixArguments: /p:BuildTargetFramework=net48
+                      # Don't fail scheduled builds on Helix work item/test failures (see above).
+                      ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+                        failOnTestFailures: false

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -54,9 +54,11 @@ extends:
                     testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
                     # On scheduled runs (always:false) don't fail the build on Helix work item or
                     # test failures, so flaky outerloop tests don't keep AzDO re-queueing the same
-                    # commit. The Send to Helix step fully succeeds (not partiallySucceeded).
+                    # commit. The Send to Helix step fully succeeds (not partiallySucceeded). Failed
+                    # work items are still surfaced as warnings in the timeline (warnOnTestFailures).
                     ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
                       failOnTestFailures: false
+                      warnOnTestFailures: true
 
         - ${{ if eq(variables['isRollingBuild'], false) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
@@ -86,9 +88,11 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-                      # Don't fail scheduled builds on Helix work item/test failures (see above).
+                      # Don't fail scheduled builds on Helix work item/test failures; surface them
+                      # as timeline warnings instead (see above).
                       ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
                         failOnTestFailures: false
+                        warnOnTestFailures: true
 
         - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
@@ -114,6 +118,8 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       extraHelixArguments: /p:BuildTargetFramework=net48
-                      # Don't fail scheduled builds on Helix work item/test failures (see above).
+                      # Don't fail scheduled builds on Helix work item/test failures; surface them
+                      # as timeline warnings instead (see above).
                       ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
                         failOnTestFailures: false
+                        warnOnTestFailures: true

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -383,4 +383,20 @@
           DestinationFiles="@(_FilesToStage -> '$(HelixDependenciesStagingPath)\%(DirName)\%(RecursiveDir)%(FileName)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
+
+  <!--
+    When a build sets FailOnWorkItemFailure/FailOnTestFailure to false (e.g. scheduled outerloop runs,
+    which must end up 'succeeded' so AzDO's always:false scheduler doesn't keep re-queueing the same
+    commit) the Helix SDK's CheckHelixJobStatus no longer reports failed work items, which hides them
+    from the build. Setting WarnOnHelixTestFailure=true surfaces each failed work item as a build
+    warning instead, keeping the failures visible in the Azure DevOps timeline without failing the
+    build. The "Send to Helix" step disables warnaserror (see _warnAsErrorParamHelixOverride), so
+    these warnings are not promoted back into build-failing errors.
+  -->
+  <Target Name="WarnOnHelixWorkItemFailure"
+          AfterTargets="CheckHelixJobStatus"
+          Condition="'$(WarnOnHelixTestFailure)' == 'true' and '$(WaitForWorkItemCompletion)' == 'true'">
+    <Warning Condition="'%(CompletedWorkItem.Failed)' == 'true'"
+             Text="Work item %(CompletedWorkItem.WorkItemName) in job %(CompletedWorkItem.JobName) has failed. Failure log: %(CompletedWorkItem.ConsoleOutputUri)" />
+  </Target>
 </Project>


### PR DESCRIPTION
Backport of #129049 and #129629 to release/9.0.

Combines both changes:
- **#129049** Make scheduled outerloop builds succeed when only Helix tests fail. Scheduled outerloop runs (`always:false`) no longer fail the build on Helix work item/test failures, so flaky tests don't keep AzDO re-queueing the same commit.
- **#129629** Surface scheduled outerloop Helix work item failures as warnings, so failures remain visible in the AzDO timeline without failing the build.

Conflicts: `helix.yml` parameters list (SuperPmi params present on this branch) was resolved by keeping both.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.