### PR TITLE
Update OutOfMemoryException test

### DIFF
--- a/src/tests/baseservices/exceptions/OutOfMemoryException/OutOfMemoryException.csproj
+++ b/src/tests/baseservices/exceptions/OutOfMemoryException/OutOfMemoryException.csproj
@@ -8,6 +8,9 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' == 'true' and '$(TargetArchitecture)' == 'x64'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <!-- GCStress runs collections very frequently and allocates its own objects, which changes
+         when the program runs out of memory. As a result the small allocations test becomes unreliable. -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <!-- Mono doesn't enforce DOTNET_GCHeapHardLimit as a GC heap limit -->
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
   </PropertyGroup>


### PR DESCRIPTION
I think the test is not GC stress compatible. The small allocations loops finish earlier than expected because of the allocations done by the GC and all the final loop can just finish instead of OOMing.

https://github.com/dotnet/runtime/blob/57fc9dc8acd841ecffb733faf8def2cd96fadfd0/src/tests/baseservices/exceptions/OutOfMemoryException/OutOfMemoryException.cs#L32-L44

Fixes #129159.