### PR TITLE
Skip host tests in s390x and ppc64le cross-builds

### DIFF
--- a/eng/pipelines/runtime-community.yml
+++ b/eng/pipelines/runtime-community.yml
@@ -65,7 +65,7 @@ extends:
           jobParameters:
             testGroup: innerloop
             nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+host+packs+libs.tests+clr.iltools+clr.packages -c $(_BuildConfig) /p:ArchiveTests=true
+            buildArgs: -s mono+libs+host.native+host.tools+host.pkg+packs+libs.tests+clr.iltools+clr.packages -c $(_BuildConfig) /p:ArchiveTests=true
             timeoutInMinutes: 180
             condition: >-
               or(

--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -101,8 +101,4 @@
           Condition="'$(IsTestProject)' == 'true'" />
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
-
-  <!-- Use local targeting/app host packs for test projects targeting NetCoreAppCurrent.
-       This avoids NuGet restore failures on platforms without published host packs (e.g. s390x, ppc64le). -->
-  <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(TargetingpacksTargetsImported)' != 'true'" />
 </Project>

--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -101,4 +101,8 @@
           Condition="'$(IsTestProject)' == 'true'" />
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+
+  <!-- Use local targeting/app host packs for test projects targeting NetCoreAppCurrent.
+       This avoids NuGet restore failures on platforms without published host packs (e.g. s390x, ppc64le). -->
+  <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(TargetingpacksTargetsImported)' != 'true'" />
 </Project>


### PR DESCRIPTION
Fixes #130335

## Summary

The s390x and ppc64le community jobs cross-build the product and library tests, but do not run host tests. Expanding the `host` subset pulled `host.pretest` and `host.tests` into the build graph, causing the xUnit v3 host test executables to restore unpublished target-architecture apphost packs.

Build the host product subsets explicitly (`host.native+host.tools+host.pkg`) so these jobs retain host product coverage without restoring unused host tests.


> [!NOTE]
> This pull request description was generated with GitHub Copilot.