### PR TITLE
Preserve HybridCacheEntryOptions.ToDistributedCacheEntryOptions from trimming

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/ILLink/ILLink.Descriptors.xml
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/ILLink/ILLink.Descriptors.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="Microsoft.Extensions.Caching.Abstractions">
+    <!-- Accessed via [UnsafeAccessor] from Microsoft.Extensions.Caching.Hybrid, which the trimmer cannot follow. -->
+    <type fullname="Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryOptions">
+      <method name="ToDistributedCacheEntryOptions" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/tests/TrimmingTests/HybridCacheEntryOptionsAccessorTest.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/tests/TrimmingTests/HybridCacheEntryOptionsAccessorTest.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+
+class Program
+{
+    // Mirrors the access pattern used by Microsoft.Extensions.Caching.Hybrid's DefaultHybridCache.
+    // HybridCacheEntryOptions.ToDistributedCacheEntryOptions is internal and is only reached via
+    // [UnsafeAccessor] from another assembly, which the trimmer cannot follow. It must be preserved
+    // by the ILLink.Descriptors.xml in Microsoft.Extensions.Caching.Abstractions.
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ToDistributedCacheEntryOptions")]
+    extern static DistributedCacheEntryOptions? ToDistributedCacheEntryOptions(HybridCacheEntryOptions options);
+
+    static int Main()
+    {
+        TimeSpan expiration = TimeSpan.FromMinutes(5);
+        HybridCacheEntryOptions options = new() { Expiration = expiration };
+
+        // Throws MissingMethodException if the target method was trimmed away.
+        DistributedCacheEntryOptions? result = ToDistributedCacheEntryOptions(options);
+
+        if (result is null || result.AbsoluteExpirationRelativeToNow != expiration)
+        {
+            return -1;
+        }
+
+        return 100;
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/tests/TrimmingTests/Microsoft.Extensions.Caching.Abstractions.TrimmingTests.proj
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/tests/TrimmingTests/Microsoft.Extensions.Caching.Abstractions.TrimmingTests.proj
@@ -1,0 +1,9 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <ItemGroup>
+    <TestConsoleAppSourceFiles Include="HybridCacheEntryOptionsAccessorTest.cs" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/130376

## Summary

In .NET 11, `Microsoft.Extensions.Caching.Abstractions` was added to the base shared framework (dotnet/dotnet#5206, decision in #67487). As a result, its assembly is now ILLink-trimmed as part of the framework, whereas previously it shipped only as an untrimmed NuGet package.

`HybridCacheEntryOptions.ToDistributedCacheEntryOptions()` is `internal` and has no caller inside its own assembly. Its only consumer is the `Microsoft.Extensions.Caching.Hybrid` implementation package, which reaches it via [`[UnsafeAccessor]`](https://github.com/dotnet/extensions/blob/8ba6add4445e324b9daec87a15aa02b6573ce74a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.L2.cs#L275-L276). The trimmer cannot follow cross-assembly `UnsafeAccessor` references (they resolve by name at runtime, with no metadata edge), so the method was trimmed out of the shared-framework build. This surfaces as a `MissingMethodException` at runtime for the Hybrid cache.

## Fix

- Add `ILLink.Descriptors.xml` to preserve the method (auto-embedded via `eng/illink.targets`).
- Add a trimming test that mirrors the Hybrid `UnsafeAccessor` access pattern and returns `100` only when the method resolves.

## Validation

Verified with a full self-contained `TrimMode=full` publish:

- **With** the descriptor: the published app exits `100`; the method is present in the trimmed assembly.
- **Without** the descriptor: the trimming-test harness reports `[Failed Test]` with exit code `-532462766` (`0xE0434352`, the `MissingMethodException`), confirming the test guards the fix.

> [!NOTE]
> This pull request was authored by Copilot (AI).
