### PR TITLE
Align keepnativesymbols option with src/tests/build

### DIFF
--- a/docs/workflow/building/coreclr/android.md
+++ b/docs/workflow/building/coreclr/android.md
@@ -201,9 +201,9 @@ This can be achieved in `Android Studio` via `Profile or Debug APK`.
 
 > [!NOTE]
 > Steps 5) through 8) can be omitted if the runtime is built without stripping debug symbols to a separate file (e.g., `libcoreclr.so.dbg`).
-> This can be achieved by including `-keepnativesymbols true` option when building the runtime, e.g.,:
+> This can be achieved by including `-keepnativesymbols` option when building the runtime, e.g.,:
 > ```
-> ./build.sh clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs -os android -arch <x64|arm64> -c Debug -keepnativesymbols true
+> ./build.sh clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs -os android -arch <x64|arm64> -c Debug -keepnativesymbols
 > ```
 
 ## See also

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -506,7 +506,7 @@ while [[ $# -gt 0 ]]; do
       ;;
 
      -keepnativesymbols)
-        arguments+=("/p:KeepNativeSymbols=true")
+      arguments+=("/p:KeepNativeSymbols=true")
       shift 1
       ;;
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -86,7 +86,7 @@ usage()
   echo "  --gcc                      Optional argument to build using gcc in PATH (default)."
   echo "  --gccx.y                   Optional argument to build using gcc version x.y."
   echo "  --portablebuild            Optional argument: set to false to force a non-portable build."
-  echo "  --keepnativesymbols        Optional argument: set to true to keep native symbols/debuginfo in generated binaries."
+  echo "  --keepnativesymbols        Optional argument: set to keep native symbols/debuginfo in generated binaries."
   echo "  --ninja                    Optional argument: use Ninja instead of Make (default: true, use --ninja false to disable)."
   echo "  --pgoinstrument            Optional argument: build PGO-instrumented runtime"
   echo "  --fsanitize                Optional argument: Specify native sanitizers to instrument the native build with. Supported values are: 'address'."
@@ -506,15 +506,8 @@ while [[ $# -gt 0 ]]; do
       ;;
 
      -keepnativesymbols)
-      if [ -z ${2+x} ]; then
-        echo "No value for keepNativeSymbols is supplied. See help (--help) for supported values." 1>&2
-        exit 1
-      fi
-      passedKeepNativeSymbols="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
-      if [ "$passedKeepNativeSymbols" = true ]; then
         arguments+=("/p:KeepNativeSymbols=true")
-      fi
-      shift 2
+      shift 1
       ;;
 
 


### PR DESCRIPTION
Before:
```sh
# value arg
$ ./build.sh --keepnativesymbols true

# switch
$ src/tests/build.sh --keepnativesymbols
```

After: both scripts have it as a switch, without a value.