### PR TITLE
Force lf line endings for managed source to fix SourceLink PDB checksums

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,8 +27,13 @@
 *.cmd text eol=crlf
 *.bat text eol=crlf
 
-*.cs text diff=csharp
-*.vb text
+# Force managed source files to lf in the working tree so the source-document
+# checksums the compiler records in portable PDBs match the lf blobs SourceLink
+# serves from GitHub raw URLs. Without eol=lf, Windows build checkouts produce
+# crlf source, making strict SourceLink/PDB byte verification fail even though
+# the content matches after line-ending normalization. See dotnet/runtime#129023.
+*.cs text eol=lf diff=csharp
+*.vb text eol=lf
 *.resx text
 *.c text
 *.cpp text
@@ -53,8 +58,8 @@
 *.m text
 *.asm text
 *.erl text
-*.fs text
-*.fsx text
+*.fs text eol=lf
+*.fsx text eol=lf
 *.hs text
 
 *.csproj text


### PR DESCRIPTION
Managed source files used .gitattributes 'text', which stores lf blobs but checks out crlf on Windows build agents. The compiler records the crlf source-document checksums in portable PDBs, while SourceLink points at GitHub raw URLs that serve the lf blobs. Strict SourceLink/PDB byte verification then fails for official packages even though the content matches after line-ending normalization.

Add eol=lf for .cs/.vb/.fs/.fsx so every checkout (including Windows CI) uses lf, matching the bytes SourceLink serves.

Contributes to dotnet/runtime#129023