### PR TITLE
Cache AES one-shot cipher handles

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesCng.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesCng.Windows.cs
@@ -8,6 +8,7 @@
 // that each of these derive from a different class, it can't be helped.
 //
 
+using System.Diagnostics;
 using System.Runtime.Versioning;
 using Internal.Cryptography;
 using Internal.NativeCrypto;
@@ -17,6 +18,11 @@ namespace System.Security.Cryptography
     public sealed class AesCng : Aes, ICngSymmetricAlgorithm
     {
         private CngKey? _key;
+        private ILiteSymmetricCipher? _encryptEcbCipher;
+        private ILiteSymmetricCipher? _decryptEcbCipher;
+        private ILiteSymmetricCipher? _encryptCbcCipher;
+        private ILiteSymmetricCipher? _decryptCbcCipher;
+        private ConcurrencyBlock _block;
 
         [SupportedOSPlatform("windows")]
         public AesCng()
@@ -81,7 +87,11 @@ namespace System.Security.Cryptography
             }
             set
             {
-                _core.SetKey(value);
+                using (ConcurrencyBlock.Enter(ref _block))
+                {
+                    _core.SetKey(value);
+                    ClearCachedCiphers();
+                }
             }
         }
 
@@ -94,7 +104,11 @@ namespace System.Security.Cryptography
 
             set
             {
-                _core.SetKeySize(value, this);
+                using (ConcurrencyBlock.Enter(ref _block))
+                {
+                    _core.SetKeySize(value, this);
+                    ClearCachedCiphers();
+                }
             }
         }
 
@@ -122,7 +136,11 @@ namespace System.Security.Cryptography
 
         public override void GenerateKey()
         {
-            _core.GenerateKey();
+            using (ConcurrencyBlock.Enter(ref _block))
+            {
+                _core.GenerateKey();
+                ClearCachedCiphers();
+            }
         }
 
         public override void GenerateIV()
@@ -136,14 +154,14 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
-                iv: default,
-                encrypting: false,
-                CipherMode.ECB,
-                feedbackSizeInBits: 0);
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
+                ILiteSymmetricCipher cipher = GetOrCreateCachedLiteCipher(
+                    ref _decryptEcbCipher,
+                    CipherMode.ECB,
+                    iv: default,
+                    encrypting: false);
+
                 return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
@@ -154,14 +172,14 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
-                iv: default,
-                encrypting: true,
-                CipherMode.ECB,
-                feedbackSizeInBits: 0);
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
+                ILiteSymmetricCipher cipher = GetOrCreateCachedLiteCipher(
+                    ref _encryptEcbCipher,
+                    CipherMode.ECB,
+                    iv: default,
+                    encrypting: true);
+
                 return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
@@ -173,14 +191,14 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
-                iv,
-                encrypting: true,
-                CipherMode.CBC,
-                feedbackSizeInBits: 0);
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
+                ILiteSymmetricCipher cipher = GetOrCreateCachedLiteCipher(
+                    ref _encryptCbcCipher,
+                    CipherMode.CBC,
+                    iv,
+                    encrypting: true);
+
                 return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
@@ -192,14 +210,14 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
-                iv,
-                encrypting: false,
-                CipherMode.CBC,
-                feedbackSizeInBits: 0);
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
+                ILiteSymmetricCipher cipher = GetOrCreateCachedLiteCipher(
+                    ref _decryptCbcCipher,
+                    CipherMode.CBC,
+                    iv,
+                    encrypting: false);
+
                 return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
@@ -212,15 +230,18 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
-                iv,
-                encrypting: false,
-                CipherMode.CFB,
-                feedbackSizeInBits);
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
-                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
+                ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                    iv,
+                    encrypting: false,
+                    CipherMode.CFB,
+                    feedbackSizeInBits);
+
+                using (cipher)
+                {
+                    return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
+                }
             }
         }
 
@@ -232,30 +253,60 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
-                iv,
-                encrypting: true,
-                CipherMode.CFB,
-                feedbackSizeInBits);
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
-                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
+                ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                    iv,
+                    encrypting: true,
+                    CipherMode.CFB,
+                    feedbackSizeInBits);
+
+                using (cipher)
+                {
+                    return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
+                }
             }
         }
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing && _key is not null)
+            if (disposing)
             {
-                _key.Dispose();
-                _key = null;
+                ClearCachedCiphers();
+
+                if (_key is not null)
+                {
+                    _key.Dispose();
+                    _key = null;
+                }
             }
 
             base.Dispose(disposing);
         }
 
-        byte[] ICngSymmetricAlgorithm.BaseKey { get { return base.Key; } set { base.Key = value; } }
+        byte[] ICngSymmetricAlgorithm.BaseKey
+        {
+            get
+            {
+                KeyValue ??= RandomNumberGenerator.GetBytes(AsymmetricAlgorithmHelpers.BitsToBytes(KeySizeValue));
+                return KeyValue.CloneByteArray()!;
+            }
+            set
+            {
+                ArgumentNullException.ThrowIfNull(value);
+
+                long bitLength = value.Length;
+                bitLength *= 8;
+                if (bitLength > int.MaxValue || !ValidKeySize((int)bitLength))
+                {
+                    throw new CryptographicException(SR.Cryptography_InvalidKeySize);
+                }
+
+                KeySizeValue = (int)bitLength;
+                KeyValue = value.CloneByteArray();
+            }
+        }
+
         int ICngSymmetricAlgorithm.BaseKeySize { get { return base.KeySize; } set { base.KeySize = value; } }
 
         bool ICngSymmetricAlgorithm.IsWeakKey(byte[] key)
@@ -296,5 +347,49 @@ namespace System.Security.Cryptography
         }
 
         private CngSymmetricAlgorithmCore _core;
+
+        private ILiteSymmetricCipher GetOrCreateCachedLiteCipher(
+            ref ILiteSymmetricCipher? cipher,
+            CipherMode cipherMode,
+            ReadOnlySpan<byte> iv,
+            bool encrypting)
+        {
+            Debug.Assert(cipherMode is CipherMode.ECB or CipherMode.CBC);
+
+            if (cipher is not null)
+            {
+                try
+                {
+                    cipher.Reset(iv);
+                    return cipher;
+                }
+                catch
+                {
+                    cipher.Dispose();
+                    cipher = null; // Null-out the cipher field passed by reference.
+                    throw;
+                }
+            }
+
+            cipher = _core.CreateLiteSymmetricCipher(
+                iv,
+                encrypting,
+                cipherMode,
+                feedbackSizeInBits: 0);
+
+            return cipher;
+        }
+
+        private void ClearCachedCiphers()
+        {
+            _encryptEcbCipher?.Dispose();
+            _encryptEcbCipher = null;
+            _decryptEcbCipher?.Dispose();
+            _decryptEcbCipher = null;
+            _encryptCbcCipher?.Dispose();
+            _encryptCbcCipher = null;
+            _decryptCbcCipher?.Dispose();
+            _decryptCbcCipher = null;
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.cs
@@ -20,9 +20,17 @@ namespace System.Security.Cryptography
             if (_keyBox is null)
             {
                 Span<byte> key = stackalloc byte[KeySize / BitsPerByte];
-                RandomNumberGenerator.Fill(key);
-                SetKeyCoreUnchecked(key);
-                Debug.Assert(_keyBox is not null);
+
+                try
+                {
+                    RandomNumberGenerator.Fill(key);
+                    SetKeyCoreUnchecked(key);
+                    Debug.Assert(_keyBox is not null);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(key);
+                }
             }
 
             return _keyBox;
@@ -81,8 +89,16 @@ namespace System.Security.Cryptography
         public sealed override unsafe void GenerateKey()
         {
             Span<byte> key = stackalloc byte[KeySize / BitsPerByte];
-            RandomNumberGenerator.Fill(key);
-            SetKeyCore(key);
+
+            try
+            {
+                RandomNumberGenerator.Fill(key);
+                SetKeyCore(key);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(key);
+            }
         }
 
         protected sealed override void Dispose(bool disposing)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.cs
@@ -9,12 +9,19 @@ namespace System.Security.Cryptography
     internal sealed partial class AesImplementation : Aes
     {
         private FixedMemoryKeyBox? _keyBox;
+        private ILiteSymmetricCipher? _encryptEcbCipher;
+        private ILiteSymmetricCipher? _decryptEcbCipher;
+        private ILiteSymmetricCipher? _encryptCbcCipher;
+        private ILiteSymmetricCipher? _decryptCbcCipher;
+        private ConcurrencyBlock _block;
 
         private FixedMemoryKeyBox GetKey()
         {
             if (_keyBox is null)
             {
-                GenerateKey();
+                Span<byte> key = stackalloc byte[KeySize / BitsPerByte];
+                RandomNumberGenerator.Fill(key);
+                SetKeyCoreUnchecked(key);
                 Debug.Assert(_keyBox is not null);
             }
 
@@ -32,9 +39,13 @@ namespace System.Security.Cryptography
             get => base.KeySize;
             set
             {
-                base.KeySize = value;
-                _keyBox?.Dispose();
-                _keyBox = null;
+                using (ConcurrencyBlock.Enter(ref _block))
+                {
+                    base.KeySize = value;
+                    ClearCachedCiphers();
+                    _keyBox?.Dispose();
+                    _keyBox = null;
+                }
             }
         }
 
@@ -78,6 +89,7 @@ namespace System.Security.Cryptography
         {
             if (disposing)
             {
+                ClearCachedCiphers();
                 _keyBox?.Dispose();
                 _keyBox = null;
             }
@@ -87,9 +99,10 @@ namespace System.Security.Cryptography
 
         protected override void SetKeyCore(ReadOnlySpan<byte> key)
         {
-            KeySizeValue = checked(BitsPerByte * key.Length);
-            _keyBox?.Dispose();
-            _keyBox = new FixedMemoryKeyBox(key);
+            using (ConcurrencyBlock.Enter(ref _block))
+            {
+                SetKeyCoreUnchecked(key);
+            }
         }
 
         protected override bool TryDecryptEcbCore(
@@ -98,19 +111,14 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = GetKey().UseKey(
-                BlockSize / BitsPerByte,
-                static (blockSizeBytes, key) => CreateLiteCipher(
-                    CipherMode.ECB,
-                    key,
-                    iv: default,
-                    blockSize: blockSizeBytes,
-                    paddingSize: blockSizeBytes,
-                    0, /*feedback size */
-                    encrypting: false));
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
+                ILiteSymmetricCipher cipher = GetOrCreateCachedLiteCipher(
+                    ref _decryptEcbCipher,
+                    CipherMode.ECB,
+                    iv: default,
+                    encrypting: false);
+
                 return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
@@ -121,19 +129,14 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = GetKey().UseKey(
-                BlockSize / BitsPerByte,
-                static (blockSizeBytes, key) => CreateLiteCipher(
-                    CipherMode.ECB,
-                    key,
-                    iv: default,
-                    blockSize: blockSizeBytes,
-                    paddingSize: blockSizeBytes,
-                    0, /*feedback size */
-                    encrypting: true));
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
+                ILiteSymmetricCipher cipher = GetOrCreateCachedLiteCipher(
+                    ref _encryptEcbCipher,
+                    CipherMode.ECB,
+                    iv: default,
+                    encrypting: true);
+
                 return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
@@ -145,20 +148,14 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = GetKey().UseKey(
-                iv,
-                BlockSize / BitsPerByte,
-                static (iv, blockSizeBytes, key) => CreateLiteCipher(
-                    CipherMode.CBC,
-                    key,
-                    iv,
-                    blockSize: blockSizeBytes,
-                    paddingSize: blockSizeBytes,
-                    0, /*feedback size */
-                    encrypting: true));
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
+                ILiteSymmetricCipher cipher = GetOrCreateCachedLiteCipher(
+                    ref _encryptCbcCipher,
+                    CipherMode.CBC,
+                    iv,
+                    encrypting: true);
+
                 return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
@@ -170,20 +167,14 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = GetKey().UseKey(
-                iv,
-                BlockSize / BitsPerByte,
-                static (iv, blockSizeBytes, key) => CreateLiteCipher(
-                    CipherMode.CBC,
-                    key,
-                    iv,
-                    blockSize: blockSizeBytes,
-                    paddingSize: blockSizeBytes,
-                    0, /*feedback size */
-                    encrypting: false));
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
+                ILiteSymmetricCipher cipher = GetOrCreateCachedLiteCipher(
+                    ref _decryptCbcCipher,
+                    CipherMode.CBC,
+                    iv,
+                    encrypting: false);
+
                 return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
@@ -198,21 +189,24 @@ namespace System.Security.Cryptography
         {
             ValidateCFBFeedbackSize(feedbackSizeInBits);
 
-            ILiteSymmetricCipher cipher = GetKey().UseKey(
-                iv,
-                (BlockSizeBytes: BlockSize / BitsPerByte, FeedbackSizeBytes: feedbackSizeInBits / BitsPerByte),
-                static (iv, state, key) => CreateLiteCipher(
-                    CipherMode.CFB,
-                    key,
-                    iv: iv,
-                    blockSize: state.BlockSizeBytes,
-                    paddingSize: state.FeedbackSizeBytes,
-                    state.FeedbackSizeBytes,
-                    encrypting: false));
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
-                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
+                ILiteSymmetricCipher cipher = GetKey().UseKey(
+                    iv,
+                    (BlockSizeBytes: BlockSize / BitsPerByte, FeedbackSizeBytes: feedbackSizeInBits / BitsPerByte),
+                    static (iv, state, key) => CreateLiteCipher(
+                        CipherMode.CFB,
+                        key,
+                        iv: iv,
+                        blockSize: state.BlockSizeBytes,
+                        paddingSize: state.FeedbackSizeBytes,
+                        state.FeedbackSizeBytes,
+                        encrypting: false));
+
+                using (cipher)
+                {
+                    return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
+                }
             }
         }
 
@@ -226,21 +220,24 @@ namespace System.Security.Cryptography
         {
             ValidateCFBFeedbackSize(feedbackSizeInBits);
 
-            ILiteSymmetricCipher cipher = GetKey().UseKey(
-                iv,
-                (BlockSizeBytes: BlockSize / BitsPerByte, FeedbackSizeBytes: feedbackSizeInBits / BitsPerByte),
-                static (iv, state, key) => CreateLiteCipher(
-                    CipherMode.CFB,
-                    key,
-                    iv,
-                    blockSize: state.BlockSizeBytes,
-                    paddingSize: state.FeedbackSizeBytes,
-                    state.FeedbackSizeBytes,
-                    encrypting: true));
-
-            using (cipher)
+            using (ConcurrencyBlock.Enter(ref _block))
             {
-                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
+                ILiteSymmetricCipher cipher = GetKey().UseKey(
+                    iv,
+                    (BlockSizeBytes: BlockSize / BitsPerByte, FeedbackSizeBytes: feedbackSizeInBits / BitsPerByte),
+                    static (iv, state, key) => CreateLiteCipher(
+                        CipherMode.CFB,
+                        key,
+                        iv,
+                        blockSize: state.BlockSizeBytes,
+                        paddingSize: state.FeedbackSizeBytes,
+                        state.FeedbackSizeBytes,
+                        encrypting: true));
+
+                using (cipher)
+                {
+                    return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
+                }
             }
         }
 
@@ -289,6 +286,66 @@ namespace System.Security.Cryptography
             {
                 throw new CryptographicException(SR.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedback, CipherMode.CFB));
             }
+        }
+
+        private ILiteSymmetricCipher GetOrCreateCachedLiteCipher(
+            ref ILiteSymmetricCipher? cipher,
+            CipherMode cipherMode,
+            ReadOnlySpan<byte> iv,
+            bool encrypting)
+        {
+            Debug.Assert(cipherMode is CipherMode.ECB or CipherMode.CBC);
+
+            if (cipher is not null)
+            {
+                try
+                {
+                    cipher.Reset(iv);
+                    return cipher;
+                }
+                catch
+                {
+                    cipher.Dispose();
+                    cipher = null; // Null-out the cipher field passed by reference.
+                    throw;
+                }
+            }
+
+            int blockSizeBytes = BlockSize / BitsPerByte;
+            cipher = GetKey().UseKey(
+                iv,
+                (BlockSizeBytes: blockSizeBytes, CipherMode: cipherMode, Encrypting: encrypting),
+                static (iv, state, key) => CreateLiteCipher(
+                    state.CipherMode,
+                    key,
+                    iv,
+                    blockSize: state.BlockSizeBytes,
+                    paddingSize: state.BlockSizeBytes,
+                    0, /* feedback size */
+                    encrypting: state.Encrypting));
+
+            return cipher;
+        }
+
+        private void SetKeyCoreUnchecked(ReadOnlySpan<byte> key)
+        {
+            KeySizeValue = checked(BitsPerByte * key.Length);
+            FixedMemoryKeyBox keyBox = new FixedMemoryKeyBox(key);
+            ClearCachedCiphers();
+            _keyBox?.Dispose();
+            _keyBox = keyBox;
+        }
+
+        private void ClearCachedCiphers()
+        {
+            _encryptEcbCipher?.Dispose();
+            _encryptEcbCipher = null;
+            _decryptEcbCipher?.Dispose();
+            _decryptEcbCipher = null;
+            _encryptCbcCipher?.Dispose();
+            _encryptCbcCipher = null;
+            _decryptCbcCipher?.Dispose();
+            _decryptCbcCipher = null;
         }
 
         private const int BitsPerByte = 8;


### PR DESCRIPTION
This caches the handles used by the AES algorithm's one-shot handles so that repeated calls to `{Encrypt,Decrypt}{Cbc,Ecb}` can re-use their handles. This means any subsequent calls to these methods don't have to re-create the key handle and do key expansion.

Because the previous implementations were more or less thread-safe, but not intentionally, we add `ConcurrencyBlock` here. We do this prevent accidental misuse of these APIs concurrently. Even though they look "safe" because they are one-shots and don't mutate state, that is not the case with the underlying platform's implementations on each handle.

For example, in OpenSSL, it internally maintains the previous block of data during CBC processing because it needs to chain the blocks. Using the cipher concurrently is a sure way to lead to data corruption.

We do not do this for CFB because 1. CFB is a less common code and 2. the feedback size is part of the handle on some platforms. That means we would need a cached handle per operation, per feedback size. That makes the `Aes` class bigger with no clear benefit. We also do not do this for 3DES/DES/RC2 because these algorithms should no longer be used on any performance critical path.

Summarizing the benchmarks:

1. "Single-use" calls to the one-shots will have a small allocation regression. This regression is a fixed amount and not dependent on the input size of the data. Because the `Aes` class itself is bigger now to hold these fields, allocating it increased its size by ~40 bytes.

    The use of `ConcurrencyBlock` introduces minimal overhead and appears to be within noise.
    
2. Any additional calls to the methods that have been cached will see big improvements. Both in wall-clock time since the handle is being re-used, and allocations are down because they do not allocate the handles. In the right circumstances they are even allocation free.

Benchmark code: https://gist.github.com/vcsjones/f6f571224aff928d7e13d6b7ac3d404e
Benchmark results:

| Method          | Job    | Length | Mean        | Ratio | RatioSD | Allocated | Alloc Ratio |
|---------------- |------- |------- |------------:|------:|--------:|----------:|------------:|
| **EncryptCbc**      | **branch** | **16**     |    **498.9 ns** |  **0.96** |    **0.01** |     **328 B** |        **1.14** |
| EncryptCbc      | main   | 16     |    519.0 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptCbcTwice | branch | 16     |    558.1 ns |  0.70 |    0.00 |     328 B |        0.91 |
| EncryptCbcTwice | main   | 16     |    799.3 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbc      | branch | 16     |    507.2 ns |  0.97 |    0.01 |     328 B |        1.14 |
| DecryptCbc      | main   | 16     |    524.7 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbcTwice | branch | 16     |    575.1 ns |  0.70 |    0.00 |     328 B |        0.91 |
| DecryptCbcTwice | main   | 16     |    825.9 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcb      | branch | 16     |    507.7 ns |  1.04 |    0.03 |     328 B |        1.14 |
| EncryptEcb      | main   | 16     |    486.7 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcbTwice | branch | 16     |    566.0 ns |  0.75 |    0.01 |     328 B |        0.91 |
| EncryptEcbTwice | main   | 16     |    758.6 ns |  1.00 |    0.01 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcb      | branch | 16     |    528.4 ns |  1.06 |    0.01 |     328 B |        1.14 |
| DecryptEcb      | main   | 16     |    498.8 ns |  1.00 |    0.02 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcbTwice | branch | 16     |    574.7 ns |  0.74 |    0.00 |     328 B |        0.91 |
| DecryptEcbTwice | main   | 16     |    772.8 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| **EncryptCbc**      | **branch** | **32**     |    **557.7 ns** |  **1.09** |    **0.01** |     **328 B** |        **1.14** |
| EncryptCbc      | main   | 32     |    511.3 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptCbcTwice | branch | 32     |    614.1 ns |  0.74 |    0.01 |     328 B |        0.91 |
| EncryptCbcTwice | main   | 32     |    825.0 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbc      | branch | 32     |    553.9 ns |  1.07 |    0.01 |     328 B |        1.14 |
| DecryptCbc      | main   | 32     |    516.5 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbcTwice | branch | 32     |    620.9 ns |  0.74 |    0.00 |     328 B |        0.91 |
| DecryptCbcTwice | main   | 32     |    842.8 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcb      | branch | 32     |    512.3 ns |  1.04 |    0.01 |     328 B |        1.14 |
| EncryptEcb      | main   | 32     |    493.0 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcbTwice | branch | 32     |    571.5 ns |  0.75 |    0.01 |     328 B |        0.91 |
| EncryptEcbTwice | main   | 32     |    759.0 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcb      | branch | 32     |    516.9 ns |  1.03 |    0.01 |     328 B |        1.14 |
| DecryptEcb      | main   | 32     |    500.0 ns |  1.00 |    0.00 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcbTwice | branch | 32     |    584.8 ns |  0.75 |    0.00 |     328 B |        0.91 |
| DecryptEcbTwice | main   | 32     |    777.8 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| **EncryptCbc**      | **branch** | **64**     |    **564.7 ns** |  **1.05** |    **0.01** |     **328 B** |        **1.14** |
| EncryptCbc      | main   | 64     |    536.6 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptCbcTwice | branch | 64     |    671.0 ns |  0.77 |    0.00 |     328 B |        0.91 |
| EncryptCbcTwice | main   | 64     |    870.1 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbc      | branch | 64     |    543.9 ns |  1.04 |    0.01 |     328 B |        1.14 |
| DecryptCbc      | main   | 64     |    521.1 ns |  1.00 |    0.00 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbcTwice | branch | 64     |    618.4 ns |  0.74 |    0.00 |     328 B |        0.91 |
| DecryptCbcTwice | main   | 64     |    836.9 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcb      | branch | 64     |    512.9 ns |  1.06 |    0.01 |     328 B |        1.14 |
| EncryptEcb      | main   | 64     |    485.4 ns |  1.00 |    0.00 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcbTwice | branch | 64     |    564.9 ns |  0.74 |    0.01 |     328 B |        0.91 |
| EncryptEcbTwice | main   | 64     |    761.9 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcb      | branch | 64     |    522.5 ns |  1.06 |    0.01 |     328 B |        1.14 |
| DecryptEcb      | main   | 64     |    493.3 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcbTwice | branch | 64     |    584.2 ns |  0.76 |    0.00 |     328 B |        0.91 |
| DecryptEcbTwice | main   | 64     |    770.6 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| **EncryptCbc**      | **branch** | **128**    |    **611.3 ns** |  **0.97** |    **0.04** |     **328 B** |        **1.14** |
| EncryptCbc      | main   | 128    |    632.0 ns |  1.00 |    0.07 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptCbcTwice | branch | 128    |    770.6 ns |  0.78 |    0.00 |     328 B |        0.91 |
| EncryptCbcTwice | main   | 128    |    989.4 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbc      | branch | 128    |    539.2 ns |  1.02 |    0.01 |     328 B |        1.14 |
| DecryptCbc      | main   | 128    |    526.6 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbcTwice | branch | 128    |    607.0 ns |  0.72 |    0.00 |     328 B |        0.91 |
| DecryptCbcTwice | main   | 128    |    838.3 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcb      | branch | 128    |    497.3 ns |  1.02 |    0.01 |     328 B |        1.14 |
| EncryptEcb      | main   | 128    |    485.8 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcbTwice | branch | 128    |    570.3 ns |  0.73 |    0.00 |     328 B |        0.91 |
| EncryptEcbTwice | main   | 128    |    783.9 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcb      | branch | 128    |    546.2 ns |  1.02 |    0.09 |     328 B |        1.14 |
| DecryptEcb      | main   | 128    |    533.0 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcbTwice | branch | 128    |    578.0 ns |  0.74 |    0.00 |     328 B |        0.91 |
| DecryptEcbTwice | main   | 128    |    782.9 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| **EncryptCbc**      | **branch** | **1024**   |  **1,474.7 ns** |  **1.04** |    **0.00** |     **328 B** |        **1.14** |
| EncryptCbc      | main   | 1024   |  1,419.7 ns |  1.00 |    0.00 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptCbcTwice | branch | 1024   |  2,503.5 ns |  0.94 |    0.00 |     328 B |        0.91 |
| EncryptCbcTwice | main   | 1024   |  2,651.7 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbc      | branch | 1024   |    624.8 ns |  1.07 |    0.01 |     328 B |        1.14 |
| DecryptCbc      | main   | 1024   |    581.4 ns |  1.00 |    0.00 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbcTwice | branch | 1024   |    745.3 ns |  0.76 |    0.00 |     328 B |        0.91 |
| DecryptCbcTwice | main   | 1024   |    978.6 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcb      | branch | 1024   |    595.3 ns |  1.02 |    0.00 |     328 B |        1.14 |
| EncryptEcb      | main   | 1024   |    583.9 ns |  1.00 |    0.00 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcbTwice | branch | 1024   |    764.7 ns |  0.76 |    0.00 |     328 B |        0.91 |
| EncryptEcbTwice | main   | 1024   |  1,003.0 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcb      | branch | 1024   |    594.8 ns |  1.02 |    0.02 |     328 B |        1.14 |
| DecryptEcb      | main   | 1024   |    585.6 ns |  1.00 |    0.03 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcbTwice | branch | 1024   |    763.0 ns |  0.78 |    0.00 |     328 B |        0.91 |
| DecryptEcbTwice | main   | 1024   |    972.6 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| **EncryptCbc**      | **branch** | **16384**  | **16,014.2 ns** |  **1.01** |    **0.00** |     **328 B** |        **1.14** |
| EncryptCbc      | main   | 16384  | 15,921.5 ns |  1.00 |    0.00 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptCbcTwice | branch | 16384  | 31,470.4 ns |  0.99 |    0.00 |     328 B |        0.91 |
| EncryptCbcTwice | main   | 16384  | 31,773.2 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbc      | branch | 16384  |  1,931.8 ns |  1.01 |    0.00 |     328 B |        1.14 |
| DecryptCbc      | main   | 16384  |  1,912.4 ns |  1.00 |    0.00 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptCbcTwice | branch | 16384  |  3,398.7 ns |  0.94 |    0.00 |     328 B |        0.91 |
| DecryptCbcTwice | main   | 16384  |  3,631.9 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcb      | branch | 16384  |  2,515.3 ns |  1.00 |    0.00 |     328 B |        1.14 |
| EncryptEcb      | main   | 16384  |  2,524.4 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| EncryptEcbTwice | branch | 16384  |  4,585.5 ns |  0.95 |    0.00 |     328 B |        0.91 |
| EncryptEcbTwice | main   | 16384  |  4,849.7 ns |  1.00 |    0.00 |     360 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcb      | branch | 16384  |  2,208.6 ns |  1.00 |    0.01 |     328 B |        1.14 |
| DecryptEcb      | main   | 16384  |  2,200.0 ns |  1.00 |    0.01 |     288 B |        1.00 |
|                 |        |        |             |       |         |           |             |
| DecryptEcbTwice | branch | 16384  |  4,008.6 ns |  0.94 |    0.00 |     328 B |        0.91 |
| DecryptEcbTwice | main   | 16384  |  4,277.2 ns |  1.00 |    0.00 |     360 B |        1.00 |
