### PR TITLE
Process.Unix: skip non-executable files during process filename resolution.

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -311,12 +311,6 @@
              Link="Common\Interop\Unix\Interop.WaitPid.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Access.cs"
              Link="Common\Interop\Unix\System.Native\Interop.Access.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.cs"
-             Link="Common\Interop\Unix\Interop.Stat.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetEUid.cs"
-             Link="Common\Interop\Unix\Interop.GetEUid.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IsMemberOfGroup.cs"
-             Link="Common\Interop\Unix\Interop.IsMemberOfGroup.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IsAtomicNonInheritablePipeCreationSupported.cs"
              Link="Common\Interop\Unix\Interop.IsAtomicNonInheritablePipeCreationSupported.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IsATty.cs"
@@ -393,6 +387,8 @@
              Link="Common\Interop\FreeBSD\Interop.Process.cs" />
     <Compile Include="$(CommonPath)Interop\FreeBSD\Interop.Process.GetProcInfo.cs"
              Link="Common\Interop\FreeBSD\Interop.Process.GetProcInfo.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.cs"
+             Link="Common\Interop\Unix\Interop.Stat.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'openbsd'">
@@ -407,6 +403,8 @@
              Link="Common\Interop\OpenBSD\Interop.Process.cs" />
     <Compile Include="$(CommonPath)Interop\OpenBSD\Interop.Process.GetProcInfo.cs"
              Link="Common\Interop\OpenBSD\Interop.Process.GetProcInfo.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.cs"
+             Link="Common\Interop\Unix\Interop.Stat.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'illumos' or '$(TargetPlatformIdentifier)' == 'solaris'">

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessUtils.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessUtils.Unix.cs
@@ -22,65 +22,7 @@ namespace System.Diagnostics
         internal static bool SupportsAtomicNonInheritablePipeCreation => Interop.Sys.IsAtomicNonInheritablePipeCreationSupported;
 
         private static bool IsExecutable(string fullPath)
-        {
-            Interop.Sys.FileStatus fileinfo;
-
-            if (Interop.Sys.Stat(fullPath, out fileinfo) < 0)
-            {
-                return false;
-            }
-
-            // Check if the path is a directory.
-            if ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR)
-            {
-                return false;
-            }
-
-            const UnixFileMode AllExecute = UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
-
-            UnixFileMode permissions = ((UnixFileMode)fileinfo.Mode) & AllExecute;
-
-            // Avoid checking user/group when permission.
-            if (permissions == AllExecute)
-            {
-                return true;
-            }
-            else if (permissions == 0)
-            {
-                return false;
-            }
-
-            uint euid = Interop.Sys.GetEUid();
-
-            if (euid == 0)
-            {
-                return true; // We're root.
-            }
-
-            if (euid == fileinfo.Uid)
-            {
-                // We own the file.
-                return (permissions & UnixFileMode.UserExecute) != 0;
-            }
-
-            bool groupCanExecute = (permissions & UnixFileMode.GroupExecute) != 0;
-            bool otherCanExecute = (permissions & UnixFileMode.OtherExecute) != 0;
-
-            // Avoid group check when group and other have same permissions.
-            if (groupCanExecute == otherCanExecute)
-            {
-                return groupCanExecute;
-            }
-
-            if (Interop.Sys.IsMemberOfGroup(fileinfo.Gid))
-            {
-                return groupCanExecute;
-            }
-            else
-            {
-                return otherCanExecute;
-            }
-        }
+            => Interop.Sys.Access(fullPath, Interop.Sys.AccessMode.X_OK) == 0 && !Directory.Exists(fullPath);
 
         internal static unsafe void EnsureInitialized()
         {
@@ -232,7 +174,7 @@ namespace System.Diagnostics
                                                               Directory.GetCurrentDirectory();
                 string filenameInWorkingDirectory = Path.Combine(workingDirectory, filename);
                 // filename is a relative path in the working directory
-                if (File.Exists(filenameInWorkingDirectory))
+                if (IsExecutable(filenameInWorkingDirectory))
                 {
                     resolvedFilename = filenameInWorkingDirectory;
                 }
@@ -248,7 +190,7 @@ namespace System.Diagnostics
                 return null;
             }
 
-            if (Interop.Sys.Access(resolvedFilename, Interop.Sys.AccessMode.X_OK) == 0)
+            if (IsExecutable(resolvedFilename))
             {
                 return resolvedFilename;
             }
@@ -368,7 +310,7 @@ namespace System.Diagnostics
                 try
                 {
                     path = Path.Combine(Path.GetDirectoryName(path)!, filename);
-                    if (File.Exists(path))
+                    if (IsExecutable(path))
                     {
                         return path;
                     }
@@ -378,7 +320,7 @@ namespace System.Diagnostics
 
             // Then check the current directory
             path = Path.Combine(Directory.GetCurrentDirectory(), filename);
-            if (File.Exists(path))
+            if (IsExecutable(path))
             {
                 return path;
             }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -200,6 +200,36 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void ProcessStart_SkipsNonExecutableFilesInCurrentDirectory()
+        {
+            const string ScriptName = "script";
+
+            // Create an executable script on PATH
+            string pathDir = Path.Combine(TestDirectory, "Path1");
+            Directory.CreateDirectory(pathDir);
+            WriteScriptFile(pathDir, ScriptName, returnValue: 42);
+
+            // Create a non-executable file named ScriptName in the working directory
+            string workDir = Path.Combine(TestDirectory, "WorkDir");
+            Directory.CreateDirectory(workDir);
+            File.WriteAllText(Path.Combine(workDir, ScriptName), "Not executable");
+
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables["PATH"] = pathDir;
+            options.StartInfo.WorkingDirectory = workDir;
+            RemoteExecutor.Invoke(() =>
+            {
+                using (var px = Process.Start(new ProcessStartInfo { FileName = ScriptName }))
+                {
+                    Assert.NotNull(px);
+                    px.WaitForExit();
+                    Assert.True(px.HasExited);
+                    Assert.Equal(42, px.ExitCode);
+                }
+            }, options).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void ProcessStart_SkipsNonExecutableFilesOnPATH()
         {
             const string ScriptName = "script";

--- a/src/native/libs/System.Native/pal_process.c
+++ b/src/native/libs/System.Native/pal_process.c
@@ -573,16 +573,6 @@ static int32_t ForkAndExecProcessInternal(
 #endif
 
     *childPid = -1;
-
-    // Make sure we can find and access the executable. exec will do this, of course, but at that point it's already
-    // in the child process, at which point it'll translate to the child process' exit code rather than to failing
-    // the Start itself.  There's a race condition here, in that this could change prior to exec's checks, but there's
-    // little we can do about that. There are also more rigorous checks exec does, such as validating the executable
-    // format of the target; such errors will emerge via the child process' exit code.
-    if (access(filename, X_OK) != 0)
-    {
-        return -1;
-    }
 #endif
 
 #if defined(TARGET_OSX) || defined(TARGET_MACCATALYST)


### PR DESCRIPTION
Use access(X_OK) in IsExecutable instead of manually checking mode bits and user/group membership. This is simpler and handles edge cases like ACLs and capabilities correctly.

Change filename resolution to use IsExecutable instead of File.Exists so non-executable files in the working directory or relative paths don't shadow executable files on PATH.

Remove the redundant access(X_OK) check from native ForkAndExecProcessInternal since the managed side now checks executability before calling it.

Fixes https://github.com/dotnet/runtime/issues/129736.

@adamsitnik ptal.