### PR TITLE
Async Profiler: Combine instrumentation flags usage over profiler/tpl/debugger.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -899,14 +899,10 @@ namespace System.Runtime.CompilerServices
             // NOTE, any changes done to this method need to be replicated in InstrumentedDispatchContinuations as well.
             private unsafe void DispatchContinuations()
             {
-                if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
                 {
-                    AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-                    if (flags != AsyncInstrumentation.Flags.Disabled)
-                    {
-                        InstrumentedDispatchContinuations(flags);
-                        return;
-                    }
+                    InstrumentedDispatchContinuations(flags);
+                    return;
                 }
 
                 // Intentionally skip initialization for this state; the Push
@@ -1001,14 +997,14 @@ namespace System.Runtime.CompilerServices
                         return;
                     }
 
-                    if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
+                    if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out flags))
                     {
                         SetContinuationState(asyncDispatcherInfo.NextContinuation);
 
                         awaitState.Pop();
                         refDispatcherInfo = asyncDispatcherInfo.Next;
 
-                        InstrumentedDispatchContinuations(AsyncInstrumentation.ActiveFlags);
+                        InstrumentedDispatchContinuations(flags);
                         return;
                     }
                 }
@@ -1126,7 +1122,7 @@ namespace System.Runtime.CompilerServices
                         return;
                     }
 
-                    flags = AsyncInstrumentation.ActiveFlags;
+                    flags = AsyncInstrumentation.LoadFlags();
                 }
             }
 
@@ -1248,14 +1244,10 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void FinalizeRuntimeAsyncTask<T>(ref RuntimeAsyncAwaitState state, RuntimeAsyncTask<T> task)
         {
-            if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
+            if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
             {
-                AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-                if (flags != AsyncInstrumentation.Flags.Disabled)
-                {
-                    InstrumentedFinalizeRuntimeAsyncTask(task, ref state, flags);
-                    return;
-                }
+                InstrumentedFinalizeRuntimeAsyncTask(task, ref state, flags);
+                return;
             }
 
             task.HandleSuspended(ref state);
@@ -1561,12 +1553,6 @@ namespace System.Runtime.CompilerServices
         // These methods should not throw - exceptions would break the dispatch loop.
         internal static class RuntimeAsyncInstrumentationHelpers
         {
-            public static bool InstrumentCheckPoint
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
-            }
-
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static void SyncPointCheck(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Continuation curContinuation)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -901,8 +901,11 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
                 {
-                    InstrumentedDispatchContinuations(flags);
-                    return;
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags) || AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
+                    {
+                        InstrumentedDispatchContinuations(flags);
+                        return;
+                    }
                 }
 
                 // Intentionally skip initialization for this state; the Push
@@ -999,13 +1002,16 @@ namespace System.Runtime.CompilerServices
 
                     if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out flags))
                     {
-                        SetContinuationState(asyncDispatcherInfo.NextContinuation);
+                        if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags) || AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
+                        {
+                            SetContinuationState(asyncDispatcherInfo.NextContinuation);
 
-                        awaitState.Pop();
-                        refDispatcherInfo = asyncDispatcherInfo.Next;
+                            awaitState.Pop();
+                            refDispatcherInfo = asyncDispatcherInfo.Next;
 
-                        InstrumentedDispatchContinuations(flags);
-                        return;
+                            InstrumentedDispatchContinuations(flags);
+                            return;
+                        }
                     }
                 }
             }
@@ -1246,8 +1252,11 @@ namespace System.Runtime.CompilerServices
         {
             if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
             {
-                InstrumentedFinalizeRuntimeAsyncTask(task, ref state, flags);
-                return;
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags) || AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
+                {
+                    InstrumentedFinalizeRuntimeAsyncTask(task, ref state, flags);
+                    return;
+                }
             }
 
             task.HandleSuspended(ref state);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
@@ -1,16 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading;
-using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Runtime.CompilerServices
 {
     internal static class AsyncInstrumentation
     {
-        public static bool IsSupported => Debugger.IsSupported || EventSource.IsSupported;
+        public static bool IsAsyncProfilerSupported => EventSource.IsSupported;
+        public static bool IsAsyncDebuggerSupported => Debugger.IsSupported;
+        public static bool IsTplSupported => EventSource.IsSupported;
+
+        public static bool IsSupported
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => IsAsyncProfilerSupported || IsTplSupported || IsAsyncDebuggerSupported;
+        }
 
         [Flags]
         public enum Flags : uint
@@ -29,40 +37,72 @@ namespace System.Runtime.CompilerServices
             // Bit 25 - 31 reserved for instrumentation clients.
             AsyncProfiler = 0x1000000,
             AsyncDebugger = 0x2000000,
+            Tpl = 0x4000000,
 
             // Bit 32 reserved for synchronization flag.
             Synchronize = 0x80000000
         }
 
-        public const Flags DefaultFlags =
+        public const Flags DefaultProfilerFlags =
+            Flags.ResumeAsyncContext | Flags.SuspendAsyncContext | Flags.CompleteAsyncContext;
+
+        public const Flags DefaultDebuggerFlags =
             Flags.CreateAsyncContext | Flags.ResumeAsyncContext | Flags.SuspendAsyncContext |
             Flags.CompleteAsyncContext | Flags.UnwindAsyncException |
             Flags.ResumeAsyncMethod | Flags.CompleteAsyncMethod;
 
+        public const Flags DefaultTplFlags = Flags.Tpl;
+
         public static class IsEnabled
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool CreateAsyncContext(Flags flags) => (Flags.CreateAsyncContext & flags) != 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool ResumeAsyncContext(Flags flags) => (Flags.ResumeAsyncContext & flags) != 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool SuspendAsyncContext(Flags flags) => (Flags.SuspendAsyncContext & flags) != 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool CompleteAsyncContext(Flags flags) => (Flags.CompleteAsyncContext & flags) != 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool UnwindAsyncException(Flags flags) => (Flags.UnwindAsyncException & flags) != 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool ResumeAsyncMethod(Flags flags) => (Flags.ResumeAsyncMethod & flags) != 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool CompleteAsyncMethod(Flags flags) => (Flags.CompleteAsyncMethod & flags) != 0;
-            public static bool AsyncProfiler(Flags flags) => (Flags.AsyncProfiler & flags) != 0;
-            public static bool AsyncDebugger(Flags flags) => (Flags.AsyncDebugger & flags) != 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool AsyncProfiler(Flags flags) => AsyncInstrumentation.IsAsyncProfilerSupported && (Flags.AsyncProfiler & flags) != 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool AsyncDebugger(Flags flags) => AsyncInstrumentation.IsAsyncDebuggerSupported && (Flags.AsyncDebugger & flags) != 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool Tpl(Flags flags) => AsyncInstrumentation.IsTplSupported && (Flags.Tpl & flags) != 0;
         }
 
-        public static Flags ActiveFlags => s_activeFlags;
+        public static bool IsActive
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => AsyncInstrumentation.IsSupported && s_activeFlags != Flags.Disabled;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Flags SyncActiveFlags()
+        public static Flags LoadFlags()
         {
-            Flags flags = s_activeFlags;
-            if ((flags & Flags.Synchronize) != 0)
+            if (!IsSupported)
             {
-                return SynchronizeFlags();
+                return Flags.Disabled;
             }
-            return flags;
+            return LoadAndSynchronizeFlags(s_activeFlags);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool LoadFlags(out Flags flags)
+        {
+            if (!IsSupported)
+            {
+                flags = Flags.Disabled;
+                return false;
+            }
+            flags = LoadAndSynchronizeFlags(s_activeFlags);
+            return flags != Flags.Disabled;
         }
 
         public static void UpdateAsyncProfilerFlags(Flags asyncProfilerFlags)
@@ -79,20 +119,57 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        private static Flags SynchronizeFlags()
+        public static void UpdateTplFlags(Flags tplFlags)
         {
-            _ = TplEventSource.Log; // Touch TplEventSource to trigger static constructor which will initialize TPL flags if EventSource is supported.
-            _ = AsyncProfilerEventSource.Log; // Touch AsyncProfilerEventSource to trigger static constructor which will initialize async profiler flags if EventSource is supported.
+            if (tplFlags != Flags.Disabled)
+            {
+                tplFlags |= Flags.Tpl;
+            }
 
             lock (s_lock)
             {
+                s_tplActiveFlags = tplFlags;
+                s_activeFlags |= Flags.Synchronize;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Flags LoadAndSynchronizeFlags(Flags flags)
+        {
+            if ((flags & Flags.Synchronize) != 0)
+            {
+                return SynchronizeFlags();
+            }
+            return flags;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Flags SynchronizeFlags()
+        {
+            if (IsTplSupported)
+            {
+                _ = TplEventSource.Log; // Touch TplEventSource to trigger static constructor which will initialize TPL flags if EventSource is supported.
+            }
+
+            if (IsAsyncProfilerSupported)
+            {
+                _ = AsyncProfilerEventSource.Log; // Touch AsyncProfilerEventSource to trigger static constructor which will initialize async profiler flags if EventSource is supported.
+            }
+
+            lock (s_lock)
+            {
+                // Read Task.s_asyncDebuggingEnabled live: unlike the profiler and TPL clients (which push their
+                // state via UpdateAsyncProfilerFlags/UpdateTplFlags), the debugger sets s_asyncDebuggingEnabled
+                // directly and, in the same update, sets the Flags.Synchronize bit on s_activeFlags to trigger this
+                // re-sync. Keep this a live read and keep the Synchronize bit value/composition stable; the debugger
+                // depends on it to make the AsyncDebugger client observable at the instrumentation checkpoints.
                 Flags asyncDebuggerActiveFlags = Flags.Disabled;
                 if (Task.s_asyncDebuggingEnabled)
                 {
-                    asyncDebuggerActiveFlags = DefaultFlags | Flags.AsyncDebugger;
+                    asyncDebuggerActiveFlags = DefaultDebuggerFlags | Flags.AsyncDebugger;
                 }
 
-                s_activeFlags = (s_asyncProfilerActiveFlags | asyncDebuggerActiveFlags) & ~Flags.Synchronize;
+                s_activeFlags = (s_asyncProfilerActiveFlags | s_tplActiveFlags | asyncDebuggerActiveFlags) & ~Flags.Synchronize;
                 return s_activeFlags;
             }
         }
@@ -100,6 +177,8 @@ namespace System.Runtime.CompilerServices
         private static Flags s_activeFlags = Flags.Synchronize;
 
         private static Flags s_asyncProfilerActiveFlags;
+
+        private static Flags s_tplActiveFlags;
 
         private static readonly Lock s_lock = new();
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
@@ -31,7 +31,7 @@ namespace System.Runtime.CompilerServices
         [ThreadStatic]
         internal static unsafe AsyncStateMachineDispatcherInfo* t_current;
 
-        public static bool InstrumentCheckPoint
+        public static bool IsSupported
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if NATIVEAOT
@@ -41,32 +41,31 @@ namespace System.Runtime.CompilerServices
             // postpone the support until proven needed.
             get => false;
 #else
-            get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
-#endif
-        }
-
-        public static bool AsyncProfilerInstrumentCheckPoint
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if NATIVEAOT
-            // See InstrumentCheckPoint above for the rationale of disabling V1 on Native AOT.
-            get => false;
-#else
-            get => InstrumentCheckPoint && AsyncInstrumentation.IsEnabled.AsyncProfiler(AsyncInstrumentation.SyncActiveFlags());
+            get => AsyncInstrumentation.IsAsyncProfilerSupported;
 #endif
         }
 
         internal static unsafe AsyncStateMachineDispatcher? GetActiveDispatcher()
         {
+            if (!IsSupported)
+            {
+                return null;
+            }
+
             AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
             return info != null ? info->Dispatcher : null;
         }
 
-        internal static unsafe AsyncStateMachineDispatcher CreateDispatcher(IAsyncStateMachineBox box)
+        internal static unsafe IAsyncStateMachineBox CreateDispatcher(IAsyncStateMachineBox box, AsyncInstrumentation.Flags flags)
         {
-            if (box is AsyncStateMachineDispatcher existing)
+            if (!IsSupported)
             {
-                return existing;
+                return box;
+            }
+
+            if (box is AsyncStateMachineDispatcher)
+            {
+                return box;
             }
 
             AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
@@ -74,7 +73,6 @@ namespace System.Runtime.CompilerServices
 
             AsyncStateMachineDispatcher dispatcher = new AsyncStateMachineDispatcher(box);
 
-            AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
                 ulong parentDispatcherId = AsyncProfiler.DispatcherIds.CaptureParentDispatcherId();
@@ -95,6 +93,11 @@ namespace System.Runtime.CompilerServices
 
         internal static unsafe void UnwindAsyncFrame(object completingBox, AsyncInstrumentation.Flags flags)
         {
+            if (!IsSupported)
+            {
+                return;
+            }
+
             AsyncStateMachineDispatcherInfo* info = t_current;
             if (info != null && ReferenceEquals(info->AsyncProfilerInfo.CurrentContinuation, completingBox))
             {
@@ -107,9 +110,13 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void ResumeAsyncMethod(IAsyncStateMachineBox box, AsyncInstrumentation.Flags flags)
         {
+            if (!IsSupported)
+            {
+                return;
+            }
+
             AsyncStateMachineDispatcherInfo* info = t_current;
             AsyncStateMachineDispatcher? activeDispatcher = info != null ? info->Dispatcher : null;
             if (activeDispatcher == null)
@@ -147,9 +154,13 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void CompleteAsyncMethod(object completingBox, AsyncInstrumentation.Flags flags)
         {
+            if (!IsSupported)
+            {
+                return;
+            }
+
             AsyncStateMachineDispatcherInfo* info = t_current;
             if (info != null && ReferenceEquals(info->AsyncProfilerInfo.CurrentContinuation, completingBox))
             {
@@ -257,10 +268,9 @@ namespace System.Runtime.CompilerServices
 
         private void InstrumentedMoveNext(ref AsyncStateMachineDispatcherInfo info, IAsyncStateMachineBox inner)
         {
-            AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.LoadFlags();
             try
             {
-                flags = AsyncInstrumentation.SyncActiveFlags();
                 if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
                 {
                     AsyncProfiler.ResumeAsyncContext.Resume(ref info);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -353,15 +353,18 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(!IsCompleted);
 
-                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                AsyncInstrumentation.Flags flags = AsyncInstrumentation.Flags.Disabled;
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out flags))
                 {
-                    AsyncStateMachineDispatcherInfo.ResumeAsyncMethod(this, AsyncInstrumentation.ActiveFlags);
-                }
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    {
+                        AsyncStateMachineDispatcherInfo.ResumeAsyncMethod(this, flags);
+                    }
 
-                bool loggingOn = TplEventSource.Log.IsEnabled();
-                if (loggingOn)
-                {
-                    TplEventSource.Log.TraceSynchronousWorkBegin(this.Id, CausalitySynchronousWork.Execution);
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    {
+                        TplEventSource.Log.TraceSynchronousWorkBegin(this.Id, CausalitySynchronousWork.Execution);
+                    }
                 }
 
                 ExecutionContext? context = Context;
@@ -387,7 +390,7 @@ namespace System.Runtime.CompilerServices
                     ClearStateUponCompletion();
                 }
 
-                if (loggingOn)
+                if (AsyncInstrumentation.IsEnabled.Tpl(flags))
                 {
                     TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
                 }
@@ -429,7 +432,7 @@ namespace System.Runtime.CompilerServices
 
             bool IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
             {
-                if (AsyncStateMachineDispatcherInfo.InstrumentCheckPoint)
+                if (AsyncStateMachineDispatcherInfo.IsSupported)
                 {
                     methodId = AsyncStateMachineDiagnostics<TStateMachine>.MethodId;
                     state = AsyncStateMachineDiagnostics<TStateMachine>.GetState(ref StateMachine);
@@ -507,14 +510,17 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(task != null, "Expected non-null task");
 
-            if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+            if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
             {
-                AsyncStateMachineDispatcherInfo.CompleteAsyncMethod(task, AsyncInstrumentation.ActiveFlags);
-            }
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                {
+                    AsyncStateMachineDispatcherInfo.CompleteAsyncMethod(task, flags);
+                }
 
-            if (TplEventSource.Log.IsEnabled())
-            {
-                TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
+                if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                {
+                    TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
+                }
             }
 
             if (!task.TrySetResult(result))
@@ -542,9 +548,12 @@ namespace System.Runtime.CompilerServices
             // Get the task, forcing initialization if it hasn't already been initialized.
             Task<TResult> task = (taskField ??= new Task<TResult>());
 
-            if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+            if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
             {
-                AsyncStateMachineDispatcherInfo.UnwindAsyncFrame(task, AsyncInstrumentation.ActiveFlags);
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                {
+                    AsyncStateMachineDispatcherInfo.UnwindAsyncFrame(task, flags);
+                }
             }
 
             // If the exception represents cancellation, cancel the task.  Otherwise, fault the task.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -102,9 +102,12 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint && obj is not IAsyncStateMachineBox)
+                    if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags) && obj is not IAsyncStateMachineBox)
                     {
-                        box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
+                        if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                        {
+                            box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box, flags);
+                        }
                     }
 
                     Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
@@ -212,9 +215,12 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint && obj is not IAsyncStateMachineBox)
+                    if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags) && obj is not IAsyncStateMachineBox)
                     {
-                        box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
+                        if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                        {
+                            box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box, flags);
+                        }
                     }
 
                     Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
@@ -247,9 +247,12 @@ namespace System.Runtime.CompilerServices
             /// <param name="result">The result.</param>
             public void SetResult(TResult result)
             {
-                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
                 {
-                    AsyncStateMachineDispatcherInfo.CompleteAsyncMethod(this, AsyncInstrumentation.ActiveFlags);
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    {
+                        AsyncStateMachineDispatcherInfo.CompleteAsyncMethod(this, flags);
+                    }
                 }
 
                 _valueTaskSource.SetResult(result);
@@ -259,9 +262,12 @@ namespace System.Runtime.CompilerServices
             /// <param name="error">The exception.</param>
             public void SetException(Exception error)
             {
-                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
                 {
-                    AsyncStateMachineDispatcherInfo.UnwindAsyncFrame(this, AsyncInstrumentation.ActiveFlags);
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    {
+                        AsyncStateMachineDispatcherInfo.UnwindAsyncFrame(this, flags);
+                    }
                 }
 
                 _valueTaskSource.SetException(error);
@@ -415,9 +421,12 @@ namespace System.Runtime.CompilerServices
             /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
             public void MoveNext()
             {
-                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
                 {
-                    AsyncStateMachineDispatcherInfo.ResumeAsyncMethod(this, AsyncInstrumentation.ActiveFlags);
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    {
+                        AsyncStateMachineDispatcherInfo.ResumeAsyncMethod(this, flags);
+                    }
                 }
 
                 ExecutionContext? context = Context;
@@ -464,7 +473,7 @@ namespace System.Runtime.CompilerServices
 
             bool IAsyncStateMachineBox.GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
             {
-                if (AsyncStateMachineDispatcherInfo.InstrumentCheckPoint)
+                if (AsyncStateMachineDispatcherInfo.IsSupported)
                 {
                     methodId = AsyncStateMachineDiagnostics<TStateMachine>.MethodId;
                     state = AsyncStateMachineDiagnostics<TStateMachine>.GetState(ref StateMachine);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -177,9 +177,12 @@ namespace System.Runtime.CompilerServices
 
             // If TaskWait* ETW events are enabled, trace a beginning event for this await
             // and set up an ending event to be traced when the asynchronous await completes.
-            if (TplEventSource.Log.IsEnabled() || Task.s_asyncDebuggingEnabled)
+            if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
             {
-                continuation = OutputWaitEtwEvents(task, continuation);
+                if (AsyncInstrumentation.IsEnabled.Tpl(flags) || AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
+                {
+                    continuation = OutputWaitEtwEvents(task, continuation);
+                }
             }
 
             // Set the continuation onto the awaited task.
@@ -194,33 +197,35 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(stateMachineBox != null);
 
-            if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+            if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
             {
-                if (task is not IAsyncStateMachineBox)
+                if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                 {
-                    stateMachineBox = AsyncStateMachineDispatcherInfo.CreateDispatcher(stateMachineBox);
-                }
-                else if (continueOnCapturedContext)
-                {
-                    bool customSyncContext = SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext);
-                    bool customTaskScheduler = TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default;
-                    if (customSyncContext || customTaskScheduler)
+                    if (task is not IAsyncStateMachineBox)
                     {
-                        stateMachineBox = AsyncStateMachineDispatcherInfo.CreateDispatcher(stateMachineBox);
+                        stateMachineBox = AsyncStateMachineDispatcherInfo.CreateDispatcher(stateMachineBox, flags);
                     }
+                    else if (continueOnCapturedContext)
+                    {
+                        bool customSyncContext = SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext);
+                        bool customTaskScheduler = TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default;
+                        if (customSyncContext || customTaskScheduler)
+                        {
+                            stateMachineBox = AsyncStateMachineDispatcherInfo.CreateDispatcher(stateMachineBox, flags);
+                        }
+                    }
+                }
+
+                // If TaskWait* ETW events are enabled, trace a beginning event for this await
+                // and set up an ending event to be traced when the asynchronous await completes.
+                if (AsyncInstrumentation.IsEnabled.Tpl(flags) || AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
+                {
+                    task.SetContinuationForAwait(OutputWaitEtwEvents(task, stateMachineBox.MoveNextAction), continueOnCapturedContext, flowExecutionContext: false);
+                    return;
                 }
             }
 
-            // If TaskWait* ETW events are enabled, trace a beginning event for this await
-            // and set up an ending event to be traced when the asynchronous await completes.
-            if (TplEventSource.Log.IsEnabled() || Task.s_asyncDebuggingEnabled)
-            {
-                task.SetContinuationForAwait(OutputWaitEtwEvents(task, stateMachineBox.MoveNextAction), continueOnCapturedContext, flowExecutionContext: false);
-            }
-            else
-            {
-                task.UnsafeSetContinuationForAwait(stateMachineBox, continueOnCapturedContext);
-            }
+            task.UnsafeSetContinuationForAwait(stateMachineBox, continueOnCapturedContext);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -94,9 +94,12 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint && obj is not IAsyncStateMachineBox)
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags) && obj is not IAsyncStateMachineBox)
                 {
-                    box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    {
+                        box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box, flags);
+                    }
                 }
 
                 Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
@@ -181,9 +184,12 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint && obj is not IAsyncStateMachineBox)
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags) && obj is not IAsyncStateMachineBox)
                 {
-                    box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    {
+                        box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box, flags);
+                    }
                 }
 
                 Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
@@ -116,16 +116,19 @@ namespace System.Runtime.CompilerServices
             {
                 Debug.Assert(box != null);
 
-                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
                 {
-                    box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
-                }
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    {
+                        box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box, flags);
+                    }
 
-                // If tracing is enabled, delegate the Action-based implementation.
-                if (TplEventSource.Log.IsEnabled())
-                {
-                    QueueContinuation(box.MoveNextAction, flowContext: false);
-                    return;
+                    // If tracing is enabled, delegate the Action-based implementation.
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    {
+                        QueueContinuation(box.MoveNextAction, flowContext: false);
+                        return;
+                    }
                 }
 
                 // Otherwise, this is the same logic as in QueueContinuation, except using

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -171,6 +171,10 @@ namespace System.Threading.Tasks
 
         // A private flag that would be set (only) by the debugger
         // When true the Async Causality logging trace is enabled as well as a dictionary to relate operation ids with Tasks
+        // The debugger sets this field together with the AsyncInstrumentation.Flags.Synchronize bit in
+        // AsyncInstrumentation's active flags (this field first, then the Synchronize bit) so the next instrumentation
+        // checkpoint re-syncs and observes the AsyncDebugger client. Do not change this field's name or the way the
+        // Synchronize bit is composed without coordinating with the debugger; see AsyncInstrumentation.SynchronizeFlags.
         internal static bool s_asyncDebuggingEnabled; // false by default
 
         // This dictionary relates the task id, from an operation id located in the Async Causality log to the actual

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -782,28 +782,30 @@ namespace System.Threading.Tasks
             // If we're not allowed to run here, schedule the action
             if (!allowInlining || !IsValidLocationForInlining)
             {
-                if (AsyncStateMachineDispatcherInfo.AsyncProfilerInstrumentCheckPoint)
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
                 {
-                    box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box);
+                    if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    {
+                        box = AsyncStateMachineDispatcherInfo.CreateDispatcher(box, flags);
+                    }
+
+                    // If logging is disabled, we can simply queue the box itself as a custom work
+                    // item, and its work item execution will just invoke its MoveNext.  However, if
+                    // logging is enabled, there is pre/post-work we need to do around logging to
+                    // match what's done for other continuations, and that requires flowing additional
+                    // information into the continuation, which we don't want to burden other cases of the
+                    // box with... so, in that case we just delegate to the AwaitTaskContinuation-based
+                    // path that already handles this, albeit at the expense of allocating the ATC
+                    // object, and potentially forcing the box's delegate into existence, when logging
+                    // is enabled.
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    {
+                        UnsafeScheduleAction(box.MoveNextAction, prevCurrentTask);
+                        return;
+                    }
                 }
 
-                // If logging is disabled, we can simply queue the box itself as a custom work
-                // item, and its work item execution will just invoke its MoveNext.  However, if
-                // logging is enabled, there is pre/post-work we need to do around logging to
-                // match what's done for other continuations, and that requires flowing additional
-                // information into the continuation, which we don't want to burden other cases of the
-                // box with... so, in that case we just delegate to the AwaitTaskContinuation-based
-                // path that already handles this, albeit at the expense of allocating the ATC
-                // object, and potentially forcing the box's delegate into existence, when logging
-                // is enabled.
-                if (TplEventSource.Log.IsEnabled())
-                {
-                    UnsafeScheduleAction(box.MoveNextAction, prevCurrentTask);
-                }
-                else
-                {
-                    ThreadPool.UnsafeQueueUserWorkItemInternal(box, preferLocal: true);
-                }
+                ThreadPool.UnsafeQueueUserWorkItemInternal(box, preferLocal: true);
                 return;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
@@ -34,6 +34,8 @@ namespace System.Threading.Tasks
 
             Debug = IsEnabled(EventLevel.Informational, Keywords.Debug);
             DebugActivityId = IsEnabled(EventLevel.Informational, Keywords.DebugActivityId);
+
+            AsyncInstrumentation.UpdateTplFlags(IsEnabled() ? AsyncInstrumentation.DefaultTplFlags : AsyncInstrumentation.Flags.Disabled);
         }
 
         /// <summary>


### PR DESCRIPTION
### Summary

Reworks AsyncInstrumentation so all three instrumentation clients — the async profiler, the async debugger, and the TPL event source — flow through a single unified flags gate, and so that the per-client support checks constant-fold when a feature area is compiled out. This lets the ILLinker dead-code-eliminate the instrumentation paths it can prove are unreachable.

### Motivation

Previously the async instrumentation entry points were gated on a monolithic AsyncInstrumentation.IsSupported (Debugger.IsSupported || EventSource.IsSupported) plus ad-hoc checks (e.g. TPL used TplEventSource.Log.IsEnabled() directly, V2 dispatch used RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint). Because the support check mixed all clients together, the trimmer couldn't remove a given client's instrumentation even when its underlying feature switch was disabled. Since we already need to load and sync the flags, folding TPL+Debugger checks into the same flag check reduce the instructions executed on hot path. The DCE guards also make sure we can eliminate the complete instrumentation block or just individual instrumentation calls depending on what features have been enabled.

It has also been verified that the DCE guards correctly get const folded in Tier1. AsyncInstrumentation.IsActive ends up in one load of s_activeFlags, a compare against 0 and a highly predictable branch bypassing the whole instrumentation block when disabled. The different AsyncInstrumentation.IsEnabled.AsyncProfiler|AsyncDebugger|Tpl all ends up as a simple bit check on the already loaded flags and a highly predicatalbe branch bypassing the respective instrumentation code when disabled.

### What changed

 - Per-client capability checks backed by feature switches: - IsAsyncProfilerSupported / IsTplSupported → EventSource.IsSupported
 - IsAsyncDebuggerSupported → Debugger.IsSupported
 - IsSupported becomes the OR of the three.
 - IsEnabled.AsyncProfiler / AsyncDebugger / Tpl now && the corresponding IsXxxSupported capability. Since EventSource.IsSupported / Debugger.IsSupported are trimmer-substituted constants, these checks fold to false when the feature is off, making the guarded instrumentation DCE-able. All IsEnabled.* helpers are AggressiveInlining.
 - TPL promoted to a first-class client: new Flags.Tpl + DefaultTplFlags; TplEventSource.OnEventCommand now pushes state via AsyncInstrumentation.UpdateTplFlags(...), and TPL's continuation-scheduling logic in TaskContinuation.RunOrScheduleAction goes through IsEnabled.Tpl(flags) instead of touching TplEventSource.Log directly.
 - Split defaults: DefaultFlags → DefaultProfilerFlags, DefaultDebuggerFlags, DefaultTplFlags.
 - Unified load path: SyncActiveFlags() → LoadFlags(), plus LoadFlags(out Flags) and IsActive. The various *InstrumentCheckPoint properties are replaced by the IsActive + LoadFlags(out flags) pattern at every call site (TaskAwaiter, ValueTaskAwaiter, ConfiguredValueTaskAwaitable, YieldAwaitable, AsyncTaskMethodBuilder, PoolingAsyncValueTaskMethodBuilder, V2 AsyncHelpers.DispatchContinuations/FinalizeRuntimeAsyncTask).
 - V1 dispatcher AsyncStateMachineDispatcherInfo.IsSupported now keys off IsAsyncProfilerSupported (still false on NativeAOT, unchanged behavior).

### Trimming result

Verified with ILLink: with both EventSource and Debugger disabled, virtually all async profiler code is removed. The only residue is the async instrumentation flags themselves and System.Runtime.CompilerServices.AsyncProfiler.Info.

### Notes

 - Debugger coordination is preserved. Unlike the profiler/TPL clients (which push state via UpdateAsyncProfilerFlags/UpdateTplFlags), the debugger sets Task.s_asyncDebuggingEnabled directly and flips the Flags.Synchronize bit to trigger a re-sync at the next checkpoint. SynchronizeFlags keeps a live read of that field, and comments were added on both Task.s_asyncDebuggingEnabled and SynchronizeFlags documenting the contract.
 - No functional/behavioral change to what gets instrumented when a client is enabled — this is a gating/structure refactor. No test changes required.