### PR TITLE
Enable trim/AOT analyzers on System.Text.Json source generator tests

### DIFF
--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.AsyncEnumerable.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.AsyncEnumerable.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -26,7 +27,7 @@ namespace System.Text.Json.Serialization.Tests
             JsonSerializerOptions options = Serializer.CreateOptions(makeReadOnly: false);
             options.DefaultBufferSize = bufferSize;
 
-            string expectedJson = JsonSerializer.Serialize(source, options);
+            string expectedJson = await Serializer.SerializeWrapper(source, options);
 
             using var stream = new Utf8MemoryStream();
             var asyncEnumerable = new MockedAsyncEnumerable<TElement>(source, delayInterval);
@@ -49,7 +50,7 @@ namespace System.Text.Json.Serialization.Tests
             JsonSerializerOptions options = Serializer.CreateOptions(makeReadOnly: false);
             options.DefaultBufferSize = bufferSize;
 
-            string expectedJson = JsonSerializer.Serialize(new EnumerableDto<TElement> { Data = source }, options);
+            string expectedJson = await Serializer.SerializeWrapper(new EnumerableDto<TElement> { Data = source }, options);
 
             using var stream = new Utf8MemoryStream();
             var asyncEnumerable = new MockedAsyncEnumerable<TElement>(source, delayInterval);
@@ -75,7 +76,7 @@ namespace System.Text.Json.Serialization.Tests
             options.DefaultBufferSize = bufferSize;
             options.IncludeFields = true;
 
-            string expectedJson = JsonSerializer.Serialize<(IEnumerable<TElement>, bool)?>((source, false), options);
+            string expectedJson = await Serializer.SerializeWrapper<(IEnumerable<TElement>, bool)?>((source, false), options);
 
             using var stream = new Utf8MemoryStream();
             var asyncEnumerable = new MockedAsyncEnumerable<TElement>(source, delayInterval);
@@ -94,7 +95,7 @@ namespace System.Text.Json.Serialization.Tests
             using var cts = new CancellationTokenSource();
 
             IAsyncEnumerable<int> value = CreateEnumerable();
-            await JsonSerializer.SerializeAsync(utf8Stream, value, Serializer.DefaultOptions, cancellationToken: cts.Token);
+            await JsonSerializer.SerializeAsync(utf8Stream, value, Serializer.DefaultOptions.GetTypeInfo<IAsyncEnumerable<int>>(), cts.Token);
             Assert.Equal("[1,2]", utf8Stream.AsString());
 
             async IAsyncEnumerable<int> CreateEnumerable([EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -128,7 +129,7 @@ namespace System.Text.Json.Serialization.Tests
             using var utf8Stream = new Utf8MemoryStream();
             using var cts = new CancellationTokenSource(delay: TimeSpan.FromMilliseconds(cancellationTokenSourceDelayMilliseconds));
             await Assert.ThrowsAsync<TaskCanceledException>(async () =>
-                await JsonSerializer.SerializeAsync(utf8Stream, longRunningEnumerable, Serializer.DefaultOptions, cancellationToken: cts.Token));
+                await JsonSerializer.SerializeAsync(utf8Stream, longRunningEnumerable, Serializer.DefaultOptions.GetTypeInfo<IAsyncEnumerable<int>>(), cts.Token));
 
             Assert.Equal(1, longRunningEnumerable.TotalCreatedEnumerators);
             Assert.Equal(1, longRunningEnumerable.TotalDisposedEnumerators);
@@ -168,7 +169,7 @@ namespace System.Text.Json.Serialization.Tests
             JsonSerializerOptions options = Serializer.CreateOptions(makeReadOnly: false);
             options.DefaultBufferSize = bufferSize;
 
-            string expectedJson = JsonSerializer.Serialize(new EnumerableDtoWithTwoProperties<TElement> { Data1 = source, Data2 = source }, options);
+            string expectedJson = await Serializer.SerializeWrapper(new EnumerableDtoWithTwoProperties<TElement> { Data1 = source, Data2 = source }, options);
 
             using var stream = new Utf8MemoryStream();
             var asyncEnumerable = new MockedAsyncEnumerable<TElement>(source, delayInterval);
@@ -192,7 +193,7 @@ namespace System.Text.Json.Serialization.Tests
             options.DefaultBufferSize = bufferSize;
 
             const int OuterEnumerableCount = 5;
-            string expectedJson = JsonSerializer.Serialize(Enumerable.Repeat(source, OuterEnumerableCount), options);
+            string expectedJson = await Serializer.SerializeWrapper(Enumerable.Repeat(source, OuterEnumerableCount), options);
 
             var innerAsyncEnumerable = new MockedAsyncEnumerable<TElement>(source, delayInterval);
             var outerAsyncEnumerable =
@@ -213,16 +214,16 @@ namespace System.Text.Json.Serialization.Tests
         public void WriteRootLevelAsyncEnumerableSync_ThrowsNotSupportedException()
         {
             IAsyncEnumerable<int> asyncEnumerable = new MockedAsyncEnumerable<int>(Enumerable.Range(1, 10));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(asyncEnumerable, Serializer.DefaultOptions));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new MemoryStream(), asyncEnumerable, Serializer.DefaultOptions));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(asyncEnumerable, Serializer.DefaultOptions.GetTypeInfo<IAsyncEnumerable<int>>()));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new MemoryStream(), asyncEnumerable, Serializer.DefaultOptions.GetTypeInfo<IAsyncEnumerable<int>>()));
         }
 
         [Fact]
         public void WriteNestedAsyncEnumerableSync_ThrowsNotSupportedException()
         {
             IAsyncEnumerable<int> asyncEnumerable = new MockedAsyncEnumerable<int>(Enumerable.Range(1, 10));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new AsyncEnumerableDto<int> { Data = asyncEnumerable }, Serializer.DefaultOptions));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new MemoryStream(), new AsyncEnumerableDto<int> { Data = asyncEnumerable }, Serializer.DefaultOptions));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new AsyncEnumerableDto<int> { Data = asyncEnumerable }, Serializer.DefaultOptions.GetTypeInfo<AsyncEnumerableDto<int>>()));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new MemoryStream(), new AsyncEnumerableDto<int> { Data = asyncEnumerable }, Serializer.DefaultOptions.GetTypeInfo<AsyncEnumerableDto<int>>()));
         }
 
         [Fact]
@@ -331,7 +332,7 @@ namespace System.Text.Json.Serialization.Tests
             // Regression test for https://github.com/dotnet/runtime/issues/57360
             using var stream = new Utf8MemoryStream();
             using var cts = new CancellationTokenSource(millisecondsDelay: 1000);
-            await Assert.ThrowsAsync<TaskCanceledException>(async () => await JsonSerializer.SerializeAsync(stream, GetNumbersAsync(), Serializer.DefaultOptions, cancellationToken: cts.Token));
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await JsonSerializer.SerializeAsync(stream, GetNumbersAsync(), Serializer.DefaultOptions.GetTypeInfo<IAsyncEnumerable<int>>(), cts.Token));
 
             static async IAsyncEnumerable<int> GetNumbersAsync()
             {
@@ -417,13 +418,6 @@ namespace System.Text.Json.Serialization.Tests
                 return;
             }
 
-            // This test requires reflection to serialize custom IAsyncEnumerable types;
-            // skip in source-gen contexts where reflection is disabled.
-            if (!JsonSerializer.IsReflectionEnabledByDefault)
-            {
-                return;
-            }
-
             var events = new List<string>();
             var inner1 = new DisposalTrackingAsyncEnumerable<int>(
                 new[] { 1, 2 }, "Inner1", events, asyncDisposal);
@@ -434,7 +428,7 @@ namespace System.Text.Json.Serialization.Tests
                 new IAsyncEnumerable<int>[] { inner1, inner2 }, "Outer", events, asyncDisposal);
 
             using var stream = new Utf8MemoryStream();
-            await JsonSerializer.SerializeAsync<IAsyncEnumerable<IAsyncEnumerable<int>>>(stream, outer);
+            await JsonSerializer.SerializeAsync(stream, (IAsyncEnumerable<IAsyncEnumerable<int>>)outer, Serializer.DefaultOptions.GetTypeInfo<IAsyncEnumerable<IAsyncEnumerable<int>>>());
 
             JsonTestHelper.AssertJsonEqual("[[1,2],[3,4]]", stream.AsString());
 

--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Dictionary.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Dictionary.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -731,6 +732,8 @@ namespace System.Text.Json.Serialization.Tests
         // levels deep, along with matching JSON, encompassing the various planes of
         // dictionaries that can be combined: generic, non-generic, BCL, user-derived,
         // immutable, mutable, readonly, concurrent, specialized.
+        [RequiresUnreferencedCode("Uses Type.MakeGenericType to construct nested dictionary types.")]
+        [RequiresDynamicCode("Uses Type.MakeGenericType to construct nested dictionary types.")]
         private static IEnumerable<(Type, string)> NestedDictionaryTypeData()
         {
             string testJson = """{"Key":1}""";
@@ -793,6 +796,8 @@ namespace System.Text.Json.Serialization.Tests
 #endif
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/66220", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+        [RequiresUnreferencedCode("Uses Type.MakeGenericType to construct nested dictionary types.")]
+        [RequiresDynamicCode("Uses Type.MakeGenericType to construct nested dictionary types.")]
         public async Task NestedDictionariesRoundtrip()
         {
             JsonSerializerOptions options = new JsonSerializerOptions();
@@ -1300,11 +1305,11 @@ namespace System.Text.Json.Serialization.Tests
             await VerifyIgnore<ClassWithIgnoredImmutableDictionary>(false, true, false, addMissing: true);
         }
 
-        private async Task VerifyIgnore<T>(bool skip1, bool skip2, bool skip3, bool addMissing = false)
+        private async Task VerifyIgnore<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(bool skip1, bool skip2, bool skip3, bool addMissing = false)
         {
             static IDictionary<string, int> GetProperty(T objectToVerify, string propertyName)
             {
-                return (IDictionary<string, int>)objectToVerify.GetType().GetProperty(propertyName).GetValue(objectToVerify);
+                return (IDictionary<string, int>)typeof(T).GetProperty(propertyName).GetValue(objectToVerify);
             }
 
             void Verify(T objectToVerify)

--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.KeyValuePair.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.KeyValuePair.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Xunit;
@@ -396,7 +397,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(KeyNameNullPolicy), "Key")]
         [InlineData(typeof(ValueNameNullPolicy), "Value")]
-        public async Task InvalidPropertyNameFail(Type policyType, string offendingProperty)
+        public async Task InvalidPropertyNameFail([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type policyType, string offendingProperty)
         {
             var options = new JsonSerializerOptions
             {

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Cache.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Cache.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -34,20 +35,20 @@ namespace System.Text.Json.Serialization.Tests
                 ((ITestClassWithParameterizedCtor)obj).Verify();
             }
 
-            async Task DeserializeObjectMinimalAsync(Type type, JsonSerializerOptions options)
+            async Task DeserializeObjectMinimalAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type, JsonSerializerOptions options)
             {
                 string json = (string)type.GetProperty("s_json_minimal").GetValue(null);
                 var obj = await Serializer.DeserializeWrapper(json, type, options);
                 ((ITestClassWithParameterizedCtor)obj).VerifyMinimal();
             };
 
-            async Task DeserializeObjectFlippedAsync(Type type, JsonSerializerOptions options)
+            async Task DeserializeObjectFlippedAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type, JsonSerializerOptions options)
             {
                 string json = (string)type.GetProperty("s_json_flipped").GetValue(null);
                 await DeserializeObjectAsync(json, type, options);
             };
 
-            async Task DeserializeObjectNormalAsync(Type type, JsonSerializerOptions options)
+            async Task DeserializeObjectNormalAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type, JsonSerializerOptions options)
             {
                 string json = (string)type.GetProperty("s_json").GetValue(null);
                 await DeserializeObjectAsync(json, type, options);
@@ -59,7 +60,7 @@ namespace System.Text.Json.Serialization.Tests
                 await Serializer.SerializeWrapper(obj, options);
             };
 
-            async Task RunTestAsync(Type type)
+            async Task RunTestAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
             {
                 // Use local options to avoid obtaining already cached metadata from the default options.
                 JsonSerializerOptions options = Serializer.CreateOptions();
@@ -129,7 +130,7 @@ namespace System.Text.Json.Serialization.Tests
         [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
         public async Task MultipleTypes()
         {
-            async Task Serialize<T>(object[] args)
+            async Task Serialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(object[] args)
             {
                 Type type = typeof(T);
 
@@ -145,7 +146,7 @@ namespace System.Text.Json.Serialization.Tests
                 obj.Verify();
             };
 
-            async Task RunTestAsync<T>(T testObj, object[] args)
+            async Task RunTestAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(T testObj, object[] args)
             {
                 // Get the test json with the default options to avoid cache pollution of DeserializeAsync() below.
                 ((ITestClass)testObj).Initialize();

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -731,7 +731,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task CanDeserialize_ObjectWith_Ctor_With_64_Params()
         {
-            async Task RunTestAsync<T>()
+            async Task RunTestAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>()
             {
                 StringBuilder sb = new StringBuilder();
                 sb.Append("{");

--- a/src/libraries/System.Text.Json/tests/Common/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ExtensionDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json.Nodes;
@@ -1353,7 +1354,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(ClassWithExtensionPropertyNoGenericParameters))]
         [InlineData(typeof(ClassWithExtensionPropertyOneGenericParameter))]
         [InlineData(typeof(ClassWithExtensionPropertyThreeGenericParameters))]
-        public async Task DeserializeIntoGenericDictionaryParameterCount(Type type)
+        public async Task DeserializeIntoGenericDictionaryParameterCount([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             object obj = await Serializer.DeserializeWrapper("{\"hello\":\"world\"}", type);
 

--- a/src/libraries/System.Text.Json/tests/Common/JsonCreationHandlingTests.Object.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonCreationHandlingTests.Object.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests;
@@ -825,10 +827,11 @@ public abstract partial class JsonCreationHandlingTests : SerializerTests
         public ClassWithRecursiveRequiredProperty? Next { get; set; }
     }
 
-    [Theory]
+    [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     [InlineData(typeof(SimpleClass))]
     [InlineData(typeof(SimpleClassWithSmallParametrizedCtor))]
     [InlineData(typeof(SimpleClassWithLargeParametrizedCtor))]
+    [RequiresDynamicCode("Uses Type.MakeGenericType to construct the generic type under test.")]
     public async Task CreationHandlingSetWithAttribute_CanPopulateOrSerialize_Callbacks(Type type)
     {
         Type finalType = typeof(ClassWithWritableProperty<>).MakeGenericType(type);
@@ -879,7 +882,10 @@ public abstract partial class JsonCreationHandlingTests : SerializerTests
     [InlineData(typeof(ClassImplementingInterfaceWithPopulateOnTypeWithInterfaceProperty), null, false)]
     [InlineData(typeof(IInterfaceWithInterfaceProperty), typeof(ClassImplementingInterfaceWithInterfaceProperty), false)]
     [InlineData(typeof(ClassImplementingInterfaceWithInterfaceProperty), null, true)]
-    public async Task CreationHandlingSetWithAttributeOnType_Interfaces(Type typeToDeserialize, Type? typeToCreate, bool shouldPopulate)
+    public async Task CreationHandlingSetWithAttributeOnType_Interfaces(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type typeToDeserialize,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? typeToCreate,
+        bool shouldPopulate)
     {
         JsonSerializerOptions options = Serializer.CreateOptions(modifier: ti =>
         {
@@ -1169,7 +1175,7 @@ public abstract partial class JsonCreationHandlingTests : SerializerTests
     [Theory]
     [InlineData(typeof(ClassWithParameterizedConstructorWithPopulateProperty))]
     [InlineData(typeof(ClassWithParameterizedConstructorWithPopulateType))]
-    public async Task ClassWithParameterizedCtor_UsingPopulateConfiguration_ThrowsNotSupportedException(Type type)
+    public async Task ClassWithParameterizedCtor_UsingPopulateConfiguration_ThrowsNotSupportedException([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         object instance = Activator.CreateInstance(type, "Jim");
         string json = """{"Username":"Jim","PhoneNumbers":["123456"]}""";

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -219,7 +219,7 @@ namespace System.Text.Json.Schema.Tests
             Assert.Same(JsonSchemaExporterOptions.Default, JsonSchemaExporterOptions.Default);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [ConditionalFact(typeof(JsonSerializer), nameof(JsonSerializer.IsReflectionEnabledByDefault))]
         [RequiresUnreferencedCode("Uses private reflection to access System.Text.Json converter internals.")]
         [RequiresDynamicCode("Uses private reflection to access System.Text.Json converter internals.")]
         public void LegacySchemaExporter_CanAccessReflectedMembers()

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -11,6 +12,7 @@ using System.Text.Json.Serialization.Metadata;
 using System.Text.Json.Serialization.Tests;
 using System.Xml.Linq;
 using Json.Schema;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Sdk;
 
@@ -38,8 +40,10 @@ namespace System.Text.Json.Schema.Tests
             AssertValidJsonSchema(testData.Type, testData.ExpectedJsonSchema, schema);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [MemberData(nameof(GetTestDataUsingAllValues))]
+        [RequiresUnreferencedCode("Uses reflection-based JsonSerializer.SerializeToNode(object, Type, options).")]
+        [RequiresDynamicCode("Uses reflection-based JsonSerializer.SerializeToNode(object, Type, options).")]
         public void TestTypes_SerializedValueMatchesGeneratedSchema(ITestData testData)
         {
             JsonSerializerOptions options = testData.SerializerOptions is { } opts
@@ -215,8 +219,9 @@ namespace System.Text.Json.Schema.Tests
             Assert.Same(JsonSchemaExporterOptions.Default, JsonSchemaExporterOptions.Default);
         }
 
-#if !BUILDING_SOURCE_GENERATOR_TESTS
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [RequiresUnreferencedCode("Uses private reflection to access System.Text.Json converter internals.")]
+        [RequiresDynamicCode("Uses private reflection to access System.Text.Json converter internals.")]
         public void LegacySchemaExporter_CanAccessReflectedMembers()
         {
             // A number of libraries such as Microsoft.Extensions.AI and Semantic Kernel
@@ -259,7 +264,6 @@ namespace System.Text.Json.Schema.Tests
 
         [JsonSerializable(typeof(PocoWithProperty))]
         partial class PocoWithPropertyContext : JsonSerializerContext;
-#endif
 
         protected void AssertValidJsonSchema(Type type, string expectedJsonSchema, JsonNode actualJsonSchema)
         {
@@ -326,6 +330,6 @@ namespace System.Text.Json.Schema.Tests
         };
 
         private string FormatJson(JsonNode? node) =>
-            JsonSerializer.Serialize(node, _indentedOptions);
+            JsonSerializer.Serialize(node, _indentedOptions.GetTypeInfo<JsonNode>());
     }
 }

--- a/src/libraries/System.Text.Json/tests/Common/JsonSerializerWrapper.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSerializerWrapper.cs
@@ -73,7 +73,14 @@ namespace System.Text.Json.Serialization.Tests
         public virtual JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions? options = null, bool mutable = false)
         {
             options ??= DefaultOptions;
+#if BUILDING_SOURCE_GENERATOR_TESTS
+            // In the source generator test project the options are always backed by a
+            // JsonSerializerContext resolver, so there is never a missing resolver to populate.
+            // Use the parameterless overload which is safe for trimming and Native AOT.
+            options.MakeReadOnly();
+#else
             options.MakeReadOnly(populateMissingResolver: true);
+#endif
             return mutable ? options.TypeInfoResolver.GetTypeInfo(type, options) : options.GetTypeInfo(type);
         }
 

--- a/src/libraries/System.Text.Json/tests/Common/JsonTestHelper.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonTestHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization;
@@ -157,6 +158,7 @@ namespace System.Text.Json
             }
         }
 
+        [RequiresUnreferencedCode("AssertOptionsEqual uses reflection to enumerate JsonSerializerOptions properties.")]
         public static void AssertOptionsEqual(JsonSerializerOptions expected, JsonSerializerOptions actual)
         {
             foreach (PropertyInfo property in typeof(JsonSerializerOptions).GetProperties(BindingFlags.Public | BindingFlags.Instance))

--- a/src/libraries/System.Text.Json/tests/Common/MetadataTests.Options.cs
+++ b/src/libraries/System.Text.Json/tests/Common/MetadataTests.Options.cs
@@ -89,20 +89,21 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public void PassingImmutableOptionsThrowsException()
         {
-            JsonSerializerOptions defaultOptions = JsonSerializerOptions.Default;
-            Assert.Throws<InvalidOperationException>(() => new MyJsonContext(defaultOptions));
+            JsonSerializerOptions options = Serializer.DefaultOptions;
+            Assert.True(options.IsReadOnly);
+
+            Assert.Throws<InvalidOperationException>(() => new MyJsonContext(options));
         }
 
         [Fact]
         public void PassingWrongOptionsInstanceToResolverThrowsException()
         {
-            JsonSerializerOptions defaultOptions = JsonSerializerOptions.Default;
             JsonSerializerOptions contextOptions = new();
             IJsonTypeInfoResolver context = new EmptyContext(contextOptions);
 
             Assert.IsAssignableFrom<JsonTypeInfo<int>>(context.GetTypeInfo(typeof(int), contextOptions));
             Assert.IsAssignableFrom<JsonTypeInfo<int>>(context.GetTypeInfo(typeof(int), null));
-            Assert.Throws<InvalidOperationException>(() => context.GetTypeInfo(typeof(int), defaultOptions));
+            Assert.Throws<InvalidOperationException>(() => context.GetTypeInfo(typeof(int), Serializer.DefaultOptions));
         }
 
         private class MyJsonContext : JsonSerializerContext
@@ -127,7 +128,10 @@ namespace System.Text.Json.Serialization.Tests
         {
             public EmptyContext(JsonSerializerOptions options) : base(options) { }
             protected override JsonSerializerOptions? GeneratedSerializerOptions => null;
-            public override JsonTypeInfo? GetTypeInfo(Type type) => JsonTypeInfo.CreateJsonTypeInfo(type, Options);
+            public override JsonTypeInfo? GetTypeInfo(Type type)
+                => type == typeof(int)
+                    ? JsonMetadataServices.CreateValueInfo<int>(Options, JsonMetadataServices.Int32Converter)
+                    : null;
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Common/MetadataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/MetadataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization.Metadata;
@@ -37,7 +38,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(ClassWithParameterizedCtor))]
         [InlineData(typeof(ClassWithMultipleConstructors))]
         [InlineData(typeof(DerivedClassWithShadowingProperties))]
-        public void TypeWithConstructor_TypeInfoReportsExpectedCtorProvider(Type typeWithCtor)
+        public void TypeWithConstructor_TypeInfoReportsExpectedCtorProvider([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type typeWithCtor)
         {
             ConstructorInfo? expectedCtor = typeWithCtor.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
                 .OrderByDescending(ctor => ctor.GetCustomAttribute<JsonConstructorAttribute>() is not null)
@@ -56,7 +57,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(ClassWithParameterizedCtor))]
         [InlineData(typeof(ClassWithMultipleConstructors))]
         [InlineData(typeof(DerivedClassWithShadowingProperties))]
-        public void TypeWithConstructor_SettingCtorDelegate_ResetsCtorAttributeProvider(Type typeWithCtor)
+        public void TypeWithConstructor_SettingCtorDelegate_ResetsCtorAttributeProvider([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type typeWithCtor)
         {
             JsonTypeInfo typeInfo = Serializer.GetTypeInfo(typeWithCtor, mutable: true);
             Assert.NotNull(typeInfo.ConstructorAttributeProvider);
@@ -97,6 +98,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(ClassWithMultipleConstructors))]
         [InlineData(typeof(DerivedClassWithShadowingProperties))]
         [InlineData(typeof(IDerivedInterface))]
+        [RequiresUnreferencedCode("Uses reflection to resolve the member backing each JsonPropertyInfo.")]
         public void JsonPropertyInfo_AttributeProvider_HasExpectedValue(Type typeWithProperties)
         {
             JsonTypeInfo typeInfo = Serializer.GetTypeInfo(typeWithProperties);
@@ -129,7 +131,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(StructWithParameterizedCtor))]
         [InlineData(typeof(ClassWithMultipleConstructors))]
         [InlineData(typeof(DerivedClassWithShadowingProperties))]
-        public void TypeWithConstructor_JsonPropertyInfo_AssociatedParameter_MatchesCtorParams(Type typeWithCtor)
+        public void TypeWithConstructor_JsonPropertyInfo_AssociatedParameter_MatchesCtorParams([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type typeWithCtor)
         {
             ConstructorInfo? expectedCtor = typeWithCtor.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
                 .OrderByDescending(ctor => ctor.GetCustomAttribute<JsonConstructorAttribute>() is not null)
@@ -243,7 +245,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(ClassWithInitOnlyProperty))]
         [InlineData(typeof(ClassWithMultipleConstructors))]
         [InlineData(typeof(DerivedClassWithShadowingProperties))]
-        public void TypeWithConstructor_SettingCtorDelegate_ResetsAssociatedParameters(Type typeWithCtor)
+        public void TypeWithConstructor_SettingCtorDelegate_ResetsAssociatedParameters([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type typeWithCtor)
         {
             JsonTypeInfo typeInfo = Serializer.GetTypeInfo(typeWithCtor, mutable: true);
             Assert.NotEmpty(typeInfo.Properties);
@@ -424,6 +426,7 @@ namespace System.Text.Json.Serialization.Tests
             return defaultValue;
         }
 
+        [RequiresUnreferencedCode("Uses Type.GetMember/Type.GetInterfaces reflection to resolve the member backing a JsonPropertyInfo.")]
         private static MemberInfo? ResolveMember(Type type, string name)
         {
             MemberInfo? result = type.GetMember(name, BindingFlags.Instance | BindingFlags.Public).FirstOrDefault();

--- a/src/libraries/System.Text.Json/tests/Common/NullableAnnotationsTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/NullableAnnotationsTests.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(GetTypesWithNonNullablePropertyGetter))]
-        public async Task WriteNullFromNotNullablePropertyGetter_EnforcedNullability_ThrowsJsonException(Type type, string propertyName)
+        public async Task WriteNullFromNotNullablePropertyGetter_EnforcedNullability_ThrowsJsonException([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, string propertyName)
         {
             object value = Activator.CreateInstance(type)!;
 
@@ -34,7 +34,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(GetTypesWithNonNullablePropertyGetter))]
-        public async Task WriteNullFromNotNullablePropertyGetter_IgnoredNullability_Succeeds(Type type, string _)
+        public async Task WriteNullFromNotNullablePropertyGetter_IgnoredNullability_Succeeds([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, string _)
         {
             object value = Activator.CreateInstance(type)!;
             string json = await Serializer.SerializeWrapper(value, type, s_optionsWithIgnoredNullability);
@@ -43,7 +43,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(GetTypesWithNonNullablePropertyGetter))]
-        public async Task WriteNullFromNotNullablePropertyGetter_EnforcedNullability_DisabledFlag_Succeeds(Type type, string propertyName)
+        public async Task WriteNullFromNotNullablePropertyGetter_EnforcedNullability_DisabledFlag_Succeeds([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, string propertyName)
         {
             object value = Activator.CreateInstance(type)!;
             JsonTypeInfo typeInfo = Serializer.GetTypeInfo(type, s_optionsWithEnforcedNullability, mutable: true);
@@ -80,7 +80,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(GetTypesWithNullablePropertyGetter))]
-        public async Task WriteNullFromNullablePropertyGetter_EnforcedNullability_Succeeds(Type type, string _)
+        public async Task WriteNullFromNullablePropertyGetter_EnforcedNullability_Succeeds([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, string _)
         {
             object value = Activator.CreateInstance(type)!;
             string json = await Serializer.SerializeWrapper(value, type, s_optionsWithEnforcedNullability);
@@ -89,7 +89,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(GetTypesWithNullablePropertyGetter))]
-        public async Task WriteNullFromNullablePropertyGetter_IgnoredNullability_Succeeds(Type type, string _)
+        public async Task WriteNullFromNullablePropertyGetter_IgnoredNullability_Succeeds([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, string _)
         {
             object value = Activator.CreateInstance(type)!;
             string json = await Serializer.SerializeWrapper(value, type, s_optionsWithIgnoredNullability);
@@ -98,7 +98,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(GetTypesWithNullablePropertyGetter))]
-        public async Task WriteNullFromNullablePropertyGetter_EnforcedNullability_EnabledFlag_ThrowsJsonException(Type type, string propertyName)
+        public async Task WriteNullFromNullablePropertyGetter_EnforcedNullability_EnabledFlag_ThrowsJsonException([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, string propertyName)
         {
             object value = Activator.CreateInstance(type)!;
             JsonTypeInfo typeInfo = Serializer.GetTypeInfo(type, s_optionsWithEnforcedNullability, mutable: true);

--- a/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -374,6 +375,8 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [RequiresUnreferencedCode("Uses Activator.CreateInstance to construct non-generic collection types.")]
+        [RequiresDynamicCode("Uses Activator.CreateInstance to construct non-generic collection types.")]
         public async Task Number_AsCollectionElement_RoundTrip()
         {
             await RunAsCollectionElementTest(JsonNumberTestData.Bytes);
@@ -419,6 +422,8 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
+        [RequiresUnreferencedCode("Uses Activator.CreateInstance to construct non-generic collection types.")]
+        [RequiresDynamicCode("Uses Activator.CreateInstance to construct non-generic collection types.")]
         private async Task RunAsCollectionElementTest<T>(List<T> numbers)
         {
             StringBuilder jsonBuilder_NumbersAsNumbers = new StringBuilder();
@@ -548,6 +553,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.False(enumerator2.MoveNext());
         }
 
+        [RequiresUnreferencedCode("Uses Activator.CreateInstance to construct non-generic collection types.")]
+        [RequiresDynamicCode("Uses Activator.CreateInstance to construct non-generic collection types.")]
         private async Task RunAllCollectionsRoundTripTest<T>(string json)
         {
             foreach (Type type in CollectionTestTypes.DeserializableGenericEnumerableTypes<T>())
@@ -585,10 +592,13 @@ namespace System.Text.Json.Serialization.Tests
                 serialized = await Serializer.SerializeWrapper(list, s_optionReadAndWriteFromStr);
                 Assert.Equal(json, serialized);
 
-                // Serialize instance which is a collection of numbers (not JsonElements).
-                obj = Activator.CreateInstance(type, new[] { list });
-                serialized = await Serializer.SerializeWrapper(obj, s_optionReadAndWriteFromStr);
-                Assert.Equal(json, serialized);
+                if (PlatformDetection.IsNotNativeAot)
+                {
+                    // Serialize instance which is a collection of numbers (not JsonElements).
+                    obj = Activator.CreateInstance(type, new[] { list });
+                    serialized = await Serializer.SerializeWrapper(obj, s_optionReadAndWriteFromStr);
+                    Assert.Equal(json, serialized);
+                }
             }
         }
 
@@ -636,6 +646,8 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/39674", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
         [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
+        [RequiresUnreferencedCode("Uses Activator.CreateInstance to construct non-generic dictionary types.")]
+        [RequiresDynamicCode("Uses Activator.CreateInstance to construct non-generic dictionary types.")]
         public async Task DictionariesRoundTrip()
         {
             await RunAllDictionariessRoundTripTest(JsonNumberTestData.ULongs);
@@ -643,6 +655,8 @@ namespace System.Text.Json.Serialization.Tests
             await RunAllDictionariessRoundTripTest(JsonNumberTestData.Doubles);
         }
 
+        [RequiresUnreferencedCode("Uses Activator.CreateInstance to construct non-generic dictionary types.")]
+        [RequiresDynamicCode("Uses Activator.CreateInstance to construct non-generic dictionary types.")]
         private async Task RunAllDictionariessRoundTripTest<T>(List<T> numbers)
         {
             StringBuilder jsonBuilder_NumbersAsStrings = new StringBuilder();
@@ -669,14 +683,17 @@ namespace System.Text.Json.Serialization.Tests
                 JsonTestHelper.AssertJsonEqual(jsonNumbersAsStrings, await Serializer.SerializeWrapper(obj, s_optionReadAndWriteFromStr));
             }
 
-            foreach (Type type in CollectionTestTypes.DeserializableNonGenericDictionaryTypes())
+            if (PlatformDetection.IsNotNativeAot)
             {
-                Dictionary<T, T> dict = await Serializer.DeserializeWrapper<Dictionary<T, T>>(jsonNumbersAsStrings, s_optionReadAndWriteFromStr);
+                foreach (Type type in CollectionTestTypes.DeserializableNonGenericDictionaryTypes())
+                {
+                    Dictionary<T, T> dict = await Serializer.DeserializeWrapper<Dictionary<T, T>>(jsonNumbersAsStrings, s_optionReadAndWriteFromStr);
 
-                // Serialize instance which is a dictionary of numbers (not JsonElements).
-                object obj = Activator.CreateInstance(type, new[] { dict });
-                string serialized = await Serializer.SerializeWrapper(obj, s_optionReadAndWriteFromStr);
-                JsonTestHelper.AssertJsonEqual(jsonNumbersAsStrings, serialized);
+                    // Serialize instance which is a dictionary of numbers (not JsonElements).
+                    object obj = Activator.CreateInstance(type, new[] { dict });
+                    string serialized = await Serializer.SerializeWrapper(obj, s_optionReadAndWriteFromStr);
+                    JsonTestHelper.AssertJsonEqual(jsonNumbersAsStrings, serialized);
+                }
             }
         }
 
@@ -2022,6 +2039,7 @@ namespace System.Text.Json.Serialization.Tests
                     s_optionReadFromStr));
         }
 
+#if !BUILDING_SOURCE_GENERATOR_TESTS
         [Fact]
         public void GetConverter_Int32_RespectsNumberHandling_AllowReadingFromString()
         {
@@ -2345,5 +2363,6 @@ namespace System.Text.Json.Serialization.Tests
             reader.Read(); reader.Read(); reader.Read();
             Assert.True(float.IsNaN(converter.Read(ref reader, typeof(float), options)));
         }
+#endif
     }
 }

--- a/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.CustomTypeHierarchies.cs
@@ -129,7 +129,7 @@ namespace System.Text.Json.Serialization.Tests
 
         //--
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Theory]
         [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Serialization))]
         public Task PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Serialization(PolymorphicClass.TestData testData)
             => TestMultiContextSerialization(
@@ -142,7 +142,7 @@ namespace System.Text.Json.Serialization.Tests
         public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Serialization()
             => PolymorphicClass.GetSerializeTestData_CustomConfigWithBaseTypeFallback().Select(entry => new object[] { entry });
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Theory]
         [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Deserialization))]
         public Task PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Deserialization(PolymorphicClass.TestData testData)
             => TestMultiContextDeserialization<PolymorphicClass>(
@@ -157,7 +157,7 @@ namespace System.Text.Json.Serialization.Tests
                 .Where(entry => entry.ExpectedJson != null)
                 .Select(entry => new object[] { entry });
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Fact]
         public async Task PolymorphicClass_CustomConfigWithBaseTypeFallback_TestDataArray_Serialization()
         {
             IEnumerable<(PolymorphicClass Value, string ExpectedJson)> inputs =
@@ -168,7 +168,7 @@ namespace System.Text.Json.Serialization.Tests
             await TestMultiContextSerialization(inputs, options: PolymorphicClass.CustomConfigWithBaseTypeFallback);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Fact]
         public async Task PolymorphicClass_CustomConfigWithBaseTypeFallbacks_TestDataArray_Deserialization()
         {
             IEnumerable<(string ExpectedJson, PolymorphicClass ExpectedRoundtripValue)> inputs =
@@ -182,7 +182,7 @@ namespace System.Text.Json.Serialization.Tests
                 options: PolymorphicClass.CustomConfigWithBaseTypeFallback);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Theory]
         [InlineData("$['$type']", """{ "$type" : "derivedClass1", "Number" : 42 }""")]
         [InlineData("$._case", """{ "_case" : "derivedClass1", "_case" : "derivedClass1", "Number" : 42 }""")]
         [InlineData("$._case", """{ "_case" : "derivedClass1", "Number" : 42, "_case" : "derivedClass1"}""")]
@@ -206,7 +206,7 @@ namespace System.Text.Json.Serialization.Tests
 
         //---
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Theory]
         [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization))]
         public Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization(PolymorphicClass.TestData testData)
             => TestMultiContextSerialization(
@@ -219,7 +219,7 @@ namespace System.Text.Json.Serialization.Tests
         public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization()
             => PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback().Select(entry => new object[] { entry });
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Theory]
         [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization))]
         public Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization(PolymorphicClass.TestData testData)
             => TestMultiContextDeserialization<PolymorphicClass>(
@@ -234,7 +234,7 @@ namespace System.Text.Json.Serialization.Tests
                     .Where(entry => entry.ExpectedJson != null)
                     .Select(entry => new object[] { entry });
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Fact]
         public async Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestDataArray_Serialization()
         {
             IEnumerable<(PolymorphicClass Value, string ExpectedJson)> inputs =
@@ -245,7 +245,7 @@ namespace System.Text.Json.Serialization.Tests
             await TestMultiContextSerialization(inputs, options: PolymorphicClass.CustomConfigWithNearestAncestorFallback);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Fact]
         public async Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestDataArray_Deserialization()
         {
             IEnumerable<(string ExpectedJson, PolymorphicClass ExpectedRoundtripValue)> inputs =
@@ -259,7 +259,7 @@ namespace System.Text.Json.Serialization.Tests
                 options: PolymorphicClass.CustomConfigWithNearestAncestorFallback);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Theory]
         [InlineData("$['$type']", """{ "$type" : "derivedClass1", "Number" : 42 }""")]
         [InlineData("$._case", """{ "_case" : "derivedClass1", "_case" : "derivedClass1", "Number" : 42 }""")]
         [InlineData("$._case", """{ "_case" : "derivedClass1", "Number" : 42, "_case" : "derivedClass1"}""")]
@@ -1935,7 +1935,7 @@ namespace System.Text.Json.Serialization.Tests
             public record TestData(PolymorphicDictionary Value, string ExpectedJson, PolymorphicDictionary ExpectedRoundtripValue);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Fact]
         public async Task PolymorphicDictionaryInterface_Serialization()
         {
             var values = new IEnumerable<KeyValuePair<int, object>>[]
@@ -1959,7 +1959,7 @@ namespace System.Text.Json.Serialization.Tests
             JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        [Fact]
         public async Task PolymorphicDictionaryInterface_Deserialization()
         {
             string json =

--- a/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.CustomTypeHierarchies.cs
@@ -34,7 +34,7 @@ namespace System.Text.Json.Serialization.Tests
                 testData.ExpectedJson,
                 testData.ExpectedRoundtripValue,
                 testData.ExpectedDeserializationException,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicClass>());
 
         public static IEnumerable<object[]> Get_PolymorphicClass_TestData_Deserialization()
             => PolymorphicClass.GetSerializeTestData().Where(entry => entry.ExpectedJson != null).Select(entry => new object[] { entry });
@@ -58,7 +58,7 @@ namespace System.Text.Json.Serialization.Tests
                     .Where(entry => entry.ExpectedRoundtripValue is not null)
                     .Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
 
-            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+            await TestMultiContextDeserialization(inputs, equalityComparer: CreateJsonEqualityComparer<PolymorphicClass>());
         }
 
         [Theory]
@@ -89,7 +89,7 @@ namespace System.Text.Json.Serialization.Tests
                 testData.ExpectedRoundtripValue,
                 testData.ExpectedDeserializationException,
                 options: s_optionsWithAllowOutOfOrderMetadata,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicClass>());
 
         [Theory]
         [InlineData("""{"Number":42, "$type":"derivedClass1", "String": "str"}""", typeof(PolymorphicClass.DerivedClass1_TypeDiscriminator))]
@@ -149,7 +149,7 @@ namespace System.Text.Json.Serialization.Tests
                 testData.ExpectedJson,
                 testData.ExpectedRoundtripValue,
                 testData.ExpectedSerializationException,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance,
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicClass>(),
                 options: PolymorphicClass.CustomConfigWithBaseTypeFallback);
 
         public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Deserialization()
@@ -178,7 +178,7 @@ namespace System.Text.Json.Serialization.Tests
 
             await TestMultiContextDeserialization(
                 inputs,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance,
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicClass>(),
                 options: PolymorphicClass.CustomConfigWithBaseTypeFallback);
         }
 
@@ -209,12 +209,21 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization))]
         public Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization(PolymorphicClass.TestData testData)
-            => TestMultiContextSerialization(
+        {
+            // Nearest-ancestor fallback for class hierarchies resolves derived types via reflection;
+            // skip in source-gen contexts where reflection is disabled.
+            if (!JsonSerializer.IsReflectionEnabledByDefault)
+            {
+                return Task.CompletedTask;
+            }
+
+            return TestMultiContextSerialization(
                 testData.Value,
                 testData.ExpectedJson,
                 testData.ExpectedSerializationException,
                 options: PolymorphicClass.CustomConfigWithNearestAncestorFallback,
                 contexts: ~SerializedValueContext.BoxedValue);
+        }
 
         public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization()
             => PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback().Select(entry => new object[] { entry });
@@ -222,12 +231,21 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization))]
         public Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization(PolymorphicClass.TestData testData)
-            => TestMultiContextDeserialization<PolymorphicClass>(
+        {
+            // Nearest-ancestor fallback for class hierarchies resolves derived types via reflection;
+            // skip in source-gen contexts where reflection is disabled.
+            if (!JsonSerializer.IsReflectionEnabledByDefault)
+            {
+                return Task.CompletedTask;
+            }
+
+            return TestMultiContextDeserialization<PolymorphicClass>(
                 testData.ExpectedJson,
                 testData.ExpectedRoundtripValue,
                 testData.ExpectedDeserializationException,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance,
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicClass>(),
                 options: PolymorphicClass.CustomConfigWithNearestAncestorFallback);
+        }
 
         public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization()
             => PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
@@ -237,6 +255,13 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         public async Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestDataArray_Serialization()
         {
+            // Nearest-ancestor fallback for class hierarchies resolves derived types via reflection;
+            // skip in source-gen contexts where reflection is disabled.
+            if (!JsonSerializer.IsReflectionEnabledByDefault)
+            {
+                return;
+            }
+
             IEnumerable<(PolymorphicClass Value, string ExpectedJson)> inputs =
                 PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
                     .Where(entry => entry.ExpectedSerializationException is null)
@@ -248,6 +273,13 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         public async Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestDataArray_Deserialization()
         {
+            // Nearest-ancestor fallback for class hierarchies resolves derived types via reflection;
+            // skip in source-gen contexts where reflection is disabled.
+            if (!JsonSerializer.IsReflectionEnabledByDefault)
+            {
+                return;
+            }
+
             IEnumerable<(string ExpectedJson, PolymorphicClass ExpectedRoundtripValue)> inputs =
                 PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
                 .Where(entry => entry.ExpectedRoundtripValue is not null)
@@ -255,7 +287,7 @@ namespace System.Text.Json.Serialization.Tests
 
             await TestMultiContextDeserialization(
                 inputs,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance,
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicClass>(),
                 options: PolymorphicClass.CustomConfigWithNearestAncestorFallback);
         }
 
@@ -302,22 +334,13 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task PolymorphicClass_ClearPolymorphismOptions_DoesNotUsePolymorphism()
         {
-            var options = new JsonSerializerOptions
+            JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(static jsonTypeInfo =>
             {
-                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                if (jsonTypeInfo.Type == typeof(PolymorphicClass))
                 {
-                    Modifiers =
-                    {
-                        static jsonTypeInfo =>
-                        {
-                            if (jsonTypeInfo.Type == typeof(PolymorphicClass))
-                            {
-                                jsonTypeInfo.PolymorphismOptions = null;
-                            }
-                        }
-                    }
+                    jsonTypeInfo.PolymorphismOptions = null;
                 }
-            };
+            });
 
             PolymorphicClass value = new PolymorphicClass.DerivedAbstractClass.DerivedClass { Number = 42, Boolean = true };
             string json = await Serializer.SerializeWrapper(value, options);
@@ -961,13 +984,13 @@ namespace System.Text.Json.Serialization.Tests
             await TestMultiContextDeserialization<PolymorphicClass_WithDerivedPolymorphicClass>(
                 json,
                 expectedValueUsingBaseContract,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass_WithDerivedPolymorphicClass>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicClass_WithDerivedPolymorphicClass>());
 
             var expectedValueUsingDerivedContract = new PolymorphicClass_WithDerivedPolymorphicClass.DerivedClass.DerivedClass2();
             await TestMultiContextDeserialization<PolymorphicClass_WithDerivedPolymorphicClass.DerivedClass>(
                 json,
                 expectedValueUsingDerivedContract,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass_WithDerivedPolymorphicClass.DerivedClass>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicClass_WithDerivedPolymorphicClass.DerivedClass>());
         }
 
         [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
@@ -1149,7 +1172,7 @@ namespace System.Text.Json.Serialization.Tests
             => TestMultiContextDeserialization<PolymorphicClassWithConstructor>(
                 testData.ExpectedJson,
                 testData.ExpectedRoundtripValue,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicClassWithConstructor>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicClassWithConstructor>());
 
         public static IEnumerable<object[]> Get_PolymorphicClassWithConstructor_TestData_Deserialization()
             => PolymorphicClassWithConstructor.GetSerializeTestData()
@@ -1171,7 +1194,7 @@ namespace System.Text.Json.Serialization.Tests
             IEnumerable<(string ExpectedJson, PolymorphicClassWithConstructor ExpectedRoundtripValue)> inputs =
                 PolymorphicClassWithConstructor.GetSerializeTestData().Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
 
-            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicClassWithConstructor>.Instance);
+            await TestMultiContextDeserialization(inputs, equalityComparer: CreateJsonEqualityComparer<PolymorphicClassWithConstructor>());
         }
 
         [JsonPolymorphic]
@@ -1300,7 +1323,7 @@ namespace System.Text.Json.Serialization.Tests
                 testData.ExpectedJson,
                 testData.ExpectedRoundtripValue,
                 testData.ExpectedDeserializationException,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicInterface>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicInterface>());
 
         public static IEnumerable<object[]> Get_PolymorphicInterface_TestData_Deserialization()
             => PolymorphicInterface.Helpers.GetSerializeTestData()
@@ -1326,7 +1349,7 @@ namespace System.Text.Json.Serialization.Tests
                 .Where(entry => entry.ExpectedRoundtripValue is not null)
                 .Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
 
-            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicInterface>.Instance);
+            await TestMultiContextDeserialization(inputs, equalityComparer: CreateJsonEqualityComparer<PolymorphicInterface>());
         }
 
         [Theory]
@@ -1369,7 +1392,7 @@ namespace System.Text.Json.Serialization.Tests
                 testData.ExpectedRoundtripValue,
                 testData.ExpectedDeserializationException,
                 options: PolymorphicInterface.Helpers.CustomConfigWithNearestAncestorFallback,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicInterface>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicInterface>());
 
         public static IEnumerable<object[]> Get_PolymorphicInterface_CustomConfigWithNearestAncestorFallback_TestData_Deserialization()
             => PolymorphicInterface.Helpers.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
@@ -1398,7 +1421,7 @@ namespace System.Text.Json.Serialization.Tests
             await TestMultiContextDeserialization(
                 inputs,
                 options: PolymorphicInterface.Helpers.CustomConfigWithNearestAncestorFallback,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicInterface>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicInterface>());
         }
 
         // --
@@ -1615,7 +1638,7 @@ namespace System.Text.Json.Serialization.Tests
             => TestMultiContextDeserialization(
                 testData.ExpectedJson,
                 testData.ExpectedRoundtripValue,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicList>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicList>());
 
         public static IEnumerable<object[]> Get_PolymorphicList_TestData_Deserialization()
             => PolymorphicList.GetSerializeTestData().Select(entry => new object[] { entry });
@@ -1635,7 +1658,7 @@ namespace System.Text.Json.Serialization.Tests
             IEnumerable<(string ExpectedJson, PolymorphicList ExpectedRoundtripValue)> inputs =
                 PolymorphicList.GetSerializeTestData().Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
 
-            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicList>.Instance);
+            await TestMultiContextDeserialization(inputs, equalityComparer: CreateJsonEqualityComparer<PolymorphicList>());
         }
 
         [Fact]
@@ -1865,7 +1888,7 @@ namespace System.Text.Json.Serialization.Tests
             => TestMultiContextDeserialization(
                 testData.ExpectedJson,
                 testData.ExpectedRoundtripValue,
-                equalityComparer: PolymorphicEqualityComparer<PolymorphicDictionary>.Instance);
+                equalityComparer: CreateJsonEqualityComparer<PolymorphicDictionary>());
 
         public static IEnumerable<object[]> Get_PolymorphicDictionary_TestData_Deserialization()
             => PolymorphicDictionary.GetSerializeTestData().Select(entry => new object[] { entry });
@@ -1885,7 +1908,7 @@ namespace System.Text.Json.Serialization.Tests
             IEnumerable<(string ExpectedJson, PolymorphicDictionary ExpectedRoundtripValue)> inputs =
                 PolymorphicDictionary.GetSerializeTestData().Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
 
-            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicDictionary>.Instance);
+            await TestMultiContextDeserialization(inputs, equalityComparer: CreateJsonEqualityComparer<PolymorphicDictionary>());
         }
 
         [Fact]
@@ -1947,6 +1970,13 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         public async Task PolymorphicDictionaryInterface_Serialization()
         {
+            // Polymorphic dictionary-interface resolution uses the reflection-based metadata fallback;
+            // skip in source-gen contexts where reflection is disabled.
+            if (!JsonSerializer.IsReflectionEnabledByDefault)
+            {
+                return;
+            }
+
             var values = new IEnumerable<KeyValuePair<int, object>>[]
             {
                 new List<KeyValuePair<int, object>> { new KeyValuePair<int, object>(0, 0) },
@@ -1971,6 +2001,13 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         public async Task PolymorphicDictionaryInterface_Deserialization()
         {
+            // Polymorphic dictionary-interface resolution uses the reflection-based metadata fallback;
+            // skip in source-gen contexts where reflection is disabled.
+            if (!JsonSerializer.IsReflectionEnabledByDefault)
+            {
+                return;
+            }
+
             string json =
                 """
                         [ [ { "Key":0, "Value":0 } ],
@@ -2130,7 +2167,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             string json = jsonTemplate("1"); // root values have reference id "1"
             PolymorphicClass actualValue = await Serializer.DeserializeWrapper<PolymorphicClass>(json, s_jsonSerializerOptionsPreserveRefs);
-            Assert.Equal(expectedValue, actualValue, PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+            Assert.Equal(expectedValue, actualValue, CreateJsonEqualityComparer<PolymorphicClass>());
         }
 
         [Theory]
@@ -2163,7 +2200,7 @@ namespace System.Text.Json.Serialization.Tests
             var result = await Serializer.DeserializeWrapper<List<PolymorphicClass>>(json, s_jsonSerializerOptionsPreserveRefs);
 
             Assert.Equal(2, result.Count);
-            Assert.Equal(expectedValue, result[0], PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+            Assert.Equal(expectedValue, result[0], CreateJsonEqualityComparer<PolymorphicClass>());
             Assert.Same(result[0], result[1]);
         }
 
@@ -2192,7 +2229,7 @@ namespace System.Text.Json.Serialization.Tests
             string json = "[" + string.Join(", ", idValues.Concat(refValues)) + "]";
 
             PolymorphicClass[] result = await Serializer.DeserializeWrapper<PolymorphicClass[]>(json, s_jsonSerializerOptionsPreserveRefs);
-            Assert.Equal(expectedValues, result, PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+            Assert.Equal(expectedValues, result, CreateJsonEqualityComparer<PolymorphicClass>());
         }
 
         public static IEnumerable<(PolymorphicClass Value, Func<string, string> JsonTemplate)> Get_ReferencePreservation_TestData()
@@ -2232,7 +2269,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             string json = jsonTemplate("1"); // root values have reference id "1"
             PolymorphicClassWithCustomTypeDiscriminator actualValue = await Serializer.DeserializeWrapper<PolymorphicClassWithCustomTypeDiscriminator>(json, s_jsonSerializerOptionsPreserveRefs);
-            Assert.Equal(expectedValue, actualValue, PolymorphicEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>.Instance);
+            Assert.Equal(expectedValue, actualValue, CreateJsonEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>());
         }
 
         [Theory]
@@ -2265,7 +2302,7 @@ namespace System.Text.Json.Serialization.Tests
             var result = await Serializer.DeserializeWrapper<List<PolymorphicClassWithCustomTypeDiscriminator>>(json, s_jsonSerializerOptionsPreserveRefs);
 
             Assert.Equal(2, result.Count);
-            Assert.Equal(expectedValue, result[0], PolymorphicEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>.Instance);
+            Assert.Equal(expectedValue, result[0], CreateJsonEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>());
             Assert.Same(result[0], result[1]);
         }
 
@@ -2294,7 +2331,7 @@ namespace System.Text.Json.Serialization.Tests
             string json = "[" + string.Join(", ", idValues.Concat(refValues)) + "]";
 
             PolymorphicClassWithCustomTypeDiscriminator[] result = await Serializer.DeserializeWrapper<PolymorphicClassWithCustomTypeDiscriminator[]>(json, s_jsonSerializerOptionsPreserveRefs);
-            Assert.Equal(expectedValues, result, PolymorphicEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>.Instance);
+            Assert.Equal(expectedValues, result, CreateJsonEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>());
         }
 
         [Theory]
@@ -2303,7 +2340,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             string json = jsonTemplate("1"); // root values have reference id "1"
             PolymorphicClass actualValue = await Serializer.DeserializeWrapper<PolymorphicClass>(json, s_jsonSerializerOptionsPreserveRefsAndAllowReadAhead);
-            Assert.Equal(expectedValue, actualValue, PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+            Assert.Equal(expectedValue, actualValue, CreateJsonEqualityComparer<PolymorphicClass>());
         }
 
         [Theory]
@@ -2320,7 +2357,7 @@ namespace System.Text.Json.Serialization.Tests
             var result = await Serializer.DeserializeWrapper<List<PolymorphicClass>>(json, s_jsonSerializerOptionsPreserveRefsAndAllowReadAhead);
 
             Assert.Equal(2, result.Count);
-            Assert.Equal(expectedValue, result[0], PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+            Assert.Equal(expectedValue, result[0], CreateJsonEqualityComparer<PolymorphicClass>());
             Assert.Same(result[0], result[1]);
         }
 
@@ -2335,7 +2372,7 @@ namespace System.Text.Json.Serialization.Tests
             string json = "[" + string.Join(", ", idValues.Concat(refValues)) + "]";
 
             PolymorphicClass[] result = await Serializer.DeserializeWrapper<PolymorphicClass[]>(json, s_jsonSerializerOptionsPreserveRefsAndAllowReadAhead);
-            Assert.Equal(expectedValues, result, PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+            Assert.Equal(expectedValues, result, CreateJsonEqualityComparer<PolymorphicClass>());
         }
 
         [Theory]
@@ -2947,7 +2984,14 @@ namespace System.Text.Json.Serialization.Tests
             public T? Extra { get; set; }
         }
 
-        [Fact]
+        // Validates the runtime programmatic API by adding polymorphism to OpenGenericBase_Programmatic<int>
+        // via a resolver modifier. The type is deliberately not registered with a JsonSerializerContext
+        // (no [JsonDerivedType]), so it relies on the reflection-based DefaultJsonTypeInfoResolver and only
+        // runs where runtime code generation is available; OpenGenericDerivedType_MixedWithRegularDerivedType_Works
+        // covers the attribute-based equivalent that also runs under source-gen.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [RequiresUnreferencedCode("Uses DefaultJsonTypeInfoResolver and reflection-based serialization.")]
+        [RequiresDynamicCode("Uses DefaultJsonTypeInfoResolver and reflection-based serialization.")]
         public async Task OpenGenericDerivedType_ProgrammaticApi_Works()
         {
             var options = new JsonSerializerOptions
@@ -3471,22 +3515,13 @@ namespace System.Text.Json.Serialization.Tests
             // Same as above with explicit FallBackToBaseType. The resolver falls through to the
             // base contract (no discriminator emitted) because the runtime type is not registered.
             // This matches the previously-described "serializes as base contract" behavior.
-            var options = new JsonSerializerOptions
+            JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(typeInfo =>
             {
-                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                if (typeInfo.Type == typeof(IVarCovBase<VarAnimal>) && typeInfo.PolymorphismOptions is { } pOpts)
                 {
-                    Modifiers =
-                    {
-                        typeInfo =>
-                        {
-                            if (typeInfo.Type == typeof(IVarCovBase<VarAnimal>) && typeInfo.PolymorphismOptions is { } pOpts)
-                            {
-                                pOpts.UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType;
-                            }
-                        }
-                    }
+                    pOpts.UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType;
                 }
-            };
+            });
 
             IVarCovBase<VarAnimal> value = new VarCovImpl<VarDog> { Value = new VarDog { Name = "Rex", Breed = "Labrador" } };
             string json = await Serializer.SerializeWrapper(value, options);
@@ -3798,51 +3833,14 @@ namespace System.Text.Json.Serialization.Tests
         #endregion
 
         #region Test Helpers
-        public class PolymorphicEqualityComparer<TBaseType> : IEqualityComparer<TBaseType>
-            where TBaseType : class
-        {
-            public static PolymorphicEqualityComparer<TBaseType> Instance { get; } = new();
-
-            public bool Equals(TBaseType? left, TBaseType? right)
-            {
-                if (left is null || right is null)
-                {
-                    return left is null == right is null;
-                }
-
-                Type runtimeType = left.GetType();
-                if (runtimeType != right.GetType())
-                {
-                    return false;
-                }
-
-                EqualityComparer<object> objComparer = EqualityComparer<object>.Default;
-
-                // Runtime type is enumerable; use enumerable sequence comparison
-                if (left is IEnumerable leftColl)
-                {
-                    IEnumerable rightColl = (IEnumerable)right;
-                    return leftColl.Cast<object>().SequenceEqual(rightColl.Cast<object>(), objComparer);
-                }
-
-                // Runtime is regular POCO; use property structural comparison
-                foreach (var propInfo in runtimeType.GetProperties())
-                {
-                    if (!objComparer.Equals(propInfo.GetValue(left), propInfo.GetValue(right)))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            public int GetHashCode(TBaseType _) => throw new NotImplementedException();
-        }
 
         public class CustomPolymorphismResolver : IJsonTypeInfoResolver
         {
+            #if BUILDING_SOURCE_GENERATOR_TESTS
+            private readonly IJsonTypeInfoResolver _inner = System.Text.Json.SourceGeneration.Tests.PolymorphicTests_Metadata.PolymorphicTestsContext_Metadata.Default;
+            #else
             private readonly DefaultJsonTypeInfoResolver _inner = new();
+            #endif
             private readonly List<JsonDerivedType> _jsonDerivedTypes = new();
 
             public CustomPolymorphismResolver(Type baseType)

--- a/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.CustomTypeHierarchies.cs
@@ -209,21 +209,12 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization))]
         public Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization(PolymorphicClass.TestData testData)
-        {
-            // Nearest-ancestor fallback for class hierarchies resolves derived types via reflection;
-            // skip in source-gen contexts where reflection is disabled.
-            if (!JsonSerializer.IsReflectionEnabledByDefault)
-            {
-                return Task.CompletedTask;
-            }
-
-            return TestMultiContextSerialization(
+            => TestMultiContextSerialization(
                 testData.Value,
                 testData.ExpectedJson,
                 testData.ExpectedSerializationException,
                 options: PolymorphicClass.CustomConfigWithNearestAncestorFallback,
                 contexts: ~SerializedValueContext.BoxedValue);
-        }
 
         public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization()
             => PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback().Select(entry => new object[] { entry });
@@ -231,21 +222,12 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization))]
         public Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization(PolymorphicClass.TestData testData)
-        {
-            // Nearest-ancestor fallback for class hierarchies resolves derived types via reflection;
-            // skip in source-gen contexts where reflection is disabled.
-            if (!JsonSerializer.IsReflectionEnabledByDefault)
-            {
-                return Task.CompletedTask;
-            }
-
-            return TestMultiContextDeserialization<PolymorphicClass>(
+            => TestMultiContextDeserialization<PolymorphicClass>(
                 testData.ExpectedJson,
                 testData.ExpectedRoundtripValue,
                 testData.ExpectedDeserializationException,
                 equalityComparer: CreateJsonEqualityComparer<PolymorphicClass>(),
                 options: PolymorphicClass.CustomConfigWithNearestAncestorFallback);
-        }
 
         public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization()
             => PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
@@ -255,13 +237,6 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         public async Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestDataArray_Serialization()
         {
-            // Nearest-ancestor fallback for class hierarchies resolves derived types via reflection;
-            // skip in source-gen contexts where reflection is disabled.
-            if (!JsonSerializer.IsReflectionEnabledByDefault)
-            {
-                return;
-            }
-
             IEnumerable<(PolymorphicClass Value, string ExpectedJson)> inputs =
                 PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
                     .Where(entry => entry.ExpectedSerializationException is null)
@@ -273,13 +248,6 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         public async Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestDataArray_Deserialization()
         {
-            // Nearest-ancestor fallback for class hierarchies resolves derived types via reflection;
-            // skip in source-gen contexts where reflection is disabled.
-            if (!JsonSerializer.IsReflectionEnabledByDefault)
-            {
-                return;
-            }
-
             IEnumerable<(string ExpectedJson, PolymorphicClass ExpectedRoundtripValue)> inputs =
                 PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
                 .Where(entry => entry.ExpectedRoundtripValue is not null)
@@ -1970,13 +1938,6 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         public async Task PolymorphicDictionaryInterface_Serialization()
         {
-            // Polymorphic dictionary-interface resolution uses the reflection-based metadata fallback;
-            // skip in source-gen contexts where reflection is disabled.
-            if (!JsonSerializer.IsReflectionEnabledByDefault)
-            {
-                return;
-            }
-
             var values = new IEnumerable<KeyValuePair<int, object>>[]
             {
                 new List<KeyValuePair<int, object>> { new KeyValuePair<int, object>(0, 0) },
@@ -2001,13 +1962,6 @@ namespace System.Text.Json.Serialization.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         public async Task PolymorphicDictionaryInterface_Deserialization()
         {
-            // Polymorphic dictionary-interface resolution uses the reflection-based metadata fallback;
-            // skip in source-gen contexts where reflection is disabled.
-            if (!JsonSerializer.IsReflectionEnabledByDefault)
-            {
-                return;
-            }
-
             string json =
                 """
                         [ [ { "Key":0, "Value":0 } ],

--- a/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.TypeClassifier.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.TypeClassifier.cs
@@ -649,7 +649,7 @@ namespace System.Text.Json.Serialization.Tests
                     new JsonDerivedType(typeof(ClassifiedCat), "cat"),
                     new JsonDerivedType(typeof(ClassifiedParrot), "parrot"),},
                                     "kind");
-            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() });
+            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, Serializer.DefaultOptions);
 
             var options = CreateOptionsWithClassifier<ClassifiedAnimalBase>(classify);
 
@@ -670,7 +670,7 @@ namespace System.Text.Json.Serialization.Tests
                     new JsonDerivedType(typeof(ClassifiedDog), "dog"),
                     new JsonDerivedType(typeof(ClassifiedCat), "cat"),},
                                     "kind");
-            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() });
+            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, Serializer.DefaultOptions);
 
             var options = CreateOptionsWithClassifier<ClassifiedAnimalBase>(classify);
 
@@ -692,7 +692,7 @@ namespace System.Text.Json.Serialization.Tests
                     new JsonDerivedType(typeof(ClassifiedDog), 1),
                     new JsonDerivedType(typeof(ClassifiedCat), 2),},
                                     "type_id");
-            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() });
+            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, Serializer.DefaultOptions);
 
             var options = CreateOptionsWithClassifier<ClassifiedAnimalBase>(classify);
 
@@ -996,7 +996,7 @@ namespace System.Text.Json.Serialization.Tests
                     new JsonDerivedType(typeof(ClassifiedDog), "dog"),
                     new JsonDerivedType(typeof(ClassifiedCat), "cat"),},
                                     "kind");
-            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() });
+            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, Serializer.DefaultOptions);
 
             var options = CreateOptionsWithClassifier<ClassifiedAnimalBase>(classify);
             string json = """[{"kind":"dog","Name":"Rex","Breed":"Lab"},{"kind":"cat","Name":"Whiskers","Lives":9}]""";
@@ -1115,7 +1115,7 @@ namespace System.Text.Json.Serialization.Tests
                     new JsonDerivedType(typeof(ClassifiedDog), "dog"),
                     new JsonDerivedType(typeof(ClassifiedCat), "cat"),},
                                     "kind");
-            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() });
+            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, Serializer.DefaultOptions);
 
             JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(typeInfo =>
             {
@@ -1239,7 +1239,7 @@ namespace System.Text.Json.Serialization.Tests
                     new JsonDerivedType(typeof(ClassifiedDog), "dog"),
                     new JsonDerivedType(typeof(ClassifiedCat), "cat"),},
                                     "kind");
-            JsonTypeClassifier animalClassify = animalFactory.CreateJsonClassifier(animalContext, new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() });
+            JsonTypeClassifier animalClassify = animalFactory.CreateJsonClassifier(animalContext, Serializer.DefaultOptions);
 
             JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(typeInfo =>
             {
@@ -1462,7 +1462,7 @@ namespace System.Text.Json.Serialization.Tests
                     new JsonDerivedType(typeof(ClassifiedDog), "dog"),
                     new JsonDerivedType(typeof(ClassifiedCat), "cat"),},
                                     "kind");
-            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() });
+            JsonTypeClassifier classify = factory.CreateJsonClassifier(context, Serializer.DefaultOptions);
 
             JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(typeInfo =>
             {

--- a/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PolymorphicTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
@@ -33,8 +34,7 @@ namespace System.Text.Json.Serialization.Tests
             json = await Serializer.SerializeWrapper(value, typeof(object));
             Assert.Equal(expectedJson, json);
 
-            var options = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
-            JsonTypeInfo<object> objectTypeInfo = options.GetTypeInfo<object>();
+            JsonTypeInfo<object> objectTypeInfo = Serializer.DefaultOptions.GetTypeInfo<object>();
             json = await Serializer.SerializeWrapper(value, objectTypeInfo);
             Assert.Equal(expectedJson, json);
         }
@@ -573,23 +573,14 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task CustomResolverWithFailingAncestorType_DoesNotSurfaceException()
         {
-            var options = new JsonSerializerOptions
+            JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(static typeInfo =>
             {
-                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                if (typeInfo.Type == typeof(MyThing) ||
+                    typeInfo.Type == typeof(IList))
                 {
-                    Modifiers =
-                    {
-                        static typeInfo =>
-                        {
-                            if (typeInfo.Type == typeof(MyThing) ||
-                                typeInfo.Type == typeof(IList))
-                            {
-                                throw new InvalidOperationException("some latent custom resolution bug");
-                            }
-                        }
-                    }
+                    throw new InvalidOperationException("some latent custom resolution bug");
                 }
-            };
+            });
 
             object value = new MyDerivedThing { Number = 42 };
             string json = await Serializer.SerializeWrapper(value, options);
@@ -627,7 +618,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(PolymorphicTypeWithConflictingPropertyNameAtBase), typeof(PolymorphicTypeWithConflictingPropertyNameAtBase.Derived))]
         [InlineData(typeof(PolymorphicTypeWithConflictingPropertyNameAtDerived), typeof(PolymorphicTypeWithConflictingPropertyNameAtDerived.Derived))]
-        public async Task PolymorphicTypesWithConflictingPropertyNames_ThrowsInvalidOperationException(Type baseType, Type derivedType)
+        public async Task PolymorphicTypesWithConflictingPropertyNames_ThrowsInvalidOperationException(Type baseType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type derivedType)
         {
             InvalidOperationException ex;
             object value = Activator.CreateInstance(derivedType);

--- a/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.InitOnly.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.InitOnly.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithInitOnlyProperty))]
         [InlineData(typeof(StructWithInitOnlyProperty))]
-        public virtual async Task InitOnlyProperties(Type type)
+        public virtual async Task InitOnlyProperties([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             // Init-only property included by default.
             object obj = await Serializer.DeserializeWrapper("""{"MyInt":1}""", type);
@@ -24,7 +25,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithCustomNamedInitOnlyProperty))]
         [InlineData(typeof(StructWithCustomNamedInitOnlyProperty))]
-        public virtual async Task CustomNamedInitOnlyProperties(Type type)
+        public virtual async Task CustomNamedInitOnlyProperties([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             // Regression test for https://github.com/dotnet/runtime/issues/82730
 
@@ -40,7 +41,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(Class_PropertyWith_PrivateInitOnlySetter))]
         [InlineData(typeof(Class_PropertyWith_InternalInitOnlySetter))]
         [InlineData(typeof(Class_PropertyWith_ProtectedInitOnlySetter))]
-        public async Task NonPublicInitOnlySetter_Without_JsonInclude_Fails(Type type)
+        public async Task NonPublicInitOnlySetter_Without_JsonInclude_Fails([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             // Non-public init-only property setter ignored.
             object obj = await Serializer.DeserializeWrapper("""{"MyInt":1}""", type);
@@ -54,7 +55,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(Class_PropertyWith_PrivateInitOnlySetter_WithAttribute))]
         [InlineData(typeof(Class_PropertyWith_InternalInitOnlySetter_WithAttribute))]
         [InlineData(typeof(Class_PropertyWith_ProtectedInitOnlySetter_WithAttribute))]
-        public virtual async Task NonPublicInitOnlySetter_With_JsonInclude(Type type)
+        public virtual async Task NonPublicInitOnlySetter_With_JsonInclude([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
         {
             // Non-public init-only property setter included with [JsonInclude].
             object obj = await Serializer.DeserializeWrapper("""{"MyInt":1}""", type);
@@ -67,7 +68,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(Class_WithIgnoredInitOnlyProperty))]
         [InlineData(typeof(Record_WithIgnoredPropertyInCtor))]
-        public async Task InitOnlySetter_With_JsonIgnoreAlways(Type type)
+        public async Task InitOnlySetter_With_JsonIgnoreAlways([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             object obj = await Serializer.DeserializeWrapper("""{"MyInt":42}""", type);
             Assert.Equal(0, (int)type.GetProperty("MyInt").GetValue(obj));
@@ -196,7 +197,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithInitOnlyPropertyDefaults))]
         [InlineData(typeof(StructWithInitOnlyPropertyDefaults))]
-        public async Task InitOnlyPropertyDefaultValues_PreservedWhenMissingFromJson(Type type)
+        public async Task InitOnlyPropertyDefaultValues_PreservedWhenMissingFromJson([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             // When no properties are present in JSON, C# default values should be preserved.
             object obj = await Serializer.DeserializeWrapper("{}", type);
@@ -207,7 +208,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithInitOnlyPropertyDefaults))]
         [InlineData(typeof(StructWithInitOnlyPropertyDefaults))]
-        public async Task InitOnlyPropertyDefaultValues_OverriddenWhenPresentInJson(Type type)
+        public async Task InitOnlyPropertyDefaultValues_OverriddenWhenPresentInJson([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             // When properties are present in JSON, specified values should be used.
             object obj = await Serializer.DeserializeWrapper("""{"Name":"Override","Number":99}""", type);
@@ -218,7 +219,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithInitOnlyPropertyDefaults))]
         [InlineData(typeof(StructWithInitOnlyPropertyDefaults))]
-        public async Task InitOnlyPropertyDefaultValues_PartialOverride(Type type)
+        public async Task InitOnlyPropertyDefaultValues_PartialOverride([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             // When only some properties are present in JSON, the rest should keep defaults.
             object obj = await Serializer.DeserializeWrapper("""{"Number":99}""", type);

--- a/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.NonPublicAccessors.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.NonPublicAccessors.cs
@@ -1,7 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization.Metadata;
@@ -169,7 +170,7 @@ namespace System.Text.Json.Serialization.Tests
         public virtual async Task HonorCustomConverter_UsingPrivateSetter()
         {
             var options = new JsonSerializerOptions();
-            options.Converters.Add(new JsonStringEnumConverter());
+            options.Converters.Add(new JsonStringEnumConverter<MySmallEnum>());
 
             string json = """{"MyEnum":"AnotherValue","MyInt":2}""";
 
@@ -360,7 +361,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(ClassWithPrivate_InitOnlyProperty_WithJsonIncludeProperty), false)]
         [InlineData(typeof(ClassWithInternal_InitOnlyProperty_WithJsonIncludeProperty), true)]
         [InlineData(typeof(ClassWithProtected_InitOnlyProperty_WithJsonIncludeProperty), false)]
-        public virtual async Task NonPublicProperty_JsonInclude_WorksAsExpected(Type type, bool isAccessibleBySourceGen)
+        public virtual async Task NonPublicProperty_JsonInclude_WorksAsExpected([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, bool isAccessibleBySourceGen)
         {
             if (!Serializer.IsSourceGeneratedSerializer || isAccessibleBySourceGen)
             {

--- a/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -1785,7 +1786,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithProperty_IgnoreConditionAlways))]
         [InlineData(typeof(ClassWithProperty_IgnoreConditionAlways_Ctor))]
-        public async Task JsonIgnoreConditionSetToAlwaysWorks(Type type)
+        public async Task JsonIgnoreConditionSetToAlwaysWorks([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             string json = """{"MyString":"Random","MyDateTime":"2020-03-23","MyInt":4}""";
 
@@ -1830,7 +1831,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(JsonIgnoreConditionWhenWritingDefault_ClassProperty_TestData))]
-        public async Task JsonIgnoreConditionWhenWritingDefault_ClassProperty(Type type, JsonSerializerOptions options)
+        public async Task JsonIgnoreConditionWhenWritingDefault_ClassProperty([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type, JsonSerializerOptions options)
         {
             // Property shouldn't be ignored if it isn't null.
             string json = """{"Int1":1,"MyString":"Random","Int2":2}""";
@@ -1916,7 +1917,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(JsonIgnoreConditionWhenWritingDefault_StructProperty_TestData))]
-        public async Task JsonIgnoreConditionWhenWritingDefault_StructProperty(Type type, JsonSerializerOptions options)
+        public async Task JsonIgnoreConditionWhenWritingDefault_StructProperty([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type, JsonSerializerOptions options)
         {
             // Property shouldn't be ignored if it isn't null.
             string json = """{"Int1":1,"MyInt":3,"Int2":2}""";
@@ -1974,7 +1975,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(JsonIgnoreConditionNever_TestData))]
-        public async Task JsonIgnoreConditionNever(Type type)
+        public async Task JsonIgnoreConditionNever([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             // Property should always be (de)serialized, even when null.
             string json = """{"Int1":1,"MyString":"Random","Int2":2}""";
@@ -2017,7 +2018,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(JsonIgnoreConditionNever_TestData))]
-        public async Task JsonIgnoreConditionNever_IgnoreNullValues_True(Type type)
+        public async Task JsonIgnoreConditionNever_IgnoreNullValues_True([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
         {
             // Property should always be (de)serialized.
             string json = """{"Int1":1,"MyString":"Random","Int2":2}""";
@@ -2903,7 +2904,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithBadIgnoreAttribute))]
         [InlineData(typeof(StructWithBadIgnoreAttribute))]
-        public virtual async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail(Type type)
+        public virtual async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
         {
             InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.DeserializeWrapper("{}", type));
             string exAsStr = ex.ToString();
@@ -2923,7 +2924,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithBadIgnoreAttribute))]
         [InlineData(typeof(StructWithBadIgnoreAttribute))]
-        public virtual async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail_EmptyJson(Type type)
+        public virtual async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail_EmptyJson([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
         {
             InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.DeserializeWrapper("", type));
             string exAsStr = ex.ToString();

--- a/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.IgnoreCycles.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.IgnoreCycles.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -28,7 +29,7 @@ namespace System.Text.Json.Serialization.Tests
             await Verify<NodeWithNodeProperty>();
             await Verify<NodeWithObjectProperty>();
 
-            async Task Verify<T>() where T : class, new()
+            async Task Verify<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>() where T : class, new()
             {
                 T root = new T();
                 SetNextProperty(typeof(T), root, root);
@@ -48,7 +49,7 @@ namespace System.Text.Json.Serialization.Tests
             await Verify<NodeWithNodeProperty>();
             await Verify<NodeWithObjectProperty>();
 
-            async Task Verify<T>() where T : class, new()
+            async Task Verify<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>() where T : class, new()
             {
                 var node = new T();
                 SetNextProperty(typeof(T), node, node);
@@ -77,7 +78,7 @@ namespace System.Text.Json.Serialization.Tests
             await Verify<ValueNodeWithIValueNodeProperty>();
             await Verify<ValueNodeWithObjectProperty>();
 
-            async Task Verify<T>() where T : new()
+            async Task Verify<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>() where T : new()
             {
                 object root = new T();
                 SetNextProperty(typeof(T), root, root);
@@ -107,7 +108,7 @@ namespace System.Text.Json.Serialization.Tests
             await Verify<ValueNodeWithIValueNodeProperty>();
             await Verify<ValueNodeWithObjectProperty>();
 
-            async Task Verify<T>() where T : new()
+            async Task Verify<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>() where T : new()
             {
                 object node = new T();
                 SetNextProperty(typeof(T), node, node);
@@ -125,7 +126,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(Dictionary<string, object>))]
         [InlineData(typeof(GenericIDictionaryWrapper<string, object>))]
-        public async Task IgnoreCycles_OnDictionary(Type typeToSerialize)
+        public async Task IgnoreCycles_OnDictionary([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type typeToSerialize)
         {
             var root = (IDictionary<string, object>)Activator.CreateInstance(typeToSerialize);
             root.Add("self", root);
@@ -172,7 +173,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(List<object>))]
         [InlineData(typeof(GenericIListWrapper<object>))]
-        public async Task IgnoreCycles_OnList(Type typeToSerialize)
+        public async Task IgnoreCycles_OnList([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type typeToSerialize)
         {
             var root = (IList<object>)Activator.CreateInstance(typeToSerialize);
             root.Add(root);
@@ -190,7 +191,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(GenericISetWrapper<object>))]
         [InlineData(typeof(GenericICollectionWrapper<object>))]
-        public async Task IgnoreCycles_OnCollections(Type typeToSerialize)
+        public async Task IgnoreCycles_OnCollections([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type typeToSerialize)
         {
             var root = (ICollection<object>)Activator.CreateInstance(typeToSerialize);
             root.Add(root);
@@ -531,12 +532,12 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         private const string Next = nameof(Next);
-        private void SetNextProperty(Type type, object obj, object value)
+        private void SetNextProperty([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type, object obj, object value)
         {
             type.GetProperty(Next).SetValue(obj, value);
         }
 
-        private object GetNextProperty(Type type, object obj)
+        private object GetNextProperty([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type, object obj)
         {
             return type.GetProperty(Next).GetValue(obj);
         }

--- a/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.Serialize.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.Serialize.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Xunit;
@@ -13,6 +14,25 @@ namespace System.Text.Json.Serialization.Tests
     {
         private static readonly JsonSerializerOptions s_serializerOptionsPreserve = new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve };
         private static readonly JsonSerializerSettings s_newtonsoftSerializerSettingsPreserve = new JsonSerializerSettings { PreserveReferencesHandling = PreserveReferencesHandling.All, ReferenceLoopHandling = ReferenceLoopHandling.Serialize };
+
+        // Asserts that the serializer output matches the Newtonsoft.Json reference-preservation baseline.
+        // The Newtonsoft.Json baseline is reflection-based (its APIs are annotated RequiresUnreferencedCode
+        // and RequiresDynamicCode), so it is only exercised when dynamic code is supported. The runtime guard
+        // makes the call unreachable under Native AOT (where PlatformDetection.IsReflectionEmitSupported is
+        // false), while still running the baseline in the non-AOT source generator configuration. The trim/AOT
+        // analyzers cannot see through the guard, so the warnings are suppressed here.
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+            Justification = "The Newtonsoft.Json baseline only runs when dynamic code is supported, guarded by PlatformDetection.IsReflectionEmitSupported.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "The Newtonsoft.Json baseline only runs when dynamic code is supported, guarded by PlatformDetection.IsReflectionEmitSupported.")]
+        private static void AssertOutputEqualsNewtonsoft(object value, string actual)
+        {
+            if (PlatformDetection.IsReflectionEmitSupported)
+            {
+                string expected = JsonConvert.SerializeObject(value, s_newtonsoftSerializerSettingsPreserve);
+                Assert.Equal(expected, actual);
+            }
+        }
 
         public class Employee
         {
@@ -52,10 +72,9 @@ namespace System.Text.Json.Serialization.Tests
 
             angela.ExtensionData = extensionData;
 
-            string expected = JsonConvert.SerializeObject(angela, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(angela, s_serializerOptionsPreserve);
 
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(angela, actual);
         }
 
         #region struct tests

--- a/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.cs
@@ -7,7 +7,7 @@ using System.Collections.Immutable;
 using System.Text.Encodings.Web;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -34,11 +34,8 @@ namespace System.Text.Json.Serialization.Tests
             Employee angela = new Employee();
             angela.Manager = angela;
 
-            // Compare parity with Newtonsoft.Json
-            string expected = JsonConvert.SerializeObject(angela, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(angela, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(angela, actual);
 
             // Ensure round-trip
             Employee angelaCopy = await Serializer.DeserializeWrapper<Employee>(actual, s_serializerOptionsPreserve);
@@ -51,10 +48,8 @@ namespace System.Text.Json.Serialization.Tests
             Employee angela = new Employee();
             angela.Subordinates = new List<Employee> { angela };
 
-            string expected = JsonConvert.SerializeObject(angela, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(angela, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(angela, actual);
 
             Employee angelaCopy = await Serializer.DeserializeWrapper<Employee>(actual, s_serializerOptionsPreserve);
             Assert.Same(angelaCopy.Subordinates[0], angelaCopy);
@@ -66,10 +61,8 @@ namespace System.Text.Json.Serialization.Tests
             Employee angela = new Employee();
             angela.Contacts = new Dictionary<string, Employee> { { "555-5555", angela } };
 
-            string expected = JsonConvert.SerializeObject(angela, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(angela, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(angela, actual);
 
             Employee angelaCopy = await Serializer.DeserializeWrapper<Employee>(actual, s_serializerOptionsPreserve);
             Assert.Same(angelaCopy.Contacts["555-5555"], angelaCopy);
@@ -84,10 +77,8 @@ namespace System.Text.Json.Serialization.Tests
             };
             angela.Manager2 = angela.Manager;
 
-            string expected = JsonConvert.SerializeObject(angela, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(angela, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(angela, actual);
 
             Employee angelaCopy = await Serializer.DeserializeWrapper<Employee>(actual, s_serializerOptionsPreserve);
             Assert.Same(angelaCopy.Manager, angelaCopy.Manager2);
@@ -102,10 +93,8 @@ namespace System.Text.Json.Serialization.Tests
             };
             angela.Contacts2 = angela.Contacts;
 
-            string expected = JsonConvert.SerializeObject(angela, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(angela, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(angela, actual);
 
             Employee angelaCopy = await Serializer.DeserializeWrapper<Employee>(actual, s_serializerOptionsPreserve);
             Assert.Same(angelaCopy.Contacts, angelaCopy.Contacts2);
@@ -120,10 +109,8 @@ namespace System.Text.Json.Serialization.Tests
             };
             angela.Subordinates2 = angela.Subordinates;
 
-            string expected = JsonConvert.SerializeObject(angela, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(angela, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(angela, actual);
 
             Employee angelaCopy = await Serializer.DeserializeWrapper<Employee>(actual, s_serializerOptionsPreserve);
             Assert.Same(angelaCopy.Subordinates, angelaCopy.Subordinates2);
@@ -253,10 +240,8 @@ namespace System.Text.Json.Serialization.Tests
             root["Self"] = root;
             root["Other"] = new DictionaryWithGenericCycle();
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             DictionaryWithGenericCycle rootCopy = await Serializer.DeserializeWrapper<DictionaryWithGenericCycle>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy, rootCopy["Self"]);
@@ -269,10 +254,8 @@ namespace System.Text.Json.Serialization.Tests
             root["Self1"] = root;
             root["Self2"] = root;
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             DictionaryWithGenericCycle rootCopy = await Serializer.DeserializeWrapper<DictionaryWithGenericCycle>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy, rootCopy["Self1"]);
@@ -285,10 +268,8 @@ namespace System.Text.Json.Serialization.Tests
             Dictionary<string, Employee> root = new Dictionary<string, Employee>();
             root["Angela"] = new Employee() { Name = "Angela", Contacts = root };
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             Dictionary<string, Employee> rootCopy = await Serializer.DeserializeWrapper<Dictionary<string, Employee>>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy, rootCopy["Angela"].Contacts);
@@ -302,10 +283,8 @@ namespace System.Text.Json.Serialization.Tests
             DictionaryWithGenericCycleWithinList root = new DictionaryWithGenericCycleWithinList();
             root["ArrayWithSelf"] = new List<DictionaryWithGenericCycleWithinList> { root };
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             DictionaryWithGenericCycleWithinList rootCopy = await Serializer.DeserializeWrapper<DictionaryWithGenericCycleWithinList>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy, rootCopy["ArrayWithSelf"][0]);
@@ -318,10 +297,8 @@ namespace System.Text.Json.Serialization.Tests
             root["Array1"] = new List<DictionaryWithGenericCycleWithinList> { root };
             root["Array2"] = root["Array1"];
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             DictionaryWithGenericCycleWithinList rootCopy = await Serializer.DeserializeWrapper<DictionaryWithGenericCycleWithinList>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy, rootCopy["Array1"][0]);
@@ -337,10 +314,8 @@ namespace System.Text.Json.Serialization.Tests
             };
             root["Employee2"] = root["Employee1"];
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             Dictionary<string, Employee> rootCopy = await Serializer.DeserializeWrapper<Dictionary<string, Employee>>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy["Employee1"], rootCopy["Employee2"]);
@@ -447,10 +422,8 @@ namespace System.Text.Json.Serialization.Tests
             ListWithGenericCycle root = new ListWithGenericCycle();
             root.Add(root);
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             ListWithGenericCycle rootCopy = await Serializer.DeserializeWrapper<ListWithGenericCycle>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy, rootCopy[0]);
@@ -461,10 +434,8 @@ namespace System.Text.Json.Serialization.Tests
             root.Add(root);
             root.Add(root);
 
-            expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             rootCopy = await Serializer.DeserializeWrapper<ListWithGenericCycle>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy, rootCopy[0]);
@@ -478,10 +449,8 @@ namespace System.Text.Json.Serialization.Tests
             List<Employee> root = new List<Employee>();
             root.Add(new Employee() { Name = "Angela", Subordinates = root });
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             List<Employee> rootCopy = await Serializer.DeserializeWrapper<List<Employee>>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy, rootCopy[0].Subordinates);
@@ -496,10 +465,8 @@ namespace System.Text.Json.Serialization.Tests
             };
             root.Add(root[0]);
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             List<Employee> rootCopy = await Serializer.DeserializeWrapper<List<Employee>>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy[0], rootCopy[1]);
@@ -513,10 +480,8 @@ namespace System.Text.Json.Serialization.Tests
             ListWithGenericCycleWithinDictionary root = new ListWithGenericCycleWithinDictionary();
             root.Add(new Dictionary<string, ListWithGenericCycleWithinDictionary> { { "Root", root } });
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             ListWithGenericCycleWithinDictionary rootCopy = await Serializer.DeserializeWrapper<ListWithGenericCycleWithinDictionary>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy, rootCopy[0]["Root"]);
@@ -531,10 +496,8 @@ namespace System.Text.Json.Serialization.Tests
             };
             root.Add(root[0]);
 
-            string expected = JsonConvert.SerializeObject(root, s_newtonsoftSerializerSettingsPreserve);
             string actual = await Serializer.SerializeWrapper(root, s_serializerOptionsPreserve);
-
-            Assert.Equal(expected, actual);
+            AssertOutputEqualsNewtonsoft(root, actual);
 
             ListWithGenericCycleWithinDictionary rootCopy = await Serializer.DeserializeWrapper<ListWithGenericCycleWithinDictionary>(actual, s_serializerOptionsPreserve);
             Assert.Same(rootCopy[0], rootCopy[1]);
@@ -864,7 +827,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithConflictingRefProperty), "$ref")]
         [InlineData(typeof(ClassWithConflictingIdProperty), "$id")]
-        public async Task ClassWithConflictingMetadataProperties_ThrowsInvalidOperationException(Type type, string propertyName)
+        public async Task ClassWithConflictingMetadataProperties_ThrowsInvalidOperationException([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, string propertyName)
         {
             InvalidOperationException ex;
             object value = Activator.CreateInstance(type);

--- a/src/libraries/System.Text.Json/tests/Common/RequiredKeywordTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/RequiredKeywordTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -490,7 +491,9 @@ namespace System.Text.Json.Serialization.Tests
             public required int RequiredField;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [RequiresUnreferencedCode("Uses JsonTypeInfo.CreateJsonPropertyInfo which requires reflection.")]
+        [RequiresDynamicCode("Uses JsonTypeInfo.CreateJsonPropertyInfo which requires reflection.")]
         public async Task RemovingPropertiesWithRequiredKeywordAllowsDeserialization()
         {
             JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(static ti =>
@@ -746,12 +749,7 @@ namespace System.Text.Json.Serialization.Tests
             public string Value { get; }
         }
 
-        private static JsonTypeInfo GetTypeInfo<T>(JsonSerializerOptions options)
-        {
-            options.TypeInfoResolver ??= JsonSerializerOptions.Default.TypeInfoResolver;
-            options.MakeReadOnly();
-            return options.GetTypeInfo(typeof(T));
-        }
+        private JsonTypeInfo GetTypeInfo<T>(JsonSerializerOptions options) => Serializer.GetTypeInfo<T>(options);
 
         private static void AssertJsonTypeInfoHasRequiredProperties(JsonTypeInfo typeInfo, params string[] requiredProperties)
         {

--- a/src/libraries/System.Text.Json/tests/Common/SerializerTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/SerializerTests.cs
@@ -249,7 +249,7 @@ namespace System.Text.Json.Serialization.Tests
             string wrappedJson;
             equalityComparer ??= expectedValue is IEquatable<TValue>
                 ? EqualityComparer<TValue>.Default
-                : new JsonEqualityComparer<TValue>();
+                : new JsonEqualityComparer<TValue>(Serializer.GetTypeInfo<TValue>(options));
 
             if (contexts.HasFlag(SerializedValueContext.RootValue))
             {
@@ -366,10 +366,39 @@ namespace System.Text.Json.Serialization.Tests
             public T Property { get; set; }
         }
 
+        // Creates a trim/AOT-safe equality comparer that compares values by serializing them
+        // using the resolved (polymorphism-aware) JsonTypeInfo and comparing the resulting JSON.
+        // Values of differing runtime types are never considered equal, preserving the behavior of
+        // the reflection-based structural comparer this replaced (so that, for example, a nearest-
+        // ancestor fallback regression cannot slip through when a derived type happens to serialize
+        // identically under its base contract).
+        protected IEqualityComparer<T> CreateJsonEqualityComparer<T>(JsonSerializerOptions? options = null)
+            => new JsonEqualityComparer<T>(Serializer.GetTypeInfo<T>(options), compareRuntimeType: true);
+
         private class JsonEqualityComparer<TValue> : IEqualityComparer<TValue>
         {
-            public bool Equals(TValue? x, TValue? y) => JsonSerializer.Serialize(x) == JsonSerializer.Serialize(y);
-            public int GetHashCode([DisallowNull] TValue obj) => JsonSerializer.Serialize(obj).GetHashCode();
+            private readonly JsonTypeInfo<TValue> _jsonTypeInfo;
+            private readonly bool _compareRuntimeType;
+
+            public JsonEqualityComparer(JsonTypeInfo<TValue> jsonTypeInfo, bool compareRuntimeType = false)
+            {
+                _jsonTypeInfo = jsonTypeInfo;
+                _compareRuntimeType = compareRuntimeType;
+            }
+
+            public bool Equals(TValue? x, TValue? y)
+            {
+                // Object.GetType() is trim/AOT-safe and lets us reject differing runtime types before
+                // falling back to structural (serialized JSON) comparison.
+                if (_compareRuntimeType && x is not null && y is not null && x.GetType() != y.GetType())
+                {
+                    return false;
+                }
+
+                return JsonSerializer.Serialize(x, _jsonTypeInfo) == JsonSerializer.Serialize(y, _jsonTypeInfo);
+            }
+
+            public int GetHashCode([DisallowNull] TValue obj) => JsonSerializer.Serialize(obj, _jsonTypeInfo).GetHashCode();
         }
 
         private class ListAssertionEqualityComparer<TValue> : IEqualityComparer<IList<TValue>>

--- a/src/libraries/System.Text.Json/tests/Common/StructuralJsonTypeClassifierTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/StructuralJsonTypeClassifierTests.cs
@@ -13,31 +13,26 @@ namespace System.Text.Json.Serialization.Tests
 {
     public abstract class StructuralJsonTypeClassifierTests(JsonSerializerWrapper serializerUnderTest) : SerializerTests(serializerUnderTest)
     {
-        private static readonly JsonSerializerOptions s_options = new()
+        private readonly JsonSerializerOptions _options = new(serializerUnderTest.DefaultOptions);
+        private readonly JsonSerializerOptions _caseInsensitiveOptions = new(serializerUnderTest.DefaultOptions)
         {
-            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+            PropertyNameCaseInsensitive = true
         };
-        private static readonly JsonSerializerOptions s_caseInsensitiveOptions = new()
+        private readonly JsonSerializerOptions _numberFromStringOptions = new(serializerUnderTest.DefaultOptions)
         {
-            PropertyNameCaseInsensitive = true,
-            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
-        };
-        private static readonly JsonSerializerOptions s_numberFromStringOptions = new()
-        {
-            NumberHandling = JsonNumberHandling.AllowReadingFromString,
-            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+            NumberHandling = JsonNumberHandling.AllowReadingFromString
         };
 
         [Fact]
         public async Task StructuralClassifier_DistinguishesObjectProperties()
         {
-            PetUnion? dog = await Serializer.DeserializeWrapper<PetUnion>("""{"Name":"Rex","Breed":"Labrador"}""", s_options);
+            PetUnion? dog = await Serializer.DeserializeWrapper<PetUnion>("""{"Name":"Rex","Breed":"Labrador"}""", _options);
             Assert.NotNull(dog);
             Dog dogValue = Assert.IsType<Dog>(GetUnionValue(dog));
             Assert.Equal("Rex", dogValue.Name);
             Assert.Equal("Labrador", dogValue.Breed);
 
-            PetUnion? cat = await Serializer.DeserializeWrapper<PetUnion>("""{"Name":"Misty","Lives":9}""", s_options);
+            PetUnion? cat = await Serializer.DeserializeWrapper<PetUnion>("""{"Name":"Misty","Lives":9}""", _options);
             Assert.NotNull(cat);
             Cat catValue = Assert.IsType<Cat>(GetUnionValue(cat));
             Assert.Equal("Misty", catValue.Name);
@@ -47,15 +42,15 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task StructuralClassifier_DistinguishesStringPatterns()
         {
-            TemporalUnion? date = await Serializer.DeserializeWrapper<TemporalUnion>("\"2026-05-11T18:00:00Z\"", s_options);
+            TemporalUnion? date = await Serializer.DeserializeWrapper<TemporalUnion>("\"2026-05-11T18:00:00Z\"", _options);
             Assert.NotNull(date);
             Assert.IsType<DateTime>(GetUnionValue(date));
 
-            TemporalUnion? duration = await Serializer.DeserializeWrapper<TemporalUnion>("\"01:02:03\"", s_options);
+            TemporalUnion? duration = await Serializer.DeserializeWrapper<TemporalUnion>("\"01:02:03\"", _options);
             Assert.NotNull(duration);
             Assert.Equal(TimeSpan.FromSeconds(3723), Assert.IsType<TimeSpan>(GetUnionValue(duration)));
 
-            TemporalUnion? guid = await Serializer.DeserializeWrapper<TemporalUnion>("\"0f8fad5b-d9cb-469f-a165-70867728950e\"", s_options);
+            TemporalUnion? guid = await Serializer.DeserializeWrapper<TemporalUnion>("\"0f8fad5b-d9cb-469f-a165-70867728950e\"", _options);
             Assert.NotNull(guid);
             Assert.Equal(new Guid("0f8fad5b-d9cb-469f-a165-70867728950e"), Assert.IsType<Guid>(GetUnionValue(guid)));
         }
@@ -63,11 +58,11 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task StructuralClassifier_SamplesCollectionElementShapes()
         {
-            ListUnion? numbers = await Serializer.DeserializeWrapper<ListUnion>("[1,2,3]", s_options);
+            ListUnion? numbers = await Serializer.DeserializeWrapper<ListUnion>("[1,2,3]", _options);
             Assert.NotNull(numbers);
             Assert.Equal([1, 2, 3], Assert.IsType<List<int>>(GetUnionValue(numbers)));
 
-            ListUnion? strings = await Serializer.DeserializeWrapper<ListUnion>("""["one","two"]""", s_options);
+            ListUnion? strings = await Serializer.DeserializeWrapper<ListUnion>("""["one","two"]""", _options);
             Assert.NotNull(strings);
             Assert.Equal(["one", "two"], Assert.IsType<List<string>>(GetUnionValue(strings)));
         }
@@ -75,11 +70,11 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task StructuralClassifier_SamplesDictionaryValueShapes()
         {
-            DictionaryUnion? numbers = await Serializer.DeserializeWrapper<DictionaryUnion>("""{"one":1,"two":2}""", s_options);
+            DictionaryUnion? numbers = await Serializer.DeserializeWrapper<DictionaryUnion>("""{"one":1,"two":2}""", _options);
             Assert.NotNull(numbers);
             Assert.Equal(2, Assert.IsType<Dictionary<string, int>>(GetUnionValue(numbers))["two"]);
 
-            DictionaryUnion? strings = await Serializer.DeserializeWrapper<DictionaryUnion>("""{"one":"uno","two":"dos"}""", s_options);
+            DictionaryUnion? strings = await Serializer.DeserializeWrapper<DictionaryUnion>("""{"one":"uno","two":"dos"}""", _options);
             Assert.NotNull(strings);
             Assert.Equal("dos", Assert.IsType<Dictionary<string, string>>(GetUnionValue(strings))["two"]);
         }
@@ -87,12 +82,12 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task StructuralClassifier_RecursesIntoNestedGenericShapes()
         {
-            BatchUnion? temperatures = await Serializer.DeserializeWrapper<BatchUnion>("""{"Source":"sensor","Items":[{"Celsius":21.5}]}""", s_options);
+            BatchUnion? temperatures = await Serializer.DeserializeWrapper<BatchUnion>("""{"Source":"sensor","Items":[{"Celsius":21.5}]}""", _options);
             Assert.NotNull(temperatures);
             Batch<TemperatureReading> temperatureBatch = Assert.IsType<Batch<TemperatureReading>>(GetUnionValue(temperatures));
             Assert.Equal(21.5, temperatureBatch.Items![0].Celsius);
 
-            BatchUnion? statuses = await Serializer.DeserializeWrapper<BatchUnion>("""{"Source":"sensor","Items":[{"IsOnline":true}]}""", s_options);
+            BatchUnion? statuses = await Serializer.DeserializeWrapper<BatchUnion>("""{"Source":"sensor","Items":[{"IsOnline":true}]}""", _options);
             Assert.NotNull(statuses);
             Batch<StatusReading> statusBatch = Assert.IsType<Batch<StatusReading>>(GetUnionValue(statuses));
             Assert.True(statusBatch.Items![0].IsOnline);
@@ -101,11 +96,11 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task StructuralClassifier_DistinguishesArrayFromDictionary()
         {
-            ArrayOrDictionaryUnion? array = await Serializer.DeserializeWrapper<ArrayOrDictionaryUnion>("[1,2,3]", s_options);
+            ArrayOrDictionaryUnion? array = await Serializer.DeserializeWrapper<ArrayOrDictionaryUnion>("[1,2,3]", _options);
             Assert.NotNull(array);
             Assert.Equal([1, 2, 3], Assert.IsType<List<int>>(GetUnionValue(array)));
 
-            ArrayOrDictionaryUnion? dictionary = await Serializer.DeserializeWrapper<ArrayOrDictionaryUnion>("""{"one":1,"two":2}""", s_options);
+            ArrayOrDictionaryUnion? dictionary = await Serializer.DeserializeWrapper<ArrayOrDictionaryUnion>("""{"one":1,"two":2}""", _options);
             Assert.NotNull(dictionary);
             Assert.Equal(2, Assert.IsType<Dictionary<string, int>>(GetUnionValue(dictionary))["two"]);
         }
@@ -113,7 +108,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task StructuralClassifier_PrefersObjectShapeOverDictionaryWhenPropertiesMatch()
         {
-            ObjectOrDictionaryUnion? result = await Serializer.DeserializeWrapper<ObjectOrDictionaryUnion>("""{"X":1,"Y":2}""", s_options);
+            ObjectOrDictionaryUnion? result = await Serializer.DeserializeWrapper<ObjectOrDictionaryUnion>("""{"X":1,"Y":2}""", _options);
             Assert.NotNull(result);
             Point point = Assert.IsType<Point>(GetUnionValue(result));
             Assert.Equal(1, point.X);
@@ -123,7 +118,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task StructuralClassifier_UsesJsonTypeInfoPropertyNames()
         {
-            RenamedPropertyUnion? result = await Serializer.DeserializeWrapper<RenamedPropertyUnion>("""{"kind":"special"}""", s_options);
+            RenamedPropertyUnion? result = await Serializer.DeserializeWrapper<RenamedPropertyUnion>("""{"kind":"special"}""", _options);
             Assert.NotNull(result);
             RenamedPropertyCase value = Assert.IsType<RenamedPropertyCase>(GetUnionValue(result));
             Assert.Equal("special", value.Kind);
@@ -132,7 +127,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task StructuralClassifier_UsesCaseInsensitivePropertyNames()
         {
-            PetUnion? dog = await Serializer.DeserializeWrapper<PetUnion>("""{"name":"Rex","breed":"Labrador"}""", s_caseInsensitiveOptions);
+            PetUnion? dog = await Serializer.DeserializeWrapper<PetUnion>("""{"name":"Rex","breed":"Labrador"}""", _caseInsensitiveOptions);
             Assert.NotNull(dog);
             Dog dogValue = Assert.IsType<Dog>(GetUnionValue(dog));
             Assert.Equal("Rex", dogValue.Name);
@@ -142,7 +137,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task StructuralClassifier_UsesNumberHandlingMetadata()
         {
-            NumberHandlingUnion? result = await Serializer.DeserializeWrapper<NumberHandlingUnion>("\"42\"", s_numberFromStringOptions);
+            NumberHandlingUnion? result = await Serializer.DeserializeWrapper<NumberHandlingUnion>("\"42\"", _numberFromStringOptions);
             Assert.NotNull(result);
             Assert.Equal(42, Assert.IsType<int>(GetUnionValue(result)));
         }
@@ -155,17 +150,17 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("true", typeof(PetUnion))]
         public async Task StructuralClassifier_AmbiguousOrUnsupportedShapesThrow(string json, Type unionType)
         {
-            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper(json, unionType, s_options));
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper(json, unionType, _options));
         }
 
         [Fact]
         public async Task StructuralClassifier_WorksForPolymorphicDerivedTypeMetadata()
         {
-            Shape? circle = await Serializer.DeserializeWrapper<Shape>("""{"Color":"red","Radius":2.5}""", s_options);
+            Shape? circle = await Serializer.DeserializeWrapper<Shape>("""{"Color":"red","Radius":2.5}""", _options);
             Assert.NotNull(circle);
             Assert.Equal(2.5, Assert.IsType<Circle>(circle).Radius);
 
-            Shape? rectangle = await Serializer.DeserializeWrapper<Shape>("""{"Color":"blue","Width":3,"Height":4}""", s_options);
+            Shape? rectangle = await Serializer.DeserializeWrapper<Shape>("""{"Color":"blue","Width":3,"Height":4}""", _options);
             Assert.NotNull(rectangle);
             Assert.Equal(4, Assert.IsType<Rectangle>(rectangle).Height);
         }

--- a/src/libraries/System.Text.Json/tests/Common/UnionTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/UnionTests.cs
@@ -182,7 +182,7 @@ namespace System.Text.Json.Serialization.Tests
 
             // Trigger configuration of the type info via GetTypeInfo (modifiers run during
             // resolver invocation, before Configure).
-            options.MakeReadOnly(populateMissingResolver: true);
+            options.MakeReadOnly();
             _ = options.GetTypeInfo(typeof(UnionWithCustomClassifier));
 
             Assert.NotNull(observedAtModifierTime);
@@ -323,7 +323,7 @@ namespace System.Text.Json.Serialization.Tests
             });
 
             options.TypeClassifiers.Add(new UnionWithOtherCaseOptionsClassifierFactory());
-            options.MakeReadOnly(populateMissingResolver: true);
+            options.MakeReadOnly();
             _ = options.GetTypeInfo(typeof(UnionWithCustomConverterCase));
 
             Assert.NotNull(observedAtModifierTime);
@@ -1140,7 +1140,7 @@ namespace System.Text.Json.Serialization.Tests
                 }
             });
 
-            options.MakeReadOnly(populateMissingResolver: true);
+            options.MakeReadOnly();
 
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
                 () => options.GetTypeInfo(typeof(NullableCaseUnion)));
@@ -1160,7 +1160,7 @@ namespace System.Text.Json.Serialization.Tests
                 }
             });
 
-            options.MakeReadOnly(populateMissingResolver: true);
+            options.MakeReadOnly();
 
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
                 () => options.GetTypeInfo(typeof(NullableCaseUnion)));
@@ -1779,7 +1779,7 @@ namespace System.Text.Json.Serialization.Tests
             };
 
             Assert.Throws<JsonException>(() =>
-                JsonSerializer.Serialize(union, options));
+                JsonSerializer.Serialize(union, options.GetTypeInfo<SelfReferentialUnion>()));
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/Common/UnsupportedTypesTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/UnsupportedTypesTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading;
@@ -168,9 +169,10 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-#if !BUILDING_SOURCE_GENERATOR_TESTS
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "NullableContextAttribute is public in corelib in .NET 8+")]
+        [RequiresUnreferencedCode("Uses reflection to construct and serialize an arbitrary runtime type.")]
+        [RequiresDynamicCode("Uses reflection to construct and serialize an arbitrary runtime type.")]
         public async Task TypeWithNullConstructorParameterName_ThrowsNotSupportedException()
         {
             // Regression test for https://github.com/dotnet/runtime/issues/58690
@@ -182,7 +184,6 @@ namespace System.Text.Json.Serialization.Tests
             await Assert.ThrowsAnyAsync<NotSupportedException>(() => Serializer.SerializeWrapper(value));
             await Assert.ThrowsAnyAsync<NotSupportedException>(() => Serializer.DeserializeWrapper("{}", type));
         }
-#endif
 
         [Fact]
         public async Task RuntimeConverterIsSupported_IntPtr()

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -121,6 +122,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         }
 
         [Fact]
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static async Task SupportsBoxedRootLevelValues()
         {
             PersonJsonContext context = PersonJsonContext.Default;
@@ -293,6 +296,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         }
 
         [Fact]
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static void FastPathSerialization_ResolvingJsonTypeInfo()
         {
             JsonSerializerOptions options = FastPathSerializationContext.Default.Options;
@@ -314,6 +319,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         [Theory]
         [MemberData(nameof(GetFastPathCompatibleResolvers))]
         [MemberData(nameof(GetFastPathIncompatibleResolvers))]
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static void FastPathSerialization_AppendedResolver_WorksAsExpected(IJsonTypeInfoResolver appendedResolver)
         {
             // Resolvers appended after ours will never introduce metadata to the type graph,
@@ -356,6 +363,8 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         [Theory]
         [MemberData(nameof(GetFastPathCompatibleResolvers))]
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static void FastPathSerialization_PrependedResolver_CompatibleResolvers_WorksAsExpected(IJsonTypeInfoResolver prependedResolver)
         {
             // We're prepending a resolver that generates metadata for the property of our type,
@@ -398,6 +407,8 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         [Theory]
         [MemberData(nameof(GetFastPathIncompatibleResolvers))]
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static void FastPathSerialization_PrependedResolver_IncompatibleResolvers_FallsBackToMetadata(IJsonTypeInfoResolver prependedResolver)
         {
             // We're prepending a resolver that generates metadata for the property of our type,
@@ -438,6 +449,8 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Equal(0, fastPathContext.FastPathInvocationCount);
         }
 
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static IEnumerable<object[]> GetFastPathCompatibleResolvers()
         {
             yield return new object[] { CompatibleWithInstrumentedFastPathContext.Default };
@@ -446,6 +459,8 @@ namespace System.Text.Json.SourceGeneration.Tests
             yield return new object[] { new CustomWrappingResolver<int> { Resolver = new ContextWithInstrumentedFastPath() } };
         }
 
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static IEnumerable<object[]> GetFastPathIncompatibleResolvers()
         {
             yield return new object[] { NotCompatibleWithInstrumentedFastPathContext.Default };
@@ -541,6 +556,8 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         [Theory]
         [MemberData(nameof(GetCombiningContextsData))]
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static void CombiningContexts_Serialization<T>(T value, string expectedJson)
         {
             IJsonTypeInfoResolver combined = JsonTypeInfoResolver.Combine(NestedContext.Default, PersonJsonContext.Default);
@@ -560,6 +577,8 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         [Theory]
         [MemberData(nameof(GetCombiningContextsData))]
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static void ChainedContexts_Serialization<T>(T value, string expectedJson)
         {
             var options = new JsonSerializerOptions { TypeInfoResolverChain = { NestedContext.Default, PersonJsonContext.Default } };
@@ -577,6 +596,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         }
 
         [Fact]
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static void CombiningContextWithCustomResolver_ReplacePoco()
         {
             TestResolver customResolver = new((type, options) =>
@@ -725,7 +746,7 @@ namespace System.Text.Json.SourceGeneration.Tests
                 StringValuesProperty = new(new[] { "abc", "def" })
             };
 
-            string json = JsonSerializer.Serialize(obj, options);
+            string json = JsonSerializer.Serialize(obj, options.GetTypeInfo<ClassWithStringValues>());
             Assert.Equal("""{"StringValuesProperty":["abc","def"]}""", json);
         }
 
@@ -741,7 +762,7 @@ namespace System.Text.Json.SourceGeneration.Tests
                 ["test"] = "baz",
             });
 
-            string json = JsonSerializer.Serialize(obj, options);
+            string json = JsonSerializer.Serialize(obj, options.GetTypeInfo<ClassWithDictionaryProperty>());
             Assert.Equal("""{"DictionaryProperty":{"foo":"bar","test":"baz"}}""", json);
         }
 
@@ -819,6 +840,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         }
 
         [Fact]
+        [RequiresUnreferencedCode("Tests reflection-based JsonSerializer APIs.")]
+        [RequiresDynamicCode("Tests reflection-based JsonSerializer APIs.")]
         public static void FastPathSerialization_EvaluatePropertyOnlyOnceWhenIgnoreNullOrDefaultIsSpecified()
         {
             JsonSerializerOptions options = FastPathSerializationContext.Default.Options;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSourceGenerationOptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSourceGenerationOptionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json.Serialization;
 using Xunit;
@@ -10,6 +11,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     public static partial class JsonSourceGenerationOptionsTests
     {
         [Fact]
+        [RequiresUnreferencedCode("AssertOptionsEqual uses reflection to enumerate JsonSerializerOptions properties.")]
         public static void ContextWithGeneralSerializerDefaults_GeneratesExpectedOptions()
         {
             JsonSerializerOptions expected = new(JsonSerializerDefaults.General) { TypeInfoResolver = ContextWithGeneralSerializerDefaults.Default };
@@ -24,6 +26,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         { }
 
         [Fact]
+        [RequiresUnreferencedCode("AssertOptionsEqual uses reflection to enumerate JsonSerializerOptions properties.")]
         public static void ContextWithWebSerializerDefaults_GeneratesExpectedOptions()
         {
             JsonSerializerOptions expected = new(JsonSerializerDefaults.Web) { TypeInfoResolver = ContextWithWebSerializerDefaults.Default };
@@ -38,6 +41,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         { }
 
         [Fact]
+        [RequiresUnreferencedCode("AssertOptionsEqual uses reflection to enumerate JsonSerializerOptions properties.")]
         public static void ContextWithStrictSerializerDefaults_GeneratesExpectedOptions()
         {
             JsonSerializerOptions expected = new(JsonSerializerDefaults.Strict) { TypeInfoResolver = ContextWithStrictSerializerDefaults.Default };
@@ -52,6 +56,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         { }
 
         [Fact]
+        [RequiresUnreferencedCode("AssertOptionsEqual uses reflection to enumerate JsonSerializerOptions properties.")]
         public static void ContextWithWebDefaultsAndOverriddenPropertyNamingPolicy_GeneratesExpectedOptions()
         {
             JsonSerializerOptions expected = new(JsonSerializerDefaults.Web)
@@ -71,6 +76,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         { }
 
         [Fact]
+        [RequiresUnreferencedCode("AssertOptionsEqual uses reflection to enumerate JsonSerializerOptions properties.")]
         public static void ContextWithAllOptionsSet_GeneratesExpectedOptions()
         {
             JsonSerializerOptions expected = new(JsonSerializerDefaults.Web)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -777,7 +777,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [Fact]
         public void ConstructingFromOptionsKeepsReference()
         {
-            JsonStringEnumConverter converter = new();
+            JsonConverter converter = new JsonStringEnumConverter<JsonIgnoreCondition>();
             JsonSerializerOptions options = new()
             {
                 PropertyNameCaseInsensitive = true,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSerializerWrapper.SourceGen.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSerializerWrapper.SourceGen.cs
@@ -23,10 +23,10 @@ namespace System.Text.Json.SourceGeneration.Tests
         public override JsonSerializerOptions DefaultOptions => _defaultContext.Options;
 
         public override Task<string> SerializeWrapper(object value, Type type, JsonSerializerOptions? options = null)
-            => Task.FromResult(JsonSerializer.Serialize(value, type, GetOptions(options)));
+            => Task.FromResult(JsonSerializer.Serialize(value, GetOptions(options).GetTypeInfo(type)));
 
         public override Task<string> SerializeWrapper<T>(T value, JsonSerializerOptions? options = null)
-            => Task.FromResult(JsonSerializer.Serialize(value, GetOptions(options)));
+            => Task.FromResult(JsonSerializer.Serialize(value, GetOptions(options).GetTypeInfo<T>()));
 
         public override Task<string> SerializeWrapper(object value, Type inputType, JsonSerializerContext context)
             => Task.FromResult(JsonSerializer.Serialize(value, inputType, context));
@@ -38,10 +38,10 @@ namespace System.Text.Json.SourceGeneration.Tests
             => Task.FromResult(JsonSerializer.Serialize(value, jsonTypeInfo));
 
         public override Task<T> DeserializeWrapper<T>(string json, JsonSerializerOptions? options = null)
-            => Task.FromResult(JsonSerializer.Deserialize<T>(json, GetOptions(options)));
+            => Task.FromResult(JsonSerializer.Deserialize(json, GetOptions(options).GetTypeInfo<T>()));
 
         public override Task<object> DeserializeWrapper(string json, Type type, JsonSerializerOptions? options = null)
-            => Task.FromResult(JsonSerializer.Deserialize(json, type, GetOptions(options)));
+            => Task.FromResult(JsonSerializer.Deserialize(json, GetOptions(options).GetTypeInfo(type)));
 
         public override Task<T> DeserializeWrapper<T>(string json, JsonTypeInfo<T> jsonTypeInfo)
             => Task.FromResult(JsonSerializer.Deserialize(json, jsonTypeInfo));
@@ -71,7 +71,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         public override IAsyncEnumerable<T> DeserializeAsyncEnumerable<T>(Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
-            return JsonSerializer.DeserializeAsyncEnumerable<T>(utf8Json, GetOptions(options), cancellationToken);
+            return JsonSerializer.DeserializeAsyncEnumerable<T>(utf8Json, GetOptions(options).GetTypeInfo<T>(), cancellationToken);
         }
 
         public override IAsyncEnumerable<T> DeserializeAsyncEnumerable<T>(Stream utf8Json, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default)
@@ -86,7 +86,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         public override IAsyncEnumerable<T> DeserializeAsyncEnumerable<T>(Stream utf8Json, bool topLevelValues, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
         {
-            return JsonSerializer.DeserializeAsyncEnumerable<T>(utf8Json, topLevelValues, GetOptions(options), cancellationToken);
+            return JsonSerializer.DeserializeAsyncEnumerable<T>(utf8Json, GetOptions(options).GetTypeInfo<T>(), topLevelValues, cancellationToken);
         }
     }
 
@@ -104,12 +104,12 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         public override async Task<T> DeserializeWrapper<T>(Stream utf8Json, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
         {
-            return await JsonSerializer.DeserializeAsync<T>(utf8Json, GetOptions(options), cancellationToken);
+            return await JsonSerializer.DeserializeAsync<T>(utf8Json, GetOptions(options).GetTypeInfo<T>(), cancellationToken);
         }
 
         public override async Task<object> DeserializeWrapper(Stream utf8Json, Type returnType, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
-            return await JsonSerializer.DeserializeAsync(utf8Json, returnType, GetOptions(options), cancellationToken);
+            return await JsonSerializer.DeserializeAsync(utf8Json, GetOptions(options).GetTypeInfo(returnType), cancellationToken);
         }
 
         public override async Task<T> DeserializeWrapper<T>(Stream utf8Json, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default)
@@ -128,10 +128,10 @@ namespace System.Text.Json.SourceGeneration.Tests
         }
 
         public override Task SerializeWrapper<T>(Stream stream, T value, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
-            => JsonSerializer.SerializeAsync<T>(stream, value, GetOptions(options), cancellationToken);
+            => JsonSerializer.SerializeAsync<T>(stream, value, GetOptions(options).GetTypeInfo<T>(), cancellationToken);
 
         public override Task SerializeWrapper(Stream stream, object value, Type inputType, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
-            => JsonSerializer.SerializeAsync(stream, value, inputType, GetOptions(options), cancellationToken);
+            => JsonSerializer.SerializeAsync(stream, value, GetOptions(options).GetTypeInfo(inputType), cancellationToken);
 
         public override Task SerializeWrapper<T>(Stream stream, T value, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default)
             => JsonSerializer.SerializeAsync(stream, value, jsonTypeInfo, cancellationToken);
@@ -161,7 +161,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         public override IAsyncEnumerable<T> DeserializeAsyncEnumerable<T>(Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
-            return JsonSerializer.DeserializeAsyncEnumerable<T>(utf8Json, GetOptions(options), cancellationToken);
+            return JsonSerializer.DeserializeAsyncEnumerable<T>(utf8Json, GetOptions(options).GetTypeInfo<T>(), cancellationToken);
         }
 
         public override IAsyncEnumerable<T> DeserializeAsyncEnumerable<T>(Stream utf8Json, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default)
@@ -176,7 +176,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         public override IAsyncEnumerable<T> DeserializeAsyncEnumerable<T>(Stream utf8Json, bool topLevelValues, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
         {
-            return JsonSerializer.DeserializeAsyncEnumerable<T>(utf8Json, topLevelValues, GetOptions(options), cancellationToken);
+            return JsonSerializer.DeserializeAsyncEnumerable<T>(utf8Json, GetOptions(options).GetTypeInfo<T>(), topLevelValues, cancellationToken);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PolymorphicTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PolymorphicTests.cs
@@ -245,6 +245,10 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(List<int>))]
         [JsonSerializable(typeof(Queue<int>))]
         [JsonSerializable(typeof(ISet<int>))]
+        [JsonSerializable(typeof(Dictionary<int, object>))]
+        [JsonSerializable(typeof(SortedDictionary<int, object>))]
+        [JsonSerializable(typeof(IReadOnlyDictionary<int, object>))]
+        [JsonSerializable(typeof(PolymorphicClass.DerivedAbstractClass), TypeInfoPropertyName = "PolymorphicClass_DerivedAbstractClass")]
         [JsonSerializable(typeof(PolymorphicInterface.DerivedInterface1))]
         [JsonSerializable(typeof(PolymorphicInterface.DerivedInterface2))]
         internal sealed partial class PolymorphicTestsContext_Metadata : JsonSerializerContext

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PolymorphicTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PolymorphicTests.cs
@@ -241,6 +241,12 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(PolymorphicTests.MyClass))]
         [JsonSerializable(typeof(PolymorphicTests.MyThingCollection))]
         [JsonSerializable(typeof(PolymorphicTests.MyThingDictionary))]
+        [JsonSerializable(typeof(PolymorphicTests.MyDerivedThing))]
+        [JsonSerializable(typeof(List<int>))]
+        [JsonSerializable(typeof(Queue<int>))]
+        [JsonSerializable(typeof(ISet<int>))]
+        [JsonSerializable(typeof(PolymorphicInterface.DerivedInterface1))]
+        [JsonSerializable(typeof(PolymorphicInterface.DerivedInterface2))]
         internal sealed partial class PolymorphicTestsContext_Metadata : JsonSerializerContext
         {
         }
@@ -486,6 +492,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(PolymorphicTests.MyClass))]
         [JsonSerializable(typeof(PolymorphicTests.MyThingCollection))]
         [JsonSerializable(typeof(PolymorphicTests.MyThingDictionary))]
+        [JsonSerializable(typeof(PolymorphicTests.MyDerivedThing))]
         internal sealed partial class PolymorphicTestsContext_Default : JsonSerializerContext
         {
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyVisibilityTests.cs
@@ -1,7 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization;
@@ -27,7 +28,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [Theory]
         [InlineData(typeof(ClassWithBadIgnoreAttribute))]
         [InlineData(typeof(StructWithBadIgnoreAttribute))]
-        public override async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail_EmptyJson(Type type)
+        public override async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail_EmptyJson([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
         {
             InvalidOperationException ioe = await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.DeserializeWrapper("", type));
             ValidateInvalidOperationException();
@@ -65,7 +66,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [InlineData(typeof(Class_PropertyWith_PrivateInitOnlySetter_WithAttribute))]
         [InlineData(typeof(Class_PropertyWith_InternalInitOnlySetter_WithAttribute))]
         [InlineData(typeof(Class_PropertyWith_ProtectedInitOnlySetter_WithAttribute))]
-        public override async Task NonPublicInitOnlySetter_With_JsonInclude(Type type)
+        public override async Task NonPublicInitOnlySetter_With_JsonInclude([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
         {
             // Inaccessible [JsonInclude] members are ignored (https://github.com/dotnet/runtime/issues/124889).
             // All types have public getter so serialization works; internal setter type can also deserialize.
@@ -94,7 +95,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             // MyEnum (private get, public set): setter works, getter excluded.
             // MyInt (public get, private set): getter works (with converter), setter excluded.
             var options = new JsonSerializerOptions();
-            options.Converters.Add(new JsonStringEnumConverter());
+            options.Converters.Add(new JsonStringEnumConverter<MySmallEnum>());
 
             string json = """{"MyEnum":"AnotherValue","MyInt":2}""";
             var obj = await Serializer.DeserializeWrapper<StructWithPropertiesWithConverter>(json, options);
@@ -147,7 +148,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Equal(0, obj.MyInt);
         }
 
-        public override async Task NonPublicProperty_JsonInclude_WorksAsExpected(Type type, bool isAccessibleBySourceGen)
+        public override async Task NonPublicProperty_JsonInclude_WorksAsExpected([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, bool isAccessibleBySourceGen)
         {
             // Inaccessible [JsonInclude] members are ignored (https://github.com/dotnet/runtime/issues/124889).
             if (isAccessibleBySourceGen)
@@ -580,7 +581,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [Theory]
         [InlineData(typeof(ClassWithBadIgnoreAttribute))]
         [InlineData(typeof(StructWithBadIgnoreAttribute))]
-        public override async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail(Type type)
+        public override async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
         {
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.DeserializeWrapper("{}", type));
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.SerializeWrapper(Activator.CreateInstance(type), type));
@@ -589,7 +590,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [Theory]
         [InlineData(typeof(ClassWithBadIgnoreAttribute))]
         [InlineData(typeof(StructWithBadIgnoreAttribute))]
-        public override async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail_EmptyJson(Type type)
+        public override async Task JsonIgnoreCondition_WhenWritingNull_OnValueType_Fail_EmptyJson([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
         {
             // Since this code goes down fast-path, there's no warm up and we hit the reader exception about having no tokens.
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.DeserializeWrapper("", type));
@@ -612,15 +613,15 @@ namespace System.Text.Json.SourceGeneration.Tests
                 PublicField = new(),
             };
 
-            string json = JsonSerializer.Serialize(obj, options);
+            string json = JsonSerializer.Serialize(obj, options.GetTypeInfo<PublicClassWithDifferentAccessibilitiesProperties>());
             Assert.Equal("""{"PublicProperty":{},"PublicField":{}}""", json);
 
-            var deserialized = JsonSerializer.Deserialize<PublicClassWithDifferentAccessibilitiesProperties>(json, options);
+            var deserialized = JsonSerializer.Deserialize(json, options.GetTypeInfo<PublicClassWithDifferentAccessibilitiesProperties>());
             Assert.NotNull(deserialized.PublicProperty);
             Assert.NotNull(deserialized.PublicField);
 
             json = "{}";
-            deserialized = JsonSerializer.Deserialize<PublicClassWithDifferentAccessibilitiesProperties>(json, options);
+            deserialized = JsonSerializer.Deserialize(json, options.GetTypeInfo<PublicClassWithDifferentAccessibilitiesProperties>());
             Assert.Null(deserialized.PublicProperty);
             Assert.Null(deserialized.PublicField);
         }
@@ -630,8 +631,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             JsonConverter obj = JsonMetadataServices.BooleanConverter;
 
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(obj, PublicContext.Default.Options));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<JsonConverter>("{}", PublicContext.Default.Options));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(obj, PublicContext.Default.Options.GetTypeInfo<JsonConverter>()));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize("{}", PublicContext.Default.Options.GetTypeInfo<JsonConverter>()));
         }
 
         [Fact]
@@ -644,9 +645,9 @@ namespace System.Text.Json.SourceGeneration.Tests
                 IncludeFields = true,
             };
 
-            string json = JsonSerializer.Serialize(obj, PublicContext.Default.Options);
+            string json = JsonSerializer.Serialize(obj, PublicContext.Default.Options.GetTypeInfo<JsonSerializerOptions>());
 
-            JsonSerializerOptions deserialized = JsonSerializer.Deserialize<JsonSerializerOptions>(json, PublicContext.Default.Options);
+            JsonSerializerOptions deserialized = JsonSerializer.Deserialize(json, PublicContext.Default.Options.GetTypeInfo<JsonSerializerOptions>());
             Assert.Equal(obj.DefaultBufferSize, deserialized.DefaultBufferSize);
             Assert.Equal(obj.DefaultIgnoreCondition, deserialized.DefaultIgnoreCondition);
             Assert.Equal(obj.IncludeFields, deserialized.IncludeFields);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationLogicTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationLogicTests.cs
@@ -83,7 +83,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         // Options with features that aren't supported in the generated serialization funcs.
         public static IEnumerable<object[]> GetOptionsUsingUnsupportedFeatures()
         {
-            yield return new object[] { new JsonSerializerOptions(s_compatibleOptions) { Converters = { new JsonStringEnumConverter() } } };
+            yield return new object[] { new JsonSerializerOptions(s_compatibleOptions) { Converters = { new JsonStringEnumConverter<JsonIgnoreCondition>() } } };
             yield return new object[] { new JsonSerializerOptions(s_compatibleOptions) { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping } };
             yield return new object[] { new JsonSerializerOptions(s_compatibleOptions) { NumberHandling = JsonNumberHandling.WriteAsString } };
             yield return new object[] { new JsonSerializerOptions(s_compatibleOptions) { NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals } };
@@ -101,7 +101,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         public static IEnumerable<object[]> GetIncompatibleOptions()
         {
             yield return new object[] { new JsonSerializerOptions() };
-            yield return new object[] { new JsonSerializerOptions { Converters = { new JsonStringEnumConverter() } } };
+            yield return new object[] { new JsonSerializerOptions { Converters = { new JsonStringEnumConverter<JsonIgnoreCondition>() } } };
             yield return new object[] { new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping } };
             yield return new object[] { new JsonSerializerOptions { NumberHandling = JsonNumberHandling.WriteAsString } };
             yield return new object[] { new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve } };

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Roslyn3.11.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Roslyn3.11.Tests.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TestedRoslynVersion>3.11</TestedRoslynVersion>
-    <!-- https://github.com/dotnet/runtime/issues/126862 -->
-    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
-    <EnableAotAnalyzer>false</EnableAotAnalyzer>
   </PropertyGroup>
 
   <Import Project="System.Text.Json.SourceGeneration.Tests.targets" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Roslyn4.4.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Roslyn4.4.Tests.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TestedRoslynVersion>4.4</TestedRoslynVersion>
-    <!-- https://github.com/dotnet/runtime/issues/126862 -->
-    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
-    <EnableAotAnalyzer>false</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
@@ -174,8 +174,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\CompilerLoweringPreserveAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicDependencyAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresDynamicCodeAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.CustomConverters.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.CustomConverters.cs
@@ -1,7 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.SourceGeneration.Tests
 {
@@ -336,7 +337,7 @@ namespace System.Text.Json.SourceGeneration.Tests
                 return default;
             }
 
-            return new(JsonSerializer.Deserialize<T>(ref reader, options)!);
+            return new(JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<T>())!);
         }
 
         public override void Write(Utf8JsonWriter writer, Option<T> value, JsonSerializerOptions options)
@@ -347,7 +348,7 @@ namespace System.Text.Json.SourceGeneration.Tests
                 return;
             }
 
-            JsonSerializer.Serialize(writer, value.Value, options);
+            JsonSerializer.Serialize(writer, value.Value, options.GetTypeInfo<T>());
         }
     }
 
@@ -380,13 +381,13 @@ namespace System.Text.Json.SourceGeneration.Tests
     {
         public override GenericWrapper<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            T value = JsonSerializer.Deserialize<T>(ref reader, options)!;
+            T value = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<T>())!;
             return new GenericWrapper<T>(value);
         }
 
         public override void Write(Utf8JsonWriter writer, GenericWrapper<T> value, JsonSerializerOptions options)
         {
-            JsonSerializer.Serialize(writer, value.WrappedValue, options);
+            JsonSerializer.Serialize(writer, value.WrappedValue, options.GetTypeInfo<T>());
         }
     }
 
@@ -430,9 +431,9 @@ namespace System.Text.Json.SourceGeneration.Tests
                     reader.Read();
 
                     if (propertyName == "Value1")
-                        result.Value1 = JsonSerializer.Deserialize<T>(ref reader, options)!;
+                        result.Value1 = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<T>())!;
                     else if (propertyName == "Value2")
-                        result.Value2 = JsonSerializer.Deserialize<U>(ref reader, options)!;
+                        result.Value2 = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<U>())!;
                 }
 
                 return result;
@@ -442,9 +443,9 @@ namespace System.Text.Json.SourceGeneration.Tests
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Value1");
-                JsonSerializer.Serialize(writer, value.Value1, options);
+                JsonSerializer.Serialize(writer, value.Value1, options.GetTypeInfo<T>());
                 writer.WritePropertyName("Value2");
-                JsonSerializer.Serialize(writer, value.Value2, options);
+                JsonSerializer.Serialize(writer, value.Value2, options.GetTypeInfo<U>());
                 writer.WriteEndObject();
             }
         }
@@ -477,7 +478,7 @@ namespace System.Text.Json.SourceGeneration.Tests
                 reader.Read();
 
                 if (propertyName == "Value")
-                    result.Value = JsonSerializer.Deserialize<T>(ref reader, options)!;
+                    result.Value = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<T>())!;
             }
 
             return result;
@@ -487,7 +488,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             writer.WriteStartObject();
             writer.WritePropertyName("Value");
-            JsonSerializer.Serialize(writer, value.Value, options);
+            JsonSerializer.Serialize(writer, value.Value, options.GetTypeInfo<T>());
             writer.WriteEndObject();
         }
     }
@@ -524,9 +525,9 @@ namespace System.Text.Json.SourceGeneration.Tests
                         reader.Read();
 
                         if (propertyName == "Value1")
-                            result.Value1 = JsonSerializer.Deserialize<T>(ref reader, options)!;
+                            result.Value1 = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<T>())!;
                         else if (propertyName == "Value2")
-                            result.Value2 = JsonSerializer.Deserialize<U>(ref reader, options)!;
+                            result.Value2 = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<U>())!;
                     }
 
                     return result;
@@ -536,9 +537,9 @@ namespace System.Text.Json.SourceGeneration.Tests
                 {
                     writer.WriteStartObject();
                     writer.WritePropertyName("Value1");
-                    JsonSerializer.Serialize(writer, value.Value1, options);
+                    JsonSerializer.Serialize(writer, value.Value1, options.GetTypeInfo<T>());
                     writer.WritePropertyName("Value2");
-                    JsonSerializer.Serialize(writer, value.Value2, options);
+                    JsonSerializer.Serialize(writer, value.Value2, options.GetTypeInfo<U>());
                     writer.WriteEndObject();
                 }
             }
@@ -581,11 +582,11 @@ namespace System.Text.Json.SourceGeneration.Tests
 
                         switch (propertyName)
                         {
-                            case "Value1": result.Value1 = JsonSerializer.Deserialize<A>(ref reader, options)!; break;
-                            case "Value2": result.Value2 = JsonSerializer.Deserialize<B>(ref reader, options)!; break;
-                            case "Value3": result.Value3 = JsonSerializer.Deserialize<C>(ref reader, options)!; break;
-                            case "Value4": result.Value4 = JsonSerializer.Deserialize<D>(ref reader, options)!; break;
-                            case "Value5": result.Value5 = JsonSerializer.Deserialize<E>(ref reader, options)!; break;
+                            case "Value1": result.Value1 = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<A>())!; break;
+                            case "Value2": result.Value2 = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<B>())!; break;
+                            case "Value3": result.Value3 = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<C>())!; break;
+                            case "Value4": result.Value4 = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<D>())!; break;
+                            case "Value5": result.Value5 = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<E>())!; break;
                         }
                     }
 
@@ -596,15 +597,15 @@ namespace System.Text.Json.SourceGeneration.Tests
                 {
                     writer.WriteStartObject();
                     writer.WritePropertyName("Value1");
-                    JsonSerializer.Serialize(writer, value.Value1, options);
+                    JsonSerializer.Serialize(writer, value.Value1, options.GetTypeInfo<A>());
                     writer.WritePropertyName("Value2");
-                    JsonSerializer.Serialize(writer, value.Value2, options);
+                    JsonSerializer.Serialize(writer, value.Value2, options.GetTypeInfo<B>());
                     writer.WritePropertyName("Value3");
-                    JsonSerializer.Serialize(writer, value.Value3, options);
+                    JsonSerializer.Serialize(writer, value.Value3, options.GetTypeInfo<C>());
                     writer.WritePropertyName("Value4");
-                    JsonSerializer.Serialize(writer, value.Value4, options);
+                    JsonSerializer.Serialize(writer, value.Value4, options.GetTypeInfo<D>());
                     writer.WritePropertyName("Value5");
-                    JsonSerializer.Serialize(writer, value.Value5, options);
+                    JsonSerializer.Serialize(writer, value.Value5, options.GetTypeInfo<E>());
                     writer.WriteEndObject();
                 }
             }
@@ -640,7 +641,7 @@ namespace System.Text.Json.SourceGeneration.Tests
                     reader.Read();
 
                     if (propertyName == "Value")
-                        result.Value = JsonSerializer.Deserialize<T>(ref reader, options)!;
+                        result.Value = JsonSerializer.Deserialize(ref reader, options.GetTypeInfo<T>())!;
                 }
 
                 return result;
@@ -650,7 +651,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Value");
-                JsonSerializer.Serialize(writer, value.Value, options);
+                JsonSerializer.Serialize(writer, value.Value, options.GetTypeInfo<T>());
                 writer.WriteEndObject();
             }
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
@@ -994,7 +994,7 @@ namespace System.Text.Json.Nodes.Tests
         [Fact]
         public static void JsonValue_CreateWithJsonTypeInfo()
         {
-            JsonTypeInfo<int> typeInfo = (JsonTypeInfo<int>)JsonSerializerOptions.Default.GetTypeInfo(typeof(int));
+            JsonTypeInfo<int> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<int>();
             
             JsonValue value = JsonValue.Create(42, typeInfo);
             Assert.Equal(42, value.GetValue<int>());
@@ -1003,7 +1003,7 @@ namespace System.Text.Json.Nodes.Tests
         [Fact]
         public static void JsonValue_CreateWithJsonTypeInfoAndOptions()
         {
-            JsonTypeInfo<string> typeInfo = (JsonTypeInfo<string>)JsonSerializerOptions.Default.GetTypeInfo(typeof(string));
+            JsonTypeInfo<string> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<string>();
             var nodeOptions = new JsonNodeOptions { PropertyNameCaseInsensitive = true };
             
             JsonValue value = JsonValue.Create("test", typeInfo, nodeOptions);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/DomTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/DomTests.cs
@@ -253,7 +253,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void SerializeToDocument_WithJsonTypeInfo()
         {
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = MyPoco.Create();
             using JsonDocument dom = JsonSerializer.SerializeToDocument(obj, typeInfo);
@@ -279,7 +279,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void SerializeToElement_WithJsonTypeInfo()
         {
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = MyPoco.Create();
             JsonElement element = JsonSerializer.SerializeToElement(obj, typeInfo);
@@ -305,7 +305,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void SerializeToNode_WithJsonTypeInfo()
         {
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = MyPoco.Create();
             JsonNode node = JsonSerializer.SerializeToNode(obj, typeInfo);
@@ -331,7 +331,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ReadOnlySpan<byte> utf8Json = """{"StringProp":"Hello","IntArrayProp":[1,2]}"""u8;
             
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = JsonSerializer.Deserialize(utf8Json, typeInfo);
             obj.Verify();
@@ -381,7 +381,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ReadOnlySpan<byte> utf8Json = "null"u8;
             
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = JsonSerializer.Deserialize(utf8Json, typeInfo);
             Assert.Null(obj);
@@ -392,7 +392,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             using JsonDocument doc = JsonDocument.Parse(Json);
             
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = doc.Deserialize(typeInfo);
             obj.Verify();
@@ -416,7 +416,7 @@ namespace System.Text.Json.Serialization.Tests
             using JsonDocument doc = JsonDocument.Parse(Json);
             JsonElement element = doc.RootElement;
             
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = element.Deserialize(typeInfo);
             obj.Verify();
@@ -440,7 +440,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             JsonNode node = JsonNode.Parse(Json);
             
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = node.Deserialize(typeInfo);
             obj.Verify();
@@ -463,7 +463,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ReadOnlySpan<char> jsonChars = Json.AsSpan();
             
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = JsonSerializer.Deserialize(jsonChars, typeInfo);
             obj.Verify();
@@ -531,7 +531,7 @@ namespace System.Text.Json.Serialization.Tests
             byte[] utf8Json = Encoding.UTF8.GetBytes(Json);
             Utf8JsonReader reader = new(utf8Json);
             
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = JsonSerializer.Deserialize(ref reader, typeInfo);
             obj.Verify();
@@ -555,7 +555,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             using MemoryStream stream = new(Encoding.UTF8.GetBytes(Json));
             
-            JsonTypeInfo<MyPoco> typeInfo = (JsonTypeInfo<MyPoco>)JsonSerializerOptions.Default.GetTypeInfo(typeof(MyPoco));
+            JsonTypeInfo<MyPoco> typeInfo = JsonSerializerOptions.Default.GetTypeInfo<MyPoco>();
             
             MyPoco obj = JsonSerializer.Deserialize(stream, typeInfo);
             obj.Verify();

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -277,9 +277,14 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Compile Include="$(CommonPath)System\Buffers\ArrayBufferWriter.cs" Link="CommonTest\System\Buffers\ArrayBufferWriter.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresDynamicCodeAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicDependencyAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\SetsRequiredMembersAttribute.cs" Link="System.Private.CoreLib\System\Diagnostics\CodeAnalysis\SetsRequiredMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\CompilerFeatureRequiredAttribute.cs" Link="System.Private.CoreLib\System\Runtime\CompilerServices\CompilerFeatureRequiredAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\CompilerLoweringPreserveAttribute.cs" Link="System.Private.CoreLib\System\Runtime\CompilerServices\CompilerLoweringPreserveAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IUnion.cs" Link="System.Private.CoreLib\System\Runtime\CompilerServices\IUnion.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\RequiredMemberAttribute.cs" Link="System.Private.CoreLib\System\Runtime\CompilerServices\RequiredMemberAttribute.cs" />


### PR DESCRIPTION
Enables the trim/AOT analyzers on the `System.Text.Json` source generator test projects so that AOT/trim regressions are caught at PR build time, instead of only surfacing in the Native AOT outerloop runs that don't execute on regular PRs.

This is a follow up to #129965.