### PR TITLE
Enable JIT\jit64 caninline test on NativeAOT

### DIFF
--- a/src/tests/JIT/jit64/opt/inl/caninline.cs
+++ b/src/tests/JIT/jit64/opt/inl/caninline.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Xunit;
-using TestLibrary;
 
 
 internal class baseclass
@@ -43,7 +42,6 @@ public class Program
     private volatile static int s_a = 5;
     private volatile static int s_b = 0;
 
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/183", typeof(Utilities), nameof(Utilities.IsNativeAot))]
     [Fact]
     public static int TestEntryPoint()
     {


### PR DESCRIPTION
Resolves dotnet/runtimelab#183.

The StackTrace infra-frame skipping issue tracked by dotnet/runtimelab#183 no longer reproduces for this test. Remove the ActiveIssue attribute (and the now-unused TestLibrary using) so the test runs on NativeAOT again.