### PR TITLE
Fix "GMT Standard Time" incorrectly interpreted as fixed-offset zone on Android

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.Android.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.Android.cs
@@ -107,7 +107,7 @@ namespace System
             {
                 return new TimeZoneInfo(id, TimeSpan.FromSeconds(0), id, name, name, null, disableDaylightSavingTime: true);
             }
-            if (name.Length >= 4 && name[0] == 'G' && name[1] == 'M' && name[2] == 'T' && (name[3] == '+' || name[3] == '-'))
+            if (name.Length > 4 && name[0] == 'G' && name[1] == 'M' && name[2] == 'T' && (name[3] == '+' || name[3] == '-'))
             {
                 return new TimeZoneInfo(id, TimeSpan.FromSeconds(ParseGMTNumericZone(name)), id, name, name, null, disableDaylightSavingTime: true);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.Android.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.Android.cs
@@ -103,11 +103,11 @@ namespace System
 
         private static TimeZoneInfo? GetTimeZone(string id, string name)
         {
-            if (name == "GMT" || name == "UTC")
+            if (name == "GMT" || name == "UTC" || name == "GMT0")
             {
                 return new TimeZoneInfo(id, TimeSpan.FromSeconds(0), id, name, name, null, disableDaylightSavingTime: true);
             }
-            if (name.Length >= 3 && name[0] == 'G' && name[1] == 'M' && name[2] == 'T')
+            if (name.Length >= 4 && name[0] == 'G' && name[1] == 'M' && name[2] == 'T' && (name[3] == '+' || name[3] == '-'))
             {
                 return new TimeZoneInfo(id, TimeSpan.FromSeconds(ParseGMTNumericZone(name)), id, name, name, null, disableDaylightSavingTime: true);
             }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2555,6 +2555,34 @@ namespace System.Tests
             }
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid))]
+        [InlineData("GMT+1", 1)]
+        [InlineData("GMT-1", -1)]
+        [InlineData("GMT+5", 5)]
+        [InlineData("GMT-5", -5)]
+        [InlineData("GMT+12", 12)]
+        [InlineData("GMT-12", -12)]
+        public static void AndroidGMTOffsetTimeZoneTest(string id, int expectedOffsetHours)
+        {
+            TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById(id);
+            Assert.Equal(TimeSpan.FromHours(expectedOffsetHours), tz.BaseUtcOffset);
+            Assert.False(tz.SupportsDaylightSavingTime);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid), nameof(PlatformDetection.IsIcuGlobalization))]
+        public static void AndroidGMTNameNotMistakenForGMTOffsetTimeZoneTest()
+        {
+            // "GMT Standard Time" is the Windows time zone for Great Britain (Europe/London)
+            // which observes daylight savings time. It should not be treated as a fixed-offset
+            // "GMT+/-" time zone.
+            Assert.True(TimeZoneInfo.TryFindSystemTimeZoneById("GMT Standard Time", out TimeZoneInfo tz));
+            Assert.True(tz.SupportsDaylightSavingTime);
+
+            // In summer, London observes BST (UTC+1)
+            var summerDate = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(TimeSpan.FromHours(1), tz.GetUtcOffset(summerDate));
+        }
+
         public static bool SupportIanaNamesConversion => PlatformDetection.IsNotMobile && PlatformDetection.ICUVersion.Major >= 52;
         public static bool SupportIanaNamesConversionAndRemoteExecution => SupportIanaNamesConversion && RemoteExecutor.IsSupported;
         public static bool DoesNotSupportIanaNamesConversion => !SupportIanaNamesConversion;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/126943

## Description

On Android, `TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time")` incorrectly returns a UTC-like time zone with no daylight saving time. "GMT Standard Time" is the Windows time zone ID for Great Britain (Europe/London) which observes BST (UTC+1) in summer.

## Root Cause

The `GetTimeZone` method in `TimeZoneInfo.Unix.Android.cs` has a check for GMT numeric offset zones (like `GMT+5`, `GMT-3`) that only verifies the first 3 characters are "GMT":

```csharp
if (name.Length >= 3 && name[0] == 'G' && name[1] == 'M' && name[2] == 'T')
```

This incorrectly matches "GMT Standard Time" and treats it as a fixed-offset zone (with offset 0 from `ParseGMTNumericZone`), preventing the correct fallback to the IANA lookup path.

## Fix

Added a check for `+` or `-` at position 3 to ensure only actual numeric offset zone names are handled:

```csharp
if (name.Length >= 4 && name[0] == 'G' && name[1] == 'M' && name[2] == 'T' && (name[3] == '+') || name[3] == '-'))
```

## Testing

- Added `AndroidGMTOffsetTimeZoneTest` — verifies GMT+/- offset zones still work correctly
- Added `AndroidGMTNameNotMistakenForGMTOffsetTimeZoneTest` — regression test verifying "GMT Standard Time" resolves with DST support
- Verified on Android emulator (Pixel 8, API 35): before fix returns `SupportsDaylightSavingTime: False`, after fix returns `True` with correct UTC+1 offset in summer