### PR TITLE
JIT: use type argument as the exact type for Activator.CreateInstance<T>

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -20828,23 +20828,6 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
                     objClass = gtGetClassHandle(call->gtArgs.GetThisArg()->GetNode(), pIsExact, pIsNonNull);
                     break;
                 }
-                if (ni == NI_System_Activator_CreateInstance_T)
-                {
-                    CallArg* instArg = call->gtArgs.FindWellKnownArg(WellKnownArg::InstParam);
-                    if (instArg != nullptr && instArg->GetNode()->IsIconHandle())
-                    {
-                        CORINFO_SIG_INFO methodSig;
-                        eeGetMethodSig((CORINFO_METHOD_HANDLE)instArg->GetNode()->AsIntCon()->GetCompileTimeHandle(),
-                                       &methodSig);
-                        if (methodSig.sigInst.methInstCount == 1)
-                        {
-                            objClass    = methodSig.sigInst.methInst[0];
-                            *pIsExact   = !eeIsSharedInst(objClass);
-                            *pIsNonNull = true;
-                        }
-                    }
-                    break;
-                }
 
                 CORINFO_CLASS_HANDLE specialObjClass = impGetSpecialIntrinsicExactReturnType(call);
                 if (specialObjClass != nullptr)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -20834,7 +20834,8 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
                     if (instArg != nullptr && instArg->GetNode()->IsIconHandle())
                     {
                         CORINFO_SIG_INFO methodSig;
-                        eeGetMethodSig((CORINFO_METHOD_HANDLE)instArg->GetNode()->AsIntCon()->IconValue(), &methodSig);
+                        eeGetMethodSig((CORINFO_METHOD_HANDLE)instArg->GetNode()->AsIntCon()->GetCompileTimeHandle(),
+                                       &methodSig);
                         if (methodSig.sigInst.methInstCount == 1)
                         {
                             objClass    = methodSig.sigInst.methInst[0];

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -20828,6 +20828,22 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
                     objClass = gtGetClassHandle(call->gtArgs.GetThisArg()->GetNode(), pIsExact, pIsNonNull);
                     break;
                 }
+                if (ni == NI_System_Activator_CreateInstance_T)
+                {
+                    CallArg* instArg = call->gtArgs.FindWellKnownArg(WellKnownArg::InstParam);
+                    if (instArg != nullptr && instArg->GetNode()->IsIconHandle())
+                    {
+                        CORINFO_SIG_INFO methodSig;
+                        eeGetMethodSig((CORINFO_METHOD_HANDLE)instArg->GetNode()->AsIntCon()->IconValue(), &methodSig);
+                        if (methodSig.sigInst.methInstCount == 1)
+                        {
+                            objClass    = methodSig.sigInst.methInst[0];
+                            *pIsExact   = !eeIsSharedInst(objClass);
+                            *pIsNonNull = true;
+                        }
+                    }
+                    break;
+                }
 
                 CORINFO_CLASS_HANDLE specialObjClass = impGetSpecialIntrinsicExactReturnType(call);
                 if (specialObjClass != nullptr)

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -9997,20 +9997,37 @@ CORINFO_CLASS_HANDLE Compiler::impGetSpecialIntrinsicExactReturnType(GenTreeCall
 
         case NI_System_Activator_CreateInstance_T:
         {
-            CallArg* instArg = call->gtArgs.FindWellKnownArg(WellKnownArg::InstParam);
-            if (instArg != nullptr && instArg->GetNode()->IsIconHandle())
+            // Expect one method generic parameter; figure out which it is.
+            CORINFO_SIG_INFO sig;
+            info.compCompHnd->getMethodSig(methodHnd, &sig);
+            assert(sig.sigInst.methInstCount == 1);
+            assert(sig.sigInst.classInstCount == 0);
+
+            CORINFO_CLASS_HANDLE typeHnd = sig.sigInst.methInst[0];
+            assert(typeHnd != nullptr);
+
+            CallArg* instParam = call->gtArgs.FindWellKnownArg(WellKnownArg::InstParam);
+            if (instParam != nullptr)
             {
-                CORINFO_SIG_INFO methodSig;
-                eeGetMethodSig((CORINFO_METHOD_HANDLE)instArg->GetNode()->AsIntCon()->GetCompileTimeHandle(),
-                               &methodSig);
-                if (methodSig.sigInst.methInstCount == 1)
+                assert(instParam->GetNext() == nullptr);
+                CORINFO_METHOD_HANDLE hMethod = gtGetHelperArgMethodHandle(instParam->GetNode());
+                if (hMethod != NO_METHOD_HANDLE)
                 {
-                    CORINFO_CLASS_HANDLE objClass = methodSig.sigInst.methInst[0];
-                    if (!eeIsSharedInst(objClass))
-                    {
-                        result = objClass;
-                    }
+                    typeHnd = getMethodInstantiationArgument(hMethod, 0);
                 }
+            }
+
+            result = eeIsSharedInst(typeHnd) ? NO_CLASS_HANDLE : typeHnd;
+
+            if (result != NO_CLASS_HANDLE)
+            {
+                JITDUMP("Special intrinsic for type %s: return type is %s\n", eeGetClassName(typeHnd),
+                        result != nullptr ? eeGetClassName(result) : "unknown");
+            }
+            else
+            {
+                JITDUMP("Special intrinsic for type %s: return type undetermined or inexact, so deferring opt\n",
+                        eeGetClassName(typeHnd));
             }
             break;
         }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -10702,8 +10702,6 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
     const char* methodName =
         info.compCompHnd->getMethodNameFromMetadata(method, &className, &namespaceName, enclosingClassNames,
                                                     ArrLen(enclosingClassNames));
-    CORINFO_SIG_INFO sig;
-    eeGetMethodSig(method, &sig);
 
     JITDUMP("Named Intrinsic ");
 
@@ -10771,9 +10769,14 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                         {
                             result = NI_System_Activator_AllocatorOf;
                         }
-                        else if (strcmp(methodName, "CreateInstance") == 0 && sig.hasTypeArg())
+                        else if (strcmp(methodName, "CreateInstance") == 0)
                         {
-                            result = NI_System_Activator_CreateInstance_T;
+                            CORINFO_SIG_INFO sig;
+                            eeGetMethodSig(method, &sig);
+                            if (sig.hasTypeArg())
+                            {
+                                result = NI_System_Activator_CreateInstance_T;
+                            }
                         }
                         else if (strcmp(methodName, "DefaultConstructorOf") == 0)
                         {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3898,6 +3898,12 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                 break;
             }
 
+            case NI_System_Activator_CreateInstance_T:
+            {
+                isSpecial = true;
+                break;
+            }
+
             case NI_System_Span_get_Item:
             case NI_System_ReadOnlySpan_get_Item:
             {
@@ -10659,6 +10665,8 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
     const char* methodName =
         info.compCompHnd->getMethodNameFromMetadata(method, &className, &namespaceName, enclosingClassNames,
                                                     ArrLen(enclosingClassNames));
+    CORINFO_SIG_INFO sig;
+    eeGetMethodSig(method, &sig);
 
     JITDUMP("Named Intrinsic ");
 
@@ -10725,6 +10733,10 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                         if (strcmp(methodName, "AllocatorOf") == 0)
                         {
                             result = NI_System_Activator_AllocatorOf;
+                        }
+                        else if (strcmp(methodName, "CreateInstance") == 0 && sig.hasTypeArg())
+                        {
+                            result = NI_System_Activator_CreateInstance_T;
                         }
                         else if (strcmp(methodName, "DefaultConstructorOf") == 0)
                         {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -10770,7 +10770,7 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                         {
                             CORINFO_SIG_INFO sig;
                             eeGetMethodSig(method, &sig);
-                            if (sig.hasTypeArg())
+                            if ((sig.sigInst.methInstCount == 1) && (sig.sigInst.classInstCount == 0))
                             {
                                 result = NI_System_Activator_CreateInstance_T;
                             }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -10003,8 +10003,8 @@ CORINFO_CLASS_HANDLE Compiler::impGetSpecialIntrinsicExactReturnType(GenTreeCall
             assert(sig.sigInst.methInstCount == 1);
             assert(sig.sigInst.classInstCount == 0);
 
-            CORINFO_CLASS_HANDLE typeHnd = sig.sigInst.methInst[0];
-            assert(typeHnd != nullptr);
+            CORINFO_CLASS_HANDLE result = sig.sigInst.methInst[0];
+            assert(result != nullptr);
 
             CallArg* instParam = call->gtArgs.FindWellKnownArg(WellKnownArg::InstParam);
             if (instParam != nullptr)
@@ -10013,11 +10013,9 @@ CORINFO_CLASS_HANDLE Compiler::impGetSpecialIntrinsicExactReturnType(GenTreeCall
                 CORINFO_METHOD_HANDLE hMethod = gtGetHelperArgMethodHandle(instParam->GetNode());
                 if (hMethod != NO_METHOD_HANDLE)
                 {
-                    typeHnd = getMethodInstantiationArgument(hMethod, 0);
+                    result = getMethodInstantiationArgument(hMethod, 0);
                 }
             }
-
-            result = eeIsSharedInst(typeHnd) ? NO_CLASS_HANDLE : typeHnd;
 
             if (result != NO_CLASS_HANDLE)
             {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -9995,6 +9995,26 @@ CORINFO_CLASS_HANDLE Compiler::impGetSpecialIntrinsicExactReturnType(GenTreeCall
             break;
         }
 
+        case NI_System_Activator_CreateInstance_T:
+        {
+            CallArg* instArg = call->gtArgs.FindWellKnownArg(WellKnownArg::InstParam);
+            if (instArg != nullptr && instArg->GetNode()->IsIconHandle())
+            {
+                CORINFO_SIG_INFO methodSig;
+                eeGetMethodSig((CORINFO_METHOD_HANDLE)instArg->GetNode()->AsIntCon()->GetCompileTimeHandle(),
+                               &methodSig);
+                if (methodSig.sigInst.methInstCount == 1)
+                {
+                    CORINFO_CLASS_HANDLE objClass = methodSig.sigInst.methInst[0];
+                    if (!eeIsSharedInst(objClass))
+                    {
+                        result = objClass;
+                    }
+                }
+            }
+            break;
+        }
+
         default:
         {
             JITDUMP("This special intrinsic not handled, sorry...\n");

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -10003,7 +10003,7 @@ CORINFO_CLASS_HANDLE Compiler::impGetSpecialIntrinsicExactReturnType(GenTreeCall
             assert(sig.sigInst.methInstCount == 1);
             assert(sig.sigInst.classInstCount == 0);
 
-            CORINFO_CLASS_HANDLE result = sig.sigInst.methInst[0];
+            result = sig.sigInst.methInst[0];
             assert(result != nullptr);
 
             CallArg* instParam = call->gtArgs.FindWellKnownArg(WellKnownArg::InstParam);

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -10003,8 +10003,8 @@ CORINFO_CLASS_HANDLE Compiler::impGetSpecialIntrinsicExactReturnType(GenTreeCall
             assert(sig.sigInst.methInstCount == 1);
             assert(sig.sigInst.classInstCount == 0);
 
-            result = sig.sigInst.methInst[0];
-            assert(result != nullptr);
+            CORINFO_CLASS_HANDLE typeHnd = sig.sigInst.methInst[0];
+            assert(typeHnd != nullptr);
 
             CallArg* instParam = call->gtArgs.FindWellKnownArg(WellKnownArg::InstParam);
             if (instParam != nullptr)

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -10021,13 +10021,12 @@ CORINFO_CLASS_HANDLE Compiler::impGetSpecialIntrinsicExactReturnType(GenTreeCall
 
             if (result != NO_CLASS_HANDLE)
             {
-                JITDUMP("Special intrinsic for type %s: return type is %s\n", eeGetClassName(typeHnd),
+                JITDUMP("Special intrinsic: return type is %s\n",
                         result != nullptr ? eeGetClassName(result) : "unknown");
             }
             else
             {
-                JITDUMP("Special intrinsic for type %s: return type undetermined or inexact, so deferring opt\n",
-                        eeGetClassName(typeHnd));
+                JITDUMP("Special intrinsic: return type undetermined or inexact, so deferring opt\n");
             }
             break;
         }

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -100,6 +100,7 @@ enum NamedIntrinsic : unsigned short
     NI_System_Type_op_Inequality,
     NI_System_Type_GetTypeFromHandle,
     NI_System_Type_GetGenericTypeDefinition,
+    NI_System_Activator_CreateInstance_T,
     NI_System_Array_Clone,
     NI_System_Array_GetLength,
     NI_System_Array_GetLowerBound,


### PR DESCRIPTION
`Activator.CreateInstance<T>` can only result in an instance of exact `T`. Teach the JIT so that when the JIT sees a call to `Activator.CreateInstance<T>`, it will know the result must be the exact `T`. Then any subsequent calls against the allocated object instance can be devirtualized.

This also applies to any `where T : new()` patterns.

Example:

```cs
class Program
{
    static T Get<T>() where T : new()
    {
        return new T();
    }

    class A
    {
        public virtual int Value => 1;
    }

    class B : A
    {
        public override int Value => 2;
    }

    static void Main()
    {
        Console.WriteLine(Get<A>().Value);
        Console.WriteLine(Get<B>().Value);
    }
}
```

Before:

```nasm
G_M27646_IG01:  ;; offset=0x0000
       sub      rsp, 40
G_M27646_IG02:  ;; offset=0x0004
       mov      rcx, 0x7FF92B6AB428      ; System.Activator:CreateInstance[Program+A]():Program+A
       call     [System.Activator:CreateInstance[System.__Canon]():System.__Canon]
       mov      rcx, rax
       mov      rax, qword ptr [rax]
       mov      rax, qword ptr [rax+0x48]
       call     [rax+0x20]Program+A:get_Value():int:this
       mov      ecx, eax
       call     [System.Console:WriteLine(int)]
       mov      rcx, 0x7FF92B6AB890      ; System.Activator:CreateInstance[Program+B]():Program+B
       call     [System.Activator:CreateInstance[System.__Canon]():System.__Canon]
       mov      rcx, rax
       mov      rax, qword ptr [rax]
       mov      rax, qword ptr [rax+0x48]
       call     [rax+0x20]Program+A:get_Value():int:this
       mov      ecx, eax
       call     [System.Console:WriteLine(int)]
       nop
G_M27646_IG03:  ;; offset=0x004F
       add      rsp, 40
       ret
```

After:

```nasm
G_M27646_IG01:  ;; offset=0x0000
       sub      rsp, 40
G_M27646_IG02:  ;; offset=0x0004
       mov      rcx, 0x7FF92C79B428      ; System.Activator:CreateInstance[Program+A]():Program+A
       call     [System.Activator:CreateInstance[System.__Canon]():System.__Canon]
       mov      ecx, 1
       call     [System.Console:WriteLine(int)]
       mov      rcx, 0x7FF92C79B890      ; System.Activator:CreateInstance[Program+B]():Program+B
       call     [System.Activator:CreateInstance[System.__Canon]():System.__Canon]
       mov      ecx, 2
       call     [System.Console:WriteLine(int)]
       nop
G_M27646_IG03:  ;; offset=0x003B
       add      rsp, 40
       ret
```

In the future we can apply escape analysis against `CreateInstance<T>` as well to omit unescaped object allocations.
