### PR TITLE
Pin blittable layout classes in NativeAOT marshalling

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.Aot.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.Aot.cs
@@ -708,6 +708,54 @@ namespace Internal.TypeSystem.Interop
 
     internal sealed class LayoutClassPtrMarshaller : Marshaller
     {
+        // Blittable layout classes passed by value CLR->native are marshalled by pinning the managed
+        // object and passing an interior pointer to its data directly to native code, mirroring CoreCLR's
+        // ILBlittablePtrMarshaller. This preserves pointer identity and gives implicit [In,Out] semantics
+        // regardless of [In]/[Out]. Byref, reverse, return, field, and non-blittable scenarios instead copy
+        // through the struct marshalling thunks.
+        private bool MarshalViaPinning =>
+            MarshalDirection == MarshalDirection.Forward
+            && !IsManagedByRef
+            && !Return
+            && MarshallerType == MarshallerType.Argument
+            && MarshalUtils.IsBlittableType(ManagedType);
+
+        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        {
+            if (!MarshalViaPinning)
+            {
+                base.AllocAndTransformManagedToNative(codeStream);
+                return;
+            }
+
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            ILCodeLabel lNull = emitter.NewCodeLabel();
+
+            // Default the native value to null so a null managed reference marshals as a null pointer.
+            codeStream.EmitLdc(0);
+            codeStream.Emit(ILOpcode.conv_i);
+            StoreNativeValue(codeStream);
+
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.brfalse, lNull);
+
+            // Pin the object and pass the address of its first field (the object's data) to native code.
+            ILLocalVariable vPinnedObject = emitter.NewLocal(ManagedType, isPinned: true);
+            LoadManagedValue(codeStream);
+            codeStream.EmitStLoc(vPinnedObject);
+
+            FieldDesc rawDataField = Context.SystemModule
+                .GetKnownType("System.Runtime.CompilerServices"u8, "RawData"u8)
+                .GetKnownField("Data"u8);
+
+            codeStream.EmitLdLoc(vPinnedObject);
+            codeStream.Emit(ILOpcode.ldflda, emitter.NewToken(rawDataField));
+            codeStream.Emit(ILOpcode.conv_i);
+            StoreNativeValue(codeStream);
+
+            codeStream.EmitLabel(lNull);
+        }
+
         protected override void AllocManagedToNative(ILCodeStream codeStream)
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
@@ -758,6 +806,13 @@ namespace Internal.TypeSystem.Interop
 
         protected override void TransformNativeToManaged(ILCodeStream codeStream)
         {
+            // When marshalling via pinning the native code operates directly on the managed object's
+            // memory, so there is nothing to copy back.
+            if (MarshalViaPinning)
+            {
+                return;
+            }
+
             ILEmitter emitter = _ilCodeStreams.Emitter;
             ILCodeLabel lNull = emitter.NewCodeLabel();
 
@@ -774,6 +829,12 @@ namespace Internal.TypeSystem.Interop
 
         protected override void EmitCleanupManaged(ILCodeStream codeStream)
         {
+            // Pinning does not allocate any native resources that require cleanup.
+            if (MarshalViaPinning)
+            {
+                return;
+            }
+
             // Only do cleanup if it is IN
             if (!In)
             {

--- a/src/tests/Interop/LayoutClass/LayoutClassTest.cs
+++ b/src/tests/Interop/LayoutClass/LayoutClassTest.cs
@@ -139,7 +139,6 @@ namespace LayoutClass
     }
 
     [SkipOnMono("needs triage")]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
     public class LayoutClassTest
     {
@@ -190,7 +189,6 @@ namespace LayoutClass
         [DllImport("LayoutClassNative", EntryPoint = "Invalid")]
         private static extern void RecursiveNativeLayoutInvalid(RecursiveTestStruct str);
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void SequentialClass()
         {
@@ -201,7 +199,6 @@ namespace LayoutClass
             Assert.True(SimpleSeqLayoutClassByRef(p));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void SequentialClassNull()
         {
@@ -210,7 +207,6 @@ namespace LayoutClass
             Assert.True(SimpleSeqLayoutClassByRefNull(null));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void DerivedClassWithEmptyBase()
         {
@@ -221,7 +217,6 @@ namespace LayoutClass
             Assert.True(DerivedSeqLayoutClassByRef(new SeqDerivedClass2(42), 42));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void ExplicitClass()
         {
@@ -240,7 +235,6 @@ namespace LayoutClass
             Assert.Equal(expected, p.a);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void BlittableClass()
         {
@@ -249,7 +243,6 @@ namespace LayoutClass
             ValidateBlittableClassInOut(SimpleBlittableSeqLayoutClassByRef);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void BlittableClassNull()
         {
@@ -258,7 +251,6 @@ namespace LayoutClass
             Assert.True(SimpleBlittableSeqLayoutClass_Null(null));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void BlittableClassByInAttr()
         {
@@ -267,7 +259,6 @@ namespace LayoutClass
             ValidateBlittableClassInOut(SimpleBlittableSeqLayoutClassByInAttr);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void BlittableClassByOutAttr()
         {
@@ -285,7 +276,6 @@ namespace LayoutClass
             Assert.Equal(expected, p.a);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void SealedBlittableClass()
         {
@@ -294,7 +284,6 @@ namespace LayoutClass
             ValidateSealedBlittableClassInOut(SealedBlittableSeqLayoutClassByRef);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void SealedBlittableClassByInAttr()
         {
@@ -303,7 +292,6 @@ namespace LayoutClass
             ValidateSealedBlittableClassInOut(SealedBlittableSeqLayoutClassByInAttr);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void SealedBlittableClassByOutAttr()
         {
@@ -312,7 +300,6 @@ namespace LayoutClass
             ValidateSealedBlittableClassInOut(SealedBlittableSeqLayoutClassByOutAttr);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void SealedBlittablePinned()
         {
@@ -321,7 +308,6 @@ namespace LayoutClass
             Assert.True(PointersEqual(blittable, ref blittable.a));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void BlittablePinned()
         {
@@ -330,7 +316,6 @@ namespace LayoutClass
             Assert.True(PointersEqual(blittable, ref blittable.a));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void NestedLayoutClass()
         {
@@ -345,7 +330,6 @@ namespace LayoutClass
             Assert.True(SimpleNestedLayoutClassByValue(target));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81673", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void RecursiveNativeLayout()
         {


### PR DESCRIPTION
Fixes #81673.

NativeAOT's ILC always copied blittable layout classes passed by value into a separate native struct, honoring In/Out flags that default to In-only. This broke pointer identity, implicit [In,Out] write-back, and [Out] semantics for blittable layout classes.

Fold pinning support into LayoutClassPtrMarshaller: when marshalling a non-byref, non-return blittable layout class argument CLR->native, pin the managed object and pass an interior pointer directly to native code, mirroring CoreCLR's ILBlittablePtrMarshaller. Byref, field, reverse, return, and non-blittable scenarios continue to copy through the struct marshalling thunks.

Re-enables the previously-disabled LayoutClass interop tests (#81673).