### PR TITLE
[cDac] Implement thread state

### DIFF
--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -28,7 +28,7 @@ enum ThreadState
 {
     Unknown             = 0x00000000,    // threads are initialized this way
     SuspensionTrapped   = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code)
-    GCSuspendRedirected = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspension routine
+    GCSuspendRedirected = 0x00000004,    // Thread has been redirected to suspension routi
     DebugSuspendPending = 0x00000008,    // Is the debugger suspending threads?
     Hijacked            = 0x00000080,    // Return address has been hijacked
     Background          = 0x00000200,    // Thread is a background thread

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -37,7 +37,7 @@ enum ThreadState
     InSTA               = 0x00004000,    // Thread hosts an STA
     InMTA               = 0x00008000,    // Thread is part of the MTA
     Stopped             = 0x00010000,    // Thread has started to shut down
-    SyncSuspended       = 0x00080000,    // Suspended via WaitSuspendEvent
+    SyncSuspended       = 0x00080000,    // Thread has suspended itself at a safe point in response to a debugger suspend request
     DebugWillSync       = 0x00100000,    // Debugger will wait for this thread to sync
     ThreadPoolWorker    = 0x01000000,    // is this a threadpool worker thread?
     WaitSleepJoin       = 0x02000000,    // Thread is in a Sleep(), Wait(), Join()

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -28,7 +28,7 @@ enum ThreadState
 {
     Unknown             = 0x00000000,    // threads are initialized this way
     SuspensionTrapped   = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code)
-    GCSuspendRedirected = 0x00000004,    // Thread has been redirected to suspension routi
+    GCSuspendRedirected = 0x00000004,    // Thread has been redirected to suspension routine
     DebugSuspendPending = 0x00000008,    // Is the debugger suspending threads?
     Hijacked            = 0x00000080,    // Return address has been hijacked
     Background          = 0x00000200,    // Thread is a background thread

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -29,7 +29,7 @@ enum ThreadState
     Unknown             = 0x00000000,    // threads are initialized this way
     SuspensionTrapped   = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code)
     GCSuspendRedirected = 0x00000004,    // Thread has been redirected to suspension routine
-    DebugSuspendPending = 0x00000008,    // Is the debugger suspending threads?
+    DebugSuspendPending = 0x00000008,    // Debugger requested this thread to be suspended
     Hijacked            = 0x00000080,    // Return address has been hijacked
     Background          = 0x00000200,    // Thread is a background thread
     Unstarted           = 0x00000400,    // Thread has never been started

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -27,32 +27,20 @@ record struct ThreadStoreCounts (
 enum ThreadState
 {
     Unknown             = 0x00000000,    // threads are initialized this way
-    AbortRequested      = 0x00000001,    // Abort the thread
     SuspensionTrapped   = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code)
     GCSuspendRedirected = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspension routine
     DebugSuspendPending = 0x00000008,    // Is the debugger suspending threads?
-    GCOnTransitions     = 0x00000010,    // Force a GC on stub transitions (GCStress only)
-    SyncBlockCleanup    = 0x00000020,    // The synch block needs to be cleaned up
-    ExecutingOnAltStack = 0x00000040,    // Runtime is executing on an alternate stack located anywhere in the memory
     Hijacked            = 0x00000080,    // Return address has been hijacked
     Background          = 0x00000200,    // Thread is a background thread
     Unstarted           = 0x00000400,    // Thread has never been started
-    Dead                = 0x00000800,    // Thread has finished shutting down and is about to be terminated by the OS
-    WeOwn               = 0x00001000,    // Exposed object initiated this thread
     CoInitialized       = 0x00002000,    // CoInitialize has been called for this thread
     InSTA               = 0x00004000,    // Thread hosts an STA
     InMTA               = 0x00008000,    // Thread is part of the MTA
     Stopped             = 0x00010000,    // Thread has started to shut down
-    FullyInitialized    = 0x00020000,    // Thread is fully initialized and we are ready to broadcast its existence to external clients
     SyncSuspended       = 0x00080000,    // Suspended via WaitSuspendEvent
     DebugWillSync       = 0x00100000,    // Debugger will wait for this thread to sync
-    StackCrawlNeeded    = 0x00200000,    // A stackcrawl is needed on this thread, such as for thread abort
     ThreadPoolWorker    = 0x01000000,    // is this a threadpool worker thread?
     WaitSleepJoin       = 0x02000000,    // Thread is in a Sleep(), Wait(), Join()
-    Interrupted         = 0x04000000,    // Thread was awakened by an interrupt APC
-    AbortInitiated      = 0x10000000,    // set when abort is begun
-    Finalized           = 0x20000000,    // The associated managed Thread object has been finalized
-    FailStarted         = 0x40000000,    // The thread failed during startup
     Detached            = unchecked((int)0x80000000), // Thread was detached
 }
 
@@ -268,7 +256,7 @@ ThreadData GetThreadData(TargetPointer address)
     return new ThreadData(
         Id: target.Read<uint>(address + /* Thread::Id offset */),
         OSId: target.ReadNUInt(address + /* Thread::OSId offset */),
-        State: (ThreadState)target.Read<uint>(address + /* Thread::State offset */),
+        State: (ThreadState)(target.Read<uint>(address + /* Thread::State offset */) & /* mask of wrapped ThreadState bits */),
         PreemptiveGCDisabled: (target.Read<uint>(address + /* Thread::PreemptiveGCDisabled offset */) & 0x1) != 0,
         AllocContextPointer: allocContextPointer,
         AllocContextLimit: allocContextLimit,

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -27,12 +27,32 @@ record struct ThreadStoreCounts (
 enum ThreadState
 {
     Unknown             = 0x00000000,    // threads are initialized this way
+    AbortRequested      = 0x00000001,    // Abort the thread
+    SuspensionTrapped   = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code)
+    GCSuspendRedirected = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspension routine
+    DebugSuspendPending = 0x00000008,    // Is the debugger suspending threads?
+    GCOnTransitions     = 0x00000010,    // Force a GC on stub transitions (GCStress only)
+    SyncBlockCleanup    = 0x00000020,    // The synch block needs to be cleaned up
+    ExecutingOnAltStack = 0x00000040,    // Runtime is executing on an alternate stack located anywhere in the memory
     Hijacked            = 0x00000080,    // Return address has been hijacked
     Background          = 0x00000200,    // Thread is a background thread
     Unstarted           = 0x00000400,    // Thread has never been started
+    Dead                = 0x00000800,    // Thread has finished shutting down and is about to be terminated by the OS
+    WeOwn               = 0x00001000,    // Exposed object initiated this thread
+    CoInitialized       = 0x00002000,    // CoInitialize has been called for this thread
+    InSTA               = 0x00004000,    // Thread hosts an STA
+    InMTA               = 0x00008000,    // Thread is part of the MTA
     Stopped             = 0x00010000,    // Thread has started to shut down
+    FullyInitialized    = 0x00020000,    // Thread is fully initialized and we are ready to broadcast its existence to external clients
+    SyncSuspended       = 0x00080000,    // Suspended via WaitSuspendEvent
+    DebugWillSync       = 0x00100000,    // Debugger will wait for this thread to sync
+    StackCrawlNeeded    = 0x00200000,    // A stackcrawl is needed on this thread, such as for thread abort
     ThreadPoolWorker    = 0x01000000,    // is this a threadpool worker thread?
     WaitSleepJoin       = 0x02000000,    // Thread is in a Sleep(), Wait(), Join()
+    Interrupted         = 0x04000000,    // Thread was awakened by an interrupt APC
+    AbortInitiated      = 0x10000000,    // set when abort is begun
+    Finalized           = 0x20000000,    // The associated managed Thread object has been finalized
+    FailStarted         = 0x40000000,    // The thread failed during startup
     Detached            = unchecked((int)0x80000000), // Thread was detached
 }
 
@@ -248,7 +268,7 @@ ThreadData GetThreadData(TargetPointer address)
     return new ThreadData(
         Id: target.Read<uint>(address + /* Thread::Id offset */),
         OSId: target.ReadNUInt(address + /* Thread::OSId offset */),
-        State: target.Read<uint>(address + /* Thread::State offset */) /* -> convert to contract enum */,
+        State: (ThreadState)target.Read<uint>(address + /* Thread::State offset */),
         PreemptiveGCDisabled: (target.Read<uint>(address + /* Thread::PreemptiveGCDisabled offset */) & 0x1) != 0,
         AllocContextPointer: allocContextPointer,
         AllocContextLimit: allocContextLimit,

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -37,7 +37,7 @@ enum ThreadState
     InSTA               = 0x00004000,    // Thread hosts an STA
     InMTA               = 0x00008000,    // Thread is part of the MTA
     Stopped             = 0x00010000,    // Thread has started to shut down
-    SyncSuspended       = 0x00080000,    // Thread has suspended itself at a safe point in response to a debugger suspend request
+    DebugSyncSuspended  = 0x00080000,    // Thread has suspended itself at a safe point in response to a debugger suspend request
     DebugWillSync       = 0x00100000,    // Debugger will wait for this thread to sync
     ThreadPoolWorker    = 0x01000000,    // is this a threadpool worker thread?
     WaitSleepJoin       = 0x02000000,    // Thread is in a Sleep(), Wait(), Join()

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -1216,14 +1216,14 @@ BOOL DacDbiInterfaceImpl::UnwindRuntimeStackFrame(StackFrameIterator * pIter)
 
 //---------------------------------------------------------------------------------------
 //
-// To aid in doing the stack walk, the shim needs to know if either TS_SyncSuspended or
+// To aid in doing the stack walk, the shim needs to know if either TS_DebugSyncSuspended or
 // TS_Hijacked is set on a given thread. This DAC helper provides that access.
 //
 // Arguments:
-//    vmThread - Thread on which to check the TS_SyncSuspended & TS_Hijacked states
+//    vmThread - Thread on which to check the TS_DebugSyncSuspended & TS_Hijacked states
 //
 // Return Value:
-//    Return true iff TS_SyncSuspended or TS_Hijacked is set on the specified thread.
+//    Return true iff TS_DebugSyncSuspended or TS_Hijacked is set on the specified thread.
 //
 
 HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, OUT BOOL * pResult)
@@ -1236,7 +1236,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsThreadSuspendedOrHijacked(VMPTR
 
         Thread * pThread = vmThread.GetDacPtr();
         Thread::ThreadState ts = pThread->GetState();
-        if ((ts & Thread::TS_SyncSuspended) != 0)
+        if ((ts & Thread::TS_DebugSyncSuspended) != 0)
         {
             *pResult = TRUE;
         }

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -874,6 +874,7 @@ HRESULT ClrDataAccess::GetThreadData(CLRDATA_ADDRESS threadAddr, struct DacpThre
     ZeroMemory (threadData, sizeof(DacpThreadData));
     threadData->corThreadId = thread->m_ThreadId;
     threadData->osThreadId = (DWORD)thread->m_OSThreadId;
+    threadData->state = thread->m_State;
     threadData->preemptiveGCDisabled = thread->m_fPreemptiveGCDisabled;
 
     gc_alloc_context* allocContext = thread->GetAllocContext();

--- a/src/coreclr/debug/di/shimstackwalk.cpp
+++ b/src/coreclr/debug/di/shimstackwalk.cpp
@@ -135,15 +135,15 @@ BOOL ShimStackWalk::ShouldTrackUMChain(StackWalkInfo * pswInfo)
     // #DacShimSwWorkAround
     //
     // This part cannot be determined using DBI alone. We must call through to the DAC
-    // because we have no other way to get at TS_Hijacked & TS_SyncSuspended.  When the
+    // because we have no other way to get at TS_Hijacked & TS_DebugSyncSuspended.  When the
     // rearchitecture is complete, this DAC call should be able to go away, and we
     // should be able to use DBI for all the info we need.
     //
-    // One might think one could avoid the DAC for TS_SyncSuspended by just checking
+    // One might think one could avoid the DAC for TS_DebugSyncSuspended by just checking
     // USER_SUSPENDED, but that won't work. Although USER_SUSPENDED will be returned some
-    // of the time when TS_SyncSuspended is set, that will not be the case when the
+    // of the time when TS_DebugSyncSuspended is set, that will not be the case when the
     // debugger must suspend the thread. Example: if the given thread is in the middle of
-    // throwing a managed exception when the debugger breaks in, then TS_SyncSuspended
+    // throwing a managed exception when the debugger breaks in, then TS_DebugSyncSuspended
     // will be set due to the debugger's breaking, but USER_SUSPENDED will not be set, so
     // we'll think the UM chain should be tracked, resulting in a stack that differs from
     // Whidbey.
@@ -151,7 +151,7 @@ BOOL ShimStackWalk::ShouldTrackUMChain(StackWalkInfo * pswInfo)
         return FALSE;
 
     // In the case the thread is throwing a managed exception, 
-    // TS_SyncSuspended might not yet be set, resulting in IsThreadSuspendedOrHijacked 
+    // TS_DebugSyncSuspended might not yet be set, resulting in IsThreadSuspendedOrHijacked 
     // returning false above. We need to check the exception state to make sure we don't
     // track the chain in this case. Since we know the type of Frame we are dealing with, 
     // we can make a more accurate determination of whether we should track the chain.

--- a/src/coreclr/debug/ee/frameinfo.cpp
+++ b/src/coreclr/debug/ee/frameinfo.cpp
@@ -1806,7 +1806,7 @@ bool ShouldSendUMLeafChain(Thread * pThread)
     }
 
     // If a thread is suspended for sync purposes, it was suspended from managed
-    // code and the only native code is a mscorwks hijack.
+    // code and the only native code is a runtime hijack.
     // There are a few caveats here:
     // - This means a thread will lose it's UM chain. But what if a user inactive thread
     // enters the CLR from native code and hits a GC toggle? We'll lose that entire
@@ -1815,14 +1815,14 @@ bool ShouldSendUMLeafChain(Thread * pThread)
     // may not have this state set, run a little, try to enter the GC, and then get
     // this state set. Thus we'll lose the UM chain right out from under our noses.
     Thread::ThreadState ts = pThread->GetState();
-    if ((ts & Thread::TS_SyncSuspended) != 0)
+    if ((ts & Thread::TS_DebugSyncSuspended) != 0)
     {
         // If we've been stopped inside the runtime (eg, at a gc-toggle) but
         // not actually at a stopping context, then the thread must have some
-        // leafframes in mscorwks.
+        // leafframes in the runtime.
         // We can detect this case by checking if GetManagedStoppedCtx(pThread) == NULL.
         // This is very significant for notifcations (like LogMessage) that are
-        // dispatches from within mscorwks w/o a filter context.
+        // dispatches from within the runtime w/o a filter context.
         // We don't send a UM chain for these cases because that would
         // cause managed debug events to be dispatched w/ UM chains on the callstack.
         // And that just seems wrong ...

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -506,7 +506,7 @@ public:
         TS_AbortRequested         = 0x00000001,    // Abort the thread
 
         TS_SuspensionTrapped      = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code). [cDAC] [Thread]: Contract depends on this value.
-        TS_GCSuspendRedirected    = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspension routine. [cDAC] [Thread]: Contract depends on this value.
+        TS_GCSuspendRedirected    = 0x00000004,    // Thread has been redirected to suspension routine. [cDAC] [Thread]: Contract depends on this value.
 
         TS_DebugSuspendPending    = 0x00000008,    // Is the debugger suspending threads? [cDAC] [Thread]: Contract depends on this value.
         TS_GCOnTransitions        = 0x00000010,    // Force a GC on stub transitions (GCStress only)

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -506,7 +506,7 @@ public:
         TS_AbortRequested         = 0x00000001,    // Abort the thread
 
         TS_SuspensionTrapped      = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code). [cDAC] [Thread]: Contract depends on this value.
-        TS_GCSuspendRedirected    = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspention routine. [cDAC] [Thread]: Contract depends on this value.
+        TS_GCSuspendRedirected    = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspension routine. [cDAC] [Thread]: Contract depends on this value.
 
         TS_DebugSuspendPending    = 0x00000008,    // Is the debugger suspending threads? [cDAC] [Thread]: Contract depends on this value.
         TS_GCOnTransitions        = 0x00000010,    // Force a GC on stub transitions (GCStress only)

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -505,10 +505,10 @@ public:
 
         TS_AbortRequested         = 0x00000001,    // Abort the thread
 
-        TS_SuspensionTrapped      = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code)
-        TS_GCSuspendRedirected    = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspention routine.
+        TS_SuspensionTrapped      = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code). [cDAC] [Thread]: Contract depends on this value.
+        TS_GCSuspendRedirected    = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspention routine. [cDAC] [Thread]: Contract depends on this value.
 
-        TS_DebugSuspendPending    = 0x00000008,    // Is the debugger suspending threads?
+        TS_DebugSuspendPending    = 0x00000008,    // Is the debugger suspending threads? [cDAC] [Thread]: Contract depends on this value.
         TS_GCOnTransitions        = 0x00000010,    // Force a GC on stub transitions (GCStress only)
 
         TS_SyncBlockCleanup       = 0x00000020,    // The synch block needs to be cleaned up.
@@ -526,10 +526,10 @@ public:
 
         TS_WeOwn                  = 0x00001000,    // Exposed object initiated this thread
 #ifdef FEATURE_COMINTEROP_APARTMENT_SUPPORT
-        TS_CoInitialized          = 0x00002000,    // CoInitialize has been called for this thread
+        TS_CoInitialized          = 0x00002000,    // CoInitialize has been called for this thread. [cDAC] [Thread]: Contract depends on this value.
 
-        TS_InSTA                  = 0x00004000,    // Thread hosts an STA
-        TS_InMTA                  = 0x00008000,    // Thread is part of the MTA
+        TS_InSTA                  = 0x00004000,    // Thread hosts an STA. [cDAC] [Thread]: Contract depends on this value.
+        TS_InMTA                  = 0x00008000,    // Thread is part of the MTA. [cDAC] [Thread]: Contract depends on this value.
 #endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
 
         // Some bits that only have meaning for reporting the state to clients.
@@ -538,8 +538,8 @@ public:
 
         // unused                 = 0x00040000,
 
-        TS_SyncSuspended          = 0x00080000,    // Suspended via WaitSuspendEvent
-        TS_DebugWillSync          = 0x00100000,    // Debugger will wait for this thread to sync
+        TS_SyncSuspended          = 0x00080000,    // Suspended via WaitSuspendEvent. [cDAC] [Thread]: Contract depends on this value.
+        TS_DebugWillSync          = 0x00100000,    // Debugger will wait for this thread to sync. [cDAC] [Thread]: Contract depends on this value.
 
         TS_StackCrawlNeeded       = 0x00200000,    // A stackcrawl is needed on this thread, such as for thread abort
                                                    // See comment for s_pWaitForStackCrawlEvent for reason.
@@ -560,7 +560,7 @@ public:
                                                    // We can clean up the unmanaged part now.
 
         TS_FailStarted            = 0x40000000,    // The thread fails during startup.
-        TS_Detached               = 0x80000000,    // Thread was detached by DllMain
+        TS_Detached               = 0x80000000,    // Thread was detached by DllMain. [cDAC] [Thread]: Contract depends on this value.
 
         // <TODO> @TODO: We need to reclaim the bits that have no concurrency issues (i.e. they are only
         //         manipulated by the owning thread) and move them off to a different DWORD.  Note if this

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -538,7 +538,7 @@ public:
 
         // unused                 = 0x00040000,
 
-        TS_SyncSuspended          = 0x00080000,    // Suspended via WaitSuspendEvent. [cDAC] [Thread]: Contract depends on this value.
+        TS_SyncSuspended          = 0x00080000,    // Thread has suspended itself at a safe point in response to a debugger suspend request. [cDAC] [Thread]: Contract depends on this value.
         TS_DebugWillSync          = 0x00100000,    // Debugger will wait for this thread to sync. [cDAC] [Thread]: Contract depends on this value.
 
         TS_StackCrawlNeeded       = 0x00200000,    // A stackcrawl is needed on this thread, such as for thread abort

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -491,11 +491,9 @@ public:
     // If we are trying to suspend a thread, we set the appropriate pending bit to
     // indicate why we want to suspend it (TS_AbortRequested or TS_DebugSuspendPending).
     //
-    // If instead the thread has blocked itself, via WaitSuspendEvent, we indicate
-    // this with TS_SyncSuspended.  However, we need to know whether the synchronous
-    // suspension is for a user request, or for an internal one (GC & Debug).  That's
-    // because a user request is not allowed to resume a thread suspended for
-    // debugging or GC.  -- That's not stricly true.  It is allowed to resume such a
+    // If instead the thread has blocked itself, via WaitForDebugSuspend, we indicate
+    // this with TS_DebugSyncSuspended.  A user request is not allowed to resume a thread
+    // suspended for debugging.  -- That's not stricly true.  It is allowed to resume such a
     // thread so long as it was ALSO suspended by the user.  In other words, this
     // ensures that user resumptions aren't unbalanced from user suspensions.
     //
@@ -538,7 +536,7 @@ public:
 
         // unused                 = 0x00040000,
 
-        TS_SyncSuspended          = 0x00080000,    // Thread has suspended itself at a safe point in response to a debugger suspend request. [cDAC] [Thread]: Contract depends on this value.
+        TS_DebugSyncSuspended     = 0x00080000,    // Thread has suspended itself at a safe point in response to a debugger suspend request. [cDAC] [Thread]: Contract depends on this value.
         TS_DebugWillSync          = 0x00100000,    // Debugger will wait for this thread to sync. [cDAC] [Thread]: Contract depends on this value.
 
         TS_StackCrawlNeeded       = 0x00200000,    // A stackcrawl is needed on this thread, such as for thread abort
@@ -2421,8 +2419,8 @@ private:
 
     // For suspends.  The thread waits on this event.  A client sets the event to cause
     // the thread to resume.
-    void    WaitSuspendEvents();
-    BOOL    WaitSuspendEventsHelper(void);
+    void    WaitForDebugSuspend();
+    BOOL    WaitForDebugSuspendHelper(void);
 
     // Helpers to ensure that the bits for suspension and the number of active
     // traps remain coordinated.
@@ -2455,7 +2453,7 @@ private:
             //
             // Construct the destination state we desire - all suspension bits turned off.
             //
-            ThreadState newState = (ThreadState)(oldState & ~(TS_DebugSuspendPending | TS_SyncSuspended));
+            ThreadState newState = (ThreadState)(oldState & ~(TS_DebugSuspendPending | TS_DebugSyncSuspended));
 
             if (InterlockedCompareExchange((LONG *)&m_State, newState, oldState) == (LONG)oldState)
             {

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -493,7 +493,7 @@ public:
     //
     // If instead the thread has blocked itself, via WaitForDebugSuspend, we indicate
     // this with TS_DebugSyncSuspended.  A user request is not allowed to resume a thread
-    // suspended for debugging.  -- That's not stricly true.  It is allowed to resume such a
+    // suspended for debugging.  -- That's not strictly true.  It is allowed to resume such a
     // thread so long as it was ALSO suspended by the user.  In other words, this
     // ensures that user resumptions aren't unbalanced from user suspensions.
     //

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -1371,7 +1371,7 @@ Thread::UserAbort(EEPolicy::ThreadAbortTypes abortType, DWORD timeout)
         // Two more cases can be folded in here as well.  If the thread is unstarted, it'll
         // abort when we start it.
         //
-        // If the thread is user suspended (SyncSuspended) -- we're out of luck.  Set the bit and
+        // If the thread is debug suspended (DebugSyncSuspended) -- we're out of luck.  Set the bit and
         // hope for the best on resume.
         //
         if ((m_State & TS_AbortInitiated) && !IsRudeAbort())
@@ -1458,9 +1458,9 @@ Thread::UserAbort(EEPolicy::ThreadAbortTypes abortType, DWORD timeout)
             }
 
             // If Threads is stopped under a managed debugger, it will have both
-            // TS_DebugSuspendPending and TS_SyncSuspended, regardless of whether
+            // TS_DebugSuspendPending and TS_DebugSyncSuspended, regardless of whether
             // the thread is actually suspended or not.
-            if (m_State & TS_SyncSuspended)
+            if (m_State & TS_DebugSyncSuspended)
             {
 #ifndef DISABLE_THREADSUSPEND
                 ResumeThread();
@@ -2131,8 +2131,8 @@ void Thread::RareDisablePreemptiveGC()
                 LOG((LF_CORDB, LL_INFO1000, "[0x%x] SUSPEND: debug suspended while switching to coop mode.\n", GetThreadId()));
             }
 #endif
-            // unsets TS_DebugSuspendPending | TS_SyncSuspended
-            WaitSuspendEvents();
+            // unsets TS_DebugSuspendPending | TS_DebugSyncSuspended
+            WaitForDebugSuspend();
 
             // disable preemptive gc.
             m_fPreemptiveGCDisabled.StoreWithoutBarrier(1);
@@ -4365,9 +4365,9 @@ void Thread::SysResumeFromDebug(AppDomain *pAppDomain)
 
 /*
  *
- * WaitSuspendEventsHelper
+ * WaitForDebugSuspendHelper
  *
- * This function is a simple helper function for WaitSuspendEvents.  It is needed
+ * This function is a simple helper function for WaitForDebugSuspend.  It is needed
  * because of the EX_TRY macro.  This macro does an alloca(), which allocates space
  * off the stack, not free'ing it.  Thus, doing a EX_TRY in a loop can easily result
  * in a stack overflow error.  By factoring out the EX_TRY into a separate function,
@@ -4380,7 +4380,7 @@ void Thread::SysResumeFromDebug(AppDomain *pAppDomain)
  *   true if meant to continue, else false.
  *
  */
-BOOL Thread::WaitSuspendEventsHelper(void)
+BOOL Thread::WaitForDebugSuspendHelper(void)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -4395,13 +4395,13 @@ BOOL Thread::WaitSuspendEventsHelper(void)
 
             while (oldState & TS_DebugSuspendPending) {
 
-                ThreadState newState = (ThreadState)(oldState | TS_SyncSuspended);
+                ThreadState newState = (ThreadState)(oldState | TS_DebugSyncSuspended);
                 if (InterlockedCompareExchange((LONG *)&m_State, newState, oldState) == (LONG)oldState)
                 {
                     result = m_DebugSuspendEvent.Wait(INFINITE,FALSE);
 #if _DEBUG
                     newState = m_State;
-                    _ASSERTE(!(newState & TS_SyncSuspended));
+                    _ASSERTE(!(newState & TS_DebugSyncSuspended));
 #endif
                     break;
                 }
@@ -4419,18 +4419,18 @@ BOOL Thread::WaitSuspendEventsHelper(void)
 
 
 // There's a bit of a workaround here
-void Thread::WaitSuspendEvents()
+void Thread::WaitForDebugSuspend()
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
 
     _ASSERTE(!PreemptiveGCDisabled());
-    _ASSERTE((m_State & TS_SyncSuspended) == 0);
+    _ASSERTE((m_State & TS_DebugSyncSuspended) == 0);
 
     // Let us do some useful work before suspending ourselves.
     while (TRUE)
     {
-        WaitSuspendEventsHelper();
+        WaitForDebugSuspendHelper();
 
         ThreadState oldState = m_State;
 
@@ -4443,7 +4443,7 @@ void Thread::WaitSuspendEvents()
             //
             // Construct the destination state we desire - all suspension bits turned off.
             //
-            ThreadState newState = (ThreadState)(oldState & ~(TS_DebugSuspendPending | TS_SyncSuspended));
+            ThreadState newState = (ThreadState)(oldState & ~(TS_DebugSuspendPending | TS_DebugSyncSuspended));
 
             if (InterlockedCompareExchange((LONG *)&m_State, newState, oldState) == (LONG)oldState)
             {

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -1457,7 +1457,7 @@ Thread::UserAbort(EEPolicy::ThreadAbortTypes abortType, DWORD timeout)
                 break;
             }
 
-            // If Threads is stopped under a managed debugger, it will have both
+            // If a thread is stopped under a managed debugger, it will have both
             // TS_DebugSuspendPending and TS_DebugSyncSuspended, regardless of whether
             // the thread is actually suspended or not.
             if (m_State & TS_DebugSyncSuspended)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -28,32 +28,20 @@ public record struct ThreadStoreCounts(
 public enum ThreadState
 {
     Unknown             = 0x00000000,   // Threads are initialized this way
-    AbortRequested      = 0x00000001,   // Abort the thread
     SuspensionTrapped   = 0x00000002,   // Thread is trapped waiting for suspension to complete (was in managed code)
     GCSuspendRedirected = 0x00000004,   // ThreadSuspend::SuspendRuntime has redirected the thread to suspension routine
     DebugSuspendPending = 0x00000008,   // Is the debugger suspending threads?
-    GCOnTransitions     = 0x00000010,   // Force a GC on stub transitions (GCStress only)
-    SyncBlockCleanup    = 0x00000020,   // The synch block needs to be cleaned up
-    ExecutingOnAltStack = 0x00000040,   // Runtime is executing on an alternate stack located anywhere in the memory
     Hijacked            = 0x00000080,   // Return address has been hijacked
     Background          = 0x00000200,   // Thread is a background thread
     Unstarted           = 0x00000400,   // Thread has never been started
-    Dead                = 0x00000800,   // Thread has finished shutting down and is about to be terminated by the OS
-    WeOwn               = 0x00001000,   // Exposed object initiated this thread
     CoInitialized       = 0x00002000,   // CoInitialize has been called for this thread
     InSTA               = 0x00004000,   // Thread hosts an STA
     InMTA               = 0x00008000,   // Thread is part of the MTA
     Stopped             = 0x00010000,   // Thread has started to shut down
-    FullyInitialized    = 0x00020000,   // Thread is fully initialized and we are ready to broadcast its existence to external clients
     SyncSuspended       = 0x00080000,   // Suspended via WaitSuspendEvent
     DebugWillSync       = 0x00100000,   // Debugger will wait for this thread to sync
-    StackCrawlNeeded    = 0x00200000,   // A stackcrawl is needed on this thread, such as for thread abort
     ThreadPoolWorker    = 0x01000000,   // Thread is a thread pool worker thread
     WaitSleepJoin       = 0x02000000,   // Thread is in a Sleep(), Wait(), Join()
-    Interrupted         = 0x04000000,   // Thread was awakened by an interrupt APC
-    AbortInitiated      = 0x10000000,   // Set when abort is begun
-    Finalized           = 0x20000000,   // The associated managed Thread object has been finalized
-    FailStarted         = 0x40000000,   // The thread failed during startup
     Detached            = unchecked((int)0x80000000), // Thread was detached
 }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -29,7 +29,7 @@ public enum ThreadState
 {
     Unknown             = 0x00000000,   // Threads are initialized this way
     SuspensionTrapped   = 0x00000002,   // Thread is trapped waiting for suspension to complete (was in managed code)
-    GCSuspendRedirected = 0x00000004,   // ThreadSuspend::SuspendRuntime has redirected the thread to suspension routine
+    GCSuspendRedirected = 0x00000004,   // Thread has been redirected to suspension routine
     DebugSuspendPending = 0x00000008,   // Is the debugger suspending threads?
     Hijacked            = 0x00000080,   // Return address has been hijacked
     Background          = 0x00000200,   // Thread is a background thread

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -27,13 +27,33 @@ public record struct ThreadStoreCounts(
 [Flags]
 public enum ThreadState
 {
-    Unknown             = 0x00000000,
+    Unknown             = 0x00000000,   // Threads are initialized this way
+    AbortRequested      = 0x00000001,   // Abort the thread
+    SuspensionTrapped   = 0x00000002,   // Thread is trapped waiting for suspension to complete (was in managed code)
+    GCSuspendRedirected = 0x00000004,   // ThreadSuspend::SuspendRuntime has redirected the thread to suspension routine
+    DebugSuspendPending = 0x00000008,   // Is the debugger suspending threads?
+    GCOnTransitions     = 0x00000010,   // Force a GC on stub transitions (GCStress only)
+    SyncBlockCleanup    = 0x00000020,   // The synch block needs to be cleaned up
+    ExecutingOnAltStack = 0x00000040,   // Runtime is executing on an alternate stack located anywhere in the memory
     Hijacked            = 0x00000080,   // Return address has been hijacked
     Background          = 0x00000200,   // Thread is a background thread
     Unstarted           = 0x00000400,   // Thread has never been started
+    Dead                = 0x00000800,   // Thread has finished shutting down and is about to be terminated by the OS
+    WeOwn               = 0x00001000,   // Exposed object initiated this thread
+    CoInitialized       = 0x00002000,   // CoInitialize has been called for this thread
+    InSTA               = 0x00004000,   // Thread hosts an STA
+    InMTA               = 0x00008000,   // Thread is part of the MTA
     Stopped             = 0x00010000,   // Thread has started to shut down
+    FullyInitialized    = 0x00020000,   // Thread is fully initialized and we are ready to broadcast its existence to external clients
+    SyncSuspended       = 0x00080000,   // Suspended via WaitSuspendEvent
+    DebugWillSync       = 0x00100000,   // Debugger will wait for this thread to sync
+    StackCrawlNeeded    = 0x00200000,   // A stackcrawl is needed on this thread, such as for thread abort
     ThreadPoolWorker    = 0x01000000,   // Thread is a thread pool worker thread
     WaitSleepJoin       = 0x02000000,   // Thread is in a Sleep(), Wait(), Join()
+    Interrupted         = 0x04000000,   // Thread was awakened by an interrupt APC
+    AbortInitiated      = 0x10000000,   // Set when abort is begun
+    Finalized           = 0x20000000,   // The associated managed Thread object has been finalized
+    FailStarted         = 0x40000000,   // The thread failed during startup
     Detached            = unchecked((int)0x80000000), // Thread was detached
 }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -38,7 +38,7 @@ public enum ThreadState
     InSTA               = 0x00004000,   // Thread hosts an STA
     InMTA               = 0x00008000,   // Thread is part of the MTA
     Stopped             = 0x00010000,   // Thread has started to shut down
-    SyncSuspended       = 0x00080000,   // Suspended via WaitSuspendEvent
+    SyncSuspended       = 0x00080000,   // Thread has suspended itself at a safe point in response to a debugger suspend request
     DebugWillSync       = 0x00100000,   // Debugger will wait for this thread to sync
     ThreadPoolWorker    = 0x01000000,   // Thread is a thread pool worker thread
     WaitSleepJoin       = 0x02000000,   // Thread is in a Sleep(), Wait(), Join()

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -38,7 +38,7 @@ public enum ThreadState
     InSTA               = 0x00004000,   // Thread hosts an STA
     InMTA               = 0x00008000,   // Thread is part of the MTA
     Stopped             = 0x00010000,   // Thread has started to shut down
-    SyncSuspended       = 0x00080000,   // Thread has suspended itself at a safe point in response to a debugger suspend request
+    DebugSyncSuspended  = 0x00080000,   // Thread has suspended itself at a safe point in response to a debugger suspend request
     DebugWillSync       = 0x00100000,   // Debugger will wait for this thread to sync
     ThreadPoolWorker    = 0x01000000,   // Thread is a thread pool worker thread
     WaitSleepJoin       = 0x02000000,   // Thread is in a Sleep(), Wait(), Join()

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -66,6 +66,18 @@ internal readonly struct Thread_1 : IThread
             threadStore.DeadCount);
     }
 
+    // The runtime Thread::m_State bitfield contains many bits that are internal to the runtime.
+    // Only the subset wrapped by the ThreadState contract enum is meaningful to the diagnostic
+    // stack, so filter the raw value to expose exactly those bits.
+    private const ThreadState WrappedThreadState =
+        ThreadState.SuspensionTrapped | ThreadState.GCSuspendRedirected | ThreadState.DebugSuspendPending |
+        ThreadState.Hijacked | ThreadState.Background | ThreadState.Unstarted |
+        ThreadState.CoInitialized | ThreadState.InSTA | ThreadState.InMTA |
+        ThreadState.Stopped | ThreadState.SyncSuspended | ThreadState.DebugWillSync |
+        ThreadState.ThreadPoolWorker | ThreadState.WaitSleepJoin | ThreadState.Detached;
+
+    private static ThreadState GetThreadState(uint state) => (ThreadState)(state & unchecked((uint)WrappedThreadState));
+
     ThreadData IThread.GetThreadData(TargetPointer threadPointer)
     {
         Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
@@ -104,7 +116,7 @@ internal readonly struct Thread_1 : IThread
             threadPointer,
             thread.Id,
             thread.OSId,
-            (ThreadState)thread.State,
+            GetThreadState(thread.State),
             (thread.PreemptiveGCDisabled & 0x1) != 0,
             thread.RuntimeThreadLocals?.AllocContext.GCAllocationContext.Pointer ?? TargetPointer.Null,
             thread.RuntimeThreadLocals?.AllocContext.GCAllocationContext.Limit ?? TargetPointer.Null,

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -21,18 +21,6 @@ internal readonly struct Thread_1 : IThread
     };
 
     [Flags]
-    private enum ThreadState_1
-    {
-        Hijacked = 0x80,
-        Background = 0x200,
-        Unstarted = 0x400,
-        Stopped = 0x10000,
-        ThreadPoolWorker = 0x1000000,
-        WaitSleepJoin = 0x2000000,
-        Detached = unchecked((int)0x80000000)
-    }
-
-    [Flags]
     private enum ExceptionFlags
     {
         DebuggerInterceptInfo = 0x00000200,
@@ -78,26 +66,6 @@ internal readonly struct Thread_1 : IThread
             threadStore.DeadCount);
     }
 
-    private static Contracts.ThreadState GetThreadState(ThreadState_1 state)
-    {
-        Contracts.ThreadState result = Contracts.ThreadState.Unknown;
-        if (state.HasFlag(ThreadState_1.Hijacked))
-            result |= Contracts.ThreadState.Hijacked;
-        if (state.HasFlag(ThreadState_1.Background))
-            result |= Contracts.ThreadState.Background;
-        if (state.HasFlag(ThreadState_1.Unstarted))
-            result |= Contracts.ThreadState.Unstarted;
-        if (state.HasFlag(ThreadState_1.Stopped))
-            result |= Contracts.ThreadState.Stopped;
-        if (state.HasFlag(ThreadState_1.WaitSleepJoin))
-            result |= Contracts.ThreadState.WaitSleepJoin;
-        if (state.HasFlag(ThreadState_1.ThreadPoolWorker))
-            result |= Contracts.ThreadState.ThreadPoolWorker;
-        if (state.HasFlag(ThreadState_1.Detached))
-            result |= Contracts.ThreadState.Detached;
-        return result;
-    }
-
     ThreadData IThread.GetThreadData(TargetPointer threadPointer)
     {
         Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
@@ -136,7 +104,7 @@ internal readonly struct Thread_1 : IThread
             threadPointer,
             thread.Id,
             thread.OSId,
-            GetThreadState((ThreadState_1)thread.State),
+            (ThreadState)thread.State,
             (thread.PreemptiveGCDisabled & 0x1) != 0,
             thread.RuntimeThreadLocals?.AllocContext.GCAllocationContext.Pointer ?? TargetPointer.Null,
             thread.RuntimeThreadLocals?.AllocContext.GCAllocationContext.Limit ?? TargetPointer.Null,

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -21,6 +21,26 @@ internal readonly struct Thread_1 : IThread
     };
 
     [Flags]
+    private enum ThreadState_1
+    {
+        SuspensionTrapped = 0x2,
+        GCSuspendRedirected = 0x4,
+        DebugSuspendPending = 0x8,
+        Hijacked = 0x80,
+        Background = 0x200,
+        Unstarted = 0x400,
+        CoInitialized = 0x2000,
+        InSTA = 0x4000,
+        InMTA = 0x8000,
+        Stopped = 0x10000,
+        SyncSuspended = 0x80000,
+        DebugWillSync = 0x100000,
+        ThreadPoolWorker = 0x1000000,
+        WaitSleepJoin = 0x2000000,
+        Detached = unchecked((int)0x80000000)
+    }
+
+    [Flags]
     private enum ExceptionFlags
     {
         DebuggerInterceptInfo = 0x00000200,
@@ -66,17 +86,41 @@ internal readonly struct Thread_1 : IThread
             threadStore.DeadCount);
     }
 
-    // The runtime Thread::m_State bitfield contains many bits that are internal to the runtime.
-    // Only the subset wrapped by the ThreadState contract enum is meaningful to the diagnostic
-    // stack, so filter the raw value to expose exactly those bits.
-    private const ThreadState WrappedThreadState =
-        ThreadState.SuspensionTrapped | ThreadState.GCSuspendRedirected | ThreadState.DebugSuspendPending |
-        ThreadState.Hijacked | ThreadState.Background | ThreadState.Unstarted |
-        ThreadState.CoInitialized | ThreadState.InSTA | ThreadState.InMTA |
-        ThreadState.Stopped | ThreadState.SyncSuspended | ThreadState.DebugWillSync |
-        ThreadState.ThreadPoolWorker | ThreadState.WaitSleepJoin | ThreadState.Detached;
-
-    private static ThreadState GetThreadState(uint state) => (ThreadState)(state & unchecked((uint)WrappedThreadState));
+    private static Contracts.ThreadState GetThreadState(ThreadState_1 state)
+    {
+        Contracts.ThreadState result = Contracts.ThreadState.Unknown;
+        if (state.HasFlag(ThreadState_1.SuspensionTrapped))
+            result |= Contracts.ThreadState.SuspensionTrapped;
+        if (state.HasFlag(ThreadState_1.GCSuspendRedirected))
+            result |= Contracts.ThreadState.GCSuspendRedirected;
+        if (state.HasFlag(ThreadState_1.DebugSuspendPending))
+            result |= Contracts.ThreadState.DebugSuspendPending;
+        if (state.HasFlag(ThreadState_1.Hijacked))
+            result |= Contracts.ThreadState.Hijacked;
+        if (state.HasFlag(ThreadState_1.Background))
+            result |= Contracts.ThreadState.Background;
+        if (state.HasFlag(ThreadState_1.Unstarted))
+            result |= Contracts.ThreadState.Unstarted;
+        if (state.HasFlag(ThreadState_1.CoInitialized))
+            result |= Contracts.ThreadState.CoInitialized;
+        if (state.HasFlag(ThreadState_1.InSTA))
+            result |= Contracts.ThreadState.InSTA;
+        if (state.HasFlag(ThreadState_1.InMTA))
+            result |= Contracts.ThreadState.InMTA;
+        if (state.HasFlag(ThreadState_1.Stopped))
+            result |= Contracts.ThreadState.Stopped;
+        if (state.HasFlag(ThreadState_1.SyncSuspended))
+            result |= Contracts.ThreadState.SyncSuspended;
+        if (state.HasFlag(ThreadState_1.DebugWillSync))
+            result |= Contracts.ThreadState.DebugWillSync;
+        if (state.HasFlag(ThreadState_1.ThreadPoolWorker))
+            result |= Contracts.ThreadState.ThreadPoolWorker;
+        if (state.HasFlag(ThreadState_1.WaitSleepJoin))
+            result |= Contracts.ThreadState.WaitSleepJoin;
+        if (state.HasFlag(ThreadState_1.Detached))
+            result |= Contracts.ThreadState.Detached;
+        return result;
+    }
 
     ThreadData IThread.GetThreadData(TargetPointer threadPointer)
     {
@@ -116,7 +160,7 @@ internal readonly struct Thread_1 : IThread
             threadPointer,
             thread.Id,
             thread.OSId,
-            GetThreadState(thread.State),
+            GetThreadState((ThreadState_1)thread.State),
             (thread.PreemptiveGCDisabled & 0x1) != 0,
             thread.RuntimeThreadLocals?.AllocContext.GCAllocationContext.Pointer ?? TargetPointer.Null,
             thread.RuntimeThreadLocals?.AllocContext.GCAllocationContext.Limit ?? TargetPointer.Null,

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -33,7 +33,7 @@ internal readonly struct Thread_1 : IThread
         InSTA = 0x4000,
         InMTA = 0x8000,
         Stopped = 0x10000,
-        SyncSuspended = 0x80000,
+        DebugSyncSuspended = 0x80000,
         DebugWillSync = 0x100000,
         ThreadPoolWorker = 0x1000000,
         WaitSleepJoin = 0x2000000,
@@ -109,8 +109,8 @@ internal readonly struct Thread_1 : IThread
             result |= Contracts.ThreadState.InMTA;
         if (state.HasFlag(ThreadState_1.Stopped))
             result |= Contracts.ThreadState.Stopped;
-        if (state.HasFlag(ThreadState_1.SyncSuspended))
-            result |= Contracts.ThreadState.SyncSuspended;
+        if (state.HasFlag(ThreadState_1.DebugSyncSuspended))
+            result |= Contracts.ThreadState.DebugSyncSuspended;
         if (state.HasFlag(ThreadState_1.DebugWillSync))
             result |= Contracts.ThreadState.DebugWillSync;
         if (state.HasFlag(ThreadState_1.ThreadPoolWorker))

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -4341,7 +4341,12 @@ public sealed unsafe partial class SOSDacImpl
             {
                 Debug.Assert(data->corThreadId == dataLocal.corThreadId, $"cDAC: {data->corThreadId}, DAC: {dataLocal.corThreadId}");
                 Debug.Assert(data->osThreadId == dataLocal.osThreadId, $"cDAC: {data->osThreadId}, DAC: {dataLocal.osThreadId}");
-                Debug.Assert(data->state == dataLocal.state, $"cDAC: {data->state}, DAC: {dataLocal.state}");
+                // The cDAC exposes only the subset of Thread::m_State bits wrapped by the
+                // ThreadState contract enum; mask the legacy raw state the same way before comparing.
+                int wrappedStateMask = 0;
+                foreach (Contracts.ThreadState stateFlag in Enum.GetValues<Contracts.ThreadState>())
+                    wrappedStateMask |= (int)stateFlag;
+                Debug.Assert(data->state == (dataLocal.state & wrappedStateMask), $"cDAC: {data->state}, DAC: {dataLocal.state & wrappedStateMask}");
                 Debug.Assert(data->preemptiveGCDisabled == dataLocal.preemptiveGCDisabled, $"cDAC: {data->preemptiveGCDisabled}, DAC: {dataLocal.preemptiveGCDisabled}");
                 Debug.Assert(data->allocContextPtr == dataLocal.allocContextPtr, $"cDAC: {data->allocContextPtr:x}, DAC: {dataLocal.allocContextPtr:x}");
                 Debug.Assert(data->allocContextLimit == dataLocal.allocContextLimit, $"cDAC: {data->allocContextLimit:x}, DAC: {dataLocal.allocContextLimit:x}");

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -4309,7 +4309,7 @@ public sealed unsafe partial class SOSDacImpl
             Contracts.ThreadData threadData = contract.GetThreadData(thread.ToTargetPointer(_target));
             data->corThreadId = (int)threadData.Id;
             data->osThreadId = (int)threadData.OSId.Value;
-            data->state = 0; // Set to 0, nobody uses this
+            data->state = (int)threadData.State;
             data->preemptiveGCDisabled = (uint)(threadData.PreemptiveGCDisabled ? 1 : 0);
             data->allocContextPtr = threadData.AllocContextPointer.ToClrDataAddress(_target);
             data->allocContextLimit = threadData.AllocContextLimit.ToClrDataAddress(_target);

--- a/src/native/managed/cdac/tests/UnitTests/ThreadTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ThreadTests.cs
@@ -102,9 +102,11 @@ public unsafe class ThreadTests
     {
         const uint id = 1;
         const ulong osId = 1234;
-        // Include a flag (AbortRequested) that the contract previously dropped to verify the
-        // full raw m_State bitfield is now reported verbatim.
-        const uint state = (uint)(ThreadState.WaitSleepJoin | ThreadState.Background | ThreadState.AbortRequested);
+        // Wrapped bits (Background, WaitSleepJoin, CoInitialized, DebugSuspendPending) plus an
+        // unwrapped runtime bit (TS_Dead = 0x800) to verify only the wrapped bits are exposed.
+        const uint wrapped = (uint)(ThreadState.Background | ThreadState.WaitSleepJoin | ThreadState.CoInitialized | ThreadState.DebugSuspendPending);
+        const uint unwrapped = 0x00000800; // TS_Dead - not part of the contract enum
+        const uint state = wrapped | unwrapped;
         MockThread? thread = null;
 
         TestPlaceholderTarget target = CreateTarget(
@@ -117,11 +119,13 @@ public unsafe class ThreadTests
 
         IThread contract = target.Contracts.Thread;
         ThreadData data = contract.GetThreadData(new TargetPointer(thread!.Address));
-        Assert.Equal(state, (uint)data.State);
+        Assert.Equal(wrapped, (uint)data.State);
         Assert.True(data.State.HasFlag(ThreadState.Background));
         Assert.True(data.State.HasFlag(ThreadState.WaitSleepJoin));
-        Assert.True(data.State.HasFlag(ThreadState.AbortRequested));
+        Assert.True(data.State.HasFlag(ThreadState.CoInitialized));
+        Assert.True(data.State.HasFlag(ThreadState.DebugSuspendPending));
         Assert.False(data.State.HasFlag(ThreadState.Stopped));
+        Assert.Equal(0u, (uint)data.State & unwrapped);
     }
 
     [Theory]

--- a/src/native/managed/cdac/tests/UnitTests/ThreadTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ThreadTests.cs
@@ -102,7 +102,9 @@ public unsafe class ThreadTests
     {
         const uint id = 1;
         const ulong osId = 1234;
-        const uint state = (uint)(ThreadState.WaitSleepJoin | ThreadState.Background);
+        // Include a flag (AbortRequested) that the contract previously dropped to verify the
+        // full raw m_State bitfield is now reported verbatim.
+        const uint state = (uint)(ThreadState.WaitSleepJoin | ThreadState.Background | ThreadState.AbortRequested);
         MockThread? thread = null;
 
         TestPlaceholderTarget target = CreateTarget(
@@ -115,8 +117,10 @@ public unsafe class ThreadTests
 
         IThread contract = target.Contracts.Thread;
         ThreadData data = contract.GetThreadData(new TargetPointer(thread!.Address));
+        Assert.Equal(state, (uint)data.State);
         Assert.True(data.State.HasFlag(ThreadState.Background));
         Assert.True(data.State.HasFlag(ThreadState.WaitSleepJoin));
+        Assert.True(data.State.HasFlag(ThreadState.AbortRequested));
         Assert.False(data.State.HasFlag(ThreadState.Stopped));
     }
 


### PR DESCRIPTION
PR #126592 ("[cDAC] Fix bug in GetThreadData") removed `threadData->state = thread->m_State;` from ClrDataAccess::GetThreadData while reworking dead-thread reporting in a different path.  We still use a LOT of the enums in threadstate to debug the runtime.  In addition to the few that were previously wrapped:

1. The GC/debug suspension flags are critical to diagnosing hangs.
2. The COM apartment flags aren't used often, but do help us track down com issues (especially hangs due to apartment cross-calls).
3. The thread abort ones are not critical in most cases, but if they were to be present it would be a HUGE clue as to what's wrong wiht the process (someone is using an obsolete feature they shouldn't).

Once I wrapped those, I didn't have a good reason to not just finish the enum.