### PR TITLE
Remove ActiveIssue for dotnet/runtimelab#901

### DIFF
--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/Exists.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/Exists.cs
@@ -275,7 +275,6 @@ namespace System.IO.Tests
             Assert.False(Exists(component));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/901", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Theory,
             MemberData(nameof(UncPathsWithoutShareName))]
         public void UncPathWithoutShareNameAsPath_ReturnsFalse(string component)

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Exists.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Exists.cs
@@ -214,7 +214,6 @@ namespace System.IO.Tests
             Assert.False(Exists(component));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/901", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Theory,
             MemberData(nameof(UncPathsWithoutShareName))]
         public void UncPathWithoutShareNameAsPath_ReturnsFalse(string component)


### PR DESCRIPTION
Resolves dotnet/runtimelab#901.