### PR TITLE
Fix XmlSerializer regression for derived XmlText properties

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionImporter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlReflectionImporter.cs
@@ -860,19 +860,20 @@ namespace System.Xml.Serialization
                 {
                     MemberMapping? member = ImportFieldMapping(model, fieldModel, memberAttrs, mapping.Namespace, limiter);
                     if (member == null) continue;
-                    if (mapping.BaseMapping != null)
+                    bool memberDeclaredByBase = mapping.BaseMapping != null && mapping.BaseMapping.Declares(member, mapping.TypeName);
+                    if (memberDeclaredByBase)
                     {
                         // If the base mapping already declares this member, then we should remove that accessor and prefer the derived one.
-                        if (mapping.BaseMapping.Declares(member, mapping.TypeName))
-                        {
-                            RemoveUniqueAccessor(member, mapping.LocalElements, mapping.LocalAttributes, isSequence);
-                        }
+                        RemoveUniqueAccessor(member, mapping.LocalElements, mapping.LocalAttributes, isSequence);
                     }
                     isSequence |= member.IsSequence;
                     // add All member accessors to the scope accessors
                     AddUniqueAccessor(member, mapping.LocalElements, mapping.LocalAttributes, isSequence);
 
-                    if (member.Text != null)
+                    // Skip text/xmlns tracking for members that override a base mapping's member:
+                    // the base mapping already registered the accessor; re-registering it here
+                    // would falsely trigger the simpleContent extension check in SetContentModel.
+                    if (member.Text != null && !memberDeclaredByBase)
                     {
                         if (!member.Text.Mapping!.TypeDesc!.CanBeTextValue && member.Text.Mapping.IsList)
                             throw new InvalidOperationException(SR.Format(SR.XmlIllegalTypedTextAttribute, typeName, member.Text.Name, member.Text.Mapping.TypeDesc.FullName));
@@ -882,7 +883,7 @@ namespace System.Xml.Serialization
                         }
                         textAccessor = member.Text;
                     }
-                    if (member.Xmlns != null)
+                    if (member.Xmlns != null && !memberDeclaredByBase)
                     {
                         if (mapping.XmlnsMember != null)
                             throw new InvalidOperationException(SR.Format(SR.XmlMultipleXmlns, model.Type.FullName));

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -3742,6 +3742,21 @@ public static partial class XmlSerializerTests
         Assert.Equal(value.Number, actual.Number);
     }
 
+    [Fact]
+    public static void Xml_DerivedTypeOverridingVirtualXmlTextProperty_CanSerialize()
+    {
+        // Regression test: XmlSerializer must not throw when a derived class re-declares
+        // [XmlText] on a virtual property override of a base class that also has [XmlText].
+        var value = new CustomerWithGroupIdRef
+        {
+            GroupIdRef = new GroupIdRef("RefValue", "SomeType")
+        };
+        CustomerWithGroupIdRef actual = SerializeAndDeserialize(value,
+            "<?xml version=\"1.0\"?><CustomerWithGroupIdRef xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><GROUP_IDREF type=\"SomeType\">RefValue</GROUP_IDREF></CustomerWithGroupIdRef>");
+        Assert.Equal("RefValue", actual.GroupIdRef?.Value);
+        Assert.Equal("SomeType", actual.GroupIdRef?.Type);
+    }
+
     [Theory]
     [InlineData(@"<TypeWithXmlElementMemberAndSibling xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><Description><p>text</p></Description><Name>Test</Name></TypeWithXmlElementMemberAndSibling>", "Test", true, "p", "text")]
     [InlineData(@"<TypeWithXmlElementMemberAndSibling xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><Description /><Name>Test</Name></TypeWithXmlElementMemberAndSibling>", "Test", false, null, null)]

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -3757,6 +3757,46 @@ public static partial class XmlSerializerTests
         Assert.Equal("SomeType", actual.GroupIdRef?.Type);
     }
 
+    [Fact]
+    public static void Xml_DerivedTypeOverridingVirtualXmlAttributeProperty_CanSerialize()
+    {
+        // Overriding a virtual [XmlAttribute] property is allowed as long as the override keeps the
+        // same attribute name. Serialization writes the attribute and deserialization assigns the
+        // overridden property (the derived setter runs).
+        var serializer = new XmlSerializer(typeof(GroupWithSameNameAttributeOverride));
+        var value = new GroupWithSameNameAttributeOverride { Code = "XYZ" };
+
+        using var ms = new MemoryStream();
+        serializer.Serialize(ms, value);
+        ms.Position = 0;
+        string xml = new StreamReader(ms).ReadToEnd();
+        Assert.Contains("aprop=\"XYZ\"", xml);
+
+        ms.Position = 0;
+        var actual = (GroupWithSameNameAttributeOverride)serializer.Deserialize(ms);
+        Assert.Equal("XYZ", actual.Code);
+        Assert.True(actual.DerivedSetterInvoked);
+    }
+
+    [Fact]
+    public static void Xml_DerivedTypeRenamingOverriddenXmlAttribute_Throws()
+    {
+        // Overriding a virtual [XmlAttribute] property but giving it a different attribute name is
+        // an invalid override; XmlSerializer rejects it rather than choosing one name over the other.
+        Assert.Throws<InvalidOperationException>(() =>
+            SerializeAndDeserialize(new GroupWithRenamedAttributeOverride { Code = "v" }, string.Empty, skipStringCompare: true));
+    }
+
+    [Fact]
+    public static void Xml_DerivedTypeDroppingOverriddenXmlAttribute_Throws()
+    {
+        // XmlSerializer reads member attributes without inheritance, so an override that omits
+        // [XmlAttribute] maps as an element and conflicts with the base attribute mapping. This is
+        // an invalid override and XmlSerializer rejects it.
+        Assert.Throws<InvalidOperationException>(() =>
+            SerializeAndDeserialize(new GroupWithDroppedAttributeOverride { Code = "v" }, string.Empty, skipStringCompare: true));
+    }
+
     [Theory]
     [InlineData(@"<TypeWithXmlElementMemberAndSibling xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><Description><p>text</p></Description><Name>Test</Name></TypeWithXmlElementMemberAndSibling>", "Test", true, "p", "text")]
     [InlineData(@"<TypeWithXmlElementMemberAndSibling xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""><Description /><Name>Test</Name></TypeWithXmlElementMemberAndSibling>", "Test", false, null, null)]

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -2385,6 +2385,47 @@ namespace SerializationTypes
             return obj;
         }
     }
+
+    // XmlSerializer test types: derived class overriding virtual [XmlText] property from base.
+    public class CustomerWithGroupIdRef
+    {
+        [XmlElement("GROUP_IDREF")]
+        public GroupIdRef? GroupIdRef { get; set; }
+    }
+
+    public abstract class GroupIdRefBase<TConcrete> where TConcrete : GroupIdRefBase<TConcrete>
+    {
+        public GroupIdRefBase() { Value = null!; }
+
+        public GroupIdRefBase(string value, string? type)
+        {
+            Type = type;
+            Value = value;
+        }
+
+        [XmlAttribute("type")]
+        public virtual string? Type { get; set; }
+
+        [XmlText]
+        public virtual string Value { get; set; }
+    }
+
+    public class GroupIdRef : GroupIdRefBase<GroupIdRef>
+    {
+        public GroupIdRef() { Value = null!; }
+
+        public GroupIdRef(string value, string? type)
+        {
+            Type = type;
+            Value = value;
+        }
+
+        [XmlAttribute("type")]
+        public override string? Type { get; set; }
+
+        [XmlText]
+        public override string Value { get; set; }
+    }
 }
 
 namespace DuplicateTypeNamesTest.ns1

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -2426,6 +2426,49 @@ namespace SerializationTypes
         [XmlText]
         public override string Value { get; set; }
     }
+
+    // XmlSerializer test types: overriding a virtual [XmlAttribute] property in a derived class.
+    // The base maps 'Code' to an attribute named "aprop".
+    public class GroupWithAttributeBase
+    {
+        [XmlAttribute("aprop")]
+        public virtual string? Code { get; set; }
+    }
+
+    // Valid override: re-applies [XmlAttribute] with the same name. The derived setter records
+    // that it was invoked so deserialization can be shown to assign the overridden property.
+    public class GroupWithSameNameAttributeOverride : GroupWithAttributeBase
+    {
+        private string? _code;
+
+        [XmlIgnore]
+        public bool DerivedSetterInvoked { get; private set; }
+
+        [XmlAttribute("aprop")]
+        public override string? Code
+        {
+            get => _code;
+            set
+            {
+                _code = value;
+                DerivedSetterInvoked = true;
+            }
+        }
+    }
+
+    // Invalid override: the override maps the same property to a different attribute name.
+    public class GroupWithRenamedAttributeOverride : GroupWithAttributeBase
+    {
+        [XmlAttribute("bprop")]
+        public override string? Code { get; set; }
+    }
+
+    // Invalid override: the override omits [XmlAttribute]. XmlSerializer reads member attributes
+    // without inheritance, so the override maps as an element and conflicts with the base attribute.
+    public class GroupWithDroppedAttributeOverride : GroupWithAttributeBase
+    {
+        public override string? Code { get; set; }
+    }
 }
 
 namespace DuplicateTypeNamesTest.ns1


### PR DESCRIPTION
Fix XmlSerializer regression: derived [XmlText]/[XmlNamespaceDeclarations] overrides on simpleContent base

When a derived class re-declares [XmlText] (or [XmlNamespaceDeclarations]) on
a virtual property override, InitializeStructMembers was incorrectly tracking
those as new text/xmlns accessors for the derived mapping. When the base
mapping has HasSimpleContent == true (only [XmlText], no elements), this caused
SetContentModel to throw XmlIllegalSimpleContentExtension.

Root cause: commit cc2019b changed the handling of base-declared members
from 'continue' (skip entirely) to 'RemoveUniqueAccessor + fall-through'. This
kept the derived member's element/attribute accessors correctly registered, but
also let text and xmlns accessors be registered again, which the simpleContent
check in SetContentModel rejects.

Fix: introduce 'memberDeclaredByBase' and guard the text and xmlns accessor
tracking with '&& !memberDeclaredByBase'. The derived member's accessors are
still correctly registered via AddUniqueAccessor and added to mapping.Members
(preserving cc2019b's intent for the reflection-based serializer); only
the content-model-level tracking is suppressed for inherited overrides.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #121881