### PR TITLE
Skip build-time RID fallback for portable builds

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -26,8 +26,8 @@
       If we're cross-building (for example building source-build for a new version of an existing distro and bootstrapping from an old version)
       then the RID we're building on would be different than the RID we're targeting.
     -->
-    <AdditionalRuntimeIdentifiers Include="$(TargetRid)" Imports="$(PortableTargetRid)" />
-    <AdditionalRuntimeIdentifiers Include="$(NETCoreSdkRuntimeIdentifier)" Imports="$(NETCoreSdkPortableRuntimeIdentifier)" />
+    <AdditionalRuntimeIdentifiers Include="$(TargetRid)" Imports="$(PortableTargetRid)" Condition="'$(TargetRid)' != '$(PortableTargetRid)'" />
+    <AdditionalRuntimeIdentifiers Include="$(NETCoreSdkRuntimeIdentifier)" Imports="$(NETCoreSdkPortableRuntimeIdentifier)" Condition="'$(NETCoreSdkRuntimeIdentifier)' != '$(NETCoreSdkPortableRuntimeIdentifier)'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When runtime.json (legacy/frozen graph) doesn't have the RID (e.g. openbsd-x64), we end up with a self-referencing RID. It only works when we have non-portable build and TargetRID != PortableTargetRID (basically "non-portable build" means two distinct things: it will use distro packages for 3p deps rather than in-tree ones, and it will have different RID with version and/or distro name; latter is not applicable if we want to just build from source with regular/portable RID).