### PR TITLE
JIT: RBO can now infer nested isinst outcomes from class relationships

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8300,6 +8300,7 @@ public:
     bool          optRelopTryInferWithOneEqualOperand(const VNFuncApp&      domApp,
                                                       const VNFuncApp&      treeApp,
                                                       RelopImplicationInfo* rii);
+    bool          optRelopTryInferFromTypeCheck(const VNFuncApp& domApp, RelopImplicationInfo* rii);
 
     /**************************************************************************
      *               Value/Assertion propagation

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -820,11 +820,26 @@ bool Compiler::optRelopTryInferFromTypeCheck(const VNFuncApp& domApp, RelopImpli
     // Ask the EE: if runtime type is-a domCls, is it also is-a treeCls?
     // Must    -> yes for every subtype of domCls  -> tree IsInstanceOf(treeCls, obj) is non-null.
     // MustNot -> no  for every subtype of domCls  -> tree IsInstanceOf(treeCls, obj) is null.
-    //   ...BUT: IDynamicInterfaceCastable lets an object dynamically claim to satisfy an
-    //   interface cast that its static type hierarchy would say MustNot. Restrict the
-    //   MustNot inference to non-interface tree targets. Must is safe: static inheritance
-    //   can't be removed by IDCC.
     // May -> ambiguous.
+    //
+    // BUT: `compareTypesForCast` answers CanCastTo(domCls, treeCls). That is designed for
+    // downcast folding, not for reasoning about arbitrary objects satisfying an isinst on
+    // the two class handles:
+    //   * treeCls interface: an object could dynamically claim to implement treeCls via
+    //     IDynamicInterfaceCastable even if the static type hierarchy would say MustNot.
+    //   * domCls interface: an object where `isinst(domCls, obj)` succeeded can have any
+    //     runtime type that implements domCls; unrelated classes could still implement it,
+    //     so a MustNot answer over the two class handles is not a proof about the object.
+    //   * treeCls derives from domCls: CanCastTo(domCls, treeCls) is false so the EE
+    //     returns MustNot, but the object could be a treeCls (a subclass of domCls) and
+    //     hence `isinst(treeCls, obj)` may succeed. So MustNot inference is unsound here.
+    // Must inference (domCls derives from treeCls) is safe: subclasses of domCls all
+    // derive from treeCls too, and IDCC cannot make a subclass "not implement" a class.
+    const unsigned domClsAttribs   = info.compCompHnd->getClassAttribs(domCls);
+    const unsigned treeClsAttribs  = info.compCompHnd->getClassAttribs(treeCls);
+    const bool     domIsInterface  = (domClsAttribs & CORINFO_FLG_INTERFACE) != 0;
+    const bool     treeIsInterface = (treeClsAttribs & CORINFO_FLG_INTERFACE) != 0;
+
     TypeCompareState const castResult = info.compCompHnd->compareTypesForCast(domCls, treeCls);
     if (castResult == TypeCompareState::May)
     {
@@ -833,8 +848,17 @@ bool Compiler::optRelopTryInferFromTypeCheck(const VNFuncApp& domApp, RelopImpli
 
     if (castResult == TypeCompareState::MustNot)
     {
-        const unsigned treeClsAttribs = info.compCompHnd->getClassAttribs(treeCls);
-        if ((treeClsAttribs & CORINFO_FLG_INTERFACE) != 0)
+        // Reject when either side is an interface (see comment above).
+        if (domIsInterface || treeIsInterface)
+        {
+            return false;
+        }
+
+        // Reject when treeCls derives from domCls: an object of runtime type treeCls is
+        // also a domCls, so `isinst(domCls, obj)` succeeds while `isinst(treeCls, obj)`
+        // may also succeed. Detected by asking the reverse cast.
+        TypeCompareState const reverseCast = info.compCompHnd->compareTypesForCast(treeCls, domCls);
+        if (reverseCast != TypeCompareState::MustNot)
         {
             return false;
         }
@@ -872,6 +896,7 @@ bool Compiler::optRelopTryInferFromTypeCheck(const VNFuncApp& domApp, RelopImpli
             "compareTypesForCast(dom, tree) = %s, canInferFromTrue = %s, canInferFromFalse = %s, reverseSense = %s\n",
             (castResult == TypeCompareState::Must) ? "Must" : "MustNot", rii->canInferFromTrue ? "true" : "false",
             rii->canInferFromFalse ? "true" : "false", rii->reverseSense ? "true" : "false");
+
     return true;
 }
 

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -501,6 +501,16 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
         }
     }
 
+    // See if dominating and tree compares are both of the form
+    //   EQ/NE(VNF_IsInstanceOf(clsA, obj), null)
+    // with the same object VN. Then we can infer the tree's value from the
+    // relationship between the two class handles.
+    //
+    if (optRelopTryInferFromTypeCheck(domApp, rii))
+    {
+        return;
+    }
+
     // See if dominating compare is a compound comparison that might
     // tell us the value of the tree compare.
     //
@@ -711,6 +721,155 @@ bool Compiler::optRelopTryInferWithOneEqualOperand(const VNFuncApp&      domApp,
     rii->canInferFromTrue  = (ifTrueStatus != RelopResult::Unknown);
     rii->canInferFromFalse = (ifFalseStatus != RelopResult::Unknown);
     rii->reverseSense      = (ifFalseStatus == RelopResult::AlwaysTrue) || (ifTrueStatus == RelopResult::AlwaysFalse);
+    return true;
+}
+
+//------------------------------------------------------------------------
+// optRelopTryInferFromTypeCheck: infer the tree relop's value when both
+//   dom and tree relops compare a VNF_IsInstanceOf against null on the
+//   same object VN, using the class-handle relationship.
+//
+// Arguments:
+//   domApp - The dominating relop's VN func app
+//   rii    - [in/out] struct with relop implication information
+//            (rii->treeNormVN is the tree relop's VN)
+//
+// Returns:
+//   True if we set canInfer.
+//
+// Recognizes:
+//     dom:  EQ/NE(VNF_IsInstanceOf(clsA, obj), null)
+//    tree:  EQ/NE(VNF_IsInstanceOf(clsB, obj), null)
+//
+// If compareTypesForCast(clsA, clsB) is Must:  dom-true implies tree-true.
+// If it is MustNot:                            dom-true implies tree-false.
+//
+bool Compiler::optRelopTryInferFromTypeCheck(const VNFuncApp& domApp, RelopImplicationInfo* rii)
+{
+    // Both dom and tree must be EQ or NE.
+    genTreeOps const domOper = genTreeOps(domApp.GetFunc());
+    if (!GenTree::StaticOperIs(domOper, GT_EQ, GT_NE))
+    {
+        return false;
+    }
+
+    VNFuncApp treeApp;
+    if (!vnStore->GetVNFunc(rii->treeNormVN, &treeApp))
+    {
+        return false;
+    }
+
+    genTreeOps const treeOper = genTreeOps(treeApp.GetFunc());
+    if (!GenTree::StaticOperIs(treeOper, GT_EQ, GT_NE))
+    {
+        return false;
+    }
+
+    // Canonicalize: put the (potentially) IsInstanceOf side on arg 0 and null side on arg 1.
+    auto extractIsInst = [this](const VNFuncApp& app, ValueNum* clsVN, ValueNum* objVN) -> bool {
+        for (unsigned side = 0; side < 2; side++)
+        {
+            ValueNum lhs = app.GetArg(side);
+            ValueNum rhs = app.GetArg(1 - side);
+
+            if (rhs != vnStore->VNForNull())
+            {
+                continue;
+            }
+
+            VNFuncApp isInstApp;
+            if (vnStore->GetVNFunc(lhs, &isInstApp) && (isInstApp.GetFunc() == VNF_IsInstanceOf))
+            {
+                *clsVN = isInstApp.GetArg(0);
+                *objVN = isInstApp.GetArg(1);
+                return true;
+            }
+        }
+        return false;
+    };
+
+    ValueNum domClsVN;
+    ValueNum domObjVN;
+    ValueNum treeClsVN;
+    ValueNum treeObjVN;
+    if (!extractIsInst(domApp, &domClsVN, &domObjVN) || !extractIsInst(treeApp, &treeClsVN, &treeObjVN))
+    {
+        return false;
+    }
+
+    // Must be on the same object VN.
+    if (domObjVN != treeObjVN)
+    {
+        return false;
+    }
+
+    // Same class handle - direct VN match should have handled this; be defensive.
+    if (domClsVN == treeClsVN)
+    {
+        return false;
+    }
+
+    // Both class-handle VNs must be constant type handles we can extract.
+    if (!vnStore->IsVNTypeHandle(domClsVN) || !vnStore->IsVNTypeHandle(treeClsVN))
+    {
+        return false;
+    }
+
+    CORINFO_CLASS_HANDLE domCls  = NO_CLASS_HANDLE;
+    CORINFO_CLASS_HANDLE treeCls = NO_CLASS_HANDLE;
+    if (!vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(domClsVN), (ssize_t*)&domCls) ||
+        !vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(treeClsVN), (ssize_t*)&treeCls))
+    {
+        return false;
+    }
+
+    if ((domCls == NO_CLASS_HANDLE) || (treeCls == NO_CLASS_HANDLE))
+    {
+        return false;
+    }
+
+    // Ask the EE: if runtime type is-a domCls, is it also is-a treeCls?
+    // Must    -> yes for every subtype of domCls  -> tree IsInstanceOf(treeCls, obj) is non-null.
+    // MustNot -> no  for every subtype of domCls  -> tree IsInstanceOf(treeCls, obj) is null.
+    // May     -> ambiguous.
+    TypeCompareState const castResult = info.compCompHnd->compareTypesForCast(domCls, treeCls);
+    if (castResult == TypeCompareState::May)
+    {
+        return false;
+    }
+
+    // Translate to the {canInferFromTrue, canInferFromFalse, reverseSense} tuple used by RBO.
+    //
+    //   dom relop = "EQ(IsInst(A,obj), null)"  is true  when "obj is NOT A"
+    //   dom relop = "NE(IsInst(A,obj), null)"  is true  when "obj is A"
+    //  tree relop = "EQ(IsInst(B,obj), null)"  is true  when "obj is NOT B"
+    //  tree relop = "NE(IsInst(B,obj), null)"  is true  when "obj is B"
+    //
+    // We can only infer the tree relop's value when the dominating path establishes
+    // "obj is A" (i.e., when the dom relop is true and domOper == NE, or when the dom
+    // relop is false and domOper == EQ). Under "obj is A", "obj is B" equals the
+    // castResult == Must outcome, so the tree relop's semantic value is
+    // (objIsB == treeTrueMeansObjIsB).
+    //
+    // The RBO consumer of `reverseSense` applies:
+    //   relopValue = !reverseSense  when using canInferFromTrue  (dom relop is true)
+    //   relopValue =  reverseSense  when using canInferFromFalse (dom relop is false)
+    // so we set reverseSense accordingly.
+    //
+    bool const treeTrueMeansObjIsB  = (treeOper == GT_NE);
+    bool const objIsB               = (castResult == TypeCompareState::Must);
+    bool const treeValueUnderObjIsA = (objIsB == treeTrueMeansObjIsB);
+
+    rii->canInfer          = true;
+    rii->vnRelation        = ValueNumStore::VN_RELATION_KIND::VRK_Inferred;
+    rii->canInferFromTrue  = (domOper == GT_NE);
+    rii->canInferFromFalse = (domOper == GT_EQ);
+    rii->reverseSense      = (domOper == GT_NE) ? !treeValueUnderObjIsA : treeValueUnderObjIsA;
+
+    JITDUMP("Can infer tree IsInstanceOf outcome from dominating IsInstanceOf: "
+            "compareTypesForCast(dom, tree) = %s, canInferFromTrue = %s, canInferFromFalse = %s, reverseSense = %s\n",
+            (castResult == TypeCompareState::Must) ? "Must" : "MustNot", rii->canInferFromTrue ? "true" : "false",
+            rii->canInferFromFalse ? "true" : "false", rii->reverseSense ? "true" : "false");
     return true;
 }
 

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -810,20 +810,9 @@ bool Compiler::optRelopTryInferFromTypeCheck(const VNFuncApp& domApp, RelopImpli
     }
 
     // Both class-handle VNs must be constant type handles we can extract.
-    if (!vnStore->IsVNTypeHandle(domClsVN) || !vnStore->IsVNTypeHandle(treeClsVN))
-    {
-        return false;
-    }
-
     CORINFO_CLASS_HANDLE domCls  = NO_CLASS_HANDLE;
     CORINFO_CLASS_HANDLE treeCls = NO_CLASS_HANDLE;
-    if (!vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(domClsVN), (ssize_t*)&domCls) ||
-        !vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(treeClsVN), (ssize_t*)&treeCls))
-    {
-        return false;
-    }
-
-    if ((domCls == NO_CLASS_HANDLE) || (treeCls == NO_CLASS_HANDLE))
+    if (!vnStore->IsVNTypeHandle(domClsVN, &domCls) || !vnStore->IsVNTypeHandle(treeClsVN, &treeCls))
     {
         return false;
     }
@@ -831,11 +820,24 @@ bool Compiler::optRelopTryInferFromTypeCheck(const VNFuncApp& domApp, RelopImpli
     // Ask the EE: if runtime type is-a domCls, is it also is-a treeCls?
     // Must    -> yes for every subtype of domCls  -> tree IsInstanceOf(treeCls, obj) is non-null.
     // MustNot -> no  for every subtype of domCls  -> tree IsInstanceOf(treeCls, obj) is null.
-    // May     -> ambiguous.
+    //   ...BUT: IDynamicInterfaceCastable lets an object dynamically claim to satisfy an
+    //   interface cast that its static type hierarchy would say MustNot. Restrict the
+    //   MustNot inference to non-interface tree targets. Must is safe: static inheritance
+    //   can't be removed by IDCC.
+    // May -> ambiguous.
     TypeCompareState const castResult = info.compCompHnd->compareTypesForCast(domCls, treeCls);
     if (castResult == TypeCompareState::May)
     {
         return false;
+    }
+
+    if (castResult == TypeCompareState::MustNot)
+    {
+        const unsigned treeClsAttribs = info.compCompHnd->getClassAttribs(treeCls);
+        if ((treeClsAttribs & CORINFO_FLG_INTERFACE) != 0)
+        {
+            return false;
+        }
     }
 
     // Translate to the {canInferFromTrue, canInferFromFalse, reverseSense} tuple used by RBO.

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -741,8 +741,10 @@ bool Compiler::optRelopTryInferWithOneEqualOperand(const VNFuncApp&      domApp,
 //     dom:  EQ/NE(VNF_IsInstanceOf(clsA, obj), null)
 //    tree:  EQ/NE(VNF_IsInstanceOf(clsB, obj), null)
 //
-// If compareTypesForCast(clsA, clsB) is Must:  dom-true implies tree-true.
-// If it is MustNot:                            dom-true implies tree-false.
+// Uses compareTypesForCast in both directions to infer whichever holds:
+//   * clsA derives from clsB     : obj is-a clsA implies obj is-a clsB.
+//   * clsB derives from clsA     : obj is-NOT-a clsA implies obj is-NOT-a clsB.
+//   * clsA and clsB unrelated    : obj is-a clsA implies obj is-NOT-a clsB.
 //
 bool Compiler::optRelopTryInferFromTypeCheck(const VNFuncApp& domApp, RelopImplicationInfo* rii)
 {
@@ -817,85 +819,102 @@ bool Compiler::optRelopTryInferFromTypeCheck(const VNFuncApp& domApp, RelopImpli
         return false;
     }
 
-    // Ask the EE: if runtime type is-a domCls, is it also is-a treeCls?
-    // Must    -> yes for every subtype of domCls  -> tree IsInstanceOf(treeCls, obj) is non-null.
-    // MustNot -> no  for every subtype of domCls  -> tree IsInstanceOf(treeCls, obj) is null.
-    // May -> ambiguous.
+    // Ask the EE how the two class handles relate. `compareTypesForCast(A, B)` answers
+    // CanCastTo(A, B), i.e., "does A derive from / implement B?". We combine forward and
+    // reverse queries to figure out which "obj is-a" implication is sound:
     //
-    // BUT: `compareTypesForCast` answers CanCastTo(domCls, treeCls). That is designed for
-    // downcast folding, not for reasoning about arbitrary objects satisfying an isinst on
-    // the two class handles:
-    //   * treeCls interface: an object could dynamically claim to implement treeCls via
-    //     IDynamicInterfaceCastable even if the static type hierarchy would say MustNot.
-    //   * domCls interface: an object where `isinst(domCls, obj)` succeeded can have any
-    //     runtime type that implements domCls; unrelated classes could still implement it,
-    //     so a MustNot answer over the two class handles is not a proof about the object.
-    //   * treeCls derives from domCls: CanCastTo(domCls, treeCls) is false so the EE
-    //     returns MustNot, but the object could be a treeCls (a subclass of domCls) and
-    //     hence `isinst(treeCls, obj)` may succeed. So MustNot inference is unsound here.
-    // Must inference (domCls derives from treeCls) is safe: subclasses of domCls all
-    // derive from treeCls too, and IDCC cannot make a subclass "not implement" a class.
+    //   forwardCast == Must:                   domCls derives from treeCls.
+    //                                            obj is-a domCls -> obj is-a treeCls.
+    //   forwardCast, reverseCast == MustNot:   domCls and treeCls are unrelated types.
+    //                                            obj is-a domCls -> obj is-NOT-a treeCls.
+    //                                            (Sound only for non-interface classes:
+    //                                            interfaces can be co-implemented, and a
+    //                                            treeCls interface is subject to IDCC.)
+    //   reverseCast == Must:                   treeCls derives from domCls.
+    //                                            obj is-a treeCls -> obj is-a domCls, so
+    //                                            (contrapositive) obj is-NOT-a domCls ->
+    //                                            obj is-NOT-a treeCls. (Sound if treeCls is
+    //                                            not an interface: IDCC could otherwise make
+    //                                            an unrelated object claim to be treeCls.)
+    //
+    // The Must case gives us information when the dom relop asserts "obj is-a domCls";
+    // the reverseCast==Must case gives us information when it asserts "obj is-NOT-a domCls".
+    //
     const unsigned domClsAttribs   = info.compCompHnd->getClassAttribs(domCls);
     const unsigned treeClsAttribs  = info.compCompHnd->getClassAttribs(treeCls);
     const bool     domIsInterface  = (domClsAttribs & CORINFO_FLG_INTERFACE) != 0;
     const bool     treeIsInterface = (treeClsAttribs & CORINFO_FLG_INTERFACE) != 0;
 
-    TypeCompareState const castResult = info.compCompHnd->compareTypesForCast(domCls, treeCls);
-    if (castResult == TypeCompareState::May)
-    {
-        return false;
-    }
+    TypeCompareState const forwardCast = info.compCompHnd->compareTypesForCast(domCls, treeCls);
+    TypeCompareState const reverseCast = info.compCompHnd->compareTypesForCast(treeCls, domCls);
 
-    if (castResult == TypeCompareState::MustNot)
+    // Pick the sound inference direction, if any.
+    //
+    //   inferredCondIsObjIsA:  true if the inference applies when "obj is-a domCls",
+    //                          false if it applies when "obj is-NOT-a domCls".
+    //   objIsBUnderCond:       value of "obj is-a treeCls" under that condition.
+    //
+    bool inferredCondIsObjIsA;
+    bool objIsBUnderCond;
+
+    if (forwardCast == TypeCompareState::Must)
     {
-        // Reject when either side is an interface (see comment above).
+        inferredCondIsObjIsA = true;
+        objIsBUnderCond      = true;
+    }
+    else if ((forwardCast == TypeCompareState::MustNot) && (reverseCast == TypeCompareState::MustNot))
+    {
         if (domIsInterface || treeIsInterface)
         {
             return false;
         }
-
-        // Reject when treeCls derives from domCls: an object of runtime type treeCls is
-        // also a domCls, so `isinst(domCls, obj)` succeeds while `isinst(treeCls, obj)`
-        // may also succeed. Detected by asking the reverse cast.
-        TypeCompareState const reverseCast = info.compCompHnd->compareTypesForCast(treeCls, domCls);
-        if (reverseCast != TypeCompareState::MustNot)
+        inferredCondIsObjIsA = true;
+        objIsBUnderCond      = false;
+    }
+    else if (reverseCast == TypeCompareState::Must)
+    {
+        if (treeIsInterface)
         {
             return false;
         }
+        inferredCondIsObjIsA = false;
+        objIsBUnderCond      = false;
+    }
+    else
+    {
+        return false;
     }
 
     // Translate to the {canInferFromTrue, canInferFromFalse, reverseSense} tuple used by RBO.
     //
-    //   dom relop = "EQ(IsInst(A,obj), null)"  is true  when "obj is NOT A"
-    //   dom relop = "NE(IsInst(A,obj), null)"  is true  when "obj is A"
-    //  tree relop = "EQ(IsInst(B,obj), null)"  is true  when "obj is NOT B"
-    //  tree relop = "NE(IsInst(B,obj), null)"  is true  when "obj is B"
+    //   dom relop = "EQ(IsInst(A,obj), null)" is true  when "obj is NOT A" and false when "obj is A"
+    //   dom relop = "NE(IsInst(A,obj), null)" is true  when "obj is A"     and false when "obj is NOT A"
+    //  tree relop = "EQ(IsInst(B,obj), null)" is true  when "obj is NOT B" and false when "obj is B"
+    //  tree relop = "NE(IsInst(B,obj), null)" is true  when "obj is B"     and false when "obj is NOT B"
     //
-    // We can only infer the tree relop's value when the dominating path establishes
-    // "obj is A" (i.e., when the dom relop is true and domOper == NE, or when the dom
-    // relop is false and domOper == EQ). Under "obj is A", "obj is B" equals the
-    // castResult == Must outcome, so the tree relop's semantic value is
-    // (objIsB == treeTrueMeansObjIsB).
-    //
-    // The RBO consumer of `reverseSense` applies:
+    // The RBO consumer applies:
     //   relopValue = !reverseSense  when using canInferFromTrue  (dom relop is true)
     //   relopValue =  reverseSense  when using canInferFromFalse (dom relop is false)
     // so we set reverseSense accordingly.
     //
+    bool const condHoldsWhenDomTrue = inferredCondIsObjIsA ? (domOper == GT_NE) : (domOper == GT_EQ);
     bool const treeTrueMeansObjIsB  = (treeOper == GT_NE);
-    bool const objIsB               = (castResult == TypeCompareState::Must);
-    bool const treeValueUnderObjIsA = (objIsB == treeTrueMeansObjIsB);
+    bool const treeValueUnderCond   = (objIsBUnderCond == treeTrueMeansObjIsB);
 
     rii->canInfer          = true;
     rii->vnRelation        = ValueNumStore::VN_RELATION_KIND::VRK_Inferred;
-    rii->canInferFromTrue  = (domOper == GT_NE);
-    rii->canInferFromFalse = (domOper == GT_EQ);
-    rii->reverseSense      = (domOper == GT_NE) ? !treeValueUnderObjIsA : treeValueUnderObjIsA;
+    rii->canInferFromTrue  = condHoldsWhenDomTrue;
+    rii->canInferFromFalse = !condHoldsWhenDomTrue;
+    rii->reverseSense      = condHoldsWhenDomTrue ? !treeValueUnderCond : treeValueUnderCond;
 
-    JITDUMP("Can infer tree IsInstanceOf outcome from dominating IsInstanceOf: "
-            "compareTypesForCast(dom, tree) = %s, canInferFromTrue = %s, canInferFromFalse = %s, reverseSense = %s\n",
-            (castResult == TypeCompareState::Must) ? "Must" : "MustNot", rii->canInferFromTrue ? "true" : "false",
-            rii->canInferFromFalse ? "true" : "false", rii->reverseSense ? "true" : "false");
+    JITDUMP("Can infer tree IsInstanceOf outcome from dominating IsInstanceOf: forwardCast = %s, "
+            "reverseCast = %s, canInferFromTrue = %s, canInferFromFalse = %s, reverseSense = %s\n",
+            (forwardCast == TypeCompareState::Must) ? "Must"
+                                                    : ((forwardCast == TypeCompareState::MustNot) ? "MustNot" : "May"),
+            (reverseCast == TypeCompareState::Must) ? "Must"
+                                                    : ((reverseCast == TypeCompareState::MustNot) ? "MustNot" : "May"),
+            rii->canInferFromTrue ? "true" : "false", rii->canInferFromFalse ? "true" : "false",
+            rii->reverseSense ? "true" : "false");
 
     return true;
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_97581/Runtime_97581.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_97581/Runtime_97581.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Regression tests for https://github.com/dotnet/runtime/issues/97581:
+// Redundant Branch Opts should recognize when a dominating `is` check tells
+// it something about a nested `is` check on the same object via class-handle
+// relationships (compareTypesForCast returning Must or MustNot).
+
+namespace Runtime_97581;
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+file class Program1 {}
+file class Program2 {}
+file class Derived1 : Program1 {}
+
+public class Runtime_97581
+{
+    // Unrelated types: (o is Program1) -> (o is Program2) is always false.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int MustNotEqTree(object o)
+    {
+        if (o is Program1)
+        {
+            if (o is Program2) return 1;
+            return 2;
+        }
+        return 3;
+    }
+
+    // Same pattern, opposite tree relop (NE instead of EQ).
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int MustNotNeTree(object o)
+    {
+        if (o is Program1)
+        {
+            if (!(o is Program2)) return 1;
+            return 2;
+        }
+        return 3;
+    }
+
+    // Derived -> Base always holds: (o is Derived1) implies (o is Program1) true.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int MustEqTree(object o)
+    {
+        if (o is Derived1)
+        {
+            if (o is Program1) return 1;
+            return 2;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int MustNeTree(object o)
+    {
+        if (o is Derived1)
+        {
+            if (!(o is Program1)) return 1;
+            return 2;
+        }
+        return 3;
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        var p1  = new Program1();
+        var p2  = new Program2();
+        var d1  = new Derived1();
+        object str = "hello";
+
+        if (MustNotEqTree(p1)  != 2) return 101;
+        if (MustNotEqTree(p2)  != 3) return 102;
+        if (MustNotEqTree(str) != 3) return 103;
+        if (MustNotEqTree(d1)  != 2) return 104;
+
+        if (MustNotNeTree(p1)  != 1) return 111;
+        if (MustNotNeTree(p2)  != 3) return 112;
+        if (MustNotNeTree(d1)  != 1) return 114;
+
+        if (MustEqTree(d1)  != 1) return 121;
+        if (MustEqTree(p1)  != 3) return 122;
+        if (MustEqTree(str) != 3) return 123;
+
+        if (MustNeTree(d1)  != 2) return 131;
+        if (MustNeTree(p1)  != 3) return 132;
+
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_97581/Runtime_97581.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_97581/Runtime_97581.cs
@@ -8,12 +8,25 @@
 
 namespace Runtime_97581;
 
+using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 file class Program1 {}
 file class Program2 {}
 file class Derived1 : Program1 {}
+
+file interface IFoo {}
+
+file class DcastToIFoo : IDynamicInterfaceCastable
+{
+    bool IDynamicInterfaceCastable.IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
+        => interfaceType.Equals(typeof(IFoo).TypeHandle);
+    RuntimeTypeHandle IDynamicInterfaceCastable.GetInterfaceImplementation(RuntimeTypeHandle interfaceType) =>
+        throw new InvalidOperationException();
+}
 
 public class Runtime_97581
 {
@@ -64,6 +77,21 @@ public class Runtime_97581
         return 3;
     }
 
+    // IDynamicInterfaceCastable can make an object dynamically implement an interface
+    // that its static type does not. compareTypesForCast(DcastToIFoo, IFoo) is MustNot
+    // statically, but the runtime cast succeeds. The optimization must not fold
+    // "o is DcastToIFoo -> o is IFoo" to false.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int MustNotInterfaceTree(object o)
+    {
+        if (o is DcastToIFoo)
+        {
+            if (o is IFoo) return 1; // must not be folded away
+            return 2;
+        }
+        return 3;
+    }
+
     [Fact]
     public static int TestEntryPoint()
     {
@@ -71,6 +99,7 @@ public class Runtime_97581
         var p2  = new Program2();
         var d1  = new Derived1();
         object str = "hello";
+        object dc  = new DcastToIFoo();
 
         if (MustNotEqTree(p1)  != 2) return 101;
         if (MustNotEqTree(p2)  != 3) return 102;
@@ -87,6 +116,12 @@ public class Runtime_97581
 
         if (MustNeTree(d1)  != 2) return 131;
         if (MustNeTree(p1)  != 3) return 132;
+
+        // The IDCC object satisfies "o is DcastToIFoo" statically and also
+        // "o is IFoo" via IDynamicInterfaceCastable. Result must be 1.
+        if (MustNotInterfaceTree(dc)  != 1) return 141;
+        if (MustNotInterfaceTree(p1)  != 3) return 142;
+        if (MustNotInterfaceTree(str) != 3) return 143;
 
         return 100;
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_97581/Runtime_97581.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_97581/Runtime_97581.cs
@@ -54,6 +54,19 @@ public class Runtime_97581
         return 3;
     }
 
+    // Exact pattern from https://github.com/dotnet/runtime/issues/97581.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Issue97581Exact(object o)
+    {
+        if (o is Program1)
+        {
+            if (o is Program2)
+            {
+                System.Console.WriteLine("this branch is never taken");
+            }
+        }
+    }
+
     // Derived -> Base always holds: (o is Derived1) implies (o is Program1) true.
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static int MustEqTree(object o)
@@ -157,6 +170,11 @@ public class Runtime_97581
         if (MustFalseImpliesFalseNeTree(d1)  != 3) return 162;
         if (MustFalseImpliesFalseNeTree(str) != 1) return 163;
         if (MustFalseImpliesFalseNeTree(p2)  != 1) return 164;
+
+        // Just make sure the exact-issue method doesn't crash and produces no output.
+        Issue97581Exact(p1);
+        Issue97581Exact(p2);
+        Issue97581Exact(str);
 
         return 100;
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_97581/Runtime_97581.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_97581/Runtime_97581.cs
@@ -92,6 +92,31 @@ public class Runtime_97581
         return 3;
     }
 
+    // False-implies-false: !(o is Program1) implies !(o is Derived1). If the outer
+    // check fails then the runtime type does not derive from Program1, so it cannot
+    // be a Derived1 either.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int MustFalseImpliesFalse(object o)
+    {
+        if (!(o is Program1))
+        {
+            if (o is Derived1) return 1; // must be folded to false
+            return 2;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int MustFalseImpliesFalseNeTree(object o)
+    {
+        if (!(o is Program1))
+        {
+            if (!(o is Derived1)) return 1;
+            return 2;
+        }
+        return 3;
+    }
+
     [Fact]
     public static int TestEntryPoint()
     {
@@ -122,6 +147,16 @@ public class Runtime_97581
         if (MustNotInterfaceTree(dc)  != 1) return 141;
         if (MustNotInterfaceTree(p1)  != 3) return 142;
         if (MustNotInterfaceTree(str) != 3) return 143;
+
+        if (MustFalseImpliesFalse(p1)  != 3) return 151;
+        if (MustFalseImpliesFalse(d1)  != 3) return 152;
+        if (MustFalseImpliesFalse(str) != 2) return 153;
+        if (MustFalseImpliesFalse(p2)  != 2) return 154;
+
+        if (MustFalseImpliesFalseNeTree(p1)  != 3) return 161;
+        if (MustFalseImpliesFalseNeTree(d1)  != 3) return 162;
+        if (MustFalseImpliesFalseNeTree(str) != 1) return 163;
+        if (MustFalseImpliesFalseNeTree(p2)  != 1) return 164;
 
         return 100;
     }

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -109,6 +109,7 @@
     <Compile Include="JitBlue\Runtime_129970\Runtime_129970.cs" />
     <Compile Include="JitBlue\Runtime_129971\Runtime_129971.cs" />
     <Compile Include="JitBlue\Runtime_129972\Runtime_129972.cs" />
+    <Compile Include="JitBlue\Runtime_97581\Runtime_97581.cs" />
     <Compile Include="JitBlue\Runtime_10337\Runtime_10337.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />


### PR DESCRIPTION
Extend optRelopImpliesRelop so that a dominating "obj is A" test implies the value of a dominated "obj is B" test when the runtime reports compareTypesForCast(A, B) as Must or MustNot.

Fixes #97581.