### PR TITLE
[clr-interp] Add support for logging interpreter IR ranges to perf map

### DIFF
--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -416,6 +416,47 @@ void PerfMap::LogPreCompiledMethod(MethodDesc * pMethod, PCODE pCode)
     EX_CATCH{} EX_END_CATCH
 }
 
+#ifdef FEATURE_INTERPRETER
+// Log an interpreter IR bytecode range to the perfmap.
+// This allows symbolication from perf scripts, when the interpreter IP is allocated to a fixed
+// register in InterpExecMethod
+void PerfMap::LogInterpreterMethod(MethodDesc * pMethod, PCODE irAddress, size_t irSize)
+{
+    CONTRACTL{
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_PREEMPTIVE;
+        PRECONDITION(pMethod != nullptr);
+        PRECONDITION(irAddress != nullptr);
+        PRECONDITION(irSize > 0);
+    } CONTRACTL_END;
+
+    if (!s_enabled)
+    {
+        return;
+    }
+
+    EX_TRY
+    {
+        SString name;
+        pMethod->GetFullMethodInfo(name);
+
+        SString line;
+        line.Printf(FMT_CODE_ADDR " %x [Interpreter] %s\n", irAddress, irSize, name.GetUTF8());
+
+        {
+            CrstHolder ch(&(s_csPerfMap));
+
+            if (s_Current != nullptr)
+            {
+                s_Current->WriteLine(line);
+            }
+        }
+    }
+    EX_CATCH{} EX_END_CATCH
+}
+#endif // FEATURE_INTERPRETER
+
 // Log a set of stub to the map.
 void PerfMap::LogStubs(const char* stubType, const char* stubOwner, PCODE pCode, size_t codeSize, PerfMapStubType stubAllocationType)
 {

--- a/src/coreclr/vm/perfmap.h
+++ b/src/coreclr/vm/perfmap.h
@@ -148,6 +148,11 @@ public:
     // Log a pre-compiled method to the map.
     static void LogPreCompiledMethod(MethodDesc * pMethod, PCODE pCode);
 
+#ifdef FEATURE_INTERPRETER
+    // Log an interpreter IR bytecode range to the perfmap
+    static void LogInterpreterMethod(MethodDesc * pMethod, PCODE irAddress, size_t irSize);
+#endif
+
     // Log a set of stub to the map.
     static void LogStubs(const char* stubType, const char* stubOwner, PCODE pCode, size_t codeSize, PerfMapStubType stubAllocationType);
 

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -878,8 +878,20 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
 #endif // PROFILING_SUPPORTED
 
 #ifdef FEATURE_PERFMAP
-    // Save the JIT'd method information so that perf can resolve JIT'd call frames.
-    PerfMap::LogJITCompiledMethod(this, pCode, sizeOfCode, pConfig);
+#if defined(FEATURE_INTERPRETER)
+    if (isInterpreterCode)
+    {
+        InterpreterPrecode* pPrecode = InterpreterPrecode::FromEntryPoint(pCode);
+        InterpByteCodeStart* interpreterCode = (InterpByteCodeStart*)pPrecode->GetData()->ByteCodeAddr;
+        PCODE irAddress = PINSTRToPCODE((TADDR)interpreterCode);
+        PerfMap::LogInterpreterMethod(this, irAddress, sizeOfCode);
+    }
+    else
+#endif // FEATURE_INTERPRETER
+    {
+        // Save the JIT'd method information so that perf can resolve JIT'd call frames.
+        PerfMap::LogJITCompiledMethod(this, pCode, sizeOfCode, pConfig);
+    }
 #endif
 
     // The notification will only occur if someone has registered for this method.


### PR DESCRIPTION
Tested that it works correctly when passing the following env vars to the runtime:
```
export DOTNET_PerfMapEnabled=1
export DOTNET_PerfMapStubGranularity=2
```

The interpreter entries from the perf map could be used to profile as described in https://gist.github.com/BrzVlad/80c1b1f61b024f251b60f39c5dedc9d3