### PR TITLE
JIT: Enable tail await optimization in async versions in tier 0

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -7290,7 +7290,7 @@ void Compiler::impSetupAsyncCall(
     }
     else
     {
-        if (opts.OptimizationEnabled() && ((prefixFlags & PREFIX_IS_ASYNC_VERSION_TAIL_AWAIT) != 0) &&
+        if (opts.Tier0OptimizationEnabled() && ((prefixFlags & PREFIX_IS_ASYNC_VERSION_TAIL_AWAIT) != 0) &&
             (call->gtReturnType == info.compRetType))
         {
             CORINFO_METHOD_HANDLE exactCalleeHnd =


### PR DESCRIPTION
Otherwise we will allocate continuations for paths that are going to be allocation free in tier 1. This shows up in traces when running TechEmpower benchmarks as a large amount of allocation happening until everything gets tiered up.

Diff on alloc metrics on platform-json:
```diff
-| Max Allocation Rate (B/sec)             | 110,580,952                             |
+| Max Allocation Rate (B/sec)             | 8,030,616                               |
```

FYI @BrennanConroy 