### PR TITLE
Clarify regex warnings

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -19,14 +19,12 @@ namespace System.Text.RegularExpressions
     /// Represents an immutable regular expression. Also contains static methods that
     /// allow use of regular expressions without instantiating a Regex explicitly.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The <see cref="Regex"/> class represents the .NET regular expression engine.
-    /// It can be used to quickly parse large amounts of text to find specific character patterns;
-    /// to extract, edit, replace, or delete text substrings; and to add the extracted strings to a
-    /// collection to generate a report.
-    /// </para>
-    /// </remarks>
+    /// <remarks><format type="text/markdown"><![CDATA[
+    /// The <xref:System.Text.RegularExpressions.Regex> class represents the .NET regular expression engine. It can be used to quickly parse large amounts of text to find specific character patterns; to extract, edit, replace, or delete text substrings; and to add the extracted strings to a collection to generate a report.
+    ///
+    /// > [!WARNING]
+    /// > Unrestricted use of this class with untrusted input can subject applications to [denial-of-service attacks](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS). Consult [Best practices for regular expressions in .NET](https://learn.microsoft.com/dotnet/standard/base-types/best-practices-regex) for guidance on how to safely use this class with untrusted input.
+    /// ]]></format></remarks>
     /// <related type="Article" href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-language-quick-reference">.NET Regular Expression Language</related>
     /// <related type="Article" href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">Regular Expression Options</related>
     /// <related type="Article" href="https://learn.microsoft.com/dotnet/standard/base-types/best-practices">Best Practices for Regular Expressions</related>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -122,7 +122,7 @@ namespace System.Text.RegularExpressions
 
         /// <summary>
         /// Enable matching using an approach that avoids backtracking and guarantees linear-time processing
-        /// in the length of the input. For more information, see the "Non-Backtracking mode" section in the
+        /// in the length of the input. For more information, see the "NonBacktracking mode" section in the
         /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
         /// Regular Expression Options</see> article.
         /// </summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -122,7 +122,7 @@ namespace System.Text.RegularExpressions
 
         /// <summary>
         /// Enable matching using an approach that avoids backtracking and guarantees linear-time processing
-        /// in the length of the input. For more information, see the
+        /// in the length of the input. For more information, see the "Non-Backtracking mode" section in the
         /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
         /// Regular Expression Options</see> article.
         /// </summary>


### PR DESCRIPTION
**Doc changes only. No code changes.**

I'm updating regex docs across the various docs repos. This is one part of that update.

Changes:
- Put a DoS warning on the type itself with forward links to relevant info.
- (Still trying to figure out where to remove the vestigial ctor-level warnings.)
- Update external link from CISA to OWASP. The CISA guidance is primarily DDoS-related, which isn't quite relevant to the discussion here. OWASP's discussion is geared specifically toward ReDoS, which is on point.

Related PRs:
- https://github.com/dotnet/docs-desktop/pull/2250
- https://github.com/dotnet/docs/pull/54621
- https://github.com/dotnet/dotnet-api-docs/pull/12848
- https://github.com/dotnet/runtime/pull/130271 (this one)