### PR TITLE
Add basic handling of OptimizationPreference for crossgen2 on mobile r2r

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -651,6 +651,10 @@ namespace ILCompiler
                     nodeFactoryFlags.StripInliningInfo = Get(_command.StripInliningInfo);
                     nodeFactoryFlags.StripDebugInfo = Get(_command.StripDebugInfo);
                     nodeFactoryFlags.StripILBodies = Get(_command.StripILBodies);
+                    if (nodeFactoryFlags.StripILBodies && !composite)
+                    {
+                        throw new Exception(SR.ErrorStripILBodiesRequiresComposite);
+                    }
 
                     builder
                         .UseMapFile(Get(_command.Map))

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -450,4 +450,7 @@
   <data name="StripILBodiesOption" xml:space="preserve">
     <value>Replace IL method bodies of compiled methods with a throwing stub in composite R2R output assemblies.</value>
   </data>
+  <data name="ErrorStripILBodiesRequiresComposite" xml:space="preserve">
+    <value>--strip-il-bodies is currently only supported for Composite ReadyToRun images.</value>
+  </data>
 </root>

--- a/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
+++ b/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
@@ -26,24 +26,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunPerfmapFormatVersion Condition="'$(PublishReadyToRunPerfmapFormatVersion)' == ''">1</PublishReadyToRunPerfmapFormatVersion>
     <PublishReadyToRunContainerFormat Condition="'$(PublishReadyToRunContainerFormat)' == ''">pe</PublishReadyToRunContainerFormat>
 
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">false</PublishReadyToRunEmitSymbols>
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">false</PublishReadyToRunEmitSymbols>
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">false</PublishReadyToRunEmitSymbols>
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">false</PublishReadyToRunEmitSymbols>
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">false</PublishReadyToRunEmitSymbols>
+    <_IsIOSLikeRid Condition="$(RuntimeIdentifier.StartsWith('ios-')) or $(RuntimeIdentifier.StartsWith('tvos-')) or $(RuntimeIdentifier.StartsWith('iossimulator-')) or $(RuntimeIdentifier.StartsWith('tvossimulator-')) or $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</_IsIOSLikeRid>
+    <_IsAndroidRid Condition="$(RuntimeIdentifier.StartsWith('android-'))">true</_IsAndroidRid>
+
+    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and '$(_IsIOSLikeRid)' == 'true'">false</PublishReadyToRunEmitSymbols>
     <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('osx-'))">false</PublishReadyToRunEmitSymbols>
 
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('ios-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('tvos-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
+    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and ('$(_IsIOSLikeRid)' == 'true' or '$(_IsAndroidRid)' == 'true')">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
+    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and ('$(_IsIOSLikeRid)' == 'true' or '$(_IsAndroidRid)' == 'true')">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
+    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripILBodies)' != 'false' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and '$(_IsIOSLikeRid)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-il-bodies</PublishReadyToRunCrossgen2ExtraArgs>
 
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('ios-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('tvos-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
+    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(Optimize)' == 'true' and ('$(_IsIOSLikeRid)' == 'true' or '$(_IsAndroidRid)' == 'true') and ('$(OptimizationPreference)' == 'Size' or '$(OptimizationPreference)' == '')">--Os;$(PublishReadyToRunCrossgen2ExtraArgs)</PublishReadyToRunCrossgen2ExtraArgs>
+    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(Optimize)' == 'true' and ('$(_IsIOSLikeRid)' == 'true' or '$(_IsAndroidRid)' == 'true') and '$(OptimizationPreference)' == 'Speed'">--Ot;$(PublishReadyToRunCrossgen2ExtraArgs)</PublishReadyToRunCrossgen2ExtraArgs>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
This also makes the r2r use the size opt (`--Os`) as a default on mobile.
Refactor repeated rid check by using `_IsIOSLikeRid` like we do in the sdk.
Disable the strip flags on debug builds, to match the sdk.
Enable `--strip-debug-info` and `--strip-inlining-info` on android release as well. `--strip-il-bodies` is not enabled because IL should still be needed for tiered jit.