### PR TITLE
[release/10.0] [QUIC] Update MsQuic to the latest 2.5 version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -161,7 +161,7 @@
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>10.0.0-preview-20251006.1</MicrosoftPrivateIntellisenseVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.18</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.5.9</MicrosoftNativeQuicMsQuicSchannelVersion>
     <SystemNetMsQuicTransportVersion>9.0.0-alpha.1.24167.3</SystemNetMsQuicTransportVersion>
     <!-- emscripten / Node -->
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftDotNetApiCompatTaskPackageVersion)</MicrosoftNETRuntimeEmscriptenVersion>


### PR DESCRIPTION
# Description

Backport of #130173. Updates MsQuic from 2.4.18 to the latest supported 2.5 release (2.5.9) by bumping `MicrosoftNativeQuicMsQuicSchannelVersion` in `eng/Versions.props`.

main PR https://github.com/dotnet/runtime/pull/130173

# Customer Impact

The MsQuic 2.4 branch is being phased out and will no longer receive servicing/security updates. Staying on 2.4.18 leaves QUIC/HTTP3 consumers on an unsupported native dependency, missing bug and security fixes shipped in the actively supported 2.5 branch.

# Regression

No. This is a native dependency version update, not a regression fix.

# Testing

Standard CI (System.Net.Quic and HTTP/3 test suites) against the updated MsQuic package.

# Risk

Low. Single version-property change consuming an already-shipping, actively-supported MsQuic 2.5.x package. 2.5 is the currently supported servicing branch for MsQuic.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
