### PR TITLE
Fix async resumption stub with byref parameters

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncResumptionStub.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncResumptionStub.cs
@@ -81,10 +81,18 @@ namespace ILCompiler
 
             foreach (var param in _targetMethod.Signature)
             {
-                var local = ilEmitter.NewLocal(param);
-                ilStream.EmitLdLoca(local);
-                ilStream.Emit(ILOpcode.initobj, ilEmitter.NewToken(param));
-                ilStream.EmitLdLoc(local);
+                if (param.IsByRef)
+                {
+                    ilStream.EmitLdc(0);
+                    ilStream.Emit(ILOpcode.conv_u);
+                }
+                else
+                {
+                    var local = ilEmitter.NewLocal(param);
+                    ilStream.EmitLdLoca(local);
+                    ilStream.Emit(ILOpcode.initobj, ilEmitter.NewToken(param));
+                    ilStream.EmitLdLoc(local);
+                }
             }
 
             ilStream.Emit(ILOpcode.call, ilEmitter.NewToken(_targetMethod));

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -15148,10 +15148,18 @@ CORINFO_METHOD_HANDLE CEEJitInfo::getAsyncResumptionStub(void** entryPoint)
     while ((ty = msig.NextArg()) != ELEMENT_TYPE_END)
     {
         TypeHandle tyHnd = msig.GetLastTypeHandleThrowing();
-        DWORD loc = pCode->NewLocal(LocalDesc(tyHnd));
-        pCode->EmitLDLOCA(loc);
-        pCode->EmitINITOBJ(pCode->GetToken(tyHnd));
-        pCode->EmitLDLOC(loc);
+        if (tyHnd.GetInternalCorElementType() == ELEMENT_TYPE_BYREF)
+        {
+            pCode->EmitLDC(0);
+            pCode->EmitCONV_U();
+        }
+        else
+        {
+            DWORD loc = pCode->NewLocal(LocalDesc(tyHnd));
+            pCode->EmitLDLOCA(loc);
+            pCode->EmitINITOBJ(pCode->GetToken(tyHnd));
+            pCode->EmitLDLOC(loc);
+        }
         numArgs++;
     }
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -15148,7 +15148,7 @@ CORINFO_METHOD_HANDLE CEEJitInfo::getAsyncResumptionStub(void** entryPoint)
     while ((ty = msig.NextArg()) != ELEMENT_TYPE_END)
     {
         TypeHandle tyHnd = msig.GetLastTypeHandleThrowing();
-        if (tyHnd.GetInternalCorElementType() == ELEMENT_TYPE_BYREF)
+        if (tyHnd.IsByRef())
         {
             pCode->EmitLDC(0);
             pCode->EmitCONV_U();

--- a/src/tests/async/byref-param/byref-param.cs
+++ b/src/tests/async/byref-param/byref-param.cs
@@ -45,5 +45,5 @@ public class Async2ByrefParam
         return DoAsync();
     }
 
-    static async Task DoAsync() => await Task.Yield();
+    private static async Task DoAsync() => await Task.Yield();
 }

--- a/src/tests/async/byref-param/byref-param.cs
+++ b/src/tests/async/byref-param/byref-param.cs
@@ -1,13 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
 
 public class Async2ByrefParam
 {
     [Fact]
-    public static int TestEntryPoint()
+    public static int TestByrefParam()
     {
         return Test().GetAwaiter().GetResult();
     }
@@ -22,4 +23,27 @@ public class Async2ByrefParam
         foo = 47;
         return Task.FromResult(53);
     }
+
+    [Fact]
+    public static int TestByrefParamWithSuspension()
+    {
+        return TestWithSuspension().GetAwaiter().GetResult();
+    }
+
+    private static async Task<int> TestWithSuspension()
+    {
+        await Verify(new string('a', 100), out int val);
+        return val;
+    }
+
+    // NoInlining ensures a suspension point in Verify
+    // (otherwise this would just tail-await)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Task Verify(string source, out int length)
+    {
+        length = source.Length;
+        return DoAsync();
+    }
+
+    static async Task DoAsync() => await Task.Yield();
 }


### PR DESCRIPTION
It is not valid IL to initialize a byref local with `initobj`. Just load the value of these directly.

We had a test for byref parameters, but it did not suspend and did not result in creation of a resumption stub. The test case requires suspension + NoInlining to guarantee a suspension point is created.

In ASP.NET's case it is [returning a `Task<VerifyResult>` from a `Task` returning function](https://github.com/dotnet/aspnetcore/blob/a6732b48f8e65c718cadbd2ee50d88222bcdf72e/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/ValidationsGeneratorTestBase.cs#L84-L92). This also requires a suspension point and resumption stub.

Fix #129990