### PR TITLE
Fix flaky StateMachineAsync_CallstackStressWithVaryingDepths test.

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1481,11 +1481,6 @@ namespace System.Threading.Tasks.Tests
             // We expect at least one marker callstack per iteration.
             AssertTrue(stream, markerCallstacks.Count >= iterations,
                 $"Expected at least {iterations} callstacks with marker, got {markerCallstacks.Count}");
-
-            // Verify multiple buffer flushes occurred -- proves the buffer machinery is exercised.
-            int bufferCount = 0;
-            ForEachEventBufferPayload(events, _ => bufferCount++);
-            AssertTrue(stream, bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");
         }
 
         [RuntimeAsyncMethodGeneration(false)]


### PR DESCRIPTION
### Summary

Removes a fragile buffer-flush-count assertion from StateMachineAsync_CallstackStressWithVaryingDepths that has been intermittently failing in CI. The rest of the test — which validates async callstack frame data across 100 randomly-varying recursion depths — is unchanged.

### Problem

The test ended with:

   int bufferCount = 0;
   ForEachEventBufferPayload(events, _ => bufferCount++);
   AssertTrue(stream, bufferCount >= 3, $"Expected at least 3 buffer flushes, got {bufferCount}");

ForEachEventBufferPayload counts per-thread event-buffer payloads, so bufferCount is a function of both the total event volume and how the work happened to be distributed across threadpool threads.

### Fix

Drop the buffer-flush-count assertion. It is:

   - Non-deterministic — depends on threadpool scheduling, not just the (seeded) workload.
   - Redundant — the buffer overflow / rent path is already exercised deterministically by StateMachineAsync max-depth stress test (Depth = byte.MaxValue, Iterations = 128), which overflows the per-thread buffer many times over.

The test retains its actual purpose: it still asserts every marker callstack has valid, resolvable frame data and that at least one marker callstack is emitted per iteration.

### Risk

  Test-only change; no product code touched. No loss of meaningful coverage.

Fixes:

https://github.com/dotnet/runtime/issues/129938
https://github.com/dotnet/runtime/issues/129871