### PR TITLE
JIT: fix incorrect bounds check removal for Phi indices with a negative minimum

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5616,7 +5616,7 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
     {
         int idxLo = getIdxRng().LowerLimit().GetConstant();
         int idxHi = getIdxRng().UpperLimit().GetConstant();
-        int lenLo = lenRng.LowerLimit().GetConstant();
+        int lenLo = getLenRng().LowerLimit().GetConstant();
 
         // GT_BOUNDS_CHECK node has an implicit contract - the length node must always be non-negative.
         // So we additionally tighten the lower bound of lenLo to be ">= 1" when we also have a

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5540,7 +5540,8 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
             else if (idxRng.IsConstantRange() && idxRng.LowerLimit().GetConstant() >= 0)
             {
                 // Get the range of the previously checked index for the same array length.
-                Range rngOfPrevIdx = RangeCheck::GetRangeFromAssertions(this, curAssertion.GetOp1().GetVN(), nullptr);
+                Range rngOfPrevIdx =
+                    RangeCheck::GetRangeFromAssertions(this, curAssertion.GetOp1().GetVN(), BitVecOps::UninitVal());
 
                 // We know the range of the previous index, we know the range of the current index.
                 //

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5497,6 +5497,9 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
     ValueNum          vnCurIdx      = optConservativeNormalVN(arrBndsChkIdx);
     ValueNum          vnCurLen      = optConservativeNormalVN(arrBndsChkLen);
 
+    // Let's see if we can remove the bounds check based on the ranges.
+    Range idxRng = GetRange(this, arrBndsChkIdx, block, assertions, /*fast*/ true);
+
     auto dropBoundsCheck = [&](INDEBUG(const char* reason)) -> GenTree* {
         JITDUMP("\nRemoving redundant (%s) bounds check in " FMT_BB ":\n", reason, compCurBB->bbNum);
         DISPTREE(tree);
@@ -5504,6 +5507,7 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
         // Extract the side effects of idx and len. We deliberately ignore the potential null-check
         // exception of the length (e.g. GT_ARR_LENGTH): having proven the bounds check redundant, we
         // have also proven the length load is non-faulting. This mirrors the hack in optRemoveRangeCheck.
+        // TODO-Bug: We really should be extracting all side effects from the length and index here.
         GenTree* sideEffList = nullptr;
         gtExtractSideEffList(arrBndsChkLen, &sideEffList, GTF_ASG);
         gtExtractSideEffList(arrBndsChkIdx, &sideEffList);
@@ -5529,63 +5533,26 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
         // Do we have a previous range check involving the same 'vnLen' upper bound?
         if (curAssertion.GetOp2().GetVN() == optConservativeNormalVN(arrBndsChkLen))
         {
-            // Do we have the exact same lower bound 'vnIdx'?
-            //       a[i] followed by a[i]
             if (curAssertion.GetOp1().GetVN() == vnCurIdx)
             {
                 return dropBoundsCheck(INDEBUG("a[i] followed by a[i]"));
             }
-            // Are we using zero as the index?
-            // It can always be considered as redundant with any previous value
-            //       a[*] followed by a[0]
-            else if (vnCurIdx == vnStore->VNZeroForType(arrBndsChkIdx->TypeGet()))
+            else if (idxRng.IsConstantRange() && idxRng.LowerLimit().GetConstant() >= 0)
             {
-                return dropBoundsCheck(INDEBUG("a[*] followed by a[0]"));
-            }
-            else
-            {
-                // index1 doesn't have to be a constant, it can be a Phi each predecessor of which is a constant.
-                // The smallest of those is what we can rely on. Example:
-                //
-                //  arr[cond ? 10 : 5] = 0;  // arr is at least 6 elements long
-                //  arr[2] = 0;              // arr must be at least 3 elements long
-                //
-                // or even:
-                //
-                //  arr[cond ? 10 : 5] = 0; // arr is at least 6 elements long
-                //  arr[cond ? 1 : 2] = 0;  // arr must be at least 3 elements long
-                //
-                auto tryGetMaxOrMinConst = [this](ValueNum vn, bool getMin, int* index) -> bool {
-                    *index = getMin ? INT_MAX : INT_MIN;
-                    return vnStore->VNVisitReachingVNs(vn,
-                                                       [this, index, getMin](ValueNum vn) -> ValueNumStore::VNVisit {
-                        int cns = 0;
-                        if (vnStore->IsVNIntegralConstant(vn, &cns))
-                        {
-                            *index = getMin ? min(*index, cns) : max(*index, cns);
-                            return ValueNumStore::VNVisit::Continue;
-                        }
-                        return ValueNumStore::VNVisit::Abort;
-                    }) == ValueNumStore::VNVisit::Continue;
-                };
+                // Get the range of the previously checked index for the same array length.
+                Range rngOfPrevIdx = RangeCheck::GetRangeFromAssertions(this, curAssertion.GetOp1().GetVN(), nullptr);
 
-                int index1;
-                int index2;
-                if (tryGetMaxOrMinConst(curAssertion.GetOp1().GetVN(), /*min*/ true, &index1) &&
-                    tryGetMaxOrMinConst(vnCurIdx, /*max*/ false, &index2))
+                // We know the range of the previous index, we know the range of the current index.
+                //
+                //  a[prevIdx] = 0; // e.g. prevIdx's range is [5..10]
+                //  a[currIdx] = 0; // e.g. currIdx's range is [0..5] -> drop bounds check for currIdx
+                //
+                if (rngOfPrevIdx.IsConstantRange() &&
+                    (rngOfPrevIdx.LowerLimit().GetConstant() >= idxRng.UpperLimit().GetConstant()))
                 {
-                    // It can always be considered as redundant with any previous higher constant value
-                    //       a[K1] followed by a[K2], with K2 >= 0 and K1 >= K2
-                    if (index2 >= 0 && index1 >= index2)
-                    {
-                        return dropBoundsCheck(INDEBUG("a[K1] followed by a[K2], with K2 >= 0 and K1 >= K2"));
-                    }
+                    return dropBoundsCheck(INDEBUG("current index is within the previous range"));
                 }
             }
-            // Extend this to remove additional redundant bounds checks:
-            // i.e.  a[i+1] followed by a[i]  by using the VN(i+1) >= VN(i)
-            //       a[i]   followed by a[j]  when j is known to be >= i
-            //       a[i]   followed by a[5]  when i is known to be >= 5
         }
     }
 
@@ -5624,8 +5591,6 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
         return dropBoundsCheck(INDEBUG("a[X u% a.Length] is always within bounds"));
     }
 
-    // Let's see if we can remove the bounds check based on the ranges.
-    Range idxRng = GetRange(this, arrBndsChkIdx, block, assertions, /*fast*/ true);
     Range lenRng = GetRange(this, arrBndsChkLen, block, assertions, /*fast*/ true);
 
     if (idxRng.IsConstantRange() && lenRng.IsConstantRange())

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5497,8 +5497,26 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
     ValueNum          vnCurIdx      = optConservativeNormalVN(arrBndsChkIdx);
     ValueNum          vnCurLen      = optConservativeNormalVN(arrBndsChkLen);
 
-    // Let's see if we can remove the bounds check based on the ranges.
-    Range idxRng = GetRange(this, arrBndsChkIdx, block, assertions, /*fast*/ true);
+    Range idxRng = Limit(Limit::LimitType::keUndef);
+    Range lenRng = Limit(Limit::LimitType::keUndef);
+
+    // Lazily compute the range of the index and length, since it may not be needed.
+
+    auto getIdxRng = [&]() -> Range {
+        if (idxRng.IsUndef())
+        {
+            idxRng = GetRange(this, arrBndsChkIdx, block, assertions, /*fast*/ true);
+        }
+        return idxRng;
+    };
+
+    auto getLenRng = [&]() -> Range {
+        if (lenRng.IsUndef())
+        {
+            lenRng = GetRange(this, arrBndsChkLen, block, assertions, /*fast*/ true);
+        }
+        return lenRng;
+    };
 
     auto dropBoundsCheck = [&](INDEBUG(const char* reason)) -> GenTree* {
         JITDUMP("\nRemoving redundant (%s) bounds check in " FMT_BB ":\n", reason, compCurBB->bbNum);
@@ -5531,26 +5549,28 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
         assert(curAssertion.GetOp2().IsVNNeverNegative());
 
         // Do we have a previous range check involving the same 'vnLen' upper bound?
-        if (curAssertion.GetOp2().GetVN() == optConservativeNormalVN(arrBndsChkLen))
+        if (curAssertion.GetOp2().GetVN() == vnCurLen)
         {
             if (curAssertion.GetOp1().GetVN() == vnCurIdx)
             {
                 return dropBoundsCheck(INDEBUG("a[i] followed by a[i]"));
             }
-            else if (idxRng.IsConstantRange() && idxRng.LowerLimit().GetConstant() >= 0)
+            else if (getIdxRng().IsConstantRange() && getIdxRng().LowerLimit().GetConstant() >= 0)
             {
                 // Get the range of the previously checked index for the same array length.
+                // NOTE: we can't re-use 'assertions' since they may not be live at the point of the previous check.
                 Range rngOfPrevIdx =
                     RangeCheck::GetRangeFromAssertions(this, curAssertion.GetOp1().GetVN(), BitVecOps::UninitVal());
 
                 // We know the range of the previous index, we know the range of the current index.
                 //
                 //  a[prevIdx] = 0; // e.g. prevIdx's range is [5..10]
-                //  a[currIdx] = 0; // e.g. currIdx's range is [0..5] -> drop bounds check for currIdx
+                //  a[currIdx] = 0; // e.g. currIdx's range is [2..5] -> drop bounds check for currIdx
                 //
                 if (rngOfPrevIdx.IsConstantRange() &&
-                    (rngOfPrevIdx.LowerLimit().GetConstant() >= idxRng.UpperLimit().GetConstant()))
+                    (rngOfPrevIdx.LowerLimit().GetConstant() >= getIdxRng().UpperLimit().GetConstant()))
                 {
+                    assert(getIdxRng().LowerLimit().GetConstant() >= 0);
                     return dropBoundsCheck(INDEBUG("currIdx upper bound covered by prevIdx lower bound"));
                 }
             }
@@ -5592,12 +5612,10 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
         return dropBoundsCheck(INDEBUG("a[X u% a.Length] is always within bounds"));
     }
 
-    Range lenRng = GetRange(this, arrBndsChkLen, block, assertions, /*fast*/ true);
-
-    if (idxRng.IsConstantRange() && lenRng.IsConstantRange())
+    if (getIdxRng().IsConstantRange() && getLenRng().IsConstantRange())
     {
-        int idxLo = idxRng.LowerLimit().GetConstant();
-        int idxHi = idxRng.UpperLimit().GetConstant();
+        int idxLo = getIdxRng().LowerLimit().GetConstant();
+        int idxHi = getIdxRng().UpperLimit().GetConstant();
         int lenLo = lenRng.LowerLimit().GetConstant();
 
         // GT_BOUNDS_CHECK node has an implicit contract - the length node must always be non-negative.

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5550,7 +5550,7 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions,
                 if (rngOfPrevIdx.IsConstantRange() &&
                     (rngOfPrevIdx.LowerLimit().GetConstant() >= idxRng.UpperLimit().GetConstant()))
                 {
-                    return dropBoundsCheck(INDEBUG("current index is within the previous range"));
+                    return dropBoundsCheck(INDEBUG("currIdx upper bound covered by prevIdx lower bound"));
                 }
             }
         }

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -533,6 +533,25 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, GenTree* tree, ASSERT_V
 }
 
 //------------------------------------------------------------------------
+// GetRangeFromAssertions: Cheaper version of TryGetRange that is based purely on assertions
+//    and does not require a full range analysis based on SSA.
+//
+// Arguments:
+//    comp             - the compiler instance
+//    vn               - the value number to analyze range for
+//    assertions       - the assertions to use
+//    budget           - the remaining budget for recursive analysis
+//
+// Return Value:
+//    The computed range
+//
+Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum vn, ASSERT_VALARG_TP assertions, int budget)
+{
+    ValueNumStore::SmallValueNumSet set;
+    return GetRangeFromAssertionsWorker(comp, vn, assertions, budget, &set);
+}
+
+//------------------------------------------------------------------------
 // GetRangeFromAssertionsWorker: Cheaper version of TryGetRange that is based purely on assertions
 //    and does not require a full range analysis based on SSA.
 //

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -547,6 +547,11 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, GenTree* tree, ASSERT_V
 //
 Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum vn, ASSERT_VALARG_TP assertions, int budget)
 {
+    if (vn == ValueNumStore::NoVN)
+    {
+        return Limit(Limit::keUnknown);
+    }
+
     ValueNumStore::SmallValueNumSet set;
     return GetRangeFromAssertionsWorker(comp, vn, assertions, budget, &set);
 }

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -831,6 +831,7 @@ public:
 
     // Cheaper version of TryGetRange that is based only on incoming assertions.
     static Range GetRangeFromAssertions(Compiler* comp, GenTree* tree, ASSERT_VALARG_TP assertions, int budget = 10);
+    static Range GetRangeFromAssertions(Compiler* comp, ValueNum vn, ASSERT_VALARG_TP assertions, int budget = 10);
 
     // Compute the range from the given type
     static Range GetRangeFromType(var_types type);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130216/Runtime_130216.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130216/Runtime_130216.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_130216
+{
+    private static int Sink;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Throws<IndexOutOfRangeException>(() => Test(new int[6], true));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Test(int[] arr, bool c)
+    {
+        int prev = arr[5];
+        int j;
+        if (c)
+        {
+            Sink = 1;
+            j = -5;
+        }
+        else
+        {
+            j = 3;
+        }
+        return prev + arr[j];
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -109,6 +109,7 @@
     <Compile Include="JitBlue\Runtime_129970\Runtime_129970.cs" />
     <Compile Include="JitBlue\Runtime_129971\Runtime_129971.cs" />
     <Compile Include="JitBlue\Runtime_129972\Runtime_129972.cs" />
+    <Compile Include="JitBlue\Runtime_130216\Runtime_130216.cs" />
     <Compile Include="JitBlue\Runtime_10337\Runtime_10337.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/130216 (a correctness issue)

Almost no [diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1494594&view=ms.vss-build-web.run-extensions-tab)