### PR TITLE
Fix NativeAOT reverse delegate stub signature with runtime marshalling disabled

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -897,7 +897,7 @@ namespace Internal.JitInterface
 
             // Varargs are not supported in .NET Core
             if (sig->callConv == CorInfoCallConv.CORINFO_CALLCONV_VARARG)
-                ThrowHelper.ThrowBadImageFormatException();
+                ThrowHelper.ThrowInvalidProgramException();
 
             if (!signature.IsStatic) sig->callConv |= CorInfoCallConv.CORINFO_CALLCONV_HASTHIS;
             if (signature.IsExplicitThis) sig->callConv |= CorInfoCallConv.CORINFO_CALLCONV_EXPLICITTHIS;

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -248,6 +248,10 @@ namespace Internal.TypeSystem.Ecma
                         return _tsc.GetFunctionPointerType(sig);
                     else
                         return null;
+                case SignatureTypeCode.Sentinel:
+                    // Varargs are not supported
+                    ThrowHelper.ThrowInvalidProgramException();
+                    return null; // unreached
                 default:
                     ThrowHelper.ThrowBadImageFormatException();
                     return null;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
@@ -143,21 +143,14 @@ namespace Internal.IL.Stubs
                         if (unmanagedCallingConvention == MethodSignatureFlags.None)
                             unmanagedCallingConvention = MethodSignatureFlags.UnmanagedCallingConvention;
 
+                        MethodSignature delegateSignature = _invokeMethod.Signature;
                         if (!MarshalHelpers.IsRuntimeMarshallingEnabled(_delegateType.Module))
                         {
                             // When runtime marshalling is disabled, arguments and the return value are passed
-                            // through blittably, so the native signature matches the managed signature. This
-                            // mirrors the Marshaller.CreateDisabledMarshaller path used when emitting the stub IL
-                            // (see PInvokeILEmitter.InitializeMarshallers), and the CoreCLR VM behavior which
-                            // gates runtime marshalling on the delegate type's own module.
-                            MethodSignature disabledDelegateSignature = _invokeMethod.Signature;
-                            TypeDesc[] disabledNativeParameterTypes = new TypeDesc[disabledDelegateSignature.Length];
-                            for (int i = 0; i < disabledDelegateSignature.Length; i++)
-                            {
-                                disabledNativeParameterTypes[i] = disabledDelegateSignature[i];
-                            }
-
-                            _signature = new MethodSignature(MethodSignatureFlags.Static | unmanagedCallingConvention, 0, disabledDelegateSignature.ReturnType, disabledNativeParameterTypes);
+                            // through blittably, so the native signature matches the managed signature.
+                            var builder = new MethodSignatureBuilder(delegateSignature);
+                            builder.Flags = MethodSignatureFlags.Static | unmanagedCallingConvention;
+                            _signature = builder.ToSignature();
                             return _signature;
                         }
 
@@ -170,7 +163,6 @@ namespace Internal.IL.Stubs
                             _ => true
                         };
 
-                        MethodSignature delegateSignature = _invokeMethod.Signature;
                         TypeDesc[] nativeParameterTypes = new TypeDesc[delegateSignature.Length];
                         ParameterMetadata[] parameterMetadataArray = _invokeMethod.GetParameterMetadata();
                         int parameterIndex = 0;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
@@ -139,6 +139,28 @@ namespace Internal.IL.Stubs
                             flags = ecmaType.GetDelegatePInvokeFlags();
                         }
 
+                        MethodSignatureFlags unmanagedCallingConvention = flags.UnmanagedCallingConvention;
+                        if (unmanagedCallingConvention == MethodSignatureFlags.None)
+                            unmanagedCallingConvention = MethodSignatureFlags.UnmanagedCallingConvention;
+
+                        if (!MarshalHelpers.IsRuntimeMarshallingEnabled(_delegateType.Module))
+                        {
+                            // When runtime marshalling is disabled, arguments and the return value are passed
+                            // through blittably, so the native signature matches the managed signature. This
+                            // mirrors the Marshaller.CreateDisabledMarshaller path used when emitting the stub IL
+                            // (see PInvokeILEmitter.InitializeMarshallers), and the CoreCLR VM behavior which
+                            // gates runtime marshalling on the delegate type's own module.
+                            MethodSignature disabledDelegateSignature = _invokeMethod.Signature;
+                            TypeDesc[] disabledNativeParameterTypes = new TypeDesc[disabledDelegateSignature.Length];
+                            for (int i = 0; i < disabledDelegateSignature.Length; i++)
+                            {
+                                disabledNativeParameterTypes[i] = disabledDelegateSignature[i];
+                            }
+
+                            _signature = new MethodSignature(MethodSignatureFlags.Static | unmanagedCallingConvention, 0, disabledDelegateSignature.ReturnType, disabledNativeParameterTypes);
+                            return _signature;
+                        }
+
                         // Mirror CharSet normalization from Marshaller.CreateMarshaller
                         bool isAnsi = flags.CharSet switch
                         {
@@ -191,10 +213,6 @@ namespace Internal.IL.Stubs
 
                             nativeParameterTypes[i] = isByRefType ? nativeType.MakePointerType() : nativeType;
                         }
-
-                        MethodSignatureFlags unmanagedCallingConvention = flags.UnmanagedCallingConvention;
-                        if (unmanagedCallingConvention == MethodSignatureFlags.None)
-                            unmanagedCallingConvention = MethodSignatureFlags.UnmanagedCallingConvention;
 
                         _signature = new MethodSignature(MethodSignatureFlags.Static | unmanagedCallingConvention, 0, nativeReturnType, nativeParameterTypes);
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LibraryRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LibraryRootProvider.cs
@@ -87,7 +87,7 @@ namespace ILCompiler
 
             // Vararg methods are not supported in .NET Core
             if ((signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) == MethodSignatureFlags.CallingConventionVarargs)
-                ThrowHelper.ThrowBadImageFormatException();
+                ThrowHelper.ThrowInvalidProgramException();
 
             CheckTypeCanBeUsedInSignature(signature.ReturnType);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LibraryRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LibraryRootProvider.cs
@@ -85,7 +85,7 @@ namespace ILCompiler
         {
             MethodSignature signature = method.Signature;
 
-            // Vararg methods are not supported in .NET Core
+            // Vararg methods are not supported
             if ((signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) == MethodSignatureFlags.CallingConventionVarargs)
                 ThrowHelper.ThrowInvalidProgramException();
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -460,7 +460,7 @@ namespace Internal.IL
 
             _compilation.TypeSystemContext.EnsureLoadableMethod(method);
             if ((method.Signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) == MethodSignatureFlags.CallingConventionVarargs)
-                ThrowHelper.ThrowBadImageFormatException();
+                ThrowHelper.ThrowInvalidProgramException();
 
             _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, method);
 

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyDisabled.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyDisabled.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
-    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/84402 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PInvokeAssemblyMarshallingDisabled/*.cs" />

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly.csproj
@@ -3,9 +3,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>DISABLE_RUNTIME_MARSHALLING;$(DefineConstants)</DefineConstants>
-
-    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/84402 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PInvokeAssemblyMarshallingDisabled/*.cs" />

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly_ro.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly_ro.csproj
@@ -6,9 +6,6 @@
     <DebugType>None</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>DISABLE_RUNTIME_MARSHALLING;$(DefineConstants)</DefineConstants>
-
-    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/84402 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PInvokeAssemblyMarshallingDisabled/*.cs" />

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_NativeAssemblyDisabled.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_NativeAssemblyDisabled.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
-    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/84402 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PInvokeAssemblyMarshallingDisabled/*.cs" />


### PR DESCRIPTION
The reverse delegate stub's native signature was computed via GetNativeMethodParameterType, which synthesizes a __NativeType__ struct, without checking whether runtime marshalling is disabled for the delegate's module. The stub body, however, is emitted using CreateDisabledMarshaller (blittable pass-through), so the declared native signature disagreed with the emitted IL, tripping the 'ClassLayout::AreCompatible' assert during ILC importation.

Gate the native signature computation on IsRuntimeMarshallingEnabled(delegate module), matching PInvokeILEmitter.InitializeMarshallers and the CoreCLR VM (which uses the delegate Invoke method's module for m_pMetadataModule). When disabled, the native signature equals the managed signature.

Re-enables the previously disabled DisabledRuntimeMarshalling NativeAOT tests.

The test was also exercising some varargs scenarios and we were not throwing the right exception type for them. So fixing that too.

Fixes https://github.com/dotnet/runtime/issues/84402