### PR TITLE
Fix range-check monotonicity for multiplication

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -313,13 +313,7 @@ void RangeCheck::Widen(BasicBlock* block, GenTree* tree, Range* pRange)
 
 bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
 {
-    assert(binop->OperIs(GT_ADD, GT_MUL, GT_LSH));
-
-    if (!binop->OperIs(GT_ADD))
-    {
-        JITDUMP("Not monotonically increasing because operation is not addition\n");
-        return false;
-    }
+    assert(binop->OperIs(GT_ADD));
 
     GenTree* op1 = binop->gtGetOp1();
     GenTree* op2 = binop->gtGetOp2();
@@ -409,7 +403,7 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
         LclSsaVarDsc* ssaDef = GetSsaDefStore(expr->AsLclVarCommon());
         return (ssaDef != nullptr) && IsMonotonicallyIncreasing(ssaDef->GetDefNode()->Data(), rejectNegativeConst);
     }
-    else if (expr->OperIs(GT_ADD, GT_MUL, GT_LSH))
+    else if (expr->OperIs(GT_ADD))
     {
         return IsBinOpMonotonicallyIncreasing(expr->AsOp());
     }

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -327,7 +327,7 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
     JITDUMP("[RangeCheck::IsBinOpMonotonicallyIncreasing] [%06d], [%06d]\n", Compiler::dspTreeID(op1),
             Compiler::dspTreeID(op2));
 
-    // Check if we have a var + const or var * const.
+    // Canonicalize to (lclVar + {lclVar|const}).
     if (op2->OperIs(GT_LCL_VAR))
     {
         std::swap(op1, op2);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -301,7 +301,16 @@ void RangeCheck::Widen(BasicBlock* block, GenTree* tree, Range* pRange)
     if (range.LowerLimit().IsDependent() || range.LowerLimit().IsUnknown())
     {
         // To determine the lower bound, ask if the loop increases monotonically.
-        bool increasing = IsMonotonicallyIncreasing(tree, false);
+        bool requiresNonNegative = false;
+        bool increasing          = IsMonotonicallyIncreasing(tree, false, &requiresNonNegative);
+        if (increasing && requiresNonNegative)
+        {
+            // Apply the requirement from the root so it reaches phi initial values regardless
+            // of whether they are visited before or after the backedge that introduced it.
+            ClearSearchPath();
+            increasing = IsMonotonicallyIncreasing(tree, true, &requiresNonNegative);
+        }
+
         if (increasing)
         {
             JITDUMP("[%06d] is monotonically increasing.\n", Compiler::dspTreeID(tree));
@@ -311,9 +320,10 @@ void RangeCheck::Widen(BasicBlock* block, GenTree* tree, Range* pRange)
     }
 }
 
-bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
+bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop, bool rejectNegativeConst, bool* pRequiresNonNegative)
 {
     assert(binop->OperIs(GT_ADD, GT_MUL, GT_LSH));
+    assert(pRequiresNonNegative != nullptr);
 
     GenTree* op1 = binop->gtGetOp1();
     GenTree* op2 = binop->gtGetOp2();
@@ -337,16 +347,32 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
         case GT_LCL_VAR:
             // When adding/multiplying/shifting two local variables, we also must ensure that any constant is
             // non-negative.
-            return IsMonotonicallyIncreasing(op1, true) && IsMonotonicallyIncreasing(op2, true);
+            *pRequiresNonNegative = true;
+            return IsMonotonicallyIncreasing(op1, true, pRequiresNonNegative) &&
+                   IsMonotonicallyIncreasing(op2, true, pRequiresNonNegative);
 
         case GT_CNS_INT:
-            if (op2->AsIntConCommon()->IconValue() < 0)
+        {
+            const ssize_t constant = op2->AsIntConCommon()->IconValue();
+            if (constant < 0)
             {
                 JITDUMP("Not monotonically increasing because of encountered negative constant\n");
                 return false;
             }
 
-            return IsMonotonicallyIncreasing(op1, false);
+            if (binop->OperIs(GT_MUL) && (constant == 0))
+            {
+                JITDUMP("Not monotonically increasing because of multiplication by zero\n");
+                return false;
+            }
+
+            // Multiplication and non-identity left shifts only increase non-negative values.
+            const bool operationRequiresNonNegative =
+                binop->OperIs(GT_MUL) || (binop->OperIs(GT_LSH) && (constant != 0));
+            *pRequiresNonNegative |= operationRequiresNonNegative;
+            return IsMonotonicallyIncreasing(op1, rejectNegativeConst || operationRequiresNonNegative,
+                                             pRequiresNonNegative);
+        }
 
         default:
             JITDUMP("Not monotonically increasing because expression is not recognized.\n");
@@ -354,9 +380,11 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
     }
 }
 
-// The parameter rejectNegativeConst is true when we are adding two local vars (see above)
-bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeConst)
+// rejectNegativeConst is true when all constants contributing to the expression must be non-negative.
+bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeConst, bool* pRequiresNonNegative)
 {
+    assert(pRequiresNonNegative != nullptr);
+
     JITDUMP("[RangeCheck::IsMonotonicallyIncreasing] [%06d]\n", Compiler::dspTreeID(expr));
 
     if (IsOverBudget())
@@ -402,11 +430,12 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
     else if (expr->IsLocal())
     {
         LclSsaVarDsc* ssaDef = GetSsaDefStore(expr->AsLclVarCommon());
-        return (ssaDef != nullptr) && IsMonotonicallyIncreasing(ssaDef->GetDefNode()->Data(), rejectNegativeConst);
+        return (ssaDef != nullptr) &&
+               IsMonotonicallyIncreasing(ssaDef->GetDefNode()->Data(), rejectNegativeConst, pRequiresNonNegative);
     }
     else if (expr->OperIs(GT_ADD, GT_MUL, GT_LSH))
     {
-        return IsBinOpMonotonicallyIncreasing(expr->AsOp());
+        return IsBinOpMonotonicallyIncreasing(expr->AsOp(), rejectNegativeConst, pRequiresNonNegative);
     }
     else if (expr->OperIs(GT_PHI))
     {
@@ -417,7 +446,7 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
             {
                 continue;
             }
-            if (!IsMonotonicallyIncreasing(use.GetNode(), rejectNegativeConst))
+            if (!IsMonotonicallyIncreasing(use.GetNode(), rejectNegativeConst, pRequiresNonNegative))
             {
                 JITDUMP("Phi argument not monotonically increasing\n");
                 return false;
@@ -427,7 +456,7 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
     }
     else if (expr->OperIs(GT_COMMA))
     {
-        return IsMonotonicallyIncreasing(expr->gtEffectiveVal(), rejectNegativeConst);
+        return IsMonotonicallyIncreasing(expr->gtEffectiveVal(), rejectNegativeConst, pRequiresNonNegative);
     }
     JITDUMP("Unknown tree type\n");
     return false;

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -301,16 +301,7 @@ void RangeCheck::Widen(BasicBlock* block, GenTree* tree, Range* pRange)
     if (range.LowerLimit().IsDependent() || range.LowerLimit().IsUnknown())
     {
         // To determine the lower bound, ask if the loop increases monotonically.
-        bool requiresNonNegative = false;
-        bool increasing          = IsMonotonicallyIncreasing(tree, false, &requiresNonNegative);
-        if (increasing && requiresNonNegative)
-        {
-            // Apply the requirement from the root so it reaches phi initial values regardless
-            // of whether they are visited before or after the backedge that introduced it.
-            ClearSearchPath();
-            increasing = IsMonotonicallyIncreasing(tree, true, &requiresNonNegative);
-        }
-
+        bool increasing = IsMonotonicallyIncreasing(tree, false);
         if (increasing)
         {
             JITDUMP("[%06d] is monotonically increasing.\n", Compiler::dspTreeID(tree));
@@ -320,10 +311,15 @@ void RangeCheck::Widen(BasicBlock* block, GenTree* tree, Range* pRange)
     }
 }
 
-bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop, bool rejectNegativeConst, bool* pRequiresNonNegative)
+bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
 {
     assert(binop->OperIs(GT_ADD, GT_MUL, GT_LSH));
-    assert(pRequiresNonNegative != nullptr);
+
+    if (!binop->OperIs(GT_ADD))
+    {
+        JITDUMP("Not monotonically increasing because operation is not addition\n");
+        return false;
+    }
 
     GenTree* op1 = binop->gtGetOp1();
     GenTree* op2 = binop->gtGetOp2();
@@ -332,7 +328,7 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop, bool rejectNeg
             Compiler::dspTreeID(op2));
 
     // Check if we have a var + const or var * const.
-    if (binop->OperIs(GT_ADD, GT_MUL) && op2->OperIs(GT_LCL_VAR))
+    if (op2->OperIs(GT_LCL_VAR))
     {
         std::swap(op1, op2);
     }
@@ -345,34 +341,17 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop, bool rejectNeg
     switch (op2->OperGet())
     {
         case GT_LCL_VAR:
-            // When adding/multiplying/shifting two local variables, we also must ensure that any constant is
-            // non-negative.
-            *pRequiresNonNegative = true;
-            return IsMonotonicallyIncreasing(op1, true, pRequiresNonNegative) &&
-                   IsMonotonicallyIncreasing(op2, true, pRequiresNonNegative);
+            // When adding two local variables, we also must ensure that any constant is non-negative.
+            return IsMonotonicallyIncreasing(op1, true) && IsMonotonicallyIncreasing(op2, true);
 
         case GT_CNS_INT:
-        {
-            const ssize_t constant = op2->AsIntConCommon()->IconValue();
-            if (constant < 0)
+            if (op2->AsIntConCommon()->IconValue() < 0)
             {
                 JITDUMP("Not monotonically increasing because of encountered negative constant\n");
                 return false;
             }
 
-            if (binop->OperIs(GT_MUL) && (constant == 0))
-            {
-                JITDUMP("Not monotonically increasing because of multiplication by zero\n");
-                return false;
-            }
-
-            // Multiplication and non-identity left shifts only increase non-negative values.
-            const bool operationRequiresNonNegative =
-                binop->OperIs(GT_MUL) || (binop->OperIs(GT_LSH) && (constant != 0));
-            *pRequiresNonNegative |= operationRequiresNonNegative;
-            return IsMonotonicallyIncreasing(op1, rejectNegativeConst || operationRequiresNonNegative,
-                                             pRequiresNonNegative);
-        }
+            return IsMonotonicallyIncreasing(op1, false);
 
         default:
             JITDUMP("Not monotonically increasing because expression is not recognized.\n");
@@ -380,11 +359,9 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop, bool rejectNeg
     }
 }
 
-// rejectNegativeConst is true when all constants contributing to the expression must be non-negative.
-bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeConst, bool* pRequiresNonNegative)
+// The parameter rejectNegativeConst is true when we are adding two local vars (see above)
+bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeConst)
 {
-    assert(pRequiresNonNegative != nullptr);
-
     JITDUMP("[RangeCheck::IsMonotonicallyIncreasing] [%06d]\n", Compiler::dspTreeID(expr));
 
     if (IsOverBudget())
@@ -430,12 +407,11 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
     else if (expr->IsLocal())
     {
         LclSsaVarDsc* ssaDef = GetSsaDefStore(expr->AsLclVarCommon());
-        return (ssaDef != nullptr) &&
-               IsMonotonicallyIncreasing(ssaDef->GetDefNode()->Data(), rejectNegativeConst, pRequiresNonNegative);
+        return (ssaDef != nullptr) && IsMonotonicallyIncreasing(ssaDef->GetDefNode()->Data(), rejectNegativeConst);
     }
     else if (expr->OperIs(GT_ADD, GT_MUL, GT_LSH))
     {
-        return IsBinOpMonotonicallyIncreasing(expr->AsOp(), rejectNegativeConst, pRequiresNonNegative);
+        return IsBinOpMonotonicallyIncreasing(expr->AsOp());
     }
     else if (expr->OperIs(GT_PHI))
     {
@@ -446,7 +422,7 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
             {
                 continue;
             }
-            if (!IsMonotonicallyIncreasing(use.GetNode(), rejectNegativeConst, pRequiresNonNegative))
+            if (!IsMonotonicallyIncreasing(use.GetNode(), rejectNegativeConst))
             {
                 JITDUMP("Phi argument not monotonically increasing\n");
                 return false;
@@ -456,7 +432,7 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
     }
     else if (expr->OperIs(GT_COMMA))
     {
-        return IsMonotonicallyIncreasing(expr->gtEffectiveVal(), rejectNegativeConst, pRequiresNonNegative);
+        return IsMonotonicallyIncreasing(expr->gtEffectiveVal(), rejectNegativeConst);
     }
     JITDUMP("Unknown tree type\n");
     return false;

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -931,10 +931,10 @@ private:
     void Widen(BasicBlock* block, GenTree* tree, Range* pRange);
 
     // Is the binary operation increasing the value.
-    bool IsBinOpMonotonicallyIncreasing(GenTreeOp* binop, bool rejectNegativeConst, bool* pRequiresNonNegative);
+    bool IsBinOpMonotonicallyIncreasing(GenTreeOp* binop);
 
     // Given an expression trace its value to check if it is monotonically increasing.
-    bool IsMonotonicallyIncreasing(GenTree* tree, bool rejectNegativeConst, bool* pRequiresNonNegative);
+    bool IsMonotonicallyIncreasing(GenTree* tree, bool rejectNegativeConst);
 
     // We allocate a budget to avoid walking long UD chains. When traversing each link in the UD
     // chain, we decrement the budget. When the budget hits 0, then no more range check optimization

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -931,10 +931,10 @@ private:
     void Widen(BasicBlock* block, GenTree* tree, Range* pRange);
 
     // Is the binary operation increasing the value.
-    bool IsBinOpMonotonicallyIncreasing(GenTreeOp* binop);
+    bool IsBinOpMonotonicallyIncreasing(GenTreeOp* binop, bool rejectNegativeConst, bool* pRequiresNonNegative);
 
     // Given an expression trace its value to check if it is monotonically increasing.
-    bool IsMonotonicallyIncreasing(GenTree* tree, bool rejectNegativeConst);
+    bool IsMonotonicallyIncreasing(GenTree* tree, bool rejectNegativeConst, bool* pRequiresNonNegative);
 
     // We allocate a budget to avoid walking long UD chains. When traversing each link in the UD
     // chain, we decrement the budget. When the budget hits 0, then no more range check optimization

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130425/Runtime_130425.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130425/Runtime_130425.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Runtime_130425;
+
+public class Runtime_130425
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Equal(1, Test(3));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int Test(int iterationCount)
+    {
+        int result = 0;
+        int iteration = 0;
+
+        for (int i = -1; (i < 0) && (iteration < iterationCount); i *= 2)
+        {
+            if (i < -2)
+            {
+                result++;
+            }
+
+            iteration++;
+        }
+
+        return result;
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -113,6 +113,7 @@
     <Compile Include="JitBlue\Runtime_130216\Runtime_130216.cs" />
     <Compile Include="JitBlue\Runtime_130248\Runtime_130248.cs" />
     <Compile Include="JitBlue\Runtime_130286\Runtime_130286.cs" />
+    <Compile Include="JitBlue\Runtime_130425\Runtime_130425.cs" />
     <Compile Include="JitBlue\Runtime_10337\Runtime_10337.cs" />
     <Compile Include="JitBlue\Runtime_125160\Runtime_125160.cs" />
   </ItemGroup>


### PR DESCRIPTION
Range analysis treated multiplication and left shifts as monotonically increasing even though both operations can decrease negative values. This could widen an invalid range and incorrectly fold comparisons.

Conservatively restrict monotonic widening to addition. SuperPMI `benchmarks.run` showed zero asm diffs compared with the more precise fix. Adds a regression test for the reported miscompile.

Fixes #130425.