### PR TITLE
Optimize MethodDataObject::FillEntryDataForAncestor for MethodImpl hierarchies

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -6698,7 +6698,69 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
     if (m_containsMethodImpl && pMT != m_pDeclMT)
         return;
 
+    NewArrayHolder<bool> pSlotFlags;
+    bool nonAllocatedBitvector[16];
     unsigned nVirtuals = pMT->GetNumVirtuals();
+    unsigned unprocesssedNonOverridenSlots = 0;
+
+    bool* pBitVector = NULL;
+
+    if (pMT == m_pDeclMT)
+    {
+        // We have a concept of Method's which have never been overridden by a subclass or called, and in that case we don't actually
+        // need to fill in the MethodTable's vtable entry with a stub. We can detect that here on the Canonical methodtable,
+        // and setup the Decl/Impl MethodDescs's for a slot even if there are MethodImpls in the inheritance chain, since the 
+        // vtable entry will only be NULL if the method could not have been involved with a MethodImpl. This optimization
+        // is only really important for the scenario where we have these NULL entries, since the MethodImpl fallback
+        // case will end up using MehtodTable::GetMethodDescForSlot_NoThrow to get the MethodDesc for the slot, and that is O(N)
+        // for the number of Method defined in the type hierarchy, and the usage of MethodDataObject tends to be O(V) for the number
+        // of virtual method slots on the type, so we get O(V*N) processing time when the not MethodImpl optimization case
+        // fails, which needs addressing.
+
+        // This optimization is only an improvement, if there is a type which is containsMethodImpl in the hierarchy, so do not run it
+        // unless there is a MethodImpl in the hierarchy.
+        bool containsMethodImplInHierarchy = m_containsMethodImpl;
+        MethodTable *pMTWalk = pMT;
+        while (!containsMethodImplInHierarchy && pMTWalk != NULL)
+        {
+            containsMethodImplInHierarchy = pMTWalk->GetClass()->ContainsMethodImpls();
+            pMTWalk = pMTWalk->GetParentMethodTable();
+        }
+        
+        if (containsMethodImplInHierarchy)
+        {
+            MethodTable *pCanonMT = pMT->GetCanonicalMethodTable();
+
+            if (nVirtuals <= sizeof(nonAllocatedBitvector))
+            {
+                pBitVector = nonAllocatedBitvector;
+                memset(pBitVector, 0, sizeof(nonAllocatedBitvector));
+            }
+            else
+            {
+                pSlotFlags = new bool[nVirtuals];
+                pBitVector = pSlotFlags;
+                memset(pBitVector, 0, nVirtuals);
+            }
+
+            for (unsigned slot = 0; slot < nVirtuals; slot++)
+            {
+                PCODE pCode = pCanonMT->GetSlotForVirtualVolatileLoadWithoutBarrier(slot);
+
+                if (pCode == (PCODE)NULL)
+                {
+                    pBitVector[slot] = true;
+                    unprocesssedNonOverridenSlots += 1;
+                }
+            }
+
+            if (unprocesssedNonOverridenSlots == 0)
+            {
+                pBitVector = NULL;
+            }
+        }
+    }
+
     unsigned nVTableLikeSlots = pMT->GetCanonicalMethodTable()->GetNumVtableSlots();
 
     MethodTable::IntroducedMethodIterator it(pMT, FALSE);
@@ -6714,8 +6776,19 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
         // data for, and the virtual methods of the parent and above
         if (pMT == m_pDeclMT)
         {
-            if (m_containsMethodImpl && slot < nVirtuals)
-                continue;
+            if (slot < nVirtuals)
+            {
+                if (pBitVector == NULL || !pBitVector[slot])
+                {
+                    if (m_containsMethodImpl)
+                        continue;
+                }
+                else
+                {
+                    _ASSERTE(unprocesssedNonOverridenSlots > 0);
+                    unprocesssedNonOverridenSlots -= 1;
+                }
+            }
 
             if (m_virtualsOnly && slot >= nVTableLikeSlots)
             {
@@ -6739,6 +6812,49 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
         if (pEntry->GetImplMethodDesc() == NULL)
         {
             pEntry->SetImplMethodDesc(pMD);
+        }
+    }
+
+    while (unprocesssedNonOverridenSlots > 0)
+    {
+        pMT = pMT->GetParentMethodTable();
+        nVirtuals = pMT->GetNumVirtuals();
+        _ASSERTE(pMT != NULL);
+        _ASSERTE(pBitVector != NULL);
+        _ASSERTE(unprocesssedNonOverridenSlots > 0);
+        MethodTable::IntroducedMethodIterator it(pMT, FALSE);
+        for (; it.IsValid(); it.Next())
+        {
+            MethodDesc * pMD = it.GetMethodDesc();
+
+            unsigned slot = pMD->GetSlot();
+            if (slot == MethodTable::NO_SLOT)
+                continue;
+
+            if (slot >= nVirtuals)
+                continue;
+
+            if (!pBitVector[slot])
+            {
+                continue;
+            }
+            else
+            {
+                _ASSERTE(unprocesssedNonOverridenSlots > 0);
+                unprocesssedNonOverridenSlots -= 1;
+            }
+
+            MethodDataObjectEntry * pEntry = GetEntry(slot);
+
+            if (pEntry->GetDeclMethodDesc() == NULL)
+            {
+                pEntry->SetDeclMethodDesc(pMD);
+            }
+
+            if (pEntry->GetImplMethodDesc() == NULL)
+            {
+                pEntry->SetImplMethodDesc(pMD);
+            }
         }
     }
 } // MethodTable::MethodDataObject::FillEntryDataForAncestor

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -6738,25 +6738,32 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
             }
             else
             {
-                pSlotFlags = new bool[nVirtuals];
+                // Use a non-throwing allocation to keep this method within its NOTHROW contract.
+                // If the allocation fails, pBitVector remains NULL and we simply fall back to the
+                // conservative (correct, but potentially slower) behavior below.
+                pSlotFlags = new (nothrow) bool[nVirtuals];
                 pBitVector = pSlotFlags;
-                memset(pBitVector, 0, nVirtuals);
+                if (pBitVector != NULL)
+                    memset(pBitVector, 0, nVirtuals * sizeof(*pBitVector));
             }
 
-            for (unsigned slot = 0; slot < nVirtuals; slot++)
+            if (pBitVector != NULL)
             {
-                PCODE pCode = pCanonMT->GetSlotForVirtualVolatileLoadWithoutBarrier(slot);
-
-                if (pCode == (PCODE)NULL)
+                for (unsigned slot = 0; slot < nVirtuals; slot++)
                 {
-                    pBitVector[slot] = true;
-                    unprocessedNonOverriddenSlots += 1;
-                }
-            }
+                    PCODE pCode = pCanonMT->GetSlotForVirtualVolatileLoadWithoutBarrier(slot);
 
-            if (unprocessedNonOverriddenSlots == 0)
-            {
-                pBitVector = NULL;
+                    if (pCode == (PCODE)NULL)
+                    {
+                        pBitVector[slot] = true;
+                        unprocessedNonOverriddenSlots += 1;
+                    }
+                }
+
+                if (unprocessedNonOverriddenSlots == 0)
+                {
+                    pBitVector = NULL;
+                }
             }
         }
     }
@@ -6786,6 +6793,7 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
                 else
                 {
                     _ASSERTE(unprocessedNonOverriddenSlots > 0);
+                    pBitVector[slot] = false;
                     unprocessedNonOverriddenSlots -= 1;
                 }
             }
@@ -6841,6 +6849,7 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
             else
             {
                 _ASSERTE(unprocessedNonOverriddenSlots > 0);
+                pBitVector[slot] = false;
                 unprocessedNonOverriddenSlots -= 1;
             }
 

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -6701,18 +6701,18 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
     NewArrayHolder<bool> pSlotFlags;
     bool nonAllocatedBitvector[16];
     unsigned nVirtuals = pMT->GetNumVirtuals();
-    unsigned unprocesssedNonOverridenSlots = 0;
+    unsigned unprocessedNonOverriddenSlots = 0;
 
     bool* pBitVector = NULL;
 
     if (pMT == m_pDeclMT)
     {
-        // We have a concept of Method's which have never been overridden by a subclass or called, and in that case we don't actually
+        // We have a concept of methods which have never been overridden by a subclass or called, and in that case we don't actually
         // need to fill in the MethodTable's vtable entry with a stub. We can detect that here on the Canonical methodtable,
-        // and setup the Decl/Impl MethodDescs's for a slot even if there are MethodImpls in the inheritance chain, since the 
+        // and setup the Decl/Impl MethodDescs for a slot even if there are MethodImpls in the inheritance chain, since the
         // vtable entry will only be NULL if the method could not have been involved with a MethodImpl. This optimization
         // is only really important for the scenario where we have these NULL entries, since the MethodImpl fallback
-        // case will end up using MehtodTable::GetMethodDescForSlot_NoThrow to get the MethodDesc for the slot, and that is O(N)
+        // case will end up using MethodTable::GetMethodDescForSlot_NoThrow to get the MethodDesc for the slot, and that is O(N)
         // for the number of Method defined in the type hierarchy, and the usage of MethodDataObject tends to be O(V) for the number
         // of virtual method slots on the type, so we get O(V*N) processing time when the not MethodImpl optimization case
         // fails, which needs addressing.
@@ -6726,12 +6726,12 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
             containsMethodImplInHierarchy = pMTWalk->GetClass()->ContainsMethodImpls();
             pMTWalk = pMTWalk->GetParentMethodTable();
         }
-        
+
         if (containsMethodImplInHierarchy)
         {
             MethodTable *pCanonMT = pMT->GetCanonicalMethodTable();
 
-            if (nVirtuals <= sizeof(nonAllocatedBitvector))
+            if (nVirtuals <= ARRAY_SIZE(nonAllocatedBitvector))
             {
                 pBitVector = nonAllocatedBitvector;
                 memset(pBitVector, 0, sizeof(nonAllocatedBitvector));
@@ -6750,11 +6750,11 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
                 if (pCode == (PCODE)NULL)
                 {
                     pBitVector[slot] = true;
-                    unprocesssedNonOverridenSlots += 1;
+                    unprocessedNonOverriddenSlots += 1;
                 }
             }
 
-            if (unprocesssedNonOverridenSlots == 0)
+            if (unprocessedNonOverriddenSlots == 0)
             {
                 pBitVector = NULL;
             }
@@ -6785,8 +6785,8 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
                 }
                 else
                 {
-                    _ASSERTE(unprocesssedNonOverridenSlots > 0);
-                    unprocesssedNonOverridenSlots -= 1;
+                    _ASSERTE(unprocessedNonOverriddenSlots > 0);
+                    unprocessedNonOverriddenSlots -= 1;
                 }
             }
 
@@ -6815,13 +6815,13 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
         }
     }
 
-    while (unprocesssedNonOverridenSlots > 0)
+    while (unprocessedNonOverriddenSlots > 0)
     {
-        pMT = pMT->GetParentMethodTable();
-        nVirtuals = pMT->GetNumVirtuals();
-        _ASSERTE(pMT != NULL);
         _ASSERTE(pBitVector != NULL);
-        _ASSERTE(unprocesssedNonOverridenSlots > 0);
+        _ASSERTE(unprocessedNonOverriddenSlots > 0);
+        pMT = pMT->GetParentMethodTable();
+        _ASSERTE(pMT != NULL);
+        nVirtuals = pMT->GetNumVirtuals();
         MethodTable::IntroducedMethodIterator it(pMT, FALSE);
         for (; it.IsValid(); it.Next())
         {
@@ -6840,8 +6840,8 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
             }
             else
             {
-                _ASSERTE(unprocesssedNonOverridenSlots > 0);
-                unprocesssedNonOverridenSlots -= 1;
+                _ASSERTE(unprocessedNonOverriddenSlots > 0);
+                unprocessedNonOverriddenSlots -= 1;
             }
 
             MethodDataObjectEntry * pEntry = GetEntry(slot);

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -6835,10 +6835,10 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
             {
                 if (pNullSlotBitvector == NULL || !IsBitVectorEntrySet(pNullSlotBitvector, slot))
                 {
-                    // We reach here if we 've disable the NullSlot optimization (due to an allocation failure),
-                    // or if the slot is not a NullSlot. This indicates that there is an implmentation of the slot, and so
-                    // the GetMethodDescForSlot_NoThrow api will operate in O(1) time (or we're in allocation failure case
-                    // and the performance implications are unimportant).)
+                    // We reach here if we've disabled the null-slot optimization (due to an allocation failure),
+                    // or if the slot is not a null slot. This indicates that there is an implementation for the slot, and so
+                    // the GetMethodDescForSlot_NoThrow API will operate in O(1) time (or we're in the allocation-failure case
+                    // and the performance implications are unimportant).
                     if (m_containsMethodImpl)
                     {
                         // If there is a MethodImpl in the hierarchy, then we will need to skip the optimization of pre-resolving
@@ -6876,8 +6876,8 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
         SetEntryDataForSlotIfNotYetSet(slot, pMD);
     }
 
-    // Walk the parent chain until we've processed all of the slots which have not been overriden/called by a subclass.
-    // NOTE: We only run this code for the top level FilEntryDataForAncestor case where (pMT == m_pDeclMT).
+    // Walk the parent chain until we've processed all of the slots that have not been overridden or called by a subclass.
+    // NOTE: We only run this code for the top-level FillEntryDataForAncestor case where (pMT == m_pDeclMT).
     // This check is enforced by unprocessedNonOverriddenSlots only being non-zero in that scenario.
     while (unprocessedNonOverriddenSlots > 0)
     {

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -771,6 +771,36 @@ void MethodTable::InitializeExtraInterfaceInfo(PVOID pInfo)
 #define SELECT_TADDR_BIT(_index) (1U << (_index))
 #endif
 
+static inline unsigned GetBitVectorByteCount(unsigned bitCount)
+{
+    LIMITED_METHOD_CONTRACT;
+    return (bitCount + 7u) / 8u;
+}
+
+static inline unsigned GetBitVectorBitCount(unsigned byteCount)
+{
+    LIMITED_METHOD_CONTRACT;
+    return byteCount * 8u;
+}
+
+static inline bool IsBitVectorEntrySet(const uint8_t* pNullSlotBitvector, unsigned index)
+{
+    LIMITED_METHOD_CONTRACT;
+    return (pNullSlotBitvector[index / 8u] & static_cast<uint8_t>(1u << (index % 8u))) != 0;
+}
+
+static inline void SetBitVectorEntry(uint8_t* pNullSlotBitvector, unsigned index)
+{
+    LIMITED_METHOD_CONTRACT;
+    pNullSlotBitvector[index / 8u] |= static_cast<uint8_t>(1u << (index % 8u));
+}
+
+static inline void ClearBitVectorEntry(uint8_t* pNullSlotBitvector, unsigned index)
+{
+    LIMITED_METHOD_CONTRACT;
+    pNullSlotBitvector[index / 8u] &= static_cast<uint8_t>(~(1u << (index % 8u)));
+}
+
 //==========================================================================================
 // For the given interface in the map (specified via map index) mark the interface as declared explicitly on
 // this class. This is not legal for dynamically added interfaces (as used by RCWs).
@@ -6671,6 +6701,23 @@ BOOL MethodTable::MethodDataObject::PopulateNextLevel()
 } // MethodTable::MethodDataObject::PopulateNextLevel
 
 //==========================================================================================
+void MethodTable::MethodDataObject::SetEntryDataForSlotIfNotYetSet(UINT32 slot, MethodDesc *pMD)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    MethodDataObjectEntry * pEntry = GetEntry(slot);
+
+    if (pEntry->GetDeclMethodDesc() == NULL)
+    {
+        pEntry->SetDeclMethodDesc(pMD);
+    }
+
+    if (pEntry->GetImplMethodDesc() == NULL)
+    {
+        pEntry->SetImplMethodDesc(pMD);
+    }
+}
+
 void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
 {
     LIMITED_METHOD_CONTRACT;
@@ -6698,12 +6745,12 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
     if (m_containsMethodImpl && pMT != m_pDeclMT)
         return;
 
-    NewArrayHolder<bool> pSlotFlags;
-    bool nonAllocatedBitvector[16];
+    NewArrayHolder<uint8_t> pSlotFlags;
+    uint8_t nonAllocatedBitvector[16];
     unsigned nVirtuals = pMT->GetNumVirtuals();
     unsigned unprocessedNonOverriddenSlots = 0;
 
-    bool* pBitVector = NULL;
+    uint8_t* pNullSlotBitvector = NULL;
 
     if (pMT == m_pDeclMT)
     {
@@ -6717,8 +6764,7 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
         // of virtual method slots on the type, so we get O(V*N) processing time when the not MethodImpl optimization case
         // fails, which needs addressing.
 
-        // This optimization is only an improvement, if there is a type which is containsMethodImpl in the hierarchy, so do not run it
-        // unless there is a MethodImpl in the hierarchy.
+        // This optimization is only an improvement, if there is a type which is containsMethodImpl in the hierarchy.
         bool containsMethodImplInHierarchy = m_containsMethodImpl;
         MethodTable *pMTWalk = pMT;
         while (!containsMethodImplInHierarchy && pMTWalk != NULL)
@@ -6731,23 +6777,23 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
         {
             MethodTable *pCanonMT = pMT->GetCanonicalMethodTable();
 
-            if (nVirtuals <= ARRAY_SIZE(nonAllocatedBitvector))
+            if (nVirtuals <= GetBitVectorBitCount(sizeof(nonAllocatedBitvector)))
             {
-                pBitVector = nonAllocatedBitvector;
-                memset(pBitVector, 0, sizeof(nonAllocatedBitvector));
+                pNullSlotBitvector = nonAllocatedBitvector;
+                memset(pNullSlotBitvector, 0, sizeof(nonAllocatedBitvector));
             }
             else
             {
                 // Use a non-throwing allocation to keep this method within its NOTHROW contract.
-                // If the allocation fails, pBitVector remains NULL and we simply fall back to the
+                // If the allocation fails, pNullSlotBitvector remains NULL and we simply fall back to the
                 // conservative (correct, but potentially slower) behavior below.
-                pSlotFlags = new (nothrow) bool[nVirtuals];
-                pBitVector = pSlotFlags;
-                if (pBitVector != NULL)
-                    memset(pBitVector, 0, nVirtuals * sizeof(*pBitVector));
+                pSlotFlags = new (nothrow) uint8_t[GetBitVectorByteCount(nVirtuals)];
+                pNullSlotBitvector = pSlotFlags;
+                if (pNullSlotBitvector != NULL)
+                    memset(pNullSlotBitvector, 0, GetBitVectorByteCount(nVirtuals) * sizeof(*pNullSlotBitvector));
             }
 
-            if (pBitVector != NULL)
+            if (pNullSlotBitvector != NULL)
             {
                 for (unsigned slot = 0; slot < nVirtuals; slot++)
                 {
@@ -6755,14 +6801,14 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
 
                     if (pCode == (PCODE)NULL)
                     {
-                        pBitVector[slot] = true;
+                        SetBitVectorEntry(pNullSlotBitvector, slot);
                         unprocessedNonOverriddenSlots += 1;
                     }
                 }
 
                 if (unprocessedNonOverriddenSlots == 0)
                 {
-                    pBitVector = NULL;
+                    pNullSlotBitvector = NULL;
                 }
             }
         }
@@ -6780,24 +6826,41 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
             continue;
 
         // We want to fill all methods introduced by the actual type we're gathering
-        // data for, and the virtual methods of the parent and above
+        // data for, and the virtual methods of the parent and above unless there are MethodImpls
+        // in the hierarchy, in which cases we can only fill in entries which are known not to 
+        // participate in complex virtual behavior.
         if (pMT == m_pDeclMT)
         {
             if (slot < nVirtuals)
             {
-                if (pBitVector == NULL || !pBitVector[slot])
+                if (pNullSlotBitvector == NULL || !IsBitVectorEntrySet(pNullSlotBitvector, slot))
                 {
+                    // We reach here if we 've disable the NullSlot optimization (due to an allocation failure),
+                    // or if the slot is not a NullSlot. This indicates that there is an implmentation of the slot, and so
+                    // the GetMethodDescForSlot_NoThrow api will operate in O(1) time (or we're in allocation failure case
+                    // and the performance implications are unimportant).)
                     if (m_containsMethodImpl)
+                    {
+                        // If there is a MethodImpl in the hierarchy, then we will need to skip the optimization of pre-resolving
+                        // MethodDesc resolution for this slot as MethodImpls may have caused complex virtual slot behavior.
                         continue;
+                    }
+
+                    // Fall through to SetEntryDataForSlotIfNotYetSet logic below
                 }
                 else
                 {
+                    // We reach here if the slot is a NullSlot which indicates that no complex virtual slot behavior is associated
+                    // with this slot, and that the method has never been called. Thus we should run the SetEntryDataForSlotIfNotYetSet logic.
                     _ASSERTE(unprocessedNonOverriddenSlots > 0);
-                    pBitVector[slot] = false;
+                    ClearBitVectorEntry(pNullSlotBitvector, slot);
                     unprocessedNonOverriddenSlots -= 1;
+
+                    // Fall through to SetEntryDataForSlotIfNotYetSet logic below
                 }
             }
 
+            // Filter out SetEntryDataForSlotIfNotYetSet calls for non-virtual methods when requested
             if (m_virtualsOnly && slot >= nVTableLikeSlots)
             {
                 _ASSERTE(!pMD->IsVirtual() || (pMT->IsValueType() && !pMD->IsUnboxingStub()));
@@ -6810,23 +6873,15 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
                 continue;
         }
 
-        MethodDataObjectEntry * pEntry = GetEntry(slot);
-
-        if (pEntry->GetDeclMethodDesc() == NULL)
-        {
-            pEntry->SetDeclMethodDesc(pMD);
-        }
-
-        if (pEntry->GetImplMethodDesc() == NULL)
-        {
-            pEntry->SetImplMethodDesc(pMD);
-        }
+        SetEntryDataForSlotIfNotYetSet(slot, pMD);
     }
 
+    // Walk the parent chain until we've processed all of the slots which have not been overriden/called by a subclass.
+    // NOTE: We only run this code for the top level FilEntryDataForAncestor case where (pMT == m_pDeclMT).
+    // This check is enforced by unprocessedNonOverriddenSlots only being non-zero in that scenario.
     while (unprocessedNonOverriddenSlots > 0)
     {
-        _ASSERTE(pBitVector != NULL);
-        _ASSERTE(unprocessedNonOverriddenSlots > 0);
+        _ASSERTE(pNullSlotBitvector != NULL);
         pMT = pMT->GetParentMethodTable();
         _ASSERTE(pMT != NULL);
         nVirtuals = pMT->GetNumVirtuals();
@@ -6842,28 +6897,15 @@ void MethodTable::MethodDataObject::FillEntryDataForAncestor(MethodTable * pMT)
             if (slot >= nVirtuals)
                 continue;
 
-            if (!pBitVector[slot])
+            if (!IsBitVectorEntrySet(pNullSlotBitvector, slot))
             {
                 continue;
             }
-            else
-            {
-                _ASSERTE(unprocessedNonOverriddenSlots > 0);
-                pBitVector[slot] = false;
-                unprocessedNonOverriddenSlots -= 1;
-            }
+            _ASSERTE(unprocessedNonOverriddenSlots > 0);
+            ClearBitVectorEntry(pNullSlotBitvector, slot);
+            unprocessedNonOverriddenSlots -= 1;
 
-            MethodDataObjectEntry * pEntry = GetEntry(slot);
-
-            if (pEntry->GetDeclMethodDesc() == NULL)
-            {
-                pEntry->SetDeclMethodDesc(pMD);
-            }
-
-            if (pEntry->GetImplMethodDesc() == NULL)
-            {
-                pEntry->SetImplMethodDesc(pMD);
-            }
+            SetEntryDataForSlotIfNotYetSet(slot, pMD);
         }
     }
 } // MethodTable::MethodDataObject::FillEntryDataForAncestor

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -1591,6 +1591,17 @@ public:
         return *GetSlotPtrRaw(slotNumber);
     }
 
+#ifndef DACCESS_COMPILE
+    PCODE GetSlotForVirtualVolatileLoadWithoutBarrier(UINT32 slotNum)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        CONSISTENCY_CHECK(slotNum < GetNumVirtuals());
+        // Virtual slots live in chunks pointed to by vtable indirections
+        return VolatileLoadWithoutBarrier(GetVtableIndirections()[GetIndexOfVtableIndirection(slotNum)] + GetIndexAfterVtableIndirection(slotNum));
+    }
+#endif // DACCESS_COMPILE
+
     // Special-case for when we know that the slot number corresponds
     // to a virtual method.
     inline PCODE GetSlotForVirtual(UINT32 slotNum)

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -3415,6 +3415,7 @@ protected:
             { LIMITED_METHOD_CONTRACT; CONSISTENCY_CHECK(i < GetNumMethods()); return GetEntryData() + i; }
 
         void FillEntryDataForAncestor(MethodTable *pMT);
+        void SetEntryDataForSlotIfNotYetSet(UINT32 i, MethodDesc *pMD);
 
         //
         // At the end of this object is an array


### PR DESCRIPTION
Optimize `MethodTable::MethodDataObject::FillEntryDataForAncestor` for MethodImpl hierarchies

## Problem

When an inheritance chain contains a MethodImpl, `FillEntryDataForAncestor` previously
stopped filling in the Decl/Impl `MethodDesc`s for **all** virtual slots (the
`if (m_containsMethodImpl && slot < nVirtuals) continue;` fast-bail). Consumers of the
resulting `MethodDataObject` then fall back to `MethodTable::GetMethodDescForSlot_NoThrow`,
which is `O(N)` in the number of methods defined in the type hierarchy. Because
`MethodDataObject` is itself typically walked `O(V)` times (once per virtual slot), the
fallback turns slot resolution into `O(V*N)`.

Types with deep hierarchies and MethodImpls — which are common in WPF — hit this quadratic
path repeatedly during startup type-loading. This is present in all .NET 10 releases and
affects WPF application startup (related to dotnet/wpf#11740).

## Fix

On the declaring `MethodTable`, scan the canonical `MethodTable`'s vtable and detect virtual
slots whose entry is `NULL`. A `NULL` canonical vtable entry means the method has never been
overridden or called and therefore **cannot** be the target of a MethodImpl, so its Decl/Impl
`MethodDesc`s can be filled directly — even when a MethodImpl exists elsewhere in the
hierarchy — by walking up the parent chain to the introducing type for those slots. The extra
work is only engaged when a MethodImpl actually exists in the hierarchy, so the common case is
unaffected.

A small `GetSlotForVirtualVolatileLoadWithoutBarrier` helper is added to `methodtable.h` to
read a canonical vtable slot without a memory barrier.

## Performance

Measured with a minimal WPF startup benchmark (empty window = *App1*; window with menu,
toolbar and a 50-row DataGrid = *App2*). Each app records `DateTime.Now - Process.StartTime`
at `ContentRendered`.

**Methodology (clean A/B — only `coreclr.dll` differs):** the change is entirely in the
native runtime, so `System.Private.CoreLib.dll`, all framework libraries, and the WPF
assemblies are byte-for-byte identical between the two configurations. Two `coreclr.dll`
binaries were produced from the same source tree — *baseline* (this change reverted) and
*modified* — and each was dropped into an otherwise identical framework-dependent
`net11.0-windows` runtime layout. 5 warmup + 40 measured interleaved iterations per
configuration; reported values are medians (robust to OS/GC scheduling outliers).

| App                              | Baseline median | Modified median | Improvement          |
|----------------------------------|-----------------|-----------------|----------------------|
| App1 (empty window)              | 919.6 ms        | 858.1 ms        | **−61.5 ms (−6.7%)** |
| App2 (menu + toolbar + DataGrid) | 1455.9 ms       | 1377.9 ms       | **−78.0 ms (−5.4%)** |

A prior run before the review edits showed the same effect (App1 −6.3%, App2 −5.1%),
confirming the result is stable.

**Note on absolute numbers:** these measurements use framework-dependent apps running on a
locally-built dev runtime, so the framework's ReadyToRun images (built for the preview
runtime) are invalidated against the dev `coreclr.dll` and fall back to JIT. This inflates
the absolute startup times relative to a shipping self-contained R2R build, but the change
targets type-loading (`MethodDataObject`) cost, which is independent of R2R — so the reported
delta is representative of the win real apps will see.

## Testing

Correctness is exercised by the existing type-loading test suite (any wrong Decl/Impl
resolution would surface broadly). Both benchmark apps run to completion (exit code 0) under
the modified runtime across all iterations.

---

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
