### PR TITLE
Block tail merges across handler and filter

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2787,8 +2787,15 @@ bool BBPredsChecker::CheckEhTryDsc(BasicBlock* block, BasicBlock* blockPred, EHb
 //
 bool BBPredsChecker::CheckEhHndDsc(BasicBlock* block, BasicBlock* blockPred, EHblkDsc* ehHndlDsc)
 {
-    // You can do a BBJ_EHFINALLYRET or BBJ_EHFILTERRET into a handler region
-    if (blockPred->KindIs(BBJ_EHFINALLYRET, BBJ_EHFILTERRET))
+    // You can do a BBJ_EHFINALLYRET into a handler region
+    if (blockPred->KindIs(BBJ_EHFINALLYRET))
+    {
+        return true;
+    }
+
+    // A filter can jump to the start of the filter handler
+    if (ehHndlDsc->HasFilter() && (ehHndlDsc->ebdHndBeg == block) && blockPred->KindIs(BBJ_EHFILTERRET) &&
+        ehHndlDsc->InFilterRegionBBRange(blockPred))
     {
         return true;
     }
@@ -2803,13 +2810,22 @@ bool BBPredsChecker::CheckEhHndDsc(BasicBlock* block, BasicBlock* blockPred, EHb
     // You can jump within the same handler region
     if (m_compiler->bbInHandlerRegions(block->getHndIndex(), blockPred))
     {
-        return true;
-    }
+        if (!ehHndlDsc->HasFilter())
+        {
+            return true;
+        }
 
-    // A filter can jump to the start of the filter handler
-    if (ehHndlDsc->HasFilter())
-    {
-        return true;
+        const bool blockInFilter     = ehHndlDsc->InFilterRegionBBRange(block);
+        const bool blockPredInFilter = ehHndlDsc->InFilterRegionBBRange(blockPred);
+        if (blockInFilter == blockPredInFilter)
+        {
+            return true;
+        }
+
+        JITDUMP("Jump between filter and filter handler regions: " FMT_BB " branches to " FMT_BB "\n", blockPred->bbNum,
+                block->bbNum);
+        assert(!"Jump between filter and filter handler regions");
+        return false;
     }
 
     JITDUMP("Jump into the middle of handler region: " FMT_BB " branches to " FMT_BB "\n", blockPred->bbNum,

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5127,6 +5127,28 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
     ArrayStack<PredInfo>    matchedPredInfo(getAllocator(CMK_ArrayStack));
     ArrayStack<BasicBlock*> retryBlocks(getAllocator(CMK_ArrayStack));
 
+    auto sameEHRegionForTailMerge = [this](BasicBlock* block1, BasicBlock* block2) -> bool {
+        if (!BasicBlock::sameEHRegion(block1, block2))
+        {
+            return false;
+        }
+
+        if (!block1->hasHndIndex())
+        {
+            assert(!block2->hasHndIndex());
+            return true;
+        }
+
+        assert(block2->hasHndIndex());
+        EHblkDsc* const hndDsc = ehGetDsc(block1->getHndIndex());
+        if (!hndDsc->HasFilter())
+        {
+            return true;
+        }
+
+        return hndDsc->InFilterRegionBBRange(block1) == hndDsc->InFilterRegionBBRange(block2);
+    };
+
     auto tryRemoveAndFixFlow = [&](BasicBlock* emptyBlock, BasicBlock* newTarget) -> bool {
         assert(emptyBlock->isEmpty());
         assert(emptyBlock->KindIs(BBJ_RETURN, BBJ_THROW, BBJ_ALWAYS));
@@ -5198,7 +5220,7 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
 
                 // Consider: bypass this for statements that can't cause exceptions.
                 //
-                if (!BasicBlock::sameEHRegion(baseBlock, otherBlock))
+                if (!sameEHRegionForTailMerge(baseBlock, otherBlock))
                 {
                     continue;
                 }
@@ -5224,7 +5246,7 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
             // and all preds have matching last statements, and we're not changing EH behavior.
             //
             bool const hasCommSucc               = (commSucc != nullptr);
-            bool const predsInSameEHRegionAsSucc = hasCommSucc && BasicBlock::sameEHRegion(baseBlock, commSucc);
+            bool const predsInSameEHRegionAsSucc = hasCommSucc && sameEHRegionForTailMerge(baseBlock, commSucc);
             bool const canMergeAllPreds = hasCommSucc && (matchedPredInfo.Height() == (int)commSucc->countOfInEdges());
             bool const canMergeIntoSucc = predsInSameEHRegionAsSucc && canMergeAllPreds;
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130248/Runtime_130248.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130248/Runtime_130248.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Runtime_130248;
+
+public static class Runtime_130248
+{
+    private static int s_value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool ThrowIfZero(int value)
+    {
+        if (value == 0)
+        {
+            throw new ArgumentOutOfRangeException();
+        }
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Id(int value) => value;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void M0()
+    {
+        // Based on the Fuzzlyn-generated repro in dotnet/runtime#130248.
+        int value = 1;
+        value--;
+
+        try
+        {
+            s_value = Id(value);
+        }
+        catch (Exception) when (ThrowIfZero(value))
+        {
+            ThrowIfZero(value);
+        }
+    }
+
+    [Fact]
+    public static void TestEntryPoint() => M0();
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -109,6 +109,7 @@
     <Compile Include="JitBlue\Runtime_129970\Runtime_129970.cs" />
     <Compile Include="JitBlue\Runtime_129971\Runtime_129971.cs" />
     <Compile Include="JitBlue\Runtime_129972\Runtime_129972.cs" />
+    <Compile Include="JitBlue\Runtime_130248\Runtime_130248.cs" />
     <Compile Include="JitBlue\Runtime_10337\Runtime_10337.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />


### PR DESCRIPTION
Block tail merges across handler and filter. Add diagnostic check for
invalid flow across handler and filter.

Fixes #130248.

> [!NOTE]
> This pull request description was generated by GitHub Copilot.