### PR TITLE
Enable StructPacking interop test on NativeAOT

### DIFF
--- a/src/tests/Interop/StructPacking/StructPacking.cs
+++ b/src/tests/Interop/StructPacking/StructPacking.cs
@@ -117,10 +117,8 @@ public unsafe partial class StructPacking
     const int Pass = 100;
     const int Fail = 0;
 
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/181", typeof(Utilities), nameof(Utilities.IsNativeAot))]
     [Fact]
     [SkipOnMono("needs triage")]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/181", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static int TestEntryPoint()
     {
         bool succeeded = true;


### PR DESCRIPTION
Resolves dotnet/runtimelab#181

The test disabled for dotnet/runtimelab#181 now passes on NativeAOT. Remove the ActiveIssue attributes to re-enable it.