### PR TITLE
Fix x86 Debugger_STRData layout and ESP adjustment in cDAC DBI

### DIFF
--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -45,7 +45,6 @@ IEnumerable<IStackDataFrameHandle> CreateStackWalk(
     bool isFirst = true);
 
 // Gets the thread context at the given stack dataframe.
-// `flags` lets the caller request platform-specific shaping of the returned context.
 byte[] GetRawContext(
     IStackDataFrameHandle stackDataFrameHandle,
     StackwalkFlag flags = StackwalkFlag.Default);
@@ -54,7 +53,6 @@ byte[] GetRawContext(
 enum StackwalkFlag
 {
     Default = 0,
-    X86ESPIgnoresCalleePoppedArgs = 0x1,
 }
 
 // Gets the Frame address at the given stack dataframe. Returns TargetPointer.Null if the current dataframe does not have a valid Frame.
@@ -490,10 +488,6 @@ byte[] GetRawContext(
     IStackDataFrameHandle stackDataFrameHandle,
     StackwalkFlag flags = StackwalkFlag.Default);
 ```
-
-##### `StackwalkFlag.X86ESPIgnoresCalleePoppedArgs`
-See [comment](https://github.com/dotnet/runtime/blob/7f8276da27a20943339702df0abdfc02e21110a4/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp#L1016-L1063)
-
 
 `GetFrameAddress` gets the address of the current capital "F" Frame. This is only valid if the `IStackDataFrameHandle` is at a point where the context is based on a capital "F" Frame. For example, it is not valid when when the current context was created by using the stack frame unwinder.
 If the Frame is not valid, returns `TargetPointer.Null`.

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7255,6 +7255,10 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::ParseContinuation(
     UINT32 state = 0;
     int numFound = 0;
 
+    *pDiagnosticIP = 0;
+    *pNextContinuation = 0;
+    *pState = 0;
+
     ApproxFieldDescIterator continuationFieldIter(pContinuationMT, ApproxFieldDescIterator::INSTANCE_FIELDS);
     for (FieldDesc *continuationField = continuationFieldIter.Next(); continuationField != NULL && numFound < 3; continuationField = continuationFieldIter.Next())
     {

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7230,7 +7230,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAssemblyFromModule(VMPTR_Modul
 
 HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::ParseContinuation(
     CORDB_ADDRESS continuationAddress,
-    OUT PCODE* pDiagnosticIP,
+    OUT CORDB_ADDRESS* pDiagnosticIP,
     OUT CORDB_ADDRESS* pNextContinuation,
     OUT UINT32* pState)
 {
@@ -7281,7 +7281,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::ParseContinuation(
         return E_FAIL;
     }
 
-    *pDiagnosticIP = pResumeInfo->pDiagnosticIP;
+    *pDiagnosticIP = static_cast<CORDB_ADDRESS>(pResumeInfo->pDiagnosticIP);
     *pNextContinuation = static_cast<CORDB_ADDRESS>(dac_cast<TADDR>(OBJECTREFToObject(pNext)));
     *pState = state;
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -145,7 +145,7 @@ public:
     HRESULT STDMETHODCALLTYPE EnableGCNotificationEvents(BOOL fEnable);
     HRESULT STDMETHODCALLTYPE GetAssemblyFromModule(VMPTR_Module vmModule, OUT VMPTR_Assembly *pvmAssembly);
     HRESULT STDMETHODCALLTYPE ParseContinuation(CORDB_ADDRESS continuationAddress,
-                                              OUT PCODE *pDiagnosticIP,
+                                              OUT CORDB_ADDRESS *pDiagnosticIP,
                                               OUT CORDB_ADDRESS *pNextContinuation,
                                               OUT UINT32 *pState);
     HRESULT STDMETHODCALLTYPE EnumerateAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, FP_ASYNC_LOCAL_CALLBACK fpCallback, CALLBACK_DATA pUserData);

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -551,6 +551,9 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateInternalFrames(VMPTR_Thr
         Frame *     pFrame     = pThread->GetFrame();
         AppDomain * pAppDomain = AppDomain::GetCurrentDomain();
 
+        // cStubFrame entries have no DT_CONTEXT buffer; leave ctx as NULL so consumers
+        // (and the cDAC cross-check, which sets ctx = 0) don't observe a garbage value.
+        frameData.ctx = NULL;
         frameData.eType = Debugger_STRData::cStubFrame;
 
         while (pFrame != FRAME_TOP)
@@ -581,7 +584,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateInternalFrames(VMPTR_Thr
             frameData.stubFrame.frameType = GetInternalFrameType(pFrame);
             if (frameData.stubFrame.frameType != STUBFRAME_NONE)
             {
-                frameData.fp = FramePointer::MakeFramePointer(PTR_HOST_TO_TADDR(pFrame));
+                frameData.fp = PTR_TO_CORDB_ADDRESS(PTR_HOST_TO_TADDR(pFrame));
 
                 frameData.vmCurrentAppDomainToken.SetHostPtr(pAppDomain);
 
@@ -761,7 +764,7 @@ void DacDbiInterfaceImpl::InitFrameData(StackFrameIterator *   pIter,
     // do common initialization of Debugger_STRData for both managed stack frames and explicit frames
     //
 
-    pFrameData->fp = GetFramePointerWorker(pIter);
+    pFrameData->fp = PTR_TO_CORDB_ADDRESS(GetFramePointerWorker(pIter).GetSPValue());
 
     pFrameData->vmCurrentAppDomainToken.SetHostPtr(AppDomain::GetCurrentDomain());
 
@@ -963,7 +966,7 @@ void DacDbiInterfaceImpl::InitParentFrameInfo(CrawlFrame * pCF,
         // to the ExInfo when we are checking if a particular frame is the parent frame.
         //
 
-        pJITFuncData->fpParentOrSelf = FramePointer::MakeFramePointer(sfParent.SP);
+        pJITFuncData->fpParentOrSelf = PTR_TO_CORDB_ADDRESS(sfParent.SP);
         pJITFuncData->parentNativeOffset = dwParentOffset;
     }
     else
@@ -976,7 +979,7 @@ void DacDbiInterfaceImpl::InitParentFrameInfo(CrawlFrame * pCF,
         // to the ExInfo when we are checking if a particular frame is the parent frame.
         //
 
-        pJITFuncData->fpParentOrSelf = FramePointer::MakeFramePointer(sfSelf.SP);
+        pJITFuncData->fpParentOrSelf = PTR_TO_CORDB_ADDRESS(sfSelf.SP);
         pJITFuncData->parentNativeOffset = 0;
     }
 }

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -2407,7 +2407,7 @@ COM_METHOD CordbProcess::GetAsyncStack(CORDB_ADDRESS continuationAddress, ICorDe
             ThrowHR(E_INVALIDARG);
         }
 
-        PCODE diagnosticIP;
+        CORDB_ADDRESS diagnosticIP;
         CORDB_ADDRESS nextContinuation;
         UINT32 state;
         if (FAILED(m_pDacPrimitives->ParseContinuation(

--- a/src/coreclr/debug/di/rsstackwalk.cpp
+++ b/src/coreclr/debug/di/rsstackwalk.cpp
@@ -588,7 +588,7 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
 
         // Create the native frame.
         CordbNativeFrame* pNativeFrame = new CordbNativeFrame(m_pCordbThread,
-                                                              frameData.fp,
+                                                              FramePointer::MakeFramePointer(CORDB_ADDRESS_TO_PTR(frameData.fp)),
                                                               pNativeCode,
                                                               (SIZE_T)pJITFuncData->nativeOffset,
                                                               (TADDR)frameData.v.taAmbientESP,
@@ -718,7 +718,7 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
         _ASSERTE(pCurrentAppDomain != NULL);
 
         CordbRuntimeUnwindableFrame * pRuntimeFrame = new CordbRuntimeUnwindableFrame(m_pCordbThread,
-                                                                                      frameData.fp,
+                                                                                      FramePointer::MakeFramePointer(CORDB_ADDRESS_TO_PTR(frameData.fp)),
                                                                                       pCurrentAppDomain,
                                                                                       &frameCtx);
 
@@ -784,7 +784,7 @@ HRESULT CordbAsyncStackWalk::PopulateFrame()
 
     while (true)
     {
-        PCODE diagnosticIP;
+        CORDB_ADDRESS diagnosticIP = 0;
         CORDB_ADDRESS nextContinuation;
         UINT32 state;
 
@@ -881,7 +881,7 @@ HRESULT CordbAsyncStackWalk::Next()
         if (m_continuationAddress == 0)
             ThrowHR(CORDBG_E_PAST_END_OF_STACK);
 
-        PCODE diagnosticIP;
+        CORDB_ADDRESS diagnosticIP = 0;
         CORDB_ADDRESS nextContinuation;
         UINT32 state;
         IfFailThrow(m_pProcess->GetDAC()->ParseContinuation(

--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -2286,7 +2286,7 @@ void CordbThread::GetActiveInternalFramesCallback(const Debugger_STRData * pFram
 
     // Create a CordbInternalFrame.
     CordbInternalFrame * pInternalFrame = new CordbInternalFrame(pThis,
-                                                                 pFrameData->fp,
+                                                                 FramePointer::MakeFramePointer(CORDB_ADDRESS_TO_PTR(pFrameData->fp)),
                                                                  pAppDomain,
                                                                  pFrameData);
 
@@ -5433,7 +5433,7 @@ CordbMiscFrame::CordbMiscFrame()
 CordbMiscFrame::CordbMiscFrame(Debugger_JITFuncData * pJITFuncData)
 {
     this->parentIP       = (SIZE_T)pJITFuncData->parentNativeOffset;
-    this->fpParentOrSelf = pJITFuncData->fpParentOrSelf;
+    this->fpParentOrSelf = FramePointer::MakeFramePointer(CORDB_ADDRESS_TO_PTR(pJITFuncData->fpParentOrSelf));
     this->fIsFilterFunclet = (pJITFuncData->fIsFilterFrame == TRUE);
 }
 

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -2170,7 +2170,7 @@ public:
 
     virtual HRESULT STDMETHODCALLTYPE ParseContinuation(
         CORDB_ADDRESS continuationAddress,
-        OUT PCODE* pDiagnosticIP,
+        OUT CORDB_ADDRESS* pDiagnosticIP,
         OUT CORDB_ADDRESS* pNextContinuation,
         OUT UINT32* pState) = 0;
 

--- a/src/coreclr/debug/inc/dacdbistructures.h
+++ b/src/coreclr/debug/inc/dacdbistructures.h
@@ -519,7 +519,8 @@ struct MSLAYOUT Debugger_JITFuncData
 
     BOOL fIsFilterFrame;
     ULONG64 parentNativeOffset;
-    FramePointer fpParentOrSelf;
+    // FramePointer as CORDB_ADDRESS (fixed 64-bit); RS converts to/from FramePointer.
+    CORDB_ADDRESS fpParentOrSelf;
 
     // indicates if the MethodDesc is a generic function or a method inside a generic class (or
     // both!).
@@ -538,7 +539,10 @@ struct MSLAYOUT Debugger_JITFuncData
 #endif                          // ARM context structures have a 16-byte alignment requirement
 struct MSLAYOUT Debugger_STRData
 {
-    FramePointer            fp;
+    // fp is a CORDB_ADDRESS (fixed 64-bit) rather than a host-sized FramePointer; the RS
+    // converts to/from FramePointer at the boundary. ctx is deliberately a host-sized
+    // pointer to a dbi-allocated DT_CONTEXT buffer that the DAC writes through.
+    CORDB_ADDRESS           fp;
     DT_CONTEXT *            ctx;
     VMPTR_AppDomain         vmCurrentAppDomainToken;
 

--- a/src/coreclr/inc/dacdbi.idl
+++ b/src/coreclr/inc/dacdbi.idl
@@ -429,7 +429,7 @@ interface IDacDbiInterface : IUnknown
     // Async and Continuations
     HRESULT ParseContinuation(
         [in] CORDB_ADDRESS continuationAddress,
-        [out] PCODE * pDiagnosticIP,
+        [out] CORDB_ADDRESS * pDiagnosticIP,
         [out] CORDB_ADDRESS * pNextContinuation,
         [out] UINT32 * pState);
     HRESULT EnumerateAsyncLocals([in] VMPTR_MethodDesc vmMethod, [in] CORDB_ADDRESS codeAddr, [in] UINT32 state, [in] FP_ASYNC_LOCAL_CALLBACK fpCallback, [in] CALLBACK_DATA pUserData);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
@@ -84,7 +84,6 @@ public record struct DebuggerEvalData(
 public enum StackwalkFlag
 {
     Default = 0,
-    X86ESPIgnoresCalleePoppedArgs = 0x1,
 }
 
 public interface IStackWalk : IContract

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -35,8 +35,7 @@ internal partial class StackWalk_1 : IStackWalk
         TargetPointer FrameAddress,
         ThreadData ThreadData,
         bool IsResumableFrame = false,
-        bool IsActiveFrame = false,
-        uint LastFramelessStackParameterSize = 0) : IStackDataFrameHandle
+        bool IsActiveFrame = false) : IStackDataFrameHandle
     { }
 
     private class StackWalkData(IPlatformAgnosticContext context, StackWalkState state, FrameIterator frameIter, ThreadData threadData)
@@ -63,7 +62,6 @@ internal partial class StackWalk_1 : IStackWalk
         // Used by UpdateState to detect exception frames (FRAME_ATTR_EXCEPTION) and
         // set IsInterrupted when transitioning to a managed frame.
         public FrameType? LastProcessedFrameType { get; set; }
-        public uint LastFramelessStackParameterSize { get; set; }
 
         public bool IsCurrentFrameResumable()
         {
@@ -115,7 +113,7 @@ internal partial class StackWalk_1 : IStackWalk
         {
             bool isResumable = IsCurrentFrameResumable();
             bool isActiveFrame = IsFirst && State == StackWalkState.Frameless;
-            return new(Context.Clone(), State, FrameIter.CurrentFrameAddress, ThreadData, isResumable, isActiveFrame, LastFramelessStackParameterSize);
+            return new(Context.Clone(), State, FrameIter.CurrentFrameAddress, ThreadData, isResumable, isActiveFrame);
         }
     }
 
@@ -821,11 +819,6 @@ internal partial class StackWalk_1 : IStackWalk
                 // Reset interrupted state after processing a managed frame.
                 // Native stackwalk.cpp: isInterrupted = false; hasFaulted = false;
                 handle.IsInterrupted = false;
-                TargetCodePointer preUnwindIp = new(handle.Context.InstructionPointer.Value);
-                if (_target.Contracts.ExecutionManager.GetCodeBlockHandle(preUnwindIp) is CodeBlockHandle cbh)
-                {
-                    handle.LastFramelessStackParameterSize = _target.Contracts.ExecutionManager.GetStackParameterSize(cbh);
-                }
 
                 // Check if the current frame is interpreter code -- if so, use
                 // interpreter virtual unwind instead of OS-level unwind.
@@ -1000,20 +993,7 @@ internal partial class StackWalk_1 : IStackWalk
     byte[] IStackWalk.GetRawContext(IStackDataFrameHandle stackDataFrameHandle, StackwalkFlag flags)
     {
         StackDataFrameHandle handle = AssertCorrectHandle(stackDataFrameHandle);
-        byte[] bytes = handle.Context.GetBytes();
-
-        if ((flags & StackwalkFlag.X86ESPIgnoresCalleePoppedArgs) != 0
-            && _target.Contracts.RuntimeInfo.GetTargetArchitecture() == RuntimeInfoArchitecture.X86
-            && handle.LastFramelessStackParameterSize > 0)
-        {
-            IPlatformAgnosticContext adjusted = IPlatformAgnosticContext.GetContextForPlatform(_target);
-            adjusted.FillFromBuffer(bytes);
-            adjusted.StackPointer = new TargetPointer(
-                unchecked(adjusted.StackPointer.Value - handle.LastFramelessStackParameterSize));
-            bytes = adjusted.GetBytes();
-        }
-
-        return bytes;
+        return handle.Context.GetBytes();
     }
 
     private IPlatformAgnosticContext RetrieveHijackedContext(IPlatformAgnosticContext ctx, bool isUnhandledException)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1533,10 +1533,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             if (handleData.IsValid)
             {
                 IStackWalk sw = _target.Contracts.StackWalk;
-                StackwalkFlag flags = (handleData.Current.State == StackWalkState.NativeMarker)
-                    ? StackwalkFlag.X86ESPIgnoresCalleePoppedArgs
-                    : StackwalkFlag.Default;
-                byte[] context = sw.GetRawContext(handleData.Current, flags);
+                byte[] context = sw.GetRawContext(handleData.Current);
 
                 // See https://github.com/dotnet/runtime/blob/ad50b412069ee7f274c585d191df797ac5548525/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp#L184
                 RuntimeInfoArchitecture arch = _target.Contracts.RuntimeInfo.GetTargetArchitecture();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
@@ -195,7 +195,7 @@ public struct Debugger_JITFuncData
     public ulong vmNativeCodeMethodDescToken;
     public Interop.BOOL fIsFilterFrame;
     public ulong parentNativeOffset;
-    public ulong fpParentOrSelf;                   // FramePointer (CORDB_ADDRESS)
+    public ulong fpParentOrSelf;
     public Interop.BOOL isInstantiatedGeneric;
     public Interop.BOOL justAfterILThrow;
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
@@ -195,7 +195,7 @@ public struct Debugger_JITFuncData
     public ulong vmNativeCodeMethodDescToken;
     public Interop.BOOL fIsFilterFrame;
     public ulong parentNativeOffset;
-    public ulong fpParentOrSelf;
+    public ulong fpParentOrSelf;                   // FramePointer (CORDB_ADDRESS)
     public Interop.BOOL isInstantiatedGeneric;
     public Interop.BOOL justAfterILThrow;
 }
@@ -224,14 +224,10 @@ public struct DebuggerIPCE_STRData_StubFrame
     public int frameType;                          // CorDebugInternalFrameType
 }
 
-// Holds data for each stack frame or chain. This data is passed from the RC to
-// the DI during a stack walk. Mirrors the native Debugger_STRData struct
-// defined in src/coreclr/debug/inc/dbgipcevents.h.
-//
-// `ctx` is a pointer into dbi-allocated memory.
-// The DAC writes the populated context through this pointer rather
-// than storing it inline. Code paths that do not produce a context
-// (e.g. EnumerateInternalFrames for cStubFrame entries) leave it as 0.
+// Holds data for each stack frame or chain, passed from the RC to the DI during a
+// stack walk. Mirrors the native Debugger_STRData in src/coreclr/debug/inc/dacdbistructures.h.
+// ctx is a host-sized pointer to a dbi-allocated DT_CONTEXT buffer the DAC writes through;
+// paths that produce no context (e.g. EnumerateInternalFrames cStubFrame entries) leave it 0.
 [StructLayout(LayoutKind.Explicit)]
 public struct Debugger_STRData
 {
@@ -242,10 +238,11 @@ public struct Debugger_STRData
         cRuntimeNativeFrame = 2,
     }
 
-    [FieldOffset(0)] public ulong fp;                           // FramePointer
-    [FieldOffset(8)] public ulong ctx;                          // DT_CONTEXT*
+    [FieldOffset(0)] public ulong fp;                           // FramePointer (CORDB_ADDRESS)
+    [FieldOffset(8)] public nuint ctx;                          // DT_CONTEXT* (host-sized)
     [FieldOffset(16)] public ulong vmCurrentAppDomainToken;     // VMPTR_AppDomain
     [FieldOffset(24)] public EType eType;
+    // v (method frame) and stubFrame overlap, mirroring the native anonymous union.
     [FieldOffset(32)] public DebuggerIPCE_STRData_MethodFrame v;
     [FieldOffset(32)] public DebuggerIPCE_STRData_StubFrame stubFrame;
 }


### PR DESCRIPTION
Standardizes DBI stack-frame/continuation structures on fixed-width `CORDB_ADDRESS` making the 32-bit DBI compatible with the CDAC

- `Debugger_STRData.fp`/`ctx`, `fpParentOrSelf`, and `GetFramePointer` → `CORDB_ADDRESS`/`ulong`
- `ParseContinuation` `pDiagnosticIP` → `CORDB_ADDRESS*`
- Removed now dead `X86ESPIgnoresCalleePoppedArgs` mechanism
- Zero `ctx` for `cStubFrame` entries