### PR TITLE
JIT: fix asserts in fgRemoveUnreachableTry

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -5197,6 +5197,10 @@ BasicBlock* Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
         // Unlink this block from the bbNext chain
         fgUnlinkBlockForRemoval(block);
 
+        // Retarget any surviving EH region whose 'last' block was this one.
+        assert(bPrev != nullptr);
+        ehUpdateLastBlocks(block, bPrev);
+
         // At this point the bbPreds and bbRefs had better be zero
         noway_assert((block->bbRefs == 0) && (block->bbPreds == nullptr));
     }

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -1811,24 +1811,11 @@ void Compiler::fgDebugCheckTryFinallyExits()
 
 //------------------------------------------------------------------------
 // fgRemoveUnreachableTry: Remove EH regions whose try entry is not
-//    reachable from the method entry.
+//    reachable from the method entry, and any regions structurally
+//    enclosed in such regions.
 //
 // Returns:
 //    PhaseStatus indicating what, if anything, was changed.
-//
-// Notes:
-//    Walks the EH table; for each entry whose try entry is not in the DFS
-//    reachable set: retargets any callfinally pairs that target the handler
-//    to its continuation, unprotects every block in the try/filter/handler,
-//    clears stale tryIndex/hndIndex on those blocks, and drops the EH table
-//    entry. After all dead entries are dropped, recomputes the DFS and runs
-//    fgRemoveBlocksOutsideDfsTree to delete the now-unreachable blocks.
-//
-//    The standard DFS is EH-aware (AllSuccessorEnumerator visits EH
-//    successors), so try-reachability normally implies handler/filter
-//    reachability; the callfinally retargeting handles the case where
-//    finally-cloning has left live callfinally pairs into an otherwise-dead
-//    handler.
 //
 PhaseStatus Compiler::fgRemoveUnreachableTry()
 {
@@ -1863,9 +1850,6 @@ PhaseStatus Compiler::fgRemoveUnreachableTry()
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
-    // Compute DFS if the caller didn't supply one; the EH-aware DFS makes
-    // try-reachability imply handler/filter reachability for the common case.
-    //
     bool ownsDfs = false;
     if (m_dfsTree == nullptr)
     {
@@ -1873,8 +1857,11 @@ PhaseStatus Compiler::fgRemoveUnreachableTry()
         ownsDfs   = true;
     }
 
-    // PASS 1: For each dead-try region, retarget any callfinally pairs that
-    // target the handler so the now-dead handler has no live preds.
+    BitVecTraits traits(compHndBBtabCount, this);
+    BitVec       markedDead(BitVecOps::MakeEmpty(&traits));
+
+    // PASS 1: directly-dead regions (try entry not in DFS); retarget any
+    // callfinally pairs targeting the now-dead handler.
     //
     bool foundDead = false;
 
@@ -1889,16 +1876,9 @@ PhaseStatus Compiler::fgRemoveUnreachableTry()
             continue;
         }
 
+        BitVecOps::AddElemD(&traits, markedDead, XTnum);
         foundDead = true;
         JITDUMP("EH#%u try entry " FMT_BB " is unreachable.\n", XTnum, tryBeg->bbNum);
-
-        // Filters are only reached via EH-succ from try blocks, so an
-        // unreachable try implies an unreachable filter.
-        //
-        if (HBtab->HasFilter())
-        {
-            assert(!m_dfsTree->Contains(HBtab->ebdFilter));
-        }
 
         if (HBtab->HasFinallyHandler())
         {
@@ -1931,10 +1911,6 @@ PhaseStatus Compiler::fgRemoveUnreachableTry()
                 }
             }
         }
-
-        // Non-finally handlers can stay DFS-reachable via two-pass EH
-        // dispatch from an outer filter; PASS 3's EH-entry removal + PASS 4's
-        // DFS rebuild will make them unreachable.
     }
 
     if (!foundDead)
@@ -1947,16 +1923,38 @@ PhaseStatus Compiler::fgRemoveUnreachableTry()
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
-    // PASS 2: Unprotect blocks in dead regions and drop the artificial
-    // bbRefs on handler/filter entries so the dead-block pass can remove them.
+    // Close `markedDead` under structural containment. EH entries are stored
+    // inner-first so an enclosing region has a higher index; a single
+    // high-to-low pass propagates death inward.
     //
-    for (unsigned XTnum = 0; XTnum < compHndBBtabCount; XTnum++)
+    for (int XTnum = (int)compHndBBtabCount - 1; XTnum >= 0; XTnum--)
     {
-        EHblkDsc* const HBtab = &compHndBBtab[XTnum];
-        if (m_dfsTree->Contains(HBtab->ebdTryBeg))
+        if (BitVecOps::IsMember(&traits, markedDead, (unsigned)XTnum))
         {
             continue;
         }
+        EHblkDsc* const HBtab = &compHndBBtab[XTnum];
+        const unsigned  encT  = HBtab->ebdEnclosingTryIndex;
+        const unsigned  encH  = HBtab->ebdEnclosingHndIndex;
+        if (((encT != EHblkDsc::NO_ENCLOSING_INDEX) && BitVecOps::IsMember(&traits, markedDead, encT)) ||
+            ((encH != EHblkDsc::NO_ENCLOSING_INDEX) && BitVecOps::IsMember(&traits, markedDead, encH)))
+        {
+            BitVecOps::AddElemD(&traits, markedDead, (unsigned)XTnum);
+            JITDUMP("EH#%u is transitively dead (enclosed in a dead region).\n", XTnum);
+        }
+    }
+
+    // PASS 2: unprotect blocks in dead regions; drop artificial handler/filter refs.
+    //
+    unsigned removedCount = 0;
+    for (unsigned XTnum = 0; XTnum < compHndBBtabCount; XTnum++)
+    {
+        if (!BitVecOps::IsMember(&traits, markedDead, XTnum))
+        {
+            continue;
+        }
+
+        EHblkDsc* const HBtab = &compHndBBtab[XTnum];
 
         for (BasicBlock* const block : Blocks(HBtab->ebdTryBeg, HBtab->ebdTryLast))
         {
@@ -1982,38 +1980,35 @@ PhaseStatus Compiler::fgRemoveUnreachableTry()
             assert(HBtab->ebdFilter->bbRefs >= 1);
             HBtab->ebdFilter->bbRefs--;
         }
+
+        removedCount++;
     }
 
-    // PASS 3: Drop the EH table entries for the dead regions, clearing the
-    // try/hnd index on any block still claimed by them so fgRemoveEHTableEntry
-    // is satisfied.
+    // PASS 3: clear stale tryIndex/hndIndex on blocks claiming a dead region,
+    // then drop EH entries highest-to-lowest so indices below remain valid.
     //
-    unsigned removedCount = 0;
-    for (unsigned XTnum = 0; XTnum < compHndBBtabCount;)
+    for (BasicBlock* const block : Blocks())
     {
-        EHblkDsc* const HBtab = &compHndBBtab[XTnum];
-        if (m_dfsTree->Contains(HBtab->ebdTryBeg))
+        if (block->hasTryIndex() && BitVecOps::IsMember(&traits, markedDead, block->getTryIndex()))
         {
-            XTnum++;
+            block->clearTryIndex();
+        }
+        if (block->hasHndIndex() && BitVecOps::IsMember(&traits, markedDead, block->getHndIndex()))
+        {
+            block->clearHndIndex();
+        }
+    }
+
+    for (int XTnum = (int)compHndBBtabCount - 1; XTnum >= 0; XTnum--)
+    {
+        if (!BitVecOps::IsMember(&traits, markedDead, (unsigned)XTnum))
+        {
             continue;
         }
 
-        for (BasicBlock* const block : Blocks())
-        {
-            if (block->hasTryIndex() && block->getTryIndex() == XTnum)
-            {
-                block->clearTryIndex();
-            }
-            if (block->hasHndIndex() && block->getHndIndex() == XTnum)
-            {
-                block->clearHndIndex();
-            }
-        }
-
-        JITDUMP("Dropping EH#%u (try entry " FMT_BB ")\n", XTnum, HBtab->ebdTryBeg->bbNum);
-        fgUpdateACDsBeforeEHTableEntryRemoval(XTnum);
-        fgRemoveEHTableEntry(XTnum);
-        removedCount++;
+        JITDUMP("Dropping EH#%u (try entry " FMT_BB ")\n", XTnum, compHndBBtab[XTnum].ebdTryBeg->bbNum);
+        fgUpdateACDsBeforeEHTableEntryRemoval((unsigned)XTnum);
+        fgRemoveEHTableEntry((unsigned)XTnum);
     }
 
     // PASS 4: Rebuild the DFS; PASS 1 and PASS 3 both invalidate it.

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129970/Runtime_129970.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129970/Runtime_129970.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Runtime_129970;
+
+public class C
+{
+    public int F1;
+    public int F2;
+    public int F3;
+}
+
+public static class Runtime_129970
+{
+    public static C s_obj = new C();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int NeverTwo() => 99;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int M(C c, int x)
+    {
+        try
+        {
+            c.F1 = x;
+        }
+        finally
+        {
+            switch (NeverTwo())
+            {
+                case 0:
+                    c.F1 = 1;
+                    break;
+                case 1:
+                    c.F1 = 2;
+                    break;
+                case 2:
+                    try
+                    {
+                        c.F1 = 3;
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            c.F2 = 4;
+                        }
+                        finally
+                        {
+                            c.F3 = 5;
+                        }
+                    }
+                    break;
+                default:
+                    c.F1 = 6;
+                    break;
+            }
+        }
+
+        return x + 1;
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return M(s_obj, 99) == 100 ? 100 : -1;
+    }
+}
+
+

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129971/Runtime_129971.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129971/Runtime_129971.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Runtime_129971;
+
+public struct S0
+{
+    public bool F0;
+}
+
+public static class Runtime_129971
+{
+    public static bool s_9;
+    public static bool s_flag;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static uint M4() => 0u;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int M(int[] arr)
+    {
+        S0 var4 = default(S0);
+        try
+        {
+            if (var4.F0)
+            {
+                try
+                {
+                    M4();
+                }
+                finally
+                {
+                    try
+                    {
+                        M4();
+                        arr[0] = 1;
+                    }
+                    catch (System.Exception)
+                    {
+                    }
+                }
+            }
+        }
+        catch (System.Exception) when (s_flag)
+        {
+        }
+
+        return 100;
+    }
+
+    [Fact]
+    public static int TestEntryPoint() => M(new int[1]);
+}
+
+
+

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129972/Runtime_129972.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129972/Runtime_129972.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Runtime_129972;
+
+public static class Runtime_129972
+{
+    public static bool s_6;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int M()
+    {
+        sbyte var0  = default(sbyte);
+        ulong[] var6  = default(ulong[]);
+        sbyte[] var18 = default(sbyte[]);
+        bool var5  = true;
+        try
+        {
+            if (var5)
+            {
+                return 100;
+            }
+
+            try
+            {
+                var0 = var0;
+            }
+            catch (System.Exception)
+            {
+                try
+                {
+                    try
+                    {
+                        var6[0] = var6[0];
+                    }
+                    finally
+                    {
+                        var18[0] = var0;
+                    }
+                }
+                catch (System.Exception) when (s_6)
+                {
+                }
+            }
+        }
+        catch (System.Exception) when (var5)
+        {
+        }
+
+        return -1;
+    }
+
+    [Fact]
+    public static int TestEntryPoint() => M();
+}
+
+
+

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -106,6 +106,9 @@
     <Compile Include="JitBlue\Runtime_129176\Runtime_129176.cs" />
     <Compile Include="JitBlue\Runtime_129527\Runtime_129527.cs" />
     <Compile Include="JitBlue\Runtime_129642\Runtime_129642.cs" />
+    <Compile Include="JitBlue\Runtime_129970\Runtime_129970.cs" />
+    <Compile Include="JitBlue\Runtime_129971\Runtime_129971.cs" />
+    <Compile Include="JitBlue\Runtime_129972\Runtime_129972.cs" />
     <Compile Include="JitBlue\Runtime_10337\Runtime_10337.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />


### PR DESCRIPTION
Ensure apparently reachable regions enclosed in an unreachable region are also correctly removed. Consistently update region ends when fgRemoveBlock removes an unreachable block.

Fixes #129970, #129971, #129972.