### PR TITLE
Improve Linux AIA fetching

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -1169,6 +1169,7 @@
     <Compile Include="System\Security\Cryptography\X509Certificates\X500NameEncoder.ManagedDecode.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\X509CertificateLoader.Unix.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\X509CertificateLoader.OpenSsl.cs" />
+    <Compile Include="System\Security\Cryptography\X509Certificates\X509MruCache.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\X509Pal.OpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\X509Persistence.cs" />
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.OpenSsl.cs
@@ -8,6 +8,9 @@ namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed partial class ChainPal
     {
+        // An input value of 0 on the timeout is treated as 15 seconds, to match Windows.
+        internal static readonly TimeSpan DefaultRetrievalTimeout = TimeSpan.FromSeconds(15);
+
         private static readonly TimeSpan s_maxUrlRetrievalTimeout = TimeSpan.FromMinutes(1);
 
 #pragma warning disable IDE0060
@@ -87,8 +90,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             if (timeout == TimeSpan.Zero)
             {
-                // An input value of 0 on the timeout is treated as 15 seconds, to match Windows.
-                timeout = TimeSpan.FromSeconds(15);
+                timeout = DefaultRetrievalTimeout;
             }
             else if (timeout > s_maxUrlRetrievalTimeout || timeout < TimeSpan.Zero)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
@@ -320,15 +320,31 @@ namespace System.Security.Cryptography.X509Certificates
                     }
 
                     int hashCode = GetHashCode(uri);
+                    CachedRequest updatedResponse = new CachedRequest(downloadTask);
 
                     lock (_lock)
                     {
-                        AddOrUpdate(
+                        CachedRequest newValue = AddOrUpdate(
                             hashCode,
                             uri,
-                            new CachedRequest(downloadTask),
+                            updatedResponse,
                             evicted: out _,
                             replaced: out _);
+
+                        // If the clock rolls back more than the refresh interval,
+                        // AddOrUpdate may decide to keep the pre-refresh value.
+                        //
+                        // Since temporal physics says that this download is, in fact, "newer",
+                        // forcibly remove the old value and add the new one again.
+                        //
+                        // That's not the same as saying updatedResponse has to be the new value,
+                        // it's possible that during the Refresh operation the original value was
+                        // removed, and some other value was added in its place.
+                        if (ReferenceEquals(newValue, node.Value))
+                        {
+                            Remove(hashCode, uri);
+                            AddOrUpdate(hashCode, uri, updatedResponse, evicted: out _, replaced: out _);
+                        }
                     }
 
                     success = true;
@@ -363,8 +379,21 @@ namespace System.Security.Cryptography.X509Certificates
                 }
             }
 
-            private protected override bool OnConflictTakeNew(Node current, CachedRequest newValue) =>
-                newValue.CacheTime > current.Value.CacheTime;
+            private protected override bool OnConflictTakeNew(Node current, CachedRequest newValue)
+            {
+                // It shouldn't be the case that we try to overwrite a finished task with a new one,
+                // but if it does happen, keep whichever task is done (assuming it finished successfully).
+
+                bool currentUsable = current.Value.DownloadTask.IsCompletedSuccessfully && current.Value.DownloadTask.Result is not null;
+                bool newUsable = newValue.DownloadTask.IsCompletedSuccessfully && newValue.DownloadTask.Result is not null;
+
+                if (currentUsable == newUsable)
+                {
+                    return newValue.CacheTime > current.Value.CacheTime;
+                }
+
+                return newUsable;
+            }
 
             private protected override void Pruned(Node? prunedNode, int countStart, int countEnd)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
@@ -321,6 +321,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                     int hashCode = GetHashCode(uri);
                     CachedRequest updatedResponse = new CachedRequest(downloadTask);
+                    CachedRequest current = node.Value;
 
                     lock (_lock)
                     {
@@ -340,7 +341,7 @@ namespace System.Security.Cryptography.X509Certificates
                         // That's not the same as saying updatedResponse has to be the new value,
                         // it's possible that during the Refresh operation the original value was
                         // removed, and some other value was added in its place.
-                        if (ReferenceEquals(newValue, node.Value))
+                        if (ReferenceEquals(newValue, current))
                         {
                             Remove(hashCode, uri);
                             AddOrUpdate(hashCode, uri, updatedResponse, evicted: out _, replaced: out _);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
@@ -146,8 +146,9 @@ namespace System.Security.Cryptography.X509Certificates
 
         private sealed class RequestCache : X509MruCache<CachedRequest>
         {
+            private static readonly TimeSpan s_refreshInterval = TimeSpan.FromMinutes(6);
+
             internal static RequestCache Instance { get; } = new();
-            internal static TimeSpan s_refreshInterval = TimeSpan.FromMinutes(6);
 
             internal byte[]? Get(string uri, TimeSpan downloadTimeout)
             {
@@ -156,7 +157,7 @@ namespace System.Security.Cryptography.X509Certificates
                     OpenSslX509ChainEventSource.Log.HttpCacheQuery(uri);
                 }
 
-                int hashCode = uri.GetHashCode();
+                int hashCode = GetHashCode(uri);
                 Node? toRefresh = null;
                 CachedRequest? req = null;
                 byte[]? ret = null;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
@@ -200,11 +200,20 @@ namespace System.Security.Cryptography.X509Certificates
 
                     if (ignoredEntry || req is null)
                     {
+                        // Since the response will be cached, raise the timeout to the default,
+                        // if it's lower.
+                        TimeSpan timeout = downloadTimeout;
+
+                        if (timeout < ChainPal.DefaultRetrievalTimeout)
+                        {
+                            timeout = ChainPal.DefaultRetrievalTimeout;
+                        }
+
                         req = AddOrUpdate(
                             hashCode,
                             uri,
                             new CachedRequest(
-                                System.Net.Http.X509ResourceClient.DownloadAssetAsync(uri, downloadTimeout)),
+                                System.Net.Http.X509ResourceClient.DownloadAssetAsync(uri, timeout)),
                             out evicted,
                             replaced: out _);
                     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
@@ -338,6 +338,11 @@ namespace System.Security.Cryptography.X509Certificates
                         OpenSslX509ChainEventSource.Log.HttpCacheBackgroundSuccess(uri);
                     }
                 }
+                catch
+                {
+                    // downloadTask should already be swallowing all exceptions, but just in case,
+                    // don't let the opportunistic background refresh end in a faulted state.
+                }
                 finally
                 {
                     if (!success)
@@ -349,6 +354,9 @@ namespace System.Security.Cryptography.X509Certificates
 
                         lock (_lock)
                         {
+                            // Strictly speaking, we don't need a lock to set this back to false,
+                            // but since this node may still be in the cache, just take the lock
+                            // to avoid any mishandling by future code.
                             node.Value.RefreshInProgress = false;
                         }
                     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Reflection;
-using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
+
 using OpenSslX509ChainEventSource = System.Security.Cryptography.X509Certificates.OpenSslX509ChainEventSource;
 
 namespace System.Security.Cryptography.X509Certificates
@@ -102,9 +101,14 @@ namespace System.Security.Cryptography.X509Certificates
             return null;
         }
 
+        internal static void ReportCrlCached(string uri)
+        {
+            RequestCache.Instance.Remove(uri);
+        }
+
         internal static SafeOcspResponseHandle? DownloadOcspGet(string uri, TimeSpan downloadTimeout)
         {
-            byte[]? data = DownloadAsset(uri, downloadTimeout);
+            byte[]? data = DownloadAssetNoCache(uri, downloadTimeout);
 
             if (data == null)
             {
@@ -132,7 +136,232 @@ namespace System.Security.Cryptography.X509Certificates
 
         private static byte[]? DownloadAsset(string uri, TimeSpan downloadTimeout)
         {
+            return RequestCache.Instance.Get(uri, downloadTimeout);
+        }
+
+        private static byte[]? DownloadAssetNoCache(string uri, TimeSpan downloadTimeout)
+        {
             return System.Net.Http.X509ResourceClient.DownloadAsset(uri, downloadTimeout);
+        }
+
+        private sealed class RequestCache : X509MruCache<CachedRequest>
+        {
+            internal static RequestCache Instance { get; } = new();
+            internal static TimeSpan s_refreshInterval = TimeSpan.FromMinutes(6);
+
+            internal byte[]? Get(string uri, TimeSpan downloadTimeout)
+            {
+                if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                {
+                    OpenSslX509ChainEventSource.Log.HttpCacheQuery(uri);
+                }
+
+                int hashCode = uri.GetHashCode();
+                Node? toRefresh = null;
+                CachedRequest? req = null;
+                byte[]? ret = null;
+                TimeSpan entryAge = default;
+                bool ignoredEntry = false;
+                Node? evicted = null;
+                bool cacheHit = false;
+
+                lock (_lock)
+                {
+                    if (TryGetNode(hashCode, uri, out Node? cached))
+                    {
+                        cacheHit = true;
+                        req = cached.Value;
+
+                        if (req.DownloadTask.IsCompleted)
+                        {
+                            byte[]? data = req.DownloadTask.Result;
+
+                            if (data is not null)
+                            {
+                                if (!req.RefreshInProgress)
+                                {
+                                    entryAge = DateTimeOffset.UtcNow - req.CacheTime;
+
+                                    if (entryAge > s_refreshInterval)
+                                    {
+                                        req.RefreshInProgress = true;
+                                        toRefresh = cached;
+                                    }
+                                }
+
+                                ret = data;
+                            }
+                            else
+                            {
+                                ignoredEntry = true;
+                            }
+                        }
+                    }
+
+                    if (ignoredEntry || req is null)
+                    {
+                        req = AddOrUpdate(
+                            hashCode,
+                            uri,
+                            new CachedRequest(
+                                System.Net.Http.X509ResourceClient.DownloadAssetAsync(uri, downloadTimeout)),
+                            out evicted,
+                            replaced: out _);
+                    }
+                }
+
+                if (toRefresh is not null)
+                {
+                    if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                    {
+                        OpenSslX509ChainEventSource.Log.HttpCacheBackgroundRefresh(
+                            (int)entryAge.TotalSeconds);
+                    }
+
+                    _ = Refresh(toRefresh);
+                }
+
+                if (ret is not null)
+                {
+                    if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                    {
+                        OpenSslX509ChainEventSource.Log.HttpCacheHitFinished(ret.Length);
+                    }
+
+                    return ret;
+                }
+
+                if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                {
+                    if (ignoredEntry)
+                    {
+                        OpenSslX509ChainEventSource.Log.HttpCacheHitIgnored();
+                    }
+                    else if (cacheHit)
+                    {
+                        OpenSslX509ChainEventSource.Log.HttpCacheHitInProgress();
+                    }
+                    else
+                    {
+                        OpenSslX509ChainEventSource.Log.HttpCacheMiss();
+
+                        if (evicted is not null)
+                        {
+                            OpenSslX509ChainEventSource.Log.HttpCacheFull(evicted.Key);
+                        }
+                    }
+                }
+
+                Debug.Assert(req is not null);
+                Task<byte[]?> downloadTask = req.DownloadTask;
+
+                if (!downloadTask.Wait(downloadTimeout))
+                {
+                    if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                    {
+                        OpenSslX509ChainEventSource.Log.HttpCacheTimeout();
+                    }
+
+                    return null;
+                }
+
+                return downloadTask.Result;
+            }
+
+            internal void Remove(string uri)
+            {
+                Debug.Assert(uri is not null);
+
+                int hashCode = GetHashCode(uri);
+
+                lock (_lock)
+                {
+                    Remove(hashCode, uri);
+                }
+
+                if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                {
+                    OpenSslX509ChainEventSource.Log.HttpCacheExplicitRemoval(uri);
+                }
+            }
+
+            private async Task Refresh(Node node)
+            {
+                bool success = false;
+                string uri = node.Key;
+
+                try
+                {
+                    Task<byte[]?> downloadTask = System.Net.Http.X509ResourceClient.DownloadAssetAsync(
+                        uri,
+                        ChainPal.DefaultRetrievalTimeout);
+
+                    byte[]? resp = await downloadTask.ConfigureAwait(false);
+
+                    if (resp is null)
+                    {
+                        return;
+                    }
+
+                    int hashCode = GetHashCode(uri);
+
+                    lock (_lock)
+                    {
+                        AddOrUpdate(
+                            hashCode,
+                            uri,
+                            new CachedRequest(downloadTask),
+                            evicted: out _,
+                            replaced: out _);
+                    }
+
+                    success = true;
+
+                    if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                    {
+                        OpenSslX509ChainEventSource.Log.HttpCacheBackgroundSuccess(uri);
+                    }
+                }
+                finally
+                {
+                    if (!success)
+                    {
+                        if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                        {
+                            OpenSslX509ChainEventSource.Log.HttpCacheBackgroundFailure(uri);
+                        }
+
+                        lock (_lock)
+                        {
+                            node.Value.RefreshInProgress = false;
+                        }
+                    }
+                }
+            }
+
+            private protected override bool OnConflictTakeNew(Node current, CachedRequest newValue) =>
+                newValue.CacheTime > current.Value.CacheTime;
+
+            private protected override void Pruned(Node? prunedNode, int countStart, int countEnd)
+            {
+                if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                {
+                    OpenSslX509ChainEventSource.Log.HttpCachePruned(countStart - countEnd, countEnd);
+                }
+            }
+        }
+
+        private sealed class CachedRequest
+        {
+            internal bool RefreshInProgress { get; set; }
+            internal Task<byte[]?> DownloadTask { get; }
+            internal DateTimeOffset CacheTime { get; }
+
+            internal CachedRequest(Task<byte[]?> downloadTask)
+            {
+                DownloadTask = downloadTask;
+                CacheTime = DateTimeOffset.UtcNow;
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
@@ -150,6 +150,12 @@ namespace System.Security.Cryptography.X509Certificates
 
             internal static RequestCache Instance { get; } = new();
 
+            // Each request can be caching a 100MB response, so limit the cache to 10 requests (1GB).
+            // The expected size of each entry is more likely in the 10s of kB.
+            private RequestCache() : base(10)
+            {
+            }
+
             internal byte[]? Get(string uri, TimeSpan downloadTimeout)
             {
                 if (OpenSslX509ChainEventSource.Log.IsEnabled())

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
@@ -501,6 +501,25 @@ namespace System.Security.Cryptography.X509Certificates
                     ret.CrlHandle.DangerousAddRef(ref ignore);
                 }
 
+                // Technically speaking, at most one of these three paths can be hit.
+                // 1) The key was not in the cache, and there's space
+                //   ret==value, evicted==null, replaced==null
+                // 2) The key was not in the cache, and adding the new value caused an eviction
+                //   ret==newValue, evicted==oldValue, replaced==null
+                // 3) The key was in the cache, and the new value replaced the old value
+                //   ret==newValue, evicted==null, replaced==oldValue
+                // 4) The key was in the cache, and the new value did not replace the old value
+                //   ret!=newValue, evicted==null, replaced==null
+                //
+                // But rather than encode that with else if, just let all three paths test.
+
+                if (!ReferenceEquals(ret, value))
+                {
+                    // The value we tried inserting into the cache was not used,
+                    // so we can release the SafeHandle.
+                    value.CrlHandle.Dispose();
+                }
+
                 replaced?.CrlHandle.Dispose();
 
                 if (evicted is not null)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
@@ -483,105 +483,33 @@ namespace System.Security.Cryptography.X509Certificates
         // The MRU CRL cache always does a DangerousAddReference before returning the value,
         // so that neither cooperative GC pruning nor a cache-value refresh trigger ReleaseHandle
         // on a CRL entry in use.
-        private sealed class MruCrlCache
+        private sealed class MruCrlCache : X509MruCache<CachedCrlEntry>
         {
-            // Each CRL is only a SafeHandle to the GC, but represents a non-trivial amount of
-            // native memory, so keep the cache small.
-            private const int MaxItems = 30;
-
-            private readonly Lock _lock = new();
-
-            private int _count = -1;
-            private Node? _head;
-            private Node? _expire;
-
             internal CachedCrlEntry AddOrUpdateAndUpRef(string key, CachedCrlEntry value)
             {
-                Debug.Assert(key is not null);
-                Debug.Assert(value is not null);
-                Debug.Assert(value.CrlHandle is not null && !value.CrlHandle.IsInvalid);
-                // Don't assert/enforce anything about expiration, because a) clock-skew, or b)
-                // the caller might have a verification time that's in the past.
-
-                int hashCode = key.GetHashCode();
-                CachedCrlEntry ret = value;
-                string? fullMemberKey = null;
-                SafeX509CrlHandle? toDispose = null;
+                CachedCrlEntry ret;
+                Node? evicted;
+                CachedCrlEntry? replaced;
+                int hashCode = GetHashCode(key);
 
                 lock (_lock)
                 {
-                    // The first time we add something, create the object to monitor for GC events.
-                    if (_count < 0)
-                    {
-                        new GCWatcher(this);
-                        _count = 0;
-                    }
+                    ret = AddOrUpdate(hashCode, key, value, out evicted, out replaced);
 
                     bool ignore = false;
-
-                    if (TryGetNode(hashCode, key, out Node? current))
-                    {
-                        Debug.Assert(current is not null);
-
-                        if (current.Value.Expiration >= value.Expiration)
-                        {
-                            toDispose = value.CrlHandle;
-                            ret = current.Value;
-                        }
-                        else
-                        {
-                            toDispose = current.Value.CrlHandle;
-                            current.Value = value;
-                        }
-                    }
-                    else
-                    {
-                        Node node = new Node(hashCode, key, value);
-                        node.Next = _head;
-
-                        if (_count < MaxItems)
-                        {
-                            _count++;
-                        }
-                        else
-                        {
-                            // Because MaxItems is small, it's better to just iterate from head
-                            // instead of using a doubly-linked list.
-
-                            Node? previous = null;
-                            Node? cur = _head;
-                            Node? next = cur?.Next;
-
-                            while (next is not null)
-                            {
-                                previous = cur;
-                                cur = next;
-                                next = cur.Next;
-                            }
-
-                            Debug.Assert(previous is not null);
-                            Debug.Assert(cur is not null);
-
-                            previous.Next = null;
-                            toDispose = cur.Value.CrlHandle;
-                            fullMemberKey = cur.Key;
-                            if (cur == _expire)
-                            {
-                                _expire = null;
-                            }
-                        }
-
-                        _head = node;
-                    }
-
                     ret.CrlHandle.DangerousAddRef(ref ignore);
                 }
 
-                toDispose?.Dispose();
+                replaced?.CrlHandle.Dispose();
 
-                if (fullMemberKey is not null && OpenSslX509ChainEventSource.Log.IsEnabled())
+                if (evicted is not null)
                 {
-                    OpenSslX509ChainEventSource.Log.CrlCacheInMemoryFull(fullMemberKey);
+                    evicted.Value.CrlHandle.Dispose();
+
+                    if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                    {
+                        OpenSslX509ChainEventSource.Log.CrlCacheInMemoryFull(evicted.Key);
+                    }
                 }
 
                 return ret;
@@ -589,7 +517,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             internal bool TryGetValueAndUpRef(string key, [NotNullWhen(true)] out CachedCrlEntry? value)
             {
-                int hashCode = key.GetHashCode();
+                int hashCode = GetHashCode(key);
 
                 lock (_lock)
                 {
@@ -606,159 +534,20 @@ namespace System.Security.Cryptography.X509Certificates
                 return false;
             }
 
-            private bool TryGetNode(int hashCode, string key, [NotNullWhen(true)] out Node? value)
+            private protected override bool OnConflictTakeNew(Node current, CachedCrlEntry newValue) => newValue.Expiration > current.Value.Expiration;
+
+            private protected override void Pruned(Node? prunedNode, int countStart, int countEnd)
             {
-                Debug.Assert(_lock.IsHeldByCurrentThread);
-
-                Node? previous = null;
-                Node? current = _head;
-
-                while (current is not null)
+                // `prunedNode` and beyond are now unlinked from the list, so we can dispose its values without holding the lock.
+                while (prunedNode is not null)
                 {
-                    if (current.MatchesKey(hashCode, key))
-                    {
-                        // If we find the expire node, move expiration to after it, so that promoting it to
-                        // most recent doesn't prune the whole list.
-                        //
-                        // This might, of course, make _expire null.
-                        if (current == _expire)
-                        {
-                            _expire = current.Next;
-                        }
-
-                        // Move the found node to the head of the list, maintaining MRU ordering.
-                        if (previous != null)
-                        {
-                            previous.Next = current.Next;
-                            current.Next = _head;
-                            _head = current;
-                        }
-
-                        value = current;
-                        return true;
-                    }
-
-                    previous = current;
-                    current = current.Next;
-                }
-
-                value = null;
-                return false;
-            }
-
-            private void PruneForGC()
-            {
-                // The general flow:
-                // * The current head is where we expire next time.
-                // * Under the lock: If there is an expire node, determine the new count by walking to it,
-                //   and unlink it from the previous node.
-                // * After the lock: Dispose all the values from the prune node onward.
-
-                Node? prune;
-                int countStart;
-                int countEnd;
-
-                lock (_lock)
-                {
-                    prune = _expire;
-                    _expire = _head;
-                    countStart = _count;
-
-                    if (prune is null)
-                    {
-                        return;
-                    }
-
-                    if (prune == _head)
-                    {
-                        _count = 0;
-                        _head = null;
-                        _expire = null;
-                    }
-                    else
-                    {
-                        Debug.Assert(_head is not null);
-                        int count = 1;
-                        Node current = _head;
-
-                        while (current.Next != prune && current.Next is not null)
-                        {
-                            count++;
-                            current = current.Next;
-                        }
-
-                        Debug.Assert(current.Next == prune, "The prune node should be in the list");
-                        current.Next = null;
-                        _count = count;
-                    }
-
-                    countEnd = _count;
-                }
-
-                // `prune` and beyond are now unlinked from the list, so we can dispose its values without holding the lock.
-                while (prune is not null)
-                {
-                    prune.Value.CrlHandle.Dispose();
-                    prune = prune.Next;
+                    prunedNode.Value.CrlHandle.Dispose();
+                    prunedNode = prunedNode.Next;
                 }
 
                 if (OpenSslX509ChainEventSource.Log.IsEnabled())
                 {
                     OpenSslX509ChainEventSource.Log.CrlCacheInMemoryPruned(countStart - countEnd, countEnd);
-                }
-            }
-
-            private sealed class Node
-            {
-                private readonly int _keyHashCode;
-
-                internal string Key { get; }
-                internal CachedCrlEntry Value { get; set; }
-                internal Node? Next { get; set; }
-
-                internal Node(int hashCode, string key, CachedCrlEntry value)
-                {
-                    Debug.Assert(key.GetHashCode() == hashCode);
-
-                    Key = key;
-                    _keyHashCode = hashCode;
-                    Value = value;
-                }
-
-                internal bool MatchesKey(int hashCode, string key)
-                {
-                    return _keyHashCode == hashCode && Key.Equals(key, StringComparison.Ordinal);
-                }
-            }
-
-            private sealed class GCWatcher
-            {
-                private readonly MruCrlCache _owner;
-
-                internal GCWatcher(MruCrlCache owner)
-                {
-                    _owner = owner;
-                }
-
-                ~GCWatcher()
-                {
-                    GC.ReRegisterForFinalize(this);
-
-                    if (GC.GetGeneration(this) == GC.MaxGeneration)
-                    {
-                        try
-                        {
-                            _owner.PruneForGC();
-                        }
-                        catch
-                        {
-                            // Eat any exception so we don't terminate the finalizer thread.
-#if DEBUG
-                            // Except in DEBUG, as we really shouldn't be hitting any exceptions here.
-                            throw;
-#endif
-                        }
-                    }
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
@@ -287,6 +287,7 @@ namespace System.Security.Cryptography.X509Certificates
             if (newEntry is not null)
             {
                 UpdateCacheAndAttachCrl(crlFileName, store, newEntry);
+                OpenSslCertificateAssetDownloader.ReportCrlCached(url);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
@@ -486,6 +486,12 @@ namespace System.Security.Cryptography.X509Certificates
         // on a CRL entry in use.
         private sealed class MruCrlCache : X509MruCache<CachedCrlEntry>
         {
+            // Each CRL is only a SafeHandle to the GC, but represents a non-trivial amount of
+            // native memory, so keep the cache small.
+            internal MruCrlCache() : base(30)
+            {
+            }
+
             internal CachedCrlEntry AddOrUpdateAndUpRef(string key, CachedCrlEntry value)
             {
                 CachedCrlEntry ret;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainEventSource.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainEventSource.cs
@@ -65,6 +65,18 @@ namespace System.Security.Cryptography.X509Certificates
         private const int EventId_CrlCacheInMemoryMiss = 51;
         private const int EventId_CrlCacheInMemoryPruned = 52;
         private const int EventId_CrlCacheInMemoryFull = 53;
+        private const int EventId_HttpCacheQuery = 54;
+        private const int EventId_HttpCacheHitFinished = 55;
+        private const int EventId_HttpCacheHitInProgress = 56;
+        private const int EventId_HttpCacheMiss = 57;
+        private const int EventId_HttpCacheFull = 58;
+        private const int EventId_HttpCacheExplicitRemoval = 59;
+        private const int EventId_HttpCacheTimeout = 60;
+        private const int EventId_HttpCacheHitIgnored = 61;
+        private const int EventId_HttpCacheBackgroundRefresh = 62;
+        private const int EventId_HttpCacheBackgroundFailure = 63;
+        private const int EventId_HttpCacheBackgroundSuccess = 64;
+        private const int EventId_HttpCachePruned = 65;
 
         private static string GetCertificateSubject(SafeX509Handle certHandle)
         {
@@ -815,6 +827,150 @@ namespace System.Security.Cryptography.X509Certificates
             if (IsEnabled())
             {
                 WriteEvent(EventId_CrlCacheInMemoryFull, cacheFileName);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheQuery,
+            Level = EventLevel.Verbose,
+            Message = "Checking the in-memory HTTP cache for '{0}'.")]
+        internal void HttpCacheQuery(string url)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheQuery, url);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheHitFinished,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory HTTP cache has a completed entry for the requested URL, {0} byte(s).")]
+        internal void HttpCacheHitFinished(int responseLength)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheHitFinished, responseLength);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheHitInProgress,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory HTTP cache has an entry in progress for the requested URL, attaching to it.")]
+        internal void HttpCacheHitInProgress()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheHitInProgress);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheHitIgnored,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory cached HTTP response indicates failure, retrying.")]
+        internal void HttpCacheHitIgnored()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheHitIgnored);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheFull,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory HTTP cache is full, dismissing '{0}'.")]
+        internal void HttpCacheFull(string uri)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheFull, uri);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheMiss,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory HTTP cache has no entry for the requested URL.")]
+        internal void HttpCacheMiss()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheMiss);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheBackgroundRefresh,
+            Level = EventLevel.Verbose,
+            Message = "The cached URL was cached {0} seconds ago, initiating background refresh.")]
+        internal void HttpCacheBackgroundRefresh(int ageInSeconds)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheBackgroundRefresh, ageInSeconds);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheBackgroundFailure,
+            Level = EventLevel.Verbose,
+            Message = "The background refresh for '{0}' failed, leaving existing entry intact.")]
+        internal void HttpCacheBackgroundFailure(string url)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheBackgroundFailure, url);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheBackgroundSuccess,
+            Level = EventLevel.Verbose,
+            Message = "The background refresh for '{0}' succeeded, updated cache.")]
+        internal void HttpCacheBackgroundSuccess(string url)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheBackgroundSuccess, url);
+            }
+        }
+
+        [Event(
+            EventId_HttpCachePruned,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory HTTP cache was pruned. {0} entries removed, {1} entries remain.")]
+        internal void HttpCachePruned(int prunedCount, int remainingCount)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCachePruned, prunedCount, remainingCount);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheExplicitRemoval,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory HTTP cache entry for '{0}' was explicitly removed.")]
+        internal void HttpCacheExplicitRemoval(string url)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheExplicitRemoval, url);
+            }
+        }
+
+        [Event(
+            EventId_HttpCacheTimeout,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory HTTP cache had a request that did not complete within the specified timeout.")]
+        internal void HttpCacheTimeout()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_HttpCacheTimeout);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
@@ -221,8 +221,13 @@ namespace System.Security.Cryptography.X509Certificates
             Interop.Crypto.X509VerifyStatusCode statusCode =
                 X509VerifyStatusCodeUniversal.X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT;
 
-            while (!IsCompleteChain(statusCode))
+            const int DownloadLimit = 2;
+            int downloadsRemaining = DownloadLimit;
+
+            while (downloadsRemaining > 0 && !IsCompleteChain(statusCode))
             {
+                downloadsRemaining--;
+
                 using (SafeX509Handle currentCert = Interop.Crypto.X509StoreCtxGetCurrentCert(storeCtx))
                 {
                     IntPtr currentHandle = currentCert.DangerousGetHandle();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
@@ -1,0 +1,260 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    internal abstract class X509MruCache<T> where T : class
+    {
+        // The CRL cache only stores a SafeHandle, but that's backed by a non-trivial amount of native memory.
+        // The HTTP cache might be holding a large response.
+        // Either way, keeping the number of items in the cache small has goodness, but it should be large enough
+        // that common scenarios aren't doing rapid eviction and repopulation of the same value.
+        // Until we see a reason that they need different sizes, use a const instead of a field.
+        private const int MaxItems = 30;
+
+        private protected readonly Lock _lock = new();
+
+        private int _count = -1;
+        private Node? _head;
+        private Node? _expire;
+
+        private protected virtual void Pruned(Node? prunedNode, int countStart, int countEnd)
+        {
+        }
+
+        private protected virtual bool OnConflictTakeNew(Node current, T newValue)
+        {
+            return false;
+        }
+
+        private protected static int GetHashCode(string key) => key.GetHashCode();
+
+        private protected bool TryGetNode(int hashCode, string key, [NotNullWhen(true)] out Node? value)
+        {
+            Debug.Assert(_lock.IsHeldByCurrentThread);
+
+            Node? previous = null;
+            Node? current = _head;
+
+            while (current is not null)
+            {
+                if (current.MatchesKey(hashCode, key))
+                {
+                    // If we find the expire node, move expiration to after it, so that promoting it to
+                    // most recent doesn't prune the whole list.
+                    //
+                    // This might, of course, make _expire null.
+                    if (current == _expire)
+                    {
+                        _expire = current.Next;
+                    }
+
+                    // Move the found node to the head of the list, maintaining MRU ordering.
+                    if (previous != null)
+                    {
+                        previous.Next = current.Next;
+                        current.Next = _head;
+                        _head = current;
+                    }
+
+                    value = current;
+                    return true;
+                }
+
+                previous = current;
+                current = current.Next;
+            }
+
+            value = null;
+            return false;
+        }
+
+        private protected T AddOrUpdate(int hashCode, string key, T value, out Node? evicted, out T? replaced)
+        {
+            Debug.Assert(key is not null);
+            Debug.Assert(value is not null);
+            Debug.Assert(_lock.IsHeldByCurrentThread);
+
+            T ret = value;
+
+            // The first time we add something, create the object to monitor for GC events.
+            if (_count < 0)
+            {
+                new GCWatcher(this);
+                _count = 0;
+            }
+
+            if (TryGetNode(hashCode, key, out Node? current))
+            {
+                Debug.Assert(current is not null);
+
+                if (OnConflictTakeNew(current, value))
+                {
+                    replaced = current.Value;
+                    current.Value = value;
+                }
+                else
+                {
+                    replaced = null;
+                    ret = current.Value;
+                }
+
+                evicted = null;
+            }
+            else
+            {
+                replaced = null;
+
+                Node node = new Node(hashCode, key, value);
+                node.Next = _head;
+
+                if (_count < MaxItems)
+                {
+                    _count++;
+                    evicted = null;
+                }
+                else
+                {
+                    // Because MaxItems is small, it's better to just iterate from head
+                    // instead of using a doubly-linked list.
+
+                    Node? previous = null;
+                    Node? cur = _head;
+                    Node? next = cur?.Next;
+
+                    while (next is not null)
+                    {
+                        previous = cur;
+                        cur = next;
+                        next = cur.Next;
+                    }
+
+                    Debug.Assert(previous is not null);
+                    Debug.Assert(cur is not null);
+
+                    previous.Next = null;
+                    evicted = cur;
+
+                    if (cur == _expire)
+                    {
+                        _expire = null;
+                    }
+                }
+
+                _head = node;
+            }
+
+            return ret;
+        }
+
+        private void PruneForGC()
+        {
+            // The general flow:
+            // * The current head is where we expire next time.
+            // * Under the lock: If there is an expire node, determine the new count by walking to it,
+            //   and unlink it from the previous node.
+            // * After the lock: Dispose all the values from the prune node onward.
+
+            Node? prune;
+            int countStart;
+            int countEnd;
+
+            lock (_lock)
+            {
+                prune = _expire;
+                _expire = _head;
+                countStart = _count;
+
+                if (prune is null)
+                {
+                    return;
+                }
+
+                if (prune == _head)
+                {
+                    _count = 0;
+                    _head = null;
+                    _expire = null;
+                }
+                else
+                {
+                    Debug.Assert(_head is not null);
+                    int count = 1;
+                    Node current = _head;
+
+                    while (current.Next != prune && current.Next is not null)
+                    {
+                        count++;
+                        current = current.Next;
+                    }
+
+                    Debug.Assert(current.Next == prune, "The prune node should be in the list");
+                    current.Next = null;
+                    _count = count;
+                }
+
+                countEnd = _count;
+            }
+
+            Pruned(prune, countStart, countEnd);
+        }
+
+        private protected sealed class Node
+        {
+            private readonly int _keyHashCode;
+
+            internal string Key { get; }
+            internal T Value { get; set; }
+            internal Node? Next { get; set; }
+
+            internal Node(int hashCode, string key, T value)
+            {
+                Debug.Assert(key.GetHashCode() == hashCode);
+
+                Key = key;
+                _keyHashCode = hashCode;
+                Value = value;
+            }
+
+            internal bool MatchesKey(int hashCode, string key)
+            {
+                return _keyHashCode == hashCode && Key.Equals(key, StringComparison.Ordinal);
+            }
+        }
+
+        private sealed class GCWatcher
+        {
+            private readonly X509MruCache<T> _owner;
+
+            internal GCWatcher(X509MruCache<T> owner)
+            {
+                _owner = owner;
+            }
+
+            ~GCWatcher()
+            {
+                GC.ReRegisterForFinalize(this);
+
+                if (GC.GetGeneration(this) == GC.MaxGeneration)
+                {
+                    try
+                    {
+                        _owner.PruneForGC();
+                    }
+                    catch
+                    {
+                        // Eat any exception so we don't terminate the finalizer thread.
+#if DEBUG
+                        // Except in DEBUG, as we really shouldn't be hitting any exceptions here.
+                        throw;
+#endif
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
@@ -9,18 +9,28 @@ namespace System.Security.Cryptography.X509Certificates
 {
     internal abstract class X509MruCache<T> where T : class
     {
-        // The CRL cache only stores a SafeHandle, but that's backed by a non-trivial amount of native memory.
-        // The HTTP cache might be holding a large response.
-        // Either way, keeping the number of items in the cache small has goodness, but it should be large enough
-        // that common scenarios aren't doing rapid eviction and repopulation of the same value.
-        // Until we see a reason that they need different sizes, use a const instead of a field.
-        private const int MaxItems = 30;
-
         private protected readonly Lock _lock = new();
 
         private int _count = -1;
         private Node? _head;
         private Node? _expire;
+        private int _capacity;
+
+        private protected X509MruCache(int capacity)
+        {
+            // This cache is based on the notion that O(n) is fast enough when n is small.
+            // 30 here represents an arbitrary balance across "linear is fast enough",
+            // "there are enough items to be useful", and "we don't want to hold onto too many items".
+            //
+            // Choosing a higher number should not be done without performance-based justification.
+            Debug.Assert(capacity <= 30);
+
+            // At one, just use a field.  By avoiding a capacity of 1 we can safely assume that
+            // the last node has a previous node, which simplifies the tail-pop.
+            Debug.Assert(capacity > 1);
+
+            _capacity = capacity;
+        }
 
         private protected virtual void Pruned(Node? prunedNode, int countStart, int countEnd)
         {
@@ -109,14 +119,14 @@ namespace System.Security.Cryptography.X509Certificates
                 Node node = new Node(hashCode, key, value);
                 node.Next = _head;
 
-                if (_count < MaxItems)
+                if (_count < _capacity)
                 {
                     _count++;
                     evicted = null;
                 }
                 else
                 {
-                    // Because MaxItems is small, it's better to just iterate from head
+                    // Because our maximum capacity is small, it's better to just iterate from head
                     // instead of using a doubly-linked list.
 
                     Node? previous = null;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
@@ -26,10 +26,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
         }
 
-        private protected virtual bool OnConflictTakeNew(Node current, T newValue)
-        {
-            return false;
-        }
+        private protected abstract bool OnConflictTakeNew(Node current, T newValue);
 
         private protected static int GetHashCode(string key) => key.GetHashCode();
 
@@ -149,6 +146,43 @@ namespace System.Security.Cryptography.X509Certificates
             }
 
             return ret;
+        }
+
+        private protected Node? Remove(int hashCode, string key)
+        {
+            Debug.Assert(key is not null);
+            Debug.Assert(_lock.IsHeldByCurrentThread);
+
+            Node? previous = null;
+            Node? current = _head;
+
+            while (current is not null)
+            {
+                if (current.MatchesKey(hashCode, key))
+                {
+                    if (previous is null)
+                    {
+                        _head = current.Next;
+                    }
+                    else
+                    {
+                        previous.Next = current.Next;
+                    }
+
+                    if (current == _expire)
+                    {
+                        _expire = current.Next;
+                    }
+
+                    _count--;
+                    return current;
+                }
+
+                previous = current;
+                current = current.Next;
+            }
+
+            return null;
         }
 
         private void PruneForGC()

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
@@ -272,22 +272,27 @@ namespace System.Security.Cryptography.X509Certificates
 
         private sealed class GCWatcher
         {
-            private readonly X509MruCache<T> _owner;
+            private readonly WeakReference<X509MruCache<T>> _ownerRef;
 
             internal GCWatcher(X509MruCache<T> owner)
             {
-                _owner = owner;
+                _ownerRef = new WeakReference<X509MruCache<T>>(owner);
             }
 
             ~GCWatcher()
             {
+                if (!_ownerRef.TryGetTarget(out X509MruCache<T>? owner))
+                {
+                    return;
+                }
+
                 GC.ReRegisterForFinalize(this);
 
                 if (GC.GetGeneration(this) == GC.MaxGeneration)
                 {
                     try
                     {
-                        _owner.PruneForGC();
+                        owner.PruneForGC();
                     }
                     catch
                     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509MruCache.cs
@@ -201,7 +201,7 @@ namespace System.Security.Cryptography.X509Certificates
             // * The current head is where we expire next time.
             // * Under the lock: If there is an expire node, determine the new count by walking to it,
             //   and unlink it from the previous node.
-            // * After the lock: Dispose all the values from the prune node onward.
+            // * After the lock: Pass the pruned head (which includes any nodes after it) to Pruned for any cleanup.
 
             Node? prune;
             int countStart;

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
@@ -215,5 +215,96 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 }
             }).Dispose();
         }
+
+        [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.Windows)]
+        [Fact]
+        public static void AiaCompletionHasLimits()
+        {
+            const int IntermediateCount = 6;
+
+            CertificateAuthority.BuildPrivatePki(
+                PkiOptions.AllRevocation,
+                out RevocationResponder responder,
+                out CertificateAuthority root,
+                out CertificateAuthority[] intermediates,
+                out X509Certificate2 endEntity,
+                intermediateAuthorityCount: IntermediateCount,
+                pkiOptionsInSubject: false);
+
+            using (responder)
+            using (root)
+            using (endEntity)
+            {
+                try
+                {
+                    RetryHelper.Execute(
+                        () =>
+                        {
+                            using (ChainHolder holder = new ChainHolder())
+                            {
+                                // This test shows that we only download two certificates at a time.
+                                // This is a Windows black-box behavior that we're matching.
+                                // White-box suggests it's supposed to be 3, but maybe there's an off-by-one.
+                                // Windows also allow registry customization... but this test can't tolerate it.
+
+                                try
+                                {
+                                    X509Chain chain = holder.Chain;
+                                    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                                    chain.ChainPolicy.VerificationFlags |=
+                                        X509VerificationFlags.AllowUnknownCertificateAuthority;
+                                    chain.ChainPolicy.VerificationTime = endEntity.NotBefore.AddMinutes(1);
+                                    chain.ChainPolicy.UrlRetrievalTimeout = DynamicRevocationTests.s_urlRetrievalLimit;
+                                    chain.ChainPolicy.ExtraStore.Add(intermediates[^2].CloneIssuerCert());
+
+                                    // EE, intermediate0 (AIA), intermediate1 (ExtraStore), intermediate2 (AIA).
+                                    AssertExtensions.TrueExpression(chain.Build(endEntity));
+                                    Assert.Equal(4, chain.ChainElements.Count);
+                                    AssertExtensions.HasFlag(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
+
+                                    CloneIntoExtraStore(chain, 1);
+                                    CloneIntoExtraStore(chain, 3);
+                                    holder.DisposeChainElements();
+
+                                    // Previous 4 plus intermediate3 and intermediate4.
+                                    AssertExtensions.TrueExpression(chain.Build(endEntity));
+                                    Assert.Equal(6, chain.ChainElements.Count);
+                                    AssertExtensions.HasFlag(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
+
+                                    CloneIntoExtraStore(chain, 4);
+                                    CloneIntoExtraStore(chain, 5);
+                                    holder.DisposeChainElements();
+
+                                    // AIA fetches intermediate5 and root, chain finishes.
+                                    AssertExtensions.TrueExpression(chain.Build(endEntity));
+                                    Assert.Equal(8, chain.ChainElements.Count);
+                                    Assert.Equal(X509ChainStatusFlags.UntrustedRoot, chain.AllStatusFlags());
+                                }
+                                finally
+                                {
+                                    foreach (X509Certificate2 cert in holder.Chain.ChainPolicy.ExtraStore)
+                                    {
+                                        cert.Dispose();
+                                    }
+                                }
+                            }
+                        });
+                }
+                finally
+                {
+                    foreach (CertificateAuthority intermediate in intermediates)
+                    {
+                        intermediate.Dispose();
+                    }
+                }
+
+                static void CloneIntoExtraStore(X509Chain chain, int index)
+                {
+                    ReadOnlySpan<byte> source = chain.ChainElements[index].Certificate.RawDataMemory.Span;
+                    X509Certificate2 cert = X509CertificateLoader.LoadCertificate(source);
+                    chain.ChainPolicy.ExtraStore.Add(cert);
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
@@ -229,7 +229,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 out CertificateAuthority[] intermediates,
                 out X509Certificate2 endEntity,
                 intermediateAuthorityCount: IntermediateCount,
-                pkiOptionsInSubject: false);
+                pkiOptionsInSubject: false,
+                testName: nameof(AiaCompletionHasLimits));
 
             using (responder)
             using (root)


### PR DESCRIPTION
This change primarily does two things:

1) Limits the Linux chain builder to two (2) AIA fetches per chain build, to match windows.
2) Reuses the MRU caching we introduced for SafeCrlHandle to unify to async AIA downloads across threads.

The caching has advantages, and disadvantages.

* Advantage: Two threads performing the same chain build will share an AIA fetch.
  * Both are doing sync-over-async via Task.Wait, but it eliminates parallel downloads.
* Disadvantage: While each thread will Task.Wait their own allotted time, the overall download allotted time is determined by the thread with the smallest timeout remaining.
  * Since the download itself is raised to the default time, what it really means is that a chain build with a large timeout specified can experience a foreshortened download window.
* Advantage: Two threads performing the same CRL download will share the download.
* Minor Inconvenience: A CRL download can evict an X509/AIA from the cache.
  * If we cared, we could separate the caches.
  * CRL downloads will remove themselves from the cache on success since they're cached at a higher object level (and thus won't download again).
* Advantage: Repeated chain builds against an untrusted root won't download repeatedly (subject to GC and MRU)
* Disadvantage: One-off AIA fetches will leave their responses in memory until two Gen2 GCs happen (one to put it behind the purge marker, one to clear it out)

Failures are not really cached.  A cached task that finished in a state with no `byte[]` is ignored, and a new download is triggered.

Just In Case the value at the URL isn't stable, the cache will trigger a background refresh for any value that is requested more than 6 minutes after it was initially cached.  That totally makes sense for CRLs (but they don't stay in the cache), it's not likely for certs... but it made me nervous, so I put it in anyways.

OCSP requests entirely skip the HTTP cache (if we cared they could use the same "on success, forget me" that CRL does)