### PR TITLE
JIT: Fold insertps chains that source a scalar extracted from another vector

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -2180,15 +2180,15 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
             if ((count_s == 0) && op2->OperIsHWIntrinsic(NI_Vector_CreateScalarUnsafe))
             {
                 GenTreeHWIntrinsic* createScalar = op2->AsHWIntrinsic();
-                GenTree*            scalarOp      = createScalar->Op(1);
+                GenTree*            scalarOp     = createScalar->Op(1);
 
                 if (scalarOp->OperIsHWIntrinsic() && (genTypeSize(scalarOp->AsHWIntrinsic()->GetSimdBaseType()) == 4))
                 {
                     GenTreeHWIntrinsic* extract   = scalarOp->AsHWIntrinsic();
                     NamedIntrinsic      extractId = extract->GetHWIntrinsicId();
 
-                    GenTree* srcVec = nullptr;
-                    GenTree* srcIdx = nullptr;
+                    GenTree* srcVec      = nullptr;
+                    GenTree* srcIdx      = nullptr;
                     ssize_t  count_s_new = 0;
 
                     if (extractId == NI_Vector_ToScalar)
@@ -2212,8 +2212,8 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
                     // the element offset in the address) and rewriting it to the register form
                     // would instead force a full vector load.
 
-                    if ((srcVec != nullptr) && !srcVec->isContained() && (count_s_new >= 0) &&
-                        (count_s_new <= 3) && IsInvariantInRange(srcVec, node))
+                    if ((srcVec != nullptr) && !srcVec->isContained() && (count_s_new >= 0) && (count_s_new <= 3) &&
+                        IsInvariantInRange(srcVec, node))
                     {
                         count_s = count_s_new;
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -2162,6 +2162,81 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
                 return nextNode;
             }
 
+            // We can also recognize when the value being inserted is itself a scalar
+            // extracted from another vector, such as:
+            //
+            //   Insert(vector, CreateScalarUnsafe(vector2.GetElement(idx1)), idx2)
+            //
+            // In this case, insertps can select the source element directly from
+            // vector2 using count_s (bits 6-7), which lets us fold away the separate
+            // extraction (which otherwise requires its own movshdup/unpckhps/shufps).
+            //
+            // insertps operates purely on the 32-bit lanes of the low 128 bits of its
+            // source register, so this is valid for any 4-byte element type (float, int,
+            // or uint) and for a source vector of any width, provided the element being
+            // extracted is one of the first four. That is all count_s can encode and all
+            // that resides in the low 128 bits, which is the only part insertps reads.
+
+            if ((count_s == 0) && op2->OperIsHWIntrinsic(NI_Vector_CreateScalarUnsafe))
+            {
+                GenTreeHWIntrinsic* createScalar = op2->AsHWIntrinsic();
+                GenTree*            scalarOp      = createScalar->Op(1);
+
+                if (scalarOp->OperIsHWIntrinsic() && (genTypeSize(scalarOp->AsHWIntrinsic()->GetSimdBaseType()) == 4))
+                {
+                    GenTreeHWIntrinsic* extract   = scalarOp->AsHWIntrinsic();
+                    NamedIntrinsic      extractId = extract->GetHWIntrinsicId();
+
+                    GenTree* srcVec = nullptr;
+                    GenTree* srcIdx = nullptr;
+                    ssize_t  count_s_new = 0;
+
+                    if (extractId == NI_Vector_ToScalar)
+                    {
+                        // ToScalar is effectively GetElement with a source index of zero
+                        srcVec = extract->Op(1);
+                    }
+                    else if ((extractId == NI_Vector_GetElement) && extract->Op(2)->IsCnsIntOrI())
+                    {
+                        srcVec      = extract->Op(1);
+                        srcIdx      = extract->Op(2);
+                        count_s_new = srcIdx->AsIntConCommon()->IconValue();
+                    }
+
+                    // The source index must fit in count_s, which also guarantees the element
+                    // resides in the low 128 bits of the source register.
+                    //
+                    // We additionally require that the source vector is used from a register.
+                    // When the extraction reads from a contained memory operand, the existing
+                    // lowering already produces an optimal `insertps xmm, m32` (which encodes
+                    // the element offset in the address) and rewriting it to the register form
+                    // would instead force a full vector load.
+
+                    if ((srcVec != nullptr) && !srcVec->isContained() && (count_s_new >= 0) &&
+                        (count_s_new <= 3) && IsInvariantInRange(srcVec, node))
+                    {
+                        count_s = count_s_new;
+
+                        ival = (count_s << 6) | (count_d << 4) | (zmask);
+                        op3->AsIntConCommon()->SetIconValue(ival);
+
+                        // Carry the original source vector directly and remove the now
+                        // unused extraction and scalar creation nodes.
+
+                        node->Op(2) = srcVec;
+                        op2         = srcVec;
+
+                        if (srcIdx != nullptr)
+                        {
+                            BlockRange().Remove(srcIdx);
+                        }
+
+                        BlockRange().Remove(extract);
+                        BlockRange().Remove(createScalar);
+                    }
+                }
+            }
+
             if (!op1->OperIsHWIntrinsic())
             {
                 // Nothing to do if op1 isn't an intrinsic

--- a/src/tests/JIT/opt/Vectorization/InsertScalarFromVector.cs
+++ b/src/tests/JIT/opt/Vectorization/InsertScalarFromVector.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Validates the JIT folding of Insert(vector, vector2.GetElement(idx1), idx2)
+// into a single insertps that selects the source element directly via the
+// count_s field of the immediate. Both the register-source form (which the fold
+// rewrites) and the memory-source form (already handled) must match a scalar
+// reference for every combination of source and destination indices.
+//
+// The indices must be JIT-time constants for the insertps immediate (and hence
+// the fold) to be formed, so each combination is dispatched through a switch of
+// literal WithElement/GetElement calls rather than passing the indices as
+// arguments.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public static class InsertScalarFromVector
+{
+    private static readonly float[] s_dst = { 10f, 11f, 12f, 13f };
+    private static readonly float[] s_src = { 20f, 21f, 22f, 23f };
+
+    // src is produced by an arithmetic op so it stays in a register, forcing the
+    // register GetElement path that the fold collapses into insertps' count_s.
+    // combo == dstIdx * 4 + srcIdx, with both indices as compile-time constants.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<float> FromRegister(Vector128<float> dst, Vector128<float> a, Vector128<float> b, int combo)
+    {
+        Vector128<float> src = a + b;
+        return combo switch
+        {
+            0  => dst.WithElement(0, src.GetElement(0)),
+            1  => dst.WithElement(0, src.GetElement(1)),
+            2  => dst.WithElement(0, src.GetElement(2)),
+            3  => dst.WithElement(0, src.GetElement(3)),
+            4  => dst.WithElement(1, src.GetElement(0)),
+            5  => dst.WithElement(1, src.GetElement(1)),
+            6  => dst.WithElement(1, src.GetElement(2)),
+            7  => dst.WithElement(1, src.GetElement(3)),
+            8  => dst.WithElement(2, src.GetElement(0)),
+            9  => dst.WithElement(2, src.GetElement(1)),
+            10 => dst.WithElement(2, src.GetElement(2)),
+            11 => dst.WithElement(2, src.GetElement(3)),
+            12 => dst.WithElement(3, src.GetElement(0)),
+            13 => dst.WithElement(3, src.GetElement(1)),
+            14 => dst.WithElement(3, src.GetElement(2)),
+            15 => dst.WithElement(3, src.GetElement(3)),
+            _  => throw new ArgumentOutOfRangeException(nameof(combo)),
+        };
+    }
+
+    // src is passed directly and is typically consumed from memory, exercising the
+    // pre-existing insertps-with-memory-operand path.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<float> FromMemory(Vector128<float> dst, Vector128<float> src, int combo)
+    {
+        return combo switch
+        {
+            0  => dst.WithElement(0, src.GetElement(0)),
+            1  => dst.WithElement(0, src.GetElement(1)),
+            2  => dst.WithElement(0, src.GetElement(2)),
+            3  => dst.WithElement(0, src.GetElement(3)),
+            4  => dst.WithElement(1, src.GetElement(0)),
+            5  => dst.WithElement(1, src.GetElement(1)),
+            6  => dst.WithElement(1, src.GetElement(2)),
+            7  => dst.WithElement(1, src.GetElement(3)),
+            8  => dst.WithElement(2, src.GetElement(0)),
+            9  => dst.WithElement(2, src.GetElement(1)),
+            10 => dst.WithElement(2, src.GetElement(2)),
+            11 => dst.WithElement(2, src.GetElement(3)),
+            12 => dst.WithElement(3, src.GetElement(0)),
+            13 => dst.WithElement(3, src.GetElement(1)),
+            14 => dst.WithElement(3, src.GetElement(2)),
+            15 => dst.WithElement(3, src.GetElement(3)),
+            _  => throw new ArgumentOutOfRangeException(nameof(combo)),
+        };
+    }
+
+    private static Vector128<float> Reference(int dstIdx, int srcIdx)
+    {
+        float[] result = (float[])s_dst.Clone();
+        result[dstIdx] = s_src[srcIdx];
+        return Vector128.Create(result[0], result[1], result[2], result[3]);
+    }
+
+    [Fact]
+    public static void TestAllCombinations()
+    {
+        Vector128<float> dst = Vector128.Create(s_dst[0], s_dst[1], s_dst[2], s_dst[3]);
+        Vector128<float> src = Vector128.Create(s_src[0], s_src[1], s_src[2], s_src[3]);
+        Vector128<float> zero = Vector128<float>.Zero;
+
+        for (int dstIdx = 0; dstIdx < 4; dstIdx++)
+        {
+            for (int srcIdx = 0; srcIdx < 4; srcIdx++)
+            {
+                int combo = (dstIdx * 4) + srcIdx;
+                Vector128<float> expected = Reference(dstIdx, srcIdx);
+
+                Assert.Equal(expected, FromRegister(dst, src, zero, combo));
+                Assert.Equal(expected, FromMemory(dst, src, combo));
+            }
+        }
+    }
+
+    // Chained WithElement using elements pulled from another vector exercises
+    // composing the source-selection fold with the existing insert chains.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<float> Chained(Vector128<float> dst, Vector128<float> a, Vector128<float> b)
+    {
+        Vector128<float> src = a + b;
+        return dst.WithElement(0, src.GetElement(3))
+                  .WithElement(2, src.GetElement(1));
+    }
+
+    [Fact]
+    public static void TestChained()
+    {
+        Vector128<float> dst = Vector128.Create(s_dst[0], s_dst[1], s_dst[2], s_dst[3]);
+        Vector128<float> src = Vector128.Create(s_src[0], s_src[1], s_src[2], s_src[3]);
+        Vector128<float> zero = Vector128<float>.Zero;
+
+        Vector128<float> actual = Chained(dst, src, zero);
+        Vector128<float> expected = Vector128.Create(s_src[3], s_dst[1], s_src[1], s_dst[3]);
+
+        Assert.Equal(expected, actual);
+    }
+
+    private static readonly float[] s_src8 = { 20f, 21f, 22f, 23f, 24f, 25f, 26f, 27f };
+
+    // Extracting from a vector wider than 128 bits is also foldable when the element
+    // is one of the source's first four (which live in the low 128 bits): the fold
+    // feeds the wide register straight to insertps for GetElement(0)/ToScalar, while
+    // the existing GetElement lowering narrows the higher elements via GetLower/GetUpper.
+    // combo == dstIdx * 8 + srcIdx, with both indices as compile-time constants.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<float> FromWideRegister(Vector128<float> dst, Vector256<float> a, Vector256<float> b, int combo)
+    {
+        Vector256<float> src = a + b;
+        return combo switch
+        {
+            0  => dst.WithElement(0, src.GetElement(0)),
+            9  => dst.WithElement(1, src.GetElement(1)),
+            18 => dst.WithElement(2, src.GetElement(2)),
+            27 => dst.WithElement(3, src.GetElement(3)),
+            4  => dst.WithElement(0, src.GetElement(4)),
+            13 => dst.WithElement(1, src.GetElement(5)),
+            22 => dst.WithElement(2, src.GetElement(6)),
+            31 => dst.WithElement(3, src.GetElement(7)),
+            _  => throw new ArgumentOutOfRangeException(nameof(combo)),
+        };
+    }
+
+    private static Vector128<float> WideReference(int dstIdx, int srcIdx)
+    {
+        float[] result = (float[])s_dst.Clone();
+        result[dstIdx] = s_src8[srcIdx];
+        return Vector128.Create(result[0], result[1], result[2], result[3]);
+    }
+
+    [Fact]
+    public static void TestWideSource()
+    {
+        Vector128<float> dst = Vector128.Create(s_dst[0], s_dst[1], s_dst[2], s_dst[3]);
+        Vector256<float> src = Vector256.Create(s_src8[0], s_src8[1], s_src8[2], s_src8[3],
+                                                s_src8[4], s_src8[5], s_src8[6], s_src8[7]);
+        Vector256<float> zero = Vector256<float>.Zero;
+
+        for (int i = 0; i < 8; i++)
+        {
+            int dstIdx = i % 4;
+            int combo = (dstIdx * 8) + i;
+
+            Assert.Equal(WideReference(dstIdx, i), FromWideRegister(dst, src, zero, combo));
+        }
+    }
+}

--- a/src/tests/JIT/opt/Vectorization/InsertScalarFromVector.csproj
+++ b/src/tests/JIT/opt/Vectorization/InsertScalarFromVector.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Recognizes `insertps` chains where the value being inserted is itself a scalar extracted from another vector and folds them into a single `insertps` that selects the source element directly via `count_s` (bits 6-7 of the imm8).

That is, it rewrites:

```
Insert(vector, CreateScalarUnsafe(vector2.GetElement(idx1)), idx2)
```

into a single `insertps` reading lane `idx1` of `vector2`, folding away the separate extraction (which otherwise requires its own `movshdup`/`unpckhps`/`shufps`).

## Details

`insertps` operates purely on the 32-bit lanes of the low 128 bits of its source register, so this fold is valid for:

- **Any 4-byte element type** (`float`, `int`, `uint`) — `count_s` selects a 32-bit dword, which maps to the element index only when the element size is 4 bytes.
- **A source vector of any width** (128/256/512) — provided the extracted element is one of the first four lanes. That is all `count_s` can encode and all that resides in the low 128 bits, which is the only part `insertps` reads. Feeding a wider (`ymm`/`zmm`) source register to the 128-bit `insertps` is physically correct since the VEX.128 form reads the `xmm` view.

Both `NI_Vector_ToScalar` (source index 0) and constant-index `NI_Vector_GetElement` feeders are handled. When the extraction reads from a contained memory operand, the existing lowering already produces an optimal `insertps xmm, m32` (which encodes the element offset in the address), so the fold keeps the register form only when the source is used from a register, avoiding a forced full-vector load.

Because the fold keys off the (already-narrowed, SIMD16) `GetElement` node rather than the vector feeding it, it naturally handles wide sources whose element access has been lowered through `GetLower`/`GetLower128`/`GetUpper`/`ExtractVector128` — the correct 128-bit chunk is materialized and `count_s` selects the right lane within it.

## Diffs

SuperPMI asmdiffs, windows x64, all collections: **-141 bytes, 18 methods improved, 0 regressed** (no PerfScore regressions).

| Collection | Δ bytes | Methods | PerfScore (in diffs) |
|---|--:|--:|--:|
| libraries.crossgen2 | -29 | 5 improved | -8.31% |
| libraries.pmi | -8 | 2 improved | -7.68% |
| libraries_tests_no_tiered | -104 | 11 improved | -0.88% |

Representative improvements: `Matrix4x4.CreateScale`, `Matrix3x2.CreateScale`, `Vector3.Reflect`, `Vector2.Reflect`, `Quaternion.Lerp`, and various `Matrix4x4` billboard/shadow/decompose helpers.

A regression test covering register/memory sources, chained inserts, and wide (`Vector256`) sources across all element indices is included.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.
