### PR TITLE
Fix TestNativeDigits for ur-IN on all Apple platforms

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoTests.cs
@@ -136,8 +136,8 @@ namespace System.Globalization.Tests
             yield return new object[] { "ccp-Cakm-BD", new string[] { "\U00011136", "\U00011137", "\U00011138", "\U00011139", "\U0001113A", "\U0001113B", "\U0001113C", "\U0001113D", "\U0001113E", "\U0001113F" }};
             yield return new object[] { "ar-SA",  new string[] {"\u0660", "\u0661", "\u0662", "\u0663", "\u0664", "\u0665", "\u0666", "\u0667", "\u0668", "\u0669" }};
             yield return new object[] { "en-US",  new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" }};
-            // Apple ICU on Apple platforms 26+ returns Latin digits for ur-IN, diverging from upstream CLDR which specifies arabext
-            yield return new object[] { "ur-IN",  PlatformDetection.IsApplePlatform26OrLater
+            // Apple ICU returns Latin digits for ur-IN, diverging from upstream CLDR which specifies arabext
+            yield return new object[] { "ur-IN",  PlatformDetection.IsApplePlatform
                 ? new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" }
                 : new string[] { "\u06F0", "\u06F1", "\u06F2", "\u06F3", "\u06F4", "\u06F5", "\u06F6", "\u06F7", "\u06F8", "\u06F9" }};
         }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 
@@ -136,10 +137,7 @@ namespace System.Globalization.Tests
             yield return new object[] { "ccp-Cakm-BD", new string[] { "\U00011136", "\U00011137", "\U00011138", "\U00011139", "\U0001113A", "\U0001113B", "\U0001113C", "\U0001113D", "\U0001113E", "\U0001113F" }};
             yield return new object[] { "ar-SA",  new string[] {"\u0660", "\u0661", "\u0662", "\u0663", "\u0664", "\u0665", "\u0666", "\u0667", "\u0668", "\u0669" }};
             yield return new object[] { "en-US",  new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" }};
-            // Apple ICU returns Latin digits for ur-IN, diverging from upstream CLDR which specifies arabext
-            yield return new object[] { "ur-IN",  PlatformDetection.IsApplePlatform
-                ? new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" }
-                : new string[] { "\u06F0", "\u06F1", "\u06F2", "\u06F3", "\u06F4", "\u06F5", "\u06F6", "\u06F7", "\u06F8", "\u06F9" }};
+            yield return new object[] { "ur-IN",  new string[] { "\u06F0", "\u06F1", "\u06F2", "\u06F3", "\u06F4", "\u06F5", "\u06F6", "\u06F7", "\u06F8", "\u06F9" }};
         }
 
         public static bool FullICUPlatform => PlatformDetection.ICUVersion.Major >= 66 && !PlatformDetection.IsWasm;
@@ -148,7 +146,20 @@ namespace System.Globalization.Tests
         [MemberData(nameof(NativeDigitTestData))]
         public void TestNativeDigits(string cultureName, string[] nativeDigits)
         {
-            Assert.Equal(nativeDigits, CultureInfo.GetCultureInfo(cultureName).NumberFormat.NativeDigits);
+            string[] actual = CultureInfo.GetCultureInfo(cultureName).NumberFormat.NativeDigits;
+
+            // The ur-IN numbering system depends on which ICU is loaded on Apple platforms. Apple's
+            // libicucore (used by CoreCLR on macOS) returns Latin digits, while the full ICU (used by
+            // Mono) returns the CLDR arabext digits. Both are valid, so accept either on Apple platforms.
+            if (cultureName == "ur-IN" && PlatformDetection.IsApplePlatform)
+            {
+                string[] latinDigits = new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+                Assert.True(actual.SequenceEqual(nativeDigits) || actual.SequenceEqual(latinDigits),
+                    $"Unexpected ur-IN NativeDigits: [{string.Join(", ", actual)}]");
+                return;
+            }
+
+            Assert.Equal(nativeDigits, actual);
         }
     }
 }


### PR DESCRIPTION
Fixes #125933.

`TestNativeDigits(cultureName: "ur-IN")` fails on Apple platforms because Apple's ICU returns Latin digits (`0`-`9`) for `ur-IN` instead of the Extended Arabic-Indic (arabext) digits `U+06F0`-`U+06F9` specified by upstream CLDR. The test was previously dormant and only began running after the xunit v3 assert upgrade.

The earlier fix (#125934) gated the Latin expectation on `IsApplePlatform26OrLater`, but the divergence is not specific to macOS 26. It also affects macOS 15 (x64 legs) and the iOS/tvOS/MacCatalyst legs, whose `OSVersion.Major` is around 18 and never satisfied `>= 26`. This change gates on `IsApplePlatform` so the expected value is correct on every Apple platform.