### PR TITLE
Emit correct ELF symbol types for data in NativeAOT objects

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/ElfObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/ElfObjectWriter.cs
@@ -279,6 +279,7 @@ namespace ILCompiler.ObjectWriter
                 var section = _sections[definition.SectionIndex];
                 var type =
                     (section.SectionHeader.Flags & SHF_TLS) == SHF_TLS ? STT_TLS :
+                    (section.SectionHeader.Flags & SHF_EXECINSTR) != SHF_EXECINSTR ? STT_OBJECT :
                     definition.Size > 0 ? STT_FUNC : STT_NOTYPE;
                 sortedSymbols.Add(new ElfSymbol
                 {


### PR DESCRIPTION
## Summary

`ElfObjectWriter.EmitSymbolTable` classified every defined symbol purely by size:

```csharp
definition.Size > 0 ? STT_FUNC : STT_NOTYPE;
```

This produced two wrong results for data symbols:

1. **Vtables emitted as `STT_NOTYPE`.** A `MethodTable`/EEType symbol points at a non-zero offset within its node (the EEType sits after the GCDesc), so `Size == 0` and it became `STT_NOTYPE`. Released lldb only infers a type for `NOTYPE` symbols whose section name is in a hard-coded list (`.text`/`.data`/`.rodata`/`.bss`); symbols in other allocated sections such as `.hydrated` (the NOBITS region that rehydrated data structures live in when data dehydration is enabled) stay untyped and are **not surfaced in lldb symbol lookup**. Tools that read `st_info` directly (`gdb`, `nm`, `addr2line`, `perf`) never see a type at all.
2. **Data emitted as `STT_FUNC`.** Data symbols with `Size > 0` in `.rodata`/`.data` were marked `STT_FUNC`, i.e. data mislabeled as code (lldb then treats them as functions).

## Fix

Classify by section kind instead of size:

```csharp
(section.SectionHeader.Flags & SHF_TLS) == SHF_TLS ? STT_TLS :
(section.SectionHeader.Flags & SHF_EXECINSTR) != SHF_EXECINSTR ? STT_OBJECT :
definition.Size > 0 ? STT_FUNC : STT_NOTYPE;
```

Non-executable sections emit `STT_OBJECT`; executable sections keep the existing `STT_FUNC`/`STT_NOTYPE` behavior unchanged. This matches the canonical typing every other ELF producer uses and is size-neutral (only the `st_info` type byte changes).

## Validation

Cross-emitted a Linux x64 object (`--targetos:linux`, dehydration on) before/after the change from an otherwise identical toolchain. Object size is byte-identical (3,555,456 bytes).

| Section | Before | After |
|---|---|---|
| `.hydrated` (NOBITS, vtables) | 1084 `NOTYPE` + 377 `FUNC` | 1461 `OBJECT` |
| `.rodata` | 245 `FUNC` (+2 `NOTYPE`) | 247 `OBJECT` |
| `.data` | 338 `FUNC` | 338 `OBJECT` |
| `.text` (code) | 83 `FUNC` | 83 `FUNC` (unchanged) |

Executable-section symbols are untouched, so ARM/AArch64/RISC-V mapping symbols (`$a`/`$d`/`$x`) and trampolines are unaffected.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.
