### PR TITLE
Fix incorrect constant folding of CompareScalar True/False comparisons

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -36145,6 +36145,7 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
                                 vecCon->gtSimdVal.u64[0] = isFalse ? 0 : 0xFFFFFFFFFFFFFFFF;
                             }
 
+                            fgUpdateConstTreeValueNumber(vecCon);
                             resultNode = vecCon;
                         }
                         else if (isFalse)
@@ -36157,7 +36158,7 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
                             // A true comparison produces an all-true mask for the given element count.
 
                             GenTreeMskCon* mskCon = gtNewMskConNode(retType);
-                            mskCon->gtSimdMaskVal = simdmask_t::AllBitsSet(simdSize / genTypeSize(simdBaseType));
+                            mskCon->gtSimdMaskVal = simdmask_t::AllBitsSet(GenTreeVecCon::ElementCount(simdSize, simdBaseType));
                             resultNode            = mskCon;
                         }
 #endif // FEATURE_MASKED_HW_INTRINSICS

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -36158,8 +36158,9 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
                             // A true comparison produces an all-true mask for the given element count.
 
                             GenTreeMskCon* mskCon = gtNewMskConNode(retType);
-                            mskCon->gtSimdMaskVal = simdmask_t::AllBitsSet(GenTreeVecCon::ElementCount(simdSize, simdBaseType));
-                            resultNode            = mskCon;
+                            mskCon->gtSimdMaskVal =
+                                simdmask_t::AllBitsSet(GenTreeVecCon::ElementCount(simdSize, simdBaseType));
+                            resultNode = mskCon;
                         }
 #endif // FEATURE_MASKED_HW_INTRINSICS
                         else

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -9459,6 +9459,14 @@ GenTree* Compiler::gtNewZeroConNode(var_types type)
     }
 #endif // FEATURE_SIMD
 
+#if defined(FEATURE_MASKED_HW_INTRINSICS)
+    if (varTypeIsMask(type))
+    {
+        // The GenTreeMskCon constructor already zero-initializes the mask value.
+        return gtNewMskConNode(type);
+    }
+#endif // FEATURE_MASKED_HW_INTRINSICS
+
     type = genActualType(type);
     switch (type)
     {
@@ -36105,16 +36113,59 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
                 {
                     case FloatComparisonMode::OrderedFalseNonSignaling:
                     case FloatComparisonMode::OrderedFalseSignaling:
-                    {
-                        resultNode = gtNewZeroConNode(retType);
-                        resultNode = gtWrapWithSideEffects(resultNode, tree, GTF_ALL_EFFECT);
-                        break;
-                    }
-
                     case FloatComparisonMode::UnorderedTrueNonSignaling:
                     case FloatComparisonMode::UnorderedTrueSignaling:
                     {
-                        resultNode = gtNewAllBitsSetConNode(retType);
+                        bool isFalse = (mode == FloatComparisonMode::OrderedFalseNonSignaling) ||
+                                       (mode == FloatComparisonMode::OrderedFalseSignaling);
+
+                        if (ni == NI_AVX_CompareScalar)
+                        {
+                            // CompareScalar only updates the lowest element and copies the remaining
+                            // (upper) elements from op1 unchanged. We can therefore only constant fold
+                            // this when op1 is itself a constant so that those upper elements are known.
+
+                            if (!op1->IsCnsVec())
+                            {
+                                break;
+                            }
+
+                            GenTreeVecCon* vecCon = op1->AsVecCon();
+
+                            // Set the lowest element to the comparison result (all zeros for a false
+                            // mode, all ones for a true mode) while leaving the upper elements intact.
+
+                            if (simdBaseType == TYP_FLOAT)
+                            {
+                                vecCon->gtSimdVal.u32[0] = isFalse ? 0 : 0xFFFFFFFF;
+                            }
+                            else
+                            {
+                                assert(simdBaseType == TYP_DOUBLE);
+                                vecCon->gtSimdVal.u64[0] = isFalse ? 0 : 0xFFFFFFFFFFFFFFFF;
+                            }
+
+                            resultNode = vecCon;
+                        }
+                        else if (isFalse)
+                        {
+                            resultNode = gtNewZeroConNode(retType);
+                        }
+#if defined(FEATURE_MASKED_HW_INTRINSICS)
+                        else if (varTypeIsMask(retType))
+                        {
+                            // A true comparison produces an all-true mask for the given element count.
+
+                            GenTreeMskCon* mskCon = gtNewMskConNode(retType);
+                            mskCon->gtSimdMaskVal = simdmask_t::AllBitsSet(simdSize / genTypeSize(simdBaseType));
+                            resultNode            = mskCon;
+                        }
+#endif // FEATURE_MASKED_HW_INTRINSICS
+                        else
+                        {
+                            resultNode = gtNewAllBitsSetConNode(retType);
+                        }
+
                         resultNode = gtWrapWithSideEffects(resultNode, tree, GTF_ALL_EFFECT);
                         break;
                     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_125160/Runtime_125160.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_125160/Runtime_125160.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+public class Runtime_125160
+{
+    // The True/False float comparison modes always produce the same result regardless of the
+    // inputs. The JIT constant folds these when the operands are constant. For the scalar form
+    // (CompareScalar) only the lowest element is set to the comparison result; the upper elements
+    // must be copied unchanged from op1. This test ensures the folded result matches the result
+    // computed at runtime from non-constant operands.
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static T Opaque<T>(T value) => value;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        if (Avx.IsSupported)
+        {
+            TestCompareScalarSingle();
+            TestCompareScalarDouble();
+        }
+
+        if (Avx512F.IsSupported)
+        {
+            TestCompareSingle();
+            TestCompareDouble();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestCompareScalarSingle()
+    {
+        Vector128<float> left = Vector128.Create(1f, 2f, 3f, 4f);
+        Vector128<float> right = Vector128.Create(5f, 6f, 7f, 8f);
+
+        // OrderedFalseNonSignaling: lowest element is all-zero, upper elements copied from op1.
+        Assert.Equal(
+            Avx.CompareScalar(Opaque(left), Opaque(right), FloatComparisonMode.OrderedFalseNonSignaling),
+            Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseNonSignaling));
+
+        Assert.Equal(
+            Avx.CompareScalar(Opaque(left), Opaque(right), FloatComparisonMode.OrderedFalseSignaling),
+            Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseSignaling));
+
+        // UnorderedTrueNonSignaling: lowest element is all-ones, upper elements copied from op1.
+        Assert.Equal(
+            Avx.CompareScalar(Opaque(left), Opaque(right), FloatComparisonMode.UnorderedTrueNonSignaling),
+            Avx.CompareScalar(left, right, FloatComparisonMode.UnorderedTrueNonSignaling));
+
+        Assert.Equal(
+            Avx.CompareScalar(Opaque(left), Opaque(right), FloatComparisonMode.UnorderedTrueSignaling),
+            Avx.CompareScalar(left, right, FloatComparisonMode.UnorderedTrueSignaling));
+
+        // Explicitly validate that the upper elements are preserved and the low element is set.
+        Vector128<float> folded = Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseNonSignaling);
+        Assert.Equal(0f, folded.GetElement(0));
+        Assert.Equal(2f, folded.GetElement(1));
+        Assert.Equal(3f, folded.GetElement(2));
+        Assert.Equal(4f, folded.GetElement(3));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestCompareScalarDouble()
+    {
+        Vector128<double> left = Vector128.Create(1d, 2d);
+        Vector128<double> right = Vector128.Create(3d, 4d);
+
+        Assert.Equal(
+            Avx.CompareScalar(Opaque(left), Opaque(right), FloatComparisonMode.OrderedFalseNonSignaling),
+            Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseNonSignaling));
+
+        Assert.Equal(
+            Avx.CompareScalar(Opaque(left), Opaque(right), FloatComparisonMode.OrderedFalseSignaling),
+            Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseSignaling));
+
+        Assert.Equal(
+            Avx.CompareScalar(Opaque(left), Opaque(right), FloatComparisonMode.UnorderedTrueNonSignaling),
+            Avx.CompareScalar(left, right, FloatComparisonMode.UnorderedTrueNonSignaling));
+
+        Assert.Equal(
+            Avx.CompareScalar(Opaque(left), Opaque(right), FloatComparisonMode.UnorderedTrueSignaling),
+            Avx.CompareScalar(left, right, FloatComparisonMode.UnorderedTrueSignaling));
+
+        Vector128<double> folded = Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseNonSignaling);
+        Assert.Equal(0d, folded.GetElement(0));
+        Assert.Equal(2d, folded.GetElement(1));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestCompareSingle()
+    {
+        Vector512<float> left = Vector512.Create(1f);
+        Vector512<float> right = Vector512.Create(2f);
+
+        Assert.Equal(
+            Avx512F.Compare(Opaque(left), Opaque(right), FloatComparisonMode.OrderedFalseNonSignaling),
+            Avx512F.Compare(left, right, FloatComparisonMode.OrderedFalseNonSignaling));
+
+        Assert.Equal(
+            Avx512F.Compare(Opaque(left), Opaque(right), FloatComparisonMode.OrderedFalseSignaling),
+            Avx512F.Compare(left, right, FloatComparisonMode.OrderedFalseSignaling));
+
+        Assert.Equal(
+            Avx512F.Compare(Opaque(left), Opaque(right), FloatComparisonMode.UnorderedTrueNonSignaling),
+            Avx512F.Compare(left, right, FloatComparisonMode.UnorderedTrueNonSignaling));
+
+        Assert.Equal(
+            Avx512F.Compare(Opaque(left), Opaque(right), FloatComparisonMode.UnorderedTrueSignaling),
+            Avx512F.Compare(left, right, FloatComparisonMode.UnorderedTrueSignaling));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestCompareDouble()
+    {
+        Vector512<double> left = Vector512.Create(1d);
+        Vector512<double> right = Vector512.Create(2d);
+
+        Assert.Equal(
+            Avx512F.Compare(Opaque(left), Opaque(right), FloatComparisonMode.OrderedFalseNonSignaling),
+            Avx512F.Compare(left, right, FloatComparisonMode.OrderedFalseNonSignaling));
+
+        Assert.Equal(
+            Avx512F.Compare(Opaque(left), Opaque(right), FloatComparisonMode.OrderedFalseSignaling),
+            Avx512F.Compare(left, right, FloatComparisonMode.OrderedFalseSignaling));
+
+        Assert.Equal(
+            Avx512F.Compare(Opaque(left), Opaque(right), FloatComparisonMode.UnorderedTrueNonSignaling),
+            Avx512F.Compare(left, right, FloatComparisonMode.UnorderedTrueNonSignaling));
+
+        Assert.Equal(
+            Avx512F.Compare(Opaque(left), Opaque(right), FloatComparisonMode.UnorderedTrueSignaling),
+            Avx512F.Compare(left, right, FloatComparisonMode.UnorderedTrueSignaling));
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_125160/Runtime_125160.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_125160/Runtime_125160.cs
@@ -58,11 +58,17 @@ public class Runtime_125160
             Avx.CompareScalar(left, right, FloatComparisonMode.UnorderedTrueSignaling));
 
         // Explicitly validate that the upper elements are preserved and the low element is set.
-        Vector128<float> folded = Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseNonSignaling);
-        Assert.Equal(0f, folded.GetElement(0));
-        Assert.Equal(2f, folded.GetElement(1));
-        Assert.Equal(3f, folded.GetElement(2));
-        Assert.Equal(4f, folded.GetElement(3));
+        Vector128<float> foldedFalse = Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseNonSignaling);
+        Assert.Equal(0f, foldedFalse.GetElement(0));
+        Assert.Equal(2f, foldedFalse.GetElement(1));
+        Assert.Equal(3f, foldedFalse.GetElement(2));
+        Assert.Equal(4f, foldedFalse.GetElement(3));
+
+        Vector128<float> foldedTrue = Avx.CompareScalar(left, right, FloatComparisonMode.UnorderedTrueNonSignaling);
+        Assert.Equal(-1, foldedTrue.AsInt32().GetElement(0));
+        Assert.Equal(2f, foldedTrue.GetElement(1));
+        Assert.Equal(3f, foldedTrue.GetElement(2));
+        Assert.Equal(4f, foldedTrue.GetElement(3));
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -87,9 +93,13 @@ public class Runtime_125160
             Avx.CompareScalar(Opaque(left), Opaque(right), FloatComparisonMode.UnorderedTrueSignaling),
             Avx.CompareScalar(left, right, FloatComparisonMode.UnorderedTrueSignaling));
 
-        Vector128<double> folded = Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseNonSignaling);
-        Assert.Equal(0d, folded.GetElement(0));
-        Assert.Equal(2d, folded.GetElement(1));
+        Vector128<double> foldedFalse = Avx.CompareScalar(left, right, FloatComparisonMode.OrderedFalseNonSignaling);
+        Assert.Equal(0d, foldedFalse.GetElement(0));
+        Assert.Equal(2d, foldedFalse.GetElement(1));
+
+        Vector128<double> foldedTrue = Avx.CompareScalar(left, right, FloatComparisonMode.UnorderedTrueNonSignaling);
+        Assert.Equal(-1L, foldedTrue.AsInt64().GetElement(0));
+        Assert.Equal(2d, foldedTrue.GetElement(1));
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -105,6 +105,7 @@
     <Compile Include="JitBlue\Runtime_129176\Runtime_129176.cs" />
     <Compile Include="JitBlue\Runtime_129642\Runtime_129642.cs" />
     <Compile Include="JitBlue\Runtime_10337\Runtime_10337.cs" />
+    <Compile Include="JitBlue\Runtime_125160\Runtime_125160.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
## Why

`Avx.CompareScalar` with a constant "always true"/"always false" float comparison mode (`OrderedFalse*`, `UnorderedTrue*`) was being constant folded to a full `Zero`/`AllBitsSet` vector. That is wrong for the scalar form: `CompareScalar` only writes the lowest element and must copy the remaining upper elements unchanged from `op1`. The fold discarded those upper elements, producing incorrect results (e.g. `CompareScalar(<1,2,3,4>, ..., OrderedFalse)` yielded `<0,0,0,0>` instead of `<0,2,3,4>`).

Separately, `gtNewZeroConNode` and `gtNewAllBitsSetConNode` did not support `TYP_MASK` (they hit `unreached()`), so folding the AVX512 mask compare (`NI_AVX512_CompareMask`, whose result type is `TYP_MASK`) for these modes crashed.

Fixes #125160

## Approach

- **`gtNewZeroConNode`** now handles `TYP_MASK` by returning a zero `GenTreeMskCon` (guarded by `FEATURE_MASKED_HW_INTRINSICS`).
- **`gtFoldExprHWIntrinsic`** True/False handling for `NI_AVX_Compare` / `NI_AVX_CompareScalar` / `NI_AVX512_CompareMask`:
  - For `CompareScalar`, bail out of folding entirely unless `op1` is itself a constant. When it is, set only the lowest element (`0` for false modes, all-ones for true modes) and leave the upper elements of `op1` intact.
  - For the non-scalar false case, use the now mask-safe `gtNewZeroConNode(retType)`.
  - For the non-scalar true case producing a mask, build a canonical true mask via `simdmask_t::AllBitsSet(elementCount)` (matching `VNAllBitsForType`) rather than relying on `gtNewAllBitsSetConNode`, which cannot know the element count. Vector (non-mask) results still use `gtNewAllBitsSetConNode`.

## Notes

- The scalar fold reuses the constant `op1` node as the result and wraps it with `gtWrapWithSideEffects(tree, ...)`; because `op1` is a side-effect-free constant, this preserves any side effects from the other operands without duplicating `op1`.
- Direct bit writes (`gtSimdVal.u32[0]` / `u64[0]`) are used for the true-mode all-ones pattern since `SetElementIntegral` asserts on floating base types.

## Testing

Added `Runtime_125160` regression test covering all four True/False modes for float and double `Avx.CompareScalar` (asserting both the low-element result and upper-element preservation) plus `Avx512F.Compare` for `Vector512<float>`/`<double>`. Verified the test fails without the fix (Expected `2`, Actual `0`) and passes with it. Baseline `clr+libs` (checked) build is clean.

> [!NOTE]
> This pull request was authored by GitHub Copilot.
