### PR TITLE
[wasm] Emit webcil-in-wasm component stubs for composite R2R

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -459,6 +459,12 @@ namespace ILCompiler
                             relativeMsilPath = Path.GetFileName(inputFile);
                         }
                         string standaloneMsilOutputFile = Path.Combine(outputDirectory, relativeMsilPath);
+                        if (_format == ReadyToRunContainerFormat.Wasm)
+                        {
+                            // For wasm, component stubs are webcil-in-wasm modules loaded by name
+                            // as "<assembly>.wasm" (matching the browser/wasi external-assembly probe).
+                            standaloneMsilOutputFile = Path.ChangeExtension(standaloneMsilOutputFile, ".wasm");
+                        }
                         RewriteComponentFile(inputFile: inputFile, outputFile: standaloneMsilOutputFile, ownerExecutableName: ownerExecutableName, compiledMethodDefs: compiledMethodDefs);
                     }
                 }
@@ -519,6 +525,13 @@ namespace ILCompiler
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_PlatformNativeImage;
             }
 
+            // Component (per-assembly forwarding) stubs use the same container format as the
+            // composite image. Windows and Apple both emit PE stubs that forward to the native
+            // composite; wasm emits webcil-in-wasm stubs to match the browser/wasi loading model,
+            // since the PE/COFF writer does not support the Wasm32 architecture.
+            ReadyToRunContainerFormat componentFormat =
+                _format == ReadyToRunContainerFormat.Wasm ? ReadyToRunContainerFormat.Wasm : ReadyToRunContainerFormat.PE;
+
             CopiedCorHeaderNode copiedCorHeader = new CopiedCorHeaderNode(inputModule);
             // Re-written components shouldn't have any additional diagnostic information - only information about the forwards.
             // Even with all of this, we might be modifying the image in a silly manner - adding a directory when if didn't have one.
@@ -533,7 +546,7 @@ namespace ILCompiler
                 win32Resources: new Win32Resources.ResourceData(inputModule),
                 flags: flags,
                 nodeFactoryOptimizationFlags: optimizationFlags,
-                format: ReadyToRunContainerFormat.PE,
+                format: componentFormat,
                 imageBase: _nodeFactory.ImageBase,
                 associatedModule: automaticTypeValidation ? inputModule : null,
                 genericCycleDepthCutoff: -1, // We don't need generic cycle detection when rewriting component assemblies
@@ -569,7 +582,7 @@ namespace ILCompiler
                 perfMapFormatVersion: _perfMapFormatVersion,
                 generateProfileFile: false,
                 _profileData.CallChainProfile,
-                ReadyToRunContainerFormat.PE,
+                componentFormat,
                 customPESectionAlignment: 0,
                 _logger);
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -525,13 +525,11 @@ namespace ILCompiler
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_PlatformNativeImage;
             }
 
-            // Component (per-assembly forwarding) stubs use the same container format as the
-            // composite image. Windows and Apple both emit PE stubs that forward to the native
-            // composite; wasm emits webcil-in-wasm stubs to match the browser/wasi loading model,
-            // since the PE/COFF writer does not support the Wasm32 architecture.
+            // Component (per-assembly forwarding) stubs are emitted as PE (even when the composite image is native),
+            // except on wasm where we emit webcil-in-wasm stubs to match the browser/wasi loading model.
+            // The PE/COFF writer does not support the Wasm32 architecture.
             ReadyToRunContainerFormat componentFormat =
                 _format == ReadyToRunContainerFormat.Wasm ? ReadyToRunContainerFormat.Wasm : ReadyToRunContainerFormat.PE;
-
             CopiedCorHeaderNode copiedCorHeader = new CopiedCorHeaderNode(inputModule);
             // Re-written components shouldn't have any additional diagnostic information - only information about the forwards.
             // Even with all of this, we might be modifying the image in a silly manner - adding a directory when if didn't have one.


### PR DESCRIPTION
Composite ReadyToRun builds rewrite each input assembly into a small per-assembly *component stub* that forwards to the composite image. In `RewriteComponentFile`, the container format for these stubs was hardcoded to `ReadyToRunContainerFormat.PE`.

On a wasm build this routes the stub through `PEObjectWriter` → `CoffObjectWriter`, which throws for the Wasm32 architecture, so a composite crossgen2 build fails **after** successfully emitting the `composite-r2r.wasm` image:

```
Emitting R2R Wasm file: .../composite-r2r.wasm
Error: Unsupported architecture
System.NotSupportedException: Unsupported architecture
   at ILCompiler.ObjectWriter.CoffObjectWriter..ctor(...)
   at ILCompiler.DependencyAnalysis.ReadyToRunObjectWriter.CreatePEObjectWriter()
   at ILCompiler.ReadyToRunCodegenCompilation.RewriteComponentFile(...)
```

As a result, composite mode could not complete a crossgen2 build for **any** wasm target (browser or wasi).

## Fix

Use the composite image's own container format for the per-assembly component stubs:

- **wasm** targets emit webcil-in-wasm stubs, written as `<assembly>.wasm` (loaded by name via the browser/wasi external-assembly probe, matching how the composite image itself is loaded).
- **PE / Apple** targets keep emitting PE stubs exactly as before (`componentFormat` resolves to `PE` for any non-wasm format).

This is a small change (15 insertions) local to `RewriteComponentFile` and its output-path selection; non-wasm behavior is unchanged.

## Validation

With this change, `crossgen2 --composite --targetos wasi --targetarch wasm` (and `--targetos browser`) on a set of assemblies emits the `composite-r2r.wasm` image plus one webcil-in-wasm stub per input assembly, all passing `wasm-tools validate`. Verified locally on macOS/arm64.

> [!NOTE]
> This change was authored with the assistance of GitHub Copilot.
