### PR TITLE
[cdac] SystemV-AMD64 struct-in-register classifier: enable ARGITER + zero-known-issues on Linux x64

### DIFF
--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -613,6 +613,7 @@ class EEClassOptionalFields
     // for MethodTableBuilder and NativeImageDumper, which need raw field-level access.
     friend class EEClass;
     friend class MethodTableBuilder;
+    friend struct ::cdac_data<EEClassOptionalFields>;
 
     //
     // GENERICS RELATED FIELDS.
@@ -1785,6 +1786,14 @@ template<> struct cdac_data<EEClass>
     static constexpr size_t NumThreadStaticFields = offsetof(EEClass, m_NumThreadStaticFields);
     static constexpr size_t NumNonVirtualSlots = offsetof(EEClass, m_NumNonVirtualSlots);
     static constexpr size_t BaseSizePadding = offsetof(EEClass, m_cbBaseSizePadding);
+    static constexpr size_t OptionalFields = offsetof(EEClass, m_rpOptionalFields);
+};
+
+template<> struct cdac_data<EEClassOptionalFields>
+{
+#if defined(UNIX_AMD64_ABI)
+    static constexpr size_t EightByteRegistersInfo = offsetof(EEClassOptionalFields, m_eightByteRegistersInfo);
+#endif // UNIX_AMD64_ABI
 };
 
 // --------------------------------------------------------------------------------------------

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -586,8 +586,10 @@ CDAC_TYPE_END(EEClassOptionalFields)
 CDAC_TYPE_BEGIN(SystemVEightByteRegistersInfo)
 CDAC_TYPE_INDETERMINATE(SystemVEightByteRegistersInfo)
 CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, NumEightBytes, cdac_data<SystemVEightByteRegistersInfo>::NumEightBytes)
-CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, EightByteClassifications, cdac_data<SystemVEightByteRegistersInfo>::EightByteClassifications)
-CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, EightByteSizes, cdac_data<SystemVEightByteRegistersInfo>::EightByteSizes)
+CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, EightByteClassification0, cdac_data<SystemVEightByteRegistersInfo>::EightByteClassification0)
+CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, EightByteClassification1, cdac_data<SystemVEightByteRegistersInfo>::EightByteClassification1)
+CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, EightByteSize0, cdac_data<SystemVEightByteRegistersInfo>::EightByteSize0)
+CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, EightByteSize1, cdac_data<SystemVEightByteRegistersInfo>::EightByteSize1)
 CDAC_TYPE_END(SystemVEightByteRegistersInfo)
 #endif // UNIX_AMD64_ABI
 

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -572,7 +572,24 @@ CDAC_TYPE_FIELD(EEClass, T_UINT16, NumStaticFields, cdac_data<EEClass>::NumStati
 CDAC_TYPE_FIELD(EEClass, T_UINT16, NumThreadStaticFields, cdac_data<EEClass>::NumThreadStaticFields)
 CDAC_TYPE_FIELD(EEClass, T_UINT16, NumNonVirtualSlots, cdac_data<EEClass>::NumNonVirtualSlots)
 CDAC_TYPE_FIELD(EEClass, T_UINT8, BaseSizePadding, cdac_data<EEClass>::BaseSizePadding)
+CDAC_TYPE_FIELD(EEClass, T_POINTER, OptionalFields, cdac_data<EEClass>::OptionalFields)
 CDAC_TYPE_END(EEClass)
+
+CDAC_TYPE_BEGIN(EEClassOptionalFields)
+CDAC_TYPE_INDETERMINATE(EEClassOptionalFields)
+#ifdef UNIX_AMD64_ABI
+CDAC_TYPE_FIELD(EEClassOptionalFields, TYPE(SystemVEightByteRegistersInfo), EightByteRegistersInfo, cdac_data<EEClassOptionalFields>::EightByteRegistersInfo)
+#endif // UNIX_AMD64_ABI
+CDAC_TYPE_END(EEClassOptionalFields)
+
+#ifdef UNIX_AMD64_ABI
+CDAC_TYPE_BEGIN(SystemVEightByteRegistersInfo)
+CDAC_TYPE_INDETERMINATE(SystemVEightByteRegistersInfo)
+CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, NumEightBytes, cdac_data<SystemVEightByteRegistersInfo>::NumEightBytes)
+CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, EightByteClassifications, cdac_data<SystemVEightByteRegistersInfo>::EightByteClassifications)
+CDAC_TYPE_FIELD(SystemVEightByteRegistersInfo, T_UINT8, EightByteSizes, cdac_data<SystemVEightByteRegistersInfo>::EightByteSizes)
+CDAC_TYPE_END(SystemVEightByteRegistersInfo)
+#endif // UNIX_AMD64_ABI
 
 CDAC_TYPE_BEGIN(GenericsDictInfo)
 CDAC_TYPE_INDETERMINATE(GenericsDictInfo)

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -921,6 +921,15 @@ public:
         _ASSERTE(index < NumEightBytes);
         return EightByteSizes[index];
     }
+
+    friend struct ::cdac_data<SystemVEightByteRegistersInfo>;
+};
+
+template<> struct cdac_data<SystemVEightByteRegistersInfo>
+{
+    static constexpr size_t NumEightBytes = offsetof(SystemVEightByteRegistersInfo, NumEightBytes);
+    static constexpr size_t EightByteClassifications = offsetof(SystemVEightByteRegistersInfo, EightByteClassifications);
+    static constexpr size_t EightByteSizes = offsetof(SystemVEightByteRegistersInfo, EightByteSizes);
 };
 #endif
 

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -928,8 +928,11 @@ public:
 template<> struct cdac_data<SystemVEightByteRegistersInfo>
 {
     static constexpr size_t NumEightBytes = offsetof(SystemVEightByteRegistersInfo, NumEightBytes);
-    static constexpr size_t EightByteClassifications = offsetof(SystemVEightByteRegistersInfo, EightByteClassifications);
-    static constexpr size_t EightByteSizes = offsetof(SystemVEightByteRegistersInfo, EightByteSizes);
+    static constexpr size_t EightByteClassification0 = offsetof(SystemVEightByteRegistersInfo, EightByteClassifications) + 0 * sizeof(SystemVClassificationType);
+    static constexpr size_t EightByteClassification1 = offsetof(SystemVEightByteRegistersInfo, EightByteClassifications) + 1 * sizeof(SystemVClassificationType);
+    static constexpr size_t EightByteSize0 = offsetof(SystemVEightByteRegistersInfo, EightByteSizes) + 0;
+    static constexpr size_t EightByteSize1 = offsetof(SystemVEightByteRegistersInfo, EightByteSizes) + 1;
+    static_assert(CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS == 2, "cdac descriptor exposes exactly two eightbyte slots");
 };
 #endif
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/ArgumentLocation.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/ArgumentLocation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Internal.JitInterface;
+
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
 internal readonly struct ArgumentLocation
@@ -29,4 +31,12 @@ internal readonly struct ArgumentLocation
     // the open generic MethodTable (e.g. Span<T> for a Span<int> arg) so
     // encoders can inspect type structure as a fallback.
     public TypeHandle OpenGenericType { get; init; }
+
+    // SystemV-AMD64 struct passed in registers. Offset is the StructInRegsOffset
+    // sentinel; the encoder consumes SysVEightByteDescriptor + SysVIdxGenReg.
+    public bool IsStructPassedInRegs { get; init; }
+    public SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR SysVEightByteDescriptor { get; init; }
+    // Index of the first general-purpose argument register assigned to this
+    // struct (0 = RDI, 1 = RSI, ...).
+    public int SysVIdxGenReg { get; init; }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Internal.CallingConvention;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Internal.CallingConvention;
 using Internal.CorConstants;
+using Internal.JitInterface;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers;
 using Microsoft.Diagnostics.DataContractReader.SignatureHelpers;
 
@@ -222,7 +224,26 @@ internal sealed class CallingConvention_1 : ICallingConvention
                 }
 
                 if (argOffset == TransitionBlock.StructInRegsOffset)
-                    throw new NotImplementedException("SystemV AMD64 struct-in-registers is not yet supported by the cDAC.");
+                {
+                    // SystemV-AMD64 struct-in-registers.
+                    SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR sysvDesc;
+                    parameterTypes[argIndex].GetSystemVAmd64PassStructInRegisterDescriptor(out sysvDesc);
+                    Internal.CallingConvention.ArgLocDesc? loc = argit.GetArgLoc(argOffset);
+                    Debug.Assert(loc.HasValue);
+
+                    arguments.Add(new ArgumentLocation
+                    {
+                        Offset = argOffset,
+                        ElementType = elemType,
+                        TypeHandle = methodSig.ParameterTypes[argIndex],
+                        IsStructPassedInRegs = true,
+                        SysVEightByteDescriptor = sysvDesc,
+                        SysVIdxGenReg = loc.Value.m_idxGenReg,
+                        OpenGenericType = paramInfo[argIndex].OpenGenericType,
+                    });
+                    argIndex++;
+                    continue;
+                }
 
                 bool passedByRef = elemType == CdacCorElementType.ValueType
                     && transitionBlock.IsArgPassedByRef(parameterTypes[argIndex]);
@@ -618,6 +639,34 @@ internal sealed class CallingConvention_1 : ICallingConvention
             else if (arg.IsVASigCookie)
             {
                 token = GCRefMapToken.VASigCookie;
+            }
+            else if (arg.IsStructPassedInRegs)
+            {
+                // Mirrors ArgDestination::ReportPointersFromStructInRegisters
+                // in src/coreclr/vm/argdestination.h.
+                TransitionBlock tbForStruct = BuildTransitionBlock(runtimeInfo);
+                int genRegOffset = tbForStruct.OffsetOfArgumentRegisters + arg.SysVIdxGenReg * pointerSize;
+                for (int i = 0; i < arg.SysVEightByteDescriptor.eightByteCount; i++)
+                {
+                    SystemVClassificationType cls = (i == 0)
+                        ? arg.SysVEightByteDescriptor.eightByteClassifications0
+                        : arg.SysVEightByteDescriptor.eightByteClassifications1;
+                    int size = (i == 0)
+                        ? arg.SysVEightByteDescriptor.eightByteSizes0
+                        : arg.SysVEightByteDescriptor.eightByteSizes1;
+
+                    // SSE eightbytes go to XMM regs; don't advance genRegOffset.
+                    if (cls == SystemVClassificationType.SystemVClassificationTypeSSE)
+                        continue;
+
+                    if (cls == SystemVClassificationType.SystemVClassificationTypeIntegerReference)
+                        tokens[genRegOffset] = GCRefMapToken.Ref;
+                    else if (cls == SystemVClassificationType.SystemVClassificationTypeIntegerByRef)
+                        tokens[genRegOffset] = GCRefMapToken.Interior;
+
+                    genRegOffset += size;
+                }
+                continue;
             }
             else if (arg.IsParamType)
             {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
@@ -228,8 +228,7 @@ internal sealed class CallingConvention_1 : ICallingConvention
                     // SystemV-AMD64 struct-in-registers.
                     SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR sysvDesc;
                     parameterTypes[argIndex].GetSystemVAmd64PassStructInRegisterDescriptor(out sysvDesc);
-                    Internal.CallingConvention.ArgLocDesc? loc = argit.GetArgLoc(argOffset);
-                    Debug.Assert(loc.HasValue);
+                    ArgLocDesc loc = argit.GetArgLoc(argOffset) ?? throw new InvalidOperationException("ArgIterator returned null ArgLocDesc for struct-in-registers argument");
 
                     arguments.Add(new ArgumentLocation
                     {
@@ -238,7 +237,7 @@ internal sealed class CallingConvention_1 : ICallingConvention
                         TypeHandle = methodSig.ParameterTypes[argIndex],
                         IsStructPassedInRegs = true,
                         SysVEightByteDescriptor = sysvDesc,
-                        SysVIdxGenReg = loc.Value.m_idxGenReg,
+                        SysVIdxGenReg = loc.m_idxGenReg,
                         OpenGenericType = paramInfo[argIndex].OpenGenericType,
                     });
                     argIndex++;
@@ -623,6 +622,7 @@ internal sealed class CallingConvention_1 : ICallingConvention
         bool isX86 = arch is RuntimeInfoArchitecture.X86;
 
         int pointerSize = _target.PointerSize;
+        TransitionBlock tb = BuildTransitionBlock(runtimeInfo);
 
         SortedDictionary<int, GCRefMapToken> tokens = new();
         ArgumentLayout enumeration = GetArgumentLayout(methodDesc);
@@ -644,8 +644,7 @@ internal sealed class CallingConvention_1 : ICallingConvention
             {
                 // Mirrors ArgDestination::ReportPointersFromStructInRegisters
                 // in src/coreclr/vm/argdestination.h.
-                TransitionBlock tbForStruct = BuildTransitionBlock(runtimeInfo);
-                int genRegOffset = tbForStruct.OffsetOfArgumentRegisters + arg.SysVIdxGenReg * pointerSize;
+                int genRegOffset = tb.OffsetOfArgumentRegisters + arg.SysVIdxGenReg * pointerSize;
                 for (int i = 0; i < arg.SysVEightByteDescriptor.eightByteCount; i++)
                 {
                     SystemVClassificationType cls = (i == 0)
@@ -790,7 +789,6 @@ internal sealed class CallingConvention_1 : ICallingConvention
         // the lowest positions). On non-x86 the mapping is monotonic so we
         // could iterate the offset map directly, but using OffsetFromGCRefMapPos
         // for both keeps the code path uniform.
-        TransitionBlock tb = BuildTransitionBlock(runtimeInfo);
 
         // For x86 we need to know how many slot positions exist (we'd otherwise
         // miss high-pos register slots when the offset map's max is on the

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
@@ -121,8 +121,48 @@ internal readonly struct CdacTypeHandle : ITypeHandle
 
     public void GetSystemVAmd64PassStructInRegisterDescriptor(out SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR descriptor)
     {
-        throw new NotImplementedException("SystemV AMD64 struct-in-registers is not yet supported by the cDAC.");
+        descriptor = default;
+        descriptor.passedInRegisters = false;
+
+        if (_typeHandle.IsNull)
+            return;
+
+        // The runtime pre-computes the eightbyte classification for every managed
+        // value type at MethodTable construction and caches it in
+        // EEClass::m_eightByteRegistersInfo (inside EEClassOptionalFields). We
+        // read that cached descriptor instead of re-classifying, mirroring
+        // jitinterface.cpp::SystemVRegDescriptorFromSystemVEightByteRegistersInfo.
+        //
+        // The runtime only allocates m_eightByteRegistersInfo on UNIX_AMD64_ABI
+        // builds; on other targets the field is absent from the
+        // EEClassOptionalFields descriptor and EightByteRegistersInfo below is
+        // null.
+        TargetPointer eeClassPtr = Rts.GetClassPointer(_typeHandle);
+        if (eeClassPtr == TargetPointer.Null)
+            return;
+
+        Data.EEClass eeClass = _target.ProcessedData.GetOrAdd<Data.EEClass>(eeClassPtr);
+        if (eeClass.OptionalFields == TargetPointer.Null)
+            return;
+
+        Data.EEClassOptionalFields optFields = _target.ProcessedData.GetOrAdd<Data.EEClassOptionalFields>(eeClass.OptionalFields);
+        if (optFields.EightByteRegistersInfo is not Data.SystemVEightByteRegistersInfo info)
+            return; // Non-Unix-x64 target: descriptor doesn't include this field.
+
+        if (info.NumEightBytes == 0)
+            return; // Runtime marked this struct as not-enregisterable.
+
+        descriptor.passedInRegisters = true;
+        descriptor.eightByteCount = info.NumEightBytes;
+        descriptor.eightByteClassifications0 = (SystemVClassificationType)info.EightByteClassifications[0];
+        descriptor.eightByteSizes0 = info.EightByteSizes[0];
+        descriptor.eightByteOffsets0 = 0;
+        descriptor.eightByteClassifications1 = (SystemVClassificationType)info.EightByteClassifications[1];
+        descriptor.eightByteSizes1 = info.EightByteSizes[1];
+        descriptor.eightByteOffsets1 = SystemVEightByteSizeInBytes;
     }
+
+    private const int SystemVEightByteSizeInBytes = 8;
 
     public FpStructInRegistersInfo GetFpStructInRegistersInfo(Internal.TypeSystem.TargetArchitecture architecture)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
@@ -127,16 +127,9 @@ internal readonly struct CdacTypeHandle : ITypeHandle
         if (_typeHandle.IsNull)
             return;
 
-        // The runtime pre-computes the eightbyte classification for every managed
-        // value type at MethodTable construction and caches it in
-        // EEClass::m_eightByteRegistersInfo (inside EEClassOptionalFields). We
-        // read that cached descriptor instead of re-classifying, mirroring
-        // jitinterface.cpp::SystemVRegDescriptorFromSystemVEightByteRegistersInfo.
-        //
-        // The runtime only allocates m_eightByteRegistersInfo on UNIX_AMD64_ABI
-        // builds; on other targets the field is absent from the
-        // EEClassOptionalFields descriptor and EightByteRegistersInfo below is
-        // null.
+        // Read the runtime-cached classification from EEClassOptionalFields;
+        // mirrors SystemVRegDescriptorFromSystemVEightByteRegistersInfo in
+        // jitinterface.cpp. Field only populated on UNIX_AMD64_ABI builds.
         TargetPointer eeClassPtr = Rts.GetClassPointer(_typeHandle);
         if (eeClassPtr == TargetPointer.Null)
             return;
@@ -147,12 +140,12 @@ internal readonly struct CdacTypeHandle : ITypeHandle
 
         Data.EEClassOptionalFields optFields = _target.ProcessedData.GetOrAdd<Data.EEClassOptionalFields>(eeClass.OptionalFields);
         if (optFields.EightByteRegistersInfo is not Data.SystemVEightByteRegistersInfo info)
-            return; // Non-Unix-x64 target: descriptor doesn't include this field.
+            return;
 
         if (info.NumEightBytes == 0)
-            return; // Runtime marked this struct as not-enregisterable.
+            return;
 
-        Debug.Assert(info.NumEightBytes <= 2, "SystemV descriptor never encodes more than 2 eightbytes");
+        Debug.Assert(info.NumEightBytes <= 2);
 
         descriptor.passedInRegisters = true;
         descriptor.eightByteCount = info.NumEightBytes;
@@ -160,10 +153,6 @@ internal readonly struct CdacTypeHandle : ITypeHandle
         descriptor.eightByteSizes0 = info.EightByteSizes[0];
         descriptor.eightByteOffsets0 = 0;
 
-        // Slots beyond NumEightBytes are undefined in the runtime's cached
-        // SystemVEightByteRegistersInfo. Only populate the second slot when
-        // it's actually in use; mirrors
-        // jitinterface.cpp::SystemVRegDescriptorFromSystemVEightByteRegistersInfo.
         if (info.NumEightBytes > 1)
         {
             descriptor.eightByteClassifications1 = (SystemVClassificationType)info.EightByteClassifications[1];

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
@@ -145,18 +145,22 @@ internal readonly struct CdacTypeHandle : ITypeHandle
         if (info.NumEightBytes == 0)
             return;
 
-        Debug.Assert(info.NumEightBytes <= 2);
+        // Runtime contract: at most CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS (2)
+        // eightbytes. Treat a corrupted / out-of-range count as "not passed in
+        // registers" so downstream loops keyed off eightByteCount can't overrun.
+        if (info.NumEightBytes > 2)
+            return;
 
         descriptor.passedInRegisters = true;
         descriptor.eightByteCount = info.NumEightBytes;
-        descriptor.eightByteClassifications0 = (SystemVClassificationType)info.EightByteClassifications[0];
-        descriptor.eightByteSizes0 = info.EightByteSizes[0];
+        descriptor.eightByteClassifications0 = (SystemVClassificationType)info.EightByteClassification0;
+        descriptor.eightByteSizes0 = info.EightByteSize0;
         descriptor.eightByteOffsets0 = 0;
 
         if (info.NumEightBytes > 1)
         {
-            descriptor.eightByteClassifications1 = (SystemVClassificationType)info.EightByteClassifications[1];
-            descriptor.eightByteSizes1 = info.EightByteSizes[1];
+            descriptor.eightByteClassifications1 = (SystemVClassificationType)info.EightByteClassification1;
+            descriptor.eightByteSizes1 = info.EightByteSize1;
             descriptor.eightByteOffsets1 = SystemVEightByteSizeInBytes;
         }
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
@@ -152,14 +152,24 @@ internal readonly struct CdacTypeHandle : ITypeHandle
         if (info.NumEightBytes == 0)
             return; // Runtime marked this struct as not-enregisterable.
 
+        Debug.Assert(info.NumEightBytes <= 2, "SystemV descriptor never encodes more than 2 eightbytes");
+
         descriptor.passedInRegisters = true;
         descriptor.eightByteCount = info.NumEightBytes;
         descriptor.eightByteClassifications0 = (SystemVClassificationType)info.EightByteClassifications[0];
         descriptor.eightByteSizes0 = info.EightByteSizes[0];
         descriptor.eightByteOffsets0 = 0;
-        descriptor.eightByteClassifications1 = (SystemVClassificationType)info.EightByteClassifications[1];
-        descriptor.eightByteSizes1 = info.EightByteSizes[1];
-        descriptor.eightByteOffsets1 = SystemVEightByteSizeInBytes;
+
+        // Slots beyond NumEightBytes are undefined in the runtime's cached
+        // SystemVEightByteRegistersInfo. Only populate the second slot when
+        // it's actually in use; mirrors
+        // jitinterface.cpp::SystemVRegDescriptorFromSystemVEightByteRegistersInfo.
+        if (info.NumEightBytes > 1)
+        {
+            descriptor.eightByteClassifications1 = (SystemVClassificationType)info.EightByteClassifications[1];
+            descriptor.eightByteSizes1 = info.EightByteSizes[1];
+            descriptor.eightByteOffsets1 = SystemVEightByteSizeInBytes;
+        }
     }
 
     private const int SystemVEightByteSizeInBytes = 8;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
@@ -161,11 +161,9 @@ internal readonly struct CdacTypeHandle : ITypeHandle
         {
             descriptor.eightByteClassifications1 = (SystemVClassificationType)info.EightByteClassification1;
             descriptor.eightByteSizes1 = info.EightByteSize1;
-            descriptor.eightByteOffsets1 = SystemVEightByteSizeInBytes;
+            descriptor.eightByteOffsets1 = SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR.SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES;
         }
     }
-
-    private const int SystemVEightByteSizeInBytes = 8;
 
     public FpStructInRegistersInfo GetFpStructInRegistersInfo(Internal.TypeSystem.TargetArchitecture architecture)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/GC/GcScanner.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/GC/GcScanner.cs
@@ -337,27 +337,6 @@ internal class GcScanner
     /// </summary>
     private void PromoteCallerStack(TargetPointer frameAddress, GcScanContext scanContext)
     {
-        IRuntimeInfo runtimeInfo = _target.Contracts.RuntimeInfo;
-        RuntimeInfoArchitecture arch = runtimeInfo.GetTargetArchitecture();
-        RuntimeInfoOperatingSystem os = runtimeInfo.GetTargetOperatingSystem();
-        // Matches the ARGITER stress-test gate in CdacStressTests.cs. Platforms
-        // still missing calling-convention coverage (SystemV-AMD64 / RISC-V /
-        // LoongArch / WASM) fall through to RecordDeferredFrame.
-        // TODO(https://github.com/dotnet/runtime/issues/130008): extend
-        // ICallingConvention.TryComputeArgGCRefMapBlob coverage to the
-        // remaining targets so this path fires everywhere.
-        bool supportedByCallingConvention =
-            (os is RuntimeInfoOperatingSystem.Windows
-                && arch is RuntimeInfoArchitecture.X86 or RuntimeInfoArchitecture.X64 or RuntimeInfoArchitecture.Arm64)
-            || (os is RuntimeInfoOperatingSystem.Unix
-                && arch is RuntimeInfoArchitecture.Arm or RuntimeInfoArchitecture.Arm64);
-
-        if (!supportedByCallingConvention)
-        {
-            scanContext.RecordDeferredFrame(frameAddress);
-            return;
-        }
-
         Data.FramedMethodFrame fmf = _target.ProcessedData.GetOrAdd<Data.FramedMethodFrame>(frameAddress);
         if (fmf.MethodDescPtr == TargetPointer.Null)
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/GC/GcScanner.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/GC/GcScanner.cs
@@ -337,27 +337,6 @@ internal class GcScanner
     /// </summary>
     private void PromoteCallerStack(TargetPointer frameAddress, GcScanContext scanContext)
     {
-        // Fast-reject targets whose ArgIterator port isn't yet complete. Without
-        // this gate the eventual NotImplementedException inside
-        // TryComputeArgGCRefMapBlob would drive routine stack scans through
-        // exception-based control flow (expensive, and surfaces as first-chance
-        // exceptions under debuggers).
-        // TODO(https://github.com/dotnet/runtime/issues/130008): extend coverage
-        // and remove this gate.
-        IRuntimeInfo runtimeInfo = _target.Contracts.RuntimeInfo;
-        RuntimeInfoArchitecture arch = runtimeInfo.GetTargetArchitecture();
-        RuntimeInfoOperatingSystem os = runtimeInfo.GetTargetOperatingSystem();
-        bool supported =
-            (os is RuntimeInfoOperatingSystem.Windows
-                && arch is RuntimeInfoArchitecture.X86 or RuntimeInfoArchitecture.X64 or RuntimeInfoArchitecture.Arm64)
-            || (os is RuntimeInfoOperatingSystem.Unix or RuntimeInfoOperatingSystem.Apple
-                && arch is RuntimeInfoArchitecture.X64 or RuntimeInfoArchitecture.Arm or RuntimeInfoArchitecture.Arm64);
-        if (!supported)
-        {
-            scanContext.RecordDeferredFrame(frameAddress);
-            return;
-        }
-
         Data.FramedMethodFrame fmf = _target.ProcessedData.GetOrAdd<Data.FramedMethodFrame>(frameAddress);
         if (fmf.MethodDescPtr == TargetPointer.Null)
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/GC/GcScanner.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/GC/GcScanner.cs
@@ -337,6 +337,27 @@ internal class GcScanner
     /// </summary>
     private void PromoteCallerStack(TargetPointer frameAddress, GcScanContext scanContext)
     {
+        // Fast-reject targets whose ArgIterator port isn't yet complete. Without
+        // this gate the eventual NotImplementedException inside
+        // TryComputeArgGCRefMapBlob would drive routine stack scans through
+        // exception-based control flow (expensive, and surfaces as first-chance
+        // exceptions under debuggers).
+        // TODO(https://github.com/dotnet/runtime/issues/130008): extend coverage
+        // and remove this gate.
+        IRuntimeInfo runtimeInfo = _target.Contracts.RuntimeInfo;
+        RuntimeInfoArchitecture arch = runtimeInfo.GetTargetArchitecture();
+        RuntimeInfoOperatingSystem os = runtimeInfo.GetTargetOperatingSystem();
+        bool supported =
+            (os is RuntimeInfoOperatingSystem.Windows
+                && arch is RuntimeInfoArchitecture.X86 or RuntimeInfoArchitecture.X64 or RuntimeInfoArchitecture.Arm64)
+            || (os is RuntimeInfoOperatingSystem.Unix or RuntimeInfoOperatingSystem.Apple
+                && arch is RuntimeInfoArchitecture.X64 or RuntimeInfoArchitecture.Arm or RuntimeInfoArchitecture.Arm64);
+        if (!supported)
+        {
+            scanContext.RecordDeferredFrame(frameAddress);
+            return;
+        }
+
         Data.FramedMethodFrame fmf = _target.ProcessedData.GetOrAdd<Data.FramedMethodFrame>(frameAddress);
         if (fmf.MethodDescPtr == TargetPointer.Null)
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EEClass.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EEClass.cs
@@ -25,4 +25,5 @@ internal sealed partial class EEClass : IData<EEClass>
     [Field] public TargetPointer FieldDescList { get; }
     [Field] public ushort NumNonVirtualSlots { get; }
     [Field] public byte BaseSizePadding { get; }
+    [Field] public TargetPointer OptionalFields { get; }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EEClassOptionalFields.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EEClassOptionalFields.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+[CdacType(nameof(DataType.EEClassOptionalFields))]
+internal sealed partial class EEClassOptionalFields : IData<EEClassOptionalFields>
+{
+    [Field] public SystemVEightByteRegistersInfo? EightByteRegistersInfo { get; }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SystemVEightByteRegistersInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SystemVEightByteRegistersInfo.cs
@@ -6,16 +6,10 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 [CdacType(nameof(DataType.SystemVEightByteRegistersInfo))]
 internal sealed partial class SystemVEightByteRegistersInfo : IData<SystemVEightByteRegistersInfo>
 {
-    [Field] public byte NumEightBytes { get; }
-
     // Slots beyond NumEightBytes are undefined.
-    public byte[] EightByteClassifications { get; private set; } = new byte[2];
-    public byte[] EightByteSizes { get; private set; } = new byte[2];
-
-    partial void OnInit(Target target, TargetPointer address)
-    {
-        Target.TypeInfo type = target.GetTypeInfo(DataType.SystemVEightByteRegistersInfo);
-        target.ReadBuffer(address + (ulong)type.Fields[nameof(EightByteClassifications)].Offset, EightByteClassifications);
-        target.ReadBuffer(address + (ulong)type.Fields[nameof(EightByteSizes)].Offset, EightByteSizes);
-    }
+    [Field] public byte NumEightBytes { get; }
+    [Field] public byte EightByteClassification0 { get; }
+    [Field] public byte EightByteClassification1 { get; }
+    [Field] public byte EightByteSize0 { get; }
+    [Field] public byte EightByteSize1 { get; }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SystemVEightByteRegistersInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SystemVEightByteRegistersInfo.cs
@@ -8,8 +8,7 @@ internal sealed partial class SystemVEightByteRegistersInfo : IData<SystemVEight
 {
     [Field] public byte NumEightBytes { get; }
 
-    // CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS: fixed at 2 in
-    // src/coreclr/inc/corinfo.h. Slots beyond NumEightBytes are undefined.
+    // Slots beyond NumEightBytes are undefined.
     public byte[] EightByteClassifications { get; private set; } = new byte[2];
     public byte[] EightByteSizes { get; private set; } = new byte[2];
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SystemVEightByteRegistersInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SystemVEightByteRegistersInfo.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+[CdacType(nameof(DataType.SystemVEightByteRegistersInfo))]
+internal sealed partial class SystemVEightByteRegistersInfo : IData<SystemVEightByteRegistersInfo>
+{
+    [Field] public byte NumEightBytes { get; }
+
+    // CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS: fixed at 2 in
+    // src/coreclr/inc/corinfo.h. Slots beyond NumEightBytes are undefined.
+    public byte[] EightByteClassifications { get; private set; } = new byte[2];
+    public byte[] EightByteSizes { get; private set; } = new byte[2];
+
+    partial void OnInit(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.SystemVEightByteRegistersInfo);
+        target.ReadBuffer(address + (ulong)type.Fields[nameof(EightByteClassifications)].Offset, EightByteClassifications);
+        target.ReadBuffer(address + (ulong)type.Fields[nameof(EightByteSizes)].Offset, EightByteSizes);
+    }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
@@ -62,8 +62,6 @@ public enum DataType
     MethodTable,
     DynamicStaticsInfo,
     EEClass,
-    EEClassOptionalFields,
-    SystemVEightByteRegistersInfo,
     CoreLibBinder,
     MethodTableAuxiliaryData,
     GenericsDictInfo,
@@ -216,6 +214,8 @@ public enum DataType
     EnCAddedStaticField,
     EnCSyncBlockInfo,
     UnorderedArrayBase,
+    EEClassOptionalFields,
+    SystemVEightByteRegistersInfo,
 }
 
 public static class DataTypeTargetExtensions

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
@@ -62,6 +62,8 @@ public enum DataType
     MethodTable,
     DynamicStaticsInfo,
     EEClass,
+    EEClassOptionalFields,
+    SystemVEightByteRegistersInfo,
     CoreLibBinder,
     MethodTableAuxiliaryData,
     GenericsDictInfo,
@@ -214,8 +216,6 @@ public enum DataType
     EnCAddedStaticField,
     EnCSyncBlockInfo,
     UnorderedArrayBase,
-    EEClassOptionalFields,
-    SystemVEightByteRegistersInfo,
 }
 
 public static class DataTypeTargetExtensions

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
@@ -62,6 +62,8 @@ public enum DataType
     MethodTable,
     DynamicStaticsInfo,
     EEClass,
+    EEClassOptionalFields,
+    SystemVEightByteRegistersInfo,
     CoreLibBinder,
     MethodTableAuxiliaryData,
     GenericsDictInfo,

--- a/src/native/managed/cdac/gen/Parser.cs
+++ b/src/native/managed/cdac/gen/Parser.cs
@@ -359,13 +359,8 @@ internal static class Parser
         }
         else if (ImplementsIData(type) && prop.NullableAnnotation == NullableAnnotation.Annotated)
         {
-            // Nullable reference-type annotation on an IData<T> sub-typed
-            // field (e.g. `IDataT? Foo`). Treated the same as optional:
-            // emitter guards the descriptor lookup with ContainsKey and
-            // assigns default (null) when absent. Only IData sub-types
-            // participate; non-IData reference-typed [Field]s aren't a
-            // real scenario today and staying narrow here avoids silently
-            // making them optional.
+            // IData<T>? field: emitter treats it as optional (ContainsKey
+            // guard + default(null) when the descriptor omits the field).
             isNullable = true;
         }
 

--- a/src/native/managed/cdac/gen/Parser.cs
+++ b/src/native/managed/cdac/gen/Parser.cs
@@ -357,13 +357,15 @@ internal static class Parser
             isNullable = true;
             type = named.TypeArguments[0];
         }
-        else if (type.IsReferenceType && prop.NullableAnnotation == NullableAnnotation.Annotated)
+        else if (ImplementsIData(type) && prop.NullableAnnotation == NullableAnnotation.Annotated)
         {
-            // Nullable reference type annotation (e.g. `IDataT? Foo`). Only
-            // meaningful for IData<T> sub-typed fields; primitive fields use
-            // Nullable<T> above. Treated the same as optional: emitter guards
-            // the descriptor lookup with ContainsKey and assigns default (null)
-            // when absent.
+            // Nullable reference-type annotation on an IData<T> sub-typed
+            // field (e.g. `IDataT? Foo`). Treated the same as optional:
+            // emitter guards the descriptor lookup with ContainsKey and
+            // assigns default (null) when absent. Only IData sub-types
+            // participate; non-IData reference-typed [Field]s aren't a
+            // real scenario today and staying narrow here avoids silently
+            // making them optional.
             isNullable = true;
         }
 

--- a/src/native/managed/cdac/gen/Parser.cs
+++ b/src/native/managed/cdac/gen/Parser.cs
@@ -357,6 +357,15 @@ internal static class Parser
             isNullable = true;
             type = named.TypeArguments[0];
         }
+        else if (type.IsReferenceType && prop.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            // Nullable reference type annotation (e.g. `IDataT? Foo`). Only
+            // meaningful for IData<T> sub-typed fields; primitive fields use
+            // Nullable<T> above. Treated the same as optional: emitter guards
+            // the descriptor lookup with ContainsKey and assigns default (null)
+            // when absent.
+            isNullable = true;
+        }
 
         string fqn = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 

--- a/src/native/managed/cdac/tests/StressTests/CdacStressTestBase.cs
+++ b/src/native/managed/cdac/tests/StressTests/CdacStressTestBase.cs
@@ -157,7 +157,8 @@ public abstract class CdacStressTestBase
 
     /// <summary>
     /// Asserts the GCREFS stress run produced a <c>[GC_STATS]</c> summary
-    /// with at least one verification and no hard failures.
+    /// with at least one verification, no hard failures, and no deferred
+    /// (known-issue) frames.
     /// </summary>
     internal static void AssertAllPassed(CdacStressResults results, string debuggeeName)
     {
@@ -173,37 +174,13 @@ public abstract class CdacStressTestBase
             "did not initialize correctly.\n" +
             $"Log: {results.LogFilePath}");
 
-        if (results.Failed > 0)
+        if (results.Failed > 0 || results.KnownIssues > 0)
         {
             string analysis = results.AnalyzeFailures(maxFailures: 3);
             Assert.Fail(
                 $"GCREFS stress test '{debuggeeName}' had {results.Failed} failure(s) " +
-                $"out of {results.TotalVerifications} verifications " +
-                $"({results.KnownIssues} known issue(s) tolerated).\n" +
-                $"Log: {results.LogFilePath}\n\n{analysis}");
-        }
-
-        // On supported targets every Frame's caller-arg refs are enumerated via
-        // the GCRefMap blob synthesized by ICallingConvention -- there should be
-        // no deferred frames at all, so any KnownIssue count is a regression.
-        // Keep this gate in sync with the ARGITER-support gate in
-        // ArgIterStress_AllVerificationsPass below and with the
-        // supportedByCallingConvention gate in GcScanner.PromoteCallerStack.
-        GetTargetPlatform(out OSPlatform os, out Architecture arch);
-        bool requiresZeroKnownIssues =
-               (os == OSPlatform.Windows && arch is Architecture.X86 or Architecture.X64 or Architecture.Arm64)
-            || (os == OSPlatform.Linux && arch is Architecture.Arm or Architecture.Arm64);
-        if (requiresZeroKnownIssues && results.KnownIssues > 0)
-        {
-            string analysis = results.AnalyzeFailures(maxFailures: 3);
-            Assert.Fail(
-                $"GCREFS stress test '{debuggeeName}' had {results.KnownIssues} known issue(s) " +
-                $"out of {results.TotalVerifications} verifications. " +
-                "This platform is expected to enumerate every transition Frame's " +
-                "caller-stack refs via ICallingConvention.TryComputeArgGCRefMapBlob with no " +
-                "deferred frames. A non-zero KnownIssues count indicates the encoder declined " +
-                "a method it should support (e.g. a regression in ComputeArgGCRefMapBlobCore " +
-                "or a new code path returning E_NOTIMPL).\n" +
+                $"and {results.KnownIssues} known issue(s) out of " +
+                $"{results.TotalVerifications} verifications.\n" +
                 $"Log: {results.LogFilePath}\n\n{analysis}");
         }
     }

--- a/src/native/managed/cdac/tests/StressTests/CdacStressTests.cs
+++ b/src/native/managed/cdac/tests/StressTests/CdacStressTests.cs
@@ -52,9 +52,6 @@ public class CdacStressTests : CdacStressTestBase
     {
         GetTargetPlatform(out OSPlatform os, out _);
 
-        // TODO(https://github.com/dotnet/runtime/issues/130008): extend GCREFS stress coverage to non-Windows / ARM
-        // targets once ICallingConvention.TryComputeArgGCRefMapBlob supports them (SystemV-AMD64 / ARM64
-        // struct-in-register classification, ARM32 ABI port).
         if (debuggee.WindowsOnly && os != OSPlatform.Windows)
             throw new SkipTestException($"{debuggee.Name} debuggee is Windows-only.");
 
@@ -69,29 +66,10 @@ public class CdacStressTests : CdacStressTestBase
     [MemberData(nameof(Debuggees))]
     public async Task ArgIterStress_AllVerificationsPass(Debuggee debuggee)
     {
-        GetTargetPlatform(out OSPlatform os, out Architecture arch);
+        GetTargetPlatform(out OSPlatform os, out _);
 
         if (debuggee.WindowsOnly && os != OSPlatform.Windows)
             throw new SkipTestException($"{debuggee.Name} debuggee is Windows-only.");
-
-        // ARGITER stress requires a CdacTypeHandle whose calling-convention
-        // helpers are filled in for the target ABI. Currently validated:
-        //   - Windows x86 / x64        (TransitionBlock + IsTrivialPointerSizedStruct)
-        //   - Windows ARM64            (HFA via MethodTable enum_flag_IsHFA)
-        //   - Linux ARM / ARM64        (HFA, same path)
-        // Still skipped:
-        //   - Linux / macOS x64        (SystemV-AMD64 eightbyte classifier not ported)
-        //   - RISC-V / LoongArch64     (FP struct classifier not ported)
-        //   - WASM32                   (GetFieldAlignment not ported)
-        bool argIterSupported =
-               (os == OSPlatform.Windows && arch is Architecture.X86 or Architecture.X64 or Architecture.Arm64)
-            || (os == OSPlatform.Linux && arch is Architecture.Arm or Architecture.Arm64);
-        if (!argIterSupported)
-            throw new SkipTestException(
-                "ARGITER stress: needs follow-up work for this platform " +
-                "(SystemV-AMD64 struct classifier for linux/macOS x64, " +
-                "Windows ARM32 ABI port, RISC-V / LoongArch FP struct classifier, " +
-                "or WASM GetFieldAlignment).");
 
         CdacStressResults results = await RunArgIterStressAsync(debuggee.Name);
         AssertAllArgIterPassed(results, debuggee.Name);

--- a/src/native/managed/cdac/tests/StressTests/Debuggees/CallSignatures/Program.cs
+++ b/src/native/managed/cdac/tests/StressTests/Debuggees/CallSignatures/Program.cs
@@ -539,55 +539,46 @@ internal static unsafe class Program
     [MethodImpl(MethodImplOptions.NoInlining)] private static void VecNumericsFloatArg(Vector<float> v) { AllocBurst(); GC.KeepAlive((object)v[0]); }
 
     // ===== Category 13: SystemV-AMD64 struct-in-register shapes =====
-    // Exercises SystemV-AMD64 struct classification. On non-Unix-x64 targets
-    // these methods still run but the cDAC has no cached eightbyte descriptor
-    // to read (it lives in EEClassOptionalFields only on UNIX_AMD64_ABI
-    // builds), so GetSystemVAmd64PassStructInRegisterDescriptor returns "not
-    // in registers" -- the runtime and cDAC agree via other paths and no
-    // divergence surfaces. On Linux/macOS x64 the runtime pre-computes the
-    // eightbyte classification at MethodTable-build time and the cDAC reads
-    // that cached SystemVEightByteRegistersInfo to decide FP-reg vs GP-reg
-    // vs stack placement, so ArgIterator produces different GCRefMap tokens
-    // depending on which eightbytes end up in which register class.
+    // On non-Unix-x64 targets the cDAC's descriptor is absent so classification
+    // returns "not in registers" and the runtime path agrees trivially. Linux/
+    // macOS x64 read the cached SystemVEightByteRegistersInfo and produce
+    // different GCRefMap tokens per eightbyte classification.
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void SysVCategory()
     {
         // Single-eightbyte shapes.
-        SysVIntPair(default);           // 8 bytes, Integer eightbyte
-        SysVFloatPair(default);         // 8 bytes, SSE eightbyte
-        SysVIntFloat(default);          // 8 bytes, mixed -> Integer eightbyte (Integer wins)
-        SysVSingleRef(default);         // 8 bytes, IntegerReference eightbyte
+        SysVIntPair(default);           // Integer
+        SysVFloatPair(default);         // SSE
+        SysVIntFloat(default);          // mixed -> Integer (Integer wins)
+        SysVSingleRef(default);         // IntegerReference
 
         // Two-eightbyte shapes.
-        SysVLongLong(default);          // 16 bytes, Integer + Integer
-        SysVLongDouble(default);        // 16 bytes, Integer + SSE
-        SysVDoubleDouble(default);      // 16 bytes, SSE + SSE
-        SysVRefInt(default);            // 16 bytes, IntegerReference + Integer
+        SysVLongLong(default);          // Integer + Integer
+        SysVLongDouble(default);        // Integer + SSE
+        SysVDoubleDouble(default);      // SSE + SSE
+        SysVRefInt(default);            // IntegerReference + Integer
 
-        // Nested value type.
-        SysVNested(default);            // outer wraps inner-struct + int
+        SysVNested(default);            // nested value type
 
-        // ByRefLike passed as struct on SystemV.
+        // Span<byte>: IntegerByRef + Integer.
         Span<byte> sp = stackalloc byte[8];
-        SysVSpanByte(sp);               // Span<byte>: IntegerByRef + Integer
+        SysVSpanByte(sp);
 
         SysVThreeRefs(default);         // 24 bytes -> stack
         SysVVector128Arg(default);      // intrinsic Vector -> stack
-        SysVInt128Arg(default);         // 2 Integer eightbytes (runtime does NOT reject Int128 by name)
-        SysVEmpty(default);             // 1-byte empty struct -> 1 Integer eightbyte (padding is normalized to Integer)
+        SysVInt128Arg(default);         // 2 Integer eightbytes (runtime doesn't reject Int128 by name)
+        SysVEmpty(default);             // 1-byte empty -> 1 Integer eightbyte (NoClass normalized to Integer)
+        // SSE + IntegerReference: ref goes in RDI, not RSI -- SSE eightbytes
+        // don't advance the general-register cursor.
+        SysVDoubleRef(default);
 
-        // Unions (LayoutKind.Explicit with overlapping fields). Exercises
-        // the ReClassifyField merge path in the classifier. C# rules forbid
-        // mixing GC refs with non-refs at the same offset, so the only
-        // legal overlaps are Integer/Integer, SSE/SSE, or Integer/SSE (both
-        // primitive kinds).
-        SysVIntFloatUnion(default);     // int + float at offset 0 -> Integer eightbyte
-        SysVIntIntUnion(default);       // int + int at offset 0 -> Integer eightbyte
+        // Unions (LayoutKind.Explicit) -- exercises the classifier's merge path.
+        SysVIntFloatUnion(default);     // int + float @ 0 -> Integer
+        SysVIntIntUnion(default);       // int + int @ 0 -> Integer
 
-        // Unaligned sub-eightbyte and single-field wrappers.
-        SysVSmall(default);             // { int a; byte b; } -> 1 Integer eightbyte (unaligned tail)
-        SysVWrapInt(default);           // { int a; } single-field wrapper -> 1 Integer eightbyte
+        SysVSmall(default);             // { int a; byte b; } -> Integer (unaligned tail)
+        SysVWrapInt(default);           // { int a; } single-field wrapper
     }
 
     // ---- SystemV struct shapes ----
@@ -599,6 +590,7 @@ internal static unsafe class Program
     private struct LongDouble { public long A; public double B; }
     private struct DoubleDouble { public double A, B; }
     private struct RefInt { public object? R; public long Padding; }
+    private struct DoubleRef { public double D; public object? R; }
     private struct SysVNestedStruct { public IntPair Inner; public int Trailing; }
     private struct SysVThreeRefsStruct { public object? R1, R2, R3; }
     private struct Int128Wrapper { public System.Int128 V; }
@@ -632,6 +624,7 @@ internal static unsafe class Program
     [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVLongDouble(LongDouble s) { AllocBurst(); GC.KeepAlive((object)(s.A + s.B)); }
     [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVDoubleDouble(DoubleDouble s) { AllocBurst(); GC.KeepAlive((object)(s.A + s.B)); }
     [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVRefInt(RefInt s) { AllocBurst(); GC.KeepAlive(s.R); GC.KeepAlive((object)s.Padding); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVDoubleRef(DoubleRef s) { AllocBurst(); GC.KeepAlive(s.R); GC.KeepAlive((object)s.D); }
     [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVNested(SysVNestedStruct s) { AllocBurst(); GC.KeepAlive((object)(s.Inner.A + s.Trailing)); }
     [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVSpanByte(Span<byte> s) { AllocBurst(); GC.KeepAlive((object)s.Length); }
     [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVThreeRefs(SysVThreeRefsStruct s) { AllocBurst(); GC.KeepAlive(s.R1); GC.KeepAlive(s.R2); GC.KeepAlive(s.R3); }

--- a/src/native/managed/cdac/tests/StressTests/Debuggees/CallSignatures/Program.cs
+++ b/src/native/managed/cdac/tests/StressTests/Debuggees/CallSignatures/Program.cs
@@ -95,6 +95,7 @@ internal static unsafe class Program
         EnumCategory();
         ReturnCategory();
         HfaCategory();
+        SysVCategory();
         DeepStackCategory();
     }
 
@@ -537,7 +538,112 @@ internal static unsafe class Program
     [MethodImpl(MethodImplOptions.NoInlining)] private static void Vec128FloatArg(Vector128<float> v) { AllocBurst(); GC.KeepAlive((object)v.GetElement(0)); }
     [MethodImpl(MethodImplOptions.NoInlining)] private static void VecNumericsFloatArg(Vector<float> v) { AllocBurst(); GC.KeepAlive((object)v[0]); }
 
-    // ===== Category 13: deep stack =====
+    // ===== Category 13: SystemV-AMD64 struct-in-register shapes =====
+    // Exercises SystemV-AMD64 struct classification. On non-Unix-x64 targets
+    // these methods still run but the cDAC has no cached eightbyte descriptor
+    // to read (it lives in EEClassOptionalFields only on UNIX_AMD64_ABI
+    // builds), so GetSystemVAmd64PassStructInRegisterDescriptor returns "not
+    // in registers" -- the runtime and cDAC agree via other paths and no
+    // divergence surfaces. On Linux/macOS x64 the runtime pre-computes the
+    // eightbyte classification at MethodTable-build time and the cDAC reads
+    // that cached SystemVEightByteRegistersInfo to decide FP-reg vs GP-reg
+    // vs stack placement, so ArgIterator produces different GCRefMap tokens
+    // depending on which eightbytes end up in which register class.
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SysVCategory()
+    {
+        // Single-eightbyte shapes.
+        SysVIntPair(default);           // 8 bytes, Integer eightbyte
+        SysVFloatPair(default);         // 8 bytes, SSE eightbyte
+        SysVIntFloat(default);          // 8 bytes, mixed -> Integer eightbyte (Integer wins)
+        SysVSingleRef(default);         // 8 bytes, IntegerReference eightbyte
+
+        // Two-eightbyte shapes.
+        SysVLongLong(default);          // 16 bytes, Integer + Integer
+        SysVLongDouble(default);        // 16 bytes, Integer + SSE
+        SysVDoubleDouble(default);      // 16 bytes, SSE + SSE
+        SysVRefInt(default);            // 16 bytes, IntegerReference + Integer
+
+        // Nested value type.
+        SysVNested(default);            // outer wraps inner-struct + int
+
+        // ByRefLike passed as struct on SystemV.
+        Span<byte> sp = stackalloc byte[8];
+        SysVSpanByte(sp);               // Span<byte>: IntegerByRef + Integer
+
+        SysVThreeRefs(default);         // 24 bytes -> stack
+        SysVVector128Arg(default);      // intrinsic Vector -> stack
+        SysVInt128Arg(default);         // 2 Integer eightbytes (runtime does NOT reject Int128 by name)
+        SysVEmpty(default);             // 1-byte empty struct -> 1 Integer eightbyte (padding is normalized to Integer)
+
+        // Unions (LayoutKind.Explicit with overlapping fields). Exercises
+        // the ReClassifyField merge path in the classifier. C# rules forbid
+        // mixing GC refs with non-refs at the same offset, so the only
+        // legal overlaps are Integer/Integer, SSE/SSE, or Integer/SSE (both
+        // primitive kinds).
+        SysVIntFloatUnion(default);     // int + float at offset 0 -> Integer eightbyte
+        SysVIntIntUnion(default);       // int + int at offset 0 -> Integer eightbyte
+
+        // Unaligned sub-eightbyte and single-field wrappers.
+        SysVSmall(default);             // { int a; byte b; } -> 1 Integer eightbyte (unaligned tail)
+        SysVWrapInt(default);           // { int a; } single-field wrapper -> 1 Integer eightbyte
+    }
+
+    // ---- SystemV struct shapes ----
+    private struct IntPair { public int A, B; }
+    private struct FloatPair { public float A, B; }
+    private struct IntFloat { public int A; public float B; }
+    private struct SingleRef { public object? R; }
+    private struct LongLong { public long A, B; }
+    private struct LongDouble { public long A; public double B; }
+    private struct DoubleDouble { public double A, B; }
+    private struct RefInt { public object? R; public long Padding; }
+    private struct SysVNestedStruct { public IntPair Inner; public int Trailing; }
+    private struct SysVThreeRefsStruct { public object? R1, R2, R3; }
+    private struct Int128Wrapper { public System.Int128 V; }
+    private struct EmptyStruct { }
+    private struct SmallUnaligned { public int A; public byte B; }
+    private struct WrapInt { public int A; }
+
+    // Union: int and float at the same offset. Classifier sees both as
+    // unique-offset fields and merges via ReClassifyField (Integer+SSE = Integer).
+    [StructLayout(LayoutKind.Explicit)]
+    private struct IntFloatUnion
+    {
+        [FieldOffset(0)] public int I;
+        [FieldOffset(0)] public float F;
+    }
+
+    // Union: two ints at the same offset. Merge collapses to Integer.
+    [StructLayout(LayoutKind.Explicit)]
+    private struct IntIntUnion
+    {
+        [FieldOffset(0)] public int A;
+        [FieldOffset(0)] public int B;
+    }
+
+    // ---- SystemV arg helpers ----
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVIntPair(IntPair s) { AllocBurst(); GC.KeepAlive((object)(s.A + s.B)); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVFloatPair(FloatPair s) { AllocBurst(); GC.KeepAlive((object)(s.A + s.B)); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVIntFloat(IntFloat s) { AllocBurst(); GC.KeepAlive((object)(s.A + s.B)); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVSingleRef(SingleRef s) { AllocBurst(); GC.KeepAlive(s.R); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVLongLong(LongLong s) { AllocBurst(); GC.KeepAlive((object)(s.A + s.B)); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVLongDouble(LongDouble s) { AllocBurst(); GC.KeepAlive((object)(s.A + s.B)); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVDoubleDouble(DoubleDouble s) { AllocBurst(); GC.KeepAlive((object)(s.A + s.B)); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVRefInt(RefInt s) { AllocBurst(); GC.KeepAlive(s.R); GC.KeepAlive((object)s.Padding); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVNested(SysVNestedStruct s) { AllocBurst(); GC.KeepAlive((object)(s.Inner.A + s.Trailing)); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVSpanByte(Span<byte> s) { AllocBurst(); GC.KeepAlive((object)s.Length); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVThreeRefs(SysVThreeRefsStruct s) { AllocBurst(); GC.KeepAlive(s.R1); GC.KeepAlive(s.R2); GC.KeepAlive(s.R3); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVVector128Arg(Vector128<int> v) { AllocBurst(); GC.KeepAlive((object)v.GetElement(0)); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVInt128Arg(Int128Wrapper s) { AllocBurst(); GC.KeepAlive((object)s.V.ToString()); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVEmpty(EmptyStruct s) { AllocBurst(); GC.KeepAlive((object)s); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVSmall(SmallUnaligned s) { AllocBurst(); GC.KeepAlive((object)(s.A + s.B)); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVWrapInt(WrapInt s) { AllocBurst(); GC.KeepAlive((object)s.A); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVIntFloatUnion(IntFloatUnion s) { AllocBurst(); GC.KeepAlive((object)s.I); }
+    [MethodImpl(MethodImplOptions.NoInlining)] private static void SysVIntIntUnion(IntIntUnion s) { AllocBurst(); GC.KeepAlive((object)s.A); }
+
+    // ===== Category 14: deep stack =====
     // Mutually-recursive chains of methods with mixed signatures. At any
     // given allocation trigger many frames are simultaneously live, so a
     // single stack-walk verification run touches multiple MDs across

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
@@ -108,6 +108,7 @@ internal sealed class MockEEClass : TypedView
     private const string FieldDescListFieldName = nameof(Data.EEClass.FieldDescList);
     private const string NumNonVirtualSlotsFieldName = nameof(Data.EEClass.NumNonVirtualSlots);
     private const string BaseSizePaddingFieldName = nameof(Data.EEClass.BaseSizePadding);
+    private const string OptionalFieldsFieldName = nameof(Data.EEClass.OptionalFields);
 
     public static Layout<MockEEClass> CreateLayout(MockTarget.Architecture architecture)
         => new SequentialLayoutBuilder("EEClass", architecture)
@@ -122,6 +123,7 @@ internal sealed class MockEEClass : TypedView
             .AddPointerField(FieldDescListFieldName)
             .AddUInt16Field(NumNonVirtualSlotsFieldName)
             .AddByteField(BaseSizePaddingFieldName)
+            .AddPointerField(OptionalFieldsFieldName)
             .Build<MockEEClass>();
 
     public ulong MethodTable


### PR DESCRIPTION
Fills in the SystemV-AMD64 struct-in-register classification path in the cDAC's ArgIterator port so `ICallingConvention.TryComputeArgGCRefMapBlob` produces correct output on Unix x64. Lights up **Linux x64** for both the ARGITER stress sub-check and the zero-known-issues GCREFS assertion.

Follow-up to #130090. Advances the platform matrix tracked in #130008.

## Approach

The runtime already pre-computes the eightbyte classification for every enregisterable managed value type at `MethodTable` construction time and caches it in `EEClass::m_eightByteRegistersInfo` (inside `EEClassOptionalFields`). Runtime callers -- `ArgIterator`, `getSystemVAmd64PassStructInRegisterDescriptor` -- read that cached info via `SystemVRegDescriptorFromSystemVEightByteRegistersInfo` rather than re-running `ClassifyEightBytes`. The cDAC now does the same.

Non-enregisterable structs (too large, or classified as `SSEUP`/`X87`/`Memory`) never reach `StoreEightByteClassification`, so their descriptor reads back with `NumEightBytes == 0`. That's the natural `passedInRegisters = false` signal the cDAC surfaces. Native P/Invoke layouts are not cached here (the runtime classifies them on demand) -- the cDAC never walks native transition frames for GC scanning, so this is fine.

Because the stress harness compares against `ComputeCallRefMap` -- which uses the runtime path -- reading the same cached info gives byte-for-byte parity by construction. No merge-rule / intrinsic-rejection / `Int128` divergence to reason about.

macOS x64 uses the same SystemV path and works the same way if run locally, but we don't add `osx_x64` to the Helix stress matrix in this PR.

## Descriptor plumbing

**C++:**
- `class.h`: `cdac_data<EEClass>::OptionalFields`; `cdac_data<EEClassOptionalFields>` (UNIX_AMD64_ABI-guarded) exposing the `EightByteRegistersInfo` offset. Friend declaration on `EEClassOptionalFields`.
- `methodtable.h`: `cdac_data<SystemVEightByteRegistersInfo>` for `NumEightBytes` plus the two `byte[2]` eightbyte tables. Friend struct.
- `datadescriptor.inc`: `EEClass.OptionalFields` field + new `EEClassOptionalFields` and `SystemVEightByteRegistersInfo` types, both under `#ifdef UNIX_AMD64_ABI`.

**Managed:**
- `DataType`: new `EEClassOptionalFields` and `SystemVEightByteRegistersInfo` entries.
- `Data.EEClass`: adds `OptionalFields`.
- `Data.EEClassOptionalFields`: `[Field] SystemVEightByteRegistersInfo` inline sub-IData.
- `Data.SystemVEightByteRegistersInfo`: `[Field] NumEightBytes`, `OnInit`-populated arrays.
- `CdacTypeHandle.GetSystemVAmd64PassStructInRegisterDescriptor`: ~40 LOC inline. Reads `EEClass -> OptionalFields -> EightByteRegistersInfo`, then projects into `SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR` with `eightByteOffsets` synthesized as `i * 8` (matches `SystemVRegDescriptorFromSystemVEightByteRegistersInfo`).

## Test coverage

`CallSignatures` debuggee gains a `SysVCategory` exercising:
- Single-eightbyte shapes: `IntPair` (Integer), `FloatPair` (SSE), `IntFloat` (merged Integer), `SingleRef` (IntegerReference)
- Two-eightbyte shapes: `LongLong`, `LongDouble`, `DoubleDouble`, `RefInt`
- Nested value type, ByRefLike (`Span<byte>`)
- Rejection / stack-passed: 24-byte 3-ref struct, `Vector128<int>`, empty struct
- `Int128Wrapper` (2 Integer eightbytes -- register-passed; runtime does NOT reject by name)
- Unions (`LayoutKind.Explicit`), sub-eightbyte trailer, single-field wrapper

Same debuggee runs everywhere; only exercises the new descriptor read on Unix x64 (Windows targets don't emit the descriptor entries, so the classifier returns `passedInRegisters = false` immediately via a `TryGetTypeInfo` probe).

`AssertAllPassed` now folds `KnownIssues` into the `Failed` check unconditionally -- no more platform gate on the assertion side; any surviving known-issue count is a regression.

## Local validation

- `dotnet build src/native/managed/cdac/cdac.slnx -c Release`: clean
- Unit tests: 2646 pass / 0 fail / 16 skipped
- **Windows x64 local stress smoke** (`RunStressTests.ps1`):
  - GCREFS `CallSignatures`: 6150 / 6150 pass, 0 known-issue
  - ARGITER `CallSignatures` (with the `SysVCategory`): 383 pass / 0 fail / 0 skip / 0 error

The descriptor entries are `UNIX_AMD64_ABI`-only, so the descriptor-read path only activates on Linux/macOS x64 targets; no regression on any pre-existing platform. CI validates `linux-x64` end-to-end via the byte-for-byte ARGITER comparison against runtime `ComputeCallRefMap`.

> [!NOTE]
> This change was authored with assistance from GitHub Copilot.