### PR TITLE
Docs: Add missing return type to Avx512BW.ShiftRightArithmetic

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.cs
@@ -1202,7 +1202,7 @@ namespace System.Runtime.Intrinsics.X86
         public static Vector512<ushort> ShiftLeftLogicalVariable(Vector512<ushort> value, Vector512<ushort> count) => ShiftLeftLogicalVariable(value, count);
 
         /// <summary>
-        ///   <para>_mm512_sra_epi16 (__m512i a, __m128i count)</para>
+        ///   <para>__m512i _mm512_sra_epi16 (__m512i a, __m128i count)</para>
         ///   <para>  VPSRAW zmm1 {k1}{z}, zmm2, xmm3/m128</para>
         /// </summary>
         public static Vector512<short> ShiftRightArithmetic(Vector512<short> value, Vector128<short> count) => ShiftRightArithmetic(value, count);


### PR DESCRIPTION
Intrinsic methods, such as `Sse2.Add`, normally include a function prototype in the XML documentation. However, documentation for `Avx512BW.ShiftRightArithmetic` (line 1204-1205) lacks a return type. This PR includes a single commit which restores the return type in the ShiftRightArithmetic documentation (which is, according to a web search, `__m512i`).
