### PR TITLE
wasm: fix R2R generic dictionary lookup debug assert

### DIFF
--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -538,7 +538,17 @@ DictionaryEntry GenericHandleWorkerCore(MethodDesc * pMD, MethodTable * pMT, LPV
 #ifdef _DEBUG
             // Only in R2R mode are the module, dictionary index and dictionary slot provided as an input
             _ASSERTE(dictionaryIndexAndSlot != (DWORD)-1);
+#ifdef TARGET_WASM
+            // On wasm, R2R code lives in the function table and data in linear memory, so
+            // FindReadyToRunModule (a code-range lookup) can't resolve the signature's data address.
+            // Check that the signature lies within pModule's R2R image bounds instead.
+            ReadyToRunInfo * pR2RInfo = pModule->GetReadyToRunInfo();
+            TADDR sigAddr = dac_cast<TADDR>(signature);
+            TADDR imageBase = dac_cast<TADDR>(pR2RInfo->GetImage()->GetBase());
+            _ASSERT(sigAddr >= imageBase && sigAddr < imageBase + pR2RInfo->GetImage()->GetVirtualSize());
+#else
             _ASSERT(ReadyToRunInfo::IsNativeImageSharedBy(pModule, ExecutionManager::FindReadyToRunModule(dac_cast<TADDR>(signature))));
+#endif
 #endif
             dictionaryIndex = (dictionaryIndexAndSlot >> 16);
         }


### PR DESCRIPTION
On wasm, R2R code lives in the function table and R2R data in linear memory, so the
`GenericHandleWorkerCore` debug assert's `ExecutionManager::FindReadyToRunModule` (a
code-range lookup) cannot resolve the dictionary signature's data address and returns the
wrong module, firing `IsNativeImageSharedBy` spuriously once more than one R2R image is
loaded. The signature is taken from `pModule`'s own R2R image (`FindToken` returns the
incoming blob), so on wasm the assert instead checks that the signature lies within
`pModule`'s R2R image bounds; other targets are unchanged.

This is a `_DEBUG`-only assert (`FindReadyToRunModule` has no other callers), so release
behavior is unaffected. It was the single most common failure when running the Pri-1 R2R
test suite on wasm, accounting for ~half of all observed assert failures and the bulk of the
generics tests.
