### PR TITLE
[Prototype] Alternative shape: derive ReadOnlyMemoryStream / WritableMemoryStream from Stream

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -22,17 +22,17 @@ namespace System.IO
     {
         private byte[] _buffer;             // Either allocated internally or externally.
         private readonly int _origin;       // For user-provided arrays, start at this origin
-        private protected int _position;    // read/write head.
-        private protected int _length;      // Number of bytes within the memory stream
+        private int _position;              // read/write head.
+        private int _length;                // Number of bytes within the memory stream
         private int _capacity;              // length of usable portion of buffer for stream
         // Note that _capacity == _buffer.Length for non-user-provided byte[]'s
 
         private bool _expandable;           // User-provided buffers aren't expandable.
-        private protected bool _writable;   // Can user write to this stream?
+        private bool _writable;             // Can user write to this stream?
         private readonly bool _exposable;   // Whether the array can be returned to the user.
-        private protected bool _isOpen;     // Is this stream open or closed?
+        private bool _isOpen;               // Is this stream open or closed?
 
-        private protected CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
+        private CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
 
         public MemoryStream()
             : this(0)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
@@ -7,48 +7,139 @@ using System.Threading.Tasks;
 namespace System.IO
 {
     /// <summary>
-    /// Provides a seekable, read-only <see cref="MemoryStream"/> over a <see cref="ReadOnlyMemory{Byte}"/>.
+    /// Provides a seekable, read-only <see cref="Stream"/> over a <see cref="ReadOnlyMemory{Byte}"/>.
     /// </summary>
     /// <remarks>
-    /// <para>The stream cannot be written to. <see cref="MemoryStream.CanWrite"/> always returns <see langword="false"/>.</para>
-    /// <para><see cref="MemoryStream.GetBuffer"/> throws and <see cref="MemoryStream.TryGetBuffer"/> returns <see langword="false"/>.</para>
+    /// <para>The stream cannot be written to. <see cref="CanWrite"/> always returns <see langword="false"/>.</para>
+    /// <para><see cref="GetBuffer"/> throws and <see cref="TryGetBuffer"/> returns <see langword="false"/>.</para>
     /// </remarks>
-    public sealed class ReadOnlyMemoryStream : MemoryStream
+    public sealed class ReadOnlyMemoryStream : Stream
     {
         private ReadOnlyMemory<byte> _memory;
+        private int _position;
+        private bool _isOpen;
+        private CachedCompletedInt32Task _lastReadTask;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyMemoryStream"/> class over the specified <see cref="ReadOnlyMemory{Byte}"/>.
         /// </summary>
         /// <param name="source">The <see cref="ReadOnlyMemory{Byte}"/> to wrap.</param>
-        public ReadOnlyMemoryStream(ReadOnlyMemory<byte> source) : base()
+        public ReadOnlyMemoryStream(ReadOnlyMemory<byte> source)
         {
-            _writable = false;
             _memory = source;
-            _length = source.Length;
+            _isOpen = true;
         }
 
         /// <inheritdoc/>
-        public override int Capacity
+        public override bool CanRead => _isOpen;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => _isOpen;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => false;
+
+        /// <inheritdoc/>
+        public override long Length
         {
             get
             {
                 EnsureNotClosed();
                 return _memory.Length;
             }
-            set => throw new NotSupportedException(SR.NotSupported_MemStreamNotExpandable);
         }
 
         /// <inheritdoc/>
-        public override byte[] GetBuffer() =>
-            throw new UnauthorizedAccessException(SR.UnauthorizedAccess_MemStreamBuffer);
+        public override long Position
+        {
+            get
+            {
+                EnsureNotClosed();
+                return _position;
+            }
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, int.MaxValue);
+                EnsureNotClosed();
+                _position = (int)value;
+            }
+        }
 
         /// <inheritdoc/>
-        public override bool TryGetBuffer(out ArraySegment<byte> buffer)
+        public override long Seek(long offset, SeekOrigin loc)
+        {
+            EnsureNotClosed();
+
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, int.MaxValue);
+
+            long target = loc switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => _position + offset,
+                SeekOrigin.End => _memory.Length + offset,
+                _ => throw new ArgumentException(SR.Argument_InvalidSeekOrigin, nameof(loc)),
+            };
+
+            if (target < 0)
+                throw new IOException(SR.IO_SeekBeforeBegin);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(target, int.MaxValue, nameof(offset));
+
+            _position = (int)target;
+            return _position;
+        }
+
+        /// <inheritdoc/>
+        public override void Flush() { }
+
+        /// <inheritdoc/>
+        public override Task FlushAsync(CancellationToken cancellationToken) =>
+            cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled(cancellationToken)
+                : Task.CompletedTask;
+
+        /// <inheritdoc/>
+        public override void SetLength(long value) =>
+            throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+
+        /// <summary>Gets the size of the underlying buffer.</summary>
+        public int Capacity
+        {
+            get
+            {
+                EnsureNotClosed();
+                return _memory.Length;
+            }
+        }
+
+        /// <summary>Always throws; the underlying buffer is not exposed.</summary>
+        /// <exception cref="UnauthorizedAccessException">Always thrown.</exception>
+        public byte[] GetBuffer() =>
+            throw new UnauthorizedAccessException(SR.UnauthorizedAccess_MemStreamBuffer);
+
+        /// <summary>Always returns <see langword="false"/>; the underlying buffer is not exposed.</summary>
+        /// <param name="buffer">When this method returns, contains the default value of <see cref="ArraySegment{Byte}"/>.</param>
+        /// <returns><see langword="false"/>.</returns>
+        public bool TryGetBuffer(out ArraySegment<byte> buffer)
         {
             buffer = default;
             return false;
         }
+
+        /// <inheritdoc/>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ValidateBufferArguments(buffer, offset, count);
+            throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+        }
+
+        /// <inheritdoc/>
+        public override void Write(ReadOnlySpan<byte> buffer) =>
+            throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+
+        /// <inheritdoc/>
+        public override void WriteByte(byte value) =>
+            throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
         public override int ReadByte()
@@ -156,8 +247,9 @@ namespace System.IO
             return Task.CompletedTask;
         }
 
-        /// <inheritdoc/>
-        public override byte[] ToArray()
+        /// <summary>Writes the stream contents to a byte array, regardless of the <see cref="Position"/>.</summary>
+        /// <returns>A new byte array containing a copy of the stream's contents.</returns>
+        public byte[] ToArray()
         {
             EnsureNotClosed();
             if (_memory.Length == 0)
@@ -170,8 +262,9 @@ namespace System.IO
             return copy;
         }
 
-        /// <inheritdoc/>
-        public override void WriteTo(Stream stream)
+        /// <summary>Writes the entire contents of this stream to another stream.</summary>
+        /// <param name="stream">The destination stream.</param>
+        public void WriteTo(Stream stream)
         {
             ArgumentNullException.ThrowIfNull(stream);
             EnsureNotClosed();
@@ -183,6 +276,7 @@ namespace System.IO
         protected override void Dispose(bool disposing)
         {
             _memory = default;
+            _isOpen = false;
             base.Dispose(disposing);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/WritableMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/WritableMemoryStream.cs
@@ -7,42 +7,117 @@ using System.Threading.Tasks;
 namespace System.IO
 {
     /// <summary>
-    /// Provides a seekable, writable <see cref="MemoryStream"/> over a <see cref="Memory{Byte}"/> with fixed capacity.
+    /// Provides a seekable, writable <see cref="Stream"/> over a <see cref="Memory{Byte}"/> with fixed capacity.
     /// </summary>
     /// <remarks>
     /// <para>The stream cannot expand beyond the initial memory capacity.</para>
-    /// <para><see cref="MemoryStream.GetBuffer"/> throws and <see cref="MemoryStream.TryGetBuffer"/> returns <see langword="false"/>.</para>
+    /// <para><see cref="GetBuffer"/> throws and <see cref="TryGetBuffer"/> returns <see langword="false"/>.</para>
     /// </remarks>
-    public sealed class WritableMemoryStream : MemoryStream
+    public sealed class WritableMemoryStream : Stream
     {
         private Memory<byte> _memory;
+        private int _position;
+        private int _length;
+        private bool _isOpen;
+        private CachedCompletedInt32Task _lastReadTask;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WritableMemoryStream"/> class over the specified <see cref="Memory{Byte}"/>.
         /// </summary>
         /// <param name="buffer">The <see cref="Memory{Byte}"/> to wrap.</param>
-        public WritableMemoryStream(Memory<byte> buffer) : base()
+        public WritableMemoryStream(Memory<byte> buffer)
         {
             _memory = buffer;
+            _isOpen = true;
         }
 
         /// <inheritdoc/>
-        public override int Capacity
+        public override bool CanRead => _isOpen;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => _isOpen;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => _isOpen;
+
+        /// <inheritdoc/>
+        public override long Length
+        {
+            get
+            {
+                EnsureNotClosed();
+                return _length;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override long Position
+        {
+            get
+            {
+                EnsureNotClosed();
+                return _position;
+            }
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, int.MaxValue);
+                EnsureNotClosed();
+                _position = (int)value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin loc)
+        {
+            EnsureNotClosed();
+
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, int.MaxValue);
+
+            long target = loc switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => _position + offset,
+                SeekOrigin.End => _length + offset,
+                _ => throw new ArgumentException(SR.Argument_InvalidSeekOrigin, nameof(loc)),
+            };
+
+            if (target < 0)
+                throw new IOException(SR.IO_SeekBeforeBegin);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(target, int.MaxValue, nameof(offset));
+
+            _position = (int)target;
+            return _position;
+        }
+
+        /// <inheritdoc/>
+        public override void Flush() { }
+
+        /// <inheritdoc/>
+        public override Task FlushAsync(CancellationToken cancellationToken) =>
+            cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled(cancellationToken)
+                : Task.CompletedTask;
+
+        /// <summary>Gets the size of the underlying buffer.</summary>
+        public int Capacity
         {
             get
             {
                 EnsureNotClosed();
                 return _memory.Length;
             }
-            set => throw new NotSupportedException(SR.NotSupported_MemStreamNotExpandable);
         }
 
-        /// <inheritdoc/>
-        public override byte[] GetBuffer() =>
+        /// <summary>Always throws; the underlying buffer is not exposed.</summary>
+        /// <exception cref="UnauthorizedAccessException">Always thrown.</exception>
+        public byte[] GetBuffer() =>
             throw new UnauthorizedAccessException(SR.UnauthorizedAccess_MemStreamBuffer);
 
-        /// <inheritdoc/>
-        public override bool TryGetBuffer(out ArraySegment<byte> buffer)
+        /// <summary>Always returns <see langword="false"/>; the underlying buffer is not exposed.</summary>
+        /// <param name="buffer">When this method returns, contains the default value of <see cref="ArraySegment{Byte}"/>.</param>
+        /// <returns><see langword="false"/>.</returns>
+        public bool TryGetBuffer(out ArraySegment<byte> buffer)
         {
             buffer = default;
             return false;
@@ -238,8 +313,9 @@ namespace System.IO
         /// <inheritdoc/>
         public override void SetLength(long value) => throw new NotSupportedException(SR.NotSupported_MemStreamNotExpandable);
 
-        /// <inheritdoc/>
-        public override byte[] ToArray()
+        /// <summary>Writes the stream contents to a byte array, regardless of the <see cref="Position"/>.</summary>
+        /// <returns>A new byte array containing a copy of the written contents.</returns>
+        public byte[] ToArray()
         {
             EnsureNotClosed();
             if (_length == 0)
@@ -252,8 +328,9 @@ namespace System.IO
             return copy;
         }
 
-        /// <inheritdoc/>
-        public override void WriteTo(Stream stream)
+        /// <summary>Writes the stream contents to another stream.</summary>
+        /// <param name="stream">The destination stream.</param>
+        public void WriteTo(Stream stream)
         {
             ArgumentNullException.ThrowIfNull(stream);
             EnsureNotClosed();
@@ -265,6 +342,7 @@ namespace System.IO
         protected override void Dispose(bool disposing)
         {
             _memory = default;
+            _isOpen = false;
             base.Dispose(disposing);
         }
 

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -11053,45 +11053,65 @@ namespace System.IO
         public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public sealed partial class ReadOnlyMemoryStream : System.IO.MemoryStream
+    public sealed partial class ReadOnlyMemoryStream : System.IO.Stream
     {
         public ReadOnlyMemoryStream(System.ReadOnlyMemory<byte> source) { }
-        public override int Capacity { get { throw null; } set { } }
+        public int Capacity { get { throw null; } }
+        public override bool CanRead { get { throw null; } }
+        public override bool CanSeek { get { throw null; } }
+        public override bool CanWrite { get { throw null; } }
+        public override long Length { get { throw null; } }
+        public override long Position { get { throw null; } set { } }
+        public override long Seek(long offset, System.IO.SeekOrigin loc) { throw null; }
+        public override void SetLength(long value) { }
+        public override void Flush() { }
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override void CopyTo(System.IO.Stream destination, int bufferSize) { }
         public override System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override void Dispose(bool disposing) { }
-        public override byte[] GetBuffer() { throw null; }
+        public byte[] GetBuffer() { throw null; }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int Read(System.Span<byte> buffer) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override int ReadByte() { throw null; }
-        public override byte[] ToArray() { throw null; }
-        public override bool TryGetBuffer(out System.ArraySegment<byte> buffer) { throw null; }
-        public override void WriteTo(System.IO.Stream stream) { }
+        public override void Write(byte[] buffer, int offset, int count) { }
+        public override void Write(System.ReadOnlySpan<byte> buffer) { }
+        public override void WriteByte(byte value) { }
+        public byte[] ToArray() { throw null; }
+        public bool TryGetBuffer(out System.ArraySegment<byte> buffer) { throw null; }
+        public void WriteTo(System.IO.Stream stream) { }
     }
-    public sealed partial class WritableMemoryStream : System.IO.MemoryStream
+    public sealed partial class WritableMemoryStream : System.IO.Stream
     {
         public WritableMemoryStream(System.Memory<byte> buffer) { }
-        public override int Capacity { get { throw null; } set { } }
+        public int Capacity { get { throw null; } }
+        public override bool CanRead { get { throw null; } }
+        public override bool CanSeek { get { throw null; } }
+        public override bool CanWrite { get { throw null; } }
+        public override long Length { get { throw null; } }
+        public override long Position { get { throw null; } set { } }
+        public override long Seek(long offset, System.IO.SeekOrigin loc) { throw null; }
+        public override void Flush() { }
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override void CopyTo(System.IO.Stream destination, int bufferSize) { }
         public override System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override void Dispose(bool disposing) { }
-        public override byte[] GetBuffer() { throw null; }
+        public byte[] GetBuffer() { throw null; }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int Read(System.Span<byte> buffer) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override int ReadByte() { throw null; }
         public override void SetLength(long value) { }
-        public override byte[] ToArray() { throw null; }
-        public override bool TryGetBuffer(out System.ArraySegment<byte> buffer) { throw null; }
+        public byte[] ToArray() { throw null; }
+        public bool TryGetBuffer(out System.ArraySegment<byte> buffer) { throw null; }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }
         public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override void WriteByte(byte value) { }
-        public override void WriteTo(System.IO.Stream stream) { }
+        public void WriteTo(System.IO.Stream stream) { }
     }
     public partial class StringWriter : System.IO.TextWriter
     {


### PR DESCRIPTION
> ⚠️ **Prototype / exploration — not proposing this as a merge or as a re-API-review item.** Per discussion on #126669 ([r3453266352](https://github.com/dotnet/runtime/pull/126669#discussion_r3453266352)) and [#22838](https://github.com/dotnet/runtime/issues/22838), I haven't seen a feature-blocking reason to revisit the base class so far, and neither approach appears to be wrong, though it could still be worth exploring further. Opening this so the alternative shape is concrete and measurable if it ever comes up again, e.g. if the allocation overhead becomes meaningful for a future hot path.

Follow-up on #126669. Shows what `ReadOnlyMemoryStream` / `WritableMemoryStream` would look like derived from `Stream` instead of `MemoryStream`.

#### Context of the trade-off (recap of the prior discussion)

- **Allocation:** [Jozkee measured](https://github.com/dotnet/runtime/pull/126669#discussion_r3453266352) ROMS 96 → 56 B, WMS 104 → 64 B (~40 B saved per instance) on a `Stream` base.
- **Ecosystem cost:** [Adam noted](https://github.com/dotnet/runtime/pull/126669#discussion_r3453266352) that several callers in the wider .NET ecosystem special-case `is MemoryStream` for fast paths; deriving from `MemoryStream` lets the new wrappers participate in those optimizations and keeps naming consistency.
- **Verdict on the prior PR:** Stay on `MemoryStream` for the initial shape, with `private protected` field promotions on `MemoryStream` so the wrappers can share state — the shape that shipped.

This PR is the other side of that fork, in case it's ever useful to compare.

#### What this prototype does

```
Before                              After (prototype)
+--------------------------+        +--------------------------+
| MemoryStream base (88 B) |        | Stream base (48 / 56 B)  |
| + _memory                |   →    | + _memory                |
+--------------------------+        | + _position              |
                                    | + _isOpen [+ _length]    |
                                    | + _lastReadTask          |
                                    +--------------------------+

ReadOnlyMemoryStream:  88 B → 48 B
WritableMemoryStream:  88 B → 56 B
```

| File | Change |
|------|--------|
| `MemoryStream.cs` | Reverts the `private protected` field promotions added in #126669 — no consumer in the hierarchy under this shape. |
| `ReadOnlyMemoryStream.cs` | Base `: MemoryStream` → `: Stream`. Adds local backing state and `Stream` overrides (`CanRead`/`CanSeek`/`CanWrite`/`Length`/`Position`/`Seek`/`Flush`/`FlushAsync`/`SetLength`). `Capacity`, `GetBuffer`, `TryGetBuffer`, `ToArray`, `WriteTo` lose `override`; `Capacity` setter dropped (only threw). `Write`/`Write(ROSpan)`/`WriteByte` throw `NotSupportedException`. |
| `WritableMemoryStream.cs` | Same skeleton; keeps `_length` and the writable surface. |
| `ref/System.Runtime.cs` | Mirrors the prototype shape. |

#### Trade-offs

**For a `Stream` base**

- Smaller instances (~40 B / -36–45 %).
- The two wrappers don't use any of `MemoryStream`'s buffer-management state (`_buffer`, `_origin`, `_capacity`, `_expandable`, `_exposable`), so the inherited fields are dead weight on every instance.
- The `MemoryStream` base also brings inherited surface (`WriteTo(byte[])`, expandable-capacity semantics, `GetBuffer`/`TryGetBuffer` over an internal `byte[]`, etc.) that doesn't really apply to a fixed `Memory<byte>` wrapper — under the current shape these have to be overridden to throw or no-op.

**Against a `Stream` base**

- Drops out of `is MemoryStream` fast paths used by several ecosystem consumers (mono, EFCore, MSBuild and friends).
- Loses naming consistency: the types are still called `…MemoryStream`, which is a soft signal to users (and to the [framework design "self-documenting names" guidance](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces)) that they *are* `MemoryStream`s. Renaming is on the table in principle, but if the names stay then a non-`MemoryStream` base is a mismatch worth flagging.

#### Testing

| Suite | Result |
|-------|-------:|
| `WritableMemoryStreamTests` | 7/7 ✓ |
| `ReadOnlyMemoryStreamTests` | 3/3 ✓ |
| `WritableMemoryStreamConformanceTests` | 128/128 ✓ |
| `ReadOnlyMemoryStreamConformanceTests` | 128/128 ✓ |
| Full `System.IO.Tests` | 2360/2360 ✓ |
| `System.IO.UnmanagedMemoryStream.Tests` | 289/289 ✓ |

`Seek` keeps `MemoryStream`'s `IOException(SR.IO_SeekBeforeBegin)` on negative target to preserve the existing conformance contract.

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot.
