### PR TITLE
Add GetStressLogMemoryRanges to ISOSDacInterface17

### DIFF
--- a/src/coreclr/inc/sospriv.idl
+++ b/src/coreclr/inc/sospriv.idl
@@ -655,4 +655,5 @@ interface ISOSDacInterface17 : IUnknown
     HRESULT GetStressLogThreadEnumerator([out] ISOSStressLogThreadEnum **ppEnum);
     HRESULT GetStressLogMessageEnumerator([in] CLRDATA_ADDRESS threadStressLogAddress,
                                           [out] ISOSStressLogMsgEnum **ppEnum);
+    HRESULT GetStressLogMemoryRanges([out] ISOSMemoryEnum **ppEnum);
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStressLog.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStressLog.cs
@@ -33,6 +33,10 @@ public record struct StressMsgData(
     ulong Timestamp,
     IReadOnlyList<TargetPointer> Args);
 
+public record struct StressLogMemoryRange(
+    TargetPointer Start,
+    ulong Size);
+
 public interface IStressLog : IContract
 {
     static string IContract.Name { get; } = nameof(StressLog);
@@ -42,6 +46,7 @@ public interface IStressLog : IContract
     IEnumerable<ThreadStressLogData> GetThreadStressLogs(TargetPointer Logs) => throw new NotImplementedException();
     IEnumerable<StressMsgData> GetStressMessages(ThreadStressLogData threadLog) => throw new NotImplementedException();
     bool IsPointerInStressLog(StressLogData stressLog, TargetPointer pointer) => throw new NotImplementedException();
+    IEnumerable<StressLogMemoryRange> GetStressLogMemoryRanges(StressLogData stressLog) => throw new NotImplementedException();
 }
 
 public readonly struct StressLog : IStressLog

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StressLog.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StressLog.cs
@@ -231,6 +231,16 @@ internal sealed class StressLogTraversal(Target target, IStressMessageReader mes
         return false;
     }
 
+    public IEnumerable<StressLogMemoryRange> GetStressLogMemoryRanges(StressLogData stressLog)
+    {
+        ulong chunkSize = target.GetTypeInfo(DataType.StressLogChunk).Size!.Value;
+        StressLogMemory stressLogMemory = target.ProcessedData.GetOrAdd<StressLogMemory>(stressLog.Logs);
+        foreach (TargetPointer chunk in stressLogMemory.Chunks)
+        {
+            yield return new StressLogMemoryRange(chunk, chunkSize);
+        }
+    }
+
     private sealed class StressLogMemory(IReadOnlyList<TargetPointer> chunks) : Data.IData<StressLogMemory>
     {
         public static StressLogMemory Create(Target target, TargetPointer address)
@@ -343,6 +353,7 @@ internal sealed class StressLog_1(Target target) : IStressLog
     public IEnumerable<ThreadStressLogData> GetThreadStressLogs(TargetPointer Logs) => traversal.GetThreadStressLogs(Logs);
     public IEnumerable<StressMsgData> GetStressMessages(ThreadStressLogData threadLog) => traversal.GetStressMessages(threadLog);
     public bool IsPointerInStressLog(StressLogData stressLog, TargetPointer pointer) => traversal.IsPointerInStressLog(stressLog, pointer);
+    public IEnumerable<StressLogMemoryRange> GetStressLogMemoryRanges(StressLogData stressLog) => traversal.GetStressLogMemoryRanges(stressLog);
 }
 
 
@@ -356,4 +367,5 @@ internal sealed class StressLog_2(Target target) : IStressLog
     public IEnumerable<ThreadStressLogData> GetThreadStressLogs(TargetPointer Logs) => traversal.GetThreadStressLogs(Logs);
     public IEnumerable<StressMsgData> GetStressMessages(ThreadStressLogData threadLog) => traversal.GetStressMessages(threadLog);
     public bool IsPointerInStressLog(StressLogData stressLog, TargetPointer pointer) => traversal.IsPointerInStressLog(stressLog, pointer);
+    public IEnumerable<StressLogMemoryRange> GetStressLogMemoryRanges(StressLogData stressLog) => traversal.GetStressLogMemoryRanges(stressLog);
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ISOSDacInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ISOSDacInterface.cs
@@ -1266,4 +1266,8 @@ public unsafe partial interface ISOSDacInterface17
         ClrDataAddress threadStressLogAddress,
         DacComNullableByRef<ISOSStressLogMsgEnum> ppEnum);
 
+    [PreserveSig]
+    int GetStressLogMemoryRanges(
+        DacComNullableByRef<ISOSMemoryEnum> ppEnum);
+
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1745,6 +1745,12 @@ public sealed unsafe partial class SOSDacImpl
             }
         }
 
+        public SOSMemoryEnum(SOSMemoryRegion[] regions, ISOSMemoryEnum? legacyMemoryEnum = null)
+        {
+            _regions = regions;
+            _legacyMemoryEnum = legacyMemoryEnum;
+        }
+
         int ISOSMemoryEnum.Next(uint count, SOSMemoryRegion[] memRegions, uint* pNeeded)
         {
             int hr = HResults.S_OK;
@@ -7339,6 +7345,36 @@ public sealed unsafe partial class SOSDacImpl
 
             IEnumerable<Contracts.StressMsgData> messages = stressLogContract.GetStressMessages(matchedThread.Value);
             ppEnum.Interface = new SOSStressLogMsgEnum(_target, messages);
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+        return hr;
+    }
+
+    int ISOSDacInterface17.GetStressLogMemoryRanges(DacComNullableByRef<ISOSMemoryEnum> ppEnum)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            Contracts.IStressLog stressLogContract = _target.Contracts.StressLog;
+            if (!stressLogContract.HasStressLog())
+                return HResults.S_FALSE;
+
+            Contracts.StressLogData logData = stressLogContract.GetStressLogData();
+
+            SOSMemoryRegion[] regions = stressLogContract.GetStressLogMemoryRanges(logData)
+                .Select(r => new SOSMemoryRegion
+                {
+                    Start = r.Start.ToClrDataAddress(_target),
+                    Size = (ClrDataAddress)r.Size,
+                    ExtraData = default,
+                    Heap = 0,
+                })
+                .ToArray();
+            ppEnum.Interface = new SOSMemoryEnum(regions);
         }
         catch (System.Exception ex)
         {


### PR DESCRIPTION
## Summary

Adds `GetStressLogMemoryRanges` to `ISOSDacInterface17`. This interface has not been used by shipping products so I'm okay with this breaking change. The method enumerates the memory ranges (chunks) that back the in-memory stress log and returns them as an `ISOSMemoryEnum`, so diagnostic tools can discover and read stress-log memory regions. This functionality wasn't required by SOS, but is exposed by CLRMD.

## Changes

- **`sospriv.idl`** -- declare `HRESULT GetStressLogMemoryRanges([out] ISOSMemoryEnum **ppEnum)` on `ISOSDacInterface17`.
- **`IStressLog` (Abstractions)** -- add a `StressLogMemoryRange(TargetPointer Start, ulong Size)` record and a `GetStressLogMemoryRanges(StressLogData)` contract API.
- **`StressLog` contract** -- implement the API by enumerating the stress log chunks from the existing `StressLogMemory` processed data, sized by the `StressLogChunk` type; surfaced through both `StressLog_1` and `StressLog_2`.
- **`SOSDacImpl`** -- implement `ISOSDacInterface17.GetStressLogMemoryRanges`, projecting the contract ranges into `SOSMemoryRegion` entries; add a `SOSMemoryEnum` constructor that takes a precomputed region array.
