### PR TITLE
Fix NativeAOT reflection invoke copyback

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -606,6 +606,11 @@ namespace Internal.Runtime.Augments
             return InvokeUtils.CheckArgument(srcObject, dstType.ToMethodTable(), InvokeUtils.CheckArgumentSemantics.DynamicInvoke, binderBundle);
         }
 
+        public static object CheckArgument(object srcObject, RuntimeTypeHandle dstType, BinderBundle? binderBundle, out bool copyBack)
+        {
+            return InvokeUtils.CheckArgument(srcObject, dstType.ToMethodTable(), InvokeUtils.CheckArgumentSemantics.DynamicInvoke, binderBundle, out copyBack);
+        }
+
         // FieldInfo.SetValueDirect() has a completely different set of rules on how to coerce the argument from
         // the other Reflection api.
         public static object CheckArgumentForDirectFieldAccess(object srcObject, RuntimeTypeHandle dstType)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -42,6 +42,13 @@ namespace System
 
         internal static object? CheckArgument(object? srcObject, MethodTable* dstEEType, CheckArgumentSemantics semantics, BinderBundle? binderBundle)
         {
+            return CheckArgument(srcObject, dstEEType, semantics, binderBundle, out _);
+        }
+
+        internal static object? CheckArgument(object? srcObject, MethodTable* dstEEType, CheckArgumentSemantics semantics, BinderBundle? binderBundle, out bool copyBack)
+        {
+            copyBack = false;
+
             // Methods with ByRefLike types in signatures should be filtered out earlier
             Debug.Assert(!dstEEType->IsByRefLike);
 
@@ -65,23 +72,24 @@ namespace System
             }
             else
             {
-                MethodTable* srcEEType = srcObject.GetMethodTable();
-
-                if (srcEEType == dstEEType ||
-                    RuntimeImports.AreTypesAssignable(srcEEType, dstEEType) ||
-                    (dstEEType->IsInterface && srcObject is Runtime.InteropServices.IDynamicInterfaceCastable castable
-                        && castable.IsInterfaceImplemented(new RuntimeTypeHandle(dstEEType), throwIfNotImplemented: false)))
+                if (IsArgumentAssignable(srcObject, dstEEType))
                 {
                     return srcObject;
                 }
 
-                return CheckArgumentConversions(srcObject, dstEEType, semantics, binderBundle);
+                return CheckArgumentConversions(srcObject, dstEEType, semantics, binderBundle, out copyBack);
             }
         }
 
         internal static object? CheckArgumentConversions(object srcObject, MethodTable* dstEEType, CheckArgumentSemantics semantics, BinderBundle? binderBundle)
         {
+            return CheckArgumentConversions(srcObject, dstEEType, semantics, binderBundle, out _);
+        }
+
+        internal static object? CheckArgumentConversions(object srcObject, MethodTable* dstEEType, CheckArgumentSemantics semantics, BinderBundle? binderBundle, out bool copyBack)
+        {
             object? dstObject;
+            copyBack = false;
             Exception exception = ConvertOrWidenPrimitivesEnumsAndPointersIfPossible(srcObject, dstEEType, semantics, out dstObject);
             if (exception == null)
                 return dstObject;
@@ -93,9 +101,19 @@ namespace System
             Type exactDstType = Type.GetTypeFromHandle(new RuntimeTypeHandle(dstEEType))!;
 
             srcObject = binderBundle.ChangeType(srcObject, exactDstType);
+            copyBack = srcObject is not null && IsArgumentAssignable(srcObject, dstEEType);
 
             // For compat with desktop, the result of the binder call gets processed through the default rules again.
             return CheckArgument(srcObject, dstEEType, semantics, binderBundle: null);
+        }
+
+        private static bool IsArgumentAssignable(object srcObject, MethodTable* dstEEType)
+        {
+            MethodTable* srcEEType = srcObject.GetMethodTable();
+            return srcEEType == dstEEType ||
+                RuntimeImports.AreTypesAssignable(srcEEType, dstEEType) ||
+                (dstEEType->IsInterface && srcObject is Runtime.InteropServices.IDynamicInterfaceCastable castable
+                    && castable.IsInterfaceImplemented(new RuntimeTypeHandle(dstEEType), throwIfNotImplemented: false));
         }
 
         // Special coersion rules for primitives, enums and pointer.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
@@ -22,7 +22,6 @@ namespace System.Reflection
         private readonly int _argumentCount;
         private readonly bool _isStatic;
         // private readonly bool _isValueTypeInstanceMethod;
-        private readonly bool _needsCopyBack;
         private readonly Transform _returnTransform;
         private readonly MethodTable* _returnType;
         private readonly ArgumentInfo[] _arguments;
@@ -77,7 +76,6 @@ namespace System.Reflection
                     Type argumentType = parameters[i].ParameterType;
                     if (argumentType.IsByRef)
                     {
-                        _needsCopyBack = true;
                         transform |= Transform.ByRef;
                         argumentType = argumentType.GetElementType()!;
                     }
@@ -419,7 +417,9 @@ namespace System.Reflection
                 RuntimeImports.RhRegisterForGCReporting(&regByRefStorage);
 
                 Span<object?> copyOfParameters = new(ref Unsafe.As<IntPtr, object?>(ref *pStorage), argCount);
-                CheckArguments(copyOfParameters, pByRefStorage, parameters, binderBundle);
+                Span<bool> shouldCopyBack = stackalloc bool[argCount];
+                shouldCopyBack.Clear();
+                bool needsCopyBack = CheckArguments(copyOfParameters, pByRefStorage, parameters, binderBundle, shouldCopyBack);
 
                 try
                 {
@@ -430,11 +430,9 @@ namespace System.Reflection
                 {
                     throw new TargetInvocationException(e);
                 }
-                finally
-                {
-                    if (_needsCopyBack)
-                        CopyBackToArray(ref Unsafe.As<IntPtr, object?>(ref *pStorage), parameters);
-                }
+
+                if (needsCopyBack)
+                    CopyBackToArray(ref Unsafe.As<IntPtr, object?>(ref *pStorage), parameters, shouldCopyBack);
             }
             finally
             {
@@ -468,13 +466,15 @@ namespace System.Reflection
                 RuntimeImports.RhRegisterForGCReporting(&regByRefStorage);
 
                 Span<object?> copyOfParameters = new(ref Unsafe.As<IntPtr, object?>(ref *pStorage), argCount);
-                CheckArguments(copyOfParameters, pByRefStorage, parameters);
+                Span<bool> shouldCopyBack = stackalloc bool[argCount];
+                shouldCopyBack.Clear();
+                bool needsCopyBack = CheckArguments(copyOfParameters, pByRefStorage, parameters, shouldCopyBack);
 
                 ret = ref RawCalliHelper.Call(InvokeThunk, (void*)methodToCall, ref thisArg, ref ret, pByRefStorage);
                 DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
 
-                if (_needsCopyBack)
-                    CopyBackToSpan(copyOfParameters, parameters);
+                if (needsCopyBack)
+                    CopyBackToSpan(copyOfParameters, parameters, shouldCopyBack);
             }
             finally
             {
@@ -496,8 +496,10 @@ namespace System.Reflection
             Span<object?> copyOfParameters = ((Span<object?>)argStorage._args).Slice(0, _argumentCount);
             StackAllocatedByRefs byrefStorage = default;
             void* pByRefStorage = (ByReference*)&byrefStorage;
+            ArgumentData<bool> copyBackStorage = default;
+            Span<bool> shouldCopyBack = ((Span<bool>)copyBackStorage).Slice(0, _argumentCount);
 
-            CheckArguments(copyOfParameters, pByRefStorage, parameters, binderBundle);
+            bool needsCopyBack = CheckArguments(copyOfParameters, pByRefStorage, parameters, binderBundle, shouldCopyBack);
 
             try
             {
@@ -508,11 +510,9 @@ namespace System.Reflection
             {
                 throw new TargetInvocationException(e);
             }
-            finally
-            {
-                if (_needsCopyBack)
-                    CopyBackToArray(ref copyOfParameters[0], parameters);
-            }
+
+            if (needsCopyBack)
+                CopyBackToArray(ref copyOfParameters[0], parameters, shouldCopyBack);
 
             return ref ret;
         }
@@ -528,19 +528,16 @@ namespace System.Reflection
             Span<object?> copyOfParameters = ((Span<object?>)argStorage._args).Slice(0, _argumentCount);
             StackAllocatedByRefs byrefStorage = default;
             void* pByRefStorage = (ByReference*)&byrefStorage;
+            ArgumentData<bool> copyBackStorage = default;
+            Span<bool> shouldCopyBack = ((Span<bool>)copyBackStorage).Slice(0, _argumentCount);
 
-            CheckArguments(copyOfParameters, pByRefStorage, parameters);
+            bool needsCopyBack = CheckArguments(copyOfParameters, pByRefStorage, parameters, shouldCopyBack);
 
-            try
-            {
-                ret = ref RawCalliHelper.Call(InvokeThunk, (void*)methodToCall, ref thisArg, ref ret, pByRefStorage);
-                DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
-            }
-            finally
-            {
-                if (_needsCopyBack)
-                    CopyBackToSpan(copyOfParameters, parameters);
-            }
+            ret = ref RawCalliHelper.Call(InvokeThunk, (void*)methodToCall, ref thisArg, ref ret, pByRefStorage);
+            DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+
+            if (needsCopyBack)
+                CopyBackToSpan(copyOfParameters, parameters, shouldCopyBack);
 
             return ref ret;
         }
@@ -560,7 +557,7 @@ namespace System.Reflection
             ret = ref RawCalliHelper.Call(InvokeThunk, (void*)methodToCall, ref thisArg, ref ret, pByRefStorage);
             DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
 
-            // No need to call CopyBack here since there are no ref values.
+            // No need to call CopyBack here since no copy of the arguments was made.
 
             return ref ret;
         }
@@ -585,17 +582,25 @@ namespace System.Reflection
             return defaultValue;
         }
 
-        private unsafe void CheckArguments(
+        private unsafe bool CheckArguments(
             Span<object?> copyOfParameters,
             void* byrefParameters,
             object?[] parameters,
-            BinderBundle? binderBundle)
+            BinderBundle? binderBundle,
+            Span<bool> shouldCopyBack)
         {
+            bool needsCopyBack = false;
+
             for (int i = 0; i < parameters.Length; i++)
             {
                 object? arg = parameters[i];
 
                 ref readonly ArgumentInfo argumentInfo = ref _arguments[i];
+                if ((argumentInfo.Transform & Transform.ByRef) != 0)
+                {
+                    shouldCopyBack[i] = true;
+                    needsCopyBack = true;
+                }
 
             Again:
                 if (arg is null)
@@ -615,8 +620,9 @@ namespace System.Reflection
                         // Missing is substited by metadata default value
                         arg = GetCoercedDefaultValue(i, in argumentInfo);
 
-                        // The metadata default value is written back into the parameters array
-                        parameters[i] = arg;
+                        // The metadata default value is written back into the parameters array after invocation.
+                        shouldCopyBack[i] = true;
+                        needsCopyBack = true;
                         if (arg is null)
                             goto Again; // Redo the argument handling to deal with null
                     }
@@ -633,7 +639,13 @@ namespace System.Reflection
                         if ((argumentInfo.Transform & Transform.ByRef) != 0)
                             throw InvokeUtils.CreateChangeTypeArgumentException(srcEEType, argumentInfo.Type, destinationIsByRef: true);
 
-                        arg = InvokeUtils.CheckArgumentConversions(arg, argumentInfo.Type, InvokeUtils.CheckArgumentSemantics.DynamicInvoke, binderBundle);
+                        bool copyBack;
+                        arg = InvokeUtils.CheckArgumentConversions(arg, argumentInfo.Type, InvokeUtils.CheckArgumentSemantics.DynamicInvoke, binderBundle, out copyBack);
+                        if (copyBack)
+                        {
+                            shouldCopyBack[i] = true;
+                            needsCopyBack = true;
+                        }
                     }
 
                     if ((argumentInfo.Transform & Transform.Reference) == 0)
@@ -664,6 +676,8 @@ namespace System.Reflection
                     ref Unsafe.As<object?, byte>(ref copyOfParameters[i]) : ref arg.GetRawData());
 #pragma warning restore 9094
             }
+
+            return needsCopyBack;
         }
 
         // This method is equivalent to the one above except that it takes 'Span<object>' instead of 'object[]'
@@ -673,11 +687,31 @@ namespace System.Reflection
             void* byrefParameters,
             Span<object?> parameters)
         {
+            Debug.Assert(parameters.Length <= MaxStackAllocArgCount);
+
+            ArgumentData<bool> copyBackStorage = default;
+            Span<bool> shouldCopyBack = ((Span<bool>)copyBackStorage).Slice(0, parameters.Length);
+            CheckArguments(copyOfParameters, byrefParameters, parameters, shouldCopyBack);
+        }
+
+        private unsafe bool CheckArguments(
+            Span<object?> copyOfParameters,
+            void* byrefParameters,
+            Span<object?> parameters,
+            Span<bool> shouldCopyBack)
+        {
+            bool needsCopyBack = false;
+
             for (int i = 0; i < parameters.Length; i++)
             {
                 object? arg = parameters[i];
 
                 ref readonly ArgumentInfo argumentInfo = ref _arguments[i];
+                if ((argumentInfo.Transform & Transform.ByRef) != 0)
+                {
+                    shouldCopyBack[i] = true;
+                    needsCopyBack = true;
+                }
 
                 if (arg is null)
                 {
@@ -732,44 +766,45 @@ namespace System.Reflection
                     ref Unsafe.As<object?, byte>(ref copyOfParameters[i]) : ref arg.GetRawData());
 #pragma warning restore 9094
             }
+
+            return needsCopyBack;
         }
 
-        private unsafe void CopyBackToArray(ref object? src, object?[] dest)
+        private unsafe void CopyBackToArray(ref object? src, object?[] dest, Span<bool> shouldCopyBack)
         {
             ArgumentInfo[] arguments = _arguments;
 
-            for (int i = 0; i < arguments.Length; i++)
+            for (int i = 0; i < dest.Length; i++)
             {
-                ref readonly ArgumentInfo argumentInfo = ref arguments[i];
-
-                Transform transform = argumentInfo.Transform;
-
-                if ((transform & Transform.ByRef) == 0)
-                    continue;
-
-                object? obj = Unsafe.Add(ref src, i);
-
-                if ((transform & (Transform.Pointer | Transform.FunctionPointer | Transform.Nullable)) != 0)
+                if (shouldCopyBack[i])
                 {
-                    if ((transform & Transform.Pointer) != 0)
-                    {
-                        Type type = Type.GetTypeFromMethodTable(argumentInfo.Type);
-                        Debug.Assert(type.IsPointer);
-                        obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref obj.GetRawData()), type);
-                    }
-                    else
-                    {
-                        obj = RuntimeExports.RhBox(
-                            (transform & Transform.FunctionPointer) != 0 ? MethodTable.Of<IntPtr>() : argumentInfo.Type,
-                            ref obj.GetRawData());
-                    }
-                }
+                    ref readonly ArgumentInfo argumentInfo = ref arguments[i];
 
-                dest[i] = obj;
+                    object? obj = Unsafe.Add(ref src, i);
+
+                    Transform transform = argumentInfo.Transform;
+                    if ((transform & (Transform.Pointer | Transform.FunctionPointer | Transform.Nullable)) != 0)
+                    {
+                        if ((transform & Transform.Pointer) != 0)
+                        {
+                            Type type = Type.GetTypeFromMethodTable(argumentInfo.Type);
+                            Debug.Assert(type.IsPointer);
+                            obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref obj.GetRawData()), type);
+                        }
+                        else
+                        {
+                            obj = RuntimeExports.RhBox(
+                                (transform & Transform.FunctionPointer) != 0 ? MethodTable.Of<IntPtr>() : argumentInfo.Type,
+                                ref obj.GetRawData());
+                        }
+                    }
+
+                    dest[i] = obj;
+                }
             }
         }
 
-        private unsafe void CopyBackToSpan(Span<object?> src, Span<object?> dest)
+        private unsafe void CopyBackToSpan(Span<object?> src, Span<object?> dest, Span<bool> shouldCopyBack)
         {
             ArgumentInfo[] arguments = _arguments;
 
@@ -777,30 +812,29 @@ namespace System.Reflection
             {
                 ref readonly ArgumentInfo argumentInfo = ref arguments[i];
 
-                Transform transform = argumentInfo.Transform;
-
-                if ((transform & Transform.ByRef) == 0)
-                    continue;
-
-                object? obj = src[i];
-
-                if ((transform & (Transform.Pointer | Transform.FunctionPointer | Transform.Nullable)) != 0)
+                if (shouldCopyBack[i])
                 {
-                    if ((transform & Transform.Pointer) != 0)
-                    {
-                        Type type = Type.GetTypeFromMethodTable(argumentInfo.Type);
-                        Debug.Assert(type.IsPointer);
-                        obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref obj.GetRawData()), type);
-                    }
-                    else
-                    {
-                        obj = RuntimeExports.RhBox(
-                            (transform & Transform.FunctionPointer) != 0 ? MethodTable.Of<IntPtr>() : argumentInfo.Type,
-                            ref obj.GetRawData());
-                    }
-                }
+                    object? obj = src[i];
 
-                dest[i] = obj;
+                    Transform transform = argumentInfo.Transform;
+                    if ((transform & (Transform.Pointer | Transform.FunctionPointer | Transform.Nullable)) != 0)
+                    {
+                        if ((transform & Transform.Pointer) != 0)
+                        {
+                            Type type = Type.GetTypeFromMethodTable(argumentInfo.Type);
+                            Debug.Assert(type.IsPointer);
+                            obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref obj.GetRawData()), type);
+                        }
+                        else
+                        {
+                            obj = RuntimeExports.RhBox(
+                                (transform & Transform.FunctionPointer) != 0 ? MethodTable.Of<IntPtr>() : argumentInfo.Type,
+                                ref obj.GetRawData());
+                        }
+                    }
+
+                    dest[i] = obj;
+                }
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/CustomMethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/CustomMethodInvoker.cs
@@ -22,15 +22,20 @@ namespace System.Reflection.Runtime.MethodInfos
         }
 
         protected sealed override object? Invoke(object? thisObject, object?[]? arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException) =>
-            InvokeSpecial(thisObject, arguments, binderBundle, wrapInTargetInvocationException);
+            InvokeSpecial(thisObject, arguments, arguments, binderBundle, wrapInTargetInvocationException);
 
         protected internal sealed override object? Invoke(object? thisObject, Span<object?> arguments) =>
-            InvokeSpecial(thisObject, arguments, binderBundle: null, wrapInTargetInvocationException: false);
+            InvokeSpecial(thisObject, arguments, copyBackArguments: null, binderBundle: null, wrapInTargetInvocationException: false);
 
         protected internal sealed override object? InvokeDirectWithFewArgs(object? thisObject, Span<object?> arguments) =>
-            InvokeSpecial(thisObject, arguments, binderBundle: null, wrapInTargetInvocationException: false);
+            InvokeSpecial(thisObject, arguments, copyBackArguments: null, binderBundle: null, wrapInTargetInvocationException: false);
 
-        private object? InvokeSpecial(object? thisObject, ReadOnlySpan<object?> arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
+        private object? InvokeSpecial(
+            object? thisObject,
+            ReadOnlySpan<object?> arguments,
+            object?[]? copyBackArguments,
+            BinderBundle binderBundle,
+            bool wrapInTargetInvocationException)
         {
             // This does not handle optional parameters. None of the methods we use custom invocation for have them.
             if (!(thisObject == null && 0 != (_options & InvokerOptions.AllowNullThis)))
@@ -41,10 +46,18 @@ namespace System.Reflection.Runtime.MethodInfos
                 throw new TargetParameterCountException();
 
             object[] convertedArguments = new object[argCount];
+            bool[]? shouldCopyBack = null;
             for (int i = 0; i < convertedArguments.Length; i++)
             {
-                convertedArguments[i] = RuntimeAugments.CheckArgument(arguments[i], _parameterTypes[i].TypeHandle, binderBundle);
+                bool copyBack;
+                convertedArguments[i] = RuntimeAugments.CheckArgument(arguments[i], _parameterTypes[i].TypeHandle, binderBundle, out copyBack);
+                if (copyBack)
+                {
+                    shouldCopyBack ??= new bool[argCount];
+                    shouldCopyBack[i] = true;
+                }
             }
+
             object result;
             try
             {
@@ -54,6 +67,18 @@ namespace System.Reflection.Runtime.MethodInfos
             {
                 throw new TargetInvocationException(e);
             }
+
+            if (shouldCopyBack is not null)
+            {
+                Debug.Assert(copyBackArguments is not null);
+
+                for (int i = 0; i < shouldCopyBack.Length; i++)
+                {
+                    if (shouldCopyBack[i])
+                        copyBackArguments[i] = convertedArguments[i];
+                }
+            }
+
             return result;
         }
 

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/Common.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/Common.cs
@@ -128,4 +128,10 @@ namespace System.Reflection.Tests
         public override PropertyInfo? SelectProperty(BindingFlags bindingAttr, PropertyInfo[] match, Type? returnType, Type[]? indexes, ParameterModifier[]? modifiers)
             => throw new NotImplementedException();
     }
+
+    public class ConvertStringToInt16Binder : ConvertStringToIntBinder
+    {
+        public override object ChangeType(object value, Type type, CultureInfo? culture)
+            => short.Parse((string)value);
+    }
 }

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/ConstructorInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/ConstructorInfoTests.cs
@@ -94,7 +94,6 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67531", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void Invoke_TwoDimensionalArray_CustomBinder_IncorrectTypeArguments()
         {
             var ctor = typeof(int[,]).GetConstructor(new[] { typeof(int), typeof(int) });
@@ -106,7 +105,6 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67531", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void Invoke_TwoParameters_CustomBinder_IncorrectTypeArgument()
         {
             ConstructorInfo[] constructors = GetConstructors(typeof(ClassWith3Constructors));

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
@@ -476,6 +476,16 @@ namespace System.Reflection.Tests
             Assert.True(args[1] is int);
         }
 
+        [Fact]
+        public void Invoke_CustomBinder_ResultRequiringPrimitiveWidening_DoesNotCopyBackWidenedArgument()
+        {
+            MethodInfo method = GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.StaticIntIntMethodReturningInt));
+            object[] args = new object[] { "10", 100 };
+
+            Assert.Equal(110, method.Invoke(null, BindingFlags.Default, new ConvertStringToInt16Binder(), args, null));
+            Assert.Equal("10", Assert.IsType<string>(args[0]));
+        }
+
         [Theory]
         [InlineData(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod1), new Type[] { typeof(int) })]
         [InlineData(typeof(MI_SubClass), nameof(MI_SubClass.GenericMethod2), new Type[] { typeof(string), typeof(int) })]

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodInfoTests.cs
@@ -467,7 +467,6 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67531", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void Invoke_TwoParameters_CustomBinder_IncorrectTypeArguments()
         {
             MethodInfo method = GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.StaticIntIntMethodReturningInt));

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Delegates.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Delegates.cs
@@ -51,7 +51,6 @@ public class Delegates
             result = Fail;
         }
 
-        TestLinqExpressions.Run();
         TestDefaultInterfaceMethods.Run();
 
         return result;
@@ -434,39 +433,6 @@ class ClassWithByRefs
     public static void Mutate(ref string x)
     {
         x += "Mutated";
-    }
-}
-
-class TestLinqExpressions
-{
-    public static void ModifyByRefAndThrow(ref int i)
-    {
-        i = 123;
-        throw new Exception();
-    }
-
-    delegate void RefIntDelegate(ref int i);
-
-    public static void Run()
-    {
-        Console.WriteLine("Testing LINQ Expressions...");
-
-        {
-            ParameterExpression pX = Expression.Parameter(typeof(int).MakeByRefType());
-            RefIntDelegate del =
-                Expression.Lambda<RefIntDelegate>(
-                    Expression.Call(null, typeof(TestLinqExpressions).GetMethod(nameof(ModifyByRefAndThrow)), pX), pX).Compile();
-
-            int i = 0;
-            try
-            {
-                del(ref i);
-            }
-            catch (Exception) { }
-
-            if (i != 123)
-                throw new Exception();
-        }
     }
 }
 


### PR DESCRIPTION
Fixes #67531.

Better to review with whitespace diffs off. We were not copying back results of binder conversions.

This also aligns reflection invoke argument copy-back with CoreCLR for byref and Type.Missing.

I was scratching my head over why we do the copyback in a `finally` (CoreCLR demonstratably doesn't and neither does .NET Framework), I guess CI will tell me if I missed something. So this aligns the copyback to also not be under `finally`.