### PR TITLE
Async Profiler: Reuse V1 dispatcher across a method's suspensions.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -961,6 +961,21 @@ namespace System.Runtime.CompilerServices
                 AsyncThreadContext.Release(context);
             }
 
+            public static void Append(AsyncStateMachineDispatcher dispatcher, ref Info info)
+            {
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+
+                SyncPoint.Check(context);
+
+                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                if (IsEnabled.AnyAsyncEvents(activeEventKeywords) && IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
+                {
+                    ResumeAsyncContext.Append(dispatcher, context, Stopwatch.GetTimestamp());
+                }
+
+                AsyncThreadContext.Release(context);
+            }
+
             public static void EmitEvent(AsyncThreadContext context, long currentTimestamp, ulong parentDispatcherId, ulong dispatcherId, AsyncEventID eventID)
             {
                 Debug.Assert(eventID == AsyncEventID.CreateRuntimeAsyncContext || eventID == AsyncEventID.CreateStateMachineAsyncContext);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
@@ -71,6 +71,16 @@ namespace System.Runtime.CompilerServices
             AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
             AsyncStateMachineDispatcher? activeDispatcher = info != null ? info->Dispatcher : null;
 
+            if (activeDispatcher != null && ReferenceEquals(activeDispatcher.InnerBox, box))
+            {
+                if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+                {
+                    AsyncProfiler.CreateAsyncContext.Append(activeDispatcher, ref info->AsyncProfilerInfo);
+                }
+
+                return activeDispatcher;
+            }
+
             AsyncStateMachineDispatcher dispatcher = new AsyncStateMachineDispatcher(box);
 
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
@@ -179,6 +189,8 @@ namespace System.Runtime.CompilerServices
         private IAsyncStateMachineBox? _inner;
         private Action? _moveNextAction;
 
+        internal IAsyncStateMachineBox? InnerBox => _inner;
+
         internal IAsyncStateMachineBox? LastContinuation;
 
         internal bool ReachedLastContinuation;
@@ -224,6 +236,9 @@ namespace System.Runtime.CompilerServices
 
             info.Dispatcher = this;
             info.AsyncProfilerInfo.CurrentContinuation = inner;
+
+            LastContinuation = null;
+            ReachedLastContinuation = false;
 
             try
             {

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -1693,19 +1693,19 @@ namespace System.Threading.Tasks.Tests
             AssertTrue(stream, completes == 1, $"Expected exactly 1 CompleteAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {completes}");
         }
 
-        // StateMachine-friendly variant: StateMachine's per-MoveNext dispatcher model emits one Create per await
-        // suspension, so a method with N awaits produces N dispatchers / N Creates within the
-        // same dispatcher tree. Each dispatcher ends in exactly one Suspend (it yielded) or one
-        // Complete (it finished), so every Create is balanced by a Suspend or a Complete:
-        // creates == completes + suspends (creates >= 1).
+        // StateMachine dispatcher model with reuse: a single dispatcher spans all of a method's yields
+        // (it resumes/suspends multiple times) and is created + completed exactly once. So within a
+        // dispatcher tree every Create is balanced by exactly one Complete; Suspends are interior events.
         private static void AssertCreateBalancesSuspendAndCompleteInChain(ParsedEventStream stream, ulong dispatcherId, string chainName)
         {
             var ids = stream.ChainEventsFromDispatcher(dispatcherId).Select(e => e.EventId).ToList();
             int creates = ids.Count(id => id == AsyncEventID.CreateStateMachineAsyncContext);
+            int resumes = ids.Count(id => id == AsyncEventID.ResumeStateMachineAsyncContext);
             int suspends = ids.Count(id => id == AsyncEventID.SuspendStateMachineAsyncContext);
             int completes = ids.Count(id => id == AsyncEventID.CompleteStateMachineAsyncContext);
             AssertTrue(stream, creates >= 1, $"Expected at least 1 CreateStateMachineAsyncContext for {chainName} (DispatcherId {dispatcherId}), got {creates}");
-            AssertTrue(stream, creates == completes + suspends, $"Expected CreateStateMachineAsyncContext count == CompleteStateMachineAsyncContext + SuspendStateMachineAsyncContext count for {chainName} (DispatcherId {dispatcherId}), got {creates} creates, {completes} completes, {suspends} suspends");
+            AssertTrue(stream, creates == completes, $"Expected CreateStateMachineAsyncContext count == CompleteStateMachineAsyncContext count for {chainName} (DispatcherId {dispatcherId}), got {creates} creates, {completes} completes");
+            AssertTrue(stream, resumes == completes + suspends, $"Expected ResumeStateMachineAsyncContext count == Complete + Suspend count for {chainName} (DispatcherId {dispatcherId}), got {resumes} resumes, {completes} completes, {suspends} suspends");
         }
 
         private sealed class InlinePostSynchronizationContext : SynchronizationContext

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -2532,8 +2532,8 @@ namespace System.Threading.Tasks.Tests
                 {
                     foundReSuspend = true;
                     int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, resumeIdx + 1);
-                    AssertTrue(stream, completeIdx < 0 || suspendIdx < completeIdx,
-                        "Outer completed before it re-suspended; inline inner completion was mis-attributed to it");
+                    AssertTrue(stream, completeIdx > suspendIdx,
+                        "Outer did not complete after it re-suspended; inline inner completion was mis-attributed to it");
                 }
             }
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1541,9 +1541,12 @@ namespace System.Threading.Tasks.Tests
             AssertTrue(stream, createCount >= 1,
                 $"Expected at least one CreateStateMachineAsyncContext event, got {createCount}");
 
-            // Each created dispatcher and each resume ends in exactly one suspend or one complete.
-            AssertEqual(stream, createCount, completeCount + suspendCount);
+            // Each resume cycle ends in exactly one suspend or one complete (model-agnostic).
             AssertEqual(stream, resumeCount, completeCount + suspendCount);
+
+            // With dispatcher reuse a single dispatcher spans all of a method's yields: it may suspend
+            // multiple times (interior) but is created and completed exactly once, so creates == completes.
+            AssertEqual(stream, createCount, completeCount);
 
             AssertTrue(stream, createCount >= 3,
                 $"Expected fan-out chain to produce at least 3 CreateStateMachineAsyncContext events (root + 2 child wraps), got {createCount}");
@@ -2507,9 +2510,11 @@ namespace System.Threading.Tasks.Tests
                 AsyncEventID.ResumeStateMachineAsyncCallstack, nameof(StateMachineAsync_PoolingValueTask_InlineReentrantCompletion_Outer_Marker));
             AssertNotEmpty(stream, markerCallstacks);
 
-            // The Outer frame resumes after resumeGate and then RE-SUSPENDS on finalGate, so its dispatcher must
-            // emit a Suspend and must NOT emit a Complete at that point. A mis-attributed inline completion of
-            // Inner flips CurrentContinuationCompleted on this frame and produces a (wrong) Complete instead.
+            // The Outer frame resumes after resumeGate, fires Inner's inline completion, then RE-SUSPENDS on
+            // finalGate before finally completing. With dispatcher reuse this is one dispatcher that Suspends
+            // (interior) and later Completes. A mis-attributed inline completion of Inner would flip
+            // CurrentContinuationCompleted on the Outer frame during its first resume, making it Complete
+            // before (or instead of) that Suspend. So: Outer must re-suspend, and its Complete must come after.
             var markerDispatcherIds = markerCallstacks.Select(c => c.DispatcherId).Distinct().ToList();
 
             bool foundReSuspend = false;
@@ -2527,8 +2532,8 @@ namespace System.Threading.Tasks.Tests
                 {
                     foundReSuspend = true;
                     int completeIdx = ids.IndexOf(AsyncEventID.CompleteStateMachineAsyncContext, resumeIdx + 1);
-                    AssertTrue(stream, completeIdx < 0,
-                        "Outer re-suspending frame emitted a Complete; inline inner completion was mis-attributed to it");
+                    AssertTrue(stream, completeIdx < 0 || suspendIdx < completeIdx,
+                        "Outer completed before it re-suspended; inline inner completion was mis-attributed to it");
                 }
             }
 


### PR DESCRIPTION
###  Summary

Optimizes the V1 (StateMachine) async profiler so a single AsyncStateMachineDispatcher spans all of a method's suspensions, instead of allocating a fresh dispatcher on every await/yield.

### Motivation

In the previous model, each time a box's continuation was scheduled (i.e. each yield), CreateDispatcher allocated a new dispatcher wrapping the same box. A method that suspends N times produced N dispatchers and N Create events within the same tree. Since the box identity is stable across its suspensions, that per-yield allocation is avoidable: when the active dispatcher is already dispatching this exact box, we can reuse it. This matches asyncv2's behavior.

### What changed

AsyncStateMachineDispatcher / CreateDispatcher:
   - Reuse guard: if the active dispatcher's inner box is reference-equal to the box being scheduled, return the existing dispatcher instead of allocating a new one.
   - MoveNext now resets LastContinuation / ReachedLastContinuation on re-entry, since a reused dispatcher would otherwise carry stale callstack-walk state from its previous resume cycle.

Preserving the late-frame append on reuse (AsyncProfiler.CreateAsyncContext.Append):
   - Allocating a new dispatcher previously ran CreateAsyncContext.Create, whose append hook flushes callstack frames that registered after the last resume walk (e.g. a parent continuation that attached late). The reuse path skips Create, so it now performs just that append-flush (no Create event emitted), gated on IsEnabled.ResumeAsyncContext(flags). This keeps AppendStateMachineAsyncCallstack firing before the subsequent Suspend, exactly as before.

### Tests

Updated the shared balance assertions to the reuse invariant:
   - AssertCreateBalancesSuspendAndCompleteInChain — now checks creates == completes and resumes == suspends + completes.
   - StateMachineAsync_WaitThenYield_BalancesResumeAndComplete — same split (createCount == completeCount, plus the model-agnostic resumeCount == completeCount + suspendCount).
   - StateMachineAsync_PoolingValueTask_InlineReentrantCompletion — the mis-attribution assertion now verifies the reused 

Outer dispatcher re-suspends before it completes (suspendIdx < completeIdx) rather than the old per-yield "re-suspending frame emits no Complete".