### PR TITLE
[clr-ios] Disable R2R IL-body stripping for library tests that need IL at run time

### DIFF
--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -157,6 +157,7 @@
       <_ApplePropertyNames Include="MainLibraryFileName" />
       <_ApplePropertyNames Include="MonoEnableLLVM" />
       <_ApplePropertyNames Include="ShouldILStrip" />
+      <_ApplePropertyNames Include="PublishReadyToRunStripILBodies" />
       <_ApplePropertyNames Include="UseConsoleUITemplate" />
       <_ApplePropertyNames Include="UseRuntimeComponents" />
       <_ApplePropertyNames Include="_NetCoreAppToolCurrent" />

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj
@@ -5,6 +5,7 @@
     <!-- https://github.com/dotnet/runtime/issues/126862 -->
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <PublishReadyToRunStripILBodies>false</PublishReadyToRunStripILBodies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsAppleMobile)' == 'true' and '$(EnableAggressiveTrimming)' == 'true' and '$(UseNativeAotRuntime)' != 'true'">

--- a/src/libraries/System.Reflection.DispatchProxy/tests/System.Reflection.DispatchProxy.Tests.csproj
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/System.Reflection.DispatchProxy.Tests.csproj
@@ -5,6 +5,7 @@
     <!-- https://github.com/dotnet/runtime/issues/126862 -->
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <PublishReadyToRunStripILBodies>false</PublishReadyToRunStripILBodies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishReadyToRunStripILBodies>false</PublishReadyToRunStripILBodies>
     <!-- 436: Type conflicts on "Interop" due to InternalsVisibleTo access
          SYSLIB0037: AssemblyName members HashAlgorithm, ProcessorArchitecture, and VersionCompatibility are obsolete. -->
     <NoWarn>$(NoWarn);436;SYSLIB0037</NoWarn>

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+    <PublishReadyToRunStripILBodies>false</PublishReadyToRunStripILBodies>
     <!-- EnC tests on targets without a remote executor need the environment variable set before launching the test -->
     <!-- Also ask Mono to use make sequence points even without a debugger attached to match "dotnet watch" behavior -->
     <WasmXHarnessMonoArgs>--setenv=DOTNET_MODIFIABLE_ASSEMBLIES=debug --setenv=MONO_DEBUG=gen-seq-points</WasmXHarnessMonoArgs>


### PR DESCRIPTION
## Description

The Apple mobile CoreCLR library test apps are published as a composite ReadyToRun image with IL bodies stripped, which the SDK turns on by default for iOS-like runtime identifiers. A stripped body is replaced with an invalid stub, so any test that needs the real IL at run time fails. `System.Runtime.Loader.Tests`, `System.Reflection.DispatchProxy.Tests`, and `System.Xml.XmlSerializer.ReflectionOnly.Tests` load assemblies into collectible `AssemblyLoadContext` instances, which cannot use the R2R native code and recompile from IL, so they throw `InvalidProgramException`; `System.Reflection.Metadata.Tests` reads a stripped method body directly and throws `BadImageFormatException`. 

The on-Helix AOT build reads only the properties forwarded through the `_ApplePropertyNames` allowlist in `tests.ioslike.targets`, so this change adds `PublishReadyToRunStripILBodies` to that allowlist and sets it to `false` on these four test projects, leaving stripping on for every other Apple mobile CoreCLR test app.