### PR TITLE
Don't retain host probing-path properties in CLR config and AppContext

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/AppContext.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/AppContext.CoreCLR.cs
@@ -9,6 +9,17 @@ namespace System
 {
     public static partial class AppContext
     {
+        // Keep in sync with IsKnownHostProperty in src/coreclr/dlls/mscoree/exports.cpp.
+        private static bool IsKnownHostProperty(string name)
+            => name is "TRUSTED_PLATFORM_ASSEMBLIES"
+                    or "NATIVE_DLL_SEARCH_DIRECTORIES"
+                    or "PLATFORM_RESOURCE_ROOTS"
+                    or "APP_PATHS";
+
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AppContext_TryGetHostPropertyValue", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool TryGetHostPropertyValue(string name, StringHandleOnStack retValue);
+
         [UnmanagedCallersOnly]
         private static unsafe void OnProcessExit(Exception* pException)
         {

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -106,8 +106,8 @@ struct HostPropertyArraysTraits final
         {
             if (IsKnownHostProperty(arrays.keys[i]))
             {
-                delete[] const_cast<WCHAR*>(arrays.keysW[i]);
-                delete[] const_cast<WCHAR*>(arrays.valuesW[i]);
+                delete[] arrays.keysW[i];
+                delete[] arrays.valuesW[i];
             }
         }
 

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -74,6 +74,17 @@ public:
     }
 };
 
+// Returns true for known host properties that do not need to be stored as CLR configuration.
+// The runtime parses these into binder/AppDomain structures during AppDomain creation, so it
+// does not need to also keep the original raw strings around in the CLR config knobs.
+static bool IsKnownHostProperty(LPCSTR key)
+{
+    return strcmp(key, HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES) == 0
+        || strcmp(key, HOST_PROPERTY_NATIVE_DLL_SEARCH_DIRECTORIES) == 0
+        || strcmp(key, HOST_PROPERTY_PLATFORM_RESOURCE_ROOTS) == 0
+        || strcmp(key, HOST_PROPERTY_APP_PATHS) == 0;
+}
+
 // Convert 8 bit string to unicode
 static LPCWSTR StringToUnicode(LPCSTR str)
 {
@@ -294,8 +305,29 @@ int coreclr_initialize(
         Bundle::AppBundle = &bundle;
     }
 
-    // This will take ownership of propertyKeysWTemp and propertyValuesWTemp
-    Configuration::InitializeConfigurationKnobs(propertyCount, propertyKeysW, propertyValuesW);
+    // Build a filtered set of properties for the CLR config knobs that excludes probing path
+    // properties (TPA, NATIVE_DLL_SEARCH_DIRECTORIES, PLATFORM_RESOURCE_ROOTS, APP_PATHS).
+    // Those are parsed into binder/AppDomain structures during CreateAppDomainWithManager,
+    // so the runtime does not need a duplicate copy held forever in the CLR config knobs.
+    // The TPA list in particular can be tens of KB.
+    LPCWSTR* configKeysW = new (nothrow) LPCWSTR[propertyCount];
+    ASSERTE_ALL_BUILDS(configKeysW != nullptr);
+    LPCWSTR* configValuesW = new (nothrow) LPCWSTR[propertyCount];
+    ASSERTE_ALL_BUILDS(configValuesW != nullptr);
+
+    int configPropertyCount = 0;
+    for (int i = 0; i < propertyCount; ++i)
+    {
+        if (IsKnownHostProperty(propertyKeys[i]))
+            continue;
+
+        configKeysW[configPropertyCount] = propertyKeysW[i];
+        configValuesW[configPropertyCount] = propertyValuesW[i];
+        ++configPropertyCount;
+    }
+
+    // Configuration takes ownership of the filtered arrays and the strings they reference.
+    Configuration::InitializeConfigurationKnobs(configPropertyCount, configKeysW, configValuesW);
 
 #ifdef TARGET_UNIX
     if (Configuration::GetKnobBooleanValue(W("System.Runtime.CrashReportBeforeSignalChaining"), CLRConfig::INTERNAL_CrashReportBeforeSignalChaining))
@@ -323,6 +355,21 @@ int coreclr_initialize(
         propertyKeysW,
         propertyValuesW,
         (DWORD *)domainId);
+
+    // The binder/AppDomain has now parsed the host probing path properties into its own
+    // structures and the managed AppContext.Setup has copied each property value into a
+    // managed string. Free the wide-string copies for the excluded properties (the rest are
+    // owned by the CLR config above) and the full property arrays themselves.
+    for (int i = 0; i < propertyCount; ++i)
+    {
+        if (IsKnownHostProperty(propertyKeys[i]))
+        {
+            delete[] (WCHAR*)propertyKeysW[i];
+            delete[] (WCHAR*)propertyValuesW[i];
+        }
+    }
+    delete[] propertyKeysW;
+    delete[] propertyValuesW;
 
     if (SUCCEEDED(hr))
     {

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -357,8 +357,7 @@ int coreclr_initialize(
         (DWORD *)domainId);
 
     // The binder/AppDomain has now parsed the host probing path properties into its own
-    // structures and the managed AppContext.Setup has copied each property value into a
-    // managed string. Free the wide-string copies for the excluded properties (the rest are
+    // structures. Free the wide-string copies for the excluded properties (the rest are
     // owned by the CLR config above) and the full property arrays themselves.
     for (int i = 0; i < propertyCount; ++i)
     {

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -85,6 +85,37 @@ static bool IsKnownHostProperty(LPCSTR key)
         || strcmp(key, HOST_PROPERTY_APP_PATHS) == 0;
 }
 
+struct HostPropertyArrays final
+{
+    int count;
+    const char** keys;
+    LPCWSTR* keysW;
+    LPCWSTR* valuesW;
+};
+
+// Frees the key and value arrays and the wide-string copies of the known host probing-path
+// properties. The remaining strings are handed to the CLR configuration knobs, which retain
+// them for the process lifetime, so they are not freed here.
+struct HostPropertyArraysTraits final
+{
+    using Type = HostPropertyArrays;
+    static Type Default() { return {}; }
+    static void Free(Type arrays)
+    {
+        for (int i = 0; i < arrays.count; ++i)
+        {
+            if (IsKnownHostProperty(arrays.keys[i]))
+            {
+                delete[] const_cast<WCHAR*>(arrays.keysW[i]);
+                delete[] const_cast<WCHAR*>(arrays.valuesW[i]);
+            }
+        }
+
+        delete[] arrays.keysW;
+        delete[] arrays.valuesW;
+    }
+};
+
 // Convert 8 bit string to unicode
 static LPCWSTR StringToUnicode(LPCSTR str)
 {
@@ -305,6 +336,12 @@ int coreclr_initialize(
         Bundle::AppBundle = &bundle;
     }
 
+    // Take ownership of the converted (unfiltered) property arrays. The unfiltered arrays
+    // are passed to CreateAppDomainWithManager so the binder/AppDomain can parse them.
+    // Afterward, the arrays and the excluded strings are freed. The other property strings
+    // are handed to the CLR config knobs, which own them for the process lifetime.
+    LifetimeHolder<HostPropertyArraysTraits> hostPropertiesHolder{ HostPropertyArrays{ propertyCount, propertyKeys, propertyKeysW, propertyValuesW } };
+
     // Build a filtered set of properties for the CLR config knobs that excludes probing path
     // properties (TPA, NATIVE_DLL_SEARCH_DIRECTORIES, PLATFORM_RESOURCE_ROOTS, APP_PATHS).
     // Those are parsed into binder/AppDomain structures during CreateAppDomainWithManager,
@@ -326,7 +363,7 @@ int coreclr_initialize(
         ++configPropertyCount;
     }
 
-    // Configuration takes ownership of the filtered arrays and the strings they reference.
+    // Configuration takes ownership of the filtered arrays and the strings they reference
     Configuration::InitializeConfigurationKnobs(configPropertyCount, configKeysW, configValuesW);
 
 #ifdef TARGET_UNIX
@@ -355,20 +392,6 @@ int coreclr_initialize(
         propertyKeysW,
         propertyValuesW,
         (DWORD *)domainId);
-
-    // The binder/AppDomain has now parsed the host probing path properties into its own
-    // structures. Free the wide-string copies for the excluded properties (the rest are
-    // owned by the CLR config above) and the full property arrays themselves.
-    for (int i = 0; i < propertyCount; ++i)
-    {
-        if (IsKnownHostProperty(propertyKeys[i]))
-        {
-            delete[] (WCHAR*)propertyKeysW[i];
-            delete[] (WCHAR*)propertyValuesW[i];
-        }
-    }
-    delete[] propertyKeysW;
-    delete[] propertyValuesW;
 
     if (SUCCEEDED(hr))
     {

--- a/src/coreclr/vm/appdomainnative.cpp
+++ b/src/coreclr/vm/appdomainnative.cpp
@@ -120,8 +120,15 @@ namespace
     // Append all paths from a StringArrayList into 'output', separated by PATH_SEPARATOR_CHAR_W.
     void AppendStringArrayList(StringArrayList* pList, SString& output)
     {
-        if (pList == NULL)
-            return;
+        CONTRACTL
+        {
+            THROWS;
+            GC_NOTRIGGER;
+            MODE_ANY;
+        }
+        CONTRACTL_END;
+
+        _ASSERTE(pList != NULL);
 
         for (DWORD i = 0; i < pList->GetCount(); ++i)
         {
@@ -153,7 +160,7 @@ extern "C" BOOL QCALLTYPE AppContext_TryGetHostPropertyValue(LPCWSTR name, QCall
             BINDER_SPACE::SimpleNameToFileNameMap* pMap = pAppContext->GetTpaList();
             _ASSERTE(pMap != NULL);
 
-            StackSString result;
+            SString result;
             BINDER_SPACE::SimpleNameToFileNameMap::Iterator i = pMap->Begin();
             BINDER_SPACE::SimpleNameToFileNameMap::Iterator end = pMap->End();
             while (i != end)
@@ -178,7 +185,7 @@ extern "C" BOOL QCALLTYPE AppContext_TryGetHostPropertyValue(LPCWSTR name, QCall
     }
     else if (u16_strcmp(name, _T(HOST_PROPERTY_NATIVE_DLL_SEARCH_DIRECTORIES)) == 0)
     {
-        StackSString result;
+        SString result;
         AppDomain::PathIterator iter = pDomain->IterateNativeDllSearchDirectories();
         while (iter.Next())
         {
@@ -199,7 +206,7 @@ extern "C" BOOL QCALLTYPE AppContext_TryGetHostPropertyValue(LPCWSTR name, QCall
         StringArrayList* pList = pAppContext->GetPlatformResourceRoots();
         if (pList != NULL && pList->GetCount() > 0)
         {
-            StackSString result;
+            SString result;
             AppendStringArrayList(pList, result);
             retValue.Set(result);
             found = TRUE;
@@ -210,7 +217,7 @@ extern "C" BOOL QCALLTYPE AppContext_TryGetHostPropertyValue(LPCWSTR name, QCall
         StringArrayList* pList = pAppContext->GetAppPaths();
         if (pList != NULL && pList->GetCount() > 0)
         {
-            StackSString result;
+            SString result;
             AppendStringArrayList(pList, result);
             retValue.Set(result);
             found = TRUE;

--- a/src/coreclr/vm/appdomainnative.cpp
+++ b/src/coreclr/vm/appdomainnative.cpp
@@ -11,6 +11,9 @@
 #include "appdomain.inl"
 #include "eventtrace.h"
 #include "../binder/inc/defaultassemblybinder.h"
+#include "../binder/inc/applicationcontext.hpp"
+#include <corehost/host_runtime_contract.h>
+#include "stringarraylist.h"
 
 // static
 extern "C" void QCALLTYPE AppDomain_CreateDynamicAssembly(QCall::ObjectHandleOnStack assemblyLoadContext, NativeAssemblyNameParts* pAssemblyNameParts, INT32 hashAlgorithm, INT32 access, QCall::ObjectHandleOnStack retAssembly)
@@ -110,6 +113,118 @@ extern "C" void QCALLTYPE AssemblyNative_GetLoadedAssemblies(QCall::ObjectHandle
     GCPROTECT_END();
 
     END_QCALL;
+}
+
+namespace
+{
+    // Append all paths from a StringArrayList into 'output', separated by PATH_SEPARATOR_CHAR_W.
+    void AppendStringArrayList(StringArrayList* pList, SString& output)
+    {
+        if (pList == NULL)
+            return;
+
+        for (DWORD i = 0; i < pList->GetCount(); ++i)
+        {
+            if (i != 0)
+                output.Append(PATH_SEPARATOR_CHAR_W);
+
+            output.Append(pList->Get(i));
+        }
+    }
+}
+
+// Get the value of a known host property from the binder/AppDomain state.
+extern "C" BOOL QCALLTYPE AppContext_TryGetHostPropertyValue(LPCWSTR name, QCall::StringHandleOnStack retValue)
+{
+    QCALL_CONTRACT;
+
+    BOOL found = FALSE;
+
+    BEGIN_QCALL;
+
+    AppDomain* pDomain = AppDomain::GetCurrentDomain();
+    DefaultAssemblyBinder* pBinder = pDomain->GetDefaultBinder();
+    BINDER_SPACE::ApplicationContext* pAppContext = pBinder->GetAppContext();
+
+    if (u16_strcmp(name, _T(HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES)) == 0)
+    {
+        if (pAppContext->IsTpaListProvided())
+        {
+            BINDER_SPACE::SimpleNameToFileNameMap* pMap = pAppContext->GetTpaList();
+            _ASSERTE(pMap != NULL);
+
+            StackSString result;
+            BINDER_SPACE::SimpleNameToFileNameMap::Iterator i = pMap->Begin();
+            BINDER_SPACE::SimpleNameToFileNameMap::Iterator end = pMap->End();
+            while (i != end)
+            {
+                if (i->m_wszILFileName != NULL)
+                {
+                    if (!result.IsEmpty())
+                        result.Append(PATH_SEPARATOR_CHAR_W);
+
+                    result.Append(i->m_wszILFileName);
+                }
+
+                ++i;
+            }
+
+            if (!result.IsEmpty())
+            {
+                retValue.Set(result);
+                found = TRUE;
+            }
+        }
+    }
+    else if (u16_strcmp(name, _T(HOST_PROPERTY_NATIVE_DLL_SEARCH_DIRECTORIES)) == 0)
+    {
+        StackSString result;
+        AppDomain::PathIterator iter = pDomain->IterateNativeDllSearchDirectories();
+        while (iter.Next())
+        {
+            if (!result.IsEmpty())
+                result.Append(PATH_SEPARATOR_CHAR_W);
+
+            result.Append(*iter.GetPath());
+        }
+
+        if (!result.IsEmpty())
+        {
+            retValue.Set(result);
+            found = TRUE;
+        }
+    }
+    else if (u16_strcmp(name, _T(HOST_PROPERTY_PLATFORM_RESOURCE_ROOTS)) == 0)
+    {
+        StringArrayList* pList = pAppContext->GetPlatformResourceRoots();
+        if (pList != NULL && pList->GetCount() > 0)
+        {
+            StackSString result;
+            AppendStringArrayList(pList, result);
+            retValue.Set(result);
+            found = TRUE;
+        }
+    }
+    else if (u16_strcmp(name, _T(HOST_PROPERTY_APP_PATHS)) == 0)
+    {
+        StringArrayList* pList = pAppContext->GetAppPaths();
+        if (pList != NULL && pList->GetCount() > 0)
+        {
+            StackSString result;
+            AppendStringArrayList(pList, result);
+            retValue.Set(result);
+            found = TRUE;
+        }
+    }
+    else
+    {
+        // Caller is expected to only request known properties.
+        _ASSERTE(!"AppContext_TryGetHostPropertyValue called with unknown name");
+    }
+
+    END_QCALL;
+
+    return found;
 }
 
 extern "C" void QCALLTYPE String_IsInterned(QCall::StringHandleOnStack str)

--- a/src/coreclr/vm/appdomainnative.hpp
+++ b/src/coreclr/vm/appdomainnative.hpp
@@ -21,6 +21,7 @@ extern "C" void QCALLTYPE String_IsInterned(QCall::StringHandleOnStack str);
 
 extern "C" void QCALLTYPE AppDomain_CreateDynamicAssembly(QCall::ObjectHandleOnStack assemblyLoadContext, NativeAssemblyNameParts* pAssemblyName, INT32 hashAlgorithm, INT32 access, QCall::ObjectHandleOnStack retAssembly);
 extern "C" void QCALLTYPE AppContext_SetFirstChanceExceptionHandler();
+extern "C" BOOL QCALLTYPE AppContext_TryGetHostPropertyValue(LPCWSTR name, QCall::StringHandleOnStack retValue);
 
 extern "C" void QCALLTYPE AssemblyNative_GetLoadedAssemblies(QCall::ObjectHandleOnStack retAssemblies);
 

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -291,6 +291,7 @@ static const Entry s_QCall[] =
     DllImportEntry(String_IsInterned)
     DllImportEntry(AppDomain_CreateDynamicAssembly)
     DllImportEntry(AppContext_SetFirstChanceExceptionHandler)
+    DllImportEntry(AppContext_TryGetHostPropertyValue)
     DllImportEntry(ThreadNative_Start)
     DllImportEntry(ThreadNative_SetPriority)
     DllImportEntry(ThreadNative_GetCurrentThread)

--- a/src/installer/tests/HostActivation.Tests/RuntimeProperties.cs
+++ b/src/installer/tests/HostActivation.Tests/RuntimeProperties.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
+using FluentAssertions;
 using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
 using Microsoft.DotNet.TestUtils;
 using Xunit;
@@ -29,7 +32,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdErrContaining($"Property {SharedTestState.AppTestPropertyName} = {SharedTestState.AppTestPropertyValue}")
-                .And.HaveStdOutContaining($"AppContext.GetData({SharedTestState.AppTestPropertyName}) = {SharedTestState.AppTestPropertyValue}");
+                .And.HavePropertyValue(SharedTestState.AppTestPropertyName, SharedTestState.AppTestPropertyValue);
         }
 
         [Fact]
@@ -40,7 +43,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdErrContaining($"Property {SharedTestState.FrameworkTestPropertyName} = {SharedTestState.FrameworkTestPropertyValue}")
-                .And.HaveStdOutContaining($"AppContext.GetData({SharedTestState.FrameworkTestPropertyName}) = {SharedTestState.FrameworkTestPropertyValue}");
+                .And.HavePropertyValue(SharedTestState.FrameworkTestPropertyName, SharedTestState.FrameworkTestPropertyValue);
         }
 
         [Fact]
@@ -56,7 +59,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdErrContaining($"Property {SharedTestState.FrameworkTestPropertyName} = {SharedTestState.AppTestPropertyValue}")
-                .And.HaveStdOutContaining($"AppContext.GetData({SharedTestState.FrameworkTestPropertyName}) = {SharedTestState.AppTestPropertyValue}");
+                .And.HavePropertyValue(SharedTestState.FrameworkTestPropertyName, SharedTestState.AppTestPropertyValue);
         }
 
         [Fact]
@@ -77,7 +80,7 @@ namespace HostActivation.Tests
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOutContaining($"Property '{SharedTestState.HostFxrPathPropertyName}' was not found.");
+                .And.NotFindProperty(SharedTestState.HostFxrPathPropertyName);
         }
 
         [Fact]
@@ -112,7 +115,24 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdErrContaining($"Property {SharedTestState.AppTestPropertyName} = {devConfigValue}")
-                .And.HaveStdOutContaining($"AppContext.GetData({SharedTestState.AppTestPropertyName}) = {devConfigValue}");
+                .And.HavePropertyValue(SharedTestState.AppTestPropertyName, devConfigValue);
+        }
+
+        [Fact]
+        public void KnownHostProperty_AppCanGetData()
+        {
+            sharedState.DotNet.Exec(sharedState.App.AppDll, PrintProperties,
+                    "TRUSTED_PLATFORM_ASSEMBLIES", "NATIVE_DLL_SEARCH_DIRECTORIES",
+                    "PLATFORM_RESOURCE_ROOTS", "APP_PATHS")
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().Pass()
+                .And.HavePropertyContaining("TRUSTED_PLATFORM_ASSEMBLIES",
+                    Path.Combine(sharedState.DotNet.GreatestVersionSharedFxPath, "System.Private.CoreLib.dll"))
+                .And.HavePropertyContaining("NATIVE_DLL_SEARCH_DIRECTORIES",
+                    sharedState.DotNet.GreatestVersionSharedFxPath)
+                .And.NotFindProperty("PLATFORM_RESOURCE_ROOTS")
+                .And.NotFindProperty("APP_PATHS");
         }
 
         public class SharedTestState : IDisposable
@@ -157,6 +177,25 @@ namespace HostActivation.Tests
                 App?.Dispose();
                 copiedDotnet.Dispose();
             }
+        }
+    }
+
+    internal static class RuntimePropertyCommandResultExtensions
+    {
+        public static AndConstraint<CommandResultAssertions> NotFindProperty(this CommandResultAssertions assertion, string propertyName)
+        {
+            return assertion.HaveStdOutContaining($"Property '{propertyName}' was not found.");
+        }
+
+        public static AndConstraint<CommandResultAssertions> HavePropertyValue(this CommandResultAssertions assertion, string propertyName, string expectedValue)
+        {
+            return assertion.HaveStdOutContaining($"AppContext.GetData({propertyName}) = {expectedValue}");
+        }
+
+        public static AndConstraint<CommandResultAssertions> HavePropertyContaining(this CommandResultAssertions assertion, string propertyName, string expectedSubstring)
+        {
+            return assertion.HaveStdOutMatching(
+                $@"AppContext\.GetData\({Regex.Escape(propertyName)}\) = .*{Regex.Escape(expectedSubstring)}");
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -58,7 +58,10 @@ namespace System
                     lock (s_dataStore)
                     {
                         if (s_dataStore.TryGetValue(name, out object? existing))
+                        {
+                            Debug.Assert(existing is string existingValue && existingValue == value);
                             return existing;
+                        }
 
                         s_dataStore[name] = value;
                         return value;

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -55,8 +55,14 @@ namespace System
                 string? value = null;
                 if (TryGetHostPropertyValue(name, new StringHandleOnStack(ref value)))
                 {
-                    SetData(name, value);
-                    return value;
+                    lock (s_dataStore)
+                    {
+                        if (s_dataStore.TryGetValue(name, out object? existing))
+                            return existing;
+
+                        s_dataStore[name] = value;
+                        return value;
+                    }
                 }
             }
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -43,12 +43,25 @@ namespace System
             if (s_dataStore == null)
                 return null;
 
-            object? data;
             lock (s_dataStore)
             {
-                s_dataStore.TryGetValue(name, out data);
+                if (s_dataStore.TryGetValue(name, out object? data))
+                    return data;
             }
-            return data;
+
+#if !MONO && !NATIVEAOT
+            if (IsKnownHostProperty(name))
+            {
+                string? value = null;
+                if (TryGetHostPropertyValue(name, new StringHandleOnStack(ref value)))
+                {
+                    SetData(name, value);
+                    return value;
+                }
+            }
+#endif
+
+            return null;
         }
 
         /// <summary>
@@ -205,7 +218,14 @@ namespace System
                 s_dataStore = new Dictionary<string, object?>(count);
                 for (int i = 0; i < count; i++)
                 {
-                    s_dataStore.Add(new string(pNames[i]), new string(pValues[i]));
+                    string name = new string(pNames[i]);
+
+                    // Avoid retaining a managed string copy of known host properties.
+                    // They will be retrieved if explicitly requested.
+                    if (IsKnownHostProperty(name))
+                        continue;
+
+                    s_dataStore.Add(name, new string(pValues[i]));
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Four well-known host probing-path properties — `TRUSTED_PLATFORM_ASSEMBLIES`, `NATIVE_DLL_SEARCH_DIRECTORIES`, `PLATFORM_RESOURCE_ROOTS`, and `APP_PATHS` — are computed by the host and then, inside the runtime, copied and retained multiple times: wide-string copies in the CLR config knobs, managed strings in `AppContext`'s data store, and the parsed binder/AppDomain structures the runtime actually uses. The config-knob and `AppContext` copies just duplicate data the runtime already owns in parsed form. The TPA list is the largest of these and grows as the app takes dependencies on other libraries or frameworks.

This change stops keeping the copies in the config knobs and managed `AppContext`. The host properties are still handed to the runtime and parsed by the binder and AppDomain, but the config knob copies for these four properties are dropped and they are no longer stored on the `AppContext` at startup. When one of these properties is requested through `AppContext.GetData`, the value is reconstructed from the binder/AppDomain state via a new QCall and stored for subsequent reads. Reconstruction is not byte-for-byte: the TPA list comes back deduplicated by simple name and in a different order, and a property the host passed as empty reads back as `null` rather than an empty string.

cc @dotnet/appmodel @AaronRobinsonMSFT 

macOS arm64 Release, framework-dependent empty console app, properties not queried via  `AppContext.GetData`:

| Memory retained | Before | After | Reduction |
|---|---:|---:|---:|
| Managed (`GC.GetTotalMemory`) | 52,360 B | 17,792 B | ~34 KB (66%) |
| Native (`mstats().bytes_used`) | 1,280,797 B | 1,232,368 B | ~47 KB (3.8%) |

> [!NOTE]
> Portions of this PR description were drafted with the assistance of GitHub Copilot.
