### PR TITLE
[cDAC] Fix `#130143` - search correct loader module for generic instantiations

### DIFF
--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -1168,11 +1168,7 @@ Contracts used:
         if (corElementType != CorElementType.FnPtr && typeHandle.Address == TargetPointer.Null)
             return new TypeHandle(TargetPointer.Null);
         ILoader loaderContract = _target.Contracts.Loader;
-        // Function pointer types may not be owned by the loader module of any single type argument,
-        // so they need their own loader-module selection.
-        TargetPointer loaderModule = corElementType == CorElementType.FnPtr
-            ? FindFnPtrLoaderModule(typeArguments)
-            : GetLoaderModule(typeHandle);
+        TargetPointer loaderModule = // see [link](https://github.com/dotnet/runtime/blob/e1979b72ccb5f916649f1d9949ef663254790c25/src/coreclr/vm/clsload.cpp#L78)
         ModuleHandle moduleHandle = loaderContract.GetModuleHandleFromModulePtr(loaderModule);
         TypeHandle potentialMatch = new TypeHandle(TargetPointer.Null);
         foreach (TargetPointer ptr in loaderContract.GetAvailableTypeParams(moduleHandle))
@@ -1198,15 +1194,6 @@ Contracts used:
             }
         }
         return new TypeHandle(TargetPointer.Null);
-    }
-
-    // Mirrors `ClassLoader::ComputeLoaderModuleForFunctionPointer`.
-    private TargetPointer FindFnPtrLoaderModule(ImmutableArray<TypeHandle> retAndArgTypes)
-    {
-        // The loader module of a
-        // function pointer type is the loader module of the collectible ret/arg type with the
-        // largest `LoaderAllocator::CreationNumber`, or CoreLib's loader module if none of the
-        // ret/arg types are collectible.
     }
 
     public TypeHandle GetPrimitiveType(CorElementType typeCode)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata.Ecma335;
 using Microsoft.Diagnostics.DataContractReader.RuntimeTypeSystemHelpers;
 using Microsoft.Diagnostics.DataContractReader.Data;
@@ -1268,7 +1269,9 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         ILoader loaderContract = _target.Contracts.Loader;
         TargetPointer loaderModule;
         if (corElementType == CorElementType.FnPtr)
-            loaderModule = FindFnPtrLoaderModule(typeArguments);
+            loaderModule = ComputeLoaderModule(TargetPointer.Null, typeArguments);
+        else if (corElementType == CorElementType.GenericInst)
+            loaderModule = ComputeLoaderModule(GetModule(typeHandle), typeArguments);
         else
             loaderModule = GetLoaderModule(typeHandle);
 
@@ -1302,52 +1305,75 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         return new TypeHandle(TargetPointer.Null);
     }
 
-    // Mirrors the native algorithm
-    // ClassLoader::ComputeLoaderModuleForFunctionPointer: the loader module is the collectible
-    // ret/arg type's loader module with the largest LoaderAllocator creation number, or CoreLib's
-    // loader module if none of the ret/arg types are collectible.
-    private TargetPointer FindFnPtrLoaderModule(ImmutableArray<TypeHandle> retAndArgTypes)
+    // See https://github.com/dotnet/runtime/blob/e1979b72ccb5f916649f1d9949ef663254790c25/src/coreclr/vm/clsload.cpp#L78
+    private TargetPointer ComputeLoaderModule(TargetPointer definitionModule, ImmutableArray<TypeHandle> inst)
     {
         ILoader loaderContract = _target.Contracts.Loader;
-
-        TargetPointer loaderModulePtr = TargetPointer.Null;
+        TargetPointer latestLoaderModule = TargetPointer.Null;
+        // Use the definition module as the loader module by default.
+        TargetPointer loaderModule = definitionModule;
         ulong latestFoundNumber = 0;
-        bool anyCollectible = false;
 
-        foreach (TypeHandle arg in retAndArgTypes)
+        if (TryGetCollectibleLoaderAllocator(definitionModule, out Data.LoaderAllocator? definitionLoaderAllocator))
+        {
+            latestLoaderModule = definitionModule;
+            latestFoundNumber = definitionLoaderAllocator.CreationNumber;
+        }
+
+        bool anyCollectible = false;
+        foreach (TypeHandle arg in inst)
         {
             if (arg.Address == TargetPointer.Null)
                 continue;
 
-            TargetPointer argModulePtr = GetLoaderModule(arg);
-            if (argModulePtr == TargetPointer.Null)
-                continue;
-
-            ModuleHandle argModuleHandle = loaderContract.GetModuleHandleFromModulePtr(argModulePtr);
-            TargetPointer argLoaderAllocator = loaderContract.GetLoaderAllocator(argModuleHandle);
-            if (argLoaderAllocator == TargetPointer.Null)
-                continue;
-
-            Data.LoaderAllocator loaderAllocator = _target.ProcessedData.GetOrAdd<Data.LoaderAllocator>(argLoaderAllocator);
-            if (!loaderAllocator.IsCollectible)
-                continue;
-
-            if (!anyCollectible || loaderAllocator.CreationNumber > latestFoundNumber)
+            TargetPointer argModule = GetLoaderModule(arg);
+            if (TryGetCollectibleLoaderAllocator(argModule, out Data.LoaderAllocator? argLoaderAllocator) &&
+                argLoaderAllocator.CreationNumber > latestFoundNumber)
             {
                 anyCollectible = true;
-                latestFoundNumber = loaderAllocator.CreationNumber;
-                loaderModulePtr = argModulePtr;
+                latestLoaderModule = argModule;
+                latestFoundNumber = argLoaderAllocator.CreationNumber;
             }
+            if (loaderModule == TargetPointer.Null)
+                loaderModule = argModule;
         }
 
         if (!anyCollectible)
         {
-            TargetPointer systemAssembly = loaderContract.GetSystemAssembly();
-            ModuleHandle coreLibModuleHandle = loaderContract.GetModuleHandleFromAssemblyPtr(systemAssembly);
-            loaderModulePtr = loaderContract.GetModule(coreLibModuleHandle);
+            if (loaderModule == TargetPointer.Null)
+            {
+                TargetPointer systemAssembly = loaderContract.GetSystemAssembly();
+                ModuleHandle coreLibModuleHandle = loaderContract.GetModuleHandleFromAssemblyPtr(systemAssembly);
+                loaderModule = loaderContract.GetModule(coreLibModuleHandle);
+            }
+            return loaderModule;
         }
 
-        return loaderModulePtr;
+        // If nothing was found, then by default we use the definition module.
+        if (latestLoaderModule != TargetPointer.Null)
+            loaderModule = latestLoaderModule;
+
+        return loaderModule;
+    }
+
+    private bool TryGetCollectibleLoaderAllocator(TargetPointer modulePtr, [NotNullWhen(true)] out Data.LoaderAllocator? loaderAllocator)
+    {
+        loaderAllocator = null;
+        if (modulePtr == TargetPointer.Null)
+            return false;
+
+        ILoader loaderContract = _target.Contracts.Loader;
+        ModuleHandle moduleHandle = loaderContract.GetModuleHandleFromModulePtr(modulePtr);
+        TargetPointer loaderAllocatorPtr = loaderContract.GetLoaderAllocator(moduleHandle);
+        if (loaderAllocatorPtr == TargetPointer.Null)
+            return false;
+
+        Data.LoaderAllocator candidate = _target.ProcessedData.GetOrAdd<Data.LoaderAllocator>(loaderAllocatorPtr);
+        if (!candidate.IsCollectible)
+            return false;
+
+        loaderAllocator = candidate;
+        return true;
     }
 
     TypeHandle IRuntimeTypeSystem.GetPrimitiveType(CorElementType typeCode)

--- a/src/native/managed/cdac/tests/DumpTests/CollectibleGenericInstDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/CollectibleGenericInstDumpTests.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
+
+/// <summary>
+/// Dump-based regression test for the RuntimeTypeSystem contract's
+/// <see cref="IRuntimeTypeSystem.GetConstructedType"/> loader-module computation.
+///
+/// The CollectibleGenericInst debuggee roots a <c>List&lt;CollectibleArg&gt;</c> whose
+/// type argument lives in a collectible <c>AssemblyLoadContext</c>. The runtime registers
+/// that instantiation in the collectible argument's loader module — not the generic
+/// definition's module — so resolving it requires computing the loader module from the
+/// type arguments (mirroring <c>ClassLoader::ComputeLoaderModuleWorker</c>). See
+/// dotnet/runtime#130143.
+/// </summary>
+public class CollectibleGenericInstDumpTests : DumpTestBase
+{
+    protected override string DebuggeeName => "CollectibleGenericInst";
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    public void GetConstructedType_ResolvesGenericInstWithCollectibleTypeArgument(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
+        IGC gc = Target.Contracts.GC;
+        IObject objectContract = Target.Contracts.Object;
+
+        // Find the List<CollectibleArg> instance rooted by the debuggee. It is the
+        // single-argument generic instantiation whose loader module differs from its
+        // definition module — the signature of a type argument from a collectible ALC.
+        TypeHandle constructed = default;
+        foreach (HandleData handle in gc.GetHandles([HandleType.Strong]))
+        {
+            TargetPointer objAddr = Target.ReadPointer(handle.Handle);
+            if (objAddr == TargetPointer.Null)
+                continue;
+
+            TypeHandle candidate = rts.GetTypeHandle(objectContract.GetMethodTableAddress(objAddr));
+            if (rts.GetInstantiation(candidate).Length == 1 &&
+                rts.GetModule(candidate) != rts.GetLoaderModule(candidate))
+            {
+                constructed = candidate;
+                break;
+            }
+        }
+
+        Assert.NotEqual(TargetPointer.Null, constructed.Address);
+
+        // Confirm the collectible scenario: the constructed type's loader module is the
+        // collectible argument's module, distinct from its (CoreLib) definition module.
+        Assert.NotEqual(rts.GetModule(constructed), rts.GetLoaderModule(constructed));
+
+        TypeHandle typeArgument = rts.GetInstantiation(constructed)[0];
+
+        // The open List<> definition lives in CoreLib; look it up by name.
+        TypeHandle listDefinition = Target.Contracts.ManagedTypeSource.GetTypeHandle(
+            "System.Collections.Generic.List`1");
+        Assert.NotEqual(TargetPointer.Null, listDefinition.Address);
+
+        // Reconstruct the instantiation. This must search the collectible argument's
+        // loader module — searching the definition's module (CoreLib) returns null.
+        TypeHandle resolved = rts.GetConstructedType(
+            listDefinition,
+            CorElementType.GenericInst,
+            0,
+            [typeArgument]);
+
+        Assert.Equal(constructed.Address, resolved.Address);
+    }
+}

--- a/src/native/managed/cdac/tests/DumpTests/CollectibleGenericInstDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/CollectibleGenericInstDumpTests.cs
@@ -43,7 +43,8 @@ public class CollectibleGenericInstDumpTests : DumpTestBase
 
             TypeHandle candidate = rts.GetTypeHandle(objectContract.GetMethodTableAddress(objAddr));
             if (rts.GetInstantiation(candidate).Length == 1 &&
-                rts.GetModule(candidate) != rts.GetLoaderModule(candidate))
+                rts.GetModule(candidate) != rts.GetLoaderModule(candidate) &&
+                rts.IsCollectible(candidate))
             {
                 constructed = candidate;
                 break;

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/CollectibleGenericInst/CollectibleGenericInst.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/CollectibleGenericInst/CollectibleGenericInst.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DumpTypes>Heap</DumpTypes>
+  </PropertyGroup>
+</Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/CollectibleGenericInst/Program.cs
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/CollectibleGenericInst/Program.cs
@@ -48,6 +48,5 @@ internal static class Program
     // Loaded into a collectible ALC and used as the type argument of List<>.
     public class CollectibleArg
     {
-        public int Value;
     }
 }

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/CollectibleGenericInst/Program.cs
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/CollectibleGenericInst/Program.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+
+/// <summary>
+/// Debuggee for cDAC dump tests — exercises the RuntimeTypeSystem contract's
+/// <c>GetConstructedType</c> loader-module computation for a generic instantiation
+/// whose type argument lives in a collectible <see cref="AssemblyLoadContext"/>.
+///
+/// The runtime assigns such an instantiation to the loader module of the collectible
+/// argument (not the generic definition's module), so the constructed type is
+/// registered in that module's <c>AvailableParamTypes</c> table. This guards the
+/// regression where cDAC searched the definition's module instead.
+///
+/// Loads a copy of this assembly into a collectible ALC, takes a type from it,
+/// constructs <c>List&lt;CollectibleArg&gt;</c> over that type, roots the instance
+/// through a GC handle, then crashes.
+/// </summary>
+internal static class Program
+{
+    private static void Main()
+    {
+        AssemblyLoadContext alc = new("cdac-collectible-alc", isCollectible: true);
+
+        byte[] assemblyBytes = File.ReadAllBytes(typeof(Program).Assembly.Location);
+        Assembly collectibleAssembly = alc.LoadFromStream(new MemoryStream(assemblyBytes));
+
+        Type collectibleArgType = collectibleAssembly.GetType(typeof(CollectibleArg).FullName!)!;
+        Type listType = typeof(List<>).MakeGenericType(collectibleArgType);
+        object genericInstance = Activator.CreateInstance(listType)!;
+
+        GCHandle handle = GCHandle.Alloc(genericInstance, GCHandleType.Normal);
+
+        GC.KeepAlive(alc);
+        GC.KeepAlive(collectibleAssembly);
+        GC.KeepAlive(genericInstance);
+        GC.KeepAlive(handle);
+
+        Environment.FailFast("cDAC dump test: CollectibleGenericInst debuggee intentional crash");
+    }
+
+    // Loaded into a collectible ALC and used as the type argument of List<>.
+    public class CollectibleArg
+    {
+        public int Value;
+    }
+}

--- a/src/native/managed/cdac/tests/DumpTests/README.md
+++ b/src/native/managed/cdac/tests/DumpTests/README.md
@@ -42,6 +42,7 @@ features and then calls `Environment.FailFast()` to produce a crash dump.
 | ExceptionHandlingInfo | EH clause reading test | Heap |
 | LocalVariables | Info about local variables | Heap |
 | AsyncContinuation | Reading async continuation method tables | Heap |
+| CollectibleGenericInst | Generic instantiation with a type argument from a collectible ALC | Heap |
 
 The dump type is configured per-debuggee via the `DumpTypes` property in each debuggee's
 `.csproj` (default: `Heap`, set in `Debuggees/Directory.Build.props`). Debuggees that
@@ -69,6 +70,7 @@ use. Tests are `[ConditionalTheory]` methods parameterized by `TestConfiguration
 | RCWCleanupListDumpTests | BuiltInCOM | RCWCleanupList |
 | RCWDumpTests | BuiltInCOM | RCW |
 | ComWrappersDumpTests | ComWrappers | ComWrappers |
+| CollectibleGenericInstDumpTests | RuntimeTypeSystem | CollectibleGenericInst |
 
 ### Runtime Versions
 


### PR DESCRIPTION
Implement correct loader module lookup algorithm in `GetConstructedType`. Fixes #130143.