### PR TITLE
Chrome upgrade PR should bump mac versions as well.

### DIFF
--- a/.github/workflows/bump-chrome-version.yml
+++ b/.github/workflows/bump-chrome-version.yml
@@ -50,8 +50,8 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const { CHROME_LINUX_VER, CHROME_WIN_VER } = process.env;
-            const title = `[wasm] Bump chrome for testing - linux: ${CHROME_LINUX_VER}, windows: ${CHROME_WIN_VER}`;
+            const { CHROME_LINUX_VER, CHROME_WIN_VER, CHROME_MAC_VER } = process.env;
+            const title = `[wasm] Bump chrome for testing - linux: ${CHROME_LINUX_VER}, windows: ${CHROME_WIN_VER}, mac: ${CHROME_MAC_VER}`;
             const { data: pullRequest } = await github.rest.pulls.create({
               base: context.ref,
               head: "update-chrome-version-${{ github.run_id }}",

--- a/.github/workflows/bump-chrome-version.yml
+++ b/.github/workflows/bump-chrome-version.yml
@@ -28,7 +28,7 @@ jobs:
           make -C src/mono/wasm build-tasks &&
           PATH=$PWD/.dotnet:$PATH dotnet build eng/testing/bump-chrome-version.proj -p:Configuration=Release &&
           git add eng/testing/BrowserVersions.props &&
-          { [ -f eng/testing/bump-chrome-pr.env ] && cat eng/testing/bump-chrome-pr.env >> "$GITHUB_ENV" || true; }
+          if [ -f eng/testing/bump-chrome-pr.env ]; then cat eng/testing/bump-chrome-pr.env >> "$GITHUB_ENV"; fi
 
       - name: Check for changes
         id: check_changes

--- a/.github/workflows/bump-chrome-version.yml
+++ b/.github/workflows/bump-chrome-version.yml
@@ -28,7 +28,7 @@ jobs:
           make -C src/mono/wasm build-tasks &&
           PATH=$PWD/.dotnet:$PATH dotnet build eng/testing/bump-chrome-version.proj -p:Configuration=Release &&
           git add eng/testing/BrowserVersions.props &&
-          cat eng/testing/bump-chrome-pr.env >> "$GITHUB_ENV"
+          { [ -f eng/testing/bump-chrome-pr.env ] && cat eng/testing/bump-chrome-pr.env >> "$GITHUB_ENV" || true; }
 
       - name: Check for changes
         id: check_changes

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -546,7 +546,7 @@ jobs:
       jobTemplate: ${{ parameters.jobTemplate }}
       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
       variables: ${{ parameters.variables }}
-      osGroup: osx
+      osGroup: browser
       archType: wasm
       targetRid: browser-wasm
       platform: browser_wasm_mac
@@ -555,7 +555,6 @@ jobs:
         hostedOs: osx
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         buildConfig: ${{ parameters.buildConfig }}
-        crossBuild: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # FreeBSD

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -538,6 +538,26 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
+# Browser WebAssembly on macOS
+
+- ${{ if containsValue(parameters.platforms, 'browser_wasm_mac') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: osx
+      archType: wasm
+      targetRid: browser-wasm
+      platform: browser_wasm_mac
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        hostedOs: osx
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
+
 # FreeBSD
 - ${{ if containsValue(parameters.platforms, 'freebsd_x64') }}:
   - template: xplat-setup.yml

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -9,6 +9,7 @@ parameters:
   scenarios: ['WasmTestOnChrome']
   shouldContinueOnError: false
   shouldRunSmokeOnly: false
+  runOnlyOnChromeVersionUpdate: false
 
 jobs:
 
@@ -87,10 +88,16 @@ jobs:
       #     - then run only if it would not have run on default pipelines (based
       #       on path changes)
       #     - else run based on path changes
-      condition: >-
-        or(
-          eq(variables['alwaysRunVar'], true),
-          eq(variables['isDefaultPipeline'], variables['shouldRunOnDefaultPipelines']))
+      ${{ if eq(parameters.runOnlyOnChromeVersionUpdate, true) }}:
+        condition: >-
+          or(
+            eq(variables['alwaysRunVar'], true),
+            eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_wasm_chrome.containsChange'], true))
+      ${{ else }}:
+        condition: >-
+          or(
+            eq(variables['alwaysRunVar'], true),
+            eq(variables['isDefaultPipeline'], variables['shouldRunOnDefaultPipelines']))
       # extra steps, run tests
       postBuildSteps:
         - template: /eng/pipelines/libraries/helix.yml

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -176,11 +176,11 @@ jobs:
           os: linux
 
         # OSX Public Build Pool (we don't have on-prem OSX BuildPool).
-        ${{ if and(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), eq(variables['System.TeamProject'], 'public')) }}:
+        ${{ if and(or(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), eq(parameters.jobParameters.hostedOs, 'osx')), eq(variables['System.TeamProject'], 'public')) }}:
           vmImage: 'macos-15'
 
         # Official build OSX pool
-        ${{ if and(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), ne(variables['System.TeamProject'], 'public')) }}:
+        ${{ if and(or(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), eq(parameters.jobParameters.hostedOs, 'osx')), ne(variables['System.TeamProject'], 'public')) }}:
           name: "Azure Pipelines"
           vmImage: 'macos-latest-internal'
           os: macOS

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -188,4 +188,8 @@ jobs:
       - ${{ if or(eq(variables['isRollingBuild'], true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
         - (Windows.Amd64.Server2022.Open)windows.amd64.server2022.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-webassembly@sha256:8e4f47735cd1ace47f522d4c317426c4fe567f88340f93d63940660c3edcef77
 
+    # Browser WebAssembly macOS
+    - ${{ if eq(parameters.platform, 'browser_wasm_mac') }}:
+      - $(helix_macos_arm64)
+
     ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -976,6 +976,18 @@ extends:
           scenarios:
             - WasmTestOnChrome
 
+      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+        parameters:
+          platforms:
+            - browser_wasm_mac
+          alwaysRun: ${{ variables.isRollingBuild }}
+          runOnlyOnChromeVersionUpdate: true
+          shouldRunSmokeOnly: 'true'
+          nameSuffix: _SmokeMac
+          extraBuildArgs: /p:AotHostArchitecture=arm64 /p:AotHostOS=$(_hostedOS)
+          scenarios:
+            - WasmTestOnChrome
+
       # WebAssembly CoreCLR
       - template: /eng/pipelines/common/templates/wasm-coreclr-library-tests.yml
         parameters:

--- a/eng/testing/WasmRunnerTemplate.sh
+++ b/eng/testing/WasmRunnerTemplate.sh
@@ -48,6 +48,9 @@ if [[ "$XHARNESS_COMMAND" == "test" ]]; then
 	fi
 else
 	if [[ "$SCENARIO" == "WasmTestOnChrome" || "$SCENARIO" == "wasmtestonchrome" ]]; then
+		if [[ -z "$BROWSER_PATH" && "$(uname -s)" == "Darwin" && -n "$HELIX_CORRELATION_PAYLOAD" ]]; then
+			BROWSER_PATH="--browser-path=$HELIX_CORRELATION_PAYLOAD/chrome-mac/Chromium.app/Contents/MacOS/Chromium"
+		fi
 		if [[ -z "$JS_ENGINE_ARGS" ]]; then
 			JS_ENGINE_ARGS="--browser-arg=--js-flags=--stack-trace-limit=1000"
 		fi
@@ -62,7 +65,7 @@ else
 fi
 
 if [[ -z "$XHARNESS_ARGS" ]]; then
-	XHARNESS_ARGS="$JS_ENGINE $JS_ENGINE_ARGS $MAIN_JS"
+	XHARNESS_ARGS="$JS_ENGINE $JS_ENGINE_ARGS $BROWSER_PATH $MAIN_JS"
 fi
 
 if [[ -n "$PREPEND_PATH" ]]; then
@@ -83,6 +86,7 @@ echo XHARNESS_COMMAND=$XHARNESS_COMMAND
 echo MAIN_JS=$MAIN_JS
 echo JS_ENGINE=$JS_ENGINE
 echo JS_ENGINE_ARGS=$JS_ENGINE_ARGS
+echo BROWSER_PATH=$BROWSER_PATH
 echo XHARNESS_ARGS=$XHARNESS_ARGS
 
 function _buildAOTFunc()

--- a/eng/testing/bump-chrome-version.proj
+++ b/eng/testing/bump-chrome-version.proj
@@ -12,8 +12,8 @@
     </PropertyGroup>
 
     <UpdateChromeVersions
-      OSIdentifiers="linux;Windows"
-      OSPrefixes="Linux_x64;Win_x64"
+      OSIdentifiers="linux;Windows;Mac"
+      OSPrefixes="Linux_x64;Win_x64;Mac_Arm"
       Channel="$(ChromeChannel)"
       MaxMajorVersionsToCheck="1"
       IntermediateOutputPath="$(ArtifactsObjDir)"

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -87,7 +87,7 @@ public partial class UpdateChromeVersions : MBU.Task
             }
             if (VersionsChanged)
             {
-                UpdateEnvVarsForPRFile(versions);
+                UpdateEnvVarsForPRFile(chromeVersionsXmlDoc, versions);
             }
             return !Log.HasLoggedErrors;
         }
@@ -161,22 +161,22 @@ public partial class UpdateChromeVersions : MBU.Task
         return true;
     }
 
-    private void UpdateEnvVarsForPRFile(List<ChromeVersionSpec> versions)
+    private void UpdateEnvVarsForPRFile(XmlDocument xmlDoc, List<ChromeVersionSpec> versions)
     {
         using StreamWriter writer = new StreamWriter(EnvVarsForPRPath);
         foreach (var version in versions)
         {
             if (string.Equals(version.os, "Linux", StringComparison.OrdinalIgnoreCase))
             {
-                writer.WriteLine($"CHROME_LINUX_VER={version.version}");
+                writer.WriteLine($"CHROME_LINUX_VER={GetNodeValue(xmlDoc, "linux_ChromeVersion")}");
             }
             else if (string.Equals(version.os, "Windows", StringComparison.OrdinalIgnoreCase))
             {
-                writer.WriteLine($"CHROME_WIN_VER={version.version}");
+                writer.WriteLine($"CHROME_WIN_VER={GetNodeValue(xmlDoc, "win_ChromeVersion")}");
             }
             else if (string.Equals(version.os, "Mac", StringComparison.OrdinalIgnoreCase))
             {
-                writer.WriteLine($"CHROME_MAC_VER={version.version}");
+                writer.WriteLine($"CHROME_MAC_VER={GetNodeValue(xmlDoc, "macos_ChromeVersion")}");
             }
             else
             {

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -111,10 +111,10 @@ public partial class UpdateChromeVersions : MBU.Task
         string existingChromeVersion = GetNodeValue(xmlDoc, $"{nodePrefix}_ChromeVersion");
         if (Version.TryParse(existingChromeVersion, out Version? existing) &&
             Version.TryParse(version.version, out Version? candidate) &&
-            candidate <= existing)
+            candidate < existing)
         {
             Log.LogMessage(MessageImportance.High,
-                $"Skipping {version.os}: candidate version {version.version} is not newer than existing {existingChromeVersion}.");
+                $"Skipping {version.os}: candidate version {version.version} is older than existing {existingChromeVersion}.");
             return false;
         }
 

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -114,6 +114,13 @@ public partial class UpdateChromeVersions : MBU.Task
             return version.v8_version != winV8Version ||
                 baseUrl != winChromeBaseSnapshotUrl;
         }
+        else if (string.Equals(version.os, "Mac", StringComparison.OrdinalIgnoreCase))
+        {
+            string macosChromeBaseSnapshotUrl = GetNodeValue(xmlDoc, "macos_ChromeBaseSnapshotUrl");
+            string macosV8Version = GetNodeValue(xmlDoc, "macos_V8Version");
+            return version.v8_version != macosV8Version ||
+                baseUrl != macosChromeBaseSnapshotUrl;
+        }
         throw new Exception($"UpdateChromeVersions task was used with unknown OS: {version.os}");
     }
 
@@ -139,6 +146,13 @@ public partial class UpdateChromeVersions : MBU.Task
             UpdateNodeValue(xmlDoc, "win_ChromeBaseSnapshotUrl", baseUrl);
             UpdateNodeValue(xmlDoc, "win_V8Version", version.v8_version);
         }
+        else if (string.Equals(version.os, "Mac", StringComparison.OrdinalIgnoreCase))
+        {
+            UpdateNodeValue(xmlDoc, "macos_ChromeVersion", version.version);
+            UpdateNodeValue(xmlDoc, "macos_ChromeRevision", version.branch_base_position);
+            UpdateNodeValue(xmlDoc, "macos_ChromeBaseSnapshotUrl", baseUrl);
+            UpdateNodeValue(xmlDoc, "macos_V8Version", version.v8_version);
+        }
         else
         {
             throw new Exception($"UpdateChromeVersions task was used with unknown OS: {version.os}");
@@ -159,6 +173,10 @@ public partial class UpdateChromeVersions : MBU.Task
             else if (string.Equals(version.os, "Windows", StringComparison.OrdinalIgnoreCase))
             {
                 writer.WriteLine($"CHROME_WIN_VER={version.version}");
+            }
+            else if (string.Equals(version.os, "Mac", StringComparison.OrdinalIgnoreCase))
+            {
+                writer.WriteLine($"CHROME_MAC_VER={version.version}");
             }
             else
             {
@@ -210,7 +228,9 @@ public partial class UpdateChromeVersions : MBU.Task
                 ? "linux_V8Version"
                 : string.Equals(osIdentifier, "windows", StringComparison.OrdinalIgnoreCase)
                     ? "win_V8Version"
-                    : throw new LogAsErrorException($"Unknown OS identifier '{osIdentifier}' for V8 version fallback");
+                    : string.Equals(osIdentifier, "Mac", StringComparison.OrdinalIgnoreCase)
+                        ? "macos_V8Version"
+                        : throw new LogAsErrorException($"Unknown OS identifier '{osIdentifier}' for V8 version fallback");
             foundV8Version = GetNodeValue(existingDoc, existingV8VersionNodeName);
             if (string.IsNullOrEmpty(foundV8Version))
                 throw new LogAsErrorException($"V8 binary for {osIdentifier} not available on CDN and no existing version found in {ChromeVersionsPath}");
@@ -265,6 +285,7 @@ public partial class UpdateChromeVersions : MBU.Task
         {
             "Linux_x64" => "linux64",
             "Win_x64" => "win32",
+            "Mac_Arm" => "mac-arm64",
             _ => throw new ArgumentException($"Unknown OS prefix '{osPrefix}' for V8 binary URL")
         };
         return $"{s_v8CanaryBaseUrl}/v8-{jsvuPlatform}-rel-{v8Version}.zip";

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -98,30 +98,30 @@ public partial class UpdateChromeVersions : MBU.Task
         }
     }
 
-    private static bool AreVersionsChanged(XmlDocument xmlDoc, ChromeVersionSpec version, string baseUrl)
+    private bool AreVersionsChanged(XmlDocument xmlDoc, ChromeVersionSpec version, string baseUrl)
     {
-        if (string.Equals(version.os, "Linux", StringComparison.OrdinalIgnoreCase))
+        string nodePrefix = version.os switch
         {
-            string linuxChromeBaseSnapshotUrl = GetNodeValue(xmlDoc, "linux_ChromeBaseSnapshotUrl");
-            string linuxV8Version = GetNodeValue(xmlDoc, "linux_V8Version");
-            return version.v8_version != linuxV8Version ||
-                baseUrl != linuxChromeBaseSnapshotUrl;
-        }
-        else if (string.Equals(version.os, "Windows", StringComparison.OrdinalIgnoreCase))
+            _ when string.Equals(version.os, "Linux", StringComparison.OrdinalIgnoreCase) => "linux",
+            _ when string.Equals(version.os, "Windows", StringComparison.OrdinalIgnoreCase) => "win",
+            _ when string.Equals(version.os, "Mac", StringComparison.OrdinalIgnoreCase) => "macos",
+            _ => throw new Exception($"UpdateChromeVersions task was used with unknown OS: {version.os}")
+        };
+
+        string existingChromeVersion = GetNodeValue(xmlDoc, $"{nodePrefix}_ChromeVersion");
+        if (Version.TryParse(existingChromeVersion, out Version? existing) &&
+            Version.TryParse(version.version, out Version? candidate) &&
+            candidate <= existing)
         {
-            string winChromeBaseSnapshotUrl = GetNodeValue(xmlDoc, "win_ChromeBaseSnapshotUrl");
-            string winV8Version = GetNodeValue(xmlDoc, "win_V8Version");
-            return version.v8_version != winV8Version ||
-                baseUrl != winChromeBaseSnapshotUrl;
+            Log.LogMessage(MessageImportance.High,
+                $"Skipping {version.os}: candidate version {version.version} is not newer than existing {existingChromeVersion}.");
+            return false;
         }
-        else if (string.Equals(version.os, "Mac", StringComparison.OrdinalIgnoreCase))
-        {
-            string macosChromeBaseSnapshotUrl = GetNodeValue(xmlDoc, "macos_ChromeBaseSnapshotUrl");
-            string macosV8Version = GetNodeValue(xmlDoc, "macos_V8Version");
-            return version.v8_version != macosV8Version ||
-                baseUrl != macosChromeBaseSnapshotUrl;
-        }
-        throw new Exception($"UpdateChromeVersions task was used with unknown OS: {version.os}");
+
+        string existingChromeBaseSnapshotUrl = GetNodeValue(xmlDoc, $"{nodePrefix}_ChromeBaseSnapshotUrl");
+        string existingV8Version = GetNodeValue(xmlDoc, $"{nodePrefix}_V8Version");
+        return version.v8_version != existingV8Version ||
+            baseUrl != existingChromeBaseSnapshotUrl;
     }
 
     private static string GetNodeValue(XmlDocument xmlDoc, string nodeName)


### PR DESCRIPTION
## Problem 1
In https://github.com/dotnet/runtime/pull/124852 we added chrome for mac version to provisioning list. Since then the version was not updated because it's not added to platforms covered by automation.

## Problem 2
In https://github.com/dotnet/runtime/pull/129851 we manually upgraded v8 version. The next automated PR https://github.com/dotnet/runtime/pull/129934 downgraded it.

## Changes
- Add mac to automated version check
- Add mac smoke tests running only on the automated bump PRs, following the pattern used in library tests on mac.
- Automated update can be only an upgrade: always check if the new value > old value.