### PR TITLE
Build mobile inner TFMs as CoreCLR in Mono host builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -238,6 +238,9 @@
 
     <!-- this property is used by the SDK to pull in mono-based runtime packs -->
     <UseMonoRuntime Condition="'$(UseMonoRuntime)' == '' and '$(RuntimeFlavor)' == 'Mono'">true</UseMonoRuntime>
+    <UseMonoRuntime Condition="'$(UseMonoRuntime)' == 'true' and '$(TargetsMobile)' != 'true' and (
+        $(TargetFramework.EndsWith('-android')) or $(TargetFramework.EndsWith('-ios')) or
+        $(TargetFramework.EndsWith('-tvos')) or $(TargetFramework.EndsWith('-maccatalyst')))">false</UseMonoRuntime>
 
     <!-- For enabling the use of XUnitLogChecker in coreclr and libraries test runs. -->
     <!-- TODO: Enable XUnitLogChecker for NativeAOT tests https://github.com/dotnet/runtime/issues/94722 -->


### PR DESCRIPTION
## Description

When the runtime is built with a Mono-based SDK (for example the source-build validation leg), every project inherits `UseMonoRuntime=true`. The multi-targeted libraries also build their mobile target frameworks (`-android`, `-ios`, `-tvos`, `-maccatalyst`), and those inner builds pick up that same flag, so the SDK tries to use Mono for mobile and fails because mobile is CoreCLR-only in net11. This change turns `UseMonoRuntime` off for the mobile target frameworks so they always build as CoreCLR, even inside a Mono host build, which keeps the source-build Mono validation leg passing.