### PR TITLE
JIT: form ldp/stp for adjacent Arm64 indexed accesses

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7842,6 +7842,9 @@ public:
 protected:
     void     optValnumCSE_Init();
     unsigned optValnumCSE_Index(GenTree* tree, Statement* stmt);
+#ifdef TARGET_ARM64
+    void optEnableArm64AddrModeCseForPairing();
+#endif
     bool optValnumCSE_Locate(CSE_HeuristicCommon* heuristic);
     void optValnumCSE_InitDataFlow();
     void optValnumCSE_SetUpAsyncByrefKills();

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -5741,8 +5741,11 @@ void Compiler::optEnableArm64AddrModeCseForPairing()
                 ssize_t  offset;
                 GenTree* baseIndex = getBaseIndex(node->AsIndir()->Addr(), &offset);
 
+                // Require a genuine "base + index": a GT_ADD whose second operand is a
+                // register index, not a constant. A "base + constant" address is already
+                // addressable as "[base, #imm]" and must not be treated as an index.
                 if (!baseIndex->OperIs(GT_ADD) || !varTypeIsIntegralOrI(baseIndex) ||
-                    ((baseIndex->gtFlags & GTF_ADDRMODE_NO_CSE) == 0))
+                    baseIndex->gtGetOp2()->IsCnsIntOrI() || ((baseIndex->gtFlags & GTF_ADDRMODE_NO_CSE) == 0))
                 {
                     continue;
                 }
@@ -5790,20 +5793,24 @@ void Compiler::optEnableArm64AddrModeCseForPairing()
 
         int  nonZeroCount = 0;
         bool adjacent     = false;
+
+        // Track offsets already seen so adjacency can be detected in O(n): an offset is
+        // adjacent when "offset +/- accessSize" was seen at an earlier use of this VN.
+        typedef JitHashTable<ssize_t, JitSmallPrimitiveKeyFuncs<ssize_t>, bool> OffsetSet;
+        OffsetSet                                                               seenOffsets(allocator);
         for (int i = 0; i < offsets->Height(); i++)
         {
-            if (offsets->Bottom(i) != 0)
+            ssize_t offset = offsets->Bottom(i);
+            if (offset != 0)
             {
                 nonZeroCount++;
             }
-            for (int j = i + 1; pairable && !adjacent && (j < offsets->Height()); j++)
+            if (pairable && !adjacent &&
+                (seenOffsets.Lookup(offset - accessSize) || seenOffsets.Lookup(offset + accessSize)))
             {
-                ssize_t delta = offsets->Bottom(i) - offsets->Bottom(j);
-                if ((delta == accessSize) || (delta == -accessSize))
-                {
-                    adjacent = true;
-                }
+                adjacent = true;
             }
+            seenOffsets.Set(offset, true, OffsetSet::Overwrite);
         }
 
         if ((nonZeroCount >= 2) || adjacent)

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -5663,6 +5663,182 @@ CSE_HeuristicCommon* Compiler::optGetCSEheuristic()
     return optCSEheuristic;
 }
 
+#ifdef TARGET_ARM64
+//------------------------------------------------------------------------
+// optEnableArm64AddrModeCseForPairing: re-enable CSE for "base + index"
+//    address expressions that can enable "ldp"/"stp" pair formation.
+//
+// Notes:
+//    On Arm64, a "base + index" address that feeds an addressing mode is marked
+//    GTF_ADDRMODE_NO_CSE, because "[base, index]" is a free addressing mode and
+//    CSE'ing it would just introduce a redundant "add". However, Arm64 cannot
+//    encode both a register index and a constant offset in a single access
+//    ("[base, index, #16]" is illegal). So when the same "base + index" is
+//    accessed at multiple offsets (for example adjacent vector loads/stores at
+//    "base + i" and "base + i + 16"), the "base + index" must be materialized
+//    into a register anyway. Making it CSE-able then lets the JIT compute it
+//    once and form "ldp"/"stp" pairs.
+//
+//    This routine clears GTF_ADDRMODE_NO_CSE on such "base + index" nodes, but
+//    only when doing so is expected to be profitable: either two or more uses
+//    carry a non-zero offset (so an "add" would otherwise be duplicated), or two
+//    uses are at offsets that differ by the access size (so a pair instruction
+//    can be formed). This preserves the common case where a "base + index" is
+//    reused at the same offset and "[base, index]" was already optimal.
+//
+void Compiler::optEnableArm64AddrModeCseForPairing()
+{
+    struct AddrModeUses
+    {
+        ArrayStack<ssize_t>* offsets;
+        unsigned             accessSize;
+        bool                 profitable;
+    };
+
+    struct Candidate
+    {
+        GenTree* baseIndex;
+        ValueNum vn;
+    };
+
+    typedef JitHashTable<ValueNum, JitSmallPrimitiveKeyFuncs<ValueNum>, AddrModeUses> AddrModeMap;
+
+    CompAllocator         allocator = getAllocator(CMK_CSE);
+    AddrModeMap           addrModeUses(allocator);
+    ArrayStack<Candidate> candidates(allocator);
+
+    // Decompose an indir address into its "base + index" subexpression (a GT_ADD
+    // with the constant offset, if any, folded out) and the offset.
+    auto getBaseIndex = [](GenTree* addr, ssize_t* offset) -> GenTree* {
+        addr               = addr->gtEffectiveVal();
+        *offset            = 0;
+        GenTree* baseIndex = addr;
+        if (addr->OperIs(GT_ADD))
+        {
+            GenTree* op2 = addr->gtGetOp2();
+            if (op2->IsCnsIntOrI() && !op2->IsIconHandle())
+            {
+                *offset   = op2->AsIntCon()->IconValue();
+                baseIndex = addr->gtGetOp1()->gtEffectiveVal();
+            }
+        }
+        return baseIndex;
+    };
+
+    // Walk the IR once, gathering the candidate "base + index" nodes and, per value
+    // number, the offsets they are accessed with.
+    for (BasicBlock* const block : Blocks())
+    {
+        for (Statement* const stmt : block->Statements())
+        {
+            for (GenTree* const node : stmt->TreeList())
+            {
+                if (!node->OperIsIndir() || node->TypeIs(TYP_STRUCT))
+                {
+                    continue;
+                }
+
+                ssize_t  offset;
+                GenTree* baseIndex = getBaseIndex(node->AsIndir()->Addr(), &offset);
+
+                if (!baseIndex->OperIs(GT_ADD) || !varTypeIsIntegralOrI(baseIndex) ||
+                    ((baseIndex->gtFlags & GTF_ADDRMODE_NO_CSE) == 0))
+                {
+                    continue;
+                }
+
+                ValueNum vn = baseIndex->gtVNPair.GetLiberal();
+                if (vn == ValueNumStore::NoVN)
+                {
+                    continue;
+                }
+
+                AddrModeUses* uses = addrModeUses.LookupPointer(vn);
+                if (uses == nullptr)
+                {
+                    AddrModeUses newUses;
+                    newUses.offsets    = new (allocator) ArrayStack<ssize_t>(allocator);
+                    newUses.accessSize = genTypeSize(node);
+                    newUses.profitable = false;
+                    addrModeUses.Set(vn, newUses);
+                    uses = addrModeUses.LookupPointer(vn);
+                }
+                uses->offsets->Push(offset);
+
+                candidates.Push({baseIndex, vn});
+            }
+        }
+    }
+
+    if (candidates.Height() == 0)
+    {
+        return;
+    }
+
+    // Determine which value numbers are profitable to CSE: either two or more uses
+    // carry a non-zero offset (so an "add" would otherwise be duplicated), or two
+    // uses are at offsets that differ by the access size (so an "ldp"/"stp" pair can
+    // be formed). Pairs only exist for 4-, 8-, and 16-byte accesses, so the adjacency
+    // case is restricted to those sizes.
+    int profitableCount = 0;
+    for (AddrModeMap::Node* const entry : AddrModeMap::KeyValueIteration(&addrModeUses))
+    {
+        AddrModeUses*        uses       = addrModeUses.LookupPointer(entry->GetKey());
+        ArrayStack<ssize_t>* offsets    = uses->offsets;
+        ssize_t              accessSize = (ssize_t)uses->accessSize;
+        const bool           pairable   = (accessSize == 4) || (accessSize == 8) || (accessSize == 16);
+
+        int  nonZeroCount = 0;
+        bool adjacent     = false;
+        for (int i = 0; i < offsets->Height(); i++)
+        {
+            if (offsets->Bottom(i) != 0)
+            {
+                nonZeroCount++;
+            }
+            for (int j = i + 1; pairable && !adjacent && (j < offsets->Height()); j++)
+            {
+                ssize_t delta = offsets->Bottom(i) - offsets->Bottom(j);
+                if ((delta == accessSize) || (delta == -accessSize))
+                {
+                    adjacent = true;
+                }
+            }
+        }
+
+        if ((nonZeroCount >= 2) || adjacent)
+        {
+            uses->profitable = true;
+            profitableCount++;
+        }
+    }
+
+    if (profitableCount == 0)
+    {
+        return;
+    }
+
+    // Re-enable CSE for the profitable "base + index" expressions.
+    for (int i = 0; i < candidates.Height(); i++)
+    {
+        const Candidate& candidate = candidates.BottomRef(i);
+
+        if ((candidate.baseIndex->gtFlags & GTF_ADDRMODE_NO_CSE) == 0)
+        {
+            continue;
+        }
+
+        AddrModeUses* uses = addrModeUses.LookupPointer(candidate.vn);
+        if ((uses != nullptr) && uses->profitable)
+        {
+            candidate.baseIndex->gtFlags &= ~GTF_ADDRMODE_NO_CSE;
+            JITDUMP("Re-enabled CSE for Arm64 base+index addr mode [%06u] (" FMT_VN ") to enable pairing\n",
+                    dspTreeID(candidate.baseIndex), candidate.vn);
+        }
+    }
+}
+#endif // TARGET_ARM64
+
 //------------------------------------------------------------------------
 // optOptimizeValnumCSEs: Perform common sub-expression elimination
 //
@@ -5687,6 +5863,10 @@ PhaseStatus Compiler::optOptimizeValnumCSEs()
     optValnumCSE_phase = true;
     optCSEweight       = -1.0f;
     bool madeChanges   = false;
+
+#ifdef TARGET_ARM64
+    optEnableArm64AddrModeCseForPairing();
+#endif
 
     optValnumCSE_Init();
 

--- a/src/tests/JIT/opt/AddrMode/LdpStpPairing.cs
+++ b/src/tests/JIT/opt/AddrMode/LdpStpPairing.cs
@@ -46,7 +46,8 @@ namespace LdpStpPairing
         {
             // Two non-adjacent, non-zero offsets cannot form a pair, but "src + i" / "dst + i"
             // should still be materialized once and shared (rather than recomputed per access).
-            // The two loads sharing a base register proves the common "add" was CSE'd.
+            // Both loads using the same base register is consistent with the shared "add"
+            // (this does not by itself prove the address is computed only once).
             //ARM64-FULL-LINE: ldr {{q[0-9]+}}, [[[SRCBASE:x[0-9]+]], #0x10]
             //ARM64-FULL-LINE: ldr {{q[0-9]+}}, [[[SRCBASE]], #0x30]
             Vector128<byte> v1 = Vector128.Load(src + i + 16);

--- a/src/tests/JIT/opt/AddrMode/LdpStpPairing.cs
+++ b/src/tests/JIT/opt/AddrMode/LdpStpPairing.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+namespace LdpStpPairing
+{
+    public unsafe class Program
+    {
+        // On Arm64, "[base, index]" and "[base, #offset]" are valid addressing modes but
+        // "[base, index, #offset]" is not. When the same "base + index" is accessed at
+        // adjacent offsets, the JIT should materialize "base + index" once (a single "add")
+        // and fold the accesses into "ldp"/"stp" pairs, rather than recomputing the address.
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void CopyTwoVectors(byte* dst, byte* src, nuint i)
+        {
+            //ARM64-FULL-LINE: ldp {{q[0-9]+}}, {{q[0-9]+}}, [{{x[0-9]+}}]
+            //ARM64-FULL-LINE: stp {{q[0-9]+}}, {{q[0-9]+}}, [{{x[0-9]+}}]
+            Vector128<byte> v1 = Vector128.Load(src + i);
+            Vector128<byte> v2 = Vector128.Load(src + i + 16);
+            v1.Store(dst + i);
+            v2.Store(dst + i + 16);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static long SumTwoLongs(long* p, nuint i)
+        {
+            //ARM64-FULL-LINE: ldp {{x[0-9]+}}, {{x[0-9]+}}, [{{x[0-9]+}}]
+            return *(p + i) + *(p + i + 1);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int LoadFourInts(int* p, nuint i)
+        {
+            //ARM64-FULL-LINE: ldp {{w[0-9]+}}, {{w[0-9]+}}, [{{x[0-9]+}}]
+            //ARM64-FULL-LINE: ldp {{w[0-9]+}}, {{w[0-9]+}}, [{{x[0-9]+}}, #0x08]
+            return *(p + i) + *(p + i + 1) + *(p + i + 2) + *(p + i + 3);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void StoreTwoFarVectors(byte* dst, byte* src, nuint i)
+        {
+            // Two non-adjacent, non-zero offsets cannot form a pair, but "src + i" / "dst + i"
+            // should still be materialized once and shared (rather than recomputed per access).
+            // The two loads sharing a base register proves the common "add" was CSE'd.
+            //ARM64-FULL-LINE: ldr {{q[0-9]+}}, [[[SRCBASE:x[0-9]+]], #0x10]
+            //ARM64-FULL-LINE: ldr {{q[0-9]+}}, [[[SRCBASE]], #0x30]
+            Vector128<byte> v1 = Vector128.Load(src + i + 16);
+            Vector128<byte> v2 = Vector128.Load(src + i + 48);
+            v1.Store(dst + i + 16);
+            v2.Store(dst + i + 48);
+        }
+
+        [Fact]
+        public static int TestEntryPoint()
+        {
+            int result = 100;
+
+            byte* src = stackalloc byte[64];
+            byte* dst = stackalloc byte[64];
+            for (int k = 0; k < 64; k++)
+            {
+                src[k] = (byte)(k + 1);
+                dst[k] = 0;
+            }
+
+            CopyTwoVectors(dst, src, 4);
+            for (int k = 0; k < 32; k++)
+            {
+                if (dst[4 + k] != src[4 + k])
+                {
+                    Console.WriteLine($"CopyTwoVectors failed at {k}");
+                    result = -1;
+                }
+            }
+
+            long* longs = stackalloc long[8];
+            for (int k = 0; k < 8; k++)
+            {
+                longs[k] = (k + 1) * 1000;
+            }
+
+            if (SumTwoLongs(longs, 2) != (longs[2] + longs[3]))
+            {
+                Console.WriteLine("SumTwoLongs failed");
+                result = -1;
+            }
+
+            int* ints = stackalloc int[8];
+            for (int k = 0; k < 8; k++)
+            {
+                ints[k] = (k + 1) * 7;
+            }
+
+            if (LoadFourInts(ints, 1) != (ints[1] + ints[2] + ints[3] + ints[4]))
+            {
+                Console.WriteLine("LoadFourInts failed");
+                result = -1;
+            }
+
+            StoreTwoFarVectors(dst, src, 0);
+            for (int k = 0; k < 16; k++)
+            {
+                if (dst[16 + k] != src[16 + k] || dst[48 + k] != src[48 + k])
+                {
+                    Console.WriteLine($"StoreTwoFarVectors failed at {k}");
+                    result = -1;
+                }
+            }
+
+            if (result == 100)
+            {
+                Console.WriteLine("PASSED");
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/tests/JIT/opt/AddrMode/LdpStpPairing.csproj
+++ b/src/tests/JIT/opt/AddrMode/LdpStpPairing.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs">
+      <HasDisasmCheck>true</HasDisasmCheck>
+    </Compile>
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Arm64 can't encode [base, index, #off], so a base+index used at multiple offsets must be materialized anyway; re-enable CSE for it before pairing so adjacent loads/stores fold into ldp/stp.

Fixes #93263.