### PR TITLE
Add openbsd-x64 to legacy RID graph

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -2589,6 +2589,23 @@
         "omnios-x64"
       ]
     },
+    "openbsd": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "openbsd-arm64": {
+      "#import": [
+        "openbsd",
+        "unix-arm64"
+      ]
+    },
+    "openbsd-x64": {
+      "#import": [
+        "openbsd",
+        "unix-x64"
+      ]
+    },
     "openindiana": {
       "#import": [
         "illumos"


### PR DESCRIPTION
Previously added in https://github.com/dotnet/runtime/blob/8207ad3ca9ad1f77606f27150c3c26ca47812f86/src/libraries/Microsoft.NETCore.Platforms/src/PortableRuntimeIdentifierGraph.json#L67 but not this file as it was supposed to be "frozen, for good".

While `dotnet restore` works without it, but `dotnet tool install` is having problem. See https://github.com/dotnet/sdk/pull/55046 as an alternative for future platforms.