### PR TITLE
[r2r] Add support for compiling szarray methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ArrayInterfaceMethodsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ArrayInterfaceMethodsNode.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    /// <summary>
+    /// Discovery node for the generic collection interface methods implemented by arrays.
+    ///
+    /// Arrays implement the generic collection interfaces (IEnumerable, IList, ICollection, IReadOnlyList,
+    /// IReadOnlyCollection). At runtime, a call through these interfaces is dispatched to methods on
+    /// SZArrayHelper. The InheritedVirtualMethodsNode doesn't see these methods as part of the array type.
+    ///
+    /// This node is created whenever an array type is used. It has conditional static dependencies:
+    /// the resolved SZArrayHelper implementation is compiled only when the corresponding interface slot is
+    /// actually used (via VirtualMethodUseNode).
+    /// </summary>
+    public class ArrayInterfaceMethodsNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly ArrayType _arrayType;
+
+        public ArrayInterfaceMethodsNode(ArrayType arrayType)
+        {
+            Debug.Assert(arrayType.IsSzArray);
+            _arrayType = arrayType;
+        }
+
+        public ArrayType ArrayType => _arrayType;
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => true;
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
+        {
+            List<CombinedDependencyListEntry> result = new List<CombinedDependencyListEntry>();
+
+            MetadataType szArrayHelper = factory.TypeSystemContext.SystemModule.GetType("System"u8, "SZArrayHelper"u8, throwIfNotFound: false);
+            if (szArrayHelper == null)
+                return result;
+
+            TypeDesc elementType = _arrayType.ElementType;
+
+            foreach (DefType interfaceType in _arrayType.RuntimeInterfaces)
+            {
+                // Only the generic collection interfaces are dispatched through SZArrayHelper.
+                if (!interfaceType.HasInstantiation)
+                    continue;
+
+                foreach (MethodDesc interfaceMethod in interfaceType.GetVirtualMethods())
+                {
+                    // SZArrayHelper provides one generic method per interface method, with a matching name.
+                    MethodDesc helperMethodDef = szArrayHelper.GetMethod(interfaceMethod.Name, null);
+                    if (helperMethodDef == null)
+                        continue;
+
+                    MethodDesc helperMethod = factory.TypeSystemContext.GetInstantiatedMethod(helperMethodDef, new Instantiation(elementType));
+                    MethodDesc canonHelperMethod = helperMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
+
+                    if (!factory.CompilationModuleGroup.ContainsMethodBody(canonHelperMethod, false))
+                        continue;
+
+                    result.Add(new CombinedDependencyListEntry(
+                        factory.CompiledMethodNode(canonHelperMethod),
+                        factory.VirtualMethodUse(interfaceMethod),
+                        "Array generic interface method implemented by SZArrayHelper"));
+                }
+            }
+
+            return result;
+        }
+
+        protected override string GetName(NodeFactory factory) => $"Array interface methods on {_arrayType}";
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
@@ -28,6 +28,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             Debug.Assert(type.IsDefType && !type.IsInterface);
             Debug.Assert(!type.IsGenericDefinition);
+            Debug.Assert(type == type.ConvertToCanonForm(CanonicalFormKind.Specific));
             _type = type;
             _interestingForDynamicDependencyAnalysis = TypeHasGVMSlots(type);
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -143,18 +143,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 // creation of InheritedVirtualMethodsNode as it is done in TypeFixupSignature, so we
                 // scan the virtual methods on this type for dependency analysis.
                 if (_typeArgument != null)
-                {
-                    TypeDesc canonType = _typeArgument.ConvertToCanonForm(CanonicalFormKind.Specific);
-                    if (!canonType.IsGenericDefinition &&
-                        !canonType.IsInterface &&
-                        canonType.IsDefType &&
-                        (factory.CompilationCurrentPhase == 0) &&
-                        factory.CompilationModuleGroup.VersionsWithType(canonType))
-                    {
-                        dependencies ??= new DependencyList();
-                        dependencies.Add(factory.InheritedVirtualMethods(canonType), "Generic lookup type discovery for virtual dispatch");
-                    }
-                }
+                    factory.AddVirtualMethodDiscoveryDependencies(ref dependencies, _typeArgument);
             }
 
             return dependencies;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -50,5 +50,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             NewArrayFixupSignature otherNode = (NewArrayFixupSignature)other;
             return comparer.Compare(_arrayType, otherNode._arrayType);
         }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            DependencyList dependencies = base.ComputeNonRelocationBasedDependencies(factory);
+
+            factory.AddVirtualMethodDiscoveryDependencies(ref dependencies, _arrayType);
+
+            return dependencies;
+        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -213,17 +213,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dependencies.Add(factory.AllMethodsOnType(_typeDesc), "Methods on generic type instantiation");
             }
 
-            // We record the usage of this type, so that virtual method dependency analysis can resolve implementations.
-            // GVMDependenciesNode uses this for generic virtual methods (dynamic dependencies).
-            // InheritedVirtualMethodsNode uses conditional static dependencies for non-GVM virtual methods.
-            if (!_typeDesc.IsGenericDefinition &&
-                !_typeDesc.IsInterface &&
-                _typeDesc.IsDefType &&
-                (factory.CompilationCurrentPhase == 0) &&
-                factory.CompilationModuleGroup.VersionsWithType(_typeDesc))
-            {
-                dependencies.Add(factory.InheritedVirtualMethods(_typeDesc), "Inherited virtual/interface methods on type");
-            }
+            factory.AddVirtualMethodDiscoveryDependencies(ref dependencies, _typeDesc);
 
             if (_fixupKind == ReadyToRunFixupKind.TypeHandle)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -22,6 +22,8 @@ using Internal.ReadyToRunConstants;
 using ILCompiler.ReadyToRun.TypeSystem;
 using ILCompiler.ReadyToRun;
 
+using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+
 namespace ILCompiler.DependencyAnalysis
 {
     public struct NodeCache<TKey, TValue>
@@ -143,9 +145,43 @@ namespace ILCompiler.DependencyAnalysis
 
         private NodeCache<TypeDesc, InheritedVirtualMethodsNode> _inheritedVirtualMethods;
 
-        public InheritedVirtualMethodsNode InheritedVirtualMethods(TypeDesc type)
+        private InheritedVirtualMethodsNode InheritedVirtualMethods(TypeDesc type)
         {
-            return _inheritedVirtualMethods.GetOrAdd(type.ConvertToCanonForm(CanonicalFormKind.Specific));
+            return _inheritedVirtualMethods.GetOrAdd(type);
+        }
+
+        private NodeCache<ArrayType, ArrayInterfaceMethodsNode> _arrayInterfaceMethods;
+
+        public ArrayInterfaceMethodsNode ArrayInterfaceMethods(ArrayType arrayType)
+        {
+            return _arrayInterfaceMethods.GetOrAdd((ArrayType)arrayType.ConvertToCanonForm(CanonicalFormKind.Specific));
+        }
+
+        public void AddVirtualMethodDiscoveryDependencies(ref DependencyList dependencies, TypeDesc type)
+        {
+            if (CompilationCurrentPhase != 0)
+                return;
+
+            type = type.ConvertToCanonForm(CanonicalFormKind.Specific);
+
+            // We record the usage of this type, so that virtual method dependency analysis can resolve implementations.
+            // GVMDependenciesNode uses this for generic virtual methods (dynamic dependencies).
+            // InheritedVirtualMethodsNode uses conditional static dependencies for non-GVM virtual methods.
+            if (!type.IsGenericDefinition &&
+                !type.IsInterface &&
+                type.IsDefType &&
+                CompilationModuleGroup.VersionsWithType(type))
+            {
+                dependencies ??= new DependencyList();
+                dependencies.Add(InheritedVirtualMethods(type), "Inherited virtual/interface methods on type");
+            }
+            // Arrays implement the generic collection interfaces through SZArrayHelper. Discover those
+            // implementations so that e.g. ((ICollection<int>)intArray).Count gets discovered.
+            else if (type.IsSzArray)
+            {
+                dependencies ??= new DependencyList();
+                dependencies.Add(ArrayInterfaceMethods((ArrayType)type), "Array generic interface methods");
+            }
         }
 
         private NodeCache<MethodDesc, GVMDependenciesNode> _gvmDependenciesNode;
@@ -299,6 +335,11 @@ namespace ILCompiler.DependencyAnalysis
             _gvmDependenciesNode = new NodeCache<MethodDesc, GVMDependenciesNode>(method =>
             {
                 return new GVMDependenciesNode(method);
+            });
+
+            _arrayInterfaceMethods = new NodeCache<ArrayType, ArrayInterfaceMethodsNode>(arrayType =>
+            {
+                return new ArrayInterfaceMethodsNode(arrayType);
             });
 
             _virtualMethodUseNodes = new NodeCache<MethodDesc, VirtualMethodUseNode>(method =>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -234,6 +234,7 @@
     <Compile Include="Compiler\CompositeImageSettings.cs" />
     <Compile Include="Compiler\CryptographicHashProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\AllMethodsOnTypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ArrayInterfaceMethodsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InheritedVirtualMethodsNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\VirtualMethodUseNode.cs" Link="Compiler\DependencyAnalysis\VirtualMethodUseNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />


### PR DESCRIPTION
For example, an array of T casts to IList<T>. Calling `get_Count` on this interface will be resolved at runtime to a call to `SZArrayHelper:get_Count`. This interface method resolution happens magically at runtime, R2R has no way to detect the methods on the `SZArrayHelper` since the array type doesn't derive from it.

In order to fix this, whenever we detect an Array type, we create the ArrayInterfaceMethodsNode for the canonicalized type. This node will iterate over all implemented generic interfaces. For each interface it will iterate over all methods and try to match them with methods from the `SZArrayHelper`, by name (the runtime asserts the names are identical in GetActualImplementationForArrayGenericIListOrIReadOnlyListMethod as well). Once we obtain a match of szArrayMethod + interfaceMethod, we add a conditional dependency that the szArrayMethod is compiled only if the equivalent interfaceMethod is discovered as well.

The initial approach included all SZArrayHelper methods naively. Using conditional dependencies for this reduced the number of compiled methods by ~6x. The size increase in negligible, less than 0.1% for corerun framework.

Fixes performance on benchmarks like EmptyTakeSelectToArray