### PR TITLE
[Wasm/RyuJit] treat all try side-entries as try entries for throw helpers

### DIFF
--- a/src/coreclr/jit/fgwasm.h
+++ b/src/coreclr/jit/fgwasm.h
@@ -408,7 +408,6 @@ BasicBlockVisit FgWasm::VisitWasmSuccs(Compiler* comp, BasicBlock* block, TFunc 
     // True if this block is a try entry or a try side-entry.
     //
     auto isGeneralizedTryEntry = [comp](BasicBlock* block) -> bool {
-
         EHblkDsc* const ehDsc = comp->ehGetBlockTryDsc(block);
 
         if (ehDsc == nullptr)

--- a/src/coreclr/jit/fgwasm.h
+++ b/src/coreclr/jit/fgwasm.h
@@ -404,6 +404,34 @@ public:
 template <typename TFunc>
 BasicBlockVisit FgWasm::VisitWasmSuccs(Compiler* comp, BasicBlock* block, TFunc func, bool useProfile)
 {
+
+    // True if this block is a try entry or a try side-entry.
+    //
+    auto isGeneralizedTryEntry = [comp](BasicBlock* block) -> bool {
+
+        EHblkDsc* const ehDsc = comp->ehGetBlockTryDsc(block);
+
+        if (ehDsc == nullptr)
+        {
+            return false;
+        }
+
+        if (comp->bbIsTryBeg(block))
+        {
+            return true;
+        }
+
+        for (BasicBlock* const blockPred : block->PredBlocks())
+        {
+            if (blockPred->HasAnyFlag(BBF_ASYNC_RESUMPTION | BBF_CATCH_RESUMPTION))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
     // Special case throw helper blocks that are not yet connected in the flow graph.
     //
     Compiler::AddCodeDscMap* const acdMap = comp->fgGetAddCodeDscMap();
@@ -411,7 +439,7 @@ BasicBlockVisit FgWasm::VisitWasmSuccs(Compiler* comp, BasicBlock* block, TFunc 
     {
         // Behave as if these blocks have edges from their respective region entry blocks.
         //
-        if ((block == comp->fgFirstBB) || comp->bbIsFuncletBeg(block) || comp->bbIsTryBeg(block))
+        if ((block == comp->fgFirstBB) || comp->bbIsFuncletBeg(block) || isGeneralizedTryEntry(block))
         {
             Compiler::AcdKeyDesignator dsg;
             const unsigned             blockData = comp->bbThrowIndex(block, &dsg);


### PR DESCRIPTION
For Wasm DFS in graphs where try regions may have side entries (async), ensure the DFS will always eagerly visit (and hence first retreat from) any throw helper blocks in the region, no matter which entry is visited first by DFS.

This ensures the throw helper ends up last in the RPO and hence is reachable by a forward branch from anywhere in the region.