### PR TITLE
Add back MinInteger/MaxInteger paths for IEnumerables in LINQ

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Max.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Max.cs
@@ -12,6 +12,27 @@ namespace System.Linq
 
         public static long Max(this IEnumerable<long> source) => Max(source, comparer: null);
 
+        private static T MaxIntegerEnumerator<T>(IEnumerable<T> source) where T : struct, IBinaryInteger<T>
+        {
+            using IEnumerator<T> e = source.GetEnumerator();
+            if (!e.MoveNext())
+            {
+                ThrowHelper.ThrowNoElementsException();
+            }
+
+            T value = e.Current;
+            while (e.MoveNext())
+            {
+                T x = e.Current;
+                if (x > value)
+                {
+                    value = x;
+                }
+            }
+
+            return value;
+        }
+
         public static int? Max(this IEnumerable<int?> source) => MaxInteger(source);
 
         public static long? Max(this IEnumerable<long?> source) => MaxInteger(source);
@@ -311,6 +332,25 @@ namespace System.Linq
             if (source.TryGetSpan(out ReadOnlySpan<TSource> span))
             {
                 return span.Max(comparer);
+            }
+
+            // For the non-span integer sequences, use a direct comparison rather than paying the
+            // per-element cost of Comparer<TSource>.Default.
+            if (comparer is null || comparer == Comparer<TSource>.Default)
+            {
+                if (typeof(TSource) == typeof(byte)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<byte>)source);
+                if (typeof(TSource) == typeof(sbyte)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<sbyte>)source);
+                if (typeof(TSource) == typeof(ushort)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<ushort>)source);
+                if (typeof(TSource) == typeof(short)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<short>)source);
+                if (typeof(TSource) == typeof(char)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<char>)source);
+                if (typeof(TSource) == typeof(uint)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<uint>)source);
+                if (typeof(TSource) == typeof(int)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<int>)source);
+                if (typeof(TSource) == typeof(ulong)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<ulong>)source);
+                if (typeof(TSource) == typeof(long)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<long>)source);
+                if (typeof(TSource) == typeof(nuint)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<nuint>)source);
+                if (typeof(TSource) == typeof(nint)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<nint>)source);
+                if (typeof(TSource) == typeof(Int128)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<Int128>)source);
+                if (typeof(TSource) == typeof(UInt128)) return (TSource)(object)MaxIntegerEnumerator((IEnumerable<UInt128>)source);
             }
 
             comparer ??= Comparer<TSource>.Default;

--- a/src/libraries/System.Linq/src/System/Linq/Min.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Min.cs
@@ -12,6 +12,27 @@ namespace System.Linq
 
         public static long Min(this IEnumerable<long> source) => Min(source, comparer: null);
 
+        private static T MinIntegerEnumerator<T>(IEnumerable<T> source) where T : struct, IBinaryInteger<T>
+        {
+            using IEnumerator<T> e = source.GetEnumerator();
+            if (!e.MoveNext())
+            {
+                ThrowHelper.ThrowNoElementsException();
+            }
+
+            T value = e.Current;
+            while (e.MoveNext())
+            {
+                T x = e.Current;
+                if (x < value)
+                {
+                    value = x;
+                }
+            }
+
+            return value;
+        }
+
         public static int? Min(this IEnumerable<int?> source) => MinInteger(source);
 
         public static long? Min(this IEnumerable<long?> source) => MinInteger(source);
@@ -290,6 +311,25 @@ namespace System.Linq
             if (source.TryGetSpan(out ReadOnlySpan<TSource> span))
             {
                 return span.Min(comparer);
+            }
+
+            // For the non-span integer sequences, use a direct comparison rather than paying the
+            // per-element cost of Comparer<TSource>.Default.
+            if (comparer is null || comparer == Comparer<TSource>.Default)
+            {
+                if (typeof(TSource) == typeof(byte)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<byte>)source);
+                if (typeof(TSource) == typeof(sbyte)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<sbyte>)source);
+                if (typeof(TSource) == typeof(ushort)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<ushort>)source);
+                if (typeof(TSource) == typeof(short)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<short>)source);
+                if (typeof(TSource) == typeof(char)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<char>)source);
+                if (typeof(TSource) == typeof(uint)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<uint>)source);
+                if (typeof(TSource) == typeof(int)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<int>)source);
+                if (typeof(TSource) == typeof(ulong)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<ulong>)source);
+                if (typeof(TSource) == typeof(long)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<long>)source);
+                if (typeof(TSource) == typeof(nuint)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<nuint>)source);
+                if (typeof(TSource) == typeof(nint)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<nint>)source);
+                if (typeof(TSource) == typeof(Int128)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<Int128>)source);
+                if (typeof(TSource) == typeof(UInt128)) return (TSource)(object)MinIntegerEnumerator((IEnumerable<UInt128>)source);
             }
 
             comparer ??= Comparer<TSource>.Default;


### PR DESCRIPTION
Fixes #130047 - perf regression from #128306 for `IEnumerable` inputs where we can't extract the span, and the `T` is an integer type. #128306 removed the loop that'll go over the `IEnumerable` and compare results via `<` instead of going through `IComparer`. This PR adds that logic back.

https://github.com/MihuBot/runtime-utils/issues/2066

| Method | Toolchain               | input       | Mean      | Error    | Ratio | Allocated | Alloc Ratio |
|------- |------------------------ |------------ |----------:|---------:|------:|----------:|------------:|
| Min    | Main | IEnumerable | 102.14 ns | 0.418 ns |  1.00 |      32 B |        1.00 |
| Min    | PR   | IEnumerable |  44.23 ns | 1.275 ns |  0.43 |         - |        0.00 |
|        |                         |             |           |          |       |           |             |
| Max    | Main | IEnumerable | 107.91 ns | 0.047 ns |  1.00 |      32 B |        1.00 |
| Max    | PR   | IEnumerable |  56.38 ns | 0.198 ns |  0.52 |         - |        0.00 |

The intention before merging that PR was to avoid such regressions, but looks like my benchmark in https://github.com/dotnet/runtime/pull/128306#discussion_r3284644655 didn't catch it https://github.com/EgorBot/Benchmarks/issues/208#issuecomment-4513371548.