### PR TITLE
[browser][coreCLR] enable -O3 after emscripten bump

### DIFF
--- a/eng/native/configureoptimization.cmake
+++ b/eng/native/configureoptimization.cmake
@@ -9,9 +9,6 @@ elseif(CLR_CMAKE_HOST_UNIX)
     if(CLR_CMAKE_TARGET_ANDROID)
         # -O2 optimization generates faster/smaller code on Android
         add_compile_options($<$<CONFIG:Release>:-O2>)
-    elseif (CLR_CMAKE_TARGET_BROWSER)
-        # -O2 prevents emscripten metadce from stripping user-requested global exports
-        add_link_options($<$<CONFIG:Release>:-O2>)
     else()
         add_compile_options($<$<CONFIG:Release>:-O3>)
     endif()

--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -111,8 +111,6 @@ else()
                 -sEXPORT_NAME=createDotnetRuntime
                 -sENVIRONMENT=node,shell,web
                 -lexports.js
-                -Wl,--export=__stack_pointer
-                -Wl,--export=__coreclr_wasm_rtlrestorecontext_tag
                 -Wl,--error-limit=0)
         endif()
 

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -747,9 +747,6 @@
 
       <!-- -lexports.js to set MINIFY_WASM_EXPORT_NAMES=0 -->
       <_EmccLinkStepArgs Include="-lexports.js" />
-      <!-- Ensure the CoreCLR WASM globals/tags are exported -->
-      <_EmccLinkStepArgs Include="-Wl,--export=__stack_pointer" />
-      <_EmccLinkStepArgs Include="-Wl,--export=__coreclr_wasm_rtlrestorecontext_tag" />
 
       <!-- Linker error limit -->
       <_EmccLinkStepArgs Include="-Wl,--error-limit=0" />

--- a/src/native/corehost/browserhost/CMakeLists.txt
+++ b/src/native/corehost/browserhost/CMakeLists.txt
@@ -123,8 +123,6 @@ target_link_options(browserhost PRIVATE
     -sENVIRONMENT=web,webview,worker,node,shell
     --emit-symbol-map
     -lexports.js
-    -Wl,--export=__stack_pointer
-    -Wl,--export=__coreclr_wasm_rtlrestorecontext_tag
     -Wl,--error-limit=0)
 
 target_link_libraries(browserhost PRIVATE


### PR DESCRIPTION
Fixes #128686.

The emscripten 5.0.6 / LLVM 23 bump (#113786) no longer strips user-requested wasm exports during `-O3` metadce, so the workarounds added in #128567 are no longer needed.

## Changes

- **eng/native/configureoptimization.cmake** — remove the browser-only `-O2` link special-case and let browser use `-O3` like the other UNIX targets (reverts the #128567 hunk; the file is now identical to its pre-#128567 state).
- **src/native/corehost/browserhost/CMakeLists.txt**, **src/coreclr/hosts/corerun/CMakeLists.txt**, **src/mono/browser/build/BrowserWasmApp.CoreCLR.targets** — drop the explicit `-Wl,--export=__stack_pointer` and `-Wl,--export=__coreclr_wasm_rtlrestorecontext_tag`. Both symbols are exported via `-sEXPORTED_FUNCTIONS` (the `EmccExportedFunction` items in `eng/native.wasm.targets`) alone.

`-lexports.js` (`MINIFY_WASM_EXPORT_NAMES=0`) is kept so the raw export names remain un-minified for the JS-side `wasmExports['__stack_pointer']` / tag lookups.

## Testing

Built `clr+libs+host` for `-os browser -c Release` (CoreCLR), 0 warnings / 0 errors, and inspected the exports with `wa-info`:

- `-O3` shared framework `dotnet.native.wasm`:
  - `(export "__stack_pointer" (GlobalIdx 0))`
  - `(export "__coreclr_wasm_rtlrestorecontext_tag" (4 1))` — the wasm tag (kind `4`) survives via `EXPORTED_FUNCTIONS`.
- `-O2` app-relinked `console-node` sample wasm: both exports present as well.
- `console-node` (Release/CoreCLR) runs and returns the expected exit code `3` (`args.Length`), exercising reverse-pinvoke (`__stack_pointer`) and the EH path (`__coreclr_wasm_rtlrestorecontext_tag`).

> [!NOTE]
> This PR description was drafted with GitHub Copilot.