### PR TITLE
Arm64: Only call checkRMWRegisters for RMW intrinsics

### DIFF
--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -360,7 +360,10 @@ void CodeGen::genEmbeddedMaskedHWIntrinsic(GenTreeHWIntrinsic* cndSelNode, regNu
     insScalableOpts sopt     = INS_SCALABLE_OPTS_NONE;
 
 #ifdef DEBUG
-    checkRMWRegisters(intrinEmbMask, targetReg);
+    if (isRMW)
+    {
+        checkRMWRegisters(intrinEmbMask, targetReg);
+    }
 #endif
 
     // Setup instruction options and handle special cases.


### PR DESCRIPTION
Fixes #130247