### PR TITLE
Remove outdated comment in OSArchitecture

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Windows.cs
@@ -39,8 +39,6 @@ namespace System.Runtime.InteropServices
 
                 if (osArch < 0)
                 {
-                    // If we are running an x64 process on a non-x64 windows machine, we will report x64 as OS architecture.
-                    //
                     // IsWow64Process2 is only available on Windows 10+, so we will perform run-time introspection via indirect load
                     IntPtr kernel32 = Interop.Kernel32.LoadLibraryEx(Interop.Libraries.Kernel32, 0, Interop.Kernel32.LOAD_LIBRARY_SEARCH_SYSTEM32);
                     if (NativeLibrary.TryGetExport(kernel32, "IsWow64Process2", out IntPtr isWow64Process2Ptr))

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Windows.cs
@@ -39,7 +39,7 @@ namespace System.Runtime.InteropServices
 
                 if (osArch < 0)
                 {
-                    // IsWow64Process2 is only available on Windows 10+, so we will perform run-time introspection via indirect load
+                    // IsWow64Process2 is only available on Windows 10 1709+, so we will perform run-time introspection via indirect load
                     IntPtr kernel32 = Interop.Kernel32.LoadLibraryEx(Interop.Libraries.Kernel32, 0, Interop.Kernel32.LOAD_LIBRARY_SEARCH_SYSTEM32);
                     if (NativeLibrary.TryGetExport(kernel32, "IsWow64Process2", out IntPtr isWow64Process2Ptr))
                     {


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/130398#issuecomment-4932155873

Per https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/7.0/osarchitecture-emulation , x64 on ARM64 emulation is correctly encountered since .NET 7.