### PR TITLE
Add support for immutable collections with CollectionBuilderAttribute

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -559,12 +559,88 @@ namespace System.Xml.Serialization
 
                 collection = a;
             }
+            else if (TryBuildWithCollectionBuilder(collectionType, collectionMember, out object? built))
+            {
+                Debug.Assert(built != null);
+                collection = built;
+            }
             else
             {
                 collection ??= ReflectionCreateObject(collectionType)!;
 
                 AddObjectsIntoTargetCollection(collection, collectionMember, collectionType);
             }
+        }
+
+        // If collectionType has a [CollectionBuilder] (e.g. ImmutableArray/List/Stack/Queue/HashSet/SortedSet),
+        // accumulate items into a typed array and invoke the static factory method instead of trying to
+        // construct the type directly + call Add (which would fail or silently no-op for immutables).
+        private static bool TryBuildWithCollectionBuilder(
+            [DynamicallyAccessedMembers(TrimmerConstants.AllMethods)] Type collectionType,
+            CollectionMember collectionMember,
+            out object? built)
+        {
+            built = null;
+            Type? elementType = GetEnumerableElementType(collectionType);
+            if (elementType == null)
+                return false;
+
+            MethodInfo? factory = TypeScope.GetCollectionBuilderMethod(collectionType, elementType);
+            if (factory == null)
+                return false;
+
+            Array buffer = Array.CreateInstance(elementType, collectionMember.Count);
+            for (int i = 0; i < collectionMember.Count; i++)
+            {
+                buffer.SetValue(collectionMember[i], i);
+            }
+
+            // ImmutableStack.Create(arr) pushes arr[0] first so arr[last] ends up on top — which inverts
+            // enumeration order on round-trip. Reverse the buffer first so the deserialized stack enumerates
+            // in the same order as the serialized one.
+            if (collectionType.IsGenericType &&
+                collectionType.GetGenericTypeDefinition().FullName == "System.Collections.Immutable.ImmutableStack`1")
+            {
+                Array.Reverse(buffer);
+            }
+
+            object? arg = buffer;
+            ParameterInfo[] pars = factory.GetParameters();
+            Debug.Assert(pars.Length == 1);
+            Type paramType = pars[0].ParameterType;
+            if (paramType.IsGenericType && paramType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>))
+            {
+                // ReadOnlySpan<T> is a ref struct and cannot be passed via MethodBase.Invoke.
+                // Build an Expression that converts the array to ReadOnlySpan<T> and invokes the factory.
+                MethodInfo? op = paramType.GetMethod("op_Implicit", BindingFlags.Public | BindingFlags.Static,
+                    new Type[] { elementType.MakeArrayType() });
+                if (op == null)
+                    return false;
+                ParameterExpression p = Expression.Parameter(typeof(Array), "arr");
+                Expression call = Expression.Call(factory, Expression.Call(op, Expression.Convert(p, elementType.MakeArrayType())));
+                if (factory.ReturnType != typeof(object))
+                {
+                    call = Expression.Convert(call, typeof(object));
+                }
+                Func<Array, object> invoker = Expression.Lambda<Func<Array, object>>(call, p).Compile();
+                built = invoker(buffer);
+                return true;
+            }
+
+            built = factory.Invoke(null, new object?[] { arg });
+            return true;
+        }
+
+        private static Type? GetEnumerableElementType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
+        {
+            foreach (Type itf in type.GetInterfaces())
+            {
+                if (itf.IsGenericType && itf.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    return itf.GetGenericArguments()[0];
+                }
+            }
+            return null;
         }
 
         private static void AddObjectsIntoTargetCollection(object targetCollection, List<object?> sourceCollection,
@@ -1137,7 +1213,9 @@ namespace System.Xml.Serialization
                     };
 
                     Type collectionType = memberMapping.TypeDesc!.Type!;
-                    o = ReflectionCreateObject(memberMapping.TypeDesc.Type!);
+                    o = memberMapping.TypeDesc.UsesCollectionBuilder
+                        ? null
+                        : ReflectionCreateObject(memberMapping.TypeDesc.Type!);
 
                     // When this array is the value of a member that carries an [XmlChoiceIdentifier]
                     // (e.g. one of the choice element types is itself an array), the parallel choice

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -996,9 +996,12 @@ namespace System.Xml.Serialization
             }
 
             // Discover [CollectionBuilder] for Collection/Enumerable types (e.g. System.Collections.Immutable).
-            // This allows XmlSerializer to deserialize immutable collections by accumulating items and
-            // then invoking the static factory method to build the immutable instance.
-            // IDictionary is not supported by XmlSerializer at all, so don't try to handle it here.
+            // This allows XmlSerializer to deserialize immutable collections by accumulating items into a T[]
+            // and then invoking the static factory method to build the immutable instance.
+            //
+            // IDictionary-implementing types are unsupported by XmlSerializer regardless of [CollectionBuilder]
+            // (see GetDefaultIndexer which unconditionally throws for them), so we skip them here to preserve
+            // the pre-existing NotSupportedException behavior instead of silently starting to accept them.
             MethodInfo? collectionBuilderMethod = null;
             if ((kind == TypeKind.Collection || kind == TypeKind.Enumerable) &&
                 arrayElementType != null &&
@@ -1009,6 +1012,14 @@ namespace System.Xml.Serialization
 #pragma warning restore IL3050
                 if (collectionBuilderMethod != null)
                 {
+                    // Builder-backed types never have a usable public parameterless ctor (the whole point of
+                    // [CollectionBuilder] is to funnel construction through the factory method). Setting the
+                    // HasDefaultConstructor flag here is a signal to the rest of the pipeline that we CAN
+                    // produce an instance of this type — the ILGen/Reflection reader paths gated on
+                    // UsesCollectionBuilder short-circuit before any actual `newobj`/`Activator.CreateInstance`
+                    // call and invoke the factory instead. Without this flag various downstream checks
+                    // (e.g. ArrayMapping xsi:type dispatch, read-only member rejection) would incorrectly
+                    // treat the type as unconstructible.
                     flags |= TypeFlags.UsesCollectionBuilder | TypeFlags.HasDefaultConstructor;
                     flags &= ~TypeFlags.CtorInaccessible;
                     exception = null; // suppress any earlier exception (e.g., no Add method)
@@ -1017,12 +1028,7 @@ namespace System.Xml.Serialization
 
             typeDesc = new TypeDesc(type, CodeIdentifier.MakeValid(TypeName(type)), type.ToString(), kind, null, flags, null);
             typeDesc.Exception = exception;
-            if (collectionBuilderMethod != null)
-            {
-                typeDesc.CollectionBuilderMethod = collectionBuilderMethod;
-            }
-
-
+            typeDesc.CollectionBuilderMethod = collectionBuilderMethod;
             if (directReference && (typeDesc.IsClass || kind == TypeKind.Serializable))
                 typeDesc.CheckNeedConstructor();
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -279,7 +279,7 @@ namespace System.Xml.Serialization
 
         internal bool CannotNew
         {
-            get { return !HasDefaultConstructor || ConstructorInaccessible; }
+            get { return (!HasDefaultConstructor && !UsesCollectionBuilder) || ConstructorInaccessible; }
         }
 
         internal bool IsAbstract
@@ -396,7 +396,7 @@ namespace System.Xml.Serialization
 
         internal void CheckNeedConstructor()
         {
-            if (!IsValueType && !IsAbstract && !HasDefaultConstructor)
+            if (!IsValueType && !IsAbstract && !HasDefaultConstructor && !UsesCollectionBuilder)
             {
                 _flags |= TypeFlags.Unsupported;
                 _exception = new InvalidOperationException(SR.Format(SR.XmlConstructorInaccessible, FullName));
@@ -1012,15 +1012,12 @@ namespace System.Xml.Serialization
 #pragma warning restore IL3050
                 if (collectionBuilderMethod != null)
                 {
-                    // Builder-backed types never have a usable public parameterless ctor (the whole point of
-                    // [CollectionBuilder] is to funnel construction through the factory method). Setting the
-                    // HasDefaultConstructor flag here is a signal to the rest of the pipeline that we CAN
-                    // produce an instance of this type — the ILGen/Reflection reader paths gated on
-                    // UsesCollectionBuilder short-circuit before any actual `newobj`/`Activator.CreateInstance`
-                    // call and invoke the factory instead. Without this flag various downstream checks
-                    // (e.g. ArrayMapping xsi:type dispatch, read-only member rejection) would incorrectly
-                    // treat the type as unconstructible.
-                    flags |= TypeFlags.UsesCollectionBuilder | TypeFlags.HasDefaultConstructor;
+                    // Builder-backed types don't have (or shouldn't use) a public parameterless ctor —
+                    // that's the whole point of [CollectionBuilder]. Do NOT set HasDefaultConstructor.
+                    // Instead, CannotNew / CheckNeedConstructor now also honor UsesCollectionBuilder so
+                    // downstream checks that ask "can we produce an instance of this?" get the right
+                    // answer while HasDefaultConstructor remains factually accurate.
+                    flags |= TypeFlags.UsesCollectionBuilder;
                     flags &= ~TypeFlags.CtorInaccessible;
                     exception = null; // suppress any earlier exception (e.g., no Add method)
                 }
@@ -1029,6 +1026,7 @@ namespace System.Xml.Serialization
             typeDesc = new TypeDesc(type, CodeIdentifier.MakeValid(TypeName(type)), type.ToString(), kind, null, flags, null);
             typeDesc.Exception = exception;
             typeDesc.CollectionBuilderMethod = collectionBuilderMethod;
+
             if (directReference && (typeDesc.IsClass || kind == TypeKind.Serializable))
                 typeDesc.CheckNeedConstructor();
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -279,7 +279,7 @@ namespace System.Xml.Serialization
 
         internal bool CannotNew
         {
-            get { return (!HasDefaultConstructor && !UsesCollectionBuilder) || ConstructorInaccessible; }
+            get { return !HasDefaultConstructor || ConstructorInaccessible; }
         }
 
         internal bool IsAbstract

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml;
 using System.Xml.Schema;
@@ -61,6 +62,7 @@ namespace System.Xml.Serialization
         UsePrivateImplementation = 0x40000,
         GenericInterface = 0x80000,
         Unsupported = 0x100000,
+        UsesCollectionBuilder = 0x200000,
     }
 
     // Shorthands for common trimmer constants
@@ -262,6 +264,13 @@ namespace System.Xml.Serialization
         {
             get { return (_flags & TypeFlags.GenericInterface) != 0; }
         }
+
+        internal bool UsesCollectionBuilder
+        {
+            get { return (_flags & TypeFlags.UsesCollectionBuilder) != 0; }
+        }
+
+        internal MethodInfo? CollectionBuilderMethod { get; set; }
 
         internal bool IsPrivateImplementation
         {
@@ -875,7 +884,18 @@ namespace System.Xml.Serialization
             else if (typeof(ICollection).IsAssignableFrom(type) && !IsArraySegment(type))
             {
                 kind = TypeKind.Collection;
-                arrayElementType = GetCollectionElementType(type, memberInfo == null ? null : $"{memberInfo.DeclaringType!.FullName}.{memberInfo.Name}");
+                // For types decorated with [CollectionBuilder] (e.g. ImmutableHashSet<T>, ImmutableSortedSet<T>),
+                // skip the default-indexer / Add-method discovery. The element type is the generic argument of
+                // the factory method; the type is finalized later via the [CollectionBuilder] detection block.
+                Type? builderElementType = TryGetCollectionBuilderElementType(type);
+                if (builderElementType != null)
+                {
+                    arrayElementType = builderElementType;
+                }
+                else
+                {
+                    arrayElementType = GetCollectionElementType(type, memberInfo == null ? null : $"{memberInfo.DeclaringType!.FullName}.{memberInfo.Name}");
+                }
                 flags |= GetConstructorFlags(type);
             }
             else if (type == typeof(XmlQualifiedName))
@@ -974,8 +994,34 @@ namespace System.Xml.Serialization
                     flags |= GetConstructorFlags(type);
                 }
             }
+
+            // Discover [CollectionBuilder] for Collection/Enumerable types (e.g. System.Collections.Immutable).
+            // This allows XmlSerializer to deserialize immutable collections by accumulating items and
+            // then invoking the static factory method to build the immutable instance.
+            // IDictionary is not supported by XmlSerializer at all, so don't try to handle it here.
+            MethodInfo? collectionBuilderMethod = null;
+            if ((kind == TypeKind.Collection || kind == TypeKind.Enumerable) &&
+                arrayElementType != null &&
+                !typeof(IDictionary).IsAssignableFrom(type))
+            {
+#pragma warning disable IL3050 // RequiresDynamicCode — XmlSerializer ILGen already uses dynamic code.
+                collectionBuilderMethod = GetCollectionBuilderMethod(type, arrayElementType);
+#pragma warning restore IL3050
+                if (collectionBuilderMethod != null)
+                {
+                    flags |= TypeFlags.UsesCollectionBuilder | TypeFlags.HasDefaultConstructor;
+                    flags &= ~TypeFlags.CtorInaccessible;
+                    exception = null; // suppress any earlier exception (e.g., no Add method)
+                }
+            }
+
             typeDesc = new TypeDesc(type, CodeIdentifier.MakeValid(TypeName(type)), type.ToString(), kind, null, flags, null);
             typeDesc.Exception = exception;
+            if (collectionBuilderMethod != null)
+            {
+                typeDesc.CollectionBuilderMethod = collectionBuilderMethod;
+            }
+
 
             if (directReference && (typeDesc.IsClass || kind == TypeKind.Serializable))
                 typeDesc.CheckNeedConstructor();
@@ -1075,7 +1121,12 @@ namespace System.Xml.Serialization
             else if (IsArraySegment(type))
                 return null;
             else if (typeof(ICollection).IsAssignableFrom(type))
+            {
+                Type? builderElementType = TryGetCollectionBuilderElementType(type);
+                if (builderElementType != null)
+                    return builderElementType;
                 return GetCollectionElementType(type, memberInfo);
+            }
             else if (typeof(IEnumerable).IsAssignableFrom(type))
             {
                 TypeFlags flags = TypeFlags.None;
@@ -1329,6 +1380,102 @@ namespace System.Xml.Serialization
             return 0;
         }
 
+        // Returns the static factory MethodInfo identified by [CollectionBuilderAttribute] on collectionType,
+        // bound to the collection's element type, or null if not applicable.
+        // Returns the element type for a [CollectionBuilder]-decorated single-T generic collection,
+        // or null if the type has no [CollectionBuilder] attribute or isn't a single-arg generic.
+        [RequiresUnreferencedCode("Looks up CollectionBuilderAttribute via reflection")]
+        internal static Type? TryGetCollectionBuilderElementType(Type collectionType)
+        {
+            if (!collectionType.IsGenericType)
+                return null;
+
+            if (collectionType.GetCustomAttribute<CollectionBuilderAttribute>(inherit: false) == null)
+                return null;
+
+            Type[] genArgs = collectionType.GetGenericArguments();
+            if (genArgs.Length != 1)
+                return null;
+
+            return genArgs[0];
+        }
+
+        // Prefers a Create<T>(T[]) overload, falls back to Create<T>(ReadOnlySpan<T>).
+        [RequiresUnreferencedCode("Looks up factory method via reflection")]
+        [RequiresDynamicCode("Calls MakeGenericMethod on the factory")]
+        internal static MethodInfo? GetCollectionBuilderMethod(Type collectionType, Type elementType)
+        {
+            if (!collectionType.IsGenericType)
+                return null;
+
+            CollectionBuilderAttribute? builder = collectionType.GetCustomAttribute<CollectionBuilderAttribute>(inherit: false);
+            if (builder == null)
+                return null;
+
+            Type builderType = builder.BuilderType;
+            string methodName = builder.MethodName;
+
+            // Try Create<T>(T[]) first.
+            MethodInfo? best = null;
+            foreach (MethodInfo m in builderType.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (m.Name != methodName || !m.IsGenericMethodDefinition)
+                    continue;
+                Type[] genArgs = m.GetGenericArguments();
+                if (genArgs.Length != 1)
+                    continue;
+                ParameterInfo[] pars = m.GetParameters();
+                if (pars.Length != 1)
+                    continue;
+                Type pt = pars[0].ParameterType;
+                // Look for T[]
+                if (pt.IsArray && pt.GetElementType() == genArgs[0])
+                {
+                    best = m;
+                    break;
+                }
+            }
+
+            if (best == null)
+            {
+                // Fall back to Create<T>(ReadOnlySpan<T>)
+                foreach (MethodInfo m in builderType.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                {
+                    if (m.Name != methodName || !m.IsGenericMethodDefinition)
+                        continue;
+                    Type[] genArgs = m.GetGenericArguments();
+                    if (genArgs.Length != 1)
+                        continue;
+                    ParameterInfo[] pars = m.GetParameters();
+                    if (pars.Length != 1)
+                        continue;
+                    Type pt = pars[0].ParameterType;
+                    if (pt.IsGenericType && pt.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>) &&
+                        pt.GetGenericArguments()[0] == genArgs[0])
+                    {
+                        best = m;
+                        break;
+                    }
+                }
+            }
+
+            if (best == null)
+                return null;
+
+            try
+            {
+                MethodInfo bound = best.MakeGenericMethod(elementType);
+                // Sanity check the return type assignability
+                if (!collectionType.IsAssignableFrom(bound.ReturnType))
+                    return null;
+                return bound;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         [RequiresUnreferencedCode("Needs to mark members on the return type of the GetEnumerator method")]
         private static Type? GetEnumeratorElementType(Type type, ref TypeFlags flags)
         {
@@ -1380,6 +1527,16 @@ namespace System.Xml.Serialization
                 }
                 if (addMethod == null)
                 {
+                    // If the type has a [CollectionBuilder] (e.g. ImmutableStack<T>, ImmutableHashSet<T>),
+                    // the deserializer will use the builder factory instead of calling Add; still return
+                    // a usable element type so the type can be classified as Enumerable.
+                    if (type.GetCustomAttribute<CollectionBuilderAttribute>(inherit: false) != null)
+                    {
+                        // Reset the Current property type as the element type when an explicit GetEnumerator
+                        // returns a generic enumerator.
+                        Type elementType = p?.PropertyType ?? typeof(object);
+                        return elementType;
+                    }
                     throw new InvalidOperationException(SR.Format(SR.XmlNoAddMethod, type.FullName, currentType, "IEnumerable"));
                 }
                 return currentType;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -3163,7 +3163,7 @@ namespace System.Xml.Serialization
                     }
                     else if (m is ArrayMapping arrayMapping)
                     {
-                        if (arrayMapping.TypeDesc!.HasDefaultConstructor)
+                        if (arrayMapping.TypeDesc!.HasDefaultConstructor || arrayMapping.TypeDesc.UsesCollectionBuilder)
                         {
                             Writer.Write("if (");
                             WriteQNameEqual("xsiType", arrayMapping.TypeName, arrayMapping.Namespace);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -43,6 +43,7 @@ namespace System.Xml.Serialization
             private readonly MemberMapping _mapping;
             private readonly bool _isArray;
             private readonly bool _isList;
+            private bool _isBuilderBacked;
             private bool _isNullable;
             private int _fixupIndex = -1;
             private string? _paramsReadSource;
@@ -83,6 +84,18 @@ namespace System.Xml.Serialization
                         _arraySource = XmlSerializationReaderILGen.GetArraySource(mapping.TypeDesc, _arrayName, multiRef);
                     _isArray = mapping.TypeDesc.IsArray;
                     _isList = !_isArray;
+                    // Builder-backed immutable collections (e.g. ImmutableArray<T>, ImmutableList<T>,
+                    // ImmutableStack<T>) are accumulated into a T[] like real arrays and finalized with a
+                    // factory call in WriteMemberEnd. Treat them as array-like for source-string purposes.
+                    _isBuilderBacked = mapping.TypeDesc.UsesCollectionBuilder;
+                    if (_isBuilderBacked && arraySource == null)
+                    {
+                        string a = _arrayName;
+                        string c = $"c{a}";
+                        string elementTypeFullName = mapping.TypeDesc.ArrayElementTypeDesc!.CSharpName;
+                        string init = $"{a} = ({elementTypeFullName}[])EnsureArrayIndex({a}, {c}, {ReflectionAwareILGen.GetStringForTypeof(elementTypeFullName)});";
+                        _arraySource = init + ReflectionAwareILGen.GetStringForArrayMember(a, $"{c}++");
+                    }
                     if (mapping.ChoiceIdentifier != null)
                     {
                         _choiceArraySource = XmlSerializationReaderILGen.GetArraySource(mapping.TypeDesc, _choiceArrayName, multiRef);
@@ -131,6 +144,11 @@ namespace System.Xml.Serialization
             internal bool IsList
             {
                 get { return _isList; }
+            }
+
+            internal bool IsBuilderBacked
+            {
+                get { return _isBuilderBacked; }
             }
 
             internal bool IsArrayLike
@@ -2146,6 +2164,15 @@ namespace System.Xml.Serialization
                             ilg.Stloc(typeof(int), $"c{member.ChoiceArrayName}");
                         }
                     }
+                    else if (member.IsBuilderBacked)
+                    {
+                        // Allocate a T[] accumulator local instead of trying to construct the immutable type;
+                        // WriteMemberEnd will invoke the [CollectionBuilder] factory to build the final value.
+                        TypeDesc elementTypeDesc = typeDesc.ArrayElementTypeDesc!;
+                        WriteArrayLocalDecl($"{elementTypeDesc.CSharpName}[]", a, "null", elementTypeDesc);
+                        ilg.Ldc(0);
+                        ilg.Stloc(typeof(int), c);
+                    }
                     else
                     {
                         if (member.Source.EndsWith('(') || member.Source.EndsWith('{'))
@@ -2661,6 +2688,62 @@ namespace System.Xml.Serialization
                             ilg.ConvertValue(XmlSerializationReader_ShrinkArray.ReturnType, member.Mapping.ChoiceIdentifier.Mapping.TypeDesc.Type!.MakeArrayType());
                             WriteSourceEnd(member.ChoiceSource!, member.Mapping.ChoiceIdentifier.Mapping.TypeDesc.Type!.MakeArrayType());
                         }
+                    }
+                    else if (member.IsBuilderBacked)
+                    {
+                        // Right-size the accumulator T[], optionally reverse for ImmutableStack to preserve
+                        // enumeration order on round-trip, then invoke the [CollectionBuilder] factory and
+                        // store the immutable result into the member.
+                        Debug.Assert(!soapRefs);
+
+                        string a = member.ArrayName;
+                        string c = $"c{a}";
+                        Type elementType = typeDesc.ArrayElementTypeDesc!.Type!;
+                        Type arrayType = elementType.MakeArrayType();
+                        MethodInfo factory = typeDesc.CollectionBuilderMethod!;
+                        bool isStack = typeDesc.Type!.IsGenericType &&
+                            typeDesc.Type.GetGenericTypeDefinition().FullName == "System.Collections.Immutable.ImmutableStack`1";
+
+                        MethodInfo XmlSerializationReader_ShrinkArray = typeof(XmlSerializationReader).GetMethod(
+                            "ShrinkArray",
+                            CodeGenerator.InstanceBindingFlags,
+                            new Type[] { typeof(Array), typeof(int), typeof(Type), typeof(bool) }
+                            )!;
+
+                        WriteSourceBegin(member.Source);
+
+                        ilg.Ldarg(0);
+                        ilg.Ldloc(ilg.GetLocal(a));
+                        ilg.Ldloc(ilg.GetLocal(c));
+                        ilg.Ldc(elementType);
+                        ilg.Ldc(member.IsNullable);
+                        ilg.Call(XmlSerializationReader_ShrinkArray);
+                        // ShrinkArray returns Array; cast to T[].
+                        ilg.Castclass(arrayType);
+
+                        if (isStack)
+                        {
+                            // Array.Reverse(Array) is void; reverse in place then reload.
+                            LocalBuilder tmp = ilg.DeclareOrGetLocal(arrayType, $"tmp_{a}");
+                            ilg.Stloc(tmp);
+                            ilg.Ldloc(tmp);
+                            MethodInfo arrayReverse = typeof(Array).GetMethod("Reverse", new Type[] { typeof(Array) })!;
+                            ilg.Call(arrayReverse);
+                            ilg.Ldloc(tmp);
+                        }
+
+                        ParameterInfo[] factoryPars = factory.GetParameters();
+                        Type factoryParamType = factoryPars[0].ParameterType;
+                        if (factoryParamType.IsGenericType && factoryParamType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>))
+                        {
+                            // Convert T[] -> ReadOnlySpan<T> via the implicit conversion operator.
+                            MethodInfo op = factoryParamType.GetMethod("op_Implicit", BindingFlags.Public | BindingFlags.Static, new Type[] { arrayType })!;
+                            ilg.Call(op);
+                        }
+
+                        ilg.Call(factory);
+                        ilg.ConvertValue(factory.ReturnType, typeDesc.Type!);
+                        WriteSourceEnd(member.Source, typeDesc.Type!);
                     }
                     else if (typeDesc.IsValueType)
                     {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -1253,7 +1253,7 @@ namespace System.Xml.Serialization
                     }
                     else if (m is ArrayMapping arrayMapping)
                     {
-                        if (arrayMapping.TypeDesc!.HasDefaultConstructor)
+                        if (arrayMapping.TypeDesc!.HasDefaultConstructor || arrayMapping.TypeDesc.UsesCollectionBuilder)
                         {
                             ilg.InitElseIf();
                             WriteQNameEqual("xsiType", arrayMapping.TypeName, arrayMapping.Namespace);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -2166,8 +2166,15 @@ namespace System.Xml.Serialization
                     }
                     else if (member.IsBuilderBacked)
                     {
-                        // Allocate a T[] accumulator local instead of trying to construct the immutable type;
-                        // WriteMemberEnd will invoke the [CollectionBuilder] factory to build the final value.
+                        // Accumulate items into a T[] rather than into a live instance of the target
+                        // collection. This deliberately mirrors the existing xml-array path (declared
+                        // just above) so we can reuse the well-established EnsureArrayIndex / ShrinkArray
+                        // machinery: element-writer IL appends to `a[c++]` via EnsureArrayIndex, which
+                        // geometrically grows the array as needed, and WriteMemberEnd trims it and passes
+                        // it to the [CollectionBuilder] factory. Using a List<T> here instead would still
+                        // require materializing a T[] to hand to the factory (whose signature is
+                        // `Create(T[])` or `Create(ReadOnlySpan<T>)`) and would fork the per-element IL
+                        // emission for no real benefit.
                         TypeDesc elementTypeDesc = typeDesc.ArrayElementTypeDesc!;
                         WriteArrayLocalDecl($"{elementTypeDesc.CSharpName}[]", a, "null", elementTypeDesc);
                         ilg.Ldc(0);
@@ -2712,13 +2719,17 @@ namespace System.Xml.Serialization
 
                         WriteSourceBegin(member.Source);
 
+                        // ShrinkArray trims the accumulator to its exact used length. The array-emitter
+                        // path (WriteMemberBegin above + EnsureArrayIndex on each append) geometrically
+                        // grows `a` so it typically ends up over-sized by up to 2x; ShrinkArray returns a
+                        // right-sized Array (or an empty singleton when count==0 and IsNullable is false).
+                        // We then cast back to T[] before passing it to the [CollectionBuilder] factory.
                         ilg.Ldarg(0);
                         ilg.Ldloc(ilg.GetLocal(a));
                         ilg.Ldloc(ilg.GetLocal(c));
                         ilg.Ldc(elementType);
                         ilg.Ldc(member.IsNullable);
                         ilg.Call(XmlSerializationReader_ShrinkArray);
-                        // ShrinkArray returns Array; cast to T[].
                         ilg.Castclass(arrayType);
 
                         if (isStack)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -1472,11 +1472,24 @@ namespace System.Xml.Serialization
             ilg.ExitScope();
         }
 
+        private static bool HasUsableIntIndexer([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+        {
+            foreach (PropertyInfo p in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                ParameterInfo[] pars = p.GetIndexParameters();
+                if (pars.Length == 1 && pars[0].ParameterType == typeof(int) && p.GetMethod != null)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         private void WriteArrayItems(ElementAccessor[] elements, TextAccessor? text, ChoiceIdentifierAccessor? choice, TypeDesc arrayTypeDesc, string arrayName, string? choiceName)
         {
             TypeDesc arrayElementTypeDesc = arrayTypeDesc.ArrayElementTypeDesc!;
 
-            if (arrayTypeDesc.IsEnumerable)
+            if (arrayTypeDesc.IsEnumerable || (arrayTypeDesc.UsesCollectionBuilder && !HasUsableIntIndexer(arrayTypeDesc.Type!)))
             {
                 LocalBuilder eLoc = ilg.DeclareLocal(typeof(IEnumerator), "e");
                 ilg.LoadAddress(ilg.GetVariable(arrayName));

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -269,90 +269,70 @@ public static partial class XmlSerializerTests
     public static void Xml_ReadOnlyCollection()
     {
         ReadOnlyCollection<string> roc = new ReadOnlyCollection<string>(new string[] { "one", "two" });
-
-#if ReflectionOnly
-        // Expect exception when _using_ the serializer
         var serializer = new XmlSerializer(typeof(ReadOnlyCollection<string>));
-        var ex = Assert.Throws<InvalidOperationException>(() => Serialize(roc, null, () => serializer));
-        Assert.Equal("There was an error generating the XML document.", ex.Message);
-        Assert.NotNull(ex.InnerException);
-        Assert.IsType<InvalidOperationException>(ex.InnerException);
-        Assert.StartsWith("To be XML serializable, types which inherit from ICollection must have an implementation of Add(System.String) at all levels of their inheritance hierarchy.", ex.InnerException.Message);
-#else
-        // Expect exception when _creating_ the serializer
-        var ex = Assert.Throws<InvalidOperationException>(() => new XmlSerializer(typeof(ReadOnlyCollection<string>)));
-        Assert.StartsWith("To be XML serializable, types which inherit from ICollection must have an implementation of Add(System.String) at all levels of their inheritance hierarchy.", ex.Message);
-#endif
+        string xml = Serialize(roc, null, () => serializer, skipStringCompare: true);
+        var rtt = (ReadOnlyCollection<string>)Deserialize(serializer, xml)!;
+        Assert.Equal(roc, rtt);
     }
 
     [Theory]
     [MemberData(nameof(Xml_ImmutableCollections_MemberData))]
-    public static void Xml_ImmutableCollections(Type type, object collection, Type createException, Type addException, string expectedXml, string exMsg = null)
+    public static void Xml_ImmutableCollections(Type type, object collection)
     {
-        XmlSerializer serializer;
-
-        // Some collections implement the required enumerator/Add combo (ImmutableList, ImmutableArray) and some don't (ImmutableStack,
-        // ImmutableQueue). If they do not, they will throw upon serializer construction in RefEmit mode. They should throw when
-        // first using the serializer in Reflection mode.
-#if ReflectionOnly
-        serializer = new XmlSerializer(type);
-        if (createException != null)
-        {
-            var ex = Assert.Throws(createException, () => Serialize(collection, expectedXml, () => serializer));
-            if (exMsg != null)
-                Assert.Contains(exMsg, $"{ex.Message} : {ex.InnerException?.Message}");
-            return;
-        }
-#else
-        if (createException != null)
-        {
-            var ex = Assert.Throws(createException, () => serializer = new XmlSerializer(type));
-            if (exMsg != null)
-                Assert.Contains(exMsg, $"{ex.Message} : {ex.InnerException?.Message}");
-            return;
-        }
-        serializer = new XmlSerializer(type);
-#endif
-
-        // If they do meet the signature requirement, they may succeed or fail depending on whether their Add/Indexer explicitly throw
-        // or not. (ImmutableArray throws. ImmutableList does not - it returns a new copy instead... which gets ignored and is thus
-        // essentially a silent failure.) Serializing out to a string first should work though.
-        string serializedValue = Serialize(collection, expectedXml, () => serializer);
-
-        if (addException != null)
-        {
-            var ex = Assert.Throws(addException, () => Deserialize(serializer, serializedValue));
-            if (exMsg != null)
-                Assert.Contains(exMsg, $"{ex.Message} : {ex.InnerException?.Message}");
-            return;
-        }
-
-        // In this case, we can execute everything without exception. But since our calls to '.Add()' do nothing, we end up
-        // with an empty collection
-        var rttCollection = Deserialize(serializer, serializedValue);
+        var serializer = new XmlSerializer(type);
+        string xml = Serialize(collection, null, () => serializer, skipStringCompare: true);
+        var rttCollection = Deserialize(serializer, xml);
         Assert.NotNull(rttCollection);
-        Assert.Empty((IEnumerable)rttCollection);
+        Assert.Equal(((IEnumerable)collection).Cast<object>().ToArray(), ((IEnumerable)rttCollection).Cast<object>().ToArray());
     }
+
     public static IEnumerable<object[]> Xml_ImmutableCollections_MemberData()
     {
-        string arrayOfInt = WithXmlHeader("<ArrayOfInt xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><int>42</int></ArrayOfInt>");
-        string arrayOfAny = WithXmlHeader("<ArrayOfAnyType xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><anyType /></ArrayOfAnyType>");
+        // Reference type element from the original #66264 repro (nullable reference value type via ConsoleColor?
+        // that originally caused an AccessViolationException for ImmutableArray<T>).
+        ConsoleColor?[] colors = new ConsoleColor?[] { ConsoleColor.Red, null, ConsoleColor.Blue };
 
+        // ImmutableArray<T>
+        yield return new object[] { typeof(ImmutableArray<int>), ImmutableArray.Create(1, 2, 3) };
+        yield return new object[] { typeof(ImmutableArray<string>), ImmutableArray.Create("a", "b", "c") };
+        yield return new object[] { typeof(ImmutableArray<ConsoleColor?>), ImmutableArray.Create(colors) };
+
+        // ImmutableList<T> (previously silently deserialized empty)
+        yield return new object[] { typeof(ImmutableList<int>), ImmutableList.Create(1, 2, 3) };
+        yield return new object[] { typeof(ImmutableList<string>), ImmutableList.Create("a", "b", "c") };
+
+        // ImmutableHashSet<T> / ImmutableSortedSet<T> (no Add, but have [CollectionBuilder])
+        yield return new object[] { typeof(ImmutableHashSet<int>), ImmutableHashSet.Create(1, 2, 3) };
+        yield return new object[] { typeof(ImmutableSortedSet<int>), ImmutableSortedSet.Create(3, 1, 2) };
+
+        // ImmutableStack<T> / ImmutableQueue<T> (no Add, ordering preserved via reversal for Stack)
+        yield return new object[] { typeof(ImmutableStack<int>), ImmutableStack.CreateRange(new[] { 1, 2, 3 }) };
+        yield return new object[] { typeof(ImmutableQueue<int>), ImmutableQueue.CreateRange(new[] { 1, 2, 3 }) };
+    }
+
+    [Theory]
+    [MemberData(nameof(Xml_UnsupportedImmutableCollections_MemberData))]
+    public static void Xml_UnsupportedImmutableCollections(Type type, Type expectedException, string exMsg)
+    {
+        // IDictionary-implementing types are not supported by XmlSerializer at all.
 #if ReflectionOnly
-        yield return new object[] { typeof(ImmutableArray<int>), ImmutableArray.Create(42), null, typeof(InvalidOperationException), arrayOfInt, "Specified method is not supported." };
-        yield return new object[] { typeof(ImmutableArray<object>), ImmutableArray.Create(new object()), null, typeof(InvalidOperationException), arrayOfAny, "Specified method is not supported." };
-        yield return new object[] { typeof(ImmutableList<int>), ImmutableList.Create(42), null, typeof(InvalidOperationException), arrayOfInt, "Specified method is not supported." };
-        yield return new object[] { typeof(ImmutableStack<int>), ImmutableStack.Create(42), typeof(InvalidOperationException), null, arrayOfInt, "To be XML serializable, types which inherit from IEnumerable must have an implementation of Add" };
-        yield return new object[] { typeof(ImmutableQueue<int>), ImmutableQueue.Create(42), typeof(InvalidOperationException), null, arrayOfInt, "To be XML serializable, types which inherit from IEnumerable must have an implementation of Add" };
-        yield return new object[] { typeof(ImmutableDictionary<string, int>), new Dictionary<string, int>() { { "one", 1 } }.ToImmutableDictionary(), typeof(InvalidOperationException), null, null, "is not supported because it implements IDictionary." };
+        var serializer = new XmlSerializer(type);
+        var ex = Assert.Throws(expectedException, () => Serialize(new object(), null, () => serializer, skipStringCompare: true));
 #else
-        yield return new object[] { typeof(ImmutableArray<int>), ImmutableArray.Create(42), null, typeof(InvalidOperationException), arrayOfInt, "Parameterless constructor is required for collections and enumerators." };
-        yield return new object[] { typeof(ImmutableArray<object>), ImmutableArray.Create(new object()), null, typeof(InvalidOperationException), arrayOfAny, "Parameterless constructor is required for collections and enumerators." };
-        yield return new object[] { typeof(ImmutableList<int>), ImmutableList.Create(42), null, null, arrayOfInt };
-        yield return new object[] { typeof(ImmutableStack<int>), ImmutableStack.Create(42), typeof(InvalidOperationException), null, arrayOfInt, "To be XML serializable, types which inherit from IEnumerable must have an implementation of Add" };
-        yield return new object[] { typeof(ImmutableQueue<int>), ImmutableQueue.Create(42), typeof(InvalidOperationException), null, arrayOfInt, "To be XML serializable, types which inherit from IEnumerable must have an implementation of Add" };
-        // IDictionary types are denied right from the start with a NotSupportedExcpetion
-        yield return new object[] { typeof(ImmutableDictionary<string, int>), new Dictionary<string, int>() { { "one", 1 } }.ToImmutableDictionary(), typeof(NotSupportedException), null, null, "is not supported because it implements IDictionary." };
+        var ex = Assert.Throws(expectedException, () => new XmlSerializer(type));
+#endif
+        if (exMsg != null)
+            Assert.Contains(exMsg, $"{ex.Message} : {ex.InnerException?.Message}");
+    }
+
+    public static IEnumerable<object[]> Xml_UnsupportedImmutableCollections_MemberData()
+    {
+#if ReflectionOnly
+        yield return new object[] { typeof(ImmutableDictionary<string, int>), typeof(InvalidOperationException), "is not supported because it implements IDictionary." };
+        yield return new object[] { typeof(ImmutableSortedDictionary<string, int>), typeof(InvalidOperationException), "is not supported because it implements IDictionary." };
+#else
+        yield return new object[] { typeof(ImmutableDictionary<string, int>), typeof(NotSupportedException), "is not supported because it implements IDictionary." };
+        yield return new object[] { typeof(ImmutableSortedDictionary<string, int>), typeof(NotSupportedException), "is not supported because it implements IDictionary." };
 #endif
     }
 #endif  // !XMLSERIALIZERGENERATORTESTS


### PR DESCRIPTION
## Problem
XmlSerializer cannot correctly round-trip immutable collections (ImmutableArray<T>, ImmutableList<T>, ImmutableHashSet<T>, ImmutableSortedSet<T>, ImmutableStack<T>, ImmutableQueue<T>, and — since it also carries [CollectionBuilderAttribute] — ReadOnlyCollection<T>).

Behavior today ranges from bad to worse depending on the type:

ImmutableArray<T> with a nullable-reference or nullable-enum element type (e.g. ImmutableArray<ConsoleColor?>) crashes with an AccessViolationException during deserialization — the original repro in #66264.
ImmutableList<T>, ImmutableStack<T>, ImmutableQueue<T> silently deserialize as empty collections. No exception; data is lost.
ImmutableHashSet<T>, ImmutableSortedSet<T>, ReadOnlyCollection<T> either throw a construction error at serializer creation time or fail at deserialization because there is no usable public parameterless constructor and no Add method to call.
Root cause: XmlSerializer's collection-deserialization pipeline is built around new T() + repeated Add(item), which is a poor match for immutable / read-only collection types.

## Fix
Recognize [CollectionBuilderAttribute] (added to these types in .NET 8 as part of the collection-expressions work) and route their construction through the associated static factory method (Create(T[]) or Create(ReadOnlySpan<T>)) instead of trying to new an instance and call Add.

Applied consistently across all three deserialization paths:

- **Type classification** (Types.cs) — new TypeFlags.UsesCollectionBuilder and TypeDesc.CollectionBuilderMethod. Detection block in ImportTypeDesc finds the factory method and marks the type so downstream code can dispatch on it. Bypass the default-indexer and Add-method requirements when a [CollectionBuilder] is present. IDictionary-implementing types are explicitly excluded so their pre-existing NotSupportedException behavior is preserved.
- **Reflection-based reader** (ReflectionXmlSerializationReader.cs) — skip up-front Activator.CreateInstance for builder-backed types; accumulate items into a T[] and invoke the factory at end-of-collection. For factories whose only overload takes ReadOnlySpan<T> (a ref struct that can't pass through MethodBase.Invoke), build a small Expression<Func<Array, object>> that performs the Array → ReadOnlySpan<T> implicit conversion and the factory call.
- **ILGen reader** (XmlSerializationReaderILGen.cs) — Member gets an IsBuilderBacked flag; WriteMemberBegin declares a T[] accumulator local (reusing the existing xml-array EnsureArrayIndex/ShrinkArray growth machinery so per-element append IL is unchanged); WriteMemberEnd emits ShrinkArray → Castclass → optional Array.Reverse (for ImmutableStack<T> to preserve enumeration order across round-trips) → optional op_Implicit conversion → factory Call.
- **ILGen writer** (XmlSerializationWriterILGen.cs) — types that use [CollectionBuilder] but have no this[int] indexer (e.g. ImmutableHashSet<T>) are routed through the existing IEnumerable/foreach serialization path instead of the for(int i; collection[i]) indexer path.

## Out of scope for this PR
**IDictionary-implementing types** (e.g. ImmutableDictionary<,>, ImmutableSortedDictionary<,>) — XmlSerializer doesn't directly support dictionaries in general (GetDefaultIndexer unconditionally throws), so those keep throwing NotSupportedException.

**DataContractSerializer** — see #21016; that will be a separate PR that applies the same strategy to the DCS code paths (where dictionary types are in scope).

## Tests
src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs:

- Rewrote Xml_ImmutableCollections as a [Theory] covering ImmutableArray<int>, ImmutableArray<string>, ImmutableArray<ConsoleColor?> (the exact #66264 repro), ImmutableList<int>, ImmutableList<string>, ImmutableHashSet<int>, ImmutableSortedSet<int>, ImmutableStack<int>, ImmutableQueue<int>. All round-trip cleanly.
- Added Xml_UnsupportedImmutableCollections — asserts NotSupportedException still thrown for ImmutableDictionary<,> and ImmutableSortedDictionary<,>.
- Updated Xml_ReadOnlyCollection to expect successful round-trip (it was previously asserting the error case, but ReadOnlyCollection<T> also carries [CollectionBuilder] and now works).

Fixes #66264