### PR TITLE
Validate targets of generic lookup in the scanner

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -210,6 +210,18 @@ namespace Internal.IL
             return (_unconditionalDependencies, conditionalDependencies);
         }
 
+        private ISymbolNode GetGenericLookupHelper(ReadyToRunHelperId helperId, TypeDesc type)
+        {
+            _compilation.TypeSystemContext.EnsureLoadableType(type.ConvertToCanonForm(CanonicalFormKind.Specific));
+            return GetGenericLookupHelper(helperId, (object)type);
+        }
+
+        private ISymbolNode GetGenericLookupHelper(ReadyToRunHelperId helperId, MethodDesc method)
+        {
+            _compilation.TypeSystemContext.EnsureLoadableMethod(method.GetCanonMethodTarget(CanonicalFormKind.Specific));
+            return GetGenericLookupHelper(helperId, (object)method);
+        }
+
         private ISymbolNode GetGenericLookupHelper(ReadyToRunHelperId helperId, object helperArgument)
         {
             GenericDictionaryLookup lookup = _compilation.ComputeGenericLookup(_canonMethod, helperId, helperArgument);

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -67,6 +67,7 @@ class Generics
         Test104913Regression.Run();
         Test105397Regression.Run();
         Test105880Regression.Run();
+        Test130028Regression.Run();
         TestInterfaceGenericCornerCase.Run();
         Test115442Regression.Run();
         TestInvokeMemberCornerCaseInGenerics.Run();
@@ -3865,6 +3866,29 @@ class Generics
         public static void Run()
         {
             Console.WriteLine(new Baz());
+        }
+    }
+
+    class Test130028Regression
+    {
+        public class C
+        {
+            public static Array Create<T>() => new InlineArray65536<T>[1];
+            [InlineArray(65536)] struct InlineArray65536<T> { T field; }
+        }
+
+        public static void Run()
+        {
+            try
+            {
+                typeof(C).GetMethod("Create").MakeGenericMethod(typeof(object)).Invoke(null, []);
+            }
+            catch (TargetInvocationException e) when (e.InnerException is TypeLoadException)
+            {
+                return;
+            }
+
+            throw new Exception();
         }
     }
 


### PR DESCRIPTION
Fixes #130028.

This way we can catch types that don't load at a spot where we can still recover (generate a throwing body). The repro already works correctly in Debug builds because we make this callout for all tokens RyuJIT resolves from IL.