### PR TITLE
Implement `Assembly.GetCallingAssembly` for native AOT

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -74,6 +75,9 @@ namespace System.Reflection
         [DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public static Assembly GetCallingAssembly()
         {
+            if (!StackTrace.IsSupported)
+                throw new NotSupportedException(SR.NotSupported_StackTraceSupportDisabled);
+
             // LookForMyCallersCaller is not guaranteed to return the correct stack frame
             // because of inlining, tail calls, etc. As a result GetCallingAssembly is not
             // guaranteed to return the correct result. It's also documented as such.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
@@ -49,8 +49,7 @@ namespace System.Reflection
                 // Skip the static constructor invocation machinery so that a GetCallingAssembly
                 // called from a class constructor sees the assembly that triggered the cctor.
                 if (dmi.DeclaringTypeName == $"System.Runtime.CompilerServices.{nameof(ClassConstructorRunner)}"
-                    && dmi.DeclaringAssemblyName?.StartsWith(CoreLib.Name) == true)
-                {
+                    && dmi.DeclaringAssemblyName?.StartsWith(CoreLib.Name, StringComparison.Ordinal) == true)
                     dmi = null;
                     continue;
                 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
@@ -50,6 +50,7 @@ namespace System.Reflection
                 // called from a class constructor sees the assembly that triggered the cctor.
                 if (dmi.DeclaringTypeName == $"System.Runtime.CompilerServices.{nameof(ClassConstructorRunner)}"
                     && dmi.DeclaringAssemblyName?.StartsWith(CoreLib.Name, StringComparison.Ordinal) == true)
+                {
                     dmi = null;
                     continue;
                 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Configuration.Assemblies;
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using System.Security;
 
 using Internal.Reflection.Augments;
 
@@ -16,12 +19,50 @@ namespace System.Reflection
         [System.Runtime.CompilerServices.Intrinsic]
         public static Assembly GetExecutingAssembly() { throw NotImplemented.ByDesign; } //Implemented by toolchain.
 
+        [DynamicSecurityMethod]
         public static Assembly GetCallingAssembly()
         {
             if (AppContext.TryGetSwitch("Switch.System.Reflection.Assembly.SimulatedCallingAssembly", out bool isSimulated) && isSimulated)
                 return GetEntryAssembly();
 
-            throw new PlatformNotSupportedException();
+            if (!StackTrace.IsSupported)
+                throw new NotSupportedException(SR.NotSupported_StackTraceSupportDisabled);
+
+            // We're interested in the frame that called the method that calls GetCallingAssembly
+            // (skipFrames: 2), but we walk the stack so that we can skip any compiler-generated
+            // thunks that don't have method info, as well as the static constructor invocation
+            // machinery (matching what CoreCLR skips when looking for the caller).
+            // The for loop typically only runs one iteration.
+            DiagnosticMethodInfo? dmi = null;
+            for (int i = 2; ; i++)
+            {
+                var frame = new StackFrame(i);
+
+                // A zero IP address means we walked off the top of the stack without finding anything.
+                if (frame.GetNativeIPAddress() == IntPtr.Zero)
+                    break;
+
+                dmi = DiagnosticMethodInfo.Create(frame);
+                if (dmi == null)
+                    continue;
+
+                // Skip the static constructor invocation machinery so that a GetCallingAssembly
+                // called from a class constructor sees the assembly that triggered the cctor.
+                if (dmi.DeclaringTypeName == $"System.Runtime.CompilerServices.{nameof(ClassConstructorRunner)}"
+                    && dmi.DeclaringAssemblyName?.StartsWith(CoreLib.Name) == true)
+                {
+                    dmi = null;
+                    continue;
+                }
+
+                break;
+            }
+
+            // If we haven't found anything, fall back to the method that called GetCallingAssembly.
+            // This simulates what CoreCLR would do if GetCallingAssembly is called from e.g. Main.
+            dmi ??= DiagnosticMethodInfo.Create(new StackFrame(1));
+
+            return dmi?.DeclaringAssemblyName is string asmName ? Load(asmName) : null;
         }
 
         public static Assembly Load(AssemblyName assemblyRef) => ReflectionAugments.Load(assemblyRef, throwOnFileNotFound: true);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1130,12 +1130,10 @@ namespace Internal.JitInterface
             if (method.IsPInvoke)
                 result |= CorInfoFlag.CORINFO_FLG_PINVOKE;
 
-#if READYTORUN
             if (method.RequireSecObject)
             {
                 result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE_CALLER;
             }
-#endif
 
             if (method.IsAggressiveOptimization)
             {
@@ -1201,6 +1199,42 @@ namespace Internal.JitInterface
 #pragma warning restore CA1822 // Mark members as static
         {
             // TODO: Inlining
+        }
+
+        private bool canTailCall(CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* declaredCalleeHnd, CORINFO_METHOD_STRUCT_* exactCalleeHnd, bool fIsTailPrefix)
+        {
+            if (!fIsTailPrefix)
+            {
+                MethodDesc caller = HandleToObject(callerHnd);
+
+                // Do not tailcall out of the entry point as it results in a confusing debugger experience.
+                if (caller is EcmaMethod em && em.Module.EntryPoint == caller)
+                {
+                    return false;
+                }
+
+                // Do not tailcall from methods that are marked as NoInlining (people often use no-inline
+                // to mean "I want to always see this method in stacktrace")
+                if (caller.IsNoInlining)
+                {
+                    // NOTE: we don't have to handle NoOptimization here, because JIT is not expected
+                    // to emit fast tail calls if optimizations are disabled.
+                    return false;
+                }
+
+                // Methods with StackCrawlMark depend on finding their caller on the stack.
+                // If we tail call one of these guys, they get confused.  For lack of
+                // a better way of identifying them, we use DynamicSecurity attribute to identify
+                // them.
+                //
+                MethodDesc callee = exactCalleeHnd == null ? null : HandleToObject(exactCalleeHnd);
+                if (callee != null && callee.RequireSecObject)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private void getMethodSig(CORINFO_METHOD_STRUCT_* ftn, CORINFO_SIG_INFO* sig, CORINFO_CLASS_STRUCT_* memberParent)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1370,42 +1370,6 @@ namespace Internal.JitInterface
             pResult = CreateConstLookupToSymbol(entrypoint);
         }
 
-        private bool canTailCall(CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* declaredCalleeHnd, CORINFO_METHOD_STRUCT_* exactCalleeHnd, bool fIsTailPrefix)
-        {
-            if (!fIsTailPrefix)
-            {
-                MethodDesc caller = HandleToObject(callerHnd);
-
-                // Do not tailcall out of the entry point as it results in a confusing debugger experience.
-                if (caller is EcmaMethod em && em.Module.EntryPoint == caller)
-                {
-                    return false;
-                }
-
-                // Do not tailcall from methods that are marked as NoInlining (people often use no-inline
-                // to mean "I want to always see this method in stacktrace")
-                if (caller.IsNoInlining)
-                {
-                    // NOTE: we don't have to handle NoOptimization here, because JIT is not expected
-                    // to emit fast tail calls if optimizations are disabled.
-                    return false;
-                }
-
-                // Methods with StackCrawlMark depend on finding their caller on the stack.
-                // If we tail call one of these guys, they get confused.  For lack of
-                // a better way of identifying them, we use DynamicSecurity attribute to identify
-                // them.
-                //
-                MethodDesc callee = exactCalleeHnd == null ? null : HandleToObject(exactCalleeHnd);
-                if (callee != null && callee.RequireSecObject)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         private FieldWithToken ComputeFieldWithToken(FieldDesc field, ref CORINFO_RESOLVED_TOKEN pResolvedToken)
         {
             ModuleToken token = HandleToModuleToken(ref pResolvedToken, out bool strippedInstantiation);

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -835,37 +835,6 @@ namespace Internal.JitInterface
             pResult = CreateConstLookupToSymbol(_compilation.NodeFactory.MethodEntrypoint(method));
         }
 
-        private bool canTailCall(CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* declaredCalleeHnd, CORINFO_METHOD_STRUCT_* exactCalleeHnd, bool fIsTailPrefix)
-        {
-            // Assume we can tail call unless proved otherwise
-            bool result = true;
-
-            if (!fIsTailPrefix)
-            {
-                MethodDesc caller = HandleToObject(callerHnd);
-
-                if (caller.OwningType is EcmaType ecmaOwningType
-                    && ecmaOwningType.Module.EntryPoint == caller)
-                {
-                    // Do not tailcall from the application entrypoint.
-                    // We want Main to be visible in stack traces.
-                    result = false;
-                }
-
-                if (caller.IsNoInlining)
-                {
-                    // Do not tailcall from methods that are marked as NoInlining (people often use no-inline
-                    // to mean "I want to always see this method in stacktrace")
-                    //
-                    // NOTE: we don't have to handle NoOptimization here, because JIT is not expected
-                    // to emit fast tail calls if optimizations are disabled.
-                    result = false;
-                }
-            }
-
-            return result;
-        }
-
         private InfoAccessType constructStringLiteral(CORINFO_MODULE_STRUCT_* module, mdToken metaTok, ref void* ppValue)
         {
             MethodIL methodIL = (MethodIL)HandleToObject((void*)module);

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3068,6 +3068,9 @@
   <data name="InvalidOperation_SpanOverlappedOperation" xml:space="preserve">
     <value>This operation is invalid on overlapping buffers.</value>
   </data>
+  <data name="NotSupported_StackTraceSupportDisabled" xml:space="preserve">
+    <value>Unable to retrieve stack trace information when StackTraceSupport feature switch is set to false.</value>
+  </data>
   <data name="InvalidOperation_TimeProviderNullLocalTimeZone" xml:space="preserve">
     <value>The operation cannot be performed when TimeProvider.LocalTimeZone is null.</value>
   </data>

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/AssemblyTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/AssemblyTests.cs
@@ -726,7 +726,6 @@ namespace System.Reflection.Tests
 
         [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51673", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69919", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [MemberData(nameof(GetCallingAssembly_TestData))]
         public void GetCallingAssembly(Assembly assembly1, Assembly assembly2, bool expected)
         {
@@ -735,7 +734,15 @@ namespace System.Reflection.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51673", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69919", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
+        public void GetCallingAssemblyThroughDelegate()
+        {
+            Func<Assembly> del = static () => Assembly.GetCallingAssembly();
+            Assert.Equal(Assembly.GetExecutingAssembly(), del());
+            Assert.Equal(typeof(System.Reflection.TestAssembly.ClassToInvoke).Assembly, System.Reflection.TestAssembly.ClassToInvoke.InvokeDelegate(del));
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51673", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         public void GetCallingAssemblyInCctor()
         {
             TestGetCallingAssemblyInCctor.Run();

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
@@ -749,7 +749,6 @@ namespace System.Reflection.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69919", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void CallStackFrame_AggressiveInlining()
         {
             MethodInfo mi = typeof(System.Reflection.TestAssembly.ClassToInvoke).GetMethod(nameof(System.Reflection.TestAssembly.ClassToInvoke.CallMe_AggressiveInlining),

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/TestAssembly/ClassToInvoke.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/TestAssembly/ClassToInvoke.cs
@@ -26,5 +26,8 @@ namespace System.Reflection.TestAssembly
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static int CallMe_AvoidTailcall() => 42;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static Assembly InvokeDelegate(Func<Assembly> del) => del();
     }
 }


### PR DESCRIPTION
* Use stack trace data to find the calling assembly.
* It is therefore only supportable if stack trace data is available. Block for the same reason under F5 debugging (CoreCLR). This is why it's a breaking change.
* Maintain an arbitrary list of methods to skip in stacktraces to make calling this API work in a .cctor. Matches similar arbitrary list in CoreCLR to the extent that is covered by tests.
* `canTailCall` is now same between ILC and crossgen2.