### PR TITLE
More precise range assertions for GT_CNS_INT

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -290,13 +290,48 @@ static Range GetRange(Compiler* comp, GenTree* tree, BasicBlock* block, ASSERT_V
 
             int64_t constValue = node->AsIntConCommon()->IntegralValue();
 
-            if (FitsIn<int32_t>(constValue))
+            if (constValue <= UINT16_MAX)
             {
-                rangeType = TYP_INT;
+                if (constValue <= UINT8_MAX)
+                {
+                    if (constValue <= INT8_MAX)
+                    {
+                        rangeType = TYP_BYTE;
+                    }
+                    else
+                    {
+                        rangeType = TYP_UBYTE;
+                    }
+                }
+                else
+                {
+                    if (constValue <= INT16_MAX)
+                    {
+                        rangeType = TYP_SHORT;
+                    }
+                    else
+                    {
+                        rangeType = TYP_USHORT;
+                    }
+                }
             }
-            else if (FitsIn<uint32_t>(constValue))
+            else
             {
-                rangeType = TYP_UINT;
+                if (constValue <= UINT32_MAX)
+                {
+                    if (constValue <= INT32_MAX)
+                    {
+                        rangeType = TYP_INT;
+                    }
+                    else
+                    {
+                        rangeType = TYP_UINT;
+                    }
+                }
+                else
+                {
+                    rangeType = TYP_LONG;
+                }
             }
 
             if (constValue >= 0)

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -289,7 +289,13 @@ static Range GetRange(Compiler* comp, GenTree* tree, BasicBlock* block, ASSERT_V
             }
 
             int64_t constValue = node->AsIntConCommon()->IntegralValue();
+            if (constValue < 0)
+            {
+                // We don't try and reason about lower bounds here to simplify the logic.
+                break;
+            }
 
+            // For a non-negative constant, try and find a tighter upper bound
             if (constValue <= UINT16_MAX)
             {
                 if (constValue <= UINT8_MAX)
@@ -334,11 +340,7 @@ static Range GetRange(Compiler* comp, GenTree* tree, BasicBlock* block, ASSERT_V
                 }
             }
 
-            if (constValue >= 0)
-            {
-                return {SymbolicIntegerValue::Zero, UpperBoundForType(rangeType)};
-            }
-            break;
+            return {SymbolicIntegerValue::Zero, UpperBoundForType(rangeType)};
         }
 
         case GT_QMARK:


### PR DESCRIPTION
Fixes #121400; We can use a simple binary search approach to narrow the upper bound for GT_CNS_INT type nodes in assertionprop. Credit for the approach to the comment here: https://github.com/dotnet/runtime/pull/120980#discussion_r2496290808