### PR TITLE
[clr-interp] Ensure initialization of MethodDesc->m_interpreterCode

### DIFF
--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -991,18 +991,6 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, COR_ILMETHOD_
     // code. This also avoid races with profiler overriding ngened code (see
     // matching SetNativeCodeInterlocked done after
     // JITCachedFunctionSearchStarted)
-    if (!pConfig->SetNativeCode(pCode, &pOtherCode))
-    {
-#ifdef HAVE_GCCOVER
-        // When GCStress is enabled, this thread should always win the publishing race
-        // since we're under a lock.
-        _ASSERTE(!GCStress<cfg_instr_jit>::IsEnabled() || !"GC Cover native code publish failed");
-#endif
-
-        // Another thread beat us to publishing its copy of the JITted code.
-        return pOtherCode;
-    }
-
 #ifdef FEATURE_INTERPRETER
     if (*pIsInterpreterCode)
     {
@@ -1017,6 +1005,18 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, COR_ILMETHOD_
         pConfig->GetMethodDesc()->SetInterpreterCode(interpreterCode);
     }
 #endif // FEATURE_INTERPRETER
+
+    if (!pConfig->SetNativeCode(pCode, &pOtherCode))
+    {
+#ifdef HAVE_GCCOVER
+        // When GCStress is enabled, this thread should always win the publishing race
+        // since we're under a lock.
+        _ASSERTE(!GCStress<cfg_instr_jit>::IsEnabled() || !"GC Cover native code publish failed");
+#endif
+
+        // Another thread beat us to publishing its copy of the JITted code.
+        return pOtherCode;
+    }
 
 #ifdef FEATURE_CODE_VERSIONING
     pConfig->SetGeneratedOrLoadedNewCode();


### PR DESCRIPTION
When calling a method, we need to determine whether the method is interpreted or not. If `m_interpreterCode` is uninitialized, we will call `ThePrestub` to trigger method compilation (PrepareInterpreterCode). The expectation is that, once `ThePrestub` finishes, the interpreter code will always be initialized. This assumption didn't hold with the current code in the following scenario:

Two threads can race to compile a method in `JitCompileCodeLocked` (since method compilation is not always done under a lock in order to prevent deadlocks from recursive dependencies). Following method compilation the code publishing flow is to set the native code first via a CAS in `SetNativeCode` followed by a simple publish of the interpreter code by the thread which wins the native code publish race. The problem with this approach is that the thread losing the race can return early, without having the interpreter code set.

We fix this by making sure the interpreter code is always published by all threads compiling the method. It shouldn't matter which thread wins the race because both compilation results are identical and they are both preserved.

Should fix sporadic assertions from https://github.com/dotnet/runtime/issues/129465