### PR TITLE
[wasm] Pin linux/win V8 to 15.1.103 for exnref support

### DIFF
--- a/eng/testing/BrowserVersions.props
+++ b/eng/testing/BrowserVersions.props
@@ -3,7 +3,7 @@
     <linux_ChromeVersion>149.0.7827.200</linux_ChromeVersion>
     <linux_ChromeRevision>1625079</linux_ChromeRevision>
     <linux_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1625084</linux_ChromeBaseSnapshotUrl>
-    <linux_V8Version>14.9.207</linux_V8Version>
+    <linux_V8Version>15.1.103</linux_V8Version>
     <macos_ChromeVersion>143.0.7499.40</macos_ChromeVersion>
     <macos_ChromeRevision>1536371</macos_ChromeRevision>
     <macos_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1536376</macos_ChromeBaseSnapshotUrl>
@@ -11,7 +11,7 @@
     <win_ChromeVersion>149.0.7827.201</win_ChromeVersion>
     <win_ChromeRevision>1625079</win_ChromeRevision>
     <win_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1625123</win_ChromeBaseSnapshotUrl>
-    <win_V8Version>14.9.207</win_V8Version>
+    <win_V8Version>15.1.103</win_V8Version>
     <linux_FirefoxRevision>140.11.0esr</linux_FirefoxRevision>
     <linux_GeckoDriverRevision>0.37.0</linux_GeckoDriverRevision>
     <win_FirefoxRevision>140.11.0esr</win_FirefoxRevision>


### PR DESCRIPTION
## Problem

WASM perf runs (and other V8 shell-engine legs) abort at startup:

```
Warning: unknown flag --experimental-wasm-exnref.
MONO_WASM: Assert failed: This browser/engine doesn't support WASM exception handling.
main.mjs: Error: Top-level await promise never resolved
```

## Root cause

- #129851 (`[browser] WASM exception handling to use the standardized exnref`) switched the runtime to the **exnref** exception-handling proposal, which requires a V8 that understands `--experimental-wasm-exnref` (V8 15.1+). That PR set `linux/macos/win_V8Version` to `15.1.103`.
- The later automated chrome-for-testing bump #129934 recomputed the V8 version from the pinned Chrome (149 → V8 14.9) and **reverted** `linux_V8Version` and `win_V8Version` back to `14.9.207` (leaving only `macos_V8Version` at `15.1.103`).

`14.9.207` predates exnref, so it rejects the flag and the runtime's startup feature check (`featureWasmFinalEh`) asserts. The wasm perf leg is hit because [`dotnet/performance` `run_performance_job.py`](https://github.com/dotnet/performance/blob/main/scripts/run_performance_job.py) reads `linux_V8Version` and installs exactly that build via `jsvu`.

## Fix

Restore `linux_V8Version` and `win_V8Version` to `15.1.103` (matching `macos_V8Version`). The `v8-linux64-rel-15.1.103.zip` and `v8-win32-rel-15.1.103.zip` binaries exist on the V8 canary CDN that `jsvu` / `DownloadAndInstallV8` use (verified 200 OK), and `15.1.103` supports exnref behind the `--experimental-wasm-exnref` flag already emitted by `eng/testing/WasmRunnerTemplate.sh` and the perf harness (dotnet/performance#5247).

## Note on the auto-updater

The chrome-for-testing auto-bump derives the V8 version from the Chrome milestone, so a future run will revert this to `14.9.x` again unless the pinned Chrome is advanced to a milestone whose V8 is 15.1+ (Chrome 151) or the updater is taught not to downgrade V8 below the exnref floor. Tracking: #129849.