### PR TITLE
Remove ECMA metadata access from cDAC SOSDacImpl.GetFieldDescData

### DIFF
--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -311,7 +311,7 @@ uint GetFieldDescMemberDef(TargetPointer fieldDescPointer);
 bool IsFieldDescThreadStatic(TargetPointer fieldDescPointer);
 bool IsFieldDescStatic(TargetPointer fieldDescPointer);
 bool IsFieldDescRVA(TargetPointer fieldDescPointer);
-uint GetFieldDescType(TargetPointer fieldDescPointer);
+CorElementType GetFieldDescType(TargetPointer fieldDescPointer);
 uint GetFieldDescOffset(TargetPointer fieldDescPointer);
 (CorElementType ElementType, uint TypeToken) GetFieldDescSignatureType(TargetPointer fieldDescPointer);
 TypeHandle GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer);
@@ -2274,10 +2274,10 @@ bool IsFieldDescRVA(TargetPointer fieldDescPointer)
     return (DWord1 & (uint)FieldDescFlags1.IsRVA) != 0;
 }
 
-uint GetFieldDescType(TargetPointer fieldDescPointer)
+CorElementType GetFieldDescType(TargetPointer fieldDescPointer)
 {
     uint DWord2 = target.Read<uint>(fieldDescPointer + /* FieldDesc::DWord2 offset */);
-    return (DWord2 & (uint)FieldDescFlags2.TypeMask) >> 27;
+    return (CorElementType)((DWord2 & (uint)FieldDescFlags2.TypeMask) >> 27);
 }
 
 uint GetFieldDescOffset(TargetPointer fieldDescPointer)

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -312,7 +312,8 @@ bool IsFieldDescThreadStatic(TargetPointer fieldDescPointer);
 bool IsFieldDescStatic(TargetPointer fieldDescPointer);
 bool IsFieldDescRVA(TargetPointer fieldDescPointer);
 uint GetFieldDescType(TargetPointer fieldDescPointer);
-uint GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition? fieldDef);
+uint GetFieldDescOffset(TargetPointer fieldDescPointer);
+(CorElementType ElementType, uint TypeToken) GetFieldDescSignatureType(TargetPointer fieldDescPointer);
 TypeHandle GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer);
 TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer, bool unboxValueTypes = true);
 TargetPointer GetFieldDescThreadStaticAddress(TargetPointer fieldDescPointer, TargetPointer thread, bool unboxValueTypes = true);
@@ -2279,7 +2280,7 @@ uint GetFieldDescType(TargetPointer fieldDescPointer)
     return (DWord2 & (uint)FieldDescFlags2.TypeMask) >> 27;
 }
 
-uint GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition? fieldDef)
+uint GetFieldDescOffset(TargetPointer fieldDescPointer)
 {
     uint DWord2 = target.Read<uint>(fieldDescPointer + /* FieldDesc::DWord2 offset */);
     // DWord2 packs the 27-bit offset (low bits) with the 5-bit field type (high bits), so the offset
@@ -2288,11 +2289,22 @@ uint GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition? fieldDe
     uint offset = DWord2 & (uint)FieldDescFlags2.OffsetMask;
     if (offset == _target.ReadGlobal<uint>("FieldOffsetBigRVA"))
     {
-        if (fieldDef is null)
-            throw new ArgumentNullException(nameof(fieldDef), "Field definition is required for big RVA fields");
-        return (uint)fieldDef.Value.GetRelativeVirtualAddress();
+        // Big-RVA fields store their offset (an RVA) in metadata; resolve the FieldDefinition
+        // (enclosing MT -> Module -> MetadataReader -> field's MemberDef) and read its RVA.
+        FieldDefinition fieldDef = /* resolve FieldDefinition from metadata */;
+        return (uint)fieldDef.GetRelativeVirtualAddress();
     }
     return offset;
+}
+
+(CorElementType ElementType, uint TypeToken) GetFieldDescSignatureType(TargetPointer fieldDescPointer)
+{
+    // Resolve enclosing MT -> Module -> MetadataReader and read the field's signature blob.
+    // If metadata is unavailable, fall back to (GetFieldDescType(fieldDescPointer), mdTypeDefNil).
+    // Otherwise read the top-level element type from the signature (skipping custom modifiers).
+    // Unlike GetFieldDescType this preserves the precise element type (e.g. String/SzArray rather
+    // than the normalized Class). For class/valuetype fields the signature also encodes a type
+    // token (a token in the field's defining module); otherwise the token is mdTypeDefNil.
 }
 
 TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer, bool unboxValueTypes = true)

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -313,7 +313,6 @@ bool IsFieldDescStatic(TargetPointer fieldDescPointer);
 bool IsFieldDescRVA(TargetPointer fieldDescPointer);
 CorElementType GetFieldDescType(TargetPointer fieldDescPointer);
 uint GetFieldDescOffset(TargetPointer fieldDescPointer);
-(CorElementType ElementType, uint TypeToken) GetFieldDescSignatureType(TargetPointer fieldDescPointer);
 TypeHandle GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer);
 TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer, bool unboxValueTypes = true);
 TargetPointer GetFieldDescThreadStaticAddress(TargetPointer fieldDescPointer, TargetPointer thread, bool unboxValueTypes = true);
@@ -2295,16 +2294,6 @@ uint GetFieldDescOffset(TargetPointer fieldDescPointer)
         return (uint)fieldDef.GetRelativeVirtualAddress();
     }
     return offset;
-}
-
-(CorElementType ElementType, uint TypeToken) GetFieldDescSignatureType(TargetPointer fieldDescPointer)
-{
-    // Resolve enclosing MT -> Module -> MetadataReader and read the field's signature blob.
-    // If metadata is unavailable, fall back to (GetFieldDescType(fieldDescPointer), mdTypeDefNil).
-    // Otherwise read the top-level element type from the signature (skipping custom modifiers).
-    // Unlike GetFieldDescType this preserves the precise element type (e.g. String/SzArray rather
-    // than the normalized Class). For class/valuetype fields the signature also encodes a type
-    // token (a token in the field's defining module); otherwise the token is mdTypeDefNil.
 }
 
 TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer, bool unboxValueTypes = true)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -309,7 +309,6 @@ public interface IRuntimeTypeSystem : IContract
     bool IsFieldDescRVA(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     CorElementType GetFieldDescType(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     uint GetFieldDescOffset(TargetPointer fieldDescPointer) => throw new NotImplementedException();
-    (CorElementType ElementType, uint TypeToken) GetFieldDescSignatureType(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     TypeHandle GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     TargetPointer GetFieldDescByName(TypeHandle typeHandle, string fieldName) => throw new NotImplementedException();
     TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer, bool unboxValueTypes = true) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -309,10 +309,6 @@ public interface IRuntimeTypeSystem : IContract
     bool IsFieldDescRVA(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     CorElementType GetFieldDescType(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     uint GetFieldDescOffset(TargetPointer fieldDescPointer) => throw new NotImplementedException();
-    // Reads the field's type from its signature (metadata). Returns the top-level CorElementType (after
-    // skipping custom modifiers) -- unlike GetFieldDescType this preserves the precise element type (e.g.
-    // String/SzArray rather than Class) -- along with the encoded type token (a token in the field's
-    // defining module) for class/valuetype fields, otherwise the nil TypeDef token.
     (CorElementType ElementType, uint TypeToken) GetFieldDescSignatureType(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     TypeHandle GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     TargetPointer GetFieldDescByName(TypeHandle typeHandle, string fieldName) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -308,7 +308,12 @@ public interface IRuntimeTypeSystem : IContract
     bool IsFieldDescStatic(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     bool IsFieldDescRVA(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     CorElementType GetFieldDescType(TargetPointer fieldDescPointer) => throw new NotImplementedException();
-    uint GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition? fieldDef) => throw new NotImplementedException();
+    uint GetFieldDescOffset(TargetPointer fieldDescPointer) => throw new NotImplementedException();
+    // Reads the field's type from its signature (metadata). Returns the top-level CorElementType (after
+    // skipping custom modifiers) -- unlike GetFieldDescType this preserves the precise element type (e.g.
+    // String/SzArray rather than Class) -- along with the encoded type token (a token in the field's
+    // defining module) for class/valuetype fields, otherwise the nil TypeDef token.
+    (CorElementType ElementType, uint TypeToken) GetFieldDescSignatureType(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     TypeHandle GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     TargetPointer GetFieldDescByName(TypeHandle typeHandle, string fieldName) => throw new NotImplementedException();
     TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer, bool unboxValueTypes = true) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
@@ -892,7 +892,7 @@ internal sealed class CallingConvention_1 : ICallingConvention
                 if (isStatic)
                     continue;
                 fieldType = rts.GetFieldDescType(fdPtr);
-                fieldOffset = rts.GetFieldDescOffset(fdPtr, fieldDef: null);
+                fieldOffset = rts.GetFieldDescOffset(fdPtr);
             }
             catch
             {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ManagedTypeSource_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ManagedTypeSource_1.cs
@@ -230,7 +230,7 @@ internal sealed class ManagedTypeSource_1 : IManagedTypeSource
             if (fieldDescAddr == TargetPointer.Null)
                 continue;
 
-            uint fdOffset = rts.GetFieldDescOffset(fieldDescAddr, fieldDef);
+            uint fdOffset = rts.GetFieldDescOffset(fieldDescAddr);
             CorElementType elementType = rts.GetFieldDescType(fieldDescAddr);
             instanceFields[fieldName] = new Target.FieldInfo
             {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -2301,25 +2301,6 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         return offset;
     }
 
-    (CorElementType ElementType, uint TypeToken) IRuntimeTypeSystem.GetFieldDescSignatureType(TargetPointer fieldDescPointer)
-    {
-        FieldDefinition? fieldDefOrNull = TryGetFieldDefinition(fieldDescPointer, out ModuleHandle moduleHandle, out _);
-        if (fieldDefOrNull is not FieldDefinition fieldDef)
-        {
-            // Metadata unavailable; fall back to the (normalized) type stored in the FieldDesc and no token.
-            return (((IRuntimeTypeSystem)this).GetFieldDescType(fieldDescPointer), (uint)EcmaMetadataUtils.TokenType.mdtTypeDef);
-        }
-
-        MetadataReader mdReader = _target.Contracts.EcmaMetadata.GetMetadata(moduleHandle)!;
-        (CorElementType typeCode, EntityHandle entityHandle) = EcmaMetadataUtils.ReadFieldSignatureType(mdReader, fieldDef.Signature);
-        // For class/valuetype fields the signature encodes the type token (in the field's defining module);
-        // otherwise there is no encoded token.
-        uint typeToken = typeCode is CorElementType.Class or CorElementType.ValueType
-            ? (uint)MetadataTokens.GetToken(entityHandle)
-            : (uint)EcmaMetadataUtils.TokenType.mdtTypeDef;
-        return (typeCode, typeToken);
-    }
-
     // Resolves the FieldDefinition (and its containing module/enclosing type) for a FieldDesc from metadata.
     // Returns null if the metadata is not available (e.g. in a minidump).
     private FieldDefinition? TryGetFieldDefinition(TargetPointer fieldDescPointer, out ModuleHandle moduleHandle, out TypeHandle enclosingType)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -2284,7 +2284,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         return (CorElementType)((fieldDesc.DWord2 & (uint)FieldDescFlags2.TypeMask) >> TYPE_MASK_OFFSET);
     }
 
-    uint IRuntimeTypeSystem.GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition? fieldDef)
+    uint IRuntimeTypeSystem.GetFieldDescOffset(TargetPointer fieldDescPointer)
     {
         Data.FieldDesc fieldDesc = _target.ProcessedData.GetOrAdd<Data.FieldDesc>(fieldDescPointer);
         // DWord2 packs the 27-bit offset (low bits) with the 5-bit field type (high bits), so the offset
@@ -2293,11 +2293,56 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         uint offset = fieldDesc.DWord2 & (uint)FieldDescFlags2.OffsetMask;
         if (offset == _target.ReadGlobal<uint>(Constants.Globals.FieldOffsetBigRVA))
         {
-            if (fieldDef is null)
-                throw new ArgumentNullException(nameof(fieldDef), "Field definition is required for big RVA fields");
-            return (uint)fieldDef.Value.GetRelativeVirtualAddress();
+            // Big-RVA fields store their offset (an RVA) in metadata; resolve the FieldDefinition for it.
+            if (TryGetFieldDefinition(fieldDescPointer, out _, out _) is not FieldDefinition fieldDef)
+                throw new InvalidOperationException("Field definition metadata is required to resolve a big RVA field offset.");
+            return (uint)fieldDef.GetRelativeVirtualAddress();
         }
         return offset;
+    }
+
+    (CorElementType ElementType, uint TypeToken) IRuntimeTypeSystem.GetFieldDescSignatureType(TargetPointer fieldDescPointer)
+    {
+        FieldDefinition? fieldDefOrNull = TryGetFieldDefinition(fieldDescPointer, out ModuleHandle moduleHandle, out _);
+        if (fieldDefOrNull is not FieldDefinition fieldDef)
+        {
+            // Metadata unavailable; fall back to the (normalized) type stored in the FieldDesc and no token.
+            return (((IRuntimeTypeSystem)this).GetFieldDescType(fieldDescPointer), (uint)EcmaMetadataUtils.TokenType.mdtTypeDef);
+        }
+
+        MetadataReader mdReader = _target.Contracts.EcmaMetadata.GetMetadata(moduleHandle)!;
+        (CorElementType typeCode, EntityHandle entityHandle) = EcmaMetadataUtils.ReadFieldSignatureType(mdReader, fieldDef.Signature);
+        // For class/valuetype fields the signature encodes the type token (in the field's defining module);
+        // otherwise there is no encoded token.
+        uint typeToken = typeCode is CorElementType.Class or CorElementType.ValueType
+            ? (uint)MetadataTokens.GetToken(entityHandle)
+            : (uint)EcmaMetadataUtils.TokenType.mdtTypeDef;
+        return (typeCode, typeToken);
+    }
+
+    // Resolves the FieldDefinition (and its containing module/enclosing type) for a FieldDesc from metadata.
+    // Returns null if the metadata is not available (e.g. in a minidump).
+    private FieldDefinition? TryGetFieldDefinition(TargetPointer fieldDescPointer, out ModuleHandle moduleHandle, out TypeHandle enclosingType)
+    {
+        moduleHandle = default;
+        enclosingType = default;
+
+        TargetPointer enclosingMT = ((IRuntimeTypeSystem)this).GetMTOfEnclosingClass(fieldDescPointer);
+        if (enclosingMT == TargetPointer.Null)
+            return null;
+        enclosingType = GetTypeHandle(enclosingMT);
+        TargetPointer modulePtr = GetModule(enclosingType);
+        if (modulePtr == TargetPointer.Null)
+            return null;
+
+        moduleHandle = _target.Contracts.Loader.GetModuleHandleFromModulePtr(modulePtr);
+        MetadataReader? mdReader = _target.Contracts.EcmaMetadata.GetMetadata(moduleHandle);
+        if (mdReader is null)
+            return null;
+
+        uint memberDef = ((IRuntimeTypeSystem)this).GetFieldDescMemberDef(fieldDescPointer);
+        FieldDefinitionHandle fieldDefHandle = (FieldDefinitionHandle)MetadataTokens.Handle((int)memberDef);
+        return mdReader.GetFieldDefinition(fieldDefHandle);
     }
 
     TypeHandle IRuntimeTypeSystem.GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer)
@@ -2419,12 +2464,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         if (@base == TargetPointer.Null)
             return TargetPointer.Null;
 
-        MetadataReader mdReader = _target.Contracts.EcmaMetadata.GetMetadata(moduleHandle)!;
-        uint token = ((IRuntimeTypeSystem)this).GetFieldDescMemberDef(fieldDescPointer);
-        FieldDefinitionHandle fieldHandle = (FieldDefinitionHandle)MetadataTokens.Handle((int)token);
-        FieldDefinition fieldDef = mdReader.GetFieldDefinition(fieldHandle);
-
-        uint offset = ((IRuntimeTypeSystem)this).GetFieldDescOffset(fieldDescPointer, fieldDef);
+        uint offset = ((IRuntimeTypeSystem)this).GetFieldDescOffset(fieldDescPointer);
         bool isRVA = ((IRuntimeTypeSystem)this).IsFieldDescRVA(fieldDescPointer);
         TargetPointer handleAddr = GetStaticAddressHandle(@base, offset, isRVA, fieldDescPointer, moduleHandle);
         if (unboxValueTypes && type == CorElementType.ValueType && !isRVA)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
@@ -244,7 +243,7 @@ public static class EcmaMetadataUtils
         BlobReader blobReader = reader.GetBlobReader(signature);
         SignatureHeader header = blobReader.ReadSignatureHeader();
         if (header.Kind != SignatureKind.Field)
-            throw new BadImageFormatException();
+            throw new System.BadImageFormatException();
 
         // Skip any custom modifiers (each is followed by a TypeDefOrRef token) to reach the underlying type.
         CorElementType typeCode;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
@@ -234,5 +235,24 @@ public static class EcmaMetadataUtils
 
         nextModule = default;
         return false;
+    }
+
+    // Reads the top-level type from a field signature, skipping custom modifiers. Returns the element type
+    // and, for class/valuetype types, the encoded type token handle (a token in the field's defining module).
+    public static (CorElementType TypeCode, EntityHandle TypeHandle) ReadFieldSignatureType(MetadataReader reader, BlobHandle signature)
+    {
+        BlobReader blobReader = reader.GetBlobReader(signature);
+        SignatureHeader header = blobReader.ReadSignatureHeader();
+        if (header.Kind != SignatureKind.Field)
+            throw new BadImageFormatException();
+        CorElementType typeCode;
+        EntityHandle entityHandle;
+        // in a loop, read custom modifiers until we get to the underlying type
+        do
+        {
+            typeCode = (CorElementType)blobReader.ReadByte();
+            entityHandle = blobReader.ReadTypeHandle(); // consume the type
+        } while (typeCode is CorElementType.CModReqd or CorElementType.CModOpt);
+        return (typeCode, entityHandle);
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
@@ -245,14 +245,22 @@ public static class EcmaMetadataUtils
         SignatureHeader header = blobReader.ReadSignatureHeader();
         if (header.Kind != SignatureKind.Field)
             throw new BadImageFormatException();
+
+        // Skip any custom modifiers (each is followed by a TypeDefOrRef token) to reach the underlying type.
         CorElementType typeCode;
-        EntityHandle entityHandle;
-        // in a loop, read custom modifiers until we get to the underlying type
-        do
+        while (true)
         {
             typeCode = (CorElementType)blobReader.ReadByte();
-            entityHandle = blobReader.ReadTypeHandle(); // consume the type
-        } while (typeCode is CorElementType.CModReqd or CorElementType.CModOpt);
+            if (typeCode is not (CorElementType.CModReqd or CorElementType.CModOpt))
+                break;
+            blobReader.ReadTypeHandle(); // consume the modifier's type token
+        }
+
+        // Only class/valuetype signatures encode a following type token; for all other element types the
+        // element-type byte fully describes the type, so there is no token to read.
+        EntityHandle entityHandle = typeCode is CorElementType.Class or CorElementType.ValueType
+            ? blobReader.ReadTypeHandle()
+            : default;
         return (typeCode, entityHandle);
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -2645,7 +2645,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                     TargetPointer baseAddr = isPrimitive ? nonGCStaticsBase : gcStaticsBase;
                     if (baseAddr != TargetPointer.Null)
                     {
-                        uint offset = rts.GetFieldDescOffset(fdPtr, null);
+                        uint offset = rts.GetFieldDescOffset(fdPtr);
                         fd.m_pFldStaticAddress = baseAddr + offset;
                     }
                 }
@@ -2653,7 +2653,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             else
             {
                 // instance: store the offset
-                uint offset = rts.GetFieldDescOffset(fdPtr, null);
+                uint offset = rts.GetFieldDescOffset(fdPtr);
                 fd.m_fldInstanceOffset = offset;
             }
         }
@@ -4783,7 +4783,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                     FieldDefinitionHandle fieldDefHandle = (FieldDefinitionHandle)MetadataTokens.Handle((int)memberDef);
                     FieldDefinition fieldDef = enclosingMdReader.GetFieldDefinition(fieldDefHandle);
 
-                    corField->offset = rts.GetFieldDescOffset(fieldDescPtr, fieldDef) + firstFieldOffset;
+                    corField->offset = rts.GetFieldDescOffset(fieldDescPtr) + firstFieldOffset;
 
                     // Resolve the field's type. If we cannot decode the signature (e.g. corrupt
                     // metadata or a type that cannot be loaded), zero out the type id and

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1068,14 +1068,14 @@ public sealed unsafe partial class SOSDacImpl
             TypeHandle ctx = rtsContract.GetTypeHandle(enclosingMT);
             TargetPointer modulePtr = rtsContract.GetModule(ctx);
 
-            // Resolve the MethodTable of the field's type from its (approximate) TypeHandle, following the
-            // DAC's TypeHandle::GetMethodTable rules used by SOS pretty-printing (src/coreclr/vm/typehandle.inl).
-            // This is an implementation detail of the DAC that we replicate here to get method tables for
-            // non-MT types that we can return to SOS for pretty-printing. In the future we may want to return
-            // a TypeHandle instead of a MethodTable, and modify SOS to do more complete pretty-printing.
             TypeHandle foundTypeHandle = rtsContract.GetFieldDescApproxTypeHandle(fieldDescTargetPtr);
             try
             {
+                // get the MT of the type
+                // This is an implementation detail of the DAC that we replicate here to get method tables for non-MT types
+                // that we can return to SOS for pretty-printing.
+                // In the future we may want to return a TypeHandle instead of a MethodTable, and modify SOS to do more complete pretty-printing.
+                // DAC equivalent: src/coreclr/vm/typehandle.inl TypeHandle::GetMethodTable
                 if (foundTypeHandle.IsNull)
                 {
                     // if we can't find the MT (e.g in a minidump)
@@ -1107,7 +1107,7 @@ public sealed unsafe partial class SOSDacImpl
             }
             catch (VirtualReadException)
             {
-                // if we can't read the MT (e.g in a minidump)
+                // if we can't find the MT (e.g in a minidump)
                 data->MTOfType = 0;
             }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1056,8 +1056,6 @@ public sealed unsafe partial class SOSDacImpl
                 throw new ArgumentException();
 
             IRuntimeTypeSystem rtsContract = _target.Contracts.RuntimeTypeSystem;
-            IEcmaMetadata ecmaMetadataContract = _target.Contracts.EcmaMetadata;
-            ISignature signatureContract = _target.Contracts.Signature;
 
             TargetPointer fieldDescTargetPtr = fieldDesc.ToTargetPointer(_target);
             CorElementType fieldDescType = rtsContract.GetFieldDescType(fieldDescTargetPtr);
@@ -1065,83 +1063,58 @@ public sealed unsafe partial class SOSDacImpl
             data->sigType = fieldDescType;
 
             uint token = rtsContract.GetFieldDescMemberDef(fieldDescTargetPtr);
-            FieldDefinitionHandle fieldHandle = (FieldDefinitionHandle)MetadataTokens.Handle((int)token);
 
             TargetPointer enclosingMT = rtsContract.GetMTOfEnclosingClass(fieldDescTargetPtr);
             TypeHandle ctx = rtsContract.GetTypeHandle(enclosingMT);
             TargetPointer modulePtr = rtsContract.GetModule(ctx);
-            Contracts.ModuleHandle moduleHandle = _target.Contracts.Loader.GetModuleHandleFromModulePtr(modulePtr);
-            MetadataReader mdReader = ecmaMetadataContract.GetMetadata(moduleHandle)!;
-            FieldDefinition fieldDef = mdReader.GetFieldDefinition(fieldHandle);
-            try
-            {
-                // try to completely decode the signature
-                TypeHandle foundTypeHandle = signatureContract.DecodeFieldSignature(fieldDef.Signature, moduleHandle, ctx);
 
+            // Resolve the MethodTable of the field's type from its (approximate) TypeHandle, following the
+            // DAC's TypeHandle::GetMethodTable rules used by SOS pretty-printing (src/coreclr/vm/typehandle.inl).
+            // This mapping operates only on TypeHandles, so no metadata is read here.
+            TypeHandle foundTypeHandle = rtsContract.GetFieldDescApproxTypeHandle(fieldDescTargetPtr);
+            if (foundTypeHandle.IsNull)
+                // if we can't find the MT (e.g in a minidump)
+                data->MTOfType = 0;
                 // get the MT of the type
                 // This is an implementation detail of the DAC that we replicate here to get method tables for non-MT types
                 // that we can return to SOS for pretty-printing.
                 // In the future we may want to return a TypeHandle instead of a MethodTable, and modify SOS to do more complete pretty-printing.
                 // DAC equivalent: src/coreclr/vm/typehandle.inl TypeHandle::GetMethodTable
-                if (rtsContract.IsFunctionPointer(foundTypeHandle, out _, out _) || rtsContract.IsPointer(foundTypeHandle))
-                    data->MTOfType = rtsContract.GetPrimitiveType(CorElementType.U).Address.ToClrDataAddress(_target);
-                // array MTs
-                else if (rtsContract.IsArray(foundTypeHandle, out _))
-                    data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
-                else
-                {
-                    try
-                    {
-                        // value typedescs
-                        TypeHandle paramTypeHandle = rtsContract.GetTypeParam(foundTypeHandle);
-                        data->MTOfType = paramTypeHandle.Address.ToClrDataAddress(_target);
-                    }
-                    catch (ArgumentException)
-                    {
-                        // non-array MTs
-                        data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
-                    }
-                }
-            }
-            catch (VirtualReadException)
-            {
-                // if we can't find the MT (e.g in a minidump)
-                data->MTOfType = 0;
-            }
-
-            // partial decoding of signature
-            BlobReader blobReader = mdReader.GetBlobReader(fieldDef.Signature);
-            SignatureHeader header = blobReader.ReadSignatureHeader();
-            // read the header byte and check for correctness
-            if (header.Kind != SignatureKind.Field)
-                throw new BadImageFormatException();
-            // read the top-level type
-            CorElementType typeCode;
-            EntityHandle entityHandle;
-            // in a loop, read custom modifiers until we get to the underlying type
-            do
-            {
-                typeCode = (CorElementType)blobReader.ReadByte();
-                entityHandle = blobReader.ReadTypeHandle(); // consume the type
-            } while (typeCode is CorElementType.CModReqd or CorElementType.CModOpt); // eat custom modifiers
-
-            if (typeCode is CorElementType.Class or CorElementType.ValueType)
-            {
-                // if the typecode is class or value, we have been able to read the token that follows in the sig
-                data->TokenOfType = (uint)MetadataTokens.GetToken(entityHandle);
-            }
+            else if (rtsContract.IsFunctionPointer(foundTypeHandle, out _, out _) || rtsContract.IsPointer(foundTypeHandle))
+                data->MTOfType = rtsContract.GetPrimitiveType(CorElementType.U).Address.ToClrDataAddress(_target);
+            // array MTs
+            else if (rtsContract.IsArray(foundTypeHandle, out _))
+                data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
             else
             {
-                // otherwise we have not found the token here, but we can encode the underlying type in sigType
-                data->TokenOfType = (uint)EcmaMetadataUtils.TokenType.mdtTypeDef;
-                if (data->MTOfType == 0)
-                    data->sigType = typeCode;
+                try
+                {
+                    // value typedescs
+                    TypeHandle paramTypeHandle = rtsContract.GetTypeParam(foundTypeHandle);
+                    data->MTOfType = paramTypeHandle.Address.ToClrDataAddress(_target);
+                }
+                catch (ArgumentException)
+                {
+                    // non-array MTs
+                    data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
+                }
+            }
+
+            // Read the field type's element type and encoded token from the field signature via the
+            // RuntimeTypeSystem contract so this method doesn't need to read ECMA metadata itself.
+            (CorElementType sigElementType, uint sigTypeToken) = rtsContract.GetFieldDescSignatureType(fieldDescTargetPtr);
+            data->TokenOfType = sigTypeToken;
+            if (sigTypeToken == (uint)EcmaMetadataUtils.TokenType.mdtTypeDef && data->MTOfType == 0)
+            {
+                // There is no encoded token (i.e. a primitive type) and no MethodTable for it, so remember
+                // the element type from the signature.
+                data->sigType = sigElementType;
             }
 
             data->ModuleOfType = modulePtr.ToClrDataAddress(_target);
             data->mb = token;
             data->MTOfEnclosingClass = ctx.Address.ToClrDataAddress(_target);
-            data->dwOffset = rtsContract.GetFieldDescOffset(fieldDescTargetPtr, fieldDef);
+            data->dwOffset = rtsContract.GetFieldDescOffset(fieldDescTargetPtr);
             data->bIsThreadLocal = rtsContract.IsFieldDescThreadStatic(fieldDescTargetPtr) ? 1 : 0;
             data->bIsContextLocal = 0;
             data->bIsStatic = rtsContract.IsFieldDescStatic(fieldDescTargetPtr) ? 1 : 0;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1070,34 +1070,45 @@ public sealed unsafe partial class SOSDacImpl
 
             // Resolve the MethodTable of the field's type from its (approximate) TypeHandle, following the
             // DAC's TypeHandle::GetMethodTable rules used by SOS pretty-printing (src/coreclr/vm/typehandle.inl).
-            // This mapping operates only on TypeHandles, so no metadata is read here.
+            // This is an implementation detail of the DAC that we replicate here to get method tables for
+            // non-MT types that we can return to SOS for pretty-printing. In the future we may want to return
+            // a TypeHandle instead of a MethodTable, and modify SOS to do more complete pretty-printing.
             TypeHandle foundTypeHandle = rtsContract.GetFieldDescApproxTypeHandle(fieldDescTargetPtr);
-            if (foundTypeHandle.IsNull)
-                // if we can't find the MT (e.g in a minidump)
-                data->MTOfType = 0;
-                // get the MT of the type
-                // This is an implementation detail of the DAC that we replicate here to get method tables for non-MT types
-                // that we can return to SOS for pretty-printing.
-                // In the future we may want to return a TypeHandle instead of a MethodTable, and modify SOS to do more complete pretty-printing.
-                // DAC equivalent: src/coreclr/vm/typehandle.inl TypeHandle::GetMethodTable
-            else if (rtsContract.IsFunctionPointer(foundTypeHandle, out _, out _) || rtsContract.IsPointer(foundTypeHandle))
-                data->MTOfType = rtsContract.GetPrimitiveType(CorElementType.U).Address.ToClrDataAddress(_target);
-            // array MTs
-            else if (rtsContract.IsArray(foundTypeHandle, out _))
-                data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
-            else
+            try
             {
-                try
+                if (foundTypeHandle.IsNull)
                 {
-                    // value typedescs
-                    TypeHandle paramTypeHandle = rtsContract.GetTypeParam(foundTypeHandle);
-                    data->MTOfType = paramTypeHandle.Address.ToClrDataAddress(_target);
+                    // if we can't find the MT (e.g in a minidump)
+                    data->MTOfType = 0;
                 }
-                catch (ArgumentException)
+                else if (rtsContract.IsFunctionPointer(foundTypeHandle, out _, out _) || rtsContract.IsPointer(foundTypeHandle))
                 {
-                    // non-array MTs
+                    data->MTOfType = rtsContract.GetPrimitiveType(CorElementType.U).Address.ToClrDataAddress(_target);
+                }
+                else if (rtsContract.IsArray(foundTypeHandle, out _))
+                {
+                    // array MTs
                     data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
                 }
+                else
+                {
+                    try
+                    {
+                        // value typedescs
+                        TypeHandle paramTypeHandle = rtsContract.GetTypeParam(foundTypeHandle);
+                        data->MTOfType = paramTypeHandle.Address.ToClrDataAddress(_target);
+                    }
+                    catch (ArgumentException)
+                    {
+                        // non-array MTs
+                        data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
+                    }
+                }
+            }
+            catch (VirtualReadException)
+            {
+                // if we can't read the MT (e.g in a minidump)
+                data->MTOfType = 0;
             }
 
             // Read the field type's element type and encoded token from the field signature via the

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1111,15 +1111,25 @@ public sealed unsafe partial class SOSDacImpl
                 data->MTOfType = 0;
             }
 
-            // Read the field type's element type and encoded token from the field signature via the
-            // RuntimeTypeSystem contract so this method doesn't need to read ECMA metadata itself.
-            (CorElementType sigElementType, uint sigTypeToken) = rtsContract.GetFieldDescSignatureType(fieldDescTargetPtr);
-            data->TokenOfType = sigTypeToken;
-            if (sigTypeToken == (uint)EcmaMetadataUtils.TokenType.mdtTypeDef && data->MTOfType == 0)
+            // TokenOfType and the fallback sigType are read from the field's signature. These are
+            // SOS-specific display values (see DacpFieldDescData / DisplayFields), so decode the signature
+            // here rather than surfacing an SOS-shaped API on the RuntimeTypeSystem contract.
+            Contracts.ModuleHandle moduleHandle = _target.Contracts.Loader.GetModuleHandleFromModulePtr(modulePtr);
+            MetadataReader mdReader = _target.Contracts.EcmaMetadata.GetMetadata(moduleHandle)!;
+            FieldDefinitionHandle fieldHandle = (FieldDefinitionHandle)MetadataTokens.Handle((int)token);
+            FieldDefinition fieldDef = mdReader.GetFieldDefinition(fieldHandle);
+            (CorElementType typeCode, EntityHandle entityHandle) = EcmaMetadataUtils.ReadFieldSignatureType(mdReader, fieldDef.Signature);
+            if (typeCode is CorElementType.Class or CorElementType.ValueType)
             {
-                // There is no encoded token (i.e. a primitive type) and no MethodTable for it, so remember
-                // the element type from the signature.
-                data->sigType = sigElementType;
+                // if the typecode is class or value, the signature encodes the type token that follows
+                data->TokenOfType = (uint)MetadataTokens.GetToken(entityHandle);
+            }
+            else
+            {
+                // otherwise there is no encoded token, but we can encode the underlying type in sigType
+                data->TokenOfType = (uint)EcmaMetadataUtils.TokenType.mdtTypeDef;
+                if (data->MTOfType == 0)
+                    data->sigType = typeCode;
             }
 
             data->ModuleOfType = modulePtr.ToClrDataAddress(_target);

--- a/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
@@ -2,12 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Microsoft.Diagnostics.DataContractReader.RuntimeTypeSystemHelpers;
 using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
 using Xunit;
 using static Microsoft.Diagnostics.DataContractReader.TestInfrastructure.TestHelpers;
 
@@ -67,6 +72,26 @@ public class MethodTableTests
             .AddContract<IRuntimeTypeSystem>(version: "c1")
             .Build();
         return target;
+    }
+
+    private static TestPlaceholderTarget CreateTarget(
+        MockTarget.Architecture arch,
+        Action<MockRTS> configure,
+        Mock<ILoader> loader,
+        Mock<IEcmaMetadata> ecmaMetadata)
+    {
+        var targetBuilder = new TestPlaceholderTarget.Builder(arch);
+        MockRTS rtsBuilder = new(targetBuilder.MemoryBuilder);
+
+        configure?.Invoke(rtsBuilder);
+
+        return targetBuilder
+            .AddTypes(CreateContractTypes(rtsBuilder))
+            .AddGlobals(CreateContractGlobals(rtsBuilder))
+            .AddContract<IRuntimeTypeSystem>(version: "c1")
+            .AddMockContract(loader)
+            .AddMockContract(ecmaMetadata)
+            .Build();
     }
 
     [Theory]
@@ -1357,5 +1382,83 @@ public class MethodTableTests
 
         IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
         Assert.Throws<InvalidOperationException>(() => contract.GetFieldDescOffset(fieldDescPtr));
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetFieldDescOffset_BigRVA_ResolvesRvaFromMetadata(MockTarget.Architecture arch)
+    {
+        const int expectedRva = 0x1234;
+        byte[] metadata = BuildMetadataWithRvaField(expectedRva, out FieldDefinitionHandle fieldHandle);
+        using MetadataReaderProvider provider = MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(metadata));
+        MetadataReader reader = provider.GetMetadataReader();
+
+        TargetPointer modulePtr = new(0x0001_0000);
+        Contracts.ModuleHandle moduleHandle = new(modulePtr);
+        Mock<ILoader> loader = new(MockBehavior.Strict);
+        loader.Setup(l => l.GetModuleHandleFromModulePtr(modulePtr)).Returns(moduleHandle);
+
+        Mock<IEcmaMetadata> ecmaMetadata = new(MockBehavior.Strict);
+        ecmaMetadata.Setup(e => e.GetMetadata(It.IsAny<Contracts.ModuleHandle>())).Returns(reader);
+
+        TargetPointer fieldDescPtr = default;
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            rtsBuilder =>
+            {
+                TargetPointer systemObjectMethodTablePtr = rtsBuilder.SystemObjectMethodTable.Address;
+
+                MockEEClass eeClass = rtsBuilder.AddEEClass("RvaType");
+                eeClass.CorTypeAttr = (uint)(TypeAttributes.Public | TypeAttributes.Class);
+
+                MockMethodTable methodTable = rtsBuilder.AddMethodTable("RvaType");
+                methodTable.BaseSize = rtsBuilder.Builder.TargetTestHelpers.ObjectBaseSize;
+                methodTable.ParentMethodTable = systemObjectMethodTablePtr;
+                methodTable.NumVirtuals = 3;
+                methodTable.Module = modulePtr;
+                eeClass.MethodTable = methodTable.Address;
+                methodTable.EEClassOrCanonMT = eeClass.Address;
+
+                fieldDescPtr = rtsBuilder.AddFieldDesc(
+                    methodTable.Address,
+                    CorElementType.I4,
+                    MockRTS.FieldOffsetBigRVAValue,
+                    (uint)MetadataTokens.GetRowNumber(fieldHandle)).Address;
+            },
+            loader,
+            ecmaMetadata);
+
+        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
+        Assert.Equal((uint)expectedRva, contract.GetFieldDescOffset(fieldDescPtr));
+    }
+
+    private static byte[] BuildMetadataWithRvaField(int rva, out FieldDefinitionHandle fieldHandle)
+    {
+        MetadataBuilder mdBuilder = new();
+        mdBuilder.AddModule(0, mdBuilder.GetOrAddString("TestModule"), mdBuilder.GetOrAddGuid(Guid.Empty), default, default);
+        mdBuilder.AddAssembly(mdBuilder.GetOrAddString("TestAssembly"), new Version(1, 0, 0, 0), default, default, 0, AssemblyHashAlgorithm.None);
+
+        BlobBuilder fieldSig = new();
+        new BlobEncoder(fieldSig).FieldSignature().Int32();
+        BlobHandle fieldSigHandle = mdBuilder.GetOrAddBlob(fieldSig);
+
+        fieldHandle = mdBuilder.AddFieldDefinition(
+            FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
+            mdBuilder.GetOrAddString("RvaField"),
+            fieldSigHandle);
+        mdBuilder.AddFieldRelativeVirtualAddress(fieldHandle, rva);
+
+        mdBuilder.AddTypeDefinition(
+            default,
+            default,
+            mdBuilder.GetOrAddString("<Module>"),
+            default,
+            fieldHandle,
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        MetadataRootBuilder rootBuilder = new(mdBuilder);
+        BlobBuilder blobBuilder = new();
+        rootBuilder.Serialize(blobBuilder, 0, 0);
+        return blobBuilder.ToArray();
     }
 }

--- a/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
@@ -3,11 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection;
-using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Microsoft.Diagnostics.DataContractReader.RuntimeTypeSystemHelpers;
@@ -1341,65 +1337,25 @@ public class MethodTableTests
             rtsBuilder => fieldDescPtr = rtsBuilder.AddFieldDesc(mtOfEnclosingClass: 0, CorElementType.Class, fieldOffset).Address);
 
         IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
-        Assert.Equal(fieldOffset, contract.GetFieldDescOffset(fieldDescPtr, fieldDef: null));
+        Assert.Equal(fieldOffset, contract.GetFieldDescOffset(fieldDescPtr));
     }
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void GetFieldDescOffset_BigRVA_ResolvesFromMetadata(MockTarget.Architecture arch)
+    public void GetFieldDescOffset_BigRVA_DetectedAfterMaskingTypeBits(MockTarget.Architecture arch)
     {
         // A big-RVA field packs the FIELD_OFFSET_BIG_RVA sentinel into DWord2's low 27 bits together with a
-        // non-zero type in the high 5 bits. Detection must mask off the type before comparing the sentinel,
-        // otherwise the branch is never taken and the sentinel leaks out as the offset.
-        const int rva = 0x1234;
-        byte[] metadata = BuildMetadataWithRvaField(rva, out FieldDefinitionHandle fieldHandle);
-        using MetadataReaderProvider provider = MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(metadata));
-        MetadataReader reader = provider.GetMetadataReader();
-        FieldDefinition fieldDef = reader.GetFieldDefinition(fieldHandle);
-
+        // non-zero type in the high 5 bits. Detection must mask off the type before comparing the sentinel;
+        // once detected, the offset is resolved from the field's metadata. Here no enclosing MethodTable is
+        // wired, so that resolution path finds no FieldDefinition and throws -- which confirms the sentinel
+        // was detected. (Before the masking fix the full packed DWord2 never equals the sentinel, so the
+        // branch is skipped and the sentinel would leak out as the offset instead of throwing.)
         TargetPointer fieldDescPtr = default;
         TestPlaceholderTarget target = CreateTarget(
             arch,
             rtsBuilder => fieldDescPtr = rtsBuilder.AddFieldDesc(mtOfEnclosingClass: 0, CorElementType.I4, MockRTS.FieldOffsetBigRVAValue).Address);
 
         IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
-        Assert.Equal((uint)rva, contract.GetFieldDescOffset(fieldDescPtr, fieldDef));
-    }
-
-    // Builds a minimal metadata image containing a single static field with a FieldRVA row.
-    private static byte[] BuildMetadataWithRvaField(int rva, out FieldDefinitionHandle fieldHandle)
-    {
-        var mdBuilder = new MetadataBuilder();
-        mdBuilder.AddModule(
-            0,
-            mdBuilder.GetOrAddString("TestModule"),
-            mdBuilder.GetOrAddGuid(Guid.Empty),
-            default, default);
-        mdBuilder.AddAssembly(
-            mdBuilder.GetOrAddString("TestAssembly"),
-            new Version(1, 0, 0, 0),
-            default, default, 0,
-            AssemblyHashAlgorithm.None);
-
-        var fieldSig = new BlobBuilder();
-        new BlobEncoder(fieldSig).FieldSignature().Int32();
-        BlobHandle fieldSigHandle = mdBuilder.GetOrAddBlob(fieldSig);
-
-        fieldHandle = mdBuilder.AddFieldDefinition(
-            FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
-            mdBuilder.GetOrAddString("RvaField"),
-            fieldSigHandle);
-        mdBuilder.AddFieldRelativeVirtualAddress(fieldHandle, rva);
-
-        // The <Module> type owns the field (required first type row).
-        mdBuilder.AddTypeDefinition(
-            default, default,
-            mdBuilder.GetOrAddString("<Module>"),
-            default, fieldHandle, MetadataTokens.MethodDefinitionHandle(1));
-
-        var rootBuilder = new MetadataRootBuilder(mdBuilder);
-        var blobBuilder = new BlobBuilder();
-        rootBuilder.Serialize(blobBuilder, 0, 0);
-        return blobBuilder.ToArray();
+        Assert.Throws<InvalidOperationException>(() => contract.GetFieldDescOffset(fieldDescPtr));
     }
 }


### PR DESCRIPTION
## Summary
`ISOSDacInterface.GetFieldDescData` in the cDAC previously read ECMA metadata directly -- pulling in `IEcmaMetadata`, `ISignature`, `MetadataReader`, `BlobReader`, and decoding the field signature inline. This moves that logic behind the `RuntimeTypeSystem` (RTS) contract so the SOS consumer layer no longer touches metadata plumbing.

## Motivation -- aligning with general contract principles
A core cDAC contract principle is: **contracts should be shaped by what diagnostic consumers (SOS/DBI/CLRMD) need, and the algorithms that produce those answers belong in the contracts -- not in the consumer.** `GetFieldDescData` violated this by reaching directly into metadata mechanics. All that a consumer needs from a `FieldDesc` is the field-type MethodTable, the type token, the signature element type, and the offset -- so those become contract APIs, and the metadata algorithm lives in RTS.

## Changes

**`IRuntimeTypeSystem` (new/changed APIs):**
- `uint GetFieldDescOffset(TargetPointer fieldDescPointer)` -- resolves big-RVA fields via metadata **internally**. Replaces the previous `GetFieldDescOffset(ptr, FieldDefinition?)` overload, which forced callers to thread a metadata object they shouldn't need (*shape to reader constraints*).
- `(CorElementType ElementType, uint TypeToken) GetFieldDescSignatureType(TargetPointer fieldDescPointer)` -- reads the field signature once and returns both signature-derived values. Degrades gracefully (nil token + FieldDesc's stored type) when metadata is absent, rather than throwing (*graceful degradation*).

**`SOSDacImpl.GetFieldDescData`:**
- No longer references `IEcmaMetadata`/`ISignature`/`MetadataReader`.
- Gets the field-type MethodTable via the existing typed `GetFieldDescApproxTypeHandle`; the `TypeHandle` -> `MethodTable` flattening stays here because it's a SOS *pretty-printing* choice, not a runtime fact.

**`EcmaMetadataUtils`:**
- New reusable `ReadFieldSignatureType(MetadataReader, BlobHandle)` helper (pure signature-blob parsing, no `Target` state).

**Consumers of the removed overload** updated to the parameterless offset API: `CallingConvention_1`, `ManagedTypeSource_1`, `DacDbiImpl` (x3), plus the internal static-address path (which also stops redundantly re-reading metadata for the offset).

## Testing
- cDAC builds clean (0 warnings / 0 errors).
- All 8 `FieldDesc` unit tests pass; the runtime `#if DEBUG` assert continues to validate cDAC output against the legacy DAC.

> [!NOTE]
> This PR description was drafted with GitHub Copilot.