### PR TITLE
AES-KWP Performance Improvements for Apple

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Aes.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Aes.cs
@@ -354,18 +354,33 @@ namespace System.Security.Cryptography
         /// </remarks>
         protected virtual unsafe int DecryptKeyWrapPaddedCore(ReadOnlySpan<byte> source, Span<byte> destination)
         {
+            return DecryptKeyWrapPaddedCore(
+                source,
+                destination,
+                this,
+                static (instance, source, destination) => instance.DecryptEcb(source, destination, PaddingMode.None));
+        }
+
+        private protected int DecryptKeyWrapPaddedCore<TState>(
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            TState state,
+            KeyWrapEcbTransform<TState> decryptEcb)
+        {
             ulong iv;
 
             if (source.Length == 16)
             {
                 Span<byte> decrypt = stackalloc byte[16];
-                DecryptEcb(source, decrypt, PaddingMode.None);
+                int written = decryptEcb(state, source, decrypt);
+                Debug.Assert(written == decrypt.Length);
+
                 iv = BinaryPrimitives.ReadUInt64BigEndian(decrypt);
                 decrypt.Slice(8).CopyTo(destination);
             }
             else
             {
-                iv = Rfc3394Unwrap(source, destination);
+                iv = Rfc3394Unwrap(source, destination, state, decryptEcb);
             }
 
             uint len = (uint)iv;
@@ -408,6 +423,24 @@ namespace System.Security.Cryptography
         /// </remarks>
         protected virtual unsafe void EncryptKeyWrapPaddedCore(ReadOnlySpan<byte> source, Span<byte> destination)
         {
+            EncryptKeyWrapPaddedCore(
+                source,
+                destination,
+                this,
+                static (instance, source, destination) => instance.EncryptEcb(source, destination, PaddingMode.None));
+        }
+
+        private protected delegate int KeyWrapEcbTransform<TState>(
+            TState state,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination);
+
+        private protected void EncryptKeyWrapPaddedCore<TState>(
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            TState state,
+            KeyWrapEcbTransform<TState> encryptEcb)
+        {
             Debug.Assert(destination.Length == GetKeyWrapPaddedLength(source.Length));
 
             const ulong AIV = 0xA65959A6;
@@ -423,14 +456,20 @@ namespace System.Security.Cryptography
                 keyPart.Clear();
                 source.CopyTo(keyPart);
 
-                EncryptEcb(buf, destination, PaddingMode.None);
-
-                // Clear out the copy we made of the key.
-                CryptographicOperations.ZeroMemory(keyPart);
+                try
+                {
+                    int written = encryptEcb(state, buf, destination);
+                    Debug.Assert(written == buf.Length);
+                }
+                finally
+                {
+                    // Clear out the copy we made of the key.
+                    CryptographicOperations.ZeroMemory(keyPart);
+                }
             }
             else if (source.Length % 8 == 0)
             {
-                Rfc3394Wrap(iv, source, destination);
+                Rfc3394Wrap(iv, source, destination, state, encryptEcb);
             }
             else
             {
@@ -442,12 +481,17 @@ namespace System.Security.Cryptography
                     source.CopyTo(lease.Span);
                     lease.Span.Slice(source.Length).Clear();
 
-                    Rfc3394Wrap(iv, lease.Span, destination);
+                    Rfc3394Wrap(iv, lease.Span, destination, state, encryptEcb);
                 }
             }
         }
 
-        private unsafe void Rfc3394Wrap(ulong iv, ReadOnlySpan<byte> source, Span<byte> destination)
+        private void Rfc3394Wrap<TState>(
+            ulong iv,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            TState state,
+            KeyWrapEcbTransform<TState> encryptEcb)
         {
             Debug.Assert(source.Length % 8 == 0);
             Debug.Assert(source.Length >= 16);
@@ -468,7 +512,8 @@ namespace System.Security.Cryptography
                 for (uint i = 0; i < source.Length; i += 8, t++, R = R.Slice(8))
                 {
                     R.Slice(0, 8).CopyTo(B.Slice(8));
-                    EncryptEcb(B, B, PaddingMode.None);
+                    int written = encryptEcb(state, B, B);
+                    Debug.Assert(written == B.Length);
 
                     uint al = BinaryPrimitives.ReadUInt32BigEndian(ALo);
                     al ^= t;
@@ -481,7 +526,11 @@ namespace System.Security.Cryptography
             A.CopyTo(destination);
         }
 
-        private unsafe ulong Rfc3394Unwrap(ReadOnlySpan<byte> source, Span<byte> destination)
+        private ulong Rfc3394Unwrap<TState>(
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            TState state,
+            KeyWrapEcbTransform<TState> decryptEcb)
         {
             Span<byte> B = stackalloc byte[16];
             Span<byte> A = B.Slice(0, 8);
@@ -503,7 +552,9 @@ namespace System.Security.Cryptography
                     BinaryPrimitives.WriteUInt32BigEndian(ALo, al);
 
                     R.Slice(0, 8).CopyTo(B.Slice(8));
-                    DecryptEcb(B, B, PaddingMode.None);
+                    int written = decryptEcb(state, B, B);
+                    Debug.Assert(written == B.Length);
+
                     B.Slice(8).CopyTo(R);
                 }
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.Apple.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.Apple.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace System.Security.Cryptography
 {
     internal sealed partial class AesImplementation
@@ -46,6 +48,54 @@ namespace System.Security.Cryptography
                 encrypting,
                 feedbackSizeInBytes,
                 paddingSize);
+        }
+
+        protected override void EncryptKeyWrapPaddedCore(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            Debug.Assert(destination.Length == GetKeyWrapPaddedLength(source.Length));
+
+            ILiteSymmetricCipher cipher = GetKey().UseKey(
+                BlockSize / BitsPerByte,
+                static (blockSizeBytes, key) => CreateLiteCipher(
+                    CipherMode.ECB,
+                    key,
+                    iv: default,
+                    blockSize: blockSizeBytes,
+                    paddingSize: blockSizeBytes,
+                    feedbackSizeInBytes: 0,
+                    encrypting: true));
+
+            using (cipher)
+            {
+                EncryptKeyWrapPaddedCore(
+                    source,
+                    destination,
+                    cipher,
+                    static (cipher, source, destination) => cipher.Transform(source, destination));
+            }
+        }
+
+        protected override int DecryptKeyWrapPaddedCore(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            ILiteSymmetricCipher cipher = GetKey().UseKey(
+                BlockSize / BitsPerByte,
+                static (blockSizeBytes, key) => CreateLiteCipher(
+                    CipherMode.ECB,
+                    key,
+                    iv: default,
+                    blockSize: blockSizeBytes,
+                    paddingSize: blockSizeBytes,
+                    feedbackSizeInBytes: 0,
+                    encrypting: false));
+
+            using (cipher)
+            {
+                return DecryptKeyWrapPaddedCore(
+                    source,
+                    destination,
+                    cipher,
+                    static (cipher, source, destination) => cipher.Transform(source, destination));
+            }
         }
     }
 }


### PR DESCRIPTION
This gives anywhere for a 5x to 10x performance improvement for AES-KWP on Apple and reduces allocations for any input larger than 8 bytes. That is expected to be the common use case, as wrapping even a small symmetric key like AES is going to be 16 bytes.

The general theme of the change is not using `EncryptEcb` on our internal `AesImplementation`. Each invocation of `EncryptEcb` creates and tears down handles. We need to keep calling `EncryptEcb` in our base class implementation because it `protected virtual` and we need to keep calling the virtual.

The `sealed internal` implementation can fast-path this though by re-using a lite cipher for each invocation of ECB.

"Single block" inputs don't change and are basically noise and are within error.

For [1, 8] there is no performance change.
For (8, 512] the improvement is ~5x.
For (512..] the improvement is ~10x.

Allocations are significantly down. Previously the allocations linearly scaled with the input length. Now the allocations are constant regardless of the input size. For example, before this change a 4096 input allocated 221,192 bytes. It now allocates 72.

---

What about Windows? That will be a follow up PR.

---


| Method               | Job    | PlaintextLength | Mean         | Ratio | Allocated | Alloc Ratio |
|--------------------- |------- |---------------- |-------------:|------:|----------:|------------:|
| **EncryptKeyWrapPadded** | **branch** | **1**               |     **286.9 ns** |  **1.01** |      **72 B** |        **1.00** |
| EncryptKeyWrapPadded | main   | 1               |     283.4 ns |  1.00 |      72 B |        1.00 |
|                      |        |                 |              |       |           |             |
| DecryptKeyWrapPadded | branch | 1               |     306.3 ns |  0.99 |      72 B |        1.00 |
| DecryptKeyWrapPadded | main   | 1               |     310.1 ns |  1.00 |      72 B |        1.00 |
|                      |        |                 |              |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **8**               |     **287.7 ns** |  **1.01** |      **72 B** |        **1.00** |
| EncryptKeyWrapPadded | main   | 8               |     283.9 ns |  1.00 |      72 B |        1.00 |
|                      |        |                 |              |       |           |             |
| DecryptKeyWrapPadded | branch | 8               |     288.7 ns |  0.97 |      72 B |        1.00 |
| DecryptKeyWrapPadded | main   | 8               |     297.0 ns |  1.00 |      72 B |        1.00 |
|                      |        |                 |              |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **15**              |     **594.4 ns** |  **0.17** |      **72 B** |        **0.08** |
| EncryptKeyWrapPadded | main   | 15              |   3,439.5 ns |  1.00 |     864 B |        1.00 |
|                      |        |                 |              |       |           |             |
| DecryptKeyWrapPadded | branch | 15              |     600.5 ns |  0.17 |      72 B |        0.08 |
| DecryptKeyWrapPadded | main   | 15              |   3,542.5 ns |  1.00 |     864 B |        1.00 |
|                      |        |                 |              |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **16**              |     **633.2 ns** |  **0.18** |      **72 B** |        **0.08** |
| EncryptKeyWrapPadded | main   | 16              |   3,539.1 ns |  1.00 |     864 B |        1.00 |
|                      |        |                 |              |       |           |             |
| DecryptKeyWrapPadded | branch | 16              |     607.5 ns |  0.17 |      72 B |        0.08 |
| DecryptKeyWrapPadded | main   | 16              |   3,520.2 ns |  1.00 |     864 B |        1.00 |
|                      |        |                 |              |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **512**             |  **11,922.3 ns** |  **0.11** |      **72 B** |       **0.003** |
| EncryptKeyWrapPadded | main   | 512             | 110,421.3 ns |  1.00 |   27649 B |       1.000 |
|                      |        |                 |              |       |           |             |
| DecryptKeyWrapPadded | branch | 512             |  10,237.2 ns |  0.09 |      72 B |       0.003 |
| DecryptKeyWrapPadded | main   | 512             | 110,095.8 ns |  1.00 |   27649 B |       1.000 |
|                      |        |                 |              |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **513**             |  **10,392.5 ns** |  **0.09** |      **72 B** |       **0.003** |
| EncryptKeyWrapPadded | main   | 513             | 109,674.0 ns |  1.00 |   28081 B |       1.000 |
|                      |        |                 |              |       |           |             |
| DecryptKeyWrapPadded | branch | 513             |  10,383.4 ns |  0.09 |      72 B |       0.003 |
| DecryptKeyWrapPadded | main   | 513             | 111,808.8 ns |  1.00 |   28081 B |       1.000 |
|                      |        |                 |              |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **4096**            |  **93,152.7 ns** |  **0.11** |      **72 B** |       **0.000** |
| EncryptKeyWrapPadded | main   | 4096            | 882,443.6 ns |  1.00 |  221192 B |       1.000 |
|                      |        |                 |              |       |           |             |
| DecryptKeyWrapPadded | branch | 4096            |  79,761.4 ns |  0.09 |      72 B |       0.000 |
| DecryptKeyWrapPadded | main   | 4096            | 881,431.3 ns |  1.00 |  221192 B |       1.000 |
|                      |        |                 |              |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **4097**            |  **79,879.8 ns** |  **0.09** |      **72 B** |       **0.000** |
| EncryptKeyWrapPadded | main   | 4097            | 867,367.3 ns |  1.00 |  221624 B |       1.000 |
|                      |        |                 |              |       |           |             |
| DecryptKeyWrapPadded | branch | 4097            |  80,013.8 ns |  0.09 |      72 B |       0.000 |
| DecryptKeyWrapPadded | main   | 4097            | 889,664.7 ns |  1.00 |  221624 B |       1.000 |
