### PR TITLE
Fix wasm EH resume for handlers nested inside VM-invoked funclets

### DIFF
--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -1719,6 +1719,7 @@ typedef DWORD_PTR (HandlerFn)(UINT_PTR uStackFrame, Object* pExceptionObj);
 #else
 typedef TADDR HandlerFn;
 TADDR GetWasmFramePointerFromStackPointer(TADDR sp);
+TADDR GetWasmEstablishingFramePointerFromTerminator(TADDR sp);
 
 DWORD_PTR CallFuncletWithThrowable(UINT_PTR pFuncletToInvoke, TADDR fp, Object *pThrowable, UINT_PTR *pFuncletCallerSP);
 DWORD_PTR CallFuncletWithoutThrowable(UINT_PTR pFuncletToInvoke, TADDR fp, UINT_PTR *pFuncletCallerSP);
@@ -1761,12 +1762,23 @@ DWORD_PTR EECodeManager::CallFunclet(OBJECTREF throwable, void* pHandler, REGDIS
         {
             UnwindStackFrame(&walkCtx);
             EECodeInfo ci(dac_cast<PCODE>(GetIP(&walkCtx)));
-            if (!ci.IsValid() || !ci.IsFunclet())
+            if (!ci.IsValid())
             {
+                // The funclet was invoked by the VM through CallFuncletWith[out]Throwable, so native
+                // unwinding terminates at that synthetic frame before reaching the method's own frame.
+                // Recover the establishing (method) frame pointer the helper stored next to the
+                // TERMINATE_R2R_STACK_WALK marker.
+                wasmFramePointer = GetWasmEstablishingFramePointerFromTerminator(GetSP(&walkCtx));
+                break;
+            }
+            if (!ci.IsFunclet())
+            {
+                // The funclet executes within the method's own native frame, which we reached directly
+                // by unwinding (no intervening CallFunclet helper frame).
+                wasmFramePointer = GetWasmFramePointerFromStackPointer(GetSP(&walkCtx));
                 break;
             }
         }
-        wasmFramePointer = GetWasmFramePointerFromStackPointer(GetSP(&walkCtx));
     }
     TADDR handlerFnIndex = CastHandlerFn(pfnHandler);
     if (throwable != NULL)

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -1752,6 +1752,22 @@ DWORD_PTR EECodeManager::CallFunclet(OBJECTREF throwable, void* pHandler, REGDIS
 
 #ifdef TARGET_WASM
     TADDR wasmFramePointer = GetWasmFramePointerFromStackPointer(GetSP(pRD->pCurrentContext));
+    // A handler that is lexically nested inside a funclet (e.g. a catch inside a finally) must
+    // run with the enclosing METHOD frame as its establishing frame.
+    if (pExInfo->m_frameIter.m_crawl.IsFunclet())
+    {
+        T_CONTEXT walkCtx = *(pRD->pCurrentContext);
+        for (;;)
+        {
+            UnwindStackFrame(&walkCtx);
+            EECodeInfo ci(dac_cast<PCODE>(GetIP(&walkCtx)));
+            if (!ci.IsValid() || !ci.IsFunclet())
+            {
+                break;
+            }
+        }
+        wasmFramePointer = GetWasmFramePointerFromStackPointer(GetSP(&walkCtx));
+    }
     TADDR handlerFnIndex = CastHandlerFn(pfnHandler);
     if (throwable != NULL)
     {

--- a/src/coreclr/vm/wasm/callhelpers.hpp
+++ b/src/coreclr/vm/wasm/callhelpers.hpp
@@ -9,6 +9,13 @@
 // and it should look for the next Frame in the Frame chain to make further progress.
 #define TERMINATE_R2R_STACK_WALK 1
 
+// Within the synthetic frame established by CallFuncletWith[out]Throwable, the establishing (method)
+// frame pointer of the funclet being invoked is stored immediately after the TERMINATE_R2R_STACK_WALK
+// marker (which lives at offset 0). This lets the stack walker recover the establishing frame for a
+// handler that is lexically nested inside a funclet that the VM invoked via CallFunclet, where native
+// unwinding terminates at this synthetic frame before reaching the method's own frame.
+#define TERMINATE_R2R_STACK_WALK_FP_OFFSET 4
+
 struct StringToWasmSigThunk
 {
     const char* key;

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -578,6 +578,12 @@ __attribute__((naked)) DWORD_PTR CallFuncletWithThrowable(UINT_PTR pFuncletToInv
          "i32.store       0\n"               // And save a terminator to the stack frame.
 
          "local.get       3\n"               // Get the stack pointer
+         "i32.const       " WASM_STRINGIFY(TERMINATE_R2R_STACK_WALK_FP_OFFSET) "\n"
+         "i32.add\n"                          // Compute the address next to the terminator
+         "local.get       1\n"               // Get the establishing (method) frame pointer argument
+         "i32.store       0\n"               // Save it so a handler nested in this funclet can recover its establishing frame.
+
+         "local.get       3\n"               // Get the stack pointer
          "local.get       1\n"               // Get the frame pointer argument for the original function
          "local.get       2\n"               // Get the exception object for the funclet
          "local.get       0\n"               // Get the funclet address to call
@@ -605,6 +611,12 @@ __attribute__((naked)) DWORD_PTR CallFuncletWithoutThrowable(UINT_PTR pFuncletTo
          "local.get       2\n"               // Get the stack pointer
          "i32.const       " WASM_STRINGIFY(TERMINATE_R2R_STACK_WALK) "\n"
          "i32.store       0\n"               // And save a terminator to the stack frame.
+
+         "local.get       2\n"               // Get the stack pointer
+         "i32.const       " WASM_STRINGIFY(TERMINATE_R2R_STACK_WALK_FP_OFFSET) "\n"
+         "i32.add\n"                          // Compute the address next to the terminator
+         "local.get       1\n"               // Get the establishing (method) frame pointer argument
+         "i32.store       0\n"               // Save it so a handler nested in this funclet can recover its establishing frame.
 
          "local.get       2\n"               // Get the stack pointer
          "local.get       1\n"               // Get the frame pointer argument for the original function
@@ -1465,9 +1477,19 @@ TADDR GetWasmFramePointerFromStackPointer(TADDR sp)
     }
 }
 
+// Recover the establishing (method) frame pointer stored by CallFuncletWith[out]Throwable next to the
+// TERMINATE_R2R_STACK_WALK marker. 'sp' must point at such a synthetic terminator frame (i.e. the SP
+// reached after natively unwinding a funclet that the VM invoked via CallFunclet).
+TADDR GetWasmEstablishingFramePointerFromTerminator(TADDR sp)
+{
+    _ASSERTE(*(int*)sp == TERMINATE_R2R_STACK_WALK);
+    return *(TADDR*)(sp + TERMINATE_R2R_STACK_WALK_FP_OFFSET);
+}
+
 TADDR GetWasmVirtualIPFromStackPointer(TADDR sp)
 {
     TADDR fp = GetWasmFramePointerFromStackPointer(sp);
+
 
     if (fp == 0)
     {

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -1490,7 +1490,6 @@ TADDR GetWasmVirtualIPFromStackPointer(TADDR sp)
 {
     TADDR fp = GetWasmFramePointerFromStackPointer(sp);
 
-
     if (fp == 0)
     {
         return 0;

--- a/src/tests/JIT/Methodical/BypassReadyToRunAttribute.cs
+++ b/src/tests/JIT/Methodical/BypassReadyToRunAttribute.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime
+{
+    // R2R compilation matches this attribute by namespace + name (see
+    // CorInfoImpl.ReadyToRun.ShouldCodeNotBeCompiledIntoFinalImage), so a local copy of the
+    // CoreLib-internal attribute is sufficient to force the annotated method to be interpreted
+    // (or otherwise excluded from the final R2R image) when a Methodical test is R2R compiled.
+    internal sealed class BypassReadyToRunAttribute : Attribute
+    {
+    }
+}

--- a/src/tests/JIT/Methodical/Methodical_d1.csproj
+++ b/src/tests/JIT/Methodical/Methodical_d1.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="Boxing/xlang/sinlib_il.ilproj" Aliases="sinlib_il" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BypassReadyToRunAttribute.cs" />
     <Compile Include="Arrays\lcs\lcs.cs" />
     <Compile Include="Arrays\lcs\lcs2.cs" />
     <Compile Include="Arrays\lcs\lcsbas.cs" />

--- a/src/tests/JIT/Methodical/Methodical_d1.csproj
+++ b/src/tests/JIT/Methodical/Methodical_d1.csproj
@@ -86,6 +86,7 @@
     <Compile Include="eh\basics\throwinfinallyerrpathfn.cs" />
     <Compile Include="eh\basics\throwoutside.cs" />
     <Compile Include="eh\basics\trycatch.cs" />
+    <Compile Include="eh\interp\interpr2rfunclets.cs" />
     <Compile Include="eh\basics\trycatchtrycatch.cs" />
     <Compile Include="eh\basics\tryfinally.cs" />
     <Compile Include="eh\basics\tryfinallytrycatch.cs" />

--- a/src/tests/JIT/Methodical/Methodical_do.csproj
+++ b/src/tests/JIT/Methodical/Methodical_do.csproj
@@ -84,6 +84,7 @@
     <Compile Include="eh\basics\throwinfinallyerrpathfn.cs" />
     <Compile Include="eh\basics\throwoutside.cs" />
     <Compile Include="eh\basics\trycatch.cs" />
+    <Compile Include="eh\interp\interpr2rfunclets.cs" />
     <Compile Include="eh\basics\trycatchtrycatch.cs" />
     <Compile Include="eh\basics\tryfinally.cs" />
     <Compile Include="eh\basics\tryfinallytrycatch.cs" />

--- a/src/tests/JIT/Methodical/Methodical_do.csproj
+++ b/src/tests/JIT/Methodical/Methodical_do.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="int64/unsigned/implicit_promotion_il.ilproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BypassReadyToRunAttribute.cs" />
     <Compile Include="Arrays\lcs\lcs.cs" />
     <Compile Include="Arrays\lcs\lcs2.cs" />
     <Compile Include="Arrays\lcs\lcsbas.cs" />

--- a/src/tests/JIT/Methodical/Methodical_r1.csproj
+++ b/src/tests/JIT/Methodical/Methodical_r1.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="Boxing/xlang/sinlib_il.ilproj" Aliases="sinlib_il" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BypassReadyToRunAttribute.cs" />
     <Compile Include="Arrays\lcs\lcs.cs" />
     <Compile Include="Arrays\lcs\lcs2.cs" />
     <Compile Include="Arrays\lcs\lcsbas.cs" />

--- a/src/tests/JIT/Methodical/Methodical_r1.csproj
+++ b/src/tests/JIT/Methodical/Methodical_r1.csproj
@@ -87,6 +87,7 @@
     <Compile Include="eh\basics\throwinfinallyerrpathfn.cs" />
     <Compile Include="eh\basics\throwoutside.cs" />
     <Compile Include="eh\basics\trycatch.cs" />
+    <Compile Include="eh\interp\interpr2rfunclets.cs" />
     <Compile Include="eh\basics\trycatchtrycatch.cs" />
     <Compile Include="eh\basics\tryfinally.cs" />
     <Compile Include="eh\basics\tryfinallytrycatch.cs" />

--- a/src/tests/JIT/Methodical/Methodical_ro.csproj
+++ b/src/tests/JIT/Methodical/Methodical_ro.csproj
@@ -84,6 +84,7 @@
     <Compile Include="eh\basics\throwinfinallyerrpathfn.cs" />
     <Compile Include="eh\basics\throwoutside.cs" />
     <Compile Include="eh\basics\trycatch.cs" />
+    <Compile Include="eh\interp\interpr2rfunclets.cs" />
     <Compile Include="eh\basics\trycatchtrycatch.cs" />
     <Compile Include="eh\basics\tryfinally.cs" />
     <Compile Include="eh\basics\tryfinallytrycatch.cs" />

--- a/src/tests/JIT/Methodical/Methodical_ro.csproj
+++ b/src/tests/JIT/Methodical/Methodical_ro.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="int64/unsigned/implicit_promotion_il.ilproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BypassReadyToRunAttribute.cs" />
     <Compile Include="Arrays\lcs\lcs.cs" />
     <Compile Include="Arrays\lcs\lcs2.cs" />
     <Compile Include="Arrays\lcs\lcsbas.cs" />

--- a/src/tests/JIT/Methodical/eh/interp/interpr2rfunclets.cs
+++ b/src/tests/JIT/Methodical/eh/interp/interpr2rfunclets.cs
@@ -70,13 +70,3 @@ namespace Test_interp_r2r_funclets
         }
     }
 }
-
-namespace System.Runtime
-{
-    // R2R compilation matches this attribute by namespace + name (see
-    // CorInfoImpl.ReadyToRun.ShouldCodeNotBeCompiledIntoFinalImage), so a local copy of the
-    // CoreLib-internal attribute is sufficient to force the annotated method to be interpreted.
-    internal sealed class BypassReadyToRunAttribute : Attribute
-    {
-    }
-}

--- a/src/tests/JIT/Methodical/eh/interp/interpr2rfunclets.cs
+++ b/src/tests/JIT/Methodical/eh/interp/interpr2rfunclets.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Exercises exception handling that interleaves interpreter and R2R (or JIT) frames and
+// funclets. InterpretedFunctionThatThrows is forced to be interpreted (via BypassReadyToRun)
+// when the test is R2R compiled, so unwinding crosses the interpreter/compiled boundary
+// repeatedly: a throw out of interpreted code propagates through a compiled finally, which
+// itself calls interpreted code that throws and is caught inside the funclet, before the
+// original exception is finally caught in the outer compiled frame.
+
+using System;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Test_interp_r2r_funclets
+{
+    public static class InterpR2RFunclets
+    {
+        private const int ExpectedValue = 0x1234567;
+
+        private static int s_staticValue;
+
+        [Fact]
+        public static void TestInterleavedInterpreterAndR2RFunclets()
+        {
+            s_staticValue = 0;
+            Assert.Equal(ExpectedValue, R2RFunction());
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int R2RFunction()
+        {
+            try
+            {
+                try
+                {
+                    InterpretedFunctionThatThrows();
+                }
+                finally
+                {
+                    try
+                    {
+                        // Throw and catch entirely within the finally funclet, which itself
+                        // runs while the exception from the inner try is in flight.
+                        InterpretedFunctionThatThrows();
+                    }
+                    catch
+                    {
+                        // Swallowed inside the funclet.
+                    }
+                }
+            }
+            catch
+            {
+                return s_staticValue;
+            }
+
+            return -1;
+        }
+
+        // Forced to be interpreted when the test is R2R compiled so that the throw originates
+        // in interpreted code and must unwind through compiled funclets.
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void InterpretedFunctionThatThrows()
+        {
+            s_staticValue = ExpectedValue;
+            throw new Exception();
+        }
+    }
+}
+
+namespace System.Runtime
+{
+    // R2R compilation matches this attribute by namespace + name (see
+    // CorInfoImpl.ReadyToRun.ShouldCodeNotBeCompiledIntoFinalImage), so a local copy of the
+    // CoreLib-internal attribute is sufficient to force the annotated method to be interpreted.
+    internal sealed class BypassReadyToRunAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Fixes wasm exception-handling resume for a handler that is lexically nested inside a funclet (e.g. a `catch` inside a `finally`) when the runtime is R2R-compiled and the funclet was invoked by the VM via `EECodeManager::CallFunclet`.

This PR contains three commits:

1. **Fix wasm EH resume for handlers nested inside funclets** (@AndyAyersMS) — cherry-picked from `fix-wasm-funclet-eh-resume`. When invoking a funclet whose handler is lexically nested inside another funclet, it natively unwinds out of the funclet frames to recover the enclosing method's establishing frame.

2. **Add EH test interleaving interpreter and R2R funclets** — a Methodical EH test (`InterpR2RFunclets`) that throws out of an interpreted method (forced via a test-local `BypassReadyToRun` attribute) and unwinds through compiled funclets, including a `finally` funclet that itself catches an exception thrown by interpreted code. Registered in the eh-bearing merged variants (`_d1`, `_do`, `_r1`, `_ro`).

3. **Fix wasm funclet establishing frame for handlers nested in VM-invoked funclets** — corrects a defect in commit 1.

## The defect being fixed

There are two ways a funclet can be reached:
- **Inline** within the method's own native frame — Andy's native unwind loop correctly lands on the method frame and `GetWasmFramePointerFromStackPointer` yields the right establishing frame.
- **Via `CallFuncletWith[out]Throwable`** — these helpers push a synthetic 16-byte frame marked with `TERMINATE_R2R_STACK_WALK`. Native unwinding **terminates at that synthetic frame** (`EECodeInfo::IsValid()` becomes false) *before* reaching the method frame, so calling `GetWasmFramePointerFromStackPointer` on that SP produces a bogus establishing frame.

## The fix

- `CallFuncletWith[out]Throwable` now store the establishing (method) frame pointer immediately after the `TERMINATE_R2R_STACK_WALK` marker (at `TERMINATE_R2R_STACK_WALK_FP_OFFSET`).
- When the unwind loop lands on the terminator (`!ci.IsValid()`), the establishing frame is recovered via the new `GetWasmEstablishingFramePointerFromTerminator` helper instead of `GetWasmFramePointerFromStackPointer`. The inline case (`ci.IsValid() && !ci.IsFunclet()`) keeps the original behavior.

## Validation

Verified on the standalone form of the test under wasm R2R (crossgen2):

| Mode | Before fix | After fix |
|------|-----------|-----------|
| R2R (crossgen2) | `Actual: 1` (unhandled exception escapes) | `Actual: 100` (PASS) |
| Interpreted | `Actual: 100` | `Actual: 100` (PASS) |

A temporary `printf` confirmed the new `GetWasmEstablishingFramePointerFromTerminator` code path is the one exercised by the nested-funclet scenario.

## Known limitation

The test is included in the **merged** Methodical assemblies rather than as a process-isolation test (merged tests are generally preferred). Crossgen2 currently emits an invalid R2R wasm image for the merged Methodical assembly due to an unrelated codegen issue, so under R2R the merged image is discarded and the assembly runs interpreted — meaning the merged test does not yet exercise the R2R funclet path. That unrelated invalid-R2R-method issue will be addressed separately; the standalone validation above confirms the fix.

> [!NOTE]
> This pull request was authored with assistance from GitHub Copilot.
