### PR TITLE
Adjust InterpreterFP handling to represent the logical FP (where funclets share the FP with the establishing method)

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -6031,6 +6031,24 @@ FunctionTableIndexRangeSection* ExecutionManager::FindFunctionTableIndexRangeSec
     return nullptr;
 }
 
+BOOL ExecutionManager::IsFuncletFuntionIndex(DWORD functionIndex)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    FunctionTableIndexRangeSection* pSection = FindFunctionTableIndexRangeSection(functionIndex);
+    if (pSection == nullptr)
+    {
+        return FALSE;
+    }
+
+    Module* pModule = pSection->pR2RModule;
+    ReadyToRunInfo* pR2RInfo = pModule->GetReadyToRunInfo();
+
+    DWORD localIndex = functionIndex - pSection->minFunctionTableIndex;
+    PTR_RUNTIME_FUNCTION pRuntimeFunction = pR2RInfo->GetRuntimeFunctions() + localIndex;
+    return RUNTIME_FUNCTION__IsFunclet(pRuntimeFunction);
+}
+
 TADDR ExecutionManager::GetWasmVirtualIPFromFunctionTableIndex(DWORD functionIndex)
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -6031,7 +6031,7 @@ FunctionTableIndexRangeSection* ExecutionManager::FindFunctionTableIndexRangeSec
     return nullptr;
 }
 
-BOOL ExecutionManager::IsFuncletFuntionIndex(DWORD functionIndex)
+BOOL ExecutionManager::IsFuncletFunctionIndex(DWORD functionIndex)
 {
     LIMITED_METHOD_CONTRACT;
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -2542,6 +2542,7 @@ public:
     // then compute and return the virtual IP for that the entrypoint for that function
     // (which may require a walk back to find the main function if functionIndex represents a funclet)
     static TADDR          GetWasmVirtualIPFromFunctionTableIndex(DWORD functionIndex);
+    static BOOL           IsFuncletFuntionIndex(DWORD functionIndex);
     static TADDR          GetWasmFunctionTableIndexFromVirtualIP(TADDR virtualIP);
 #endif // TARGET_WASM
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -2542,7 +2542,7 @@ public:
     // then compute and return the virtual IP for that the entrypoint for that function
     // (which may require a walk back to find the main function if functionIndex represents a funclet)
     static TADDR          GetWasmVirtualIPFromFunctionTableIndex(DWORD functionIndex);
-    static BOOL           IsFuncletFuntionIndex(DWORD functionIndex);
+    static BOOL           IsFuncletFunctionIndex(DWORD functionIndex);
     static TADDR          GetWasmFunctionTableIndexFromVirtualIP(TADDR virtualIP);
 #endif // TARGET_WASM
 

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -1718,9 +1718,6 @@ EXTERN_C DWORD_PTR STDCALL CallEHFilterFunclet(Object *pThrowable, TADDR FP, UIN
 typedef DWORD_PTR (HandlerFn)(UINT_PTR uStackFrame, Object* pExceptionObj);
 #else
 typedef TADDR HandlerFn;
-TADDR GetWasmFramePointerFromStackPointer(TADDR sp);
-TADDR GetWasmEstablishingFramePointerFromTerminator(TADDR sp);
-
 DWORD_PTR CallFuncletWithThrowable(UINT_PTR pFuncletToInvoke, TADDR fp, Object *pThrowable, UINT_PTR *pFuncletCallerSP);
 DWORD_PTR CallFuncletWithoutThrowable(UINT_PTR pFuncletToInvoke, TADDR fp, UINT_PTR *pFuncletCallerSP);
 #endif // TARGET_WASM
@@ -1752,34 +1749,8 @@ DWORD_PTR EECodeManager::CallFunclet(OBJECTREF throwable, void* pHandler, REGDIS
     UINT_PTR *pFuncletCallerSP = &(pExInfo->m_csfEHClause.SP);
 
 #ifdef TARGET_WASM
-    TADDR wasmFramePointer = GetWasmFramePointerFromStackPointer(GetSP(pRD->pCurrentContext));
-    // A handler that is lexically nested inside a funclet (e.g. a catch inside a finally) must
-    // run with the enclosing METHOD frame as its establishing frame.
-    if (pExInfo->m_frameIter.m_crawl.IsFunclet())
-    {
-        T_CONTEXT walkCtx = *(pRD->pCurrentContext);
-        for (;;)
-        {
-            UnwindStackFrame(&walkCtx);
-            EECodeInfo ci(dac_cast<PCODE>(GetIP(&walkCtx)));
-            if (!ci.IsValid())
-            {
-                // The funclet was invoked by the VM through CallFuncletWith[out]Throwable, so native
-                // unwinding terminates at that synthetic frame before reaching the method's own frame.
-                // Recover the establishing (method) frame pointer the helper stored next to the
-                // TERMINATE_R2R_STACK_WALK marker.
-                wasmFramePointer = GetWasmEstablishingFramePointerFromTerminator(GetSP(&walkCtx));
-                break;
-            }
-            if (!ci.IsFunclet())
-            {
-                // The funclet executes within the method's own native frame, which we reached directly
-                // by unwinding (no intervening CallFunclet helper frame).
-                wasmFramePointer = GetWasmFramePointerFromStackPointer(GetSP(&walkCtx));
-                break;
-            }
-        }
-    }
+    TADDR wasmFramePointer = GetFP(pRD->pCurrentContext);
+    _ASSERTE(wasmFramePointer != 0);
     TADDR handlerFnIndex = CastHandlerFn(pfnHandler);
     if (throwable != NULL)
     {

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -10320,11 +10320,11 @@ void SoftwareExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = m_Context.regname;
     ENUM_FP_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
-#else
+#else // TARGET_WASM
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = m_Context.regname;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
-#endif // TARGET_WASM
+#endif // !TARGET_WASM
 
     SetIP(pRD->pCurrentContext, ::GetIP(&m_Context));
     SetSP(pRD->pCurrentContext, ::GetSP(&m_Context));
@@ -10343,9 +10343,11 @@ void SoftwareExceptionFrame::SetContext(T_CONTEXT *pContext)
 
     m_Context = *pContext;
 
+#ifndef TARGET_WASM
 #define CALLEE_SAVED_REGISTER(regname) m_ContextPointers.regname = &m_Context.regname;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
+#endif // !TARGET_WASM
 
     m_ReturnAddress = ::GetIP(&m_Context);
 }
@@ -10748,7 +10750,6 @@ void SoftwareExceptionFrame::UpdateContextFromTransitionBlock(TransitionBlock *p
 }
 
 #elif defined(TARGET_WASM)
-TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE controlPC);
 void SoftwareExceptionFrame::UpdateContextFromTransitionBlock(TransitionBlock *pTransitionBlock)
 {
     LIMITED_METHOD_CONTRACT;
@@ -10761,6 +10762,7 @@ void SoftwareExceptionFrame::UpdateContextFromTransitionBlock(TransitionBlock *p
     {
         m_Context.InterpreterSP = pTransitionBlock->m_StackPointer;
         m_Context.InterpreterIP = GetWasmVirtualIPFromStackPointer(pTransitionBlock->m_StackPointer);
+        _ASSERTE(m_Context.InterpreterIP != 0); // We should only ever reach here with a valid VirtualIP
         m_Context.InterpreterFP = GetWasmFramePointerFromStackPointer(m_Context.InterpreterSP, (PCODE)m_Context.InterpreterIP);
         m_ReturnAddress = m_Context.InterpreterIP;
         m_Context.InterpreterWalkFramePointer = 0;

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -10302,6 +10302,7 @@ void SoftwareExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
+#ifndef TARGET_WASM
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = *dac_cast<PTR_SIZE_T>((TADDR)m_ContextPointers.regname);
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
@@ -10319,6 +10320,11 @@ void SoftwareExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = m_Context.regname;
     ENUM_FP_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
+#else
+#define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = m_Context.regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+#endif // TARGET_WASM
 
     SetIP(pRD->pCurrentContext, ::GetIP(&m_Context));
     SetSP(pRD->pCurrentContext, ::GetSP(&m_Context));
@@ -10742,7 +10748,7 @@ void SoftwareExceptionFrame::UpdateContextFromTransitionBlock(TransitionBlock *p
 }
 
 #elif defined(TARGET_WASM)
-TADDR GetWasmFramePointerFromStackPointer(TADDR sp);
+TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE controlPC);
 void SoftwareExceptionFrame::UpdateContextFromTransitionBlock(TransitionBlock *pTransitionBlock)
 {
     LIMITED_METHOD_CONTRACT;
@@ -10754,8 +10760,8 @@ void SoftwareExceptionFrame::UpdateContextFromTransitionBlock(TransitionBlock *p
     if (pTransitionBlock != nullptr)
     {
         m_Context.InterpreterSP = pTransitionBlock->m_StackPointer;
-        m_Context.InterpreterFP = GetWasmFramePointerFromStackPointer(m_Context.InterpreterSP);
         m_Context.InterpreterIP = GetWasmVirtualIPFromStackPointer(pTransitionBlock->m_StackPointer);
+        m_Context.InterpreterFP = GetWasmFramePointerFromStackPointer(m_Context.InterpreterSP, (PCODE)m_Context.InterpreterIP);
         m_ReturnAddress = m_Context.InterpreterIP;
         m_Context.InterpreterWalkFramePointer = 0;
     }

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -2166,10 +2166,6 @@ template <> OBJECTREF* TGcInfoDecoder<InterpreterGcInfoEncoding>::GetStackSlot(
 }
 #endif
 
-#ifdef TARGET_WASM
-TADDR GetWasmFramePointerFromStackPointer(TADDR sp);
-#endif
-
 template <typename GcInfoEncoding> OBJECTREF* TGcInfoDecoder<GcInfoEncoding>::GetStackSlot(
                         INT32           spOffset,
                         GcStackSlotBase spBase,
@@ -2195,8 +2191,7 @@ template <typename GcInfoEncoding> OBJECTREF* TGcInfoDecoder<GcInfoEncoding>::Ge
         // Wasm is a bit strange and when we do SetStackBaseRegister(REG_FPBASE)
         //  what that actually does is set it to REG_NA, which currently has the value 2.
         _ASSERTE( 2 == m_StackBaseRegister );
-        // We have the stack pointer, use it to recover the frame pointer.
-        TADDR pFrameReg = GetWasmFramePointerFromStackPointer((TADDR)pRD->SP);
+        TADDR pFrameReg = (TADDR)pRD->pCurrentContext->InterpreterFP;
 
         pObjRef = (OBJECTREF*)(pFrameReg + spOffset);
 

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -1468,6 +1468,7 @@ void StackFrameIterator::SkipTo(StackFrameIterator *pOtherStackFrameIterator)
     pRD->SSP = pOtherRD->SSP;
 #endif
 
+#ifndef TARGET_WASM
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = (pRD->pCurrentContextPointers->regname == NULL) ? pOtherRD->pCurrentContext->regname : *pRD->pCurrentContextPointers->regname;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
@@ -1475,6 +1476,11 @@ void StackFrameIterator::SkipTo(StackFrameIterator *pOtherStackFrameIterator)
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = pOtherRD->pCurrentContext->regname;
     ENUM_FP_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
+#else
+#define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = pOtherRD->pCurrentContext->regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+#endif // TARGET_WASM
 
     pRD->IsCallerContextValid = pOtherRD->IsCallerContextValid;
     if (pRD->IsCallerContextValid)
@@ -1487,6 +1493,7 @@ void StackFrameIterator::SkipTo(StackFrameIterator *pOtherStackFrameIterator)
         SetFirstArgReg(pRD->pCallerContext, GetFirstArgReg(pOtherRD->pCallerContext));
 #endif
 
+#ifndef TARGET_WASM
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCallerContext->regname = (pRD->pCallerContextPointers->regname == NULL) ? pOtherRD->pCallerContext->regname : *pRD->pCallerContextPointers->regname;
         ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
@@ -1494,6 +1501,11 @@ void StackFrameIterator::SkipTo(StackFrameIterator *pOtherStackFrameIterator)
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCallerContext->regname = pOtherRD->pCallerContext->regname;
         ENUM_FP_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
+#else
+#define CALLEE_SAVED_REGISTER(regname) pRD->pCallerContext->regname = pOtherRD->pCallerContext->regname;
+        ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+#endif
     }
     SyncRegDisplayToCurrentContext(pRD);
 }

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -1476,11 +1476,11 @@ void StackFrameIterator::SkipTo(StackFrameIterator *pOtherStackFrameIterator)
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = pOtherRD->pCurrentContext->regname;
     ENUM_FP_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
-#else
+#else // TARGET_WASM
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = pOtherRD->pCurrentContext->regname;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
-#endif // TARGET_WASM
+#endif // !TARGET_WASM
 
     pRD->IsCallerContextValid = pOtherRD->IsCallerContextValid;
     if (pRD->IsCallerContextValid)
@@ -1501,11 +1501,11 @@ void StackFrameIterator::SkipTo(StackFrameIterator *pOtherStackFrameIterator)
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCallerContext->regname = pOtherRD->pCallerContext->regname;
         ENUM_FP_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
-#else
+#else // TARGET_WASM
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCallerContext->regname = pOtherRD->pCallerContext->regname;
         ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
-#endif
+#endif // !TARGET_WASM
     }
     SyncRegDisplayToCurrentContext(pRD);
 }

--- a/src/coreclr/vm/wasm/callhelpers.hpp
+++ b/src/coreclr/vm/wasm/callhelpers.hpp
@@ -5,6 +5,20 @@
 #ifndef __WASM_CALLHELPERS_HPP__
 #define __WASM_CALLHELPERS_HPP__
 
+#define WASM_STACKFRAME_FUNCTION_INDEX_OFFSET 0
+
+#ifdef TARGET_64BIT
+#define WASM_STACKFRAME_INDIRECT_TO_FRAMEPOINTER_OFFSET 8 // The framepointer is a pointer value, and therefore should be pointer aligned
+#else
+#define WASM_STACKFRAME_INDIRECT_TO_FRAMEPOINTER_OFFSET 4 // The framepointer is a pointer value, and therefore should be pointer aligned
+#endif
+
+#define WASM_STACKFRAME_VIRTUALIP_OFFSET 4 // Virtual IPs are 32bit, and will remain so even on 64bit platforms, as they are an index into the R2R function table, which is limited to 4GB of entries.
+
+// A sentinel value to indicate to the stackwalker that a stack pointer is not a framepointer, and should
+// use an indirection to find the actual frame pointer
+#define STACK_WALK_INDIRECT_TO_FRAMEPOINTER 0
+
 // A sentinel value to indicate to the stack walker that this frame is NOT R2R generated managed code,
 // and it should look for the next Frame in the Frame chain to make further progress.
 #define TERMINATE_R2R_STACK_WALK 1
@@ -14,7 +28,11 @@
 // marker (which lives at offset 0). This lets the stack walker recover the establishing frame for a
 // handler that is lexically nested inside a funclet that the VM invoked via CallFunclet, where native
 // unwinding terminates at this synthetic frame before reaching the method's own frame.
-#define TERMINATE_R2R_STACK_WALK_FP_OFFSET 4
+#ifdef TARGET_64BIT
+#define TERMINATE_R2R_STACK_WALK_FP_OFFSET 8 // The framepointer is a pointer value, and therefore should be pointer aligned
+#else
+#define TERMINATE_R2R_STACK_WALK_FP_OFFSET 4 // The framepointer is a pointer value, and therefore should be pointer aligned
+#endif
 
 struct StringToWasmSigThunk
 {

--- a/src/coreclr/vm/wasm/cgencpu.h
+++ b/src/coreclr/vm/wasm/cgencpu.h
@@ -112,7 +112,7 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return context->InterpreterFP;
 }
 
-#define ENUM_CALLEE_SAVED_REGISTERS()
+#define ENUM_CALLEE_SAVED_REGISTERS() CALLEE_SAVED_REGISTER(InterpreterFP)
 
 #define ENUM_FP_CALLEE_SAVED_REGISTERS()
 

--- a/src/coreclr/vm/wasm/cgencpu.h
+++ b/src/coreclr/vm/wasm/cgencpu.h
@@ -158,4 +158,6 @@ inline TADDR GetSecondArgReg(T_CONTEXT *context)
     return 0;
 }
 
+TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE controlPC);
+
 #endif // __cgenwasm_h__

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -1527,8 +1527,8 @@ TADDR GetWasmVirtualIPFromStackPointer(TADDR sp)
     }
     else
     {
-        uint32_t r2rFunctionTableEntryNumber = *(uint32_t*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET);
-        uint32_t functionLocalVirtualIP = (*(uint32_t*)(sp + WASM_STACKFRAME_VIRTUALIP_OFFSET)) * 2; // Multiply by 2 as virtual IPs are encoded in units of 2 to leave the low bit in the VirtualIP mapping available to distinguish between virtual IPs and interpreter addresses/PortableEntryPoints.
+        uint32_t r2rFunctionTableEntryNumber = *(uint32_t*)(fp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET);
+        uint32_t functionLocalVirtualIP = (*(uint32_t*)(fp + WASM_STACKFRAME_VIRTUALIP_OFFSET)) * 2; // Multiply by 2 as virtual IPs are encoded in units of 2 to leave the low bit in the VirtualIP mapping available to distinguish between virtual IPs and interpreter addresses/PortableEntryPoints.
         TADDR baseVirtualIP = ExecutionManager::GetWasmVirtualIPFromFunctionTableIndex(r2rFunctionTableEntryNumber);
         if (baseVirtualIP == 0)
             return 0;
@@ -1560,7 +1560,7 @@ TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE controlPC)
 
     TADDR internalFunctionFramePointer = GetWasmFramePointerFromStackPointer_Internal(sp);
     _ASSERTE(internalFunctionFramePointer != 0);
-    uint32_t r2rFunctionTableEntryNumber = *(uint32_t*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET);
+    uint32_t r2rFunctionTableEntryNumber = *(uint32_t*)(internalFunctionFramePointer + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET);
     _ASSERTE(GetWasmVirtualIPFromStackPointer(sp) == controlPC);
 
     if (ExecutionManager::IsFuncletFunctionIndex(r2rFunctionTableEntryNumber))

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -1493,11 +1493,11 @@ static TADDR GetWasmFramePointerFromStackPointer_Internal(TADDR sp)
     }
     else
     {
-        if (*(int*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET) == STACK_WALK_INDIRECT_TO_FRAMEPOINTER)
+        if (*(int32_t*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET) == STACK_WALK_INDIRECT_TO_FRAMEPOINTER)
         {
             sp = *(TADDR*)(sp + WASM_STACKFRAME_INDIRECT_TO_FRAMEPOINTER_OFFSET);
         }
-        if (*(int*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET) == TERMINATE_R2R_STACK_WALK)
+        if (*(int32_t*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET) == TERMINATE_R2R_STACK_WALK)
         {
             return 0;
         }
@@ -1513,7 +1513,7 @@ static TADDR GetWasmFramePointerFromStackPointer_Internal(TADDR sp)
 // reached after natively unwinding a funclet that the VM invoked via CallFunclet).
 TADDR GetWasmEstablishingFramePointerFromTerminator(TADDR sp)
 {
-    _ASSERTE(*(int*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET) == TERMINATE_R2R_STACK_WALK);
+    _ASSERTE(*(int32_t*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET) == TERMINATE_R2R_STACK_WALK);
     return *(TADDR*)(sp + TERMINATE_R2R_STACK_WALK_FP_OFFSET);
 }
 
@@ -1575,7 +1575,7 @@ TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE controlPC)
 
         WasmUnwindStackFrameCore(&sp, &controlPC, uImageBase, pFunctionEntry);
 
-        if (*(int*)sp == TERMINATE_R2R_STACK_WALK)
+        if (*(int32_t*)sp == TERMINATE_R2R_STACK_WALK)
         {
             // The funclet was invoked by the VM through CallFuncletWith[out]Throwable, so native
             // unwinding terminates at that synthetic frame before reaching the method's own frame.

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -497,11 +497,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 
     pRD->pCurrentContext->InterpreterSP = *(DWORD *)&m_pCallSiteSP;
     pRD->pCurrentContext->InterpreterFP = *(DWORD *)&m_pCalleeSavedFP;
-
-#define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContextPointers->regname = NULL;
-    ENUM_CALLEE_SAVED_REGISTERS();
-#undef CALLEE_SAVED_REGISTER
-
+    
     SyncRegDisplayToCurrentContext(pRD);
 
 #ifdef FEATURE_INTERPRETER
@@ -520,7 +516,7 @@ void FaultingExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
     PORTABILITY_ASSERT("FaultingExceptionFrame::UpdateRegDisplay_Impl is not implemented on wasm");
 }
 
-TADDR GetWasmFramePointerFromStackPointer(TADDR sp);
+TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE virtualIP);
 
 void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
@@ -539,7 +535,7 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
     bool hasR2RStackPointer = (pTransitionBlock != NULL) &&
                               (pTransitionBlock->m_ReturnAddress != 0) &&
                               (pTransitionBlock->m_StackPointer != 0);
-    pRD->pCurrentContext->InterpreterFP = hasR2RStackPointer ? GetWasmFramePointerFromStackPointer(sp) : 0;
+    pRD->pCurrentContext->InterpreterFP = hasR2RStackPointer ? GetWasmFramePointerFromStackPointer(sp, (PCODE)pRD->pCurrentContext->InterpreterIP) : 0;
 
     SyncRegDisplayToCurrentContext(pRD);
 
@@ -1488,7 +1484,7 @@ void InvokeUnmanagedMethod(MethodDesc *targetMethod, int8_t *pArgs, int8_t *pRet
     PORTABILITY_ASSERT("Attempted to execute unmanaged code from interpreter on wasm, this is not yet implemented");
 }
 
-TADDR GetWasmFramePointerFromStackPointer(TADDR sp)
+static TADDR GetWasmFramePointerFromStackPointer_Internal(TADDR sp)
 {
     if (sp <= 0x1000)
     {
@@ -1525,7 +1521,7 @@ TADDR GetWasmEstablishingFramePointerFromTerminator(TADDR sp)
 
 TADDR GetWasmVirtualIPFromStackPointer(TADDR sp)
 {
-    TADDR fp = GetWasmFramePointerFromStackPointer(sp);
+    TADDR fp = GetWasmFramePointerFromStackPointer_Internal(sp);
 
     if (fp == 0)
     {
@@ -1539,6 +1535,67 @@ TADDR GetWasmVirtualIPFromStackPointer(TADDR sp)
         if (baseVirtualIP == 0)
             return 0;
         return baseVirtualIP + functionLocalVirtualIP;
+    }
+}
+
+void WasmUnwindStackFrameCore(TADDR* pSP, TADDR* pIP, UINT_PTR ImageBase, PRUNTIME_FUNCTION FunctionEntry)
+{
+    TADDR sp = *pSP;
+    TADDR fp = GetWasmFramePointerFromStackPointer_Internal(sp);
+    if (fp == 0)
+    {
+        *pSP = 0;
+        *pIP = 0;
+    }
+    else
+    {
+        PTR_BYTE pUnwindData = dac_cast<PTR_BYTE>(FunctionEntry->UnwindData + ImageBase);
+        *pSP = fp + DecodeULEB128AsU32(&pUnwindData); // Unwind the frame pointer to the callers stack pointer
+        *pIP = GetWasmVirtualIPFromStackPointer(*pSP);
+    }
+}
+
+TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE controlPC)
+{
+    // Get the frame pointer of the individual WASM function from the stack pointer. However, if this is a funclet, the logical
+    // frame pointer is found by unwinding to either its containing function, or to a CallFunclet location.
+
+    TADDR internalFunctionFramePointer = GetWasmFramePointerFromStackPointer_Internal(sp);
+    uint32_t r2rFunctionTableEntryNumber = ((uint32_t*)internalFunctionFramePointer)[0];
+    _ASSERTE(GetWasmVirtualIPFromStackPointer(sp) == controlPC);
+
+    if (ExecutionManager::IsFuncletFuntionIndex(r2rFunctionTableEntryNumber))
+    {
+        UINT_PTR            uImageBase;
+        PT_RUNTIME_FUNCTION pFunctionEntry;
+        EECodeInfo codeInfo;
+
+        codeInfo.Init(controlPC);
+        pFunctionEntry = codeInfo.GetFunctionEntry();
+        uImageBase = (UINT_PTR)codeInfo.GetModuleBase();
+
+        WasmUnwindStackFrameCore(&sp, &controlPC, uImageBase, pFunctionEntry);
+
+        if (*(int*)sp == TERMINATE_R2R_STACK_WALK)
+        {
+            // The funclet was invoked by the VM through CallFuncletWith[out]Throwable, so native
+            // unwinding terminates at that synthetic frame before reaching the method's own frame.
+            // Recover the establishing (method) frame pointer the helper stored next to the
+            // TERMINATE_R2R_STACK_WALK marker.
+            return GetWasmEstablishingFramePointerFromTerminator(sp);
+        }
+        else
+        {
+            // The funclet was called by its containing method or funclet.
+            // Recurse to find out if we're dealing with another funclet, or the non-exceptional
+            // finally case.
+            return GetWasmFramePointerFromStackPointer(sp, controlPC);
+        }
+    }
+    else
+    {
+        // Return the normal method frame pointer
+        return internalFunctionFramePointer;
     }
 }
 
@@ -1565,21 +1622,19 @@ RtlVirtualUnwind (
     *HandlerData = 0;
     *EstablisherFrame = 0;
 
-    TADDR sp = ContextRecord->InterpreterSP;
-    TADDR fp = GetWasmFramePointerFromStackPointer(sp);
-    if (fp != 0)
+    WasmUnwindStackFrameCore((TADDR*)&ContextRecord->InterpreterSP, (TADDR*)&ContextRecord->InterpreterIP, ImageBase, FunctionEntry);
+
+    if (ContextRecord->InterpreterSP != 0)
     {
-        PTR_BYTE pUnwindData = dac_cast<PTR_BYTE>(FunctionEntry->UnwindData + ImageBase);
-        ContextRecord->InterpreterSP = fp + DecodeULEB128AsU32(&pUnwindData); // Unwind the frame pointer to the callers stack pointer
-        ContextRecord->InterpreterIP = GetWasmVirtualIPFromStackPointer(ContextRecord->InterpreterSP);
-        ContextRecord->InterpreterFP = GetWasmFramePointerFromStackPointer(ContextRecord->InterpreterSP);
+        if (ContextRecord->InterpreterIP != 0)
+            ContextRecord->InterpreterFP = GetWasmFramePointerFromStackPointer(ContextRecord->InterpreterSP, (PCODE)ContextRecord->InterpreterIP);
+        else
+            ContextRecord->InterpreterFP = GetWasmFramePointerFromStackPointer_Internal(ContextRecord->InterpreterSP);
     }
     else
     {
         // Unwind failed!
         _ASSERTE(FALSE);
-        ContextRecord->InterpreterIP = 0;
-        ContextRecord->InterpreterSP = 0;
         ContextRecord->InterpreterFP = 0;
     }
 

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -516,8 +516,6 @@ void FaultingExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
     PORTABILITY_ASSERT("FaultingExceptionFrame::UpdateRegDisplay_Impl is not implemented on wasm");
 }
 
-TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE virtualIP);
-
 void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
     pRD->IsCallerContextValid = FALSE;
@@ -1495,11 +1493,11 @@ static TADDR GetWasmFramePointerFromStackPointer_Internal(TADDR sp)
     }
     else
     {
-        if (*(int*)sp == 0)
+        if (*(int*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET) == STACK_WALK_INDIRECT_TO_FRAMEPOINTER)
         {
-            sp = *(TADDR*)(sp + sizeof(TADDR));
+            sp = *(TADDR*)(sp + WASM_STACKFRAME_INDIRECT_TO_FRAMEPOINTER_OFFSET);
         }
-        if (*(int*)sp == TERMINATE_R2R_STACK_WALK)
+        if (*(int*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET) == TERMINATE_R2R_STACK_WALK)
         {
             return 0;
         }
@@ -1515,7 +1513,7 @@ static TADDR GetWasmFramePointerFromStackPointer_Internal(TADDR sp)
 // reached after natively unwinding a funclet that the VM invoked via CallFunclet).
 TADDR GetWasmEstablishingFramePointerFromTerminator(TADDR sp)
 {
-    _ASSERTE(*(int*)sp == TERMINATE_R2R_STACK_WALK);
+    _ASSERTE(*(int*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET) == TERMINATE_R2R_STACK_WALK);
     return *(TADDR*)(sp + TERMINATE_R2R_STACK_WALK_FP_OFFSET);
 }
 
@@ -1529,8 +1527,8 @@ TADDR GetWasmVirtualIPFromStackPointer(TADDR sp)
     }
     else
     {
-        uint32_t r2rFunctionTableEntryNumber = ((uint32_t*)fp)[0];
-        uint32_t functionLocalVirtualIP = ((uint32_t*)fp)[1] * 2; // Multiply by 2 as virtual IPs are encoded in units of 2 to leave the low bit in the VirtualIP mapping available to distinguish between virtual IPs and interpreter addresses/PortableEntryPoints.
+        uint32_t r2rFunctionTableEntryNumber = *(uint32_t*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET);
+        uint32_t functionLocalVirtualIP = (*(uint32_t*)(sp + WASM_STACKFRAME_VIRTUALIP_OFFSET)) * 2; // Multiply by 2 as virtual IPs are encoded in units of 2 to leave the low bit in the VirtualIP mapping available to distinguish between virtual IPs and interpreter addresses/PortableEntryPoints.
         TADDR baseVirtualIP = ExecutionManager::GetWasmVirtualIPFromFunctionTableIndex(r2rFunctionTableEntryNumber);
         if (baseVirtualIP == 0)
             return 0;
@@ -1538,7 +1536,7 @@ TADDR GetWasmVirtualIPFromStackPointer(TADDR sp)
     }
 }
 
-void WasmUnwindStackFrameCore(TADDR* pSP, TADDR* pIP, UINT_PTR ImageBase, PRUNTIME_FUNCTION FunctionEntry)
+static void WasmUnwindStackFrameCore(TADDR* pSP, TADDR* pIP, UINT_PTR ImageBase, PRUNTIME_FUNCTION FunctionEntry)
 {
     TADDR sp = *pSP;
     TADDR fp = GetWasmFramePointerFromStackPointer_Internal(sp);
@@ -1561,10 +1559,11 @@ TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE controlPC)
     // frame pointer is found by unwinding to either its containing function, or to a CallFunclet location.
 
     TADDR internalFunctionFramePointer = GetWasmFramePointerFromStackPointer_Internal(sp);
-    uint32_t r2rFunctionTableEntryNumber = ((uint32_t*)internalFunctionFramePointer)[0];
+    _ASSERTE(internalFunctionFramePointer != 0);
+    uint32_t r2rFunctionTableEntryNumber = *(uint32_t*)(sp + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET);
     _ASSERTE(GetWasmVirtualIPFromStackPointer(sp) == controlPC);
 
-    if (ExecutionManager::IsFuncletFuntionIndex(r2rFunctionTableEntryNumber))
+    if (ExecutionManager::IsFuncletFunctionIndex(r2rFunctionTableEntryNumber))
     {
         UINT_PTR            uImageBase;
         PT_RUNTIME_FUNCTION pFunctionEntry;
@@ -1626,10 +1625,12 @@ RtlVirtualUnwind (
 
     if (ContextRecord->InterpreterSP != 0)
     {
+        // If InterpreterSP is set, then we successfully unwound, but if InterpreterIP is 0, then the caller
+        // frame is not a frame on the RyuJit frame chain, so only get the InterpreterFP for those scenarios.
         if (ContextRecord->InterpreterIP != 0)
             ContextRecord->InterpreterFP = GetWasmFramePointerFromStackPointer(ContextRecord->InterpreterSP, (PCODE)ContextRecord->InterpreterIP);
         else
-            ContextRecord->InterpreterFP = GetWasmFramePointerFromStackPointer_Internal(ContextRecord->InterpreterSP);
+            ContextRecord->InterpreterFP = 0;
     }
     else
     {


### PR DESCRIPTION
- Set this FP at context construction, and flow it around instead of reconstructing from the SP
- This fixes GC reporting while in a funclet
- Notably, this change is relevant only for RyuJit generated code