### PR TITLE
Fsw.Tests: FileMove_FromWatchedToUnwatched: remove ActiveIssue.

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
@@ -186,7 +186,6 @@ namespace System.IO.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96728", typeof(PlatformDetection), nameof(PlatformDetection.IsReadyToRunCompiled))]
         private void FileMove_FromWatchedToUnwatched(WatcherChangeTypes eventType)
         {
             string dir_watched = CreateTestDirectory(TestDirectory, "dir_watched");


### PR DESCRIPTION
.NET 11 reduces the number of inotify instances a single application uses to one. This reduces contention during the test run.

Fixes https://github.com/dotnet/runtime/issues/96728.

@jkotas ptal.