### PR TITLE
Optimize access to the default FuncPtrStub

### DIFF
--- a/src/coreclr/vm/fptrstubs.cpp
+++ b/src/coreclr/vm/fptrstubs.cpp
@@ -69,9 +69,15 @@ PCODE FuncPtrStubs::GetFuncPtrStub(MethodDesc * pMD, PrecodeType type)
     CONTRACTL_END
 
     Precode* pPrecode = NULL;
+
+    if (type != GetDefaultType(pMD))
     {
         CrstHolder ch(&m_hashTableCrst);
         pPrecode = m_hashTable.Lookup(PrecodeKey(pMD, type));
+    }
+    else
+    {
+        pPrecode = pMD->GetDefaultFuncPtrStub();
     }
 
     if (pPrecode != NULL)
@@ -128,6 +134,23 @@ PCODE FuncPtrStubs::GetFuncPtrStub(MethodDesc * pMD, PrecodeType type)
             pNewPrecode->SetTargetInterlocked(target);
         }
 
+        if (type == GetDefaultType(pMD))
+        {
+            // Set the default funcptr stub in the MethodDesc if it is not already set. If another thread beat us to it, then
+            // we will use the one that was set by the other thread.
+            if (pMD->SetDefaultFuncPtrStub(pNewPrecode))
+            {
+                pPrecode = pNewPrecode;
+                amt.SuppressRelease();
+            }
+            else
+            {
+                pPrecode = pMD->GetDefaultFuncPtrStub();
+                _ASSERTE(pPrecode != NULL);
+                setTargetAfterAddingToHashTable = false;
+            }
+        }
+        else
         {
             CrstHolder ch(&m_hashTableCrst);
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -275,6 +275,16 @@ void MethodDesc::SetMethodDescOptimizationTier(NativeCodeVersion::OptimizationTi
     VolatileStoreWithoutBarrier(&m_codeData->OptimizationTier, tier);
 }
 
+bool MethodDesc::SetDefaultFuncPtrStub(Precode* stub)
+{
+    STANDARD_VM_CONTRACT;
+
+    IfFailThrow(EnsureCodeDataExists(NULL));
+
+    _ASSERTE(m_codeData != NULL);
+    return InterlockedCompareExchangeT((void**)&m_codeData->DefaultFuncPtrStub, (void*)stub, (void*)NULL) == NULL;
+}
+
 #if defined(_DEBUG) && defined(ALLOW_SXS_JIT)
 HRESULT MethodDesc::SetMethodDescAltJitPatchpointInfo(PatchpointInfo* pInfo)
 {
@@ -342,6 +352,15 @@ NativeCodeVersion::OptimizationTier MethodDesc::GetMethodDescOptimizationTier()
     if (codeData == NULL)
         return NativeCodeVersion::OptimizationTierUnknown;
     return VolatileLoadWithoutBarrier(&codeData->OptimizationTier);
+}
+
+Precode* MethodDesc::GetDefaultFuncPtrStub()
+{
+    WRAPPER_NO_CONTRACT;
+    PTR_MethodDescCodeData codeData = VolatileLoadWithoutBarrier(&m_codeData);
+    if (codeData == NULL)
+        return NULL;
+    return VolatileLoadWithoutBarrier(&codeData->DefaultFuncPtrStub);
 }
 #endif // FEATURE_CODE_VERSIONING
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -262,6 +262,7 @@ struct MethodDescCodeData final
 #ifdef FEATURE_CODE_VERSIONING
     PTR_MethodDescVersioningState VersioningState;
     NativeCodeVersion::OptimizationTier OptimizationTier;
+    Precode* DefaultFuncPtrStub;
 #endif // FEATURE_CODE_VERSIONING
     PCODE TemporaryEntryPoint;
 #ifdef FEATURE_INTERPRETER
@@ -2010,9 +2011,11 @@ public:
     HRESULT SetMethodDescAltJitPatchpointInfo(PatchpointInfo* pInfo);
     PatchpointInfo* GetMethodDescAltJitPatchpointInfo();
 #endif
+    bool SetDefaultFuncPtrStub(Precode* stub);
 #endif // !DACCESS_COMPILE
     PTR_MethodDescVersioningState GetMethodDescVersionState();
     NativeCodeVersion::OptimizationTier GetMethodDescOptimizationTier();
+    Precode* GetDefaultFuncPtrStub();
 #endif // FEATURE_CODE_VERSIONING
 
 public:


### PR DESCRIPTION
Caches the default-type `FuncPtrStub` precode directly on the `MethodDesc` (in `MethodDescCodeData`) so the common `FuncPtrStubs::GetFuncPtrStub` path avoids taking the `FuncPtrStubs` hash-table critical section.

A new `DefaultFuncPtrStub` field plus `SetDefaultFuncPtrStub`/`GetDefaultFuncPtrStub` accessors store and retrieve the cached precode using an interlocked publish. For the default precode type, lookup and insertion now go through the cached field instead of the hash table + `m_hashTableCrst`.

This was extracted from #129019 to keep the optimization independent of the preemptive-mode changes in that PR.

(It's not clear to me this is worth it, but it's certainly not a good part of that original PR).

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.