### PR TITLE
[release/8.0-staging] Disable failing iOS device tests

### DIFF
--- a/src/tests/FunctionalTests/iOS/Device/AOT/iOS.Device.Aot.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Device/AOT/iOS.Device.Aot.Test.csproj
@@ -11,6 +11,8 @@
     <SelfContained>true</SelfContained>
     <UseConsoleUITemplate>true</UseConsoleUITemplate>
     <Optimized Condition="'$(Configuration)' == 'Release'">true</Optimized>
+    <!-- The servicing test infrastructure will not be updated for newer macOS versions. -->
+    <IgnoreForCI>true</IgnoreForCI>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RunAOTCompilation)' == 'true'">

--- a/src/tests/FunctionalTests/iOS/Device/ExportManagedSymbols/iOS.Device.ExportManagedSymbols.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Device/ExportManagedSymbols/iOS.Device.ExportManagedSymbols.Test.csproj
@@ -10,6 +10,8 @@
     <UseConsoleUITemplate>true</UseConsoleUITemplate>
     <Optimized Condition="'$(Configuration)' == 'Release'">true</Optimized>
     <NativeMainSource>$(MSBuildProjectDirectory)/main.m</NativeMainSource>
+    <!-- The servicing test infrastructure will not be updated for newer macOS versions. -->
+    <IgnoreForCI>true</IgnoreForCI>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RunAOTCompilation)' == 'true'">


### PR DESCRIPTION
## Summary

- Disable `iOS.Device.Aot.Test` and `iOS.Device.ExportManagedSymbols.Test` on this servicing branch.
- The tests only run on physical iOS devices and no longer provide useful CI signal.
- The servicing test infrastructure will not be updated for newer macOS versions.

Related to #119665.

## Testing

Not run locally because these tests require physical iOS device infrastructure. CI will validate the change.

> [!NOTE]
> This PR description was generated by GitHub Copilot.
