### PR TITLE
JIT: initialize emitCurIG at declaration

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2818,7 +2818,7 @@ public:
     bool emitChkAlign; // perform some alignment checks
 #endif
 
-    insGroup* emitCurIG;
+    insGroup* emitCurIG = nullptr;
 
     void emitSetShortJump(instrDescJmp* id);
     void emitSetMediumJump(instrDescJmp* id);


### PR DESCRIPTION
The RISC-V emitter has cost-estimation calls into `emitLoadImmediate` from `gtSetEvalOrder` that hit the new `emitGeneratingPrologOrFuncletProlog` check before codegen runs `emitter::Init()`, reading a poisoned `emitCurIG` and crashing (SIGSEGV in `emitIGisInProlog(ig=0xdddddddddddddddd)`).

Fixes #130145.

Verified locally by reproducing the CI failure with an x64-host RISC-V cross-JIT on `ilc @ilc.ilc.rsp`: prior to this change, exits 139 with a coredump whose stack is `emitIGisInProlog(0xdddd...) <- emitGeneratingPrologOrFuncletProlog <- emitLoadImmediate<false> <- gtSetEvalOrder <- fgFindOperOrder <- compCompile` while JITing `System.DateTimeOffset:ToString()`. With this change, `ilc` produces the RISC-V `ilc.o` and exits 0.

> [!NOTE]
> AI-assisted PR created via GitHub Copilot CLI.
