### PR TITLE
[release/10.0] JIT: fix widened IV init placed in unreachable block

### DIFF
--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -923,7 +923,11 @@ bool Compiler::optWidenPrimaryIV(FlowGraphNaturalLoop* loop, unsigned lclNum, Sc
 
     BasicBlock* preheader = loop->EntryEdge(0)->getSourceBlock();
     BasicBlock* initBlock = preheader;
-    if ((startSsaDsc->GetBlock() != nullptr) && (startSsaDsc->GetDefNode() != nullptr))
+    // Prefer to initialize the widened IV in the same block as the reaching def
+    // of the narrow IV, but only if the reaching def is not a phi. RBO's jump threading
+    // can leave stale SSA with the once-containing block being unreachable.
+    if ((startSsaDsc->GetBlock() != nullptr) && (startSsaDsc->GetDefNode() != nullptr) &&
+        !startSsaDsc->GetDefNode()->IsPhiDefn())
     {
         initBlock = startSsaDsc->GetBlock();
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130189/Runtime_130189.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130189/Runtime_130189.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+// Regression test for https://github.com/dotnet/runtime/issues/130189
+//
+// Redundant branch opts' dominator-based jump threading used to bypass a block
+// that contained a globally-used PHI def without updating SSA. That left the
+// loop reading a stale (soon to be dead) PHI value, which subsequent induction
+// variable widening then miscompiled, producing a wrong result.
+
+public sealed class Runtime_130189
+{
+    ushort[] d = [0, 0, 1, 65535, 1, 0, 1, 65535, 65535];
+    int[] a = [0, 4];
+    int i;
+
+    bool Next(out int p)
+    {
+        bool r;
+        if (r = i < a.Length)
+            p = a[i++];
+        else
+            p = -1;
+        return r;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    internal long Sum()
+    {
+        i = 0;
+        long s = 0;
+        int x, p;
+        while (Next(out p))
+        {
+            while ((x = d[p]) != 65535)
+            {
+                s += x;
+                p++;
+            }
+        }
+        return s;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Equal(3, new Runtime_130189().Sum());
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130189/Runtime_130189.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130189/Runtime_130189.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #130190 to release/10.0

/cc @EgorBo

## Customer Impact

- [ ] Customer reported
- [x] Found internally

Bad codegen. IV widening could emit the widened IV initialization into a block that redundant branch opts' jump threading had made unreachable (stale SSA). A later flow-graph pass removes that dead block, so the widened IV is never initialized and the loop computes a wrong result (#130189).

## Regression

- [x] Yes
- [ ] No

Latent wrong-code bug introduced in .NET 9

## Testing

Added regression test `Runtime_130189` (fails without the fix, passes with it).

## Risk

Low

> [!NOTE]
> This PR description was generated with the help of GitHub Copilot.
