### PR TITLE
[clr-ios] Disable R2R IL-body stripping for more library tests that need IL at run time

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -436,6 +436,8 @@ public class R2RTestSuites
     /// <summary>
     /// #129813 / PR #129884: crossgen2 --strip-il-bodies must preserve the IL of non-async
     /// Task/ValueTask-returning methods, which is needed to compile the runtime-async variant.
+    /// It must also strip a non-async Task-returning method whose async variant has already been
+    /// compiled, since the IL is no longer needed at runtime.
     /// </summary>
     [Fact]
     public void RuntimeAsyncStripILBodiesPreservesTaskReturningIL()
@@ -485,6 +487,9 @@ public class R2RTestSuites
             Assert.True(R2RAssert.MethodILIsStripped(componentFile, "StripILBodies", "AsyncValueTaskMethod", out diag), diag);
             Assert.True(R2RAssert.HasAsyncVariant(reader, "AsyncTaskMethod", out diag), diag);
             Assert.True(R2RAssert.HasAsyncVariant(reader, "AsyncValueTaskMethod", out diag), diag);
+
+            Assert.True(R2RAssert.HasAsyncVariant(reader, "SyncTaskWithCompiledAsyncVariant", out diag), diag);
+            Assert.True(R2RAssert.MethodILIsStripped(componentFile, "StripILBodies", "SyncTaskWithCompiledAsyncVariant", out diag), diag);
         }
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/RuntimeAsync/StripILBodies.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/RuntimeAsync/StripILBodies.cs
@@ -1,6 +1,9 @@
 // Test: crossgen2 --strip-il-bodies IL preservation.
 // Validates that non-async Task/ValueTask-returning methods, generic methods,
 // and methods on generic types keep their IL, while plain and async methods are stripped.
+// Also validates that a non-async Task-returning method whose async variant is compiled
+// (because a runtime-async method awaits it) has its IL stripped, since the IL is no longer
+// needed to synthesize the async variant at runtime.
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -57,6 +60,20 @@ public static class StripILBodies
     public static async ValueTask AsyncValueTaskMethod()
     {
         await Task.Yield();
+    }
+
+    // Non-async Task-returning method whose async variant is compiled because
+    // AwaitSyncTaskForcingAsyncVariant awaits it. Its IL should be stripped.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static Task<int> SyncTaskWithCompiledAsyncVariant(int value)
+    {
+        return Task.FromResult(value + 4);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task<int> AwaitSyncTaskForcingAsyncVariant()
+    {
+        return await SyncTaskWithCompiledAsyncVariant(10);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
@@ -82,15 +82,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask())
             {
-                if (!method.IsAsync)
-                {
-                    // IL may be needed for async version of non-async Task-returning method
-                    return true;
-                }
-
                 MethodDesc asyncVariant = method.GetAsyncVariant().GetTypicalMethodDefinition();
                 if (!factory.OptimizationFlags.CompiledMethodDefs.Contains(asyncVariant))
                 {
+                    // IL may be needed to compile the async variant at runtime
                     return true;
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
@@ -58,7 +58,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (factory.OptimizationFlags.StripILBodies
                 && factory.OptimizationFlags.CompiledMethodDefs.Contains(_method)
-                && !MayNeedILAtRuntime(_method))
+                && !MayNeedILAtRuntime(factory, _method))
             {
                 return new ObjectData(s_minimalILBody, Array.Empty<Relocation>(), 4, new ISymbolDefinitionNode[] { this });
             }
@@ -72,7 +72,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return new ObjectData(bodyBytes, Array.Empty<Relocation>(), 4, new ISymbolDefinitionNode[] { this });
         }
 
-        private static bool MayNeedILAtRuntime(MethodDesc method)
+        private static bool MayNeedILAtRuntime(NodeFactory factory, MethodDesc method)
         {
             if (method.HasInstantiation || method.OwningType.HasInstantiation)
             {
@@ -80,10 +80,19 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return true;
             }
 
-            if (method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask() && !method.IsAsync)
+            if (method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask())
             {
-                // IL may be needed for async version of non-async Task-returning method
-                return true;
+                if (!method.IsAsync)
+                {
+                    // IL may be needed for async version of non-async Task-returning method
+                    return true;
+                }
+
+                MethodDesc asyncVariant = method.GetAsyncVariant().GetTypicalMethodDefinition();
+                if (!factory.OptimizationFlags.CompiledMethodDefs.Contains(asyncVariant))
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/src/libraries/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <PublishReadyToRunStripILBodies>false</PublishReadyToRunStripILBodies>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
 

--- a/src/libraries/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+    <PublishReadyToRunStripILBodies>false</PublishReadyToRunStripILBodies>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
 

--- a/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
+++ b/src/libraries/System.IO.Hashing/tests/System.IO.Hashing.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishReadyToRunStripILBodies>false</PublishReadyToRunStripILBodies>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System.Runtime.Extensions.Tests.csproj
@@ -3,6 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+    <PublishReadyToRunStripILBodies>false</PublishReadyToRunStripILBodies>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent)-browser</TargetFrameworks>
 
      <!-- some tests require full ICU data, force it -->

--- a/src/tests/JIT/Regression/Regression_o_2.csproj
+++ b/src/tests/JIT/Regression/Regression_o_2.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Optimize>True</Optimize>
     <HasMergedInTests>True</HasMergedInTests>
+    <PublishReadyToRunStripILBodies>false</PublishReadyToRunStripILBodies>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="JitBlue\Runtime_105467\Runtime_105467.cs" />


### PR DESCRIPTION
## Description

Follow-up to #130360. The SDK strips IL bodies from the Apple mobile CoreCLR composite ReadyToRun image by default, replacing each body with an invalid stub, so any test that needs the real IL at run time fails. Three more projects hit this: `System.Runtime.Extensions.Tests` (`AppDomainTests.ExecuteAssembly` invokes a stripped entry point, `InvalidProgramException`), `System.IO.Hashing.Tests` (`Crc64ParameterSet.ForwardCrc64.InitializeVectorized`, a `Vector128` intrinsic fallback), and `System.Diagnostics.StackTrace.Tests` (the runtime-async `V2Methods.Quuux` in `ToString_Async`). This sets `PublishReadyToRunStripILBodies` to `false` on those three test projects, which #130360 already forwards through the `_ApplePropertyNames` allowlist, leaving stripping on for every other Apple mobile CoreCLR test app.