### PR TITLE
Fix failing symlink tests (10.0)

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -431,9 +431,13 @@ namespace System.Formats.Tar
                 return true;
             }
 
-            // Walk relative components, resolving symlinks at each step
-            string relative = normalizedFile.Substring(logicalPrefix.Length)
-                .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            // Walk relative components, resolving symlinks at each step.
+            // When the file resolves to the destination directory itself, there are no components to walk,
+            // so the relative path is empty. Guarding here avoids an out-of-range Substring on the prefix length.
+            string relative = normalizedFile.Equals(logicalDest, pathComparison)
+                ? string.Empty
+                : normalizedFile.Substring(logicalPrefix.Length)
+                    .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
             string[] components = relative.Split(new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
                 StringSplitOptions.RemoveEmptyEntries);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -398,7 +398,9 @@ namespace System.Formats.Tar
             return (fileDestinationPath, linkTargetPath);
         }
 
-        // Check if the file destination path or the link target path escapes the destination directory, by walking through the relative path components and resolving symlinks at each step.
+        // Prevent an archive from escaping the extraction root through symlinks that were created by earlier entries in the same archive.
+        // This protection applies only to links introduced by the archive itself. It is not intended to defend against preexisting symlinks
+        // already present on disk before extraction
         private static bool FilePathEscapesDirectory(string destinationDirectoryPath, string fileDestinationPath)
         {
             // Windows is case insensitive while Linux is case sensitive
@@ -408,6 +410,13 @@ namespace System.Formats.Tar
                 : StringComparison.Ordinal;
 
             string resolvedDest = ResolvePhysicalPath(destinationDirectoryPath);
+
+            // Use the logical destination path for computing the relative path
+            string logicalDest = Path.GetFullPath(destinationDirectoryPath);
+            string logicalPrefix = logicalDest.EndsWith(Path.DirectorySeparatorChar)
+                ? logicalDest
+                : logicalDest + Path.DirectorySeparatorChar;
+
             string destPrefix = resolvedDest.EndsWith(Path.DirectorySeparatorChar)
                 ? resolvedDest
                 : resolvedDest + Path.DirectorySeparatorChar;
@@ -415,8 +424,15 @@ namespace System.Formats.Tar
             // Normalize file path (resolves .. and . but not symlinks)
             string normalizedFile = Path.GetFullPath(fileDestinationPath);
 
+            // Guard with StartsWith before computing relative path
+            if (!normalizedFile.StartsWith(logicalPrefix, pathComparison) &&
+                !normalizedFile.Equals(logicalDest, pathComparison))
+            {
+                return true;
+            }
+
             // Walk relative components, resolving symlinks at each step
-            string relative = normalizedFile.Substring(resolvedDest.Length)
+            string relative = normalizedFile.Substring(logicalPrefix.Length)
                 .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
             string[] components = relative.Split(new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
@@ -427,16 +443,7 @@ namespace System.Formats.Tar
             foreach (string component in components)
             {
                 current = Path.Combine(current, component);
-
-                if (Path.Exists(current))
-                {
-                    string? resolved = ResolveSymlink(current);
-                    if (resolved is null)
-                    {
-                        return true;
-                    }
-                    current = resolved;
-                }
+                current = ResolveSymlink(current);
 
                 string normalizedCurrent = Path.GetFullPath(current);
                 if (!normalizedCurrent.StartsWith(destPrefix, pathComparison) &&
@@ -449,15 +456,18 @@ namespace System.Formats.Tar
             return false;
         }
 
-        private static string? ResolveSymlink(string path)
+        private static string ResolveSymlink(string path)
         {
-            FileSystemInfo? target = new FileInfo(path).ResolveLinkTarget(returnFinalTarget: true);
+            var info = new FileInfo(path);
 
-            if (target is null)
+            // Check LinkTarget first so dangling symlinks/junctions (whose final target doesn't exist yet)
+            // are still resolved to their raw target, rather than being treated as a non-link.
+            if (info.LinkTarget is null)
             {
                 return Path.GetFullPath(path);
             }
 
+            FileSystemInfo target = info.ResolveLinkTarget(returnFinalTarget: true) ?? info;
             return target.FullName;
         }
 
@@ -481,12 +491,7 @@ namespace System.Formats.Tar
                 current = Path.Combine(current, component);
                 if (Path.Exists(current))
                 {
-                    string? resolved = ResolveSymlink(current);
-                    if (resolved is null)
-                    {
-                        return current;
-                    }
-                    current = resolved;
+                    current = ResolveSymlink(current);
                 }
             }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -400,7 +400,7 @@ namespace System.Formats.Tar
 
         // Prevent an archive from escaping the extraction root through symlinks that were created by earlier entries in the same archive.
         // This protection applies only to links introduced by the archive itself. It is not intended to defend against preexisting symlinks
-        // already present on disk before extraction
+        // already present on disk before extraction.
         private static bool FilePathEscapesDirectory(string destinationDirectoryPath, string fileDestinationPath)
         {
             // Windows is case insensitive while Linux is case sensitive

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -347,7 +347,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void LinkBeforeTarget()
         {
             using TempDirectory source = new TempDirectory();
@@ -377,7 +376,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void ExtractToDirectory_RejectsSymlinkDirectoryTraversal_WithNestedFile()
         {
             using TempDirectory root = new TempDirectory();
@@ -419,7 +417,6 @@ namespace System.Formats.Tar.Tests
 
 
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void ExtractToDirectory_RejectsChainedSymlinkDirectoryTraversal_WithNestedFile()
         {
             // dir a/

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -46,7 +46,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void SetsLastModifiedTimeOnExtractedFiles()
         {
             using TempDirectory root = new TempDirectory();
@@ -74,7 +73,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void SetsLastModifiedTimeOnExtractedDirectories()
         {
             using TempDirectory root = new TempDirectory();
@@ -211,7 +209,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void ExtractArchiveWithEntriesThatStartWithSlashDotPrefix()
         {
             using TempDirectory root = new TempDirectory();
@@ -237,7 +234,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void UnixFileModes(bool overwrite)
         {
             using TempDirectory source = new TempDirectory();
@@ -306,7 +302,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void UnixFileModes_RestrictiveParentDir(bool overwrite)
         {
             using TempDirectory source = new TempDirectory();

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -445,8 +445,17 @@ namespace System.Formats.Tar.Tests
 
             if (OperatingSystem.IsWindows())
             {
-                // Windows only creates file symlinks and trying to process a directory symlink will throw UnauthorizedAccessException instead of IOException
-                Assert.Throws<UnauthorizedAccessException>(() => TarFile.ExtractToDirectory(tarPath, destDir, overwriteFiles: true));
+                // Windows always creates file symlinks (FileInfo.CreateAsSymbolicLink), so entry "a/b" becomes a
+                // *file* symlink whose target (".") is a *directory*. Processing the nested entries forces the
+                // extractor to resolve/descend through that type-mismatched reparse point, which Windows rejects,
+                // but the surfaced exception depends on the OS build:
+                //   - Some builds throw UnauthorizedAccessException while resolving the link (FileInfo.ResolveLinkTarget
+                //     during the traversal-safety walk in FilePathEscapesDirectory).
+                //   - Others resolve the link successfully, then fail creating a directory where the file symlink
+                //     already exists, throwing IOException ("a file or directory with the same name already exists").
+                // Either way the archive is rejected and nothing escapes (verified below), so accept both.
+                Exception ex = Assert.ThrowsAny<Exception>(() => TarFile.ExtractToDirectory(tarPath, destDir, overwriteFiles: true));
+                Assert.True(ex is IOException or UnauthorizedAccessException, $"Unexpected exception type: {ex}");            
             }
             else
             {

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -455,7 +455,7 @@ namespace System.Formats.Tar.Tests
                 //     already exists, throwing IOException ("a file or directory with the same name already exists").
                 // Either way the archive is rejected and nothing escapes (verified below), so accept both.
                 Exception ex = Assert.ThrowsAny<Exception>(() => TarFile.ExtractToDirectory(tarPath, destDir, overwriteFiles: true));
-                Assert.True(ex is IOException or UnauthorizedAccessException, $"Unexpected exception type: {ex}");            
+                Assert.True(ex is IOException or UnauthorizedAccessException, $"Unexpected exception type: {ex}");
             }
             else
             {

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -76,7 +76,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(TarEntryType.SymbolicLink)]
         [InlineData(TarEntryType.HardLink)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void Extract_LinkEntry_TargetOutsideDirectory(TarEntryType entryType)
         {
             using MemoryStream archive = new MemoryStream();
@@ -99,25 +98,21 @@ namespace System.Formats.Tar.Tests
         [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void Extract_SymbolicLinkEntry_TargetInsideDirectory(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.SymbolicLink, format, null);
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsHardLinkCreation))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void Extract_HardLinkEntry_TargetInsideDirectory(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.HardLink, format, null);
 
         [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void Extract_SymbolicLinkEntry_TargetInsideDirectory_LongBaseDir(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.SymbolicLink, format, new string('a', 99));
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsHardLinkCreation))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void Extract_HardLinkEntry_TargetInsideDirectory_LongBaseDir(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.HardLink, format, new string('a', 99));
 
         // This test would not pass for the V7 and Ustar formats in some OSs like MacCatalyst, tvOSSimulator and OSX, because the TempDirectory gets created in
@@ -157,7 +152,6 @@ namespace System.Formats.Tar.Tests
         [InlineData(512)]
         [InlineData(512 + 1)]
         [InlineData(512 + 512 - 1)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void Extract_UnseekableStream_BlockAlignmentPadding_DoesNotAffectNextEntries(int contentSize)
         {
             byte[] fileContents = new byte[contentSize];
@@ -214,7 +208,6 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(GetTestTarFormats))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public void UnseekableStreams_RoundTrip(TestTarFormat testFormat)
         {
             using TempDirectory root = new();

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -57,7 +57,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public async Task SetsLastModifiedTimeOnExtractedFiles()
         {
             using TempDirectory root = new TempDirectory();
@@ -85,7 +84,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public async Task SetsLastModifiedTimeOnExtractedDirectories()
         {
             using TempDirectory root = new TempDirectory();
@@ -238,7 +236,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public async Task ExtractArchiveWithEntriesThatStartWithSlashDotPrefix_Async()
         {
             using (TempDirectory root = new TempDirectory())
@@ -267,7 +264,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public async Task UnixFileModes_Async(bool overwrite)
         {
             using TempDirectory source = new TempDirectory();
@@ -334,7 +330,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public async Task UnixFileModes_RestrictiveParentDir_Async()
         {
             using TempDirectory source = new TempDirectory();
@@ -368,7 +363,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public async Task LinkBeforeTargetAsync()
         {
             using TempDirectory source = new TempDirectory();

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -136,7 +136,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(TarEntryType.SymbolicLink)]
         [InlineData(TarEntryType.HardLink)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public async Task Extract_LinkEntry_TargetOutsideDirectory_Async(TarEntryType entryType)
         {
             await using (MemoryStream archive = new MemoryStream())
@@ -161,25 +160,21 @@ namespace System.Formats.Tar.Tests
         [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public Task Extract_SymbolicLinkEntry_TargetInsideDirectory_Async(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal_Async(TarEntryType.SymbolicLink, format, null);
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsHardLinkCreation))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public Task Extract_HardLinkEntry_TargetInsideDirectory_Async(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal_Async(TarEntryType.HardLink, format, null);
 
         [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public Task Extract_SymbolicLinkEntry_TargetInsideDirectory_LongBaseDir_Async(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal_Async(TarEntryType.SymbolicLink, format, new string('a', 99));
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsHardLinkCreation))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public Task Extract_HardLinkEntry_TargetInsideDirectory_LongBaseDir_Async(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal_Async(TarEntryType.HardLink, format, new string('a', 99));
 
         // This test would not pass for the V7 and Ustar formats in some OSs like MacCatalyst, tvOSSimulator and OSX, because the TempDirectory gets created in
@@ -222,7 +217,6 @@ namespace System.Formats.Tar.Tests
         [InlineData(512)]
         [InlineData(512 + 1)]
         [InlineData(512 + 512 - 1)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public async Task Extract_UnseekableStream_BlockAlignmentPadding_DoesNotAffectNextEntries_Async(int contentSize)
         {
             byte[] fileContents = new byte[contentSize];
@@ -279,7 +273,6 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(GetTestTarFormats))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227")]
         public async Task UnseekableStreams_RoundTrip_Async(TestTarFormat testFormat)
         {
             using TempDirectory root = new();


### PR DESCRIPTION
Backport of #130342 to release/10.0.

Fixes #129227

## Customer Impact

The new tar symlink resolution is not working properly on some platforms.

Found internally via test failures in servicing branches - see #129227.

Corrects a length mismatch that made the Tar traversal guard crash with  ArgumentOutOfRangeException  (subtracting a symlink-resolved path length from a logical path). Without it, extraction to any symlinked destination (macOS  /var ,  /tmp ) is broken.

## Regression

Yes - caught by test failures in servicing branches - see #129227.

## Testing

Re-enabled failing CI tests.

## Risk

Low.