### PR TITLE
Fix cgroup v2 memory max extraction

### DIFF
--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -463,7 +463,9 @@ private:
         size_t cgroupPathLength = strlen(s_memory_cgroup_path);
 
         // Iterate over the directory hierarchy representing the cgroup hierarchy until reaching the 
-        // mount directory. The mount directory doesn't contain the memory.max.
+// Iterate over the directory hierarchy representing the cgroup hierarchy until reaching the 
+// mount directory. The mount directory can also contain the memory.max in case it
+// is not the global root cgroup.
         do
         {
             if (ReadMemoryValueFromFile(mem_limit_filename, &limit))

--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -463,9 +463,8 @@ private:
         size_t cgroupPathLength = strlen(s_memory_cgroup_path);
 
         // Iterate over the directory hierarchy representing the cgroup hierarchy until reaching the 
-// Iterate over the directory hierarchy representing the cgroup hierarchy until reaching the 
-// mount directory. The mount directory can also contain the memory.max in case it
-// is not the global root cgroup.
+        // mount directory. The mount directory can also contain the memory.max in case it
+        // is not the global root cgroup.
         do
         {
             if (ReadMemoryValueFromFile(mem_limit_filename, &limit))

--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -475,6 +475,11 @@ private:
                 }
             }
 
+            if (cgroupPathLength == memory_cgroup_hierarchy_mount_length)
+            {
+                break;
+            }
+
             // Get the parent cgroup memory limit file path
             char *parent_directory_end = mem_limit_filename + cgroupPathLength - 1;
             while (*parent_directory_end != '/')
@@ -486,7 +491,7 @@ private:
 
             strcpy(parent_directory_end, CGROUP2_MEMORY_LIMIT_FILENAME);
         }
-        while (cgroupPathLength != memory_cgroup_hierarchy_mount_length);
+        while (true);
 
         free(mem_limit_filename);
 


### PR DESCRIPTION
In the edge case when the current process is assigned to the root cgroup, the hierarchical memory limit extraction goes past the root cgroup hierarchy mount path and the process ends up crashing.

This was discovered in google colab environment when attempting to run NativeAOT application in a jupyter notebook

Close #130092