### PR TITLE
Improve FileSystem tests on FAT32 temp volumes

### DIFF
--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Base/BaseGetSetTimes.cs
@@ -14,12 +14,14 @@ namespace System.IO.Tests
         public delegate void SetTime(T item, DateTime time);
         public delegate DateTime GetTime(T item);
         // AppContainer restricts access to DriveFormat (::GetVolumeInformation)
-        private static string driveFormat = PlatformDetection.IsInAppContainer ? string.Empty : new DriveInfo(Path.GetTempPath()).DriveFormat;
+        private static string driveFormat = TempDriveFormat;
 
         private static bool isHFS => driveFormat != null && driveFormat.Equals("hfs", StringComparison.InvariantCultureIgnoreCase);
+        private static bool isFat32 => IsTempPathOnFat32;
+        private static int TemporalResolutionSafeSecond => isFat32 ? 4 : 3;
 
         protected static bool SecondTemporalResolution => true;
-        protected static bool MilliSecondTemporalResolution => SecondTemporalResolution && !isHFS;  // HFS only supports temporal resolution of 1 second
+        protected static bool MilliSecondTemporalResolution => SecondTemporalResolution && !isHFS && !isFat32; // HFS and FAT32 have low temporal resolution
         protected static bool NanoSecondTemporalResolution => MilliSecondTemporalResolution && !PlatformDetection.IsBrowser; // Browser does not support nanosecond resolution
         protected static bool NotMilliSecondTemporalResolution => !MilliSecondTemporalResolution;
         protected static bool NotNanoSecondTemporalResolution => !NanoSecondTemporalResolution;
@@ -73,7 +75,7 @@ namespace System.IO.Tests
                 bool isLink = linkTarget is not null;
 
                 // Checking that milliseconds are not dropped after setter.
-                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, NotMilliSecondTemporalResolution ? 0 : 321, function.Kind);
+                DateTime dt = new DateTime(2014, 12, 1, 12, 3, TemporalResolutionSafeSecond, NotMilliSecondTemporalResolution ? 0 : 321, function.Kind);
                 function.Setter(item, dt);
 
                 T getTarget = !isLink || ApiTargetsLink ? item : linkTarget;
@@ -207,9 +209,9 @@ namespace System.IO.Tests
                 bool reverse = functions.reverse;
 
                 // Checking that milliseconds are not dropped after setter.
-                DateTime dt1 = new DateTime(2002, 12, 1, 12, 3, 3, NotMilliSecondTemporalResolution ? 0 : 321, DateTimeKind.Utc);
-                DateTime dt2 = new DateTime(2001, 12, 1, 12, 3, 3, NotMilliSecondTemporalResolution ? 0 : 321, DateTimeKind.Utc);
-                DateTime dt3 = new DateTime(2000, 12, 1, 12, 3, 3, NotMilliSecondTemporalResolution ? 0 : 321, DateTimeKind.Utc);
+                DateTime dt1 = new DateTime(2002, 12, 1, 12, 3, TemporalResolutionSafeSecond, NotMilliSecondTemporalResolution ? 0 : 321, DateTimeKind.Utc);
+                DateTime dt2 = new DateTime(2001, 12, 1, 12, 3, TemporalResolutionSafeSecond, NotMilliSecondTemporalResolution ? 0 : 321, DateTimeKind.Utc);
+                DateTime dt3 = new DateTime(2000, 12, 1, 12, 3, TemporalResolutionSafeSecond, NotMilliSecondTemporalResolution ? 0 : 321, DateTimeKind.Utc);
                 if (reverse) //reverse the order of setting dates
                 {
                     (dt1, dt3) = (dt3, dt1);

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Base/BaseGetSetTimes.cs
@@ -116,7 +116,7 @@ namespace System.IO.Tests
             SettingUpdatesPropertiesCore(item);
         }
 
-        [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(TempPathSupportsSymbolicLinks))]
         [PlatformSpecific(~TestPlatforms.Browser)] // Browser is excluded as it doesn't support symlinks
         [InlineData(false)]
         [InlineData(true)]

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Base/FileGetSetAttributes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Base/FileGetSetAttributes.cs
@@ -106,9 +106,9 @@ namespace System.IO.Tests
             Assert.Equal(FileAttributes.Normal, GetAttributes(path));
         }
 
-        [Theory,
-            InlineData(":bar"),
-            InlineData(":bar:$DATA")]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(FileSystemTest.SupportsAlternateDataStreams))]
+        [InlineData(":bar")]
+        [InlineData(":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void GettingAndSettingAttributes_AlternateDataStream_Windows(string streamName)
         {

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/GetFileSystemEntries_str.cs
@@ -213,8 +213,17 @@ namespace System.IO.Tests
                 {
                     case '/':
                     case '\\':
-                    case ':':
                         Assert.Throws<DirectoryNotFoundException>(() => GetEntries(badPath));
+                        break;
+                    case ':':
+                        if (SupportsAlternateDataStreams)
+                        {
+                            Assert.Throws<DirectoryNotFoundException>(() => GetEntries(badPath));
+                        }
+                        else
+                        {
+                            Assert.Throws<IOException>(() => GetEntries(badPath));
+                        }
                         break;
                     case '\0':
                         Assert.Throws<ArgumentException>(() => GetEntries(badPath));

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/GetFileSystemEntries_str.cs
@@ -222,7 +222,7 @@ namespace System.IO.Tests
                         }
                         else
                         {
-                            Assert.Throws<IOException>(() => GetEntries(badPath));
+                            Assert.ThrowsAny<IOException>(() => GetEntries(badPath));
                         }
                         break;
                     case '\0':

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/GetSetTimes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/GetSetTimes.cs
@@ -30,18 +30,21 @@ namespace System.IO.Tests
                     ((path) => Directory.GetCreationTimeUtc(path)),
                     DateTimeKind.Utc);
             }
-            yield return TimeFunction.Create(
-                ((path, time) => Directory.SetLastAccessTime(path, time)),
-                ((path) => Directory.GetLastAccessTime(path)),
-                DateTimeKind.Local);
-            yield return TimeFunction.Create(
-                ((path, time) => Directory.SetLastAccessTimeUtc(path, time)),
-                ((path) => Directory.GetLastAccessTimeUtc(path)),
-                DateTimeKind.Unspecified);
-            yield return TimeFunction.Create(
-                ((path, time) => Directory.SetLastAccessTimeUtc(path, time)),
-                ((path) => Directory.GetLastAccessTimeUtc(path)),
-                DateTimeKind.Utc);
+            if (TempPathSupportsPreciseLastAccessTime)
+            {
+                yield return TimeFunction.Create(
+                    ((path, time) => Directory.SetLastAccessTime(path, time)),
+                    ((path) => Directory.GetLastAccessTime(path)),
+                    DateTimeKind.Local);
+                yield return TimeFunction.Create(
+                    ((path, time) => Directory.SetLastAccessTimeUtc(path, time)),
+                    ((path) => Directory.GetLastAccessTimeUtc(path)),
+                    DateTimeKind.Unspecified);
+                yield return TimeFunction.Create(
+                    ((path, time) => Directory.SetLastAccessTimeUtc(path, time)),
+                    ((path) => Directory.GetLastAccessTimeUtc(path)),
+                    DateTimeKind.Utc);
+            }
             yield return TimeFunction.Create(
                 ((path, time) => Directory.SetLastWriteTime(path, time)),
                 ((path) => Directory.GetLastWriteTime(path)),

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/DirectoryInfo/GetSetTimes.cs
@@ -36,18 +36,21 @@ namespace System.IO.Tests
                      ((testDir) => testDir.CreationTimeUtc),
                      DateTimeKind.Utc);
             }
-            yield return TimeFunction.Create(
-                ((testDir, time) => {testDir.LastAccessTime = time; }),
-                ((testDir) => testDir.LastAccessTime),
-                DateTimeKind.Local);
-            yield return TimeFunction.Create(
-                ((testDir, time) => {testDir.LastAccessTimeUtc = time; }),
-                ((testDir) => testDir.LastAccessTimeUtc),
-                DateTimeKind.Unspecified);
-            yield return TimeFunction.Create(
-                ((testDir, time) => { testDir.LastAccessTimeUtc = time; }),
-                ((testDir) => testDir.LastAccessTimeUtc),
-                DateTimeKind.Utc);
+            if (TempPathSupportsPreciseLastAccessTime)
+            {
+                yield return TimeFunction.Create(
+                    ((testDir, time) => {testDir.LastAccessTime = time; }),
+                    ((testDir) => testDir.LastAccessTime),
+                    DateTimeKind.Local);
+                yield return TimeFunction.Create(
+                    ((testDir, time) => {testDir.LastAccessTimeUtc = time; }),
+                    ((testDir) => testDir.LastAccessTimeUtc),
+                    DateTimeKind.Unspecified);
+                yield return TimeFunction.Create(
+                    ((testDir, time) => { testDir.LastAccessTimeUtc = time; }),
+                    ((testDir) => testDir.LastAccessTimeUtc),
+                    DateTimeKind.Utc);
+            }
             yield return TimeFunction.Create(
                 ((testDir, time) => {testDir.LastWriteTime = time; }),
                 ((testDir) => testDir.LastWriteTime),

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Copy.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Copy.cs
@@ -141,8 +141,12 @@ namespace System.IO.Tests
                 AssertExtensions.Equal(data, readData);
             }
 
-            // Ensure last write/access time on the new file is appropriate
-            Assert.InRange(File.GetLastWriteTimeUtc(testFileDest), lastWriteTime.AddSeconds(-1), lastWriteTime.AddSeconds(1));
+            // Ensure last write/access time on the new file is appropriate.
+            TimeSpan tolerance = IsTempPathOnFat32 ? TimeSpan.FromSeconds(3) : TimeSpan.FromSeconds(1);
+            Assert.InRange(
+                File.GetLastWriteTimeUtc(testFileDest),
+                lastWriteTime.Subtract(tolerance),
+                lastWriteTime.Add(tolerance));
 
             Assert.Equal(readOnly, (File.GetAttributes(testFileDest) & FileAttributes.ReadOnly) != 0);
             if (readOnly)
@@ -203,11 +207,11 @@ namespace System.IO.Tests
             Assert.True(File.Exists(Path.Combine(TestDirectory, valid)));
         }
 
-        [Theory,
-            InlineData("", ":bar"),
-            InlineData("", ":bar:$DATA"),
-            InlineData("::$DATA", ":bar"),
-            InlineData("::$DATA", ":bar:$DATA")]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(FileSystemTest.SupportsAlternateDataStreams))]
+        [InlineData("", ":bar")]
+        [InlineData("", ":bar:$DATA")]
+        [InlineData("::$DATA", ":bar")]
+        [InlineData("::$DATA", ":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsAlternateDataStream(string defaultStream, string alternateStream)
         {
@@ -347,11 +351,11 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory,
-            InlineData("", ":bar"),
-            InlineData("", ":bar:$DATA"),
-            InlineData("::$DATA", ":bar"),
-            InlineData("::$DATA", ":bar:$DATA")]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(FileSystemTest.SupportsAlternateDataStreams))]
+        [InlineData("", ":bar")]
+        [InlineData("", ":bar:$DATA")]
+        [InlineData("::$DATA", ":bar")]
+        [InlineData("::$DATA", ":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/83659", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsArm64Process))]
         public void WindowsAlternateDataStreamOverwrite(string defaultStream, string alternateStream)

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Create.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Create.cs
@@ -301,10 +301,10 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory,
-            InlineData(":bar"),
-            InlineData(":bar:$DATA"),
-            InlineData("::$DATA")]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(FileSystemTest.SupportsAlternateDataStreams))]
+        [InlineData(":bar")]
+        [InlineData(":bar:$DATA")]
+        [InlineData("::$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsAlternateDataStream(string streamName)
         {
@@ -316,9 +316,9 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory,
-            InlineData(":bar"),
-            InlineData(":bar:$DATA")]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(FileSystemTest.SupportsAlternateDataStreams))]
+        [InlineData(":bar")]
+        [InlineData(":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsAlternateDataStream_OnExisting(string streamName)
         {

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Delete.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Delete.cs
@@ -184,9 +184,9 @@ namespace System.IO.Tests
             Assert.False(testFile.Exists);
         }
 
-        [Theory,
-            InlineData(":bar"),
-            InlineData(":bar:$DATA")]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(FileSystemTest.SupportsAlternateDataStreams))]
+        [InlineData(":bar")]
+        [InlineData(":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsDeleteAlternateDataStream(string streamName)
         {

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/GetSetAttributes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/GetSetAttributes.cs
@@ -19,9 +19,9 @@ namespace System.IO.Tests
         }
 
         // Getting only throws for File, not FileInfo
-        [Theory,
-            InlineData(":bar"),
-            InlineData(":bar:$DATA")]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(FileSystemTest.SupportsAlternateDataStreams))]
+        [InlineData(":bar")]
+        [InlineData(":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void GetAttributes_MissingAlternateDataStream_Windows(string streamName)
         {

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/GetSetTimes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/GetSetTimes.cs
@@ -11,7 +11,9 @@ namespace System.IO.Tests
     {
         // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
         // 32bit Unix has time_t up to ~ 2038.
-        protected static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (!PlatformDetection.Is32BitProcess && !PlatformDetection.IsApplePlatform);
+        protected static bool SupportsLongMaxDateTime =>
+            !IsTempPathOnFat32 &&
+            (PlatformDetection.IsWindows || (!PlatformDetection.Is32BitProcess && !PlatformDetection.IsApplePlatform));
 
         protected override bool CanBeReadOnly => true;
 

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/GetSetTimes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/GetSetTimes.cs
@@ -113,18 +113,21 @@ namespace System.IO.Tests
                     GetCreationTimeUtc,
                     DateTimeKind.Utc);
             }
-            yield return TimeFunction.Create(
-                SetLastAccessTime,
-                GetLastAccessTime,
-                DateTimeKind.Local);
-            yield return TimeFunction.Create(
-                SetLastAccessTimeUtc,
-                GetLastAccessTimeUtc,
-                DateTimeKind.Unspecified);
-            yield return TimeFunction.Create(
-                SetLastAccessTimeUtc,
-                GetLastAccessTimeUtc,
-                DateTimeKind.Utc);
+            if (TempPathSupportsPreciseLastAccessTime)
+            {
+                yield return TimeFunction.Create(
+                    SetLastAccessTime,
+                    GetLastAccessTime,
+                    DateTimeKind.Local);
+                yield return TimeFunction.Create(
+                    SetLastAccessTimeUtc,
+                    GetLastAccessTimeUtc,
+                    DateTimeKind.Unspecified);
+                yield return TimeFunction.Create(
+                    SetLastAccessTimeUtc,
+                    GetLastAccessTimeUtc,
+                    DateTimeKind.Utc);
+            }
             yield return TimeFunction.Create(
                 SetLastWriteTime,
                 GetLastWriteTime,

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Move.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/Move.cs
@@ -325,11 +325,11 @@ namespace System.IO.Tests
 
         }
 
-        [Theory,
-            InlineData("", ":bar"),
-            InlineData("", ":bar:$DATA"),
-            InlineData("::$DATA", ":bar"),
-            InlineData("::$DATA", ":bar:$DATA")]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(FileSystemTest.SupportsAlternateDataStreams))]
+        [InlineData("", ":bar")]
+        [InlineData("", ":bar:$DATA")]
+        [InlineData("::$DATA", ":bar")]
+        [InlineData("::$DATA", ":bar:$DATA")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsAlternateDataStreamMove(string defaultStream, string alternateStream)
         {

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/GetSetTimes.cs
@@ -84,18 +84,21 @@ namespace System.IO.Tests
                     ((testFile) => testFile.CreationTimeUtc),
                     DateTimeKind.Utc);
             }
-            yield return TimeFunction.Create(
-                ((testFile, time) => { testFile.LastAccessTime = time; }),
-                ((testFile) => testFile.LastAccessTime),
-                DateTimeKind.Local);
-            yield return TimeFunction.Create(
-                ((testFile, time) => { testFile.LastAccessTimeUtc = time; }),
-                ((testFile) => testFile.LastAccessTimeUtc),
-                DateTimeKind.Unspecified);
-            yield return TimeFunction.Create(
-                ((testFile, time) => { testFile.LastAccessTimeUtc = time; }),
-                ((testFile) => testFile.LastAccessTimeUtc),
-                DateTimeKind.Utc);
+            if (TempPathSupportsPreciseLastAccessTime)
+            {
+                yield return TimeFunction.Create(
+                    ((testFile, time) => { testFile.LastAccessTime = time; }),
+                    ((testFile) => testFile.LastAccessTime),
+                    DateTimeKind.Local);
+                yield return TimeFunction.Create(
+                    ((testFile, time) => { testFile.LastAccessTimeUtc = time; }),
+                    ((testFile) => testFile.LastAccessTimeUtc),
+                    DateTimeKind.Unspecified);
+                yield return TimeFunction.Create(
+                    ((testFile, time) => { testFile.LastAccessTimeUtc = time; }),
+                    ((testFile) => testFile.LastAccessTimeUtc),
+                    DateTimeKind.Utc);
+            }
             yield return TimeFunction.Create(
                 ((testFile, time) => { testFile.LastWriteTime = time; }),
                 ((testFile) => testFile.LastWriteTime),

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileStream/ctor_options.Windows.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileStream/ctor_options.Windows.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Pipes;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -41,7 +39,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalTheory(typeof(FileStream_ctor_options), nameof(IsFat32))]
+        [ConditionalTheory(typeof(FileSystemTest), nameof(FileSystemTest.IsTempPathOnFat32))]
         [InlineData(FileMode.Create)]
         [InlineData(FileMode.CreateNew)]
         public void WhenFileIsTooLargeTheErrorMessageContainsAllDetails(FileMode mode)
@@ -57,43 +55,5 @@ namespace System.IO.Tests
 
             Assert.False(File.Exists(filePath)); // ensure it was NOT created
         }
-
-        public static bool IsFat32
-        {
-            get
-            {
-                string testDirectory = Path.GetTempPath(); // logic taken from FileCleanupTestBase, can't call the property here as it's not static
-
-                var volumeNameBuffer = new StringBuilder(250);
-                var fileSystemNameBuffer = new StringBuilder(250);
-
-                if (GetVolumeInformation(
-                    Path.GetPathRoot(testDirectory),
-                    volumeNameBuffer,
-                    volumeNameBuffer.Capacity,
-                    out uint _,
-                    out uint _,
-                    out uint _,
-                    fileSystemNameBuffer,
-                    fileSystemNameBuffer.Capacity
-                    ))
-                {
-                    return fileSystemNameBuffer.ToString().Equals("FAT32", StringComparison.OrdinalIgnoreCase);
-                }
-
-                return false;
-            }
-        }
-
-        [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Auto, SetLastError = true)]
-        public extern static bool GetVolumeInformation(
-           string rootPathName,
-           StringBuilder volumeNameBuffer,
-           int volumeNameSize,
-           out uint volumeSerialNumber,
-           out uint maximumComponentLength,
-           out uint fileSystemFlags,
-           StringBuilder fileSystemNameBuffer,
-           int fileSystemNameSize);
     }
 }

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileStream/ctor_str_fm.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileStream/ctor_str_fm.cs
@@ -62,7 +62,7 @@ namespace System.IO.Tests
                 TheoryData<string> data = new TheoryData<string>();
                 data.Add("");
 
-                if (PlatformDetection.IsWindows)
+                if (SupportsAlternateDataStreams)
                 {
                     data.Add("::$DATA");        // Same as default stream (e.g. main file)
                     data.Add(":bar");           // $DATA isn't necessary

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileStream/ctor_str_fm_fa_fs.delete.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileStream/ctor_str_fm_fa_fs.delete.cs
@@ -20,7 +20,7 @@ namespace System.IO.Tests
                 if (OperatingSystem.IsWindows())
                 {
                     // Prior to 1903 Windows would not delete the filename until the last file handle is closed.
-                    Assert.Equal(PlatformDetection.IsWindows10Version1903OrGreater, !File.Exists(fileName));
+                    Assert.Equal(DeletesOpenFileNameImmediately, !File.Exists(fileName));
                 }
             }
 
@@ -58,7 +58,7 @@ namespace System.IO.Tests
                 if (OperatingSystem.IsWindows())
                 {
                     // Prior to 1903 Windows would not delete the filename until the last file handle is closed.
-                    Assert.Equal(PlatformDetection.IsWindows10Version1903OrGreater, !File.Exists(fileName));
+                    Assert.Equal(DeletesOpenFileNameImmediately, !File.Exists(fileName));
                 }
             }
 
@@ -106,13 +106,13 @@ namespace System.IO.Tests
                     Assert.Equal(0, fs2.ReadByte());
 
                     // Prior to 1903 Windows would not delete the filename until the last file handle is closed.
-                    Assert.Equal(PlatformDetection.IsWindows10Version1903OrGreater, !File.Exists(fileName));
+                    Assert.Equal(DeletesOpenFileNameImmediately, !File.Exists(fileName));
                 }
 
                 Assert.Equal(0, fs1.ReadByte());
                 fs1.WriteByte(0xFF);
 
-                if (PlatformDetection.IsWindows10Version1903OrGreater)
+                if (DeletesOpenFileNameImmediately)
                 {
                     // On 1903 the filename is immediately released after delete is called
                     Assert.Throws<FileNotFoundException>(() => CreateFileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.ReadWrite));

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileSystemTest.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileSystemTest.cs
@@ -15,6 +15,51 @@ namespace System.IO.Tests
 
         public static bool IsAsyncIoSupportedForRegularFiles => PlatformDetection.IsWindows;
 
+        private static readonly Lazy<string> s_tempDriveFormat = new Lazy<string>(() =>
+            PlatformDetection.IsInAppContainer ? string.Empty : new DriveInfo(Path.GetTempPath()).DriveFormat);
+
+        private static readonly Lazy<bool> s_supportsAlternateDataStreams =
+            new Lazy<bool>(GetSupportsAlternateDataStreams);
+
+        public static string TempDriveFormat => s_tempDriveFormat.Value;
+
+        public static bool IsTempPathOnFat32 =>
+            string.Equals(TempDriveFormat, "FAT32", StringComparison.OrdinalIgnoreCase);
+
+        public static bool TempPathSupportsLargeFiles => !IsTempPathOnFat32;
+
+        public static bool DeletesOpenFileNameImmediately =>
+            PlatformDetection.IsWindows10Version1903OrGreater && !IsTempPathOnFat32;
+
+        public static bool SupportsAlternateDataStreams => s_supportsAlternateDataStreams.Value;
+
+        private static bool GetSupportsAlternateDataStreams()
+        {
+            if (!PlatformDetection.IsWindows)
+            {
+                return false;
+            }
+
+            string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            string streamPath = path + ":stream";
+
+            try
+            {
+                File.WriteAllText(path, string.Empty);
+                File.WriteAllText(streamPath, "stream");
+
+                return File.ReadAllText(streamPath) == "stream";
+            }
+            catch (Exception ex) when (ex is IOException || ex is NotSupportedException || ex is UnauthorizedAccessException)
+            {
+                return false;
+            }
+            finally
+            {
+                try { File.Delete(path); } catch { }
+            }
+        }
+
         public static TheoryData<string> PathsWithInvalidColons = TestData.PathsWithInvalidColons;
         public static TheoryData<string> PathsWithInvalidCharacters = TestData.PathsWithInvalidCharacters;
         public static TheoryData<char> TrailingCharacters = TestData.TrailingCharacters;

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileSystemTest.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileSystemTest.cs
@@ -28,6 +28,10 @@ namespace System.IO.Tests
 
         public static bool TempPathSupportsLargeFiles => !IsTempPathOnFat32;
 
+        public static bool TempPathSupportsPreciseLastAccessTime => !IsTempPathOnFat32;
+
+        public static bool TempPathSupportsSymbolicLinks => !IsTempPathOnFat32 && MountHelper.CanCreateSymbolicLinks;
+
         public static bool DeletesOpenFileNameImmediately =>
             PlatformDetection.IsWindows10Version1903OrGreater && !IsTempPathOnFat32;
 

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/LargeFileTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/LargeFileTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.FileSystem.Tests
     [Collection(nameof(DisableParallelization))] // don't create multiple large files at the same time
     public class LargeFileTests : FileSystemTest
     {
-        [Fact]
+        [ConditionalFact(typeof(FileSystemTest), nameof(FileSystemTest.TempPathSupportsLargeFiles))]
         public async Task ReadAllBytesOverLimit()
         {
             using FileStream fs = new (GetTestFilePath(), FileMode.Create, FileAccess.Write, FileShare.Read, 4096, FileOptions.DeleteOnClose);
@@ -26,7 +26,7 @@ namespace System.IO.FileSystem.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(FileSystemTest), nameof(FileSystemTest.TempPathSupportsLargeFiles))]
         public void NoInt32OverflowInTheBufferingLogic()
         {
             const long position1 = 10;


### PR DESCRIPTION
Fixes #66544

## Summary
- Add shared temp-volume capability helpers for FAT32, large-file support, alternate data streams, and delete-open-file behavior.
- Adjust System.IO.FileSystem tests so FAT32 temp volumes use safer timestamp expectations and skip capabilities the volume cannot support.
- Reuse the shared helpers across File, FileStream, Directory, and LargeFile test cases instead of scattered local detection.

## Impact
This should reduce false failures when the test temp path is on FAT32, while keeping the existing assertions active on file systems that support the required capabilities.

## Validation
- `git diff --check`
- Roslyn syntax sanity check over the edited C# files using the repo-local compiler package
- Attempted targeted `System.IO.FileSystem.Tests` project builds, but the builds did not finish within the local time budget on this machine