### PR TITLE
Fix inaccurate LogLevel constraint in LoggerMessageAttribute remarks

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
@@ -12,10 +12,11 @@ namespace Microsoft.Extensions.Logging
     /// <para>The method this attribute is applied to:</para>
     /// <para>   - Must be a partial method.</para>
     /// <para>   - Must return <c>void</c>.</para>
-    /// <para>   - Must not be generic.</para>
-    /// <para>   - Must have an <see cref="ILogger"/> as one of its parameters.</para>
-    /// <para>   - Must specify a log level, either on the attribute (through a constructor or the <see cref="Level"/> property) or as a <see cref="Microsoft.Extensions.Logging.LogLevel"/> parameter on the method.</para>
-    /// <para>   - None of the parameters can be generic.</para>
+    /// <para>   - Must have a <see cref="Microsoft.Extensions.Logging.LogLevel"/> as one of its parameters, if the attribute does not specify it.</para>
+    /// <para>   - Must have access to an <see cref="ILogger"/>: as a parameter (which is required when the method is <c>static</c>), or, for an instance method, through an <see cref="ILogger"/> field or primary constructor parameter on the containing type.</para>
+    /// <para>   - Must not have a name that starts with an underscore, or any parameter whose name starts with an underscore.</para>
+    /// <para>   - Can be generic, but its type parameters cannot have the <c>allows ref struct</c> anti-constraint.</para>
+    /// <para>   - Must not have parameters that use the <c>params</c>, <c>scoped</c>, or <c>out</c> modifiers, or that are <c>ref struct</c> types.</para>
     /// </remarks>
     /// <example>
     /// <format type="text/markdown"><![CDATA[

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.Logging
     /// <para>   - Must return <c>void</c>.</para>
     /// <para>   - Must not be generic.</para>
     /// <para>   - Must have an <see cref="ILogger"/> as one of its parameters.</para>
-    /// <para>   - Must have a <see cref="Microsoft.Extensions.Logging.LogLevel"/> as one of its parameters.</para>
+    /// <para>   - Must specify a log level, either on the attribute (through a constructor or the <see cref="Level"/> property) or as a <see cref="Microsoft.Extensions.Logging.LogLevel"/> parameter on the method.</para>
     /// <para>   - None of the parameters can be generic.</para>
     /// </remarks>
     /// <example>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Logging
     /// <para>   - Must have a <see cref="Microsoft.Extensions.Logging.LogLevel"/> as one of its parameters, if the attribute does not specify it.</para>
     /// <para>   - Must have access to an <see cref="ILogger"/>: as a parameter (which is required when the method is <c>static</c>), or, for an instance method, through an <see cref="ILogger"/> field or primary constructor parameter on the containing type.</para>
     /// <para>   - Must not have a name that starts with an underscore, or any parameter whose name starts with an underscore.</para>
-    /// <para>   - Can be generic, but its type parameters cannot have the <c>allows ref struct</c> anti-constraint.</para>
+    /// <para>   - Can be generic, but its type parameters cannot use the <c>allows ref struct</c> constraint.</para>
     /// <para>   - Must not have parameters that use the <c>params</c>, <c>scoped</c>, or <c>out</c> modifiers, or that are <c>ref struct</c> types.</para>
     /// </remarks>
     /// <example>


### PR DESCRIPTION
The remarks for `LoggerMessageAttribute` incorrectly stated that the decorated method must have a `LogLevel` parameter. The log level can instead be set on the attribute (via a constructor or the `Level` property), and defaults to `LogLevel.None` when unspecified. Updated the remarks accordingly.

Fixes https://github.com/dotnet/runtime/issues/130319