### PR TITLE
Use ThrowHelper.ThrowInvalidOperationException in ImmutableCollection

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Enumerator.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Enumerator.cs
@@ -106,15 +106,14 @@ namespace System.Collections.Immutable
             {
                 get
                 {
-                    // this.index >= 0 && this.index < this.array.Length
-                    // unsigned compare performs the range check above in one compare
-                    if (unchecked((uint)_index) < (uint)_array.Length)
+                    // unsigned compare performs the range check in one compare
+                    if (unchecked((uint)_index) >= (uint)_array.Length)
                     {
-                        return _array[_index];
+                        // Before first or after last MoveNext.
+                        ThrowHelper.ThrowInvalidOperationException();
                     }
 
-                    // Before first or after last MoveNext.
-                    throw new InvalidOperationException();
+                    return _array[_index];
                 }
             }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
@@ -64,7 +64,7 @@ namespace System.Collections.Immutable
                 {
                     if (this.IsEmpty)
                     {
-                        throw new InvalidOperationException();
+                        ThrowHelper.ThrowInvalidOperationException();
                     }
 
                     return _firstValue;

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Enumerator.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Enumerator.cs
@@ -124,12 +124,12 @@ namespace System.Collections.Immutable
                 get
                 {
                     this.ThrowIfDisposed();
-                    if (_current != null)
+                    if (_current == null)
                     {
-                        return _current.Value;
+                        ThrowHelper.ThrowInvalidOperationException();
                     }
 
-                    throw new InvalidOperationException();
+                    return _current.Value;
                 }
             }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Enumerator.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Enumerator.cs
@@ -90,12 +90,12 @@ namespace System.Collections.Immutable
                 get
                 {
                     this.ThrowIfDisposed();
-                    if (_current != null)
+                    if (_current == null)
                     {
-                        return _current.Value;
+                        ThrowHelper.ThrowInvalidOperationException();
                     }
 
-                    throw new InvalidOperationException();
+                    return _current.Value;
                 }
             }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Enumerator.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Enumerator.cs
@@ -107,12 +107,12 @@ namespace System.Collections.Immutable
                 get
                 {
                     this.ThrowIfDisposed();
-                    if (_current != null)
+                    if (_current == null)
                     {
-                        return _current.Value;
+                        ThrowHelper.ThrowInvalidOperationException();
                     }
 
-                    throw new InvalidOperationException();
+                    return _current.Value;
                 }
             }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.Enumerator.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.Enumerator.cs
@@ -44,12 +44,10 @@ namespace System.Collections.Immutable
                 {
                     if (_remainingStack == null || _remainingStack.IsEmpty)
                     {
-                        throw new InvalidOperationException();
+                        ThrowHelper.ThrowInvalidOperationException();
                     }
-                    else
-                    {
-                        return _remainingStack.Peek();
-                    }
+
+                    return _remainingStack.Peek();
                 }
             }
 
@@ -113,12 +111,10 @@ namespace System.Collections.Immutable
                     this.ThrowIfDisposed();
                     if (_remainingStack == null || _remainingStack.IsEmpty)
                     {
-                        throw new InvalidOperationException();
+                        ThrowHelper.ThrowInvalidOperationException();
                     }
-                    else
-                    {
-                        return _remainingStack.Peek();
-                    }
+
+                    return _remainingStack.Peek();
                 }
             }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.Enumerator.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.Enumerator.cs
@@ -76,12 +76,12 @@ namespace System.Collections.Immutable
                 get
                 {
                     this.ThrowIfDisposed();
-                    if (_current != null)
+                    if (_current == null)
                     {
-                        return _current.Value;
+                        ThrowHelper.ThrowInvalidOperationException();
                     }
 
-                    throw new InvalidOperationException();
+                    return _current.Value;
                 }
             }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -651,7 +652,7 @@ namespace System.Linq
 
             if (!builder.Any())
             {
-                throw new InvalidOperationException();
+                ThrowHelper.ThrowInvalidOperationException();
             }
 
             return builder[0];
@@ -677,7 +678,7 @@ namespace System.Linq
 
             if (!builder.Any())
             {
-                throw new InvalidOperationException();
+                ThrowHelper.ThrowInvalidOperationException();
             }
 
             return builder[builder.Count - 1];


### PR DESCRIPTION
This PR replaces inline `throw new InvalidOperationException` statements with `ThrowHelper.ThrowInvalidOperationException` calls, following the pattern established in `FrozenSet`/`FrozenDictionary`.