### PR TITLE
Fix NETSDK1242 build error on NativeAOT and the Mono smoke test

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -236,10 +236,8 @@
     <CoreLibProject Condition="'$(UseNativeAotCoreLib)' == 'true'">$([MSBuild]::NormalizePath('$(CoreClrProjectRoot)', 'nativeaot', 'System.Private.CoreLib', 'src', 'System.Private.CoreLib.csproj'))</CoreLibProject>
     <UriProject>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'System.Private.Uri', 'src', 'System.Private.Uri.csproj'))</UriProject>
 
-    <!-- NativeAOT is CoreCLR-based and never uses the Mono runtime. Force UseMonoRuntime off so the mobile inner target frameworks of
-         multi-targeted libraries do not default to Mono during restore, which would fail the .NET 11 SDK's mobile check (NETSDK1242). -->
-    <UseMonoRuntime Condition="'$(UseMonoRuntime)' == '' and '$(UseNativeAOTRuntime)' == 'true'">false</UseMonoRuntime>
     <!-- this property is used by the SDK to pull in mono-based runtime packs -->
+    <UseMonoRuntime Condition="'$(UseMonoRuntime)' == '' and '$(UseNativeAOTRuntime)' == 'true'">false</UseMonoRuntime>
     <UseMonoRuntime Condition="'$(UseMonoRuntime)' == '' and '$(RuntimeFlavor)' == 'Mono'">true</UseMonoRuntime>
     <UseMonoRuntime Condition="'$(UseMonoRuntime)' == 'true' and '$(TargetsMobile)' != 'true' and (
         $(TargetFramework.EndsWith('-android')) or $(TargetFramework.EndsWith('-ios')) or

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -236,6 +236,9 @@
     <CoreLibProject Condition="'$(UseNativeAotCoreLib)' == 'true'">$([MSBuild]::NormalizePath('$(CoreClrProjectRoot)', 'nativeaot', 'System.Private.CoreLib', 'src', 'System.Private.CoreLib.csproj'))</CoreLibProject>
     <UriProject>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'System.Private.Uri', 'src', 'System.Private.Uri.csproj'))</UriProject>
 
+    <!-- NativeAOT is CoreCLR-based and never uses the Mono runtime. Force UseMonoRuntime off so the mobile inner target frameworks of
+         multi-targeted libraries do not default to Mono during restore, which would fail the .NET 11 SDK's mobile check (NETSDK1242). -->
+    <UseMonoRuntime Condition="'$(UseMonoRuntime)' == '' and '$(UseNativeAOTRuntime)' == 'true'">false</UseMonoRuntime>
     <!-- this property is used by the SDK to pull in mono-based runtime packs -->
     <UseMonoRuntime Condition="'$(UseMonoRuntime)' == '' and '$(RuntimeFlavor)' == 'Mono'">true</UseMonoRuntime>
     <UseMonoRuntime Condition="'$(UseMonoRuntime)' == 'true' and '$(TargetsMobile)' != 'true' and (

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -33,7 +33,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:RunAOTCompilation=true /p:MonoForceInterpreter=true
+      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:_DisableCheckForUnsupportedMonoMobileRuntime=true
       timeoutInMinutes: 240
       # extra steps, run tests
       postBuildSteps:


### PR DESCRIPTION
## Description

The latest .NET 11 SDK started enforcing `NETSDK1242`, which fails the build when a project targets a mobile platform with the Mono runtime. The CoreCLR mobile legs already pass `/p:UseMonoRuntime=false`, so the check never fires for them, but the NativeAOT legs do not, so during restore the mobile target frameworks of the multi-targeted `libs.tests` projects default to Mono and fail the build.