### PR TITLE
[clr-interp][debugger] Skip ResumeInUpdatedFunction for Interpreter

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -9470,13 +9470,25 @@ TP_RESULT DebuggerEnCBreakpoint::TriggerPatch(DebuggerControllerPatch *patch,
     // Has the debugger requested a remap?
     if (resumeIL != (SIZE_T) -1)
     {
-        // This will jit the function, update the context, and resume execution at the new location.
-        g_pEEInterface->ResumeInUpdatedFunction(pModule,
-                                                pMD,
-                                                (void*)pJitInfo,
-                                                resumeIL,
-                                                pContext);
-        _ASSERTE(!"Returned from ResumeInUpdatedFunction!");
+#ifdef FEATURE_INTERPRETER
+        // TODO: The interpreter does not support EnC remap. If we're in interpreted code,
+        // skip the remap and let execution continue in the old version.
+        EECodeInfo codeInfo(GetIP(pContext));
+        if (codeInfo.IsInterpretedCode())
+        {
+            LOG((LF_ENC, LL_ALWAYS, "DEnCBP::TP: method is interpreted, EnC remap not supported - skipping\n"));
+        }
+        else
+#endif // FEATURE_INTERPRETER
+        {
+            // This will jit the function, update the context, and resume execution at the new location.
+            g_pEEInterface->ResumeInUpdatedFunction(pModule,
+                                                    pMD,
+                                                    (void*)pJitInfo,
+                                                    resumeIL,
+                                                    pContext);
+            _ASSERTE(!"Returned from ResumeInUpdatedFunction!");
+        }
     }
 
     LOG((LF_CORDB, LL_ALWAYS, "DEnCB::TP: We've returned from ResumeInUpdatedFunction"

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -9470,25 +9470,13 @@ TP_RESULT DebuggerEnCBreakpoint::TriggerPatch(DebuggerControllerPatch *patch,
     // Has the debugger requested a remap?
     if (resumeIL != (SIZE_T) -1)
     {
-#ifdef FEATURE_INTERPRETER
-        // TODO: The interpreter does not support EnC remap. If we're in interpreted code,
-        // skip the remap and let execution continue in the old version.
-        EECodeInfo codeInfo(GetIP(pContext));
-        if (codeInfo.IsInterpretedCode())
-        {
-            LOG((LF_ENC, LL_ALWAYS, "DEnCBP::TP: method is interpreted, EnC remap not supported - skipping\n"));
-        }
-        else
-#endif // FEATURE_INTERPRETER
-        {
-            // This will jit the function, update the context, and resume execution at the new location.
-            g_pEEInterface->ResumeInUpdatedFunction(pModule,
-                                                    pMD,
-                                                    (void*)pJitInfo,
-                                                    resumeIL,
-                                                    pContext);
-            _ASSERTE(!"Returned from ResumeInUpdatedFunction!");
-        }
+        // This will jit the function, update the context, and resume execution at the new location.
+        g_pEEInterface->ResumeInUpdatedFunction(pModule,
+                                                pMD,
+                                                (void*)pJitInfo,
+                                                resumeIL,
+                                                pContext);
+        _ASSERTE(!"Returned from ResumeInUpdatedFunction!");
     }
 
     LOG((LF_CORDB, LL_ALWAYS, "DEnCB::TP: We've returned from ResumeInUpdatedFunction"

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -12723,6 +12723,20 @@ HRESULT Debugger::UpdateFunction(MethodDesc* pMD, SIZE_T encVersion)
         return S_OK;
     }
 
+#ifdef FEATURE_INTERPRETER
+    // The interpreter does not support on-stack replacement via EnC remap.
+    // Skip planting remap breakpoints so we never offer a RemapOpportunity
+    // that we cannot fulfill.
+    {
+        EECodeInfo codeInfo((PCODE)pJitInfo->m_addrOfCode);
+        if (codeInfo.IsInterpretedCode())
+        {
+            LOG((LF_CORDB, LL_INFO10000, "D::UF: method is interpreted, skipping EnC remap breakpoints\n"));
+            return S_OK;
+        }
+    }
+#endif // FEATURE_INTERPRETER
+
     //
     // Mine the old version of the method with patches so that we can provide
     // remap opportunities whenever the old version of the method is executed.


### PR DESCRIPTION
We currently do not support EnC when debugging code from CoreCLR interpreter. By skipping the `ResumeInUpdatedFunction` we allow the changes to take place on subsequent method execution.