### PR TITLE
[wasm] Bail R2R for all SIMD parameter sizes, not just SIMD16

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -105,15 +105,15 @@ void CodeGen::genMarkLabelsForCodegen()
 //
 void CodeGen::genBeginFnProlog()
 {
-    // SIMD16 (Vector128) parameters are lowered to i32 in the wasm signature, so any
-    // v128 operation performed on them produces an invalid module (e.g. a v128 op with
-    // an i32 operand). Bail such methods to the interpreter until SIMD16 parameters are
+    // SIMD (Vector2/3/4, Vector128) parameters are lowered to i32 in the wasm signature, so any
+    // vector operation performed on them produces an invalid module (e.g. a v128/f64 op with
+    // an i32 operand). Bail such methods to the interpreter until SIMD parameters are
     // properly supported in the wasm calling convention.
     for (unsigned lclNum = 0; lclNum < m_compiler->info.compArgsCount; lclNum++)
     {
-        if (m_compiler->lvaGetDesc(lclNum)->TypeGet() == TYP_SIMD16)
+        if (varTypeIsSIMD(m_compiler->lvaGetDesc(lclNum)->TypeGet()))
         {
-            NYI_WASM_SIMD("SIMD16 parameter");
+            NYI_WASM_SIMD("SIMD parameter");
         }
     }
 


### PR DESCRIPTION
Vector2 (`TYP_SIMD8`) and Vector3 (`TYP_SIMD12`) parameters are lowered to `i32` in the wasm signature, the same as Vector128 (`TYP_SIMD16`), but the argument-spill prolog in `genBeginFnProlog` only bailed R2R for `TYP_SIMD16`.

As a result, a method with an 8-byte SIMD parameter — e.g. `System.Numerics.Matrix3x2.CreateRotation(float, Vector2)` — emitted an `f64.store` fed by the `i32` parameter local, producing an invalid module that fails wasm validation:

```
func 20691 failed to validate
  type mismatch: expected f64, found i32
```

This currently prevents `System.Private.CoreLib` from producing a valid R2R image (both single-file and composite).

## Fix

Broaden the parameter bail from `== TYP_SIMD16` to `varTypeIsSIMD(...)` so `SIMD8`/`SIMD12`/`SIMD16` parameters are all sent to the interpreter until SIMD parameters are supported in the wasm calling convention.

This is a direct follow-up to the SIMD16 parameter bail added in #130101 ("Fix a few missing SIMD bail outs that prevent SPC from validating") — it was the same class of bug, just missed for the smaller SIMD sizes.

## Validation

With this change, crossgen2 `--targetos wasi --targetarch wasm` on `System.Private.CoreLib` (and a composite including it) produces a module that passes `wasm-tools validate --features all`. Verified locally on macOS/arm64.

> [!NOTE]
> This change was authored with the assistance of GitHub Copilot.