### PR TITLE
Clear some stale GTF_ORDER_SIDEEFF flags

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3647,7 +3647,7 @@ void Compiler::fgDebugCheckFlagsHelper(GenTree* tree, GenTreeFlags actualFlags, 
         //
         GenTreeFlags flagsToCheck = ~GTF_GLOB_REF;
 
-        // GTF_ORDER_SIDEEFF is stale if set set on a node whose oper does not support it,
+        // GTF_ORDER_SIDEEFF is stale if set on a node whose oper does not support it,
         // and whose children do not have it set
         if (tree->OperSupportsOrderingSideEffect())
         {

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3643,9 +3643,15 @@ void Compiler::fgDebugCheckFlagsHelper(GenTree* tree, GenTreeFlags actualFlags, 
     }
     else if (actualFlags & ~expectedFlags)
     {
-        // We can't/don't consider these flags (GTF_GLOB_REF or GTF_ORDER_SIDEEFF) as being "extra" flags
+        // We can't/don't consider GTF_GLOB_REF as being "extra" flags
         //
-        GenTreeFlags flagsToCheck = ~GTF_GLOB_REF & ~GTF_ORDER_SIDEEFF;
+        GenTreeFlags flagsToCheck = ~GTF_GLOB_REF;
+
+        // GTF_ORDER_SIDEEFF is a valid flag on a node whose oper supports it, or on a node that has a SIDE EFF child
+        if (tree->OperSupportsOrderingSideEffect())
+        {
+            flagsToCheck &= ~GTF_ORDER_SIDEEFF;
+        }
 
         if (tree->isIndir() && tree->AsIndir()->Addr()->IsIconHandle(GTF_ICON_FTN_ADDR))
         {

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3647,7 +3647,8 @@ void Compiler::fgDebugCheckFlagsHelper(GenTree* tree, GenTreeFlags actualFlags, 
         //
         GenTreeFlags flagsToCheck = ~GTF_GLOB_REF;
 
-        // GTF_ORDER_SIDEEFF is a valid flag on a node whose oper supports it, or on a node that has a SIDE EFF child
+        // GTF_ORDER_SIDEEFF is stale if set set on a node whose oper does not support it,
+        // and whose children do not have it set
         if (tree->OperSupportsOrderingSideEffect())
         {
             flagsToCheck &= ~GTF_ORDER_SIDEEFF;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11786,17 +11786,17 @@ void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
             // and whose children do not have ordering side effects, should not have the ordering side effect flag set.
             if (((tree->gtFlags & GTF_ORDER_SIDEEFF) != 0) && !tree->OperSupportsOrderingSideEffect())
             {
-                bool childHasOrderingSideEffect = false;
-                tree->VisitOperands([&childHasOrderingSideEffect](GenTree* operand) -> GenTree::VisitResult {
+                bool hasChildWithOrderSideEff = false;
+                tree->VisitOperands([&hasChildWithOrderSideEff](GenTree* operand) -> GenTree::VisitResult {
                     if ((operand->gtFlags & GTF_ORDER_SIDEEFF) != 0)
                     {
-                        childHasOrderingSideEffect = true;
+                        hasChildWithOrderSideEff = true;
                         return GenTree::VisitResult::Abort;
                     }
                     return GenTree::VisitResult::Continue;
                 });
 
-                if (!childHasOrderingSideEffect)
+                if (!hasChildWithOrderSideEff)
                 {
                     tree->gtFlags &= ~GTF_ORDER_SIDEEFF;
                 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11810,7 +11810,7 @@ void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
 //    tree            - Tree to update the side effects on
 //
 // Notes:
-//    This method currently only updates GTF_EXCEPT, GTF_ASG, and GTF_CALL flags.
+//    This method currently only updates GTF_EXCEPT, GTF_ASG, GTF_CALL, and GTF_ORDER_SIDEEFF flags.
 //    The other side effect flags may remain unnecessarily (conservatively) set.
 //    The caller of this method is expected to update the flags based on the children's flags.
 //
@@ -11845,6 +11845,13 @@ void Compiler::gtUpdateNodeOperSideEffects(GenTree* tree)
     else
     {
         tree->gtFlags &= ~GTF_CALL;
+    }
+
+    // Clear stale side effect flags here.  This is safe as
+    // callers are expected to recalculate this flag based on tree's children
+    if (((tree->gtFlags & GTF_ORDER_SIDEEFF) != 0) && !tree->OperSupportsOrderingSideEffect())
+    {
+        tree->gtFlags &= ~GTF_ORDER_SIDEEFF;
     }
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11781,6 +11781,27 @@ void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
                 tree->gtFlags |= GTF_IND_NONFAULTING;
             }
 
+            // Clear stale order-side-effect bits.
+            // A node whose oper does not itself support ordering side effects,
+            // and whose children do not have ordering side effects, should not have the ordering side effect flag set.
+            if (((tree->gtFlags & GTF_ORDER_SIDEEFF) != 0) && !tree->OperSupportsOrderingSideEffect())
+            {
+                bool childHasOrderingSideEffect = false;
+                tree->VisitOperands([&childHasOrderingSideEffect](GenTree* operand) -> GenTree::VisitResult {
+                    if ((operand->gtFlags & GTF_ORDER_SIDEEFF) != 0)
+                    {
+                        childHasOrderingSideEffect = true;
+                        return GenTree::VisitResult::Abort;
+                    }
+                    return GenTree::VisitResult::Continue;
+                });
+
+                if (!childHasOrderingSideEffect)
+                {
+                    tree->gtFlags &= ~GTF_ORDER_SIDEEFF;
+                }
+            }
+
             // Then update the parent's side effects based on this node.
             if (user != nullptr)
             {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11754,7 +11754,7 @@ void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
             // Attempt to clear stale SIDEEFF bits
             // if this node does indeed need GTF_ORDER_SIDEEFF, then the bit will later be propagated up and re-set
             // during the child's post-order visit
-            if (!tree->OperSupportsOrderingSideEffect())
+            if (((tree->gtFlags & GTF_ORDER_SIDEEFF) != 0) && !tree->OperSupportsOrderingSideEffect())
             {
                 tree->gtFlags &= ~GTF_ORDER_SIDEEFF;
             }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11750,6 +11750,15 @@ void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
         {
             GenTree* tree = *use;
             tree->gtFlags &= ~(GTF_ASG | GTF_CALL | GTF_EXCEPT);
+
+            // Attempt to clear stale SIDEEFF bits
+            // if this node does indeed need GTF_ORDER_SIDEEFF, then the bit will later be propagated up and re-set
+            // during the child's post-order visit
+            if (!tree->OperSupportsOrderingSideEffect())
+            {
+                tree->gtFlags &= ~GTF_ORDER_SIDEEFF;
+            }
+
             return WALK_CONTINUE;
         }
 
@@ -11779,27 +11788,6 @@ void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
             if (tree->OperIsIndirOrArrMetaData() && ((tree->gtFlags & GTF_EXCEPT) == 0))
             {
                 tree->gtFlags |= GTF_IND_NONFAULTING;
-            }
-
-            // Clear stale order-side-effect bits.
-            // A node whose oper does not itself support ordering side effects,
-            // and whose children do not have ordering side effects, should not have the ordering side effect flag set.
-            if (((tree->gtFlags & GTF_ORDER_SIDEEFF) != 0) && !tree->OperSupportsOrderingSideEffect())
-            {
-                bool hasChildWithOrderSideEff = false;
-                tree->VisitOperands([&hasChildWithOrderSideEff](GenTree* operand) -> GenTree::VisitResult {
-                    if ((operand->gtFlags & GTF_ORDER_SIDEEFF) != 0)
-                    {
-                        hasChildWithOrderSideEff = true;
-                        return GenTree::VisitResult::Abort;
-                    }
-                    return GenTree::VisitResult::Continue;
-                });
-
-                if (!hasChildWithOrderSideEff)
-                {
-                    tree->gtFlags &= ~GTF_ORDER_SIDEEFF;
-                }
             }
 
             // Then update the parent's side effects based on this node.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11863,7 +11863,7 @@ void Compiler::gtUpdateNodeOperSideEffects(GenTree* tree)
 //    tree            - Tree to update the side effects on
 //
 // Notes:
-//    This method currently only updates GTF_EXCEPT, GTF_ASG, and GTF_CALL flags.
+//    This method currently only updates GTF_EXCEPT, GTF_ASG, GTF_CALL, and GTF_ORDER_SIDEEFF flags.
 //    The other side effect flags may remain unnecessarily (conservatively) set.
 //
 void Compiler::gtUpdateNodeSideEffects(GenTree* tree)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11751,8 +11751,8 @@ void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
             GenTree* tree = *use;
             tree->gtFlags &= ~(GTF_ASG | GTF_CALL | GTF_EXCEPT);
 
-            // Attempt to clear stale SIDEEFF bits
-            // if this node does indeed need GTF_ORDER_SIDEEFF, then the bit will later be propagated up and re-set
+            // Attempt to clear stale GTF_ORDER_SIDEEFF bits
+            // If this node does indeed need GTF_ORDER_SIDEEFF, then the bit will later be propagated up and re-set
             // during the child's post-order visit
             if (((tree->gtFlags & GTF_ORDER_SIDEEFF) != 0) && !tree->OperSupportsOrderingSideEffect())
             {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2160,6 +2160,10 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         call->gtFlags &= ~GTF_EXCEPT;
     }
 
+    // Calls themselves don't originate an ordering side effect.
+    // Instead, derive it from the call args via flagsSummary
+    call->gtFlags &= ~GTF_ORDER_SIDEEFF;
+
     // Union in the side effect flags from the call's operands
     call->gtFlags |= flagsSummary & GTF_ALL_EFFECT;
 


### PR DESCRIPTION
Clear stale `GTF_ORDER_SIDEEFF` flags to enable more if-conversion and optimize bools.

Motivating example was `o.GetType() == typeof(int) || o.GetType() == typeof(uint) || o.GetType() == typeof(long)` - we couldn't combine into `OR` because leftover side effect bit in one of the blocks.

If an op doesn't itself support side effects, and none of node's children have the bit, then the node may have the bit cleared.

Diffs show more optimize bools+if conversion taking place.
One of the bad diffs was block layout changing and causing LSRA to spill slightly different.
Another bad diff exposed an issue where edge-likelihoods weren't recalculated properly after optimize bools, and caused perfscore to balloon.  I'm working on a fix for that seperately.