### PR TITLE
[clr-ios] Default Apple mobile CoreCLR ReadyToRun to composite regardless of BuildTestsOnHelix

### DIFF
--- a/src/mono/msbuild/apple/build/AppleBuild.props
+++ b/src/mono/msbuild/apple/build/AppleBuild.props
@@ -11,8 +11,11 @@
 
   <PropertyGroup Condition="'$(UseMonoRuntime)' != 'true' and '$(UseNativeAOTRuntime)' != 'true' and '$(BuildTestsOnHelix)' != 'true'">
     <PublishReadyToRun Condition="'$(PublishReadyToRun)' == ''">true</PublishReadyToRun>
-    <PublishReadyToRunComposite Condition="'$(PublishReadyToRun)' == 'true'">true</PublishReadyToRunComposite>
-    <PublishReadyToRunContainerFormat Condition="'$(PublishReadyToRun)' == 'true'">macho</PublishReadyToRunContainerFormat>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseMonoRuntime)' != 'true' and '$(UseNativeAOTRuntime)' != 'true' and '$(PublishReadyToRun)' == 'true'">
+    <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == ''">true</PublishReadyToRunComposite>
+    <PublishReadyToRunContainerFormat Condition="'$(PublishReadyToRunContainerFormat)' == ''">macho</PublishReadyToRunContainerFormat>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(PublishReadyToRun)' != 'true' and '$(UseMonoRuntime)' != 'true' and '$(UseNativeAOTRuntime)' != 'true'">


### PR DESCRIPTION
## Description

The composite and macho defaults for Apple mobile CoreCLR ReadyToRun were gated on `BuildTestsOnHelix != 'true'`, so a test that enables ReadyToRun while building with `BuildTestsOnHelix=true`, which is why `iOS.CoreCLR.R2R.Test` published per-assembly `pe` while every other Apple mobile CoreCLR image is composite macho.