### PR TITLE
Add default install dir for OpenBSD

### DIFF
--- a/src/native/corehost/hostmisc/pal.unix.c
+++ b/src/native/corehost/hostmisc/pal.unix.c
@@ -302,6 +302,8 @@ pal_char_t* pal_get_default_installation_dir(void)
     }
 
     return pal_strdup(_X("/usr/local/share/dotnet"));
+#elif defined(TARGET_OPENBSD)
+    return pal_strdup(_X("/usr/local/share/dotnet"));
 #else
     return pal_strdup(_X("/usr/share/dotnet"));
 #endif


### PR DESCRIPTION
Default to `/usr/local/share/dotnet` which is the appropriate place on OpenBSD.

Note there is no `CTL_USER` sysctl like there is on FreeBSD so we have to hard code this path here.

Contributes to #124911.

CC @am11