### PR TITLE
Migrate more CoreCLR holders to `LifetimeHolder<>`

### DIFF
--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -34,6 +34,7 @@ extern void trace_verbose_printf(const char* format, ...);
 
 #include <windows.h>
 #include <stdlib.h>
+#include <crtdbg.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>

--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -804,13 +804,13 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
 
         // If the timestamp and size don't match, then this is the wrong file!
         // Map the file and check them.
-        HandleHolder hMDFile = WszCreateFile(pszFullPathName,
+        HandleHolder hMDFile{ WszCreateFile(pszFullPathName,
                                               GENERIC_READ,
                                               FILE_SHARE_READ,
                                               NULL,                 // default security descriptor
                                               OPEN_EXISTING,
                                               FILE_ATTRIBUTE_NORMAL,
-                                              NULL);
+                                              NULL) };
 
         if (hMDFile == INVALID_HANDLE_VALUE)
         {
@@ -828,7 +828,7 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
 
         _ASSERTE(dwFileHigh == 0);
 
-        HandleHolder hMap = CreateFileMapping(hMDFile, NULL, PAGE_READONLY, dwFileHigh, dwFileLow, NULL);
+        HandleHolder hMap{ CreateFileMapping(hMDFile, NULL, PAGE_READONLY, dwFileHigh, dwFileLow, NULL) };
         if (hMap == NULL)
         {
             LOG((LF_CORDB,LL_WARNING, "CM::IM: Couldn't create mapping of file \"%s\" (GLE=%x)\n", pszFullPathName, GetLastError()));

--- a/src/coreclr/debug/di/shimlocaldatatarget.cpp
+++ b/src/coreclr/debug/di/shimlocaldatatarget.cpp
@@ -385,10 +385,10 @@ ShimLocalDataTarget::GetThreadContext(
         return E_INVALIDARG;
     }
 
-    HandleHolder hThread = OpenThread(
+    HandleHolder hThread{ OpenThread(
         THREAD_GET_CONTEXT | THREAD_SET_CONTEXT | THREAD_QUERY_INFORMATION ,
         FALSE, // thread handle is not inheritable.
-        dwThreadID);
+        dwThreadID) };
 
     if (hThread != NULL)
     {
@@ -421,10 +421,10 @@ ShimLocalDataTarget::SetThreadContext(
     }
 
 
-    HandleHolder hThread = OpenThread(
+    HandleHolder hThread{ OpenThread(
         THREAD_GET_CONTEXT | THREAD_SET_CONTEXT | THREAD_QUERY_INFORMATION,
         FALSE, // thread handle is not inheritable.
-        dwThreadID);
+        dwThreadID) };
 
     if (hThread != NULL)
     {

--- a/src/coreclr/debug/di/windowspipeline.cpp
+++ b/src/coreclr/debug/di/windowspipeline.cpp
@@ -177,7 +177,7 @@ BOOL WindowsNativePipeline::TerminateProcess(UINT32 exitCode)
     _ASSERTE(m_dwProcessId != 0);
 
     // Get a process handle for the process ID.
-    HandleHolder hProc = OpenProcess(PROCESS_TERMINATE, FALSE, m_dwProcessId);
+    HandleHolder hProc{ OpenProcess(PROCESS_TERMINATE, FALSE, m_dwProcessId) };
 
     if (hProc == NULL)
     {

--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -318,7 +318,7 @@ HRESULT DebuggerRCThread::Init(void)
     if (dwStatus == ERROR_ALREADY_EXISTS)
     {
         // clean up the handle now
-        rightSideEventAvailable.Clear();
+        rightSideEventAvailable.Free();
     }
 
     HandleHolder rightSideEventRead(CreateEvent(NULL, (BOOL) kAutoResetEvent, FALSE, NULL));
@@ -331,7 +331,7 @@ HRESULT DebuggerRCThread::Init(void)
     if (dwStatus == ERROR_ALREADY_EXISTS)
     {
         // clean up the handle now
-        rightSideEventRead.Clear();
+        rightSideEventRead.Free();
     }
 
 
@@ -340,12 +340,6 @@ HRESULT DebuggerRCThread::Init(void)
     // Copy RSEA and RSER into the control block only if shared memory is created without error.
     if (m_pDCB)
     {
-        // Since Init() gets ownership of handles as soon as it's called, we can
-        // release our ownership now.
-        rightSideEventAvailable.SuppressRelease();
-        rightSideEventRead.SuppressRelease();
-        leftSideUnmanagedWaitEvent.SuppressRelease();
-
         // NOTE: initialization of the debugger control block occurs partly on the left side and partly on
         // the right side. This initialization occurs in parallel, so it's unsafe to make assumptions about
         // the order in which the fields will be initialized.
@@ -356,6 +350,12 @@ HRESULT DebuggerRCThread::Init(void)
                                        leftSideUnmanagedWaitEvent);
 
         _ASSERTE(SUCCEEDED(hr)); // throws on error.
+
+        // Since Init() gets ownership of handles, we can
+        // release our ownership now.
+        rightSideEventAvailable.Detach();
+        rightSideEventRead.Detach();
+        leftSideUnmanagedWaitEvent.Detach();
     }
 #endif //FEATURE_DBGIPC_TRANSPORT_VM
 

--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -343,19 +343,15 @@ HRESULT DebuggerRCThread::Init(void)
         // NOTE: initialization of the debugger control block occurs partly on the left side and partly on
         // the right side. This initialization occurs in parallel, so it's unsafe to make assumptions about
         // the order in which the fields will be initialized.
-        hr = m_pDCB->Init(rightSideEventAvailable,
-                                       rightSideEventRead,
+        // Since Init() gets ownership of handles, we can release our ownership now.
+        hr = m_pDCB->Init(rightSideEventAvailable.Detach(),
+                                       rightSideEventRead.Detach(),
                                        NULL,
                                        NULL,
-                                       leftSideUnmanagedWaitEvent);
+                                       leftSideUnmanagedWaitEvent.Detach());
 
         _ASSERTE(SUCCEEDED(hr)); // throws on error.
 
-        // Since Init() gets ownership of handles, we can
-        // release our ownership now.
-        rightSideEventAvailable.Detach();
-        rightSideEventRead.Detach();
-        leftSideUnmanagedWaitEvent.Detach();
     }
 #endif //FEATURE_DBGIPC_TRANSPORT_VM
 

--- a/src/coreclr/inc/holder.h
+++ b/src/coreclr/inc/holder.h
@@ -942,20 +942,8 @@ protected:
     ULONG32 m_cElements;
 };
 
-
 //-----------------------------------------------------------------------------
-// Wrap win32 functions using HANDLE
-//-----------------------------------------------------------------------------
-
-FORCEINLINE void VoidCloseHandle(HANDLE h) { if (h != NULL) CloseHandle(h); }
-
-// (UINT_PTR) -1 is INVALID_HANDLE_VALUE
-//@TODO: Dangerous default value. Some Win32 functions return INVALID_HANDLE_VALUE, some return NULL (such as CreatEvent).
-typedef Wrapper<HANDLE, DoNothing<HANDLE>, VoidCloseHandle, (UINT_PTR) -1> HandleHolder;
-
-
-//-----------------------------------------------------------------------------
-// Misc holders
+// Holders
 //-----------------------------------------------------------------------------
 
 template<typename T>
@@ -1033,6 +1021,22 @@ public:
         return value;
     }
 };
+
+//-----------------------------------------------------------------------------
+// Wrap win32 functions using HANDLE
+//-----------------------------------------------------------------------------
+struct HandleTraits final
+{
+    using Type = HANDLE;
+    static Type Default() { return INVALID_HANDLE_VALUE; }
+    static void Free(Type h)
+    {
+        STATIC_CONTRACT_WRAPPER;
+        if (h != NULL && h != Default())
+            CloseHandle(h);
+    }
+};
+using HandleHolder = LifetimeHolder<HandleTraits>;
 
 struct MapViewTraits final
 {

--- a/src/coreclr/inc/holder.h
+++ b/src/coreclr/inc/holder.h
@@ -13,6 +13,7 @@
 
 #include <utility>
 #include <type_traits>
+#include <memory>
 
 #if defined(FEATURE_COMINTEROP) && !defined(STRIKE)
 #include <Inspectable.h>
@@ -979,7 +980,7 @@ public:
     LifetimeHolder& operator=(LifetimeHolder&& other)
     {
         STATIC_CONTRACT_WRAPPER;
-        if (this != &other)
+        if (this != std::addressof(other))
         {
             Free();
             m_value = other.Detach();

--- a/src/coreclr/md/enc/stgio.cpp
+++ b/src/coreclr/md/enc/stgio.cpp
@@ -287,7 +287,7 @@ HRESULT StgIO::Open(                    // Return code.
                 return (PostError(CLDB_E_NO_DATA));
 
             // Data will come from the file.
-            m_hFile = hFile.Extract();
+            m_hFile = hFile.Detach();
 
             m_iType = STGIO_HFILE;
         }

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -191,13 +191,13 @@ static LPVOID CreateMemoryMappedFile(LPWSTR logFilename, size_t maxBytesTotal)
     WCHAR logFilenameReplaced[MAX_PATH];
     ReplacePid(logFilename, logFilenameReplaced, MAX_PATH);
 
-    HandleHolder hFile = WszCreateFile(logFilenameReplaced,
+    HandleHolder hFile{ WszCreateFile(logFilenameReplaced,
         GENERIC_READ | GENERIC_WRITE,
         FILE_SHARE_READ,
         NULL,                 // default security descriptor
         CREATE_ALWAYS,
         FILE_ATTRIBUTE_NORMAL,
-        NULL);
+        NULL) };
 
     if (hFile == INVALID_HANDLE_VALUE)
     {
@@ -205,7 +205,7 @@ static LPVOID CreateMemoryMappedFile(LPWSTR logFilename, size_t maxBytesTotal)
     }
 
     size_t fileSize = maxBytesTotal;
-    HandleHolder hMap = CreateFileMapping(hFile, NULL, PAGE_READWRITE, (DWORD)(fileSize >> 32), (DWORD)fileSize, NULL);
+    HandleHolder hMap{ CreateFileMapping(hFile, NULL, PAGE_READWRITE, (DWORD)(fileSize >> 32), (DWORD)fileSize, NULL) };
     if (hMap == NULL)
     {
         return nullptr;

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -2424,7 +2424,7 @@ namespace Util
 #ifdef HOST_WINDOWS
     // Struct used to scope suspension of client impersonation for the current thread.
     // https://learn.microsoft.com/windows/desktop/secauthz/client-impersonation
-    class SuspendImpersonation
+    class SuspendImpersonation final
     {
     public:
         SuspendImpersonation()
@@ -2448,11 +2448,14 @@ namespace Util
         ~SuspendImpersonation()
         {
             if (_token != nullptr)
+            {
                 ::SetThreadToken(nullptr, _token);
+                ::CloseHandle(_token);
+            }
         }
 
     private:
-        HandleHolder _token;
+        HANDLE _token;
     };
 
     struct ProcessIntegrityResult

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -1727,7 +1727,7 @@ void ComCallWrapper::Cleanup()
             // Check for an associated RCW
             RCWHolder pRCW(GetThread());
             pRCW.InitNoCheck(pSyncBlock);
-            NewRCWHolder pNewRCW = pRCW.GetRawRCWUnsafe();
+            NewRCWHolder pNewRCW{ pRCW.GetRawRCWUnsafe() };
 
             if (!pRCW.IsNull())
             {

--- a/src/coreclr/vm/cominterfacemarshaler.cpp
+++ b/src/coreclr/vm/cominterfacemarshaler.cpp
@@ -204,7 +204,7 @@ void COMInterfaceMarshaler::CreateObjectRef(BOOL fDuplicate, OBJECTREF *pComObj,
                 fInserted = m_pWrapperCache->FindOrInsertWrapper_NoLock(m_pIdentity, &pRCW, !fExisting);
                 _ASSERTE(fInserted);
 
-                pNewRCW.SuppressRelease();
+                pNewRCW.Detach();
             }
             else
             {
@@ -215,7 +215,7 @@ void COMInterfaceMarshaler::CreateObjectRef(BOOL fDuplicate, OBJECTREF *pComObj,
         else
         {
             // If we did insert this wrapper in the table, make sure we don't delete it.
-            pNewRCW.SuppressRelease();
+            pNewRCW.Detach();
         }
     }
 

--- a/src/coreclr/vm/crossloaderallocatorhash.h
+++ b/src/coreclr/vm/crossloaderallocatorhash.h
@@ -308,7 +308,7 @@ private:
         static LADependentHandleToNativeObject *CreateDependentHandle(
             LoaderAllocator *loaderAllocator,
             LADependentKeyToValuesHash *dependentKeyValueStoreHash);
-        ~LAHashDependentHashTracker(); // only accessible via DecRefCount()
+        ~LAHashDependentHashTracker(); // only accessible via Release()
 
     public:
         bool IsLoaderAllocatorLive() const { return _dependentHandle->GetDependentObject() != NULL; }
@@ -325,13 +325,13 @@ private:
         LoaderAllocator *GetLoaderAllocatorUnsafe() const { return _loaderAllocator; }
 
     #ifndef DACCESS_COMPILE
-        void IncRefCount()
+        void AddRef()
         {
             _ASSERTE(_refCount != 0);
             ++_refCount;
         }
 
-        void DecRefCount()
+        void Release()
         {
             _ASSERTE(_refCount != 0);
             if (--_refCount == 0)
@@ -339,16 +339,6 @@ private:
                 delete this;
             }
         }
-
-        static void StaticDecRefCount(LAHashDependentHashTracker *dependentTracker)
-        {
-            if (dependentTracker != NULL)
-            {
-                dependentTracker->DecRefCount();
-            }
-        }
-
-        using NewTrackerHolder = SpecializedWrapper<LAHashDependentHashTracker, StaticDecRefCount>;
     #endif // !DACCESS_COMPILE
     };
 
@@ -379,7 +369,7 @@ private:
         #ifndef DACCESS_COMPILE
             // Dependent trackers may be stored in multiple hash tables and are ref-counted when added/removed from a hash
             // table. The ref count decrement may also delete the tracker.
-            dependentTracker->DecRefCount();
+            dependentTracker->Release();
         #endif
         }
 

--- a/src/coreclr/vm/crossloaderallocatorhash.inl
+++ b/src/coreclr/vm/crossloaderallocatorhash.inl
@@ -135,7 +135,7 @@ CrossLoaderAllocatorHash<TRAITS>::LAHashKeyToTrackers::~LAHashKeyToTrackers()
     }
     else
     {
-        static_cast<LAHashDependentHashTracker *>(trackerOrTrackerSet)->DecRefCount();
+        static_cast<LAHashDependentHashTracker *>(trackerOrTrackerSet)->Release();
     }
 }
 
@@ -831,7 +831,7 @@ CrossLoaderAllocatorHash<TRAITS>::GetDependentTrackerForLoaderAllocator(LoaderAl
     }
 
     NewHolder<LADependentKeyToValuesHash> laDependentKeyToValuesHashHolder = new LADependentKeyToValuesHash();
-    typename LAHashDependentHashTracker::NewTrackerHolder dependentTrackerHolder =
+    ReleaseHolder<LAHashDependentHashTracker> dependentTrackerHolder =
         new LAHashDependentHashTracker(pLoaderAllocator, laDependentKeyToValuesHashHolder);
     laDependentKeyToValuesHashHolder.SuppressRelease();
 
@@ -862,7 +862,7 @@ CrossLoaderAllocatorHash<TRAITS>::GetKeyToValueCrossLAHashForHashkeyToTrackers(
     {
         dependentTracker = GetDependentTrackerForLoaderAllocator(pValueLoaderAllocator);
         hashKeyToTrackers->_trackerOrTrackerSet = dependentTracker;
-        dependentTracker->IncRefCount();
+        dependentTracker->AddRef();
     }
     else if (!hashKeyToTrackers->_trackerOrTrackerSet->IsTrackerSet())
     {
@@ -879,8 +879,8 @@ CrossLoaderAllocatorHash<TRAITS>::GetKeyToValueCrossLAHashForHashkeyToTrackers(
             if (!dependentTrackerMaybe->IsLoaderAllocatorLive())
             {
                 hashKeyToTrackers->_trackerOrTrackerSet = dependentTracker;
-                dependentTrackerMaybe->DecRefCount();
-                dependentTracker->IncRefCount();
+                dependentTrackerMaybe->Release();
+                dependentTracker->AddRef();
             }
             else
             {
@@ -890,7 +890,7 @@ CrossLoaderAllocatorHash<TRAITS>::GetKeyToValueCrossLAHashForHashkeyToTrackers(
                     new LAHashDependentHashTrackerSetWrapper();
                 LAHashDependentHashTrackerHash *dependentTrackerHash = dependentTrackerHashWrapperHolder->GetTrackerSet();
                 dependentTrackerHash->Add(dependentTracker);
-                dependentTracker->IncRefCount();
+                dependentTracker->AddRef();
                 dependentTrackerHash->Add(dependentTrackerMaybe);
                 hashKeyToTrackers->_trackerOrTrackerSet = dependentTrackerHashWrapperHolder.Extract();
             }
@@ -909,7 +909,7 @@ CrossLoaderAllocatorHash<TRAITS>::GetKeyToValueCrossLAHashForHashkeyToTrackers(
             // Get dependent tracker
             dependentTracker = GetDependentTrackerForLoaderAllocator(pValueLoaderAllocator);
             dependentTrackerHash->Add(dependentTracker);
-            dependentTracker->IncRefCount();
+            dependentTracker->AddRef();
         }
     }
 

--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -1358,7 +1358,7 @@ STRINGREF* LCGMethodResolver::GetOrInternString(STRINGREF *pProtectedStringRef)
     StringLiteralEntryHolder pEntry(pStringLiteralMap->GetInternedString(pProtectedStringRef, dwHash, /* bAddIfNotFound */ TRUE));
 
     DynamicStringLiteral* pStringLiteral = (DynamicStringLiteral*)m_jitTempData.New(sizeof(DynamicStringLiteral));
-    pStringLiteral->m_pEntry = pEntry.Extract();
+    pStringLiteral->m_pEntry = pEntry.Detach();
 
     // Add to m_DynamicStringLiterals:
     //  we don't need to check for duplicate because the string literal entries in

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -749,7 +749,7 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
 
         DisplayStackOverflowException();
 
-        HandleHolder stackDumpThreadHandle = Thread::CreateUtilityThread(Thread::StackSize_Small, LogStackOverflowStackTraceThread, GetThreadNULLOk(), W(".NET SO Tracer"));
+        HandleHolder stackDumpThreadHandle{ Thread::CreateUtilityThread(Thread::StackSize_Small, LogStackOverflowStackTraceThread, GetThreadNULLOk(), W(".NET SO Tracer")) };
         if (stackDumpThreadHandle != INVALID_HANDLE_VALUE)
         {
             // Wait for the stack trace logging completion

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -3409,7 +3409,7 @@ CreateCrashDumpIfEnabled(bool stackoverflow)
     {
         if (stackoverflow)
         {
-            HandleHolder createDumpThreadHandle = Thread::CreateUtilityThread(Thread::StackSize_Small, (LPTHREAD_START_ROUTINE)LaunchCreateDump, (void*)createDumpCommandLine, W(".NET SO Dumper"));
+            HandleHolder createDumpThreadHandle{ Thread::CreateUtilityThread(Thread::StackSize_Small, (LPTHREAD_START_ROUTINE)LaunchCreateDump, (void*)createDumpCommandLine, W(".NET SO Dumper")) };
             if (createDumpThreadHandle != INVALID_HANDLE_VALUE)
             {
                 // Wait for the dump to be generated

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -728,7 +728,7 @@ NATIVE_LIBRARY_HANDLE NativeLibrary::LoadLibraryByName(LPCWSTR libraryName, Asse
 
 namespace
 {
-    NATIVE_LIBRARY_HANDLE LoadNativeLibrary(PInvokeMethodDesc * pMD, LoadLibErrorTracker * pErrorTracker)
+    NativeLibraryHandleHolder LoadNativeLibrary(PInvokeMethodDesc * pMD, LoadLibErrorTracker * pErrorTracker)
     {
         CONTRACTL
         {
@@ -739,15 +739,17 @@ namespace
 
         LPCUTF8 name = pMD->GetLibName();
         if ( !name || !*name )
-            return NULL;
+        {
+            return {};
+        }
 
         _ASSERTE( name != NULL );
         MAKE_WIDEPTR_FROMUTF8( wszLibName, name );
 
-        NativeLibraryHandleHolder hmod = LoadNativeLibraryViaDllImportResolver(pMD, wszLibName);
+        NativeLibraryHandleHolder hmod{ LoadNativeLibraryViaDllImportResolver(pMD, wszLibName) };
         if (hmod != NULL)
         {
-            return hmod.Extract();
+            return hmod;
         }
 
         AppDomain* pDomain = GetAppDomain();
@@ -756,13 +758,13 @@ namespace
         hmod = LoadNativeLibraryViaAssemblyLoadContext(pAssembly, wszLibName);
         if (hmod != NULL)
         {
-            return hmod.Extract();
+            return hmod;
         }
 
         hmod = pDomain->FindUnmanagedImageInCache(wszLibName);
         if (hmod != NULL)
         {
-            return hmod.Extract();
+            return hmod;
         }
 
         hmod = LoadNativeLibraryBySearch(pMD, pErrorTracker, wszLibName);
@@ -770,16 +772,11 @@ namespace
         {
             // If we have a handle add it to the cache.
             pDomain->AddUnmanagedImageToCache(wszLibName, hmod);
-            return hmod.Extract();
+            return hmod;
         }
 
         hmod = LoadNativeLibraryViaAssemblyLoadContextEvent(pAssembly, wszLibName);
-        if (hmod != NULL)
-        {
-            return hmod.Extract();
-        }
-
-        return hmod.Extract();
+        return hmod;
     }
 }
 
@@ -794,7 +791,7 @@ NATIVE_LIBRARY_HANDLE NativeLibrary::LoadLibraryFromMethodDesc(PInvokeMethodDesc
     CONTRACT_END;
 
     LoadLibErrorTracker errorTracker;
-    NATIVE_LIBRARY_HANDLE hmod = LoadNativeLibrary(pMD, &errorTracker);
+    NativeLibraryHandleHolder hmod = LoadNativeLibrary(pMD, &errorTracker);
     if (hmod == NULL)
     {
         if (pMD->GetLibName() == NULL)
@@ -804,5 +801,5 @@ NATIVE_LIBRARY_HANDLE NativeLibrary::LoadLibraryFromMethodDesc(PInvokeMethodDesc
         errorTracker.Throw(ssLibName);
     }
 
-    RETURN hmod;
+    RETURN hmod.Detach();
 }

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -766,7 +766,7 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
         if (view == NULL)
             ThrowLastError();
 
-        m_FileView.Assign(view);
+        m_FileView = view;
         addr = (LPVOID)((size_t)view + offset - mapBegin);
 
         if (isCompressed)
@@ -780,7 +780,7 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
             if (anonMap == NULL)
                 ThrowLastError();
 
-            CLRMapViewHolder anonView = CLRMapViewOfFile(anonMap, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, 0);
+            CLRMapViewHolder anonView{ CLRMapViewOfFile(anonMap, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, 0) };
             if (anonView == NULL)
                 ThrowLastError();
 
@@ -813,7 +813,7 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
             addr = anonView;
             size = uncompressedSize;
             // Replace file handles with the handles to anonymous map. This will release the handles to the original view and map.
-            m_FileView.Assign(anonView.Extract());
+            m_FileView = std::move(anonView);
             m_FileMap.Assign(anonMap.Extract());
 #else
             _ASSERTE(!"Failure extracting contents of the application bundle. Compressed files used with a standalone (not singlefile) apphost.");
@@ -865,7 +865,7 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner, const BYTE* array, COUNT_T siz
         if (m_FileMap == NULL)
             ThrowLastError();
 
-        m_FileView.Assign(CLRMapViewOfFile(m_FileMap, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, 0));
+        m_FileView = CLRMapViewOfFile(m_FileMap, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, 0);
         if (m_FileView == NULL)
             ThrowLastError();
 

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -748,7 +748,7 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
             mapAccess = PAGE_EXECUTE_READ;
         }
 #endif
-        m_FileMap.Assign(CreateFileMapping(hFile, NULL, mapAccess, 0, 0, NULL));
+        m_FileMap = CreateFileMapping(hFile, NULL, mapAccess, 0, 0, NULL);
         if (m_FileMap == NULL)
             ThrowLastError();
 
@@ -776,7 +776,7 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
             // We will create another anonymous memory-only mapping and uncompress file there.
             // The flat image will refer to the anonymous mapping instead and we will release the original mapping.
 
-            HandleHolder anonMap = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, uncompressedSize >> 32, (DWORD)uncompressedSize, NULL);
+            HandleHolder anonMap{ CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, uncompressedSize >> 32, (DWORD)uncompressedSize, NULL) };
             if (anonMap == NULL)
                 ThrowLastError();
 
@@ -814,7 +814,7 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
             size = uncompressedSize;
             // Replace file handles with the handles to anonymous map. This will release the handles to the original view and map.
             m_FileView = std::move(anonView);
-            m_FileMap.Assign(anonMap.Extract());
+            m_FileMap = std::move(anonMap);
 #else
             _ASSERTE(!"Failure extracting contents of the application bundle. Compressed files used with a standalone (not singlefile) apphost.");
             ThrowHR(E_FAIL); // we don't have any indication of what kind of failure. Possibly a corrupt image.
@@ -861,7 +861,7 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner, const BYTE* array, COUNT_T siz
 
 #endif // defined(TARGET_WINDOWS)
 
-        m_FileMap.Assign(CreateFileMapping(INVALID_HANDLE_VALUE, NULL, mapAccess, 0, size, NULL));
+        m_FileMap = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, mapAccess, 0, size, NULL);
         if (m_FileMap == NULL)
             ThrowLastError();
 

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -357,7 +357,7 @@ OBJECTREF ComClassFactory::CreateAggregatedInstance(MethodTable* pMTClass, BOOL 
     {
         pOuter.SuppressRelease();
         pClassFact.SuppressRelease();
-        pNewRCW.SuppressRelease();
+        pNewRCW.Detach();
     }
 
     return oref;
@@ -1687,7 +1687,7 @@ void RCW::CreateDuplicateWrapper(MethodTable *pNewMT, RCWHolder* pNewRCW)
     }
     GCPROTECT_END();
 
-    pNewWrap.SuppressRelease();
+    pNewWrap.Detach();
 }
 
 //--------------------------------------------------------------------------------

--- a/src/coreclr/vm/runtimecallablewrapper.h
+++ b/src/coreclr/vm/runtimecallablewrapper.h
@@ -717,26 +717,31 @@ private:
 };
 #endif // FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
 
-FORCEINLINE void NewRCWHolderRelease(RCW* p)
+struct NewRCWHolderTraits final
 {
-    CONTRACTL
+    using Type = RCW*;
+    static constexpr Type Default() { return NULL; }
+    static void Free(Type p)
     {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_ANY;
+        }
+        CONTRACTL_END;
 
-    if (p)
-    {
-        GCX_COOP();
+        if (p)
+        {
+            GCX_COOP();
 
-        p->DecoupleFromObject();
-        p->Cleanup();
+            p->DecoupleFromObject();
+            p->Cleanup();
+        }
     }
 };
 
-using NewRCWHolder = SpecializedWrapper<RCW, NewRCWHolderRelease>;
+using NewRCWHolder = LifetimeHolder<NewRCWHolderTraits>;
 
 #ifndef DACCESS_COMPILE
 class RCWHolder

--- a/src/coreclr/vm/stringliteralmap.cpp
+++ b/src/coreclr/vm/stringliteralmap.cpp
@@ -155,73 +155,58 @@ STRINGREF *StringLiteralMap::GetStringLiteral(EEStringData *pStringData, BOOL bA
     }
     CONTRACTL_END;
 
+    DWORD dwHash = m_StringToEntryHashTable->GetHash(pStringData);
+
+    // Retrieve the string literal from the global string literal map.
+    CrstHolder gch(&(SystemDomain::GetGlobalStringLiteralMap()->m_HashTableCrstGlobal));
+
     // Don't use FOH for collectible modules to avoid potential memory leaks
     const bool preferFrozenObjectHeap = !bIsCollectible;
 
-    // This method never returns a pinned string; only the global-map path below can.
-    if (ppPinnedString != nullptr)
-        *ppPinnedString = nullptr;
+    StringLiteralEntryHolder pEntry(SystemDomain::GetGlobalStringLiteralMap()->GetStringLiteral(pStringData, dwHash, bAddIfNotFound, preferFrozenObjectHeap));
 
-    HashDatum Data;
-    DWORD dwHash = m_StringToEntryHashTable->GetHash(pStringData);
-    if (m_StringToEntryHashTable->GetValue(pStringData, &Data, dwHash))
+    _ASSERTE(pEntry || !bAddIfNotFound);
+
+    // If pEntry is non-null then the entry exists in the Global map. (either we retrieved it or added it just now)
+    if (pEntry)
     {
-        // Only collectible entries are tracked in the per-map table; non-collectible
-        // ones are kept alive by the global map and never inserted here.
-        _ASSERTE(bIsCollectible);
-        STRINGREF* pStrObj = ((StringLiteralEntry*)Data)->GetStringObject();
+        // pEntry holds a counted reference to a live entry, so read the (immutable)
+        // string object up front. This keeps the read independent of what we
+        // decide to do with our reference below.
+        STRINGREF* pStrObj = pEntry->GetStringObject();
         _ASSERTE(!bAddIfNotFound || pStrObj);
+
+        if (pStrObj != nullptr && ppPinnedString != nullptr && preferFrozenObjectHeap && pEntry->IsStringFrozen())
+        {
+            *ppPinnedString = *reinterpret_cast<void**>(pStrObj);
+        }
+
+        // Decide the fate of our reference. The global map lock (gch) is held for
+        // every outcome, as releasing a StringLiteralEntry requires.
+        if (!bIsCollectible)
+        {
+            // The appdomain never unloads, so we don't track the entry in the
+            // per-map table and simply keep the global reference alive.
+            LOG((LF_APPDOMAIN, LL_INFO10000, "Avoided adding String literal to appdomain map: size: %d bytes\n", pStringData->GetCharCount()));
+            pEntry.Detach();
+        }
+        else if (HashDatum Data; m_StringToEntryHashTable->GetValue(pStringData, &Data))
+        {
+            // Another thread already added the entry, release our reference.
+            _ASSERTE((StringLiteralEntry*)Data == (StringLiteralEntry*)pEntry);
+            pEntry.Free();
+        }
+        else
+        {
+            // Hand ownership of our reference to the per-map table, which releases
+            // it when the map is torn down.
+            m_StringToEntryHashTable->InsertValue(pStringData, (LPVOID)pEntry, FALSE);
+            pEntry.Detach();
+        }
+
         return pStrObj;
     }
-    else
-    {
-        // Retrieve the string literal from the global string literal map.
-        CrstHolder gch(&(SystemDomain::GetGlobalStringLiteralMap()->m_HashTableCrstGlobal));
 
-        StringLiteralEntryHolder pEntry(SystemDomain::GetGlobalStringLiteralMap()->GetStringLiteral(pStringData, dwHash, bAddIfNotFound, preferFrozenObjectHeap));
-
-        _ASSERTE(pEntry || !bAddIfNotFound);
-
-        // If pEntry is non-null then the entry exists in the Global map. (either we retrieved it or added it just now)
-        if (pEntry)
-        {
-            // pEntry holds a counted reference to a live entry, so read the (immutable)
-            // string object up front. This keeps the read independent of what we
-            // decide to do with our reference below.
-            STRINGREF* pStrObj = pEntry->GetStringObject();
-            _ASSERTE(!bAddIfNotFound || pStrObj);
-
-            if (pStrObj != nullptr && ppPinnedString != nullptr && preferFrozenObjectHeap && pEntry->IsStringFrozen())
-            {
-                *ppPinnedString = *reinterpret_cast<void**>(pStrObj);
-            }
-
-            // Decide the fate of our reference. The global map lock (gch) is held for
-            // every outcome, as releasing a StringLiteralEntry requires.
-            if (!bIsCollectible)
-            {
-                // The appdomain never unloads, so we don't track the entry in the
-                // per-map table and simply keep the global reference alive.
-                LOG((LF_APPDOMAIN, LL_INFO10000, "Avoided adding String literal to appdomain map: size: %d bytes\n", pStringData->GetCharCount()));
-                pEntry.Detach();
-            }
-            else if (m_StringToEntryHashTable->GetValue(pStringData, &Data))
-            {
-                // Another thread already added the entry, release our reference.
-                _ASSERTE((StringLiteralEntry*)Data == (StringLiteralEntry*)pEntry);
-                pEntry.Free();
-            }
-            else
-            {
-                // Hand ownership of our reference to the per-map table, which releases
-                // it when the map is torn down.
-                m_StringToEntryHashTable->InsertValue(pStringData, (LPVOID)pEntry, FALSE);
-                pEntry.Detach();
-            }
-
-            return pStrObj;
-        }
-    }
     // If the bAddIfNotFound flag is set then we better have a string
     // string object at this point.
     _ASSERTE(!bAddIfNotFound);

--- a/src/coreclr/vm/stringliteralmap.cpp
+++ b/src/coreclr/vm/stringliteralmap.cpp
@@ -174,41 +174,40 @@ STRINGREF *StringLiteralMap::GetStringLiteral(EEStringData *pStringData, BOOL bA
     // If pEntry is non-null then the entry exists in the Global map. (either we retrieved it or added it just now)
     if (pEntry)
     {
-        // If the entry exists in the Global map and the appdomain wont ever unload then we really don't need to add a
-        // hashentry in the appdomain specific map.
-        // TODO: except that by not inserting into our local table we always take the global map lock
-        // and come into this path, when we could succeed at a lock free lookup above.
-
-        if (bIsCollectible)
-        {
-            // Make sure some other thread has not already added it.
-            if (!m_StringToEntryHashTable->GetValue(pStringData, &Data))
-            {
-                // Insert the handle to the string into the hash table.
-                m_StringToEntryHashTable->InsertValue(pStringData, (LPVOID)pEntry, FALSE);
-            }
-            else
-            {
-                pEntry.Free(); //while we're still under lock
-            }
-        }
-#ifdef _DEBUG
-        else
-        {
-            LOG((LF_APPDOMAIN, LL_INFO10000, "Avoided adding String literal to appdomain map: size: %d bytes\n", pStringData->GetCharCount()));
-        }
-#endif
-        StringLiteralEntry* entry = pEntry.Detach();
-        STRINGREF *pStrObj = NULL;
-        // Retrieve the string objectref from the string literal entry.
-        pStrObj = entry->GetStringObject();
+        // pEntry holds a counted reference to a live entry, so read the (immutable)
+        // string object up front. This keeps the read independent of what we
+        // decide to do with our reference below.
+        STRINGREF* pStrObj = pEntry->GetStringObject();
         _ASSERTE(!bAddIfNotFound || pStrObj);
 
-
-        if (pStrObj != nullptr && ppPinnedString != nullptr && preferFrozenObjectHeap && entry->IsStringFrozen())
+        if (pStrObj != nullptr && ppPinnedString != nullptr && preferFrozenObjectHeap && pEntry->IsStringFrozen())
         {
             *ppPinnedString = *reinterpret_cast<void**>(pStrObj);
         }
+
+        // Decide the fate of our reference. The global map lock (gch) is held for
+        // every outcome, as releasing a StringLiteralEntry requires.
+        if (!bIsCollectible)
+        {
+            // The appdomain never unloads, so we don't track the entry in the
+            // per-map table and simply keep the global reference alive.
+            LOG((LF_APPDOMAIN, LL_INFO10000, "Avoided adding String literal to appdomain map: size: %d bytes\n", pStringData->GetCharCount()));
+            pEntry.Detach();
+        }
+        else if (m_StringToEntryHashTable->GetValue(pStringData, &Data))
+        {
+            // Another thread already added the entry, release our reference.
+            _ASSERTE((StringLiteralEntry*)Data == (StringLiteralEntry*)pEntry);
+            pEntry.Free();
+        }
+        else
+        {
+            // Hand ownership of our reference to the per-map table, which releases
+            // it when the map is torn down.
+            m_StringToEntryHashTable->InsertValue(pStringData, (LPVOID)pEntry, FALSE);
+            pEntry.Detach();
+        }
+
         return pStrObj;
     }
     // If the bAddIfNotFound flag is set then we better have a string
@@ -258,32 +257,39 @@ STRINGREF *StringLiteralMap::GetInternedString(STRINGREF *pString, BOOL bAddIfNo
         // If pEntry is non-null then the entry exists in the Global map. (either we retrieved it or added it just now)
         if (pEntry)
         {
-            // If the entry exists in the Global map and the appdomain wont ever unload then we really don't need to add a
-            // hashentry in the appdomain specific map.
-            // TODO: except that by not inserting into our local table we always take the global map lock
-            // and come into this path, when we could succeed at a lock free lookup above.
+            // pEntry holds a counted reference to a live entry, so read the string
+            // object up front, independent of what we do with our reference below.
+            STRINGREF* pStrObj = pEntry->GetStringObject();
 
-            if (bIsCollectible)
+            // Decide the fate of our reference. The global map lock (gch) is held
+            // for every outcome, as releasing a StringLiteralEntry requires.
+            if (!bIsCollectible)
             {
-                // Since GlobalStringLiteralMap::GetInternedString() could have caused a GC,
-                // we need to recreate the string data.
+                // The appdomain never unloads, keep the global reference alive.
+                pEntry.Detach();
+            }
+            else
+            {
+                // GlobalStringLiteralMap::GetInternedString() may have triggered a
+                // GC, so recreate the string data used as the hash-table key.
                 StringData = EEStringData((*pString)->GetStringLength(), (*pString)->GetBuffer());
 
-                // Make sure some other thread has not already added it.
-                if (!m_StringToEntryHashTable->GetValue(&StringData, &Data))
+                if (m_StringToEntryHashTable->GetValue(&StringData, &Data))
                 {
-                    // Insert the handle to the string into the hash table.
-                    m_StringToEntryHashTable->InsertValue(&StringData, (LPVOID)pEntry, FALSE);
+                    // Another thread already added the entry; release our redundant
+                    // reference. The global map is canonical, so the entry already
+                    // present must be the same one we just resolved.
+                    _ASSERTE((StringLiteralEntry*)Data == (StringLiteralEntry*)pEntry);
+                    pEntry.Free();
                 }
                 else
                 {
-                    pEntry.Free(); // while we're under lock
+                    // Hand ownership of our reference to the per-map table.
+                    m_StringToEntryHashTable->InsertValue(&StringData, (LPVOID)pEntry, FALSE);
+                    pEntry.Detach();
                 }
             }
-            StringLiteralEntry* entry = pEntry.Detach();
-            // Retrieve the string objectref from the string literal entry.
-            STRINGREF *pStrObj = NULL;
-            pStrObj = entry->GetStringObject();
+
             return pStrObj;
         }
     }

--- a/src/coreclr/vm/stringliteralmap.cpp
+++ b/src/coreclr/vm/stringliteralmap.cpp
@@ -155,60 +155,72 @@ STRINGREF *StringLiteralMap::GetStringLiteral(EEStringData *pStringData, BOOL bA
     }
     CONTRACTL_END;
 
-    HashDatum Data;
-
-    DWORD dwHash = m_StringToEntryHashTable->GetHash(pStringData);
-    // Retrieve the string literal from the global string literal map.
-    CrstHolder gch(&(SystemDomain::GetGlobalStringLiteralMap()->m_HashTableCrstGlobal));
-
-    // TODO: We can be more efficient by checking our local hash table now to see if
-    // someone beat us to inserting it. (m_StringToEntryHashTable->GetValue(pStringData, &Data))
-    // (Rather than waiting until after we look the string up in the global map)
-
     // Don't use FOH for collectible modules to avoid potential memory leaks
     const bool preferFrozenObjectHeap = !bIsCollectible;
-    StringLiteralEntryHolder pEntry(SystemDomain::GetGlobalStringLiteralMap()->GetStringLiteral(pStringData, dwHash, bAddIfNotFound, preferFrozenObjectHeap));
 
-    _ASSERTE(pEntry || !bAddIfNotFound);
+    // This method never returns a pinned string; only the global-map path below can.
+    if (ppPinnedString != nullptr)
+        *ppPinnedString = nullptr;
 
-    // If pEntry is non-null then the entry exists in the Global map. (either we retrieved it or added it just now)
-    if (pEntry)
+    HashDatum Data;
+    DWORD dwHash = m_StringToEntryHashTable->GetHash(pStringData);
+    if (m_StringToEntryHashTable->GetValue(pStringData, &Data, dwHash))
     {
-        // pEntry holds a counted reference to a live entry, so read the (immutable)
-        // string object up front. This keeps the read independent of what we
-        // decide to do with our reference below.
-        STRINGREF* pStrObj = pEntry->GetStringObject();
+        // Only collectible entries are tracked in the per-map table; non-collectible
+        // ones are kept alive by the global map and never inserted here.
+        _ASSERTE(bIsCollectible);
+        STRINGREF* pStrObj = ((StringLiteralEntry*)Data)->GetStringObject();
         _ASSERTE(!bAddIfNotFound || pStrObj);
-
-        if (pStrObj != nullptr && ppPinnedString != nullptr && preferFrozenObjectHeap && pEntry->IsStringFrozen())
-        {
-            *ppPinnedString = *reinterpret_cast<void**>(pStrObj);
-        }
-
-        // Decide the fate of our reference. The global map lock (gch) is held for
-        // every outcome, as releasing a StringLiteralEntry requires.
-        if (!bIsCollectible)
-        {
-            // The appdomain never unloads, so we don't track the entry in the
-            // per-map table and simply keep the global reference alive.
-            LOG((LF_APPDOMAIN, LL_INFO10000, "Avoided adding String literal to appdomain map: size: %d bytes\n", pStringData->GetCharCount()));
-            pEntry.Detach();
-        }
-        else if (m_StringToEntryHashTable->GetValue(pStringData, &Data))
-        {
-            // Another thread already added the entry, release our reference.
-            _ASSERTE((StringLiteralEntry*)Data == (StringLiteralEntry*)pEntry);
-            pEntry.Free();
-        }
-        else
-        {
-            // Hand ownership of our reference to the per-map table, which releases
-            // it when the map is torn down.
-            m_StringToEntryHashTable->InsertValue(pStringData, (LPVOID)pEntry, FALSE);
-            pEntry.Detach();
-        }
-
         return pStrObj;
+    }
+    else
+    {
+        // Retrieve the string literal from the global string literal map.
+        CrstHolder gch(&(SystemDomain::GetGlobalStringLiteralMap()->m_HashTableCrstGlobal));
+
+        StringLiteralEntryHolder pEntry(SystemDomain::GetGlobalStringLiteralMap()->GetStringLiteral(pStringData, dwHash, bAddIfNotFound, preferFrozenObjectHeap));
+
+        _ASSERTE(pEntry || !bAddIfNotFound);
+
+        // If pEntry is non-null then the entry exists in the Global map. (either we retrieved it or added it just now)
+        if (pEntry)
+        {
+            // pEntry holds a counted reference to a live entry, so read the (immutable)
+            // string object up front. This keeps the read independent of what we
+            // decide to do with our reference below.
+            STRINGREF* pStrObj = pEntry->GetStringObject();
+            _ASSERTE(!bAddIfNotFound || pStrObj);
+
+            if (pStrObj != nullptr && ppPinnedString != nullptr && preferFrozenObjectHeap && pEntry->IsStringFrozen())
+            {
+                *ppPinnedString = *reinterpret_cast<void**>(pStrObj);
+            }
+
+            // Decide the fate of our reference. The global map lock (gch) is held for
+            // every outcome, as releasing a StringLiteralEntry requires.
+            if (!bIsCollectible)
+            {
+                // The appdomain never unloads, so we don't track the entry in the
+                // per-map table and simply keep the global reference alive.
+                LOG((LF_APPDOMAIN, LL_INFO10000, "Avoided adding String literal to appdomain map: size: %d bytes\n", pStringData->GetCharCount()));
+                pEntry.Detach();
+            }
+            else if (m_StringToEntryHashTable->GetValue(pStringData, &Data))
+            {
+                // Another thread already added the entry, release our reference.
+                _ASSERTE((StringLiteralEntry*)Data == (StringLiteralEntry*)pEntry);
+                pEntry.Free();
+            }
+            else
+            {
+                // Hand ownership of our reference to the per-map table, which releases
+                // it when the map is torn down.
+                m_StringToEntryHashTable->InsertValue(pStringData, (LPVOID)pEntry, FALSE);
+                pEntry.Detach();
+            }
+
+            return pStrObj;
+        }
     }
     // If the bAddIfNotFound flag is set then we better have a string
     // string object at this point.
@@ -234,22 +246,15 @@ STRINGREF *StringLiteralMap::GetInternedString(STRINGREF *pString, BOOL bAddIfNo
     DWORD dwHash = m_StringToEntryHashTable->GetHash(&StringData);
     if (m_StringToEntryHashTable->GetValue(&StringData, &Data, dwHash))
     {
-        STRINGREF *pStrObj = NULL;
-        pStrObj = ((StringLiteralEntry*)Data)->GetStringObject();
+        STRINGREF* pStrObj = ((StringLiteralEntry*)Data)->GetStringObject();
         _ASSERTE(!bAddIfNotFound || pStrObj);
         return pStrObj;
-
     }
     else
     {
         CrstHolder gch(&(SystemDomain::GetGlobalStringLiteralMap()->m_HashTableCrstGlobal));
 
-        // TODO: We can be more efficient by checking our local hash table now to see if
-        // someone beat us to inserting it. (m_StringToEntryHashTable->GetValue(pStringData, &Data))
-        // (Rather than waiting until after we look the string up in the global map)
-
         // Retrieve the string literal from the global string literal map.
-
         StringLiteralEntryHolder pEntry(SystemDomain::GetGlobalStringLiteralMap()->GetInternedString(pString, dwHash, bAddIfNotFound));
 
         _ASSERTE(pEntry || !bAddIfNotFound);

--- a/src/coreclr/vm/stringliteralmap.cpp
+++ b/src/coreclr/vm/stringliteralmap.cpp
@@ -189,7 +189,7 @@ STRINGREF *StringLiteralMap::GetStringLiteral(EEStringData *pStringData, BOOL bA
             }
             else
             {
-                pEntry.Release(); //while we're still under lock
+                pEntry.Free(); //while we're still under lock
             }
         }
 #ifdef _DEBUG
@@ -198,14 +198,14 @@ STRINGREF *StringLiteralMap::GetStringLiteral(EEStringData *pStringData, BOOL bA
             LOG((LF_APPDOMAIN, LL_INFO10000, "Avoided adding String literal to appdomain map: size: %d bytes\n", pStringData->GetCharCount()));
         }
 #endif
-        pEntry.SuppressRelease();
+        StringLiteralEntry* entry = pEntry.Detach();
         STRINGREF *pStrObj = NULL;
         // Retrieve the string objectref from the string literal entry.
-        pStrObj = pEntry->GetStringObject();
+        pStrObj = entry->GetStringObject();
         _ASSERTE(!bAddIfNotFound || pStrObj);
 
 
-        if (pStrObj != nullptr && ppPinnedString != nullptr && preferFrozenObjectHeap && pEntry->IsStringFrozen())
+        if (pStrObj != nullptr && ppPinnedString != nullptr && preferFrozenObjectHeap && entry->IsStringFrozen())
         {
             *ppPinnedString = *reinterpret_cast<void**>(pStrObj);
         }
@@ -277,13 +277,13 @@ STRINGREF *StringLiteralMap::GetInternedString(STRINGREF *pString, BOOL bAddIfNo
                 }
                 else
                 {
-                    pEntry.Release(); // while we're under lock
+                    pEntry.Free(); // while we're under lock
                 }
             }
-            pEntry.SuppressRelease();
+            StringLiteralEntry* entry = pEntry.Detach();
             // Retrieve the string objectref from the string literal entry.
             STRINGREF *pStrObj = NULL;
-            pStrObj = pEntry->GetStringObject();
+            pStrObj = entry->GetStringObject();
             return pStrObj;
         }
     }
@@ -506,8 +506,7 @@ StringLiteralEntry *GlobalStringLiteralMap::AddStringLiteral(EEStringData *pStri
         _ASSERT(preferFrozenObjHeap);
         StringLiteralEntryHolder pEntry(StringLiteralEntry::AllocateFrozenEntry(pStringData, strObj));
         m_StringToEntryHashTable->InsertValue(pStringData, pEntry, FALSE);
-        pEntry.SuppressRelease();
-        pRet = pEntry;
+        pRet = pEntry.Detach();
         _ASSERT(pRet->IsStringFrozen());
     }
     else
@@ -525,8 +524,7 @@ StringLiteralEntry *GlobalStringLiteralMap::AddStringLiteral(EEStringData *pStri
             pStrObj.SuppressRelease();
             // Insert the handle to the string into the hash table.
             m_StringToEntryHashTable->InsertValue(pStringData, pEntry, FALSE);
-            pEntry.SuppressRelease();
-            pRet = pEntry;
+            pRet = pEntry.Detach();
         }
         GCPROTECT_END();
     }
@@ -569,8 +567,7 @@ StringLiteralEntry *GlobalStringLiteralMap::AddInternedString(STRINGREF *pString
 
         // Insert the handle to the string into the hash table.
         m_StringToEntryHashTable->InsertValue(&StringData, (LPVOID)pEntry, FALSE);
-        pEntry.SuppressRelease();
-        pRet = pEntry;
+        pRet = pEntry.Detach();
     }
 
     return pRet;

--- a/src/coreclr/vm/stringliteralmap.cpp
+++ b/src/coreclr/vm/stringliteralmap.cpp
@@ -156,13 +156,11 @@ STRINGREF *StringLiteralMap::GetStringLiteral(EEStringData *pStringData, BOOL bA
     CONTRACTL_END;
 
     DWORD dwHash = m_StringToEntryHashTable->GetHash(pStringData);
-
     // Retrieve the string literal from the global string literal map.
     CrstHolder gch(&(SystemDomain::GetGlobalStringLiteralMap()->m_HashTableCrstGlobal));
 
     // Don't use FOH for collectible modules to avoid potential memory leaks
     const bool preferFrozenObjectHeap = !bIsCollectible;
-
     StringLiteralEntryHolder pEntry(SystemDomain::GetGlobalStringLiteralMap()->GetStringLiteral(pStringData, dwHash, bAddIfNotFound, preferFrozenObjectHeap));
 
     _ASSERTE(pEntry || !bAddIfNotFound);

--- a/src/coreclr/vm/stringliteralmap.h
+++ b/src/coreclr/vm/stringliteralmap.h
@@ -320,7 +320,18 @@ private:
     static StringLiteralEntry      *s_FreeEntryList; // free list chained thru the arrays.
 };
 
-typedef Wrapper<StringLiteralEntry*,DoNothing,StringLiteralEntry::StaticRelease> StringLiteralEntryHolder;
+struct StringLiteralEntryTraits final
+{
+    using Type = StringLiteralEntry*;
+    static constexpr Type Default() { return NULL; }
+    static void Free(Type pEntry)
+    {
+        STATIC_CONTRACT_WRAPPER;
+        if (pEntry != NULL)
+            StringLiteralEntry::StaticRelease(pEntry);
+    }
+};
+using StringLiteralEntryHolder = LifetimeHolder<StringLiteralEntryTraits>;
 
 class StringLiteralEntryArray
 {

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -443,12 +443,20 @@ struct CLRMapViewTraits final
 using CLRMapViewHolder = LifetimeHolder<CLRMapViewTraits>;
 
 #ifdef TARGET_UNIX
+struct PALPEFileTraits final
+{
+    using Type = void*;
+    static constexpr Type Default() { return NULL; }
+    static void Free(Type ptr)
+    {
+        STATIC_CONTRACT_WRAPPER;
 #ifndef DACCESS_COMPILE
-FORCEINLINE void VoidPALUnloadPEFile(void *ptr) { PAL_LOADUnloadPEFile(ptr); }
-typedef Wrapper<void *, DoNothing, VoidPALUnloadPEFile> PALPEFileHolder;
-#else
-typedef Wrapper<void *, DoNothing, DoNothing> PALPEFileHolder;
+        if (ptr != NULL)
+            PAL_LOADUnloadPEFile(ptr);
 #endif
+    }
+};
+using PALPEFileHolder = LifetimeHolder<PALPEFileTraits>;
 #endif // TARGET_UNIX
 
 #define SetupThreadForComCall(OOMRetVal)            \

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -456,21 +456,26 @@ typedef Wrapper<void *, DoNothing, DoNothing> PALPEFileHolder;
 #define SetupForComCallDWORD() SetupThreadForComCall(ERROR_OUTOFMEMORY)
 
 // A holder for NATIVE_LIBRARY_HANDLE.
-FORCEINLINE void VoidFreeNativeLibrary(NATIVE_LIBRARY_HANDLE h)
+struct NativeLibraryHandleTraits final
 {
-    WRAPPER_NO_CONTRACT;
+    using Type = NATIVE_LIBRARY_HANDLE;
+    static constexpr Type Default() { return NULL; }
+    static void Free(Type h)
+    {
+        STATIC_CONTRACT_WRAPPER;
 
-    if (h == NULL)
-        return;
+        if (h == NULL)
+            return;
 
 #ifdef HOST_UNIX
-    PAL_FreeLibraryDirect(h);
+        PAL_FreeLibraryDirect(h);
 #else
-    FreeLibrary(h);
+        FreeLibrary(h);
 #endif
-}
+    }
+};
 
-typedef Wrapper<NATIVE_LIBRARY_HANDLE, DoNothing<NATIVE_LIBRARY_HANDLE>, VoidFreeNativeLibrary, 0> NativeLibraryHandleHolder;
+using NativeLibraryHandleHolder = LifetimeHolder<NativeLibraryHandleTraits>;
 
 extern thread_local size_t t_CantStopCount;
 

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -427,12 +427,20 @@ CLRUnmapViewOfFile(
     IN LPVOID lpBaseAddress
     );
 
+struct CLRMapViewTraits final
+{
+    using Type = void*;
+    static constexpr Type Default() { return NULL; }
+    static void Free(Type ptr)
+    {
+        STATIC_CONTRACT_WRAPPER;
 #ifndef DACCESS_COMPILE
-FORCEINLINE void VoidCLRUnmapViewOfFile(void *ptr) { CLRUnmapViewOfFile(ptr); }
-typedef Wrapper<void *, DoNothing, VoidCLRUnmapViewOfFile> CLRMapViewHolder;
-#else
-typedef Wrapper<void *, DoNothing, DoNothing> CLRMapViewHolder;
+        if (ptr != NULL)
+            CLRUnmapViewOfFile(ptr);
 #endif
+    }
+};
+using CLRMapViewHolder = LifetimeHolder<CLRMapViewTraits>;
 
 #ifdef TARGET_UNIX
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
Continues the migration of legacy `Wrapper`/`SpecializedWrapper`-based RAII holders to the trait-based `LifetimeHolder<Traits>` pattern (follow-up to #126368, #126522, #128103).

Each holder is converted in its own commit:

- `StringLiteralEntryHolder` → `LifetimeHolder<Traits>`
- `NativeLibraryHandleHolder` → `LifetimeHolder<Traits>` (also reworks `LoadNativeLibrary` to return the holder, so `LoadLibraryFromMethodDesc` has a single `Detach`)
- `CLRMapViewHolder` → `LifetimeHolder<Traits>`
- `PALPEFileHolder` → `LifetimeHolder<Traits>`
- Replace `NewTrackerHolder` with `ReleaseHolder<LAHashDependentHashTracker>` (renames `IncRefCount`/`DecRefCount` → `AddRef`/`Release`).
- `NewRCWHolder` → `LifetimeHolder<Traits>` *(Windows-only, `FEATURE_COMINTEROP`)*.
- `HandleHolder` → `LifetimeHolder<HandleTraits>`. `HandleTraits::Free` guards both `NULL` and `INVALID_HANDLE_VALUE`. `SuspendImpersonation` drops the holder for a raw `HANDLE` (the class already does manual RAII).

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot.
