### PR TITLE
cDAC dump tests: resolve managed modules from the Loader contract (matching SOS/dotnet-dump)

### DIFF
--- a/src/native/managed/cdac/tests/TestInfrastructure/ClrMdDumpHost.cs
+++ b/src/native/managed/cdac/tests/TestInfrastructure/ClrMdDumpHost.cs
@@ -22,8 +22,13 @@ public sealed class ClrMdDumpHost : IDisposable
         "libcoreclr.dylib",
     };
 
+    public readonly record struct ManagedModuleImage(ulong Base, ulong Size, string FileName, uint TimeStamp, uint ImageSize);
+
+    private readonly record struct ModuleEntry(ManagedModuleImage Image, Lazy<string?> FilePath);
+
     private readonly DataTarget _dataTarget;
     private readonly string[] _searchPaths;
+    private readonly List<ModuleEntry> _modules = [];
 
     public string DumpPath { get; }
 
@@ -61,31 +66,32 @@ public sealed class ClrMdDumpHost : IDisposable
             if (bytesRead == buffer.Length)
                 return 0; // success
 
-            // If we couldn't read the full buffer, maybe it's in a PE image
-            ModuleInfo? info = GetModuleForAddress(address);
-            if (info is null || info.FileName is null)
+            ModuleEntry? module = FindModule(address + (ulong)bytesRead);
+            if (module is null)
             {
                 return -1;
             }
 
-            string? foundFile = FindFileOnDisk(info.FileName);
-            if (foundFile is null)
+            string? filePath = module.Value.FilePath.Value;
+            if (filePath is null)
             {
                 return -1;
             }
 
-            using FileStream fs = File.OpenRead(foundFile);
+            using FileStream fs = File.OpenRead(filePath);
             using PEReader peReader = new PEReader(fs);
 
             int filled = bytesRead;
             ulong current = address + (ulong)bytesRead;
             while (filled < buffer.Length)
             {
-                PEMemoryBlock block = peReader.GetSectionData((int)(current - info.ImageBase));
-                if (block.Length == 0)
-                {
+                long rvaLong = (long)(current - module.Value.Image.Base);
+                if (rvaLong < 0 || rvaLong > int.MaxValue)
                     return -1;
-                }
+
+                PEMemoryBlock block = peReader.GetSectionData((int)rvaLong);
+                if (block.Length == 0)
+                    return -1;
 
                 int toCopy = Math.Min(block.Length, buffer.Length - filled);
                 unsafe
@@ -104,6 +110,25 @@ public sealed class ClrMdDumpHost : IDisposable
         }
     }
 
+    private ModuleEntry? FindModule(ulong address)
+    {
+        foreach (ModuleEntry entry in _modules)
+        {
+            if (address >= entry.Image.Base && address < entry.Image.Base + entry.Image.Size)
+                return entry;
+        }
+        return null;
+    }
+
+    public void RegisterManagedModules(IEnumerable<ManagedModuleImage> modules)
+    {
+        _modules.Clear();
+        foreach (ManagedModuleImage module in modules)
+        {
+            _modules.Add(new ModuleEntry(module, new Lazy<string?>(() => ResolveFile(module))));
+        }
+    }
+
     /// <summary>
     /// Get a thread's register context from the dump.
     /// Returns 0 on success, non-zero on failure.
@@ -113,14 +138,45 @@ public sealed class ClrMdDumpHost : IDisposable
         return _dataTarget.DataReader.GetThreadContext(threadId, contextFlags, buffer) ? 0 : -1;
     }
 
-    private ModuleInfo? GetModuleForAddress(ulong address)
+    private string? ResolveFile(ManagedModuleImage module)
     {
-        foreach (ModuleInfo module in _dataTarget.DataReader.EnumerateModules())
+        foreach (string candidate in EnumerateCandidatePaths(module.FileName))
         {
-            if (address >= module.ImageBase && address < module.ImageBase + (ulong)module.ImageSize)
-                return module;
+            if (File.Exists(candidate) && KeyMatches(candidate, module.TimeStamp, module.ImageSize))
+                return candidate;
         }
         return null;
+    }
+
+    private IEnumerable<string> EnumerateCandidatePaths(string modulePath)
+    {
+        // The path recorded in the runtime (may be absolute; only meaningful on the collecting host).
+        yield return modulePath;
+
+        int lastSep = Math.Max(modulePath.LastIndexOf('/'), modulePath.LastIndexOf('\\'));
+        string fileName = lastSep >= 0 ? modulePath[(lastSep + 1)..] : modulePath;
+        foreach (string searchPath in _searchPaths)
+            yield return Path.Combine(searchPath, fileName);
+    }
+
+    private static bool KeyMatches(string path, uint expectedTimeStamp, uint expectedImageSize)
+    {
+        // A zero key means the module didn't report identity info; accept a name match in that case.
+        if (expectedTimeStamp == 0 && expectedImageSize == 0)
+            return true;
+        try
+        {
+            using FileStream fs = File.OpenRead(path);
+            using PEReader peReader = new PEReader(fs);
+            PEHeaders headers = peReader.PEHeaders;
+            uint actualTimeStamp = (uint)headers.CoffHeader.TimeDateStamp;
+            uint actualImageSize = (uint)(headers.PEHeader?.SizeOfImage ?? 0);
+            return actualTimeStamp == expectedTimeStamp && actualImageSize == expectedImageSize;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     /// <summary>
@@ -157,24 +213,6 @@ public sealed class ClrMdDumpHost : IDisposable
         }
 
         throw new InvalidOperationException("Could not find DotNetRuntimeContractDescriptor export in any runtime module in the dump.");
-    }
-
-    private string? FindFileOnDisk(string modulePath)
-    {
-        // for local runs
-        if (File.Exists(modulePath))
-            return modulePath;
-        int lastSep = Math.Max(modulePath.LastIndexOf('/'), modulePath.LastIndexOf('\\'));
-        string fileName = lastSep >= 0 ? modulePath[(lastSep + 1)..] : modulePath;
-
-        foreach (string searchPath in _searchPaths)
-        {
-            string candidate = Path.Combine(searchPath, fileName);
-            if (File.Exists(candidate))
-                return candidate;
-        }
-
-        return null;
     }
 
     private static bool IsRuntimeModule(string fileName)

--- a/src/native/managed/cdac/tests/TestInfrastructure/DumpTestBase.cs
+++ b/src/native/managed/cdac/tests/TestInfrastructure/DumpTestBase.cs
@@ -119,6 +119,7 @@ public abstract class DumpTestBase : IDisposable
             out _target);
 
         Assert.True(created, $"Failed to create ContractDescriptorTarget from dump: {dumpPath}");
+        RegisterManagedModules();
     }
 
     /// <summary>
@@ -145,12 +146,65 @@ public abstract class DumpTestBase : IDisposable
             out _target);
 
         Assert.True(created, $"Failed to create ContractDescriptorTarget from dump: {dumpPath}");
+        RegisterManagedModules();
     }
 
     public void Dispose()
     {
         _host?.Dispose();
         System.GC.SuppressFinalize(this);
+    }
+
+    private void RegisterManagedModules()
+    {
+        if (_host is null || _target is null)
+            return;
+
+        ILoader loader = _target.Contracts.Loader;
+        TargetPointer appDomain = loader.GetAppDomain();
+        if (appDomain == TargetPointer.Null)
+            return;
+
+        _host.RegisterManagedModules(EnumerateManagedModules(loader, appDomain));
+    }
+
+    private static IEnumerable<ClrMdDumpHost.ManagedModuleImage> EnumerateManagedModules(ILoader loader, TargetPointer appDomain)
+    {
+        foreach (Contracts.ModuleHandle handle in loader.GetModuleHandles(appDomain, AssemblyIterationFlags.IncludeLoaded | AssemblyIterationFlags.IncludeExecution))
+        {
+            ClrMdDumpHost.ManagedModuleImage? image = TryDescribeModule(loader, handle);
+            if (image is not null)
+                yield return image.Value;
+        }
+    }
+
+    private static ClrMdDumpHost.ManagedModuleImage? TryDescribeModule(ILoader loader, Contracts.ModuleHandle handle)
+    {
+        try
+        {
+            if (loader.IsDynamic(handle))
+                return null;
+            if (!loader.TryGetLoadedImageContents(handle, out TargetPointer baseAddress, out uint size, out _)
+                || baseAddress == TargetPointer.Null || size == 0)
+                return null;
+
+            string fileName = loader.GetPath(handle);
+            if (string.IsNullOrEmpty(fileName))
+                fileName = loader.GetFileName(handle);
+            if (string.IsNullOrEmpty(fileName))
+                return null;
+
+            // PE identity key (COFF TimeDateStamp + optional-header SizeOfImage) used to
+            // verify the on-disk file matches the module captured in the dump.
+            loader.GetFileHeadersInfo(handle, out uint timeStamp, out uint imageSize);
+
+            return new ClrMdDumpHost.ManagedModuleImage(baseAddress, size, fileName, timeStamp, imageSize);
+        }
+        catch (System.Exception)
+        {
+            // Skip modules the Loader contract can't fully describe (e.g. in-memory/dynamic).
+            return null;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
# cDAC dump tests: resolve managed modules from the Loader contract (matching SOS/dotnet-dump)

## Motivation

The dump-test host had a homegrown on-disk read fallback (used for ECMA metadata, which heap/mini dumps don't capture) sourced from `ClrMD's DataReader.EnumerateModules()`. That doesn't match how SOS/dotnet-dump actually resolve managed module reads out of a dump.

**What SOS does today.** SOS and dotnet-dump serve reads outside the dump through dotnet/diagnostics' `ImageMappingMemoryService` -- an `IMemoryService` decorator that, on a miss, looks up the owning module, downloads/opens its PE image by symbol-store key, translates the loaded RVA to a file offset, and returns bytes. On non-Windows dumps it stacks **two** layers on top of the raw dump reader:

- A **native module** layer sourced from the platform dump format (`MINIDUMP_MODULE`, ELF `NT_FILE`, dyld image list).
- A **managed module** layer -- `ManagedModuleService` -- sourced from `ClrRuntime.EnumerateModules()`, i.e. from the DAC's own view of what a Module is.

The managed layer exists because the platform dump format is not sufficient for managed R2R modules on Linux/macOS: the runtime keeps two mappings of the same PE file (a flat/file layout at base A and a loaded/converted layout at base B), and only the flat mapping ends up in `NT_FILE`. The runtime's image-relative pointers (e.g. the ECMA metadata pointer for a Module) point into **B**, and `ClrRuntime.EnumerateModules()` -> DAC `ilBase` returns **B**. That's the layer SOS relies on to page metadata in from disk.

**What our tests were doing.** `ClrMdDumpHost` was using only the ClrMD `EnumerateModules()` list (a raw scan of platform dump-format module records) for its fallback -- i.e. we had the native-module source but no equivalent of the managed layer that SOS uses. Metadata reads outside the dump would fall outside every ClrMD entry and return `-1`. The failure is ASLR-dependent, so it's a latent footgun rather than an active red test today; I hit it while experimenting with a different dump-collection setup.

The previous fallback also located an on-disk file **by name only** and read bytes from whatever it found, so a stale same-named assembly on the search path would be silently used. `ImageMappingMemoryService`'s file download is keyed on the module's PE identity, so it can't be fooled that way.

## Change

Align the cDAC dump tests with the same strategy SOS uses -- run the on-disk fallback off a runtime/DAC-sourced managed module list, not off ClrMD's raw module scan. The cDAC Loader contract plays the role that `ClrRuntime.EnumerateModules()` plays in dotnet/diagnostics (both are DAC/runtime-backed, both return the loaded base):

- `DumpTestBase.RegisterManagedModules()` enumerates modules via `ILoader.GetModuleHandles` at test-init time. For each module it records the loaded image base + size (`TryGetLoadedImageContents`), the on-disk path (`GetPath`/`GetFileName`), and the PE identity key (`GetFileHeadersInfo` -- COFF `TimeDateStamp` + optional-header `SizeOfImage`).
- `ClrMdDumpHost.RegisterManagedModules(...)` stores those images. On the first fallback read that lands in a module, it lazily (`Lazy<string?>`) locates the on-disk file and verifies the PE identity key matches (mirroring `ImageMappingMemoryService`'s symbol-store-key check). Stale/mismatched files are rejected rather than read silently. The lookup happens at most once per module.
- The read fallback resolves module ownership solely from this table; ClrMD's module list is no longer consulted for it.

ClrMD is retained only for what it's actually good at against a raw dump: memory reads, thread context, and the one-time contract-descriptor export lookup that bootstraps the `Target`.

Because we're using the same runtime-sourced module strategy SOS uses in production, cDAC exercised under a real debugger (dotnet-dump, SOS, lldb) sees module mappings equivalent to what the tests see -- this isn't a test-only mapping shortcut.

## Testing

Full cDAC dump test suite locally on Windows x64 -> **267 passed / 0 failed / 699 skipped** (net10.0 heap tests + arch/OS-gated tests). Windows dumps only exercise one image layout, so this mainly validates the refactor is a no-op on the platform that already worked.

> [!NOTE]
> This PR was drafted with assistance from GitHub Copilot.
