### PR TITLE
JIT: unpin locals fed by non-GC typed values

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1222,6 +1222,12 @@ public:
 
     bool IsNotGcDef() const
     {
+        // A non-GC typed value (eg native int reinterpreted as byref) cannot designate a movable object.
+        if (!varTypeIsGC(TypeGet()))
+        {
+            return true;
+        }
+
         if (IsIntegralConst(0) || OperIs(GT_LCL_ADDR, GT_LCLHEAP))
         {
             return true;


### PR DESCRIPTION
Treat a non-GC typed def (eg a native int reinterpreted as a byref, as in a Span built from a pointer) as non-movable, so the pinned local can be unpinned. Fixes #129993.