### PR TITLE
Remove NoWarn for NU1511 false positives

### DIFF
--- a/src/installer/tests/AppHost.Bundle.Tests/AppHost.Bundle.Tests.csproj
+++ b/src/installer/tests/AppHost.Bundle.Tests/AppHost.Bundle.Tests.csproj
@@ -9,9 +9,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <!-- Reduce the length of the test output dir to make it more reliable on Windows. -->
     <TestsOutputName>ahb</TestsOutputName>
-    <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
-         This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
-    <NoWarn>$(NoWarn);NU1511;xUnit1004</NoWarn>
     <TestRunnerName>XUnitV3</TestRunnerName>
   </PropertyGroup>
 

--- a/src/installer/tests/HostActivation.Tests/HostActivation.Tests.csproj
+++ b/src/installer/tests/HostActivation.Tests/HostActivation.Tests.csproj
@@ -8,9 +8,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <!-- Reduce the length of the test output dir to make it more reliable on Windows. -->
     <TestsOutputName>ha</TestsOutputName>
-    <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
-         This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
-    <NoWarn>$(NoWarn);NU1511</NoWarn>
     <TestRunnerName>XUnitV3</TestRunnerName>
   </PropertyGroup>
 

--- a/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
+++ b/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
@@ -6,9 +6,6 @@
     <!-- Package tests run on the host, not the target -->
     <RuntimeIdentifier>$(HostRid)</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
-    <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
-         This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
-    <NoWarn>$(NoWarn);NU1511</NoWarn>
     <TestRunnerName>XUnitV3</TestRunnerName>
   </PropertyGroup>
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Tests.csproj
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Tests.csproj
@@ -8,9 +8,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <!-- Reduce the length of the test output dir to make it more reliable on Windows. -->
     <TestsOutputName>hm</TestsOutputName>
-    <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
-         This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
-    <NoWarn>$(NoWarn);NU1511;xUnit1004</NoWarn>
     <TestRunnerName>XUnitV3</TestRunnerName>
   </PropertyGroup>
 

--- a/src/installer/tests/TestUtils/TestUtils.csproj
+++ b/src/installer/tests/TestUtils/TestUtils.csproj
@@ -5,9 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>TestUtils</AssemblyName>
     <PackageId>TestUtils</PackageId>
-    <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
-         This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
-    <NoWarn>$(NoWarn);NU1511</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+    <!-- This test library intentionally references an inbox P2P as it needs the implementation, instead of the contract.
+         Suppress the NU1511 warning in the whole project as putting it on a P2P doesn't work: https://github.com/NuGet/Home/issues/14121 -->
     <NoWarn>$(NoWarn);NU1511</NoWarn>
     <!-- CS0436: DynamicallyAccessedMemberTypes conflicts with imported type -->
     <NoWarn Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">$(NoWarn);CS0436</NoWarn>

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/tests/Microsoft.Extensions.Hosting.Abstractions.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/tests/Microsoft.Extensions.Hosting.Abstractions.Tests.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
-    <!-- Suppress the NU1511 warning in the whole project as putting it on a P2P doesn't work: https://github.com/NuGet/Home/issues/14121 -->
+    <!-- This test library intentionally references an inbox P2P as it needs the implementation, instead of the contract.
+         Suppress the NU1511 warning in the whole project as putting it on a P2P doesn't work: https://github.com/NuGet/Home/issues/14121 -->
     <NoWarn>$(NoWarn);NU1511</NoWarn>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Microsoft.Extensions.Logging.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Microsoft.Extensions.Logging.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <!-- This test library intentionally references an inbox P2P as it needs the implementation, instead of the contract.
+         Suppress the NU1511 warning in the whole project as putting it on a P2P doesn't work: https://github.com/NuGet/Home/issues/14121 -->
     <NoWarn>$(NoWarn);NU1511</NoWarn>
   </PropertyGroup>
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricOuterLoopTests/MetricOuterLoop.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricOuterLoopTests/MetricOuterLoop.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-browser;$(NetFrameworkCurrent)</TargetFrameworks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <NoWarn>NU1511</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
@@ -24,7 +23,7 @@
     <Compile Include="MetricEventSourceTests.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ProjectReference Include="..\..\src\System.Diagnostics.DiagnosticSource.csproj" />
   </ItemGroup>
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricOuterLoopTests/MetricOuterLoop1.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricOuterLoopTests/MetricOuterLoop1.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-browser;$(NetFrameworkCurrent)</TargetFrameworks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <NoWarn>NU1511</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
@@ -24,7 +23,7 @@
     <Compile Include="MetricEventSourceTests1.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ProjectReference Include="..\..\src\System.Diagnostics.DiagnosticSource.csproj" />
   </ItemGroup>
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-browser;$(NetFrameworkCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <NoWarn>NU1511</NoWarn>
     <EventSourceSupport Condition="'$(TestNativeAot)' == 'true'">true</EventSourceSupport>
     <!-- https://github.com/dotnet/runtime/issues/126862 -->
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
@@ -71,7 +70,7 @@
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs" Link="Common\System\Net\Configuration.Http.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ProjectReference Include="..\src\System.Diagnostics.DiagnosticSource.csproj" />
   </ItemGroup>
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
@@ -17,9 +17,6 @@
     <!-- SYSLIB1226: Suppress JsonIgnoreCondition.Always on type warning (tested explicitly) -->
     <NoWarn>$(NoWarn);SYSLIB0020;SYSLIB0049;SYSLIB1030;SYSLIB1034;SYSLIB1037;SYSLIB1038;SYSLIB1039;SYSLIB1220;SYSLIB1223;SYSLIB1225;SYSLIB1226</NoWarn>
     <IgnoreForCI Condition="'$(TargetsMobile)' == 'true' or '$(TargetsLinuxBionic)' == 'true' or '$(TargetArchitecture)' == 'ARMv6'">true</IgnoreForCI>
-    <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
-         This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
-    <NoWarn>$(NoWarn);NU1511</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -161,7 +158,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <ProjectReference Include="..\..\src\System.Text.Json.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Json\src\System.Text.Json.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Collections.Immutable\src\System.Collections.Immutable.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Linq.AsyncEnumerable\src\System.Linq.AsyncEnumerable.csproj" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -180,7 +178,6 @@
 
   <ItemGroup>
     <DefaultReferenceExclusion Include="System.Text.Json.SourceGeneration" />
-    <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj" />
   </ItemGroup>
 
   <Target Name="FixIncrementalCoreCompileWithAnalyzers" BeforeTargets="CoreCompile">

--- a/src/libraries/System.Threading.AccessControl/tests/System.Threading.AccessControl.Tests.csproj
+++ b/src/libraries/System.Threading.AccessControl/tests/System.Threading.AccessControl.Tests.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkCurrent)</TargetFrameworks>
-    <!-- This test library intentionally references inbox P2Ps as it needs the implementation, instead of the contract.
-         Suppress the NU1511 warning in the whole project as putting it on a P2P doesn't work: https://github.com/NuGet/Home/issues/14121 -->
-    <NoWarn>$(NoWarn);NU1511</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +17,7 @@
     <Compile Include="ThreadingAclExtensionsTests.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ProjectReference Include="..\src\System.Threading.AccessControl.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
The upstream nuget issue was fixed, remove the warning suppressions.

Also unify the comments for the remaining genuine NU1511 suppressions so that we use the same text everywhere.
In some cases we were able to remove the suppression by making a P2P reference .NETFramework only, since the assembly was moved to the base shared framework in .NET 11.