### PR TITLE
Fix breaking-change-doc fork check expression

### DIFF
--- a/.github/workflows/breaking-change-doc.lock.yml
+++ b/.github/workflows/breaking-change-doc.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"411454be0b76f8489d8af4a88ac252de655107e9042e5425155e4b22b1cbcb48","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"96a3c1132b78cfe1588a98637fe68e1ab1648ee6bb4e7946f8b7d149646a6a66","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -101,7 +101,7 @@ jobs:
     if: >
       needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'workflow_dispatch' ||
       (
-      !github.event.repository.fork &&
+      github.event.repository.fork == false &&
       github.event.pull_request.merged &&
       contains(github.event.pull_request.labels.*.name, 'needs-breaking-change-doc-created')
       ))
@@ -235,20 +235,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_571edf9c05ec0872_EOF'
+          cat << 'GH_AW_PROMPT_dd95a70496851939_EOF'
           <system>
-          GH_AW_PROMPT_571edf9c05ec0872_EOF
+          GH_AW_PROMPT_dd95a70496851939_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_571edf9c05ec0872_EOF'
+          cat << 'GH_AW_PROMPT_dd95a70496851939_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_571edf9c05ec0872_EOF
+          GH_AW_PROMPT_dd95a70496851939_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_571edf9c05ec0872_EOF'
+          cat << 'GH_AW_PROMPT_dd95a70496851939_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -277,12 +277,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_571edf9c05ec0872_EOF
+          GH_AW_PROMPT_dd95a70496851939_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_571edf9c05ec0872_EOF'
+          cat << 'GH_AW_PROMPT_dd95a70496851939_EOF'
           </system>
           {{#runtime-import .github/workflows/breaking-change-doc.md}}
-          GH_AW_PROMPT_571edf9c05ec0872_EOF
+          GH_AW_PROMPT_dd95a70496851939_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -479,9 +479,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_80ac430331ad7b0f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_06cf2fc66e629c8c_EOF'
           {"add_comment":{"max":1,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_80ac430331ad7b0f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_06cf2fc66e629c8c_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -670,7 +670,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8ceb2e233eee9e0c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_2a19d2894def277d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -711,7 +711,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8ceb2e233eee9e0c_EOF
+          GH_AW_MCP_CONFIG_2a19d2894def277d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1379,7 +1379,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (
-      !github.event.repository.fork &&
+      github.event.repository.fork == false &&
       github.event.pull_request.merged &&
       contains(github.event.pull_request.labels.*.name, 'needs-breaking-change-doc-created')
       )

--- a/.github/workflows/breaking-change-doc.md
+++ b/.github/workflows/breaking-change-doc.md
@@ -25,7 +25,7 @@ safe-outputs:
 if: |
   github.event_name == 'workflow_dispatch' ||
   (
-    !github.event.repository.fork &&
+    github.event.repository.fork == false &&
     github.event.pull_request.merged &&
     contains(github.event.pull_request.labels.*.name, 'needs-breaking-change-doc-created')
   )


### PR DESCRIPTION
This changes `breaking-change-doc` to use `github.event.repository.fork == false` instead of unary `!github.event.repository.fork`, and regenerates the lock file with the same gh-aw compiler version already recorded in that workflow.

Audit notes:
- Current agentic workflows checked in the repo: only `breaking-change-doc` still used this risky unary-`!` fork check form.
- Recorded failed runs: I did not find corresponding failed runs for `breaking-change-doc`; recent runs are skipped/cancelled rather than parser failures.
- Related recorded failures: `ci-failure-scan` has recorded failing runs from the invalid compiled form, but the current repo state no longer contains that pattern there.

> [!NOTE]
> This PR body was generated with the assistance of GitHub Copilot.
