### PR TITLE
JIT: fix stale VN in redundant branch opts dominating-branch simplification

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -790,7 +790,8 @@ bool Compiler::optRedundantDominatingBranch(BasicBlock* const block)
         return false;
     }
 
-    const ValueNum treeNormVN = vnStore->VNNormalValue(tree->GetVN(VNK_Liberal));
+    // Not const: the relop simplification below may rewrite `tree` and refresh this VN.
+    ValueNum treeNormVN = vnStore->VNNormalValue(tree->GetVN(VNK_Liberal));
 
     if (vnStore->IsVNConstant(treeNormVN))
     {
@@ -1105,6 +1106,9 @@ bool Compiler::optRedundantDominatingBranch(BasicBlock* const block)
             }
 
             fgValueNumberTree(tree);
+
+            // We rewrote block's relop; refresh its VN so later dom branches don't use a stale one (#128062).
+            treeNormVN = vnStore->VNNormalValue(tree->GetVN(VNK_Liberal));
         }
         madeChanges = true;
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_128062/Runtime_128062.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_128062/Runtime_128062.cs
@@ -36,8 +36,8 @@ public class Runtime_128062
         Assert.Equal(1024, Validate(1024));
 
         // Zero and negatives (other than -1) still throw.
-        Assert.Throws<ArgumentOutOfRangeException>(() => Validate(0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Validate(-2));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Validate(int.MinValue));
+        Assert.Throws<ArgumentOutOfRangeException>(() => { Validate(0); });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { Validate(-2); });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { Validate(int.MinValue); });
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_128062/Runtime_128062.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_128062/Runtime_128062.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Redundant branch opts walks up the dominator tree and may simplify an
+// intermediate dominating relop (e.g. rewrite `x < 0` and `x != 0` into `x > 0`).
+// While doing so it rewrote the start block's relop but kept reasoning about a
+// stale value number, which let it unsoundly fold a higher dominating guard
+// `if (x == -1)`. As a result `Validate(-1)` threw instead of returning.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_128062
+{
+    // Mirrors StreamReader.ValidateArgsAndOpenPath's buffer-size check.
+    // AggressiveOptimization forces FullOpts so the buggy phase (RBO) runs.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int Validate(int bufferSize)
+    {
+        if (bufferSize != -1)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferSize);
+        }
+
+        return bufferSize;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        // -1 is the sentinel and must be accepted without throwing.
+        Assert.Equal(-1, Validate(-1));
+
+        // Positive values are accepted.
+        Assert.Equal(1024, Validate(1024));
+
+        // Zero and negatives (other than -1) still throw.
+        Assert.Throws<ArgumentOutOfRangeException>(() => Validate(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Validate(-2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Validate(int.MinValue));
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_128062/Runtime_128062.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_128062/Runtime_128062.csproj
@@ -1,8 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <Optimize>True</Optimize>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="$(MSBuildProjectName).cs" />
-  </ItemGroup>
-</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_128062/Runtime_128062.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_128062/Runtime_128062.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -98,6 +98,7 @@
     <Compile Include="JitBlue\Runtime_126060\Runtime_126060.cs" />
     <Compile Include="JitBlue\Runtime_127260\Runtime_127260.cs" />
     <Compile Include="JitBlue\Runtime_127446\Runtime_127446.cs" />
+    <Compile Include="JitBlue\Runtime_128062\Runtime_128062.cs" />
     <Compile Include="JitBlue\Runtime_128392\Runtime_128392.cs" />
     <Compile Include="JitBlue\Runtime_128631\Runtime_128631.cs" />
     <Compile Include="JitBlue\Runtime_128801\Runtime_128801.cs" />


### PR DESCRIPTION
Fixes #128062.

## Root cause

`Compiler::optRedundantDominatingBranch` (Redundant Branch Opts) walks up the dominator tree from a conditional block, trying to fold dominating branches whose outcome is implied by the current block's condition. While doing so it can *simplify* an intermediate dominating relop, rewriting the **start block's** relop in place:

```cpp
tree->SetOper(newRelop);
...
fgValueNumberTree(tree);
```

However, `treeNormVN` (the start block's condition value number) was cached **once** as `const` before the dominator walk. After the relop is rewritten, the loop keeps reasoning about the **stale** VN on the next iteration, which can unsoundly fold a higher dominating guard.

### Concrete miscompile

`StreamReader.ValidateArgsAndOpenPath` contains:

```csharp
if (bufferSize != -1)
    ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferSize);
```

which lowers to three conditional blocks:

```
BB01: if (x == -1) goto Return        // the != -1 guard
BB02: if (x <  0)  goto Throw
BB06: if (x != 0)  goto Return else Throw
```

RBO starts at `BB06`, simplifies `BB02`'s `x < 0` away and rewrites `BB06`'s relop to `x > 0`. It then walks up to `BB01` but still uses the **stale** `NE(x, 0)` VN, concludes the `x == -1` guard is redundant, and folds it. The result is `if (x > 0) return; else throw`, so `x == -1` now **throws** `ArgumentOutOfRangeException` instead of being accepted.

This is exposed in CI on the `libraries-pgo` / `jitosr_stress_random` legs (which disable R2R, so framework code is JIT-compiled at optimized tiers), but it reproduces at plain FullOpts — no PGO/OSR needed.

Regression introduced by #127181.

## Fix

Refresh `treeNormVN` right after the start block's relop is re-value-numbered, so subsequent dominator iterations reason about the block's current condition.

## Testing

- New regression test `Runtime_128062` (fails on the pre-fix JIT, passes after).
- SuperPMI `asmdiffs` on `benchmarks.run` (+pgo, +pgo_optrepeat) and `libraries.pmi`: **~530K contexts, no asserts, zero asm diffs** — the change only suppresses the rare unsound fold.
