### PR TITLE
Don't oversubscribe cores for framework crossgen on macOS; raise single-assembly timeout

### DIFF
--- a/src/coreclr/tools/r2rtest/ProcessRunner.cs
+++ b/src/coreclr/tools/r2rtest/ProcessRunner.cs
@@ -13,8 +13,11 @@ public class ProcessParameters
 {
     /// <summary>
     /// Maximum time for CPAOT / Crossgen compilation.
+    /// System.Private.CoreLib is by far the largest single assembly and, when compiled
+    /// with limited per-process parallelism (--crossgen2-parallelism 1), can take a long
+    /// time on slower CI machines, so allow a generous timeout to avoid spurious failures.
     /// </summary>
-    public const int DefaultIlcTimeout = 10 * 60 * 1000;
+    public const int DefaultIlcTimeout = 15 * 60 * 1000;
 
     /// <summary>
     /// Increase compilation timeout for composite builds.

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -402,7 +402,7 @@ if [[ "$platform" == "freebsd" || "$platform" == "openbsd" ]]; then
 elif [[ "$platform" == "netbsd" || "$platform" == "sunos" ]]; then
   __NumProc="$(($(getconf NPROCESSORS_ONLN)+1))"
 elif [[ "$platform" == "darwin" ]]; then
-  __NumProc="$(($(getconf _NPROCESSORS_ONLN)+1))"
+  __NumProc="$(getconf _NPROCESSORS_ONLN)"
 elif command -v nproc > /dev/null 2>&1; then
   __NumProc="$(nproc)"
 elif (NAME=""; . /etc/os-release; test "$NAME" = "Tizen"); then


### PR DESCRIPTION
The Generate CORE_ROOT step compiles each framework assembly with a separate single-threaded crossgen2 process (`-dop N --crossgen2-parallelism 1`). On macOS the process count was `cores+1`, which oversubscribes and steals cycles from the critical-path `System.Private.CoreLib` compile, slowing the whole step. This uses exactly the core count instead.

Also raises the non-composite compilation timeout from 10 to 15 minutes so `System.Private.CoreLib` stops timing out on slower Mac CI machines.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.