### PR TITLE
Gate ILCompiler pack version update to explicit references

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -52,10 +52,15 @@
           Condition="'$(_IlcReferencedAsPackage)' != 'false'"
           BeforeTargets="ProcessFrameworkReferences">
     <ItemGroup>
+      <_ExplicitILCompilerPackageReference Include="@(PackageReference)"
+                                           Condition="'%(PackageReference.Identity)' == 'Microsoft.DotNet.ILCompiler' And '%(PackageReference.IsImplicitlyDefined)' != 'true'" />
+
       <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler"
-                           Condition="'%(PackageReference.Identity)' == 'Microsoft.DotNet.ILCompiler' And '%(PackageReference.IsImplicitlyDefined)' != 'true'">
+                           Condition="'@(_ExplicitILCompilerPackageReference)' != ''">
         <ILCompilerPackVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName($(ILCompilerTargetsPath)))))))</ILCompilerPackVersion>
       </KnownILCompilerPack>
+
+      <_ExplicitILCompilerPackageReference Remove="@(_ExplicitILCompilerPackageReference)" />
     </ItemGroup>
   </Target>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -48,11 +48,16 @@
 
   <!-- Update the KnownILCompilerPack version to match the PackageReference, in case there's an explicit reference to a specific version. -->
   <!-- The _IlcReferencedAsPackage check is only there for using live ILCompiler targets (not a supported scenario outside of dotnet/runtime). -->
-  <ItemGroup Condition="'$(_IlcReferencedAsPackage)' != 'false'">
-    <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
-      <ILCompilerPackVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName($(ILCompilerTargetsPath)))))))</ILCompilerPackVersion>
-    </KnownILCompilerPack>
-  </ItemGroup>
+  <Target Name="UpdateKnownILCompilerPackForExplicitPackageReference"
+          Condition="'$(_IlcReferencedAsPackage)' != 'false'"
+          BeforeTargets="ProcessFrameworkReferences">
+    <ItemGroup>
+      <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler"
+                           Condition="'%(PackageReference.Identity)' == 'Microsoft.DotNet.ILCompiler' And '%(PackageReference.IsImplicitlyDefined)' != 'true'">
+        <ILCompilerPackVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName($(ILCompilerTargetsPath)))))))</ILCompilerPackVersion>
+      </KnownILCompilerPack>
+    </ItemGroup>
+  </Target>
 
   <!-- Generate a warning if the user added an explicit PackageReference  -->
   <Target Name="GenerateILCompilerExplicitPackageReferenceWarning" Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(ILCompilerTargetsPath)' != ''"


### PR DESCRIPTION
Fixes a stale restore/design-time restore interaction where imported Microsoft.DotNet.ILCompiler package targets could overwrite the SDK bundled KnownILCompilerPack version from an old assets file.

The package targets still update KnownILCompilerPack for explicit Microsoft.DotNet.ILCompiler PackageReference entries, preserving the documented custom/daily ILC package scenario, but they no longer do so for SDK-generated implicit references.

Validation:
- Verified implicit PackageReference keeps the SDK bundled ILCompiler version while explicit PackageReference still updates KnownILCompilerPack to the package version.
- Reproduced the SDK upgrade stale-assets scenario with SDK 10.0.100 -> 10.0.103 and verified CollectPackageReferences now reports Microsoft.DotNet.ILCompiler 10.0.3 instead of stale 10.0.0.