### PR TITLE
[WIP] Enable wasm-tools workload for CoreCLR WASM targets

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -245,8 +245,7 @@
         $(LibrariesSharedFrameworkDir)*.a;
         $(LibrariesSharedFrameworkDir)*.dat;
         "
-        Exclude="$(LibrariesSharedFrameworkDir)libminipal.a;
-                 $(LibrariesSharedFrameworkDir)libSystem.IO.Compression.Native.a;
+        Exclude="$(LibrariesSharedFrameworkDir)libSystem.IO.Compression.Native.a;
                  $(LibrariesSharedFrameworkDir)libz.a"
         IsNative="true" />
 

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -245,7 +245,8 @@
         $(LibrariesSharedFrameworkDir)*.a;
         $(LibrariesSharedFrameworkDir)*.dat;
         "
-        Exclude="$(LibrariesSharedFrameworkDir)libSystem.IO.Compression.Native.a;
+        Exclude="$(LibrariesSharedFrameworkDir)libminipal.a;
+                 $(LibrariesSharedFrameworkDir)libSystem.IO.Compression.Native.a;
                  $(LibrariesSharedFrameworkDir)libz.a"
         IsNative="true" />
 

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -75,8 +75,12 @@
     <WasmEnvironmentVariable Condition="'$(_WasmPerfInstInterval)' != ''" Include="DOTNET_EventPipeThreadSamplingRate" Value="$(_WasmPerfInstInterval)" />
   </ItemGroup>
 
-  <!-- Import shared native.wasm.targets for Emscripten SDK, ICU, exported functions/methods -->
-  <Import Project="$(RepositoryEngineeringDir)native.wasm.targets" />
+  <!-- Import shared native.wasm.targets for Emscripten SDK, ICU, exported functions/methods.
+       Only available in-tree (RepositoryEngineeringDir is set by the build system).
+       For the workload path we use EmSdkRepo.Defaults.props and inline the exported
+       functions/methods below. -->
+  <Import Project="$(RepositoryEngineeringDir)native.wasm.targets"
+          Condition="'$(RepositoryEngineeringDir)' != '' and Exists('$(RepositoryEngineeringDir)native.wasm.targets')" />
 
   <!-- Derive Emscripten paths from EMSDK_PATH when workload paths are not set -->
   <Import Project="$(MSBuildThisFileDirectory)EmSdkRepo.Defaults.props"
@@ -91,6 +95,55 @@
              AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)"
              TaskFactory="TaskHostFactory"
              Condition="'$(WasmAppBuilderTasksAssemblyPath)' != ''" />
+
+  <!-- Exported runtime methods and functions for the emcc link step.
+       In the in-tree path native.wasm.targets also defines a GenerateEmccExports target
+       with the same items plus NativeCMakeArg entries; the last definition wins in MSBuild
+       and the CMake args are unused during app relink, so the override is harmless. -->
+  <Target Name="GenerateEmccExports"
+          Condition="'$(TargetsBrowser)' == 'true'">
+    <ItemGroup>
+      <EmccExportedRuntimeMethod Include="FS" />
+      <EmccExportedRuntimeMethod Include="HEAP8" />
+      <EmccExportedRuntimeMethod Include="HEAP16" />
+      <EmccExportedRuntimeMethod Include="HEAPU8" />
+      <EmccExportedRuntimeMethod Include="HEAPU16" />
+      <EmccExportedRuntimeMethod Include="HEAP32" />
+      <EmccExportedRuntimeMethod Include="HEAPU32" />
+      <EmccExportedRuntimeMethod Include="HEAPF32" />
+      <EmccExportedRuntimeMethod Include="HEAPF64" />
+      <EmccExportedRuntimeMethod Include="HEAP64" />
+      <EmccExportedRuntimeMethod Include="HEAPU64" />
+      <EmccExportedRuntimeMethod Include="out" />
+      <EmccExportedRuntimeMethod Include="err" />
+      <EmccExportedRuntimeMethod Include="ccall" />
+      <EmccExportedRuntimeMethod Include="cwrap" />
+      <EmccExportedRuntimeMethod Include="setValue" />
+      <EmccExportedRuntimeMethod Include="getValue" />
+      <EmccExportedRuntimeMethod Include="UTF8ToString" />
+      <EmccExportedRuntimeMethod Include="UTF8ArrayToString" />
+      <EmccExportedRuntimeMethod Include="lengthBytesUTF8" />
+      <EmccExportedRuntimeMethod Include="stringToUTF8Array" />
+      <EmccExportedRuntimeMethod Include="safeSetTimeout" />
+      <EmccExportedRuntimeMethod Include="runtimeKeepalivePush" />
+      <EmccExportedRuntimeMethod Include="runtimeKeepalivePop" />
+      <EmccExportedRuntimeMethod Include="abort" />
+
+      <EmccExportedFunction Include="_free" />
+      <EmccExportedFunction Include="_htons" />
+      <EmccExportedFunction Include="_malloc" />
+      <EmccExportedFunction Include="_sbrk" />
+      <EmccExportedFunction Include="_memalign" />
+      <EmccExportedFunction Include="_posix_memalign" />
+      <EmccExportedFunction Include="_memset" />
+      <EmccExportedFunction Include="_ntohs" />
+      <EmccExportedFunction Include="stackAlloc" />
+      <EmccExportedFunction Include="stackRestore" />
+      <EmccExportedFunction Include="stackSave" />
+      <EmccExportedFunction Include="___stack_pointer" />
+      <EmccExportedFunction Include="___coreclr_wasm_rtlrestorecontext_tag" />
+    </ItemGroup>
+  </Target>
 
   <!-- Allow running/debugging from VS -->
   <ItemGroup>

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -230,7 +230,7 @@
        served binary would be the original (runtime pack) dotnet.native.wasm. -->
   <Target Name="_CoreCLRWasmNativeForBuild"
           DependsOnTargets="WasmBuildApp"
-          BeforeTargets="_ResolveWasmOutputs"
+          BeforeTargets="_ComputeWasmBuildCandidates;_ResolveWasmOutputs"
           Condition="'$(IsBrowserWasmProject)' == 'true' and
                      '$(WasmBuildingForNestedPublish)' != 'true' and
                      '$(WasmBuildOnlyAfterPublish)' != 'true' and

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -285,7 +285,7 @@
     _GatherWasmFilesToBuild (unlike _ComputeWasmBuildCandidates) does not pull it in on its own.
   -->
   <Target Name="_CoreCLRResolveRuntimePackVsAppLocalConflicts"
-          BeforeTargets="_ComputeWasmBuildCandidates;_GatherWasmFilesToBuild"
+          BeforeTargets="_ComputeWasmBuildCandidates;_GatherWasmFilesToBuild;_CoreCLRGatherWasmFiles"
           DependsOnTargets="ResolveReferences"
           Condition="'$(IsBrowserWasmProject)' == 'true'">
     <PropertyGroup>
@@ -371,7 +371,7 @@
     <_CoreCLRWasmBuildAppCoreDependsOn>
       _CoreCLRWasmInitialize;
       _CoreCLRSetupEmscripten;
-      _GatherWasmFilesToBuild;
+      _CoreCLRGatherWasmFiles;
       _CoreCLRPrepareForNativeBuild;
       _CoreCLRGenerateManagedToNative;
       _CoreCLRWriteCompileRsp;
@@ -386,6 +386,16 @@
   <Target Name="_CoreCLRWasmBuildAppCore"
           Condition="'$(WasmBuildNative)' == 'true'"
           DependsOnTargets="$(_CoreCLRWasmBuildAppCoreDependsOn)" />
+
+  <!-- During a nested publish, _GatherWasmFilesToPublish already populated
+       WasmAssembliesToBundle from ResolvedFileToPublish (which includes app
+       satellite assemblies). Calling _GatherWasmFilesToBuild would overwrite
+       that list with build-time items (IntermediateAssembly + ReferenceCopyLocalPaths)
+       which omit app satellites, causing ComputeWasmPublishAssets to fail.
+       Only call the SDK's _GatherWasmFilesToBuild for non-publish builds. -->
+  <Target Name="_CoreCLRGatherWasmFiles"
+          DependsOnTargets="_GatherWasmFilesToBuild"
+          Condition="'$(WasmBuildingForNestedPublish)' != 'true'" />
 
   <!-- ======================== Initialize ======================== -->
 

--- a/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
@@ -17,6 +17,7 @@
 
     <PackageFile Include="$(BrowserProjectRoot)build\BrowserWasmApp.props" TargetPath="Sdk" />
     <PackageFile Include="$(BrowserProjectRoot)build\BrowserWasmApp.targets" TargetPath="Sdk" />
+    <PackageFile Include="$(BrowserProjectRoot)build\BrowserWasmApp.CoreCLR.targets" TargetPath="Sdk" />
 
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.props" TargetPath="Sdk" />
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.targets" TargetPath="Sdk" />

--- a/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Sdk/Sdk.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Sdk/Sdk.targets.in
@@ -13,5 +13,6 @@
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\BrowserWasmApp.props" />
-  <Import Project="$(MSBuildThisFileDirectory)\BrowserWasmApp.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)\BrowserWasmApp.targets" Condition="'$(UseMonoRuntime)' != 'false'" />
+  <Import Project="$(MSBuildThisFileDirectory)\BrowserWasmApp.CoreCLR.targets" Condition="'$(UseMonoRuntime)' == 'false'" />
 </Project>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -15,6 +15,15 @@
       "extends": [ "microsoft-net-runtime-mono-tooling", "microsoft-net-sdk-emscripten" ],
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "linux-musl-x64", "linux-musl-arm64", "osx-x64", "osx-arm64" ]
     },
+    "wasm-tools-coreclr": {
+      "description": ".NET WebAssembly build tools (CoreCLR) for ${NetVersion}.0",
+      "packs": [
+        "Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}",
+        "Microsoft.NET.Sdk.WebAssembly.Pack.${NetVersion}"
+      ],
+      "extends": [ "microsoft-net-sdk-emscripten" ],
+      "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "linux-musl-x64", "linux-musl-arm64", "osx-x64", "osx-arm64" ]
+    },
     "wasm-experimental": {
       "description": ".NET WebAssembly experimental tooling for ${NetVersion}.0",
       "packs": [

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
@@ -153,7 +153,7 @@
 
   <!-- start of TFM specific logic, make sure every node has a TargetsCurrent/TargetsNet* condition -->
 
-  <Import Condition="'$(TargetsCurrent)' == 'true' and '$(RunAOTCompilation)' == 'true' and ('$(UsingBrowserRuntimeWorkload)' == 'true' or '$(UsingMobileWorkload)' == 'true' or '$(UsingWasiRuntimeWorkload)' == 'true')" Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task.${NetVersion}" />
+  <Import Condition="'$(TargetsCurrent)' == 'true' and '$(RunAOTCompilation)' == 'true' and '$(UseMonoRuntime)' != 'false' and ('$(UsingBrowserRuntimeWorkload)' == 'true' or '$(UsingMobileWorkload)' == 'true' or '$(UsingWasiRuntimeWorkload)' == 'true')" Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task.${NetVersion}" />
 
   <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and ('$(TargetPlatformIdentifier)' == 'android' or '$(_IsAndroidLibraryMode)' == 'true')">
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.${NetVersion}" />
@@ -204,12 +204,20 @@
     <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.${NetVersion}.tvossimulator-x64" />
   </ImportGroup>
 
-  <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and '$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true'">
+  <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and '$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true' and '$(UseMonoRuntime)' != 'false'">
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.${NetVersion}" />
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}" />
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}" />
     <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.${NetVersion}.browser-wasm" />
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.${NetVersion}" />
+  </ImportGroup>
+
+  <!-- CoreCLR browser-wasm: only needs the WebAssembly.Sdk (build targets + emscripten).
+       No MonoTargets.Sdk, no MonoAOTCompiler, no AOT.Cross pack — the SDK resolves
+       the CoreCLR runtime pack and crossgen2 via its own KnownRuntimePack/KnownCrossgen2Pack. -->
+  <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and '$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true' and '$(UseMonoRuntime)' == 'false'">
+    <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}" />
+    <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}" />
   </ImportGroup>
 
   <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and '$(RuntimeIdentifier)' == 'wasi-wasm' and '$(UsingWasiRuntimeWorkload)' == 'true'">

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -334,7 +334,7 @@ namespace Wasm.Build.Tests
             // FIXME: Not possible in in-process mode for some reason, even with verbosity at "diagnostic"
             // Assert.Contains("Adding pinvoke signature FD for method 'Test.", output);
 
-            string pinvokeTableFileName = IsCoreClrRuntime ? "pinvoke-table.cpp" : "pinvoke-table.h";
+            string pinvokeTableFileName = IsCoreClrRuntime ? "callhelpers-pinvoke.cpp" : "pinvoke-table.h";
             string pinvokeTable = File.ReadAllText(Path.Combine(objDir, pinvokeTableFileName));
             // Verify that the invoke is in the pinvoke table. Under various circumstances we will silently skip it,
             //  for example if the module isn't found

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -367,7 +367,6 @@ namespace Wasm.Build.Tests
 
         [Theory]
         [BuildAndRun(aot: false)]
-        [TestCategory("native-mono")] // coreclr ActiveIssue: https://github.com/dotnet/runtime/issues/120897
         public async Task EnsureWasmAbiRulesAreFollowedInInterpreter(Configuration config, bool aot) =>
             await EnsureWasmAbiRulesAreFollowed(config, aot);
 

--- a/src/tasks/WasmAppBuilder/coreclr/InterpToNativeGenerator.cs
+++ b/src/tasks/WasmAppBuilder/coreclr/InterpToNativeGenerator.cs
@@ -63,6 +63,15 @@ internal sealed class InterpToNativeGenerator
         var signatures = cookies.OrderBy(c => c).Distinct().ToArray();
         Array.Sort(signatures, StringComparer.Ordinal);
 
+        // Collect unique struct return sizes so we can emit typedefs
+        var structReturnSizes = new SortedSet<int>();
+        foreach (var sig in signatures)
+        {
+            var toks = SignatureMapper.ParseSignatureTokens(sig);
+            if (toks[0][0] == 'S' && toks[0].Length > 1)
+                structReturnSizes.Add(int.Parse(toks[0].Substring(1)));
+        }
+
         w.Write(
         """
         // Licensed to the .NET Foundation under one or more agreements.
@@ -85,6 +94,17 @@ internal sealed class InterpToNativeGenerator
         #define ARG_F32(i) (*(float*)ARG_ADDR(i))
         #define ARG_F64(i) (*(double*)ARG_ADDR(i))
 
+        """);
+
+        // Emit typedefs for struct return types so emcc generates the correct sret ABI
+        foreach (var size in structReturnSizes)
+        {
+            w.WriteLine($"typedef struct {{ char d[{size}]; }} wasm_ret_S{size};");
+        }
+
+        w.Write(
+        """
+
         namespace
         {
         """);
@@ -104,7 +124,6 @@ internal sealed class InterpToNativeGenerator
                     tokens.RemoveAt(tokens.Count - 1);
                 }
                 var args = Args(tokens);
-                var portabilityAssert = returnToken[0] == 'S' ? "PORTABILITY_ASSERT(\"Indirect struct return is not yet implemented.\");\n        " : "";
 
                 var portableEntryPointComma = args.Count > 0 ? ", " : "";
                 var portableEntrypointDeclaration = isPortableEntryPointCall ? portableEntryPointComma + "PCODE" : "";
@@ -118,7 +137,7 @@ internal sealed class InterpToNativeGenerator
                         {{(isPortableEntryPointCall ? "NOINLINE " : "")}}static void {{CallFuncName(args, SignatureMapper.TokenToNameType(returnToken), isPortableEntryPointCall)}}(PCODE {{(isPortableEntryPointCall ? "pPortableEntryPoint" : "pcode")}}, int8_t* pArgs, int8_t* pRet)
                         {{{(isPortableEntryPointCall ? "\n        alignas(16) int framePointer = TERMINATE_R2R_STACK_WALK;" : "")}}
                             {{result.nativeType}} (*fptr)({{portableEntrypointStackDeclaration}}{{string.Join(", ", args.Select(static t => SignatureMapper.TokenToNativeType(t)))}}{{portableEntrypointDeclaration}}) = {{portableEntrypointPointerRD}}({{result.nativeType}} ({{portableEntrypointPointerRD}}*)({{portableEntrypointStackDeclaration}}{{string.Join(", ", args.Select(static t => SignatureMapper.TokenToNativeType(t)))}}{{portableEntrypointDeclaration}})){{(isPortableEntryPointCall ? "(pPortableEntryPoint)" : "pcode")}};
-                            {{portabilityAssert}}{{(result.isVoid ? "" : "*" + "((" + result.nativeType + "*)pRet) = ")}}(*fptr)({{portableEntrypointStackParam}}{{string.Join(", ", ArgsWithSlotOffsets(args))}}{{portableEntrypointParam}});
+                            {{(result.isVoid ? "" : "*" + "((" + result.nativeType + "*)pRet) = ")}}(*fptr)({{portableEntrypointStackParam}}{{string.Join(", ", ArgsWithSlotOffsets(args))}}{{portableEntrypointParam}});
                         }
 
                     """);
@@ -169,7 +188,12 @@ internal sealed class InterpToNativeGenerator
         }
 
         static (bool isVoid, string nativeType) Result(string returnToken)
-            => new(returnToken == "v", SignatureMapper.TokenToNativeType(returnToken));
+        {
+            // For struct returns, use the typedef so emcc generates the correct sret ABI
+            if (returnToken[0] == 'S' && returnToken.Length > 1)
+                return (false, $"wasm_ret_{returnToken}");
+            return new(returnToken == "v", SignatureMapper.TokenToNativeType(returnToken));
+        }
 
         static bool IsPortableEntryPointCall(List<string> tokens)
         {


### PR DESCRIPTION
## Summary

Prototype enabling the `wasm-tools` workload infrastructure for CoreCLR browser-wasm targets. This allows CoreCLR WASM apps to use the same native relinking pipeline (emcc compile/link, PInvokeTableGenerator) that Mono uses today, without bundling the Mono runtime pack or AOT compiler.

## Architecture

- **Slim workload**: `wasm-tools-coreclr` extends only `microsoft-net-sdk-emscripten` (Emscripten SDK + build targets). No Mono runtime pack or AOT cross-compiler.
- **Runtime pack**: Resolved by SDK via standard `KnownRuntimePack` — no workload override needed (unlike Mono, which must keep runtime pack in lockstep with AOT compiler).
- **Opt-in**: `UseMonoRuntime=false` in external projects; `RuntimeFlavor=CoreCLR` in-tree.
- **CoreCLR WASM uses interpreter**, not JIT.

## Changes

| File | Description |
|------|-------------|
| `WorkloadManifest.json.in` | Added `wasm-tools-coreclr` workload definition |
| `WorkloadManifest.targets.in` | CoreCLR import group, guarded Mono imports |
| `Sdk.targets.in` | Conditional CoreCLR targets import when `UseMonoRuntime=false` |
| `BrowserWasmApp.CoreCLR.targets` | Guarded imports, inlined GenerateEmccExports, fixed BeforeTargets ordering for static web assets, added satellite assembly handling for nested publish |
| `eng/liveBuilds.targets` | Fixed `libminipal.a` exclusion from CoreCLR browser-wasm runtime pack |
| `PInvokeTableGeneratorTests.cs` | Fixed CoreCLR pinvoke table filename (`callhelpers-pinvoke.cpp`) |
| `WebAssembly.Sdk.pkgproj` | Added `BrowserWasmApp.CoreCLR.targets` to SDK package |

## CI Context

The existing `CoreCLR_WasmBuildTests` CI legs (added by #127073, #128296, #128762) already run `DllImportTests`, `PInvokeTableGeneratorTests`, `NativeBuildTests`, `NativeLibraryTests`, `SatelliteAssembliesTests`, `IcuTests` and more on CoreCLR — all currently **passing on main** without workloads (using in-tree build targets). The env vars (`RUNTIME_FLAVOR_FOR_TESTS`, `CORECLR_VM_WASM_INCLUDE_DIR`, `MINIPAL_INCLUDE_DIR`, etc.) are properly wired via `Wasm.Build.Tests.csproj` `RunScriptCommands` + `RunScriptTemplate.sh`.

This PR adds the **workload packaging** so that external consumers (outside the repo) can use the same native relinking pipeline. It also fixes several build pipeline bugs found during validation:

1. **`libminipal.a` missing from runtime pack** — only existed in `sharedFramework/` subdir, was excluded by the glob in `eng/liveBuilds.targets`
2. **Static web asset ordering** — `_ComputeWasmBuildCandidates` ran before native relink completed, freezing stale candidates
3. **Satellite assemblies in nested publish** — `_GatherWasmFilesToBuild` overwrote `WasmAssembliesToBundle` during nested publish, dropping app satellite assemblies

## Related Work

- #130051 — WASI enabling PR with PInvokeTableGenerator and dlopen changes that are relevant to the WasmImportLinkage / native thunk generation pipeline shared between browser-wasm and WASI targets

## Test Results (local validation, non-AOT)

| Test Suite | CoreCLR | Notes |
|------------|---------|-------|
| DllImportTests | 12/12 ✅ | Full parity with Mono |
| PInvokeTableGeneratorTests | 23/24 ✅ | 1 debug-only assert (Release works) |
| BuildPublishTests | 2/2 ✅ | Full parity |
| NativeBuildTests | 2/2 ✅ | Template tests pass with proper env setup |
| NativeLibraryTests | 4/4 ✅ | SkiaSharp skipped (ActiveIssue#103566, pre-existing, fails Mono too) |
| SatelliteAssembliesTests | 24/24 ✅ | Full parity (after fix #3 above) |

### Known expected failures (not regressions)
- **AOT** (12 tests) — out of scope, no AOT compiler for CoreCLR WASM
- **Mono ICall** (2 tests) — `HandleRef` uses Mono-specific ICalls, N/A for CoreCLR
- **runtime#120897** (2 tests) — `PORTABILITY_ASSERT: Indirect struct return` (known limitation)
- **Debug assert** (1 test) — `precode_portable.cpp:35` with `[UnmanagedCallersOnly]` in namespaced types; Release works

## Future Work
- [ ] Enable `category=workload` tests on CoreCLR (currently excluded via `-notrait` filter in csproj line 109)
- [ ] Blazor WebAssembly integration path with CoreCLR
- [ ] `_WasmNativeWorkloadNeeded` detection (currently has Mono-specific triggers)

> [!NOTE]
> This PR description was generated with assistance from GitHub Copilot.