### PR TITLE
[cDAC] Arm64Unwinder. An overflow in the arithmetic expression (ulong)spOffset of type ulong may occur

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64/ARM64Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64/ARM64Unwinder.cs
@@ -1080,7 +1080,7 @@ internal class ARM64Unwinder(Target target)
         }
         if (spOffset < 0)
         {
-            context.Sp -= (ulong)spOffset;
+            context.Sp -= (ulong)-spOffset;
         }
 
         return true;
@@ -1130,7 +1130,7 @@ internal class ARM64Unwinder(Target target)
         }
         if (spOffset < 0)
         {
-            context.Sp -= (ulong)spOffset;
+            context.Sp -= (ulong)-spOffset;
         }
 
         return true;
@@ -1184,7 +1184,7 @@ internal class ARM64Unwinder(Target target)
         }
         if (spOffset < 0)
         {
-            context.Sp -= (ulong)spOffset;
+            context.Sp -= (ulong)-spOffset;
         }
 
         return true;


### PR DESCRIPTION
problem line(s):
```
 if (spOffset < 0)
        {
        context.Sp -= (ulong)spOffset;
       }
```

Casting a negative int to a unsigned ulong will result is widening conversions rather than simply taking the absolute value
**ex**:
```
int negativeValue = -5;
(ulong)negativeValue; // this will be 18446744073709551611
```

**but**:
```
int negativeValue = -5;
ulong beginValue = 555;
beginValue -= (ulong)negativeValue;
Console.WriteLine(beginValue);
// beginValue will be 560 ( again not expected result)
```


Base on comment: 
```
    /// Specifies a stack offset. Positive values are simply used
    /// as a base offset. Negative values assume a pre-decrement behavior:
```
, we expect subtraction. So to achieve the desired result without connecting additional libraries, we can use the approach in this commit

----
Found by Linux Verification Center (linuxtesting.org) with SVACE.