### PR TITLE
Improve AES-KWP for Windows

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Aes.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Aes.cs
@@ -365,7 +365,7 @@ namespace System.Security.Cryptography
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             TState state,
-            KeyWrapEcbTransform<TState> decryptEcb)
+            Func<TState, ReadOnlySpan<byte>, Span<byte>, int> decryptEcb)
         {
             ulong iv;
 
@@ -429,17 +429,11 @@ namespace System.Security.Cryptography
                 this,
                 static (instance, source, destination) => instance.EncryptEcb(source, destination, PaddingMode.None));
         }
-
-        private protected delegate int KeyWrapEcbTransform<TState>(
-            TState state,
-            ReadOnlySpan<byte> source,
-            Span<byte> destination);
-
         private protected void EncryptKeyWrapPaddedCore<TState>(
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             TState state,
-            KeyWrapEcbTransform<TState> encryptEcb)
+            Func<TState, ReadOnlySpan<byte>, Span<byte>, int> encryptEcb)
         {
             Debug.Assert(destination.Length == GetKeyWrapPaddedLength(source.Length));
 
@@ -491,7 +485,7 @@ namespace System.Security.Cryptography
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             TState state,
-            KeyWrapEcbTransform<TState> encryptEcb)
+            Func<TState, ReadOnlySpan<byte>, Span<byte>, int> encryptEcb)
         {
             Debug.Assert(source.Length % 8 == 0);
             Debug.Assert(source.Length >= 16);
@@ -530,7 +524,7 @@ namespace System.Security.Cryptography
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             TState state,
-            KeyWrapEcbTransform<TState> decryptEcb)
+            Func<TState, ReadOnlySpan<byte>, Span<byte>, int> decryptEcb)
         {
             Span<byte> B = stackalloc byte[16];
             Span<byte> A = B.Slice(0, 8);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Internal.Cryptography;
 using Internal.NativeCrypto;
 
@@ -43,6 +44,54 @@ namespace System.Security.Cryptography
                 ownsParentHandle: false,
                 iv,
                 encrypting);
+        }
+
+        protected override void EncryptKeyWrapPaddedCore(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            Debug.Assert(destination.Length == GetKeyWrapPaddedLength(source.Length));
+
+            ILiteSymmetricCipher cipher = GetKey().UseKey(
+                BlockSize / BitsPerByte,
+                static (blockSizeBytes, key) => CreateLiteCipher(
+                    CipherMode.ECB,
+                    key,
+                    iv: default,
+                    blockSize: blockSizeBytes,
+                    paddingSize: blockSizeBytes,
+                    feedbackSize: 0,
+                    encrypting: true));
+
+            using (cipher)
+            {
+                EncryptKeyWrapPaddedCore(
+                    source,
+                    destination,
+                    cipher,
+                    static (cipher, source, destination) => cipher.Transform(source, destination));
+            }
+        }
+
+        protected override int DecryptKeyWrapPaddedCore(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            ILiteSymmetricCipher cipher = GetKey().UseKey(
+                BlockSize / BitsPerByte,
+                static (blockSizeBytes, key) => CreateLiteCipher(
+                    CipherMode.ECB,
+                    key,
+                    iv: default,
+                    blockSize: blockSizeBytes,
+                    paddingSize: blockSizeBytes,
+                    feedbackSize: 0,
+                    encrypting: false));
+
+            using (cipher)
+            {
+                return DecryptKeyWrapPaddedCore(
+                    source,
+                    destination,
+                    cipher,
+                    static (cipher, source, destination) => cipher.Transform(source, destination));
+            }
         }
     }
 }


### PR DESCRIPTION
This is the follow up to https://github.com/dotnet/runtime/pull/129911.

This is the Windows "Implementation" counterpart to AES-KWP. Like Apple, the performance improvements are 5x-20x faster and allocations go from input-length aligned to constant.

This makes also one other small improvement I noticed after I merged the apple changes - we don't need a custom delegate type. We only need `Func`. Originally I had the delegate signature have an `out`, but it went away, so the need for a custom delegate went away too.


Benchmark:

| Method               | Job    | PlaintextLength | Mean           | Ratio | Allocated | Alloc Ratio |
|--------------------- |------- |---------------- |---------------:|------:|----------:|------------:|
| **EncryptKeyWrapPadded** | **branch** | **1**               |       **537.3 ns** |  **0.99** |      **88 B** |        **1.00** |
| EncryptKeyWrapPadded | main   | 1               |       544.0 ns |  1.00 |      88 B |        1.00 |
|                      |        |                 |                |       |           |             |
| DecryptKeyWrapPadded | branch | 1               |       556.9 ns |  0.99 |      88 B |        1.00 |
| DecryptKeyWrapPadded | main   | 1               |       565.1 ns |  1.00 |      88 B |        1.00 |
|                      |        |                 |                |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **8**               |       **542.0 ns** |  **0.94** |      **88 B** |        **1.00** |
| EncryptKeyWrapPadded | main   | 8               |       574.3 ns |  1.00 |      88 B |        1.00 |
|                      |        |                 |                |       |           |             |
| DecryptKeyWrapPadded | branch | 8               |       562.6 ns |  1.01 |      88 B |        1.00 |
| DecryptKeyWrapPadded | main   | 8               |       556.4 ns |  1.00 |      88 B |        1.00 |
|                      |        |                 |                |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **15**              |       **928.7 ns** |  **0.14** |      **88 B** |        **0.08** |
| EncryptKeyWrapPadded | main   | 15              |     6,582.2 ns |  1.00 |    1056 B |        1.00 |
|                      |        |                 |                |       |           |             |
| DecryptKeyWrapPadded | branch | 15              |       928.3 ns |  0.14 |      88 B |        0.08 |
| DecryptKeyWrapPadded | main   | 15              |     6,845.7 ns |  1.00 |    1056 B |        1.00 |
|                      |        |                 |                |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **16**              |       **960.1 ns** |  **0.14** |      **88 B** |        **0.08** |
| EncryptKeyWrapPadded | main   | 16              |     6,792.0 ns |  1.00 |    1056 B |        1.00 |
|                      |        |                 |                |       |           |             |
| DecryptKeyWrapPadded | branch | 16              |       923.1 ns |  0.12 |      88 B |        0.08 |
| DecryptKeyWrapPadded | main   | 16              |     7,506.2 ns |  1.00 |    1056 B |        1.00 |
|                      |        |                 |                |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **512**             |    **14,375.8 ns** |  **0.07** |      **88 B** |       **0.003** |
| EncryptKeyWrapPadded | main   | 512             |   209,731.5 ns |  1.00 |   33794 B |       1.000 |
|                      |        |                 |                |       |           |             |
| DecryptKeyWrapPadded | branch | 512             |    12,935.9 ns |  0.06 |      88 B |       0.003 |
| DecryptKeyWrapPadded | main   | 512             |   213,465.4 ns |  1.00 |   33794 B |       1.000 |
|                      |        |                 |                |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **513**             |    **13,531.5 ns** |  **0.06** |      **88 B** |       **0.003** |
| EncryptKeyWrapPadded | main   | 513             |   210,454.6 ns |  1.00 |   34322 B |       1.000 |
|                      |        |                 |                |       |           |             |
| DecryptKeyWrapPadded | branch | 513             |    12,787.1 ns |  0.06 |      88 B |       0.003 |
| DecryptKeyWrapPadded | main   | 513             |   214,187.2 ns |  1.00 |   34322 B |       1.000 |
|                      |        |                 |                |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **4096**            |   **110,426.7 ns** |  **0.07** |      **88 B** |       **0.000** |
| EncryptKeyWrapPadded | main   | 4096            | 1,670,374.7 ns |  1.00 |  270351 B |       1.000 |
|                      |        |                 |                |       |           |             |
| DecryptKeyWrapPadded | branch | 4096            |    99,576.4 ns |  0.06 |      88 B |       0.000 |
| DecryptKeyWrapPadded | main   | 4096            | 1,683,202.4 ns |  1.00 |  270351 B |       1.000 |
|                      |        |                 |                |       |           |             |
| **EncryptKeyWrapPadded** | **branch** | **4097**            |   **104,499.7 ns** |  **0.06** |      **88 B** |       **0.000** |
| EncryptKeyWrapPadded | main   | 4097            | 1,666,576.3 ns |  1.00 |  270879 B |       1.000 |
|                      |        |                 |                |       |           |             |
| DecryptKeyWrapPadded | branch | 4097            |    97,603.9 ns |  0.05 |      88 B |       0.000 |
| DecryptKeyWrapPadded | main   | 4097            | 1,813,706.9 ns |  1.00 |  270879 B |       1.000 |