### PR TITLE
Fix reflection XmlSerializer choice identifier with XmlEnum aliases

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -812,7 +812,7 @@ namespace System.Xml.Serialization
                 {
                     string? ns = e!.Form == XmlSchemaForm.Qualified ? e.Namespace : string.Empty;
                     bool isList = member!.Mapping.TypeDesc!.IsArrayLike && !member.Mapping.TypeDesc.IsArray;
-                    WriteElement(e, isList && member.Mapping.TypeDesc.IsNullable, member.Mapping.ReadOnly, ns, member.FixupIndex, fixup, member);
+                    WriteElement(e, isList && member.Mapping.TypeDesc.IsNullable, member.Mapping.ReadOnly, ns, member.FixupIndex, fixup, member, elementIndex);
                 }
             }
             else
@@ -828,7 +828,7 @@ namespace System.Xml.Serialization
                         if (element.Any && element.Name.Length == 0)
                         {
                             string? ns = element.Form == XmlSchemaForm.Qualified ? element.Namespace : string.Empty;
-                            WriteElement(element, false, false, ns, fixup: fixup, member: member);
+                            WriteElement(element, false, false, ns, fixup: fixup, member: member, elementIndex: i);
                             break;
                         }
                     }
@@ -841,7 +841,7 @@ namespace System.Xml.Serialization
             }
         }
 
-        private object? WriteElement(ElementAccessor element, bool checkForNull, bool readOnly, string? defaultNamespace, int fixupIndex = -1, Fixup? fixup = null, Member? member = null)
+        private object? WriteElement(ElementAccessor element, bool checkForNull, bool readOnly, string? defaultNamespace, int fixupIndex = -1, Fixup? fixup = null, Member? member = null, int elementIndex = -1)
         {
             object? value = null;
             if (element.Mapping is ArrayMapping arrayMapping)
@@ -1013,7 +1013,7 @@ namespace System.Xml.Serialization
                 throw new InvalidOperationException(SR.XmlInternalError);
             }
 
-            member?.ChoiceSource?.Invoke(element.Name);
+            member?.ChoiceSource?.Invoke(elementIndex);
 
             if (member?.ArraySource != null)
             {
@@ -1744,19 +1744,20 @@ namespace System.Xml.Serialization
                     ChoiceIdentifierAccessor? choice = mapping.ChoiceIdentifier;
                     if (choice != null && o != null)
                     {
-                        member.ChoiceSource = (elementNameObject) =>
+                        member.ChoiceSource = (elementIndex) =>
                         {
-                            string? elementName = elementNameObject as string;
-                            foreach (var name in choice.MemberIds!)
+                            // The choice enum member that corresponds to the selected element is stored
+                            // positionally in MemberIds, parallel to the member's Elements. This mirrors
+                            // how the IL-generated reader resolves the choice (choice.MemberIds[elementIndex]),
+                            // and honors [XmlEnum] aliases because the importer already resolved them.
+                            string[]? memberIds = choice.MemberIds;
+                            if (memberIds is null || (uint)elementIndex >= (uint)memberIds.Length)
                             {
-                                if (name == elementName)
-                                {
-                                    object choiceValue = Enum.Parse(choice.Mapping!.TypeDesc!.Type!, name);
-                                    SetOrAddValueToMember(o, choiceValue, choice.MemberInfo!);
-
-                                    break;
-                                }
+                                return;
                             }
+
+                            object choiceValue = Enum.Parse(choice.Mapping!.TypeDesc!.Type!, memberIds[elementIndex]);
+                            SetOrAddValueToMember(o, choiceValue, choice.MemberInfo!);
                         };
                     }
 
@@ -2107,7 +2108,7 @@ namespace System.Xml.Serialization
             public Func<object?>? GetSource;
             public Action<object>? ArraySource;
             public Action<object?>? CheckSpecifiedSource;
-            public Action<object>? ChoiceSource;
+            public Action<int>? ChoiceSource;
             public Action<string, string>? XmlnsSource;
             public Action<object>? EnsureCollection;
 

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -3153,6 +3153,22 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
+    public static void Xml_TypeWithAliasedChoiceIdentifier()
+    {
+        var value = new TypeWithAliasedChoiceIdentifier()
+        {
+            Item = 42,
+            ChoiceType = AliasedChoiceType.NumberChoice
+        };
+
+        var actual = SerializeAndDeserialize(value, WithXmlHeader("<TypeWithAliasedChoiceIdentifier xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><Number>42</Number></TypeWithAliasedChoiceIdentifier>"));
+
+        Assert.NotNull(actual);
+        Assert.Equal(value.Item, actual.Item);
+        Assert.Equal(value.ChoiceType, actual.ChoiceType);
+    }
+
+    [Fact]
     public static void Xml_XmlIncludedTypesInTypedCollection()
     {
         var value = new List<BaseClass>() {

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -2266,6 +2266,25 @@ namespace SerializationTypes
         public MoreChoices[] ChoiceArray;
     }
 
+    public enum AliasedChoiceType
+    {
+        [XmlEnum("Word")]
+        WordChoice,
+        [XmlEnum("Number")]
+        NumberChoice,
+    }
+
+    public class TypeWithAliasedChoiceIdentifier
+    {
+        [XmlChoiceIdentifier("ChoiceType")]
+        [XmlElement("Word", typeof(string))]
+        [XmlElement("Number", typeof(int))]
+        public object Item;
+
+        [XmlIgnore]
+        public AliasedChoiceType ChoiceType;
+    }
+
     internal class MyFileStreamSurrogateProvider : ISerializationSurrogateProvider
     {
         static MyFileStreamSurrogateProvider()


### PR DESCRIPTION
The reflection-based XmlSerializer (ReflectionXmlSerializationReader) resolved an [XmlChoiceIdentifier] enum value during deserialization by comparing the choice enum member identifiers directly against the matched XML element name. That only works when the enum member name equals the element name, so a choice enum using [XmlEnum] aliases (e.g. [XmlEnum("Number")] NumberChoice) failed to round-trip: the choice field was left at its default instead of the value implied by the element.

Resolve the choice value positionally instead, using the element index already computed when matching the element and reading the corresponding choice.MemberIds[elementIndex]. This mirrors exactly how the IL-generated reader resolves the choice and reuses the alias-aware MemberIds table that XmlReflectionImporter builds up front, so [XmlEnum] aliases are honored.

Add a regression test (Xml_TypeWithAliasedChoiceIdentifier) plus the supporting AliasedChoiceType enum and TypeWithAliasedChoiceIdentifier type, covering the previously untested combination of [XmlChoiceIdentifier] with [XmlEnum] aliases. The test runs against both the reflection reader and the ReflectionOnly serializer configurations.

Fixes #130017