### PR TITLE
[release/9.0-staging] [QUIC] Update MsQuic to the latest 2.5 version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -228,7 +228,7 @@
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>9.0.0-rtm.26356.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.18</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.5.9</MicrosoftNativeQuicMsQuicSchannelVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>19.1.0-alpha.1.26256.3</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>19.1.0-alpha.1.26256.3</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>


### PR DESCRIPTION
# Description

Backport of #130173. Updates MsQuic from 2.4.18 to the latest supported 2.5 release (2.5.9) by bumping `MicrosoftNativeQuicMsQuicSchannelVersion` in `eng/Versions.props`.

main PR https://github.com/dotnet/runtime/pull/130173

# Customer Impact

The MsQuic 2.4 branch is being phased out and will no longer receive servicing/security updates. Staying on 2.4.18 leaves QUIC/HTTP3 consumers on an unsupported native dependency, missing bug and security fixes shipped in the actively supported 2.5 branch.

# Regression

No. This is a native dependency version update, not a regression fix.

# Testing

Standard CI (System.Net.Quic and HTTP/3 test suites) against the updated MsQuic package.

# Risk

Low. Single version-property change consuming an already-shipping, actively-supported MsQuic 2.5.x package. 2.5 is the currently supported servicing branch for MsQuic.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
