### PR TITLE
Remove extra x86 unwind from DBI

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -718,9 +718,6 @@ public:
     // Return the stack parameter size of the given method.
     ULONG32 GetStackParameterSize(EECodeInfo * pCodeInfo);
 
-    // Return the FramePointer of the current frame at which the stackwalker is stopped.
-    HRESULT STDMETHODCALLTYPE GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal);
-
     FramePointer GetFramePointerWorker(StackFrameIterator * pIter);
 
     // Return TRUE if the specified CONTEXT is the CONTEXT of the leaf frame.

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -638,18 +638,16 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStackParameterSize(CORDB_ADDRE
 }
 
 #ifdef TARGET_X86
-static FramePointer ComputeX86FramePointer(CrawlFrame * pCF, T_CONTEXT * pSourceContext)
+static FramePointer ComputeX86FramePointer(T_CONTEXT * pSourceContext)
 {
-    REGDISPLAY * pRD = pCF->GetRegisterSet();
-
     T_CONTEXT tempContext;
     CopyOSContext(&tempContext, pSourceContext);
-    pCF->GetCodeManager()->UnwindStackFrame(&tempContext);
 
     EECodeInfo codeInfo;
-    codeInfo.Init(pRD->pCurrentContext->Eip);
+    codeInfo.Init(pSourceContext->Eip);
+    codeInfo.GetCodeManager()->UnwindStackFrame(&tempContext);
 
-    LPVOID PCTAddr = tempContext.Esp - codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo) - sizeof(DWORD);
+    UINT_PTR PCTAddr = tempContext.Esp - codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo) - sizeof(DWORD);
     return FramePointer::MakeFramePointer(PCTAddr);
 }
 #endif // TARGET_X86
@@ -668,7 +666,7 @@ FramePointer DacDbiInterfaceImpl::GetFramePointerWorker(StackFrameIterator * pIt
         case StackFrameIterator::SFITER_FRAMELESS_METHOD:
         {
 #ifdef TARGET_X86
-            fp = ComputeX86FramePointer(pCF, pRD->pCurrentContext);
+            fp = ComputeX86FramePointer(pRD->pCurrentContext);
 #else
             fp = FramePointer::MakeFramePointer(GetRegdisplayStackMark(pRD));
 #endif
@@ -683,9 +681,11 @@ FramePointer DacDbiInterfaceImpl::GetFramePointerWorker(StackFrameIterator * pIt
         case StackFrameIterator::SFITER_INITIAL_NATIVE_CONTEXT:
         {
 #ifdef TARGET_X86
-            // We only get here if we are unwinding a runtime-unwindable stub.
-            // So first we need to unwind the stub to get to the caller frame, and then we can get the frame pointer from that.
-            fp = ComputeX86FramePointer(pCF, RetrieveHijackedContext(pRD));
+            // We only get here if we are unwinding a runtime-unwindable stub.  RetrieveHijackedContext already
+            // returns the context the stub unwinds to, so we take the stack address of its return address directly.
+            T_CONTEXT * pHijackedContext = RetrieveHijackedContext(pRD);
+            UINT_PTR PCTAddr = pHijackedContext->Esp - sizeof(DWORD);
+            fp = FramePointer::MakeFramePointer(PCTAddr);
 #else
             fp = FramePointer::MakeFramePointer(GetRegdisplayStackMark(pRD));
 #endif

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -637,23 +637,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStackParameterSize(CORDB_ADDRE
     return hr;
 }
 
-// Return the FramePointer of the current frame at which the stackwalker is stopped.
-HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal)
-{
-    DD_ENTER_MAY_THROW;
-
-    HRESULT hr = S_OK;
-    EX_TRY
-    {
-
-        StackFrameIterator * pIter = GetIteratorFromHandle(pSFIHandle);
-        *pRetVal = GetFramePointerWorker(pIter);
-    }
-    EX_CATCH_HRESULT(hr);
-    return hr;
-}
-
-// Internal helper for GetFramePointer.
+// Internal helper for GetStackWalkCurrentFrameInfo.
 FramePointer DacDbiInterfaceImpl::GetFramePointerWorker(StackFrameIterator * pIter)
 {
     CrawlFrame * pCF = &(pIter->m_crawl);
@@ -665,8 +649,21 @@ FramePointer DacDbiInterfaceImpl::GetFramePointerWorker(StackFrameIterator * pIt
         // For managed methods, we have the full CONTEXT.  Additionally, we also have the caller CONTEXT
         // on WIN64.
         case StackFrameIterator::SFITER_FRAMELESS_METHOD:
+        {
+#ifdef TARGET_X86
+            // physical unwind
+            T_CONTEXT tempContext;
+            CopyOSContext(&tempContext, pRD->pCurrentContext);
+            pCF->GetCodeManager()->UnwindStackFrame(&tempContext);
+            EECodeInfo tempCodeInfo;
+            tempCodeInfo.Init(tempContext.Eip);
+            LPVOID PCTAddr = tempContext.Esp - tempCodeInfo.GetCodeManager()->GetStackParameterSize(&tempCodeInfo) - sizeof(DWORD);
+            fp = FramePointer::MakeFramePointer(PCTAddr);
+#else
             fp = FramePointer::MakeFramePointer(GetRegdisplayStackMark(pRD));
+#endif
             break;
+        }
 
         // In these cases, we only have the full CONTEXT, not the caller CONTEXT.
         case StackFrameIterator::SFITER_NATIVE_MARKER_FRAME:
@@ -674,8 +671,23 @@ FramePointer DacDbiInterfaceImpl::GetFramePointerWorker(StackFrameIterator * pIt
             // fall through
             //
         case StackFrameIterator::SFITER_INITIAL_NATIVE_CONTEXT:
+        {
+#ifdef TARGET_X86
+            // We only get here if we are unwinding a runtime-unwindable stub.
+            // So first we need to unwind the stub to get to the caller frame, and then we can get the frame pointer from that.
+            T_CONTEXT * pContext = RetrieveHijackedContext(pRD);
+            T_CONTEXT tempContext;
+            CopyOSContext(&tempContext, pContext);
+            pCF->GetCodeManager()->UnwindStackFrame(&tempContext);
+            EECodeInfo tempCodeInfo;
+            tempCodeInfo.Init(tempContext.Eip);
+            LPVOID PCTAddr = tempContext.Esp - tempCodeInfo.GetCodeManager()->GetStackParameterSize(&tempCodeInfo) - sizeof(DWORD);
+            fp = FramePointer::MakeFramePointer(PCTAddr);
+#else
             fp = FramePointer::MakeFramePointer(GetRegdisplayStackMark(pRD));
+#endif
             break;
+        }
 
         // In these cases, we use the address of the explicit frame as the frame marker.
         case StackFrameIterator::SFITER_FRAME_FUNCTION:

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -637,6 +637,23 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStackParameterSize(CORDB_ADDRE
     return hr;
 }
 
+#ifdef TARGET_X86
+static FramePointer ComputeX86FramePointer(CrawlFrame * pCF, T_CONTEXT * pSourceContext)
+{
+    REGDISPLAY * pRD = pCF->GetRegisterSet();
+
+    T_CONTEXT tempContext;
+    CopyOSContext(&tempContext, pSourceContext);
+    pCF->GetCodeManager()->UnwindStackFrame(&tempContext);
+
+    EECodeInfo codeInfo;
+    codeInfo.Init(pRD->pCurrentContext->Eip);
+
+    LPVOID PCTAddr = tempContext.Esp - codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo) - sizeof(DWORD);
+    return FramePointer::MakeFramePointer(PCTAddr);
+}
+#endif // TARGET_X86
+
 // Internal helper for GetStackWalkCurrentFrameInfo.
 FramePointer DacDbiInterfaceImpl::GetFramePointerWorker(StackFrameIterator * pIter)
 {
@@ -651,14 +668,7 @@ FramePointer DacDbiInterfaceImpl::GetFramePointerWorker(StackFrameIterator * pIt
         case StackFrameIterator::SFITER_FRAMELESS_METHOD:
         {
 #ifdef TARGET_X86
-            // physical unwind
-            T_CONTEXT tempContext;
-            CopyOSContext(&tempContext, pRD->pCurrentContext);
-            pCF->GetCodeManager()->UnwindStackFrame(&tempContext);
-            EECodeInfo tempCodeInfo;
-            tempCodeInfo.Init(tempContext.Eip);
-            LPVOID PCTAddr = tempContext.Esp - tempCodeInfo.GetCodeManager()->GetStackParameterSize(&tempCodeInfo) - sizeof(DWORD);
-            fp = FramePointer::MakeFramePointer(PCTAddr);
+            fp = ComputeX86FramePointer(pCF, pRD->pCurrentContext);
 #else
             fp = FramePointer::MakeFramePointer(GetRegdisplayStackMark(pRD));
 #endif
@@ -675,14 +685,7 @@ FramePointer DacDbiInterfaceImpl::GetFramePointerWorker(StackFrameIterator * pIt
 #ifdef TARGET_X86
             // We only get here if we are unwinding a runtime-unwindable stub.
             // So first we need to unwind the stub to get to the caller frame, and then we can get the frame pointer from that.
-            T_CONTEXT * pContext = RetrieveHijackedContext(pRD);
-            T_CONTEXT tempContext;
-            CopyOSContext(&tempContext, pContext);
-            pCF->GetCodeManager()->UnwindStackFrame(&tempContext);
-            EECodeInfo tempCodeInfo;
-            tempCodeInfo.Init(tempContext.Eip);
-            LPVOID PCTAddr = tempContext.Esp - tempCodeInfo.GetCodeManager()->GetStackParameterSize(&tempCodeInfo) - sizeof(DWORD);
-            fp = FramePointer::MakeFramePointer(PCTAddr);
+            fp = ComputeX86FramePointer(pCF, RetrieveHijackedContext(pRD));
 #else
             fp = FramePointer::MakeFramePointer(GetRegdisplayStackMark(pRD));
 #endif

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -6386,12 +6386,6 @@ private:
 
     // cached flag used for refreshing a CordbStackWalk
     CorDebugSetContextFlag m_cachedSetContextFlag;
-
-    // We unwind one frame ahead of time to get the FramePointer on x86.
-    // These fields are used for the bookkeeping.
-    RSSmartPtr<CordbFrame> m_pCachedFrame;
-    HRESULT m_cachedHR;
-    bool m_fIsOneFrameAhead;
 };
 
 

--- a/src/coreclr/debug/di/rsstackwalk.cpp
+++ b/src/coreclr/debug/di/rsstackwalk.cpp
@@ -194,8 +194,7 @@ void CordbStackWalk::RefreshIfNeeded()
     // check if we need to refresh
     if (m_lastSyncFlushCounter != pProcess->m_flushCounter)
     {
-        // Make a local copy of the CONTEXT here.  DeleteAll() will delete the CONTEXT on the cached frame,
-        // and CreateStackWalk() actually uses the CONTEXT buffer we pass to it.
+        // Make a local copy of the CONTEXT here.
         DT_CONTEXT ctx = m_context;
 
         // clear all the state
@@ -418,7 +417,7 @@ HRESULT CordbStackWalk::Next()
             ThrowHR(CORDBG_E_PAST_END_OF_STACK);
         }
 
-        // update the cahced flag to indicate that we have reached an unwind CONTEXT
+        // update the cached flag to indicate that we have reached an unwind CONTEXT
         m_cachedSetContextFlag = SET_CONTEXT_FLAG_UNWIND_FRAME;
 
         if (UnwindStackFrame())

--- a/src/coreclr/debug/di/rsstackwalk.cpp
+++ b/src/coreclr/debug/di/rsstackwalk.cpp
@@ -25,11 +25,8 @@ CordbStackWalk::CordbStackWalk(CordbThread * pCordbThread)
   : CordbBase(pCordbThread->GetProcess(), 0, enumCordbStackWalk),
     m_pCordbThread(pCordbThread),
     m_pSFIHandle(NULL),
-    m_cachedSetContextFlag(SET_CONTEXT_FLAG_ACTIVE_FRAME),
-    m_cachedHR(S_OK),
-    m_fIsOneFrameAhead(false)
+    m_cachedSetContextFlag(SET_CONTEXT_FLAG_ACTIVE_FRAME)
 {
-    m_pCachedFrame.Clear();
 }
 
 void CordbStackWalk::Init()
@@ -136,11 +133,6 @@ void CordbStackWalk::DeleteAll()
         SIMPLIFYING_ASSUMPTION_SUCCEEDED(hr);
         m_pSFIHandle = NULL;
     }
-
-    // clear out the cached frame
-    m_pCachedFrame.Clear();
-    m_cachedHR = S_OK;
-    m_fIsOneFrameAhead = false;
 }
 
 //---------------------------------------------------------------------------------------
@@ -204,15 +196,7 @@ void CordbStackWalk::RefreshIfNeeded()
     {
         // Make a local copy of the CONTEXT here.  DeleteAll() will delete the CONTEXT on the cached frame,
         // and CreateStackWalk() actually uses the CONTEXT buffer we pass to it.
-        DT_CONTEXT ctx;
-        if (m_fIsOneFrameAhead)
-        {
-            ctx = *(m_pCachedFrame->GetContext());
-        }
-        else
-        {
-            ctx = m_context;
-        }
+        DT_CONTEXT ctx = m_context;
 
         // clear all the state
         DeleteAll();
@@ -282,48 +266,27 @@ HRESULT CordbStackWalk::GetContext(ULONG32   contextFlags,
                 ThrowWin32(ERROR_INSUFFICIENT_BUFFER);
             }
 
-            // Check if we are one frame ahead.  If so, returned the CONTEXT on the cached frame.
-            if (m_fIsOneFrameAhead)
+            // We have to call the DDI.
+            IDacDbiInterface * pDAC = GetProcess()->GetDAC();
+
+            IDacDbiInterface::FrameType ft;
+            IfFailThrow(pDAC->GetStackWalkCurrentFrameInfo(m_pSFIHandle, NULL, &ft));
+            if (ft == IDacDbiInterface::kInvalid)
             {
-                if (m_pCachedFrame != NULL)
-                {
-                    const DT_CONTEXT * pSrcContext = m_pCachedFrame->GetContext();
-                    _ASSERTE(pSrcContext);
-                    CORDbgCopyThreadContext(pContext, pSrcContext);
-                }
-                else
-                {
-                    // We encountered a problem when we were trying to initialize the CordbNativeFrame.
-                    // However, the problem occurred after we have unwound the current frame.
-                    // What do we do here?  We don't have the CONTEXT anymore.
-                    _ASSERTE(FAILED(m_cachedHR));
-                    ThrowHR(m_cachedHR);
-                }
+                ThrowHR(E_FAIL);
+            }
+            else if (ft == IDacDbiInterface::kAtEndOfStack)
+            {
+                ThrowHR(CORDBG_E_PAST_END_OF_STACK);
+            }
+            else if (ft == IDacDbiInterface::kExplicitFrame)
+            {
+                ThrowHR(CORDBG_E_NO_CONTEXT_FOR_INTERNAL_FRAME);
             }
             else
             {
-                // No easy way out in this case.  We have to call the DDI.
-                IDacDbiInterface * pDAC = GetProcess()->GetDAC();
-
-                IDacDbiInterface::FrameType ft;
-                IfFailThrow(pDAC->GetStackWalkCurrentFrameInfo(m_pSFIHandle, NULL, &ft));
-                if (ft == IDacDbiInterface::kInvalid)
-                {
-                    ThrowHR(E_FAIL);
-                }
-                else if (ft == IDacDbiInterface::kAtEndOfStack)
-                {
-                    ThrowHR(CORDBG_E_PAST_END_OF_STACK);
-                }
-                else if (ft == IDacDbiInterface::kExplicitFrame)
-                {
-                    ThrowHR(CORDBG_E_NO_CONTEXT_FOR_INTERNAL_FRAME);
-                }
-                else
-                {
-                    // We always store the current CONTEXT, so just copy it into the buffer.
-                    CORDbgCopyThreadContext(pContext, &m_context);
-                }
+                // We always store the current CONTEXT, so just copy it into the buffer.
+                CORDbgCopyThreadContext(pContext, &m_context);
             }
         }
     }
@@ -375,11 +338,6 @@ void CordbStackWalk::SetContextWorker(CorDebugSetContextFlag flag, ULONG32 conte
     {
         ThrowWin32(ERROR_INSUFFICIENT_BUFFER);
     }
-
-    // invalidate the cache
-    m_pCachedFrame.Clear();
-    m_cachedHR = S_OK;
-    m_fIsOneFrameAhead = false;
 
     DT_CONTEXT * pSrcContext = reinterpret_cast<DT_CONTEXT *>(context);
 
@@ -450,40 +408,26 @@ HRESULT CordbStackWalk::Next()
     PUBLIC_REENTRANT_API_BEGIN(this)
     {
         RefreshIfNeeded();
-        if (m_fIsOneFrameAhead)
+
+        IDacDbiInterface * pDAC = GetProcess()->GetDAC();
+        IDacDbiInterface::FrameType ft = IDacDbiInterface::kInvalid;
+
+        IfFailThrow(pDAC->GetStackWalkCurrentFrameInfo(this->m_pSFIHandle, NULL, &ft));
+        if (ft == IDacDbiInterface::kAtEndOfStack)
         {
-            // We have already unwound to the next frame when we materialize the CordbNativeFrame
-            // for the current frame.  So we just need to clear the cache because we are already at
-            // the next frame.
-            if (m_pCachedFrame != NULL)
-            {
-                m_pCachedFrame.Clear();
-            }
-            m_cachedHR = S_OK;
-            m_fIsOneFrameAhead = false;
+            ThrowHR(CORDBG_E_PAST_END_OF_STACK);
+        }
+
+        // update the cahced flag to indicate that we have reached an unwind CONTEXT
+        m_cachedSetContextFlag = SET_CONTEXT_FLAG_UNWIND_FRAME;
+
+        if (UnwindStackFrame())
+        {
+            hr = S_OK;
         }
         else
         {
-            IDacDbiInterface * pDAC = GetProcess()->GetDAC();
-            IDacDbiInterface::FrameType ft = IDacDbiInterface::kInvalid;
-
-            IfFailThrow(pDAC->GetStackWalkCurrentFrameInfo(this->m_pSFIHandle, NULL, &ft));
-            if (ft == IDacDbiInterface::kAtEndOfStack)
-            {
-                ThrowHR(CORDBG_E_PAST_END_OF_STACK);
-            }
-
-            // update the cahced flag to indicate that we have reached an unwind CONTEXT
-            m_cachedSetContextFlag = SET_CONTEXT_FLAG_UNWIND_FRAME;
-
-            if (UnwindStackFrame())
-            {
-                hr = S_OK;
-            }
-            else
-            {
-                hr = CORDBG_S_AT_END_OF_STACK;
-            }
+            hr = CORDBG_S_AT_END_OF_STACK;
         }
     }
     PUBLIC_REENTRANT_API_END(hr);
@@ -525,17 +469,6 @@ HRESULT CordbStackWalk::GetFrame(ICorDebugFrame ** ppFrame)
     }
     PUBLIC_REENTRANT_API_END(hr);
 
-    if (FAILED(hr))
-    {
-        if (m_fIsOneFrameAhead && (m_pCachedFrame == NULL))
-        {
-            // We encountered a problem when we try to materialize a CordbNativeFrame.
-            // Cache the failure HR so that we can return it later if the caller
-            // calls GetFrame() again or GetContext().
-            m_cachedHR = hr;
-        }
-    }
-
     return hr;
 }
 
@@ -555,24 +488,6 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
     *ppFrame = NULL;
 
     RSInitHolder<CordbFrame> pResultFrame(NULL);
-
-    if (m_fIsOneFrameAhead)
-    {
-        if (m_pCachedFrame != NULL)
-        {
-            pResultFrame.Assign(m_pCachedFrame);
-            pResultFrame.TransferOwnershipExternal(ppFrame);
-            return S_OK;
-        }
-        else
-        {
-            // We encountered a problem when we were trying to initialize the CordbNativeFrame.
-            // However, the problem occurred after we have unwound the current frame.
-            // Whatever error code we return, it should be the same one GetContext() returns.
-            _ASSERTE(FAILED(m_cachedHR));
-            ThrowHR(m_cachedHR);
-        }
-    }
 
     IDacDbiInterface * pDAC = NULL;
     Debugger_STRData frameData;
@@ -627,18 +542,6 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
         _ASSERTE(frameData.eType == Debugger_STRData::cMethodFrame);
 
         HRESULT hr = S_OK;
-
-        // In order to find the FramePointer on x86, we need to unwind to the next frame.
-        // Technically, only x86 needs to do this, because the x86 runtime stackwalker doesn't uwnind
-        // one frame ahead of time.  However, we are doing this on all platforms to keep things simple.
-        BOOL fSuccess = UnwindStackFrame();
-        (void)fSuccess; //prevent "unused variable" error from GCC
-        _ASSERTE(fSuccess);
-
-        m_fIsOneFrameAhead = true;
-#if defined(TARGET_X86)
-        IfFailThrow(pDAC->GetFramePointer(m_pSFIHandle, &frameData.fp));
-#endif // TARGET_X86
 
         // currentFuncData contains general information about the method.
         // It has no information about any particular jitted instance of the method.
@@ -695,7 +598,6 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
                                                               &frameCtx);
 
         pResultFrame.Assign(static_cast<CordbFrame *>(pNativeFrame));
-        m_pCachedFrame.Assign(static_cast<CordbFrame *>(pNativeFrame));
 
         // @dbgtodo  dynamic language debugging
         // If we are dealing with a dynamic method (e.g. an IL stub, a LCG method, etc.),
@@ -811,18 +713,6 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
     {
         _ASSERTE(frameData.eType == Debugger_STRData::cRuntimeNativeFrame);
 
-        // In order to find the FramePointer on x86, we need to unwind to the next frame.
-        // Technically, only x86 needs to do this, because the x86 runtime stackwalker doesn't uwnind
-        // one frame ahead of time.  However, we are doing this on all platforms to keep things simple.
-        BOOL fSuccess = UnwindStackFrame();
-        (void)fSuccess; //prevent "unused variable" error from GCC
-        _ASSERTE(fSuccess);
-
-        m_fIsOneFrameAhead = true;
-#if defined(TARGET_X86)
-        IfFailThrow(pDAC->GetFramePointer(m_pSFIHandle, &frameData.fp));
-#endif // TARGET_X86
-
         // Lookup the appdomain that the thread was in when it was executing code for this frame. We pass this
         // to the frame when we create it so we can properly resolve locals in that frame later.
         CordbAppDomain * pCurrentAppDomain = GetProcess()->GetAppDomain();
@@ -834,7 +724,6 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
                                                                                       &frameCtx);
 
         pResultFrame.Assign(static_cast<CordbFrame *>(pRuntimeFrame));
-        m_pCachedFrame.Assign(static_cast<CordbFrame *>(pRuntimeFrame));
 
         STRESS_LOG2(LF_CORDB, LL_INFO1000, "CSW::GFW - runtime unwindable stack frame (%p): 0x%p",
                     this, pRuntimeFrame);

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -1230,31 +1230,6 @@ public:
     virtual HRESULT STDMETHODCALLTYPE GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal) = 0;
 
     //
-    // Get the FramePointer of the current frame where the stackwalker is stopped at.
-    //
-    // Arguments:
-    //    pSFIHandle - the handle to the stackwalker
-    //    pRetVal - [out] The FramePointer of the current frame.
-    //
-    // Return Value:
-    //    S_OK on success; otherwise, an appropriate failure HRESULT.
-    //
-    // Notes:
-    //    The FramePointer of a stack frame is:
-    //    the stack address of the return address on x86,
-    //    the current SP on AMD64,
-    //
-    //    On x86, to get the stack address of the return address, we need to unwind one more frame
-    //    and use the SP of the caller frame as the FramePointer of the callee frame.  This
-    //    function does NOT do that.  It just returns the SP.  The caller needs to handle the
-    //    unwinding.
-    //
-    //    The FramePointer of an explicit frame is just the stack address of the explicit frame.
-    //
-
-    virtual HRESULT STDMETHODCALLTYPE GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal) = 0;
-
-    //
     // Check whether the specified CONTEXT is the CONTEXT of the leaf frame.  This function doesn't care
     // whether the leaf frame is native or managed.
     //

--- a/src/coreclr/inc/dacdbi.idl
+++ b/src/coreclr/inc/dacdbi.idl
@@ -38,7 +38,7 @@ struct DacSharedReJitInfo;
 cpp_quote("#if 0")
 
 // FramePointer - wrapper around a single pointer (LPVOID m_sp in native code)
-// Passed by value in IsMatchingParentFrame, GetFramePointer, and the internal frame callback.
+// Passed by value in IsMatchingParentFrame and the internal frame callback.
 typedef struct { UINT_PTR m_sp; } FramePointer;
 
 // AsyncLocalData - struct passed by pointer to FP_ASYNC_LOCAL_CALLBACK.
@@ -281,7 +281,6 @@ interface IDacDbiInterface : IUnknown
     HRESULT GetCountOfInternalFrames([in] VMPTR_Thread vmThread, [out] ULONG32 * pRetVal);
     HRESULT EnumerateInternalFrames([in] VMPTR_Thread vmThread, [in] FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, [in] CALLBACK_DATA pUserData);
     HRESULT GetStackParameterSize([in] CORDB_ADDRESS controlPC, [out] ULONG32 * pRetVal);
-    HRESULT GetFramePointer([in] StackWalkHandle pSFIHandle, [out] FramePointer * pRetVal);
     HRESULT IsLeafFrame([in] VMPTR_Thread vmThread, [in] const DT_CONTEXT * pContext, [out] BOOL * pResult);
     HRESULT GetContext([in] VMPTR_Thread vmThread, [out] DT_CONTEXT * pContextBuffer);
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1820,17 +1820,6 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         return hr;
     }
 
-    public int GetFramePointer(nuint pSFIHandle, ulong* pRetVal)
-    {
-        if (pSFIHandle == 0)
-            return HResults.E_INVALIDARG;
-
-        nuint legacyHandle = TryGetLegacyHandle(pSFIHandle);
-        return _legacy is not null && LegacyFallbackHelper.CanFallback() && legacyHandle != 0
-            ? _legacy.GetFramePointer(legacyHandle, pRetVal)
-            : HResults.E_NOTIMPL;
-    }
-
     private static nuint TryGetLegacyHandle(nuint pSFIHandle)
     {
         try

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
@@ -584,9 +584,6 @@ public unsafe partial interface IDacDbiInterface
     int GetStackParameterSize(ulong controlPC, uint* pRetVal);
 
     [PreserveSig]
-    int GetFramePointer(nuint pSFIHandle, ulong* pRetVal);
-
-    [PreserveSig]
     int IsLeafFrame(ulong vmThread, byte* pContext, Interop.BOOL* pResult);
 
     [PreserveSig]


### PR DESCRIPTION
In the DBI, we unwind the stack walk one frame ahead when we need to generate a frame pointer on x86. This is because the frame pointer is derived from the caller context. I replaced this with inline physical unwind, and derived the frame pointer from the formula here: https://github.com/dotnet/runtime/blob/46b72c7c81592b429e062bacebe8d39f17362333/src/coreclr/vm/stackwalk.cpp#L375

We had unwound one ahead when we are on a runtime-unwindable or managed frame. In either case, we would unhijack the runtime-unwindable stub, or do one physical unwind, plus however many unwinds it took to get us to the next managed frame. Here, we stop after the first step to calculate the frame pointer. This is a behavioral change, if the caller is non-managed, but it should produce if anything more accurate / strictly ordered frame boundaries, especially in use cases such as `GetStackRange`.

The goal of this PR is to hide as much of the platform-specific details behind DacDbi as possible - we will no longer have to do a custom adjustment in DBI just for X86 targets. In addition, we consolidate the retrieval of general stack frame info into the DacDbi API `GetStackWalkCurrentFrameInfo`.