### PR TITLE
Publish GCHandle assignments with release semantics

### DIFF
--- a/src/coreclr/gc/handletable.inl
+++ b/src/coreclr/gc/handletable.inl
@@ -43,8 +43,9 @@ inline void HndAssignHandle(OBJECTHANDLE handle, OBJECTREF objref)
     if (value)
         HndWriteBarrier(handle, objref);
 
-    // store the pointer
-    *(_UNCHECKED_OBJECTREF *)handle = value;
+    // Store the pointer with release semantics so object field writes are visible
+    // before the handle can publish the object to another thread.
+    VolatileStore((_UNCHECKED_OBJECTREF *)handle, value);
 }
 
 // This is used by the GC before we actually construct the object so we cannot
@@ -69,8 +70,9 @@ inline void HndAssignHandleGC(OBJECTHANDLE handle, uint8_t* objref)
     if (value)
         HndWriteBarrierWorker(handle, value);
 
-    // store the pointer
-    *(_UNCHECKED_OBJECTREF *)handle = value;
+    // Store the pointer with release semantics so object field writes are visible
+    // before the handle can publish the object to another thread.
+    VolatileStore((_UNCHECKED_OBJECTREF *)handle, value);
 }
 
 inline void* HndInterlockedCompareExchangeHandle(OBJECTHANDLE handle, OBJECTREF objref, OBJECTREF oldObjref)


### PR DESCRIPTION
## Summary

 Use release-store semantics when assigning GC handle slots in `HndAssignHandle` and `HndAssignHandleGC`.

On weakly ordered ARM64 systems, the previous plain store could publish an object reference through a GC handle before prior object initialization writes were visible to another thread observing that handle.
This can allow weak-reference readers to see partially initialized managed objects.

## Details

GC handle assignment stores the raw object reference into the handle slot with a plain store:
https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/handletable.inl#L47

```cpp
  *(_UNCHECKED_OBJECTREF *)handle = value;
```

This changes that store to VolatileStore, making handle assignment a release publication point:

```cpp
  VolatileStore((_UNCHECKED_OBJECTREF *)handle, value);
```

This matches the runtime's existing volatile publication pattern and ensures prior writes are visible before another thread can observe the object through the handle.

Discovered this via rare NullReferenceExceptions in Regex.Replace in an application when running on arm64 (10.0.9). The repro for that is https://gist.github.com/BradBarnich/4e6368d7e3ae5a32896852c146e0eb3f. It can take a lot of time to produce an error but was most reliable on graviton4. Never did produce on Mac.

This produced a dump file that showed the partial object (null ._rules) and focuses the analysis on the WeakReference

There is a shared WeakReference to RegexReplacement and the exception was thrown when it would sometimes observe a partially constructed RegexReplacement. The `WeakReference.SetTarget` is called after construction https://github.com/dotnet/runtime/blob/main/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs#L107-L117

Internally `WeakReference.SetTarget` calls `GCHandle.InternalSet` https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs#L120
 
## Validation

Validated with a focused WeakReference publication repro https://gist.github.com/BradBarnich/ccd7e3811cfbe4142ff7c85ec8305c76

Without the patch, the repro fails quickly on Mac and AWS arm64. Does not fail on x64.

When the patch, does not fail on Mac or AWS arm64

