### PR TITLE
Fix wasm EH resume for handlers nested inside funclets

### DIFF
--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -1752,6 +1752,22 @@ DWORD_PTR EECodeManager::CallFunclet(OBJECTREF throwable, void* pHandler, REGDIS
 
 #ifdef TARGET_WASM
     TADDR wasmFramePointer = GetWasmFramePointerFromStackPointer(GetSP(pRD->pCurrentContext));
+    // A handler that is lexically nested inside a funclet (e.g. a catch inside a finally) must
+    // run with the enclosing METHOD frame as its establishing frame.
+    if (pExInfo->m_frameIter.m_crawl.IsFunclet())
+    {
+        T_CONTEXT walkCtx = *(pRD->pCurrentContext);
+        for (;;)
+        {
+            UnwindStackFrame(&walkCtx);
+            EECodeInfo ci(dac_cast<PCODE>(GetIP(&walkCtx)));
+            if (!ci.IsValid() || !ci.IsFunclet())
+            {
+                break;
+            }
+        }
+        wasmFramePointer = GetWasmFramePointerFromStackPointer(GetSP(&walkCtx));
+    }
     TADDR handlerFnIndex = CastHandlerFn(pfnHandler);
     if (throwable != NULL)
     {


### PR DESCRIPTION
On wasm, a handler lexically nested inside a funclet (e.g. a `catch` inside a `finally`) was invoked with the funclet's own frame as its establishing frame instead of the enclosing **method** frame. Because the method's locals and the FP-relative resume-IP slot live on the method frame, such a handler could not see method locals and wrote its resume IP into the wrong frame; the enclosing finally's resume switch then read a stale `0` and never resumed, so the original exception escaped.

The fix walks up the establisher chain (through any number of nested funclets) to the method (non-funclet) frame when the handler's containing frame is itself a funclet. It is wasm-only and a no-op for non-funclet-nested handlers.

Validated against the wasm R2R EH-resume test family (TryCatchInFinally, InnerFinallyAndCatch, Recurse, ThrowInFinallyNestedInTry, GoryManagedPresent, Pending, CollidedUnwind, ThrowInCatch) with no regressions.