### PR TITLE
System.Native: Stop using EV_RECEIPT in the kevent code

### DIFF
--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -3343,13 +3343,8 @@ static int32_t CloseSocketEventPortInner(int32_t port)
 static int32_t TryChangeSocketEventRegistrationInner(
     int32_t port, int32_t socket, SocketEvents currentEvents, SocketEvents newEvents, uintptr_t data)
 {
-#ifdef EV_RECEIPT
-    const uint16_t AddFlags = EV_ADD | EV_CLEAR | EV_RECEIPT;
-    const uint16_t RemoveFlags = EV_DELETE | EV_RECEIPT;
-#else
     const uint16_t AddFlags = EV_ADD | EV_CLEAR;
     const uint16_t RemoveFlags = EV_DELETE;
-#endif
 
     assert(currentEvents != newEvents);
 
@@ -3370,22 +3365,6 @@ static int32_t TryChangeSocketEventRegistrationInner(
                0,
                0,
                GetKeventUdata(data));
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
-        // Issue: #30698
-        // FreeBSD and OpenBSD have an issue when setting read/write events together
-        // in a single kevent() call: the second (write) filter is silently not armed,
-        // so connect-completion is never delivered and async connect hangs.
-        // As a workaround use separate kevent() calls.
-        if (writeChanged)
-        {
-            while ((err = kevent(port, events, GetKeventNchanges(i), NULL, 0, NULL)) < 0 && errno == EINTR);
-            if (err != 0)
-            {
-                return SystemNative_ConvertErrorPlatformToPal(errno);
-            }
-            i = 0;
-        }
-#endif
     }
 
     if (writeChanged)


### PR DESCRIPTION
The EV_RECEIPT is used for two reasons:
1. If we want to know specifically which events from changelist have failed to register. This is not the case for us, as we're passing eventlist=NULL and nevents=0
2. If we want to stop processing changelist after the first error encountered. This is achieved by passing nevents=0, like this code does, but it doesn't really want that. Avoiding passing EV_RECEIPT allows to remove the FreeBSD/OpenBSD hack that was trying to accomodate for the behavior caused by passing the flag.

This solution is explained in https://github.com/dotnet/runtime/issues/26633#issuecomment-555216735 and https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=229741#c6

@sec @buzuka @wfurt 