### PR TITLE
[cDAC] Remove vestigial JupiterRefCount from HandleData contract

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IGC.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IGC.cs
@@ -37,7 +37,6 @@ public record struct HandleData(
     uint Type,
     bool StrongReference,
     uint RefCount,
-    uint JupiterRefCount,
     bool IsPegged);
 
 public readonly struct GCHeapData

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GC_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GC_1.cs
@@ -644,7 +644,6 @@ internal struct GC_1 : IGC
         HandleData handleData = default;
         handleData.Handle = handleAddress;
         handleData.Type = GetInternalHandleType(type);
-        handleData.JupiterRefCount = 0;
         handleData.IsPegged = false;
         handleData.StrongReference = IsStrongReference(type);
         if (HasSecondary(type))

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1636,7 +1636,7 @@ public sealed unsafe partial class SOSDacImpl
                     Type = h.Type,
                     StrongReference = h.StrongReference ? 1 : 0,
                     RefCount = h.RefCount,
-                    JupiterRefCount = h.JupiterRefCount,
+                    JupiterRefCount = 0,
                     IsPegged = h.IsPegged ? 1 : 0,
                 };
             }


### PR DESCRIPTION
## Summary

- Remove the vestigial `JupiterRefCount` member from the managed cDAC `HandleData` contract type.
- Preserve the public `SOSHandleData.JupiterRefCount` COM ABI field and report it as `0`.
- Keep the DEBUG cDAC-vs-DAC parity assert intact; both implementations continue to expose `0` for this field.

## Details

`JupiterRefCount` represents a dead Windows 8-era WinRT/Jupiter concept. The cDAC contract never populated meaningful data for it, and the legacy DAC also hardcodes this value to `0`. This cleanup removes the field from the internal managed contract surface while leaving the shipped COM struct unchanged for compatibility.

## Testing

- `build.cmd clr+libs -rc release` (after cleaning stale native CMake cache directories)
- `dotnet build src\native\managed\cdac\cdac.slnx -c Debug -m:1`
- `dotnet test src\native\managed\cdac\tests\UnitTests\Microsoft.Diagnostics.DataContractReader.Tests.csproj -c Debug --no-build`

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.