### PR TITLE
Clamp replenishment timer period to 1ms in rate limiters

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -38,6 +38,10 @@ namespace System.Threading.RateLimiting
         private static readonly RateLimitLease SuccessfulLease = new FixedWindowLease(true, null);
         private static readonly RateLimitLease FailedLease = new FixedWindowLease(false, null);
 
+        // System.Threading.Timer truncates its period to whole milliseconds; a sub-millisecond period
+        // becomes 0 and disables periodic firing. This is the minimum period used for the replenishment timer.
+        private static readonly TimeSpan s_minTimerPeriod = TimeSpan.FromMilliseconds(1);
+
         /// <inheritdoc />
         public override TimeSpan? IdleDuration => RateLimiterHelper.GetElapsedTime(_idleSince);
 
@@ -82,7 +86,12 @@ namespace System.Threading.RateLimiting
 
             if (_options.AutoReplenishment)
             {
-                _renewTimer = new Timer(Replenish, this, _options.Window, _options.Window);
+                // System.Threading.Timer truncates the period to whole milliseconds, so a sub-millisecond
+                // window becomes 0 and the timer never fires periodically, silently stopping replenishment.
+                // Clamp the timer period to a 1ms floor so auto-replenishment keeps running. Each tick still
+                // refreshes the full window, so the limiter is at worst slightly more restrictive.
+                TimeSpan timerPeriod = _options.Window < s_minTimerPeriod ? s_minTimerPeriod : _options.Window;
+                _renewTimer = new Timer(Replenish, this, timerPeriod, timerPeriod);
             }
         }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
@@ -11,6 +11,7 @@ namespace System.Threading.RateLimiting
         /// <summary>
         /// Specifies the time window that takes in the requests.
         /// Must be set to a value greater than <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="FixedWindowRateLimiter"/>.
+        /// When <see cref="AutoReplenishment" /> is <see langword="true" /> and this value is less than 1 millisecond, a period of 1 millisecond is used for the internal replenishment timer instead, as <see cref="System.Threading.Timer"/> does not support sub-millisecond periods.
         /// </summary>
         public TimeSpan Window { get; set; } = TimeSpan.Zero;
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -35,6 +35,10 @@ namespace System.Threading.RateLimiting
         private static readonly RateLimitLease SuccessfulLease = new SlidingWindowLease(true, null);
         private static readonly RateLimitLease FailedLease = new SlidingWindowLease(false, null);
 
+        // System.Threading.Timer truncates its period to whole milliseconds; a sub-millisecond period
+        // becomes 0 and disables periodic firing. This is the minimum period used for the replenishment timer.
+        private static readonly TimeSpan s_minTimerPeriod = TimeSpan.FromMilliseconds(1);
+
         /// <inheritdoc />
         public override TimeSpan? IdleDuration => RateLimiterHelper.GetElapsedTime(_idleSince);
 
@@ -89,7 +93,12 @@ namespace System.Threading.RateLimiting
 
             if (_options.AutoReplenishment)
             {
-                _renewTimer = new Timer(Replenish, this, ReplenishmentPeriod, ReplenishmentPeriod);
+                // ReplenishmentPeriod is derived as Window / SegmentsPerWindow, so it can be sub-millisecond even
+                // when Window is not. System.Threading.Timer truncates the period to whole milliseconds, so a
+                // sub-millisecond period becomes 0 and the timer never fires periodically, silently stopping
+                // replenishment. Clamp the timer period to a 1ms floor so auto-replenishment keeps running.
+                TimeSpan timerPeriod = ReplenishmentPeriod < s_minTimerPeriod ? s_minTimerPeriod : ReplenishmentPeriod;
+                _renewTimer = new Timer(Replenish, this, timerPeriod, timerPeriod);
             }
         }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
@@ -11,6 +11,7 @@ namespace System.Threading.RateLimiting
         /// <summary>
         /// Specifies the minimum period between replenishments.
         /// Must be set to a value greater than <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="SlidingWindowRateLimiter"/>.
+        /// The internal replenishment timer fires every <see cref="Window" /> divided by <see cref="SegmentsPerWindow" />. When <see cref="AutoReplenishment" /> is <see langword="true" /> and that derived period is less than 1 millisecond, a period of 1 millisecond is used instead, as <see cref="System.Threading.Timer"/> does not support sub-millisecond periods.
         /// </summary>
         public TimeSpan Window { get; set; } = TimeSpan.Zero;
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -33,6 +33,10 @@ namespace System.Threading.RateLimiting
         private static readonly RateLimitLease SuccessfulLease = new TokenBucketLease(true, null);
         private static readonly RateLimitLease FailedLease = new TokenBucketLease(false, null);
 
+        // System.Threading.Timer truncates its period to whole milliseconds; a sub-millisecond period
+        // becomes 0 and disables periodic firing. This is the minimum period used for the replenishment timer.
+        private static readonly TimeSpan s_minTimerPeriod = TimeSpan.FromMilliseconds(1);
+
         /// <inheritdoc />
         public override TimeSpan? IdleDuration => RateLimiterHelper.GetElapsedTime(_idleSince);
 
@@ -83,7 +87,13 @@ namespace System.Threading.RateLimiting
 
             if (_options.AutoReplenishment)
             {
-                _renewTimer = new Timer(Replenish, this, _options.ReplenishmentPeriod, _options.ReplenishmentPeriod);
+                // System.Threading.Timer truncates the period to whole milliseconds, so a sub-millisecond
+                // period becomes 0 and the timer never fires periodically, silently stopping replenishment.
+                // Clamp the timer period to a 1ms floor so auto-replenishment keeps running. The replenishment
+                // amount is unchanged: each tick still adds TokensPerPeriod, so the limiter is at worst slightly
+                // more restrictive than a sub-millisecond period would have been.
+                TimeSpan timerPeriod = _options.ReplenishmentPeriod < s_minTimerPeriod ? s_minTimerPeriod : _options.ReplenishmentPeriod;
+                _renewTimer = new Timer(Replenish, this, timerPeriod, timerPeriod);
             }
         }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
@@ -11,6 +11,7 @@ namespace System.Threading.RateLimiting
         /// <summary>
         /// Specifies the minimum period between replenishments.
         /// Must be set to a value greater than <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="TokenBucketRateLimiter"/>.
+        /// When <see cref="AutoReplenishment" /> is <see langword="true" /> and this value is less than 1 millisecond, a period of 1 millisecond is used for the internal replenishment timer instead, as <see cref="System.Threading.Timer"/> does not support sub-millisecond periods.
         /// </summary>
         public TimeSpan ReplenishmentPeriod { get; set; } = TimeSpan.Zero;
 

--- a/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
@@ -1016,6 +1016,28 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
+        public void SubMillisecondWindowWithAutoReplenishmentDoesNotDisableTimer()
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/109027
+            // System.Threading.Timer truncates its period to whole milliseconds, so a sub-millisecond
+            // Window previously produced a timer period of 0, which fires once and never again,
+            // silently stopping auto-replenishment. The timer period is now clamped to a 1ms floor.
+            var subMillisecond = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond / 2); // 500 microseconds
+            using ReplenishingRateLimiter limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                Window = subMillisecond,
+                AutoReplenishment = true
+            });
+
+            // The clamp affects only the internal timer; the observable ReplenishmentPeriod still reflects the configured Window.
+            Assert.True(limiter.IsAutoReplenishing);
+            Assert.Equal(subMillisecond, limiter.ReplenishmentPeriod);
+        }
+
+        [Fact]
         public async Task RetryAfterWithPartiallyElapsedWindow()
         {
             var options = new FixedWindowRateLimiterOptions

--- a/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
@@ -1072,6 +1072,45 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
+        public void SubMillisecondReplenishmentPeriodWithAutoReplenishmentDoesNotDisableTimer()
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/109027
+            // The effective replenishment period is Window / SegmentsPerWindow, so it can be sub-millisecond
+            // even when Window is not. System.Threading.Timer truncates its period to whole milliseconds, so a
+            // sub-millisecond period previously produced a timer period of 0, which fires once and never again,
+            // silently stopping auto-replenishment. The timer period is now clamped to a 1ms floor.
+
+            // Case 1: Window itself is sub-millisecond.
+            var subMillisecondWindow = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond / 2); // 500 microseconds
+            using ReplenishingRateLimiter limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                Window = subMillisecondWindow,
+                SegmentsPerWindow = 1,
+                AutoReplenishment = true
+            });
+            Assert.True(limiter.IsAutoReplenishing);
+            Assert.Equal(subMillisecondWindow, limiter.ReplenishmentPeriod);
+
+            // Case 2: Window is >= 1ms, but Window / SegmentsPerWindow is sub-millisecond (5ms / 10 = 500us).
+            var window = TimeSpan.FromMilliseconds(5);
+            using ReplenishingRateLimiter limiter2 = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                Window = window,
+                SegmentsPerWindow = 10,
+                AutoReplenishment = true
+            });
+            Assert.True(limiter2.IsAutoReplenishing);
+            // The clamp affects only the internal timer; the observable derived ReplenishmentPeriod is unchanged.
+            Assert.Equal(new TimeSpan(window.Ticks / 10), limiter2.ReplenishmentPeriod);
+        }
+
+        [Fact]
         public override async Task CanFillQueueWithNewestFirstAfterCancelingQueuedRequestWithAnotherQueuedRequest()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -1261,6 +1261,29 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
+        public void SubMillisecondReplenishmentPeriodWithAutoReplenishmentDoesNotDisableTimer()
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/109027
+            // System.Threading.Timer truncates its period to whole milliseconds, so a sub-millisecond
+            // ReplenishmentPeriod previously produced a timer period of 0, which fires once and never again,
+            // silently stopping auto-replenishment. The timer period is now clamped to a 1ms floor.
+            var subMillisecond = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond / 2); // 500 microseconds
+            using ReplenishingRateLimiter limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 10,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                ReplenishmentPeriod = subMillisecond,
+                TokensPerPeriod = 1,
+                AutoReplenishment = true
+            });
+
+            // The clamp affects only the internal timer; the observable ReplenishmentPeriod still reflects the configured value.
+            Assert.True(limiter.IsAutoReplenishing);
+            Assert.Equal(subMillisecond, limiter.ReplenishmentPeriod);
+        }
+
+        [Fact]
         public override void GetStatisticsReturnsNewInstances()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions


### PR DESCRIPTION
Fixes #109027

## Problem

`System.Threading.Timer` truncates its period to whole milliseconds. So a sub-millisecond `ReplenishmentPeriod` (TokenBucket) or `Window` (FixedWindow / SlidingWindow) ends up as a timer period of 0. A period of 0 fires once and then never again, so auto-replenishment silently stops. No exception, the limiter just stalls. The repro in the issue used `ReplenishmentPeriod = 500us`.

## Fix

Clamp the timer period to a 1ms floor at timer creation, in all three replenishing limiters (`TokenBucketRateLimiter`, `FixedWindowRateLimiter`, `SlidingWindowRateLimiter`).

This is the clamp-not-throw direction settled on in the issue. Existing limiters keep working, and a config that would have produced a sub-1ms interval ends up slightly more restrictive than asked for, which is safer than slightly less restrictive.

## Notes

The clamp is on the timer only, not on the options. The public `ReplenishmentPeriod` property still returns whatever the user configured. The tests check this.

SlidingWindow is the easy one to miss here. Its effective period is `Window / SegmentsPerWindow`, so it can be sub-millisecond even when `Window` itself is >= 1ms (e.g. `Window = 5ms, SegmentsPerWindow = 10` gives 500us). There's a test case for that.

No new exception, so no new resource string. The doc comments on the three options types now mention the 1ms floor.

One thing I left alone: `FixedWindowRateLimiter.CreateFailedWindowLease` and `TokenBucketRateLimiter.CreateFailedTokenLease` still compute `RetryAfter` from the original un-clamped value, so with a sub-1ms config the reported `RetryAfter` can be a touch under the real timer cadence. Didn't want to change user-visible lease metadata as part of this.

## Testing

One regression test per limiter: a sub-millisecond period constructs fine with `AutoReplenishment = true`, and the observable `ReplenishmentPeriod` still reflects the configured value. The SlidingWindow test also covers the derived-period case above.

Built and ran the RateLimiting test suite locally on macOS/arm64. Relying on CI for the .NET Framework leg.