### PR TITLE
createdump: use 47-bit-valid SpecialDiagInfo address on arm64 macOS

### DIFF
--- a/src/coreclr/debug/createdump/specialdiaginfo.h
+++ b/src/coreclr/debug/createdump/specialdiaginfo.h
@@ -17,7 +17,15 @@
 #define SPECIAL_DIAGINFO_VERSION 2
 
 #ifdef __APPLE__
+#if defined(HOST_ARM64) || defined(__arm64__) || defined(__aarch64__)
+// Apple Silicon (arm64) macOS user-space VM is 47 bits — addresses above 0x7FFF_FFFF_FFFF
+// are not mappable and lldb's core file reader rejects segments at those addresses. Use a
+// 47-bit-valid address here. The legacy x86_64 macOS address is also probed at read time by
+// SOS/dotnet-dump (see the diagnostics repo) so older dumps remain recognized.
+const uint64_t SpecialDiagInfoAddress = 0x00007ffffff10000;
+#else
 const uint64_t SpecialDiagInfoAddress = 0x7fffffff10000000;
+#endif
 #else
 #if TARGET_64BIT
 const uint64_t SpecialDiagInfoAddress = 0x00007ffffff10000;


### PR DESCRIPTION
## Summary

Fixes the createdump (write) side of the SpecialDiagInfo issue addressed on the
reader side in dotnet/diagnostics#5823.

On Apple Silicon, the legacy macOS SpecialDiagInfo address `0x7fffffff10000000`
is above the 47-bit user-space VM limit. createdump still writes a segment at
that address, but lldb's MachO core reader refuses to return reads above
`0x7FFF_FFFFFFFF`, so SOS reports:

`Special diagnostics info read failed`


and falls through to the slower managed-side path (or fails outright on older
builds without that fallback).

## Change

`src/coreclr/debug/createdump/specialdiaginfo.h` now selects the address by arch
on macOS:

- **arm64 macOS** → `0x00007ffffff10000` (47-bit valid; same address already
  used on Linux/other 64-bit)
- **x86_64 macOS** → `0x7fffffff10000000` (legacy, unchanged)

All other platforms (Linux/other 64-bit, 32-bit) are unchanged.

The matching diagnostics reader (dotnet/diagnostics#5823) probes both the new
and legacy addresses, so dumps produced by older createdump binaries remain
readable — no regression.

## Notes

- `SpecialThreadInfoAddress` (`0x7fffffff00000000`) is intentionally left as-is;
  it's out of scope for this fix and lldb tolerates that region.

> [!NOTE]
> This PR description was drafted with GitHub Copilot.