### PR TITLE
Add configurable HTTP connection eviction, expose ConnectionId APIs

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -320,3 +320,4 @@ Diagnostic id values for experimental APIs must not be recycled, as that could s
 |  __`SYSLIB5004`__ |     .NET 9 |     TBD | `X86Base.DivRem` is experimental since performance is not as optimized as `T.DivRem` |
 |  __`SYSLIB5005`__ |     .NET 9 | .NET 10 | `System.Formats.Nrbf` is experimental |
 |  __`SYSLIB5006`__ |    .NET 10 |     TBD | Types for Post-Quantum Cryptography (PQC) are experimental. |
+|  __`SYSLIB5007`__ |    .NET 11 |     TBD | `SocketsHttpHandler` connection eviction control APIs are experimental. |

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -320,4 +320,4 @@ Diagnostic id values for experimental APIs must not be recycled, as that could s
 |  __`SYSLIB5004`__ |     .NET 9 |     TBD | `X86Base.DivRem` is experimental since performance is not as optimized as `T.DivRem` |
 |  __`SYSLIB5005`__ |     .NET 9 | .NET 10 | `System.Formats.Nrbf` is experimental |
 |  __`SYSLIB5006`__ |    .NET 10 |     TBD | Types for Post-Quantum Cryptography (PQC) are experimental. |
-|  __`SYSLIB5007`__ |    .NET 11 |     TBD | `SocketsHttpHandler` connection eviction control APIs are experimental. |
+|  __`SYSLIB5008`__ |    .NET 11 |     TBD | `SocketsHttpHandler` connection eviction control and `HttpRequestMessage.ConnectionId` APIs are experimental. |

--- a/src/libraries/Common/src/System/Experimentals.cs
+++ b/src/libraries/Common/src/System/Experimentals.cs
@@ -33,6 +33,9 @@ namespace System
         // Types for Post-Quantum Cryptography (PQC) are experimental.
         internal const string PostQuantumCryptographyDiagId = "SYSLIB5006";
 
+        // SocketsHttpHandler connection eviction control APIs are experimental.
+        internal const string SocketsHttpHandlerConnectionEvictionDiagId = "SYSLIB5007";
+
         // When adding a new diagnostic ID, add it to the table in docs\project\list-of-diagnostics.md as well.
         // Keep new const identifiers above this comment.
     }

--- a/src/libraries/Common/src/System/Experimentals.cs
+++ b/src/libraries/Common/src/System/Experimentals.cs
@@ -33,8 +33,8 @@ namespace System
         // Types for Post-Quantum Cryptography (PQC) are experimental.
         internal const string PostQuantumCryptographyDiagId = "SYSLIB5006";
 
-        // SocketsHttpHandler connection eviction control APIs are experimental.
-        internal const string SocketsHttpHandlerConnectionEvictionDiagId = "SYSLIB5007";
+        // SocketsHttpHandler connection eviction control and HttpRequestMessage.ConnectionId APIs are experimental.
+        internal const string SocketsHttpHandlerExperimentalDiagId = "SYSLIB5008";
 
         // When adding a new diagnostic ID, add it to the table in docs\project\list-of-diagnostics.md as well.
         // Keep new const identifiers above this comment.

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -424,8 +424,20 @@ namespace System.Net.Http
     public sealed partial class SocketsHttpConnectionContext
     {
         internal SocketsHttpConnectionContext() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5007", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public long ConnectionId { get { throw null; } }
         public System.Net.DnsEndPoint DnsEndPoint { get { throw null; } }
         public System.Net.Http.HttpRequestMessage InitialRequestMessage { get { throw null; } }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5007", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class SocketsHttpConnectionEvictionContext
+    {
+        internal SocketsHttpConnectionEvictionContext() { }
+        public System.TimeSpan Age { get { throw null; } }
+        public long ConnectionId { get { throw null; } }
+        public System.Net.DnsEndPoint DnsEndPoint { get { throw null; } }
+        public System.Version HttpVersion { get { throw null; } }
+        public System.Net.IPEndPoint? RemoteEndPoint { get { throw null; } }
     }
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class SocketsHttpHandler : System.Net.Http.HttpMessageHandler
@@ -465,6 +477,8 @@ namespace System.Net.Http
         public System.Net.Http.HeaderEncodingSelector<System.Net.Http.HttpRequestMessage>? RequestHeaderEncodingSelector { get { throw null; } set { } }
         public System.TimeSpan ResponseDrainTimeout { get { throw null; } set { } }
         public System.Net.Http.HeaderEncodingSelector<System.Net.Http.HttpRequestMessage>? ResponseHeaderEncodingSelector { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5007", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public System.Func<System.Net.Http.SocketsHttpConnectionEvictionContext, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>>? ShouldEvictConnection { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public System.Net.Security.SslClientAuthenticationOptions SslOptions { get { throw null; } set { } }
         public bool UseCookies { get { throw null; } set { } }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -303,7 +303,7 @@ namespace System.Net.Http
         public HttpRequestMessage() { }
         public HttpRequestMessage(System.Net.Http.HttpMethod method, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("Uri")] string? requestUri) { }
         public HttpRequestMessage(System.Net.Http.HttpMethod method, System.Uri? requestUri) { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public long? ConnectionId { get { throw null; } set { } }
         public System.Net.Http.HttpContent? Content { get { throw null; } set { } }
         public System.Net.Http.Headers.HttpRequestHeaders Headers { get { throw null; } }
@@ -426,12 +426,12 @@ namespace System.Net.Http
     public sealed partial class SocketsHttpConnectionContext
     {
         internal SocketsHttpConnectionContext() { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public long ConnectionId { get { throw null; } }
         public System.Net.DnsEndPoint DnsEndPoint { get { throw null; } }
         public System.Net.Http.HttpRequestMessage InitialRequestMessage { get { throw null; } }
     }
-    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
     public sealed partial class SocketsHttpConnectionEvictionContext
     {
         internal SocketsHttpConnectionEvictionContext() { }
@@ -479,7 +479,7 @@ namespace System.Net.Http
         public System.Net.Http.HeaderEncodingSelector<System.Net.Http.HttpRequestMessage>? RequestHeaderEncodingSelector { get { throw null; } set { } }
         public System.TimeSpan ResponseDrainTimeout { get { throw null; } set { } }
         public System.Net.Http.HeaderEncodingSelector<System.Net.Http.HttpRequestMessage>? ResponseHeaderEncodingSelector { get { throw null; } set { } }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public System.Func<System.Net.Http.SocketsHttpConnectionEvictionContext, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>>? ShouldEvictConnection { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public System.Net.Security.SslClientAuthenticationOptions SslOptions { get { throw null; } set { } }
@@ -492,7 +492,7 @@ namespace System.Net.Http
     public sealed partial class SocketsHttpPlaintextStreamFilterContext
     {
         internal SocketsHttpPlaintextStreamFilterContext() { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public long ConnectionId { get { throw null; } }
         public System.Net.Http.HttpRequestMessage InitialRequestMessage { get { throw null; } }
         public System.Version NegotiatedHttpVersion { get { throw null; } }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -492,6 +492,8 @@ namespace System.Net.Http
     public sealed partial class SocketsHttpPlaintextStreamFilterContext
     {
         internal SocketsHttpPlaintextStreamFilterContext() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public long ConnectionId { get { throw null; } }
         public System.Net.Http.HttpRequestMessage InitialRequestMessage { get { throw null; } }
         public System.Version NegotiatedHttpVersion { get { throw null; } }
         public System.IO.Stream PlaintextStream { get { throw null; } }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -303,6 +303,8 @@ namespace System.Net.Http
         public HttpRequestMessage() { }
         public HttpRequestMessage(System.Net.Http.HttpMethod method, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("Uri")] string? requestUri) { }
         public HttpRequestMessage(System.Net.Http.HttpMethod method, System.Uri? requestUri) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public long? ConnectionId { get { throw null; } set { } }
         public System.Net.Http.HttpContent? Content { get { throw null; } set { } }
         public System.Net.Http.Headers.HttpRequestHeaders Headers { get { throw null; } }
         public System.Net.Http.HttpMethod Method { get { throw null; } set { } }
@@ -424,12 +426,12 @@ namespace System.Net.Http
     public sealed partial class SocketsHttpConnectionContext
     {
         internal SocketsHttpConnectionContext() { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5007", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public long ConnectionId { get { throw null; } }
         public System.Net.DnsEndPoint DnsEndPoint { get { throw null; } }
         public System.Net.Http.HttpRequestMessage InitialRequestMessage { get { throw null; } }
     }
-    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5007", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
     public sealed partial class SocketsHttpConnectionEvictionContext
     {
         internal SocketsHttpConnectionEvictionContext() { }
@@ -477,7 +479,7 @@ namespace System.Net.Http
         public System.Net.Http.HeaderEncodingSelector<System.Net.Http.HttpRequestMessage>? RequestHeaderEncodingSelector { get { throw null; } set { } }
         public System.TimeSpan ResponseDrainTimeout { get { throw null; } set { } }
         public System.Net.Http.HeaderEncodingSelector<System.Net.Http.HttpRequestMessage>? ResponseHeaderEncodingSelector { get { throw null; } set { } }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5007", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5008", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public System.Func<System.Net.Http.SocketsHttpConnectionEvictionContext, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>>? ShouldEvictConnection { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public System.Net.Security.SslClientAuthenticationOptions SslOptions { get { throw null; } set { } }

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-linux;$(NetCoreAppCurrent)-osx;$(NetCoreAppCurrent)-freebsd;$(NetCoreAppCurrent)-openbsd;$(NetCoreAppCurrent)-maccatalyst;$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos;$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-solaris;$(NetCoreAppCurrent)-haiku;$(NetCoreAppCurrent)-android;$(NetCoreAppCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);HTTP_DLL</DefineConstants>
+    <!-- SocketsHttpHandler connection eviction control APIs are experimental and consumed internally. -->
+    <NoWarn>$(NoWarn);SYSLIB5007</NoWarn>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
@@ -160,6 +162,8 @@
              Link="Common\System\Text\ValueStringBuilder.AppendSpanFormattable.cs" />
     <Compile Include="$(CommonPath)System\Obsoletions.cs"
              Link="Common\System\Obsoletions.cs" />
+    <Compile Include="$(CommonPath)System\Experimentals.cs"
+             Link="Common\System\Experimentals.cs" />
     <Compile Include="$(CommonPath)System\Net\CredentialCacheKey.cs"
              Link="Common\System\Net\CredentialCacheKey.cs" />
   </ItemGroup>
@@ -218,6 +222,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\PreAuthCredentialCache.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RawConnectionStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RedirectHandler.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpConnectionEvictionContext.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpConnectionContext.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpHandler.cs" />
     <Compile Include="System\Net\Http\HttpTelemetry.AnyOS.cs" />
@@ -434,6 +439,7 @@
              Link="Common\System\Net\HttpStatusDescription.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpKeepAlivePingPolicy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpConnectionEvictionContext.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpConnectionContext.cs" />
     <Compile Include="System\Net\Http\BrowserHttpHandler\SystemProxyInfo.Browser.cs" />
     <Compile Include="System\Net\Http\BrowserHttpHandler\SocketsHttpHandler.cs" />
@@ -449,6 +455,7 @@
              Link="Common\System\Net\HttpStatusDescription.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpKeepAlivePingPolicy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpConnectionEvictionContext.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpConnectionContext.cs" />
     <Compile Include="System\Net\Http\BrowserHttpHandler\SocketsHttpHandler.cs" />
     <Compile Include="System\Net\Http\WasiHttpHandler\SystemProxyInfo.Wasi.cs" />

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -4,8 +4,8 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-linux;$(NetCoreAppCurrent)-osx;$(NetCoreAppCurrent)-freebsd;$(NetCoreAppCurrent)-openbsd;$(NetCoreAppCurrent)-maccatalyst;$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos;$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-solaris;$(NetCoreAppCurrent)-haiku;$(NetCoreAppCurrent)-android;$(NetCoreAppCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);HTTP_DLL</DefineConstants>
-    <!-- SocketsHttpHandler connection eviction control APIs are experimental and consumed internally. -->
-    <NoWarn>$(NoWarn);SYSLIB5007</NoWarn>
+    <!-- SocketsHttpHandler connection eviction control and HttpRequestMessage.ConnectionId (SYSLIB5008) APIs are experimental and consumed internally. -->
+    <NoWarn>$(NoWarn);SYSLIB5008</NoWarn>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
@@ -213,5 +213,12 @@ namespace System.Net.Http
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
+
+        [Experimental(Experimentals.SocketsHttpHandlerConnectionEvictionDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public Func<SocketsHttpConnectionEvictionContext, CancellationToken, Task<bool>>? ShouldEvictConnection
+        {
+            get => throw new PlatformNotSupportedException();
+            set => throw new PlatformNotSupportedException();
+        }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
@@ -214,7 +214,7 @@ namespace System.Net.Http
             set => throw new PlatformNotSupportedException();
         }
 
-        [Experimental(Experimentals.SocketsHttpHandlerConnectionEvictionDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
         public Func<SocketsHttpConnectionEvictionContext, CancellationToken, Task<bool>>? ShouldEvictConnection
         {
             get => throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -123,14 +123,26 @@ namespace System.Net.Http
         public HttpRequestOptions Options => _options ??= new HttpRequestOptions();
 
         /// <summary>
-        /// Gets or sets the identifier of the connection that this request was most recently sent on, or <see langword="null"/>
-        /// if it has not been sent over a <see cref="SocketsHttpHandler"/> connection.
+        /// Gets or sets the identifier of the connection that this request was most recently sent on. The value is not
+        /// guaranteed to be set: it remains <see langword="null"/> when the request was not handled by a connection, for
+        /// example because it timed out before a connection could be obtained.
         /// </summary>
         /// <remarks>
-        /// The value matches the connection id reported through EventSource telemetry, and the id surfaced to
-        /// <see cref="SocketsHttpHandler.ConnectCallback"/> and <see cref="SocketsHttpHandler.ShouldEvictConnection"/>,
-        /// allowing a caller to correlate a request with the connection that served it. When a request is sent over
-        /// multiple connections (for example after a redirect or a retry), the value reflects the most recent attempt.
+        /// When the request is sent through a <see cref="SocketsHttpHandler"/>, the value matches the connection id
+        /// reported through EventSource telemetry and the id passed to
+        /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/> for the connection that served the request, allowing
+        /// a caller to correlate a request with that connection. It also matches the id surfaced to a custom
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/>, except when the request is served over an HTTP CONNECT
+        /// proxy tunnel: there the callback observes the tunnel's underlying transport connection to the proxy, whose
+        /// id differs from this one (which identifies the tunneled connection that carried the request). Both ids remain
+        /// observable through a <see cref="SocketsHttpHandler.PlaintextStreamFilter"/>, which runs once per hop and
+        /// reports the transport connection's id for the CONNECT hop and this id for the tunneled hop. When a request
+        /// is sent over multiple connections (for example after a redirect or a retry), the value reflects the most
+        /// recent attempt.
+        /// <para>
+        /// These correlations apply only when the request is handled by <see cref="SocketsHttpHandler"/>. Another
+        /// <see cref="HttpMessageHandler"/> may never set this value, or may assign it a different meaning.
+        /// </para>
         /// <para>
         /// This property is intended to be read after the request has been sent. Assigning a value before the request
         /// is sent has no effect on how the request is handled: it does not request or influence the use of a particular

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -122,6 +122,25 @@ namespace System.Net.Http
         /// </summary>
         public HttpRequestOptions Options => _options ??= new HttpRequestOptions();
 
+        /// <summary>
+        /// Gets or sets the identifier of the connection that this request was most recently sent on, or <see langword="null"/>
+        /// if it has not been sent over a <see cref="SocketsHttpHandler"/> connection.
+        /// </summary>
+        /// <remarks>
+        /// The value matches the connection id reported through EventSource telemetry, and the id surfaced to
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/> and <see cref="SocketsHttpHandler.ShouldEvictConnection"/>,
+        /// allowing a caller to correlate a request with the connection that served it. When a request is sent over
+        /// multiple connections (for example after a redirect or a retry), the value reflects the most recent attempt.
+        /// <para>
+        /// This property is intended to be read after the request has been sent. Assigning a value before the request
+        /// is sent has no effect on how the request is handled: it does not request or influence the use of a particular
+        /// connection, and any value set by the caller is overwritten with the id of the connection that actually serves
+        /// the request.
+        /// </para>
+        /// </remarks>
+        [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public long? ConnectionId { get; set; }
+
         public HttpRequestMessage()
             : this(HttpMethod.Get, (Uri?)null)
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -135,13 +135,16 @@ namespace System.Net.Http
         /// reported through EventSource telemetry and the id passed to
         /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/> for the connection that served the request, allowing
         /// a caller to correlate a request with that connection. It also matches the id surfaced to a custom
-        /// <see cref="SocketsHttpHandler.ConnectCallback"/>, except when the request is served over an HTTP CONNECT
-        /// proxy tunnel: there the callback observes the tunnel's underlying transport connection to the proxy, whose
-        /// id differs from this one (which identifies the tunneled connection that carried the request). Both ids remain
-        /// observable through a <see cref="SocketsHttpHandler.PlaintextStreamFilter"/>, which runs once per hop and
-        /// reports the transport connection's id for the CONNECT hop and this id for the tunneled hop. When a request
-        /// is sent over multiple connections (for example after a redirect or a retry), the value reflects the most
-        /// recent attempt.
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/>. When a request is sent over multiple connections (for
+        /// example after a redirect or a retry), the value reflects the most recent attempt.
+        /// <para>
+        /// HTTP CONNECT proxy tunnels are an exception to the correlation with a custom
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/>: when the request is served over such a tunnel, the callback
+        /// observes the tunnel's underlying transport connection to the proxy, whose id differs from this one (which
+        /// identifies the tunneled connection that carried the request). Both ids remain observable through a
+        /// <see cref="SocketsHttpHandler.PlaintextStreamFilter"/>, which runs once per hop and reports the transport
+        /// connection's id for the CONNECT hop and this id for the tunneled hop.
+        /// </para>
         /// <para>
         /// These correlations apply only when the request is handled by <see cref="SocketsHttpHandler"/>. Another
         /// <see cref="HttpMessageHandler"/> may never set this value, or may assign it a different meaning.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Threading;
 
 namespace System.Net.Http
 {
@@ -15,15 +14,19 @@ namespace System.Net.Http
         internal static Version DefaultRequestVersion => HttpVersion.Version11;
         internal static HttpVersionPolicy DefaultVersionPolicy => HttpVersionPolicy.RequestVersionOrLower;
 
-        private const int MessageNotYetSent = 0;
-        private const int MessageAlreadySent = 1;
-        private const int PropagatorStateInjectedByDiagnosticsHandler = 2;
-        private const int MessageDisposed = 4;
-        private const int AuthDisabled = 8;
+        [Flags]
+        private enum MessageFlags
+        {
+            AlreadySent = 1,
+            PropagatorStateInjectedByDiagnosticsHandler = 2,
+            Disposed = 4,
+            AuthDisabled = 8,
+            ConnectionIdSet = 16,
+        }
 
-        // Track whether the message has been sent.
-        // The message shouldn't be sent again if this field is equal to MessageAlreadySent.
-        private int _sendStatus = MessageNotYetSent;
+        private MessageFlags _flags;
+
+        private long _connectionId;
 
         private HttpMethod _method;
         private Uri? _requestUri;
@@ -151,7 +154,23 @@ namespace System.Net.Http
         /// </para>
         /// </remarks>
         [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
-        public long? ConnectionId { get; set; }
+        public long? ConnectionId
+        {
+            // ConnectionIdSet is stored separately to avoid the extra bytes needed for a nullable 'long?' field.
+            get => _flags.HasFlag(MessageFlags.ConnectionIdSet) ? _connectionId : null;
+            set
+            {
+                if (value is null)
+                {
+                    _flags &= ~MessageFlags.ConnectionIdSet;
+                }
+                else
+                {
+                    _connectionId = value.Value;
+                    _flags |= MessageFlags.ConnectionIdSet;
+                }
+            }
+        }
 
         public HttpRequestMessage()
             : this(HttpMethod.Get, (Uri?)null)
@@ -206,25 +225,30 @@ namespace System.Net.Http
             return sb.ToString();
         }
 
-        internal bool MarkAsSent() => Interlocked.CompareExchange(ref _sendStatus, MessageAlreadySent, MessageNotYetSent) == MessageNotYetSent;
+        internal bool MarkAsSent()
+        {
+            MessageFlags previousFlags = _flags;
+            _flags = previousFlags | MessageFlags.AlreadySent;
+            return !previousFlags.HasFlag(MessageFlags.AlreadySent);
+        }
 
-        internal bool WasSentByHttpClient() => (_sendStatus & MessageAlreadySent) != 0;
+        internal bool WasSentByHttpClient() => _flags.HasFlag(MessageFlags.AlreadySent);
 
-        internal void MarkPropagatorStateInjectedByDiagnosticsHandler() => _sendStatus |= PropagatorStateInjectedByDiagnosticsHandler;
+        internal void MarkPropagatorStateInjectedByDiagnosticsHandler() => _flags |= MessageFlags.PropagatorStateInjectedByDiagnosticsHandler;
 
-        internal bool WasPropagatorStateInjectedByDiagnosticsHandler() => (_sendStatus & PropagatorStateInjectedByDiagnosticsHandler) != 0;
+        internal bool WasPropagatorStateInjectedByDiagnosticsHandler() => _flags.HasFlag(MessageFlags.PropagatorStateInjectedByDiagnosticsHandler);
 
-        internal void DisableAuth() => _sendStatus |= AuthDisabled;
+        internal void DisableAuth() => _flags |= MessageFlags.AuthDisabled;
 
-        internal bool IsAuthDisabled() => (_sendStatus & AuthDisabled) != 0;
+        internal bool IsAuthDisabled() => _flags.HasFlag(MessageFlags.AuthDisabled);
 
         private bool Disposed
         {
-            get => (_sendStatus & MessageDisposed) != 0;
+            get => _flags.HasFlag(MessageFlags.Disposed);
             set
             {
                 Debug.Assert(value);
-                _sendStatus |= MessageDisposed;
+                _flags |= MessageFlags.Disposed;
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http1.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http1.cs
@@ -293,14 +293,14 @@ namespace System.Net.Http
 
         internal async ValueTask<HttpConnection> CreateHttp11ConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
-            (Stream stream, TransportContext? transportContext, Activity? activity, IPEndPoint? remoteEndPoint) = await ConnectAsync(request, async, isForHttp2: false, cancellationToken).ConfigureAwait(false);
-            return await ConstructHttp11ConnectionAsync(async, stream, transportContext, request, activity, remoteEndPoint, cancellationToken).ConfigureAwait(false);
+            (Stream stream, TransportContext? transportContext, Activity? activity, IPEndPoint? remoteEndPoint, long connectionId) = await ConnectAsync(request, async, isForHttp2: false, cancellationToken).ConfigureAwait(false);
+            return await ConstructHttp11ConnectionAsync(async, stream, transportContext, request, activity, remoteEndPoint, connectionId, cancellationToken).ConfigureAwait(false);
         }
 
-        private async ValueTask<HttpConnection> ConstructHttp11ConnectionAsync(bool async, Stream stream, TransportContext? transportContext, HttpRequestMessage request, Activity? activity, IPEndPoint? remoteEndPoint, CancellationToken cancellationToken)
+        private async ValueTask<HttpConnection> ConstructHttp11ConnectionAsync(bool async, Stream stream, TransportContext? transportContext, HttpRequestMessage request, Activity? activity, IPEndPoint? remoteEndPoint, long connectionId, CancellationToken cancellationToken)
         {
             Stream newStream = await ApplyPlaintextFilterAsync(async, stream, HttpVersion.Version11, request, cancellationToken).ConfigureAwait(false);
-            return new HttpConnection(this, newStream, transportContext, activity, remoteEndPoint);
+            return new HttpConnection(this, newStream, transportContext, activity, remoteEndPoint, connectionId);
         }
 
         private void HandleHttp11ConnectionFailure(HttpConnectionWaiter<HttpConnection>? requestWaiter, Exception e)
@@ -367,6 +367,11 @@ namespace System.Net.Http
         private void ReturnHttp11Connection(HttpConnection connection)
         {
             connection.MarkConnectionAsIdle();
+
+            // Eviction callback checks are normally triggered from a background timer that looks at all idle connections.
+            // If this connection was in use during that time, the eviction callback may have been skipped for it.
+            // Check whether that's the case now by comparing the last EvictionGeneration of the connection with that of the pool.
+            connection.RunEvictionEvaluationIfNeeded();
 
             // The fast path when there are enough connections and no pending requests
             // is that we'll see _http11RequestQueueIsEmptyAndNotDisposed being true both

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http1.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http1.cs
@@ -299,7 +299,7 @@ namespace System.Net.Http
 
         private async ValueTask<HttpConnection> ConstructHttp11ConnectionAsync(bool async, Stream stream, TransportContext? transportContext, HttpRequestMessage request, Activity? activity, IPEndPoint? remoteEndPoint, long connectionId, CancellationToken cancellationToken)
         {
-            Stream newStream = await ApplyPlaintextFilterAsync(async, stream, HttpVersion.Version11, request, cancellationToken).ConfigureAwait(false);
+            Stream newStream = await ApplyPlaintextFilterAsync(async, stream, HttpVersion.Version11, request, connectionId, cancellationToken).ConfigureAwait(false);
             return new HttpConnection(this, newStream, transportContext, activity, remoteEndPoint, connectionId);
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
@@ -185,7 +185,7 @@ namespace System.Net.Http
             CancellationTokenSource cts = GetConnectTimeoutCancellationTokenSource(waiter);
             try
             {
-                (Stream stream, TransportContext? transportContext, Activity? activity, IPEndPoint? remoteEndPoint) = await ConnectAsync(queueItem.Request, true, isForHttp2: true, cts.Token).ConfigureAwait(false);
+                (Stream stream, TransportContext? transportContext, Activity? activity, IPEndPoint? remoteEndPoint, long connectionId) = await ConnectAsync(queueItem.Request, true, isForHttp2: true, cts.Token).ConfigureAwait(false);
 
                 if (IsSecure)
                 {
@@ -202,19 +202,19 @@ namespace System.Net.Http
                         }
                         else
                         {
-                            connection = await ConstructHttp2ConnectionAsync(stream, queueItem.Request, activity, remoteEndPoint, cts.Token).ConfigureAwait(false);
+                            connection = await ConstructHttp2ConnectionAsync(stream, queueItem.Request, activity, remoteEndPoint, connectionId, cts.Token).ConfigureAwait(false);
                         }
                     }
                     else
                     {
                         // We established an SSL connection, but the server denied our request for HTTP2.
-                        await HandleHttp11Downgrade(queueItem.Request, stream, transportContext, activity, remoteEndPoint, cts.Token).ConfigureAwait(false);
+                        await HandleHttp11Downgrade(queueItem.Request, stream, transportContext, activity, remoteEndPoint, connectionId, cts.Token).ConfigureAwait(false);
                         return;
                     }
                 }
                 else
                 {
-                    connection = await ConstructHttp2ConnectionAsync(stream, queueItem.Request, activity, remoteEndPoint, cts.Token).ConfigureAwait(false);
+                    connection = await ConstructHttp2ConnectionAsync(stream, queueItem.Request, activity, remoteEndPoint, connectionId, cts.Token).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -244,11 +244,11 @@ namespace System.Net.Http
             }
         }
 
-        private async ValueTask<Http2Connection> ConstructHttp2ConnectionAsync(Stream stream, HttpRequestMessage request, Activity? activity, IPEndPoint? remoteEndPoint, CancellationToken cancellationToken)
+        private async ValueTask<Http2Connection> ConstructHttp2ConnectionAsync(Stream stream, HttpRequestMessage request, Activity? activity, IPEndPoint? remoteEndPoint, long connectionId, CancellationToken cancellationToken)
         {
             stream = await ApplyPlaintextFilterAsync(async: true, stream, HttpVersion.Version20, request, cancellationToken).ConfigureAwait(false);
 
-            Http2Connection http2Connection = new Http2Connection(this, stream, activity, remoteEndPoint);
+            Http2Connection http2Connection = new Http2Connection(this, stream, activity, remoteEndPoint, connectionId);
             try
             {
                 await http2Connection.SetupAsync(cancellationToken).ConfigureAwait(false);
@@ -299,7 +299,7 @@ namespace System.Net.Http
             _http2SessionAuthSeen = true;
         }
 
-        private async Task HandleHttp11Downgrade(HttpRequestMessage request, Stream stream, TransportContext? transportContext, Activity? activity, IPEndPoint? remoteEndPoint, CancellationToken cancellationToken)
+        private async Task HandleHttp11Downgrade(HttpRequestMessage request, Stream stream, TransportContext? transportContext, Activity? activity, IPEndPoint? remoteEndPoint, long connectionId, CancellationToken cancellationToken)
         {
             if (NetEventSource.Log.IsEnabled()) Trace("Server does not support HTTP2; disabling HTTP2 use and proceeding with HTTP/1.1 connection");
 
@@ -357,7 +357,7 @@ namespace System.Net.Http
             try
             {
                 // Note, the same CancellationToken from the original HTTP2 connection establishment still applies here.
-                http11Connection = await ConstructHttp11ConnectionAsync(true, stream, transportContext, request, activity, remoteEndPoint, cancellationToken).ConfigureAwait(false);
+                http11Connection = await ConstructHttp11ConnectionAsync(true, stream, transportContext, request, activity, remoteEndPoint, connectionId, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException oce) when (oce.CancellationToken == cancellationToken)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
@@ -246,7 +246,7 @@ namespace System.Net.Http
 
         private async ValueTask<Http2Connection> ConstructHttp2ConnectionAsync(Stream stream, HttpRequestMessage request, Activity? activity, IPEndPoint? remoteEndPoint, long connectionId, CancellationToken cancellationToken)
         {
-            stream = await ApplyPlaintextFilterAsync(async: true, stream, HttpVersion.Version20, request, cancellationToken).ConfigureAwait(false);
+            stream = await ApplyPlaintextFilterAsync(async: true, stream, HttpVersion.Version20, request, connectionId, cancellationToken).ConfigureAwait(false);
 
             Http2Connection http2Connection = new Http2Connection(this, stream, activity, remoteEndPoint, connectionId);
             try

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -266,14 +266,15 @@ namespace System.Net.Http
                     connectionSetupActivity = ConnectionSetupDistributedTracing.StartConnectionSetupActivity(isSecure: true, _telemetryServerAddress, authority.Port);
                     // If the authority was sent as an option through alt-svc then include alt-used header.
                     connection = new Http3Connection(this, authority, includeAltUsedHeader: _http3Authority == authority);
-                    QuicConnection quicConnection = await ConnectHelper.ConnectQuicAsync(queueItem.Request, new DnsEndPoint(authority.IdnHost, authority.Port), _poolManager.Settings._pooledConnectionIdleTimeout, _sslOptionsHttp3!, connection.StreamCapacityCallback, cts.Token).ConfigureAwait(false);
+                    var connectEndPoint = new DnsEndPoint(authority.IdnHost, authority.Port);
+                    QuicConnection quicConnection = await ConnectHelper.ConnectQuicAsync(queueItem.Request, connectEndPoint, _poolManager.Settings._pooledConnectionIdleTimeout, _sslOptionsHttp3!, connection.StreamCapacityCallback, cts.Token).ConfigureAwait(false);
                     if (quicConnection.NegotiatedApplicationProtocol != SslApplicationProtocol.Http3)
                     {
                         await quicConnection.DisposeAsync().ConfigureAwait(false);
                         throw new HttpRequestException(HttpRequestError.ConnectionError, "QUIC connected but no HTTP/3 indicated via ALPN.", null, RequestRetryType.RetryOnConnectionFailure);
                     }
                     if (connectionSetupActivity is not null) ConnectionSetupDistributedTracing.StopConnectionSetupActivity(connectionSetupActivity, null, quicConnection.RemoteEndPoint);
-                    connection.InitQuicConnection(quicConnection, connectionSetupActivity);
+                    connection.InitQuicConnection(quicConnection, connectionSetupActivity, connectEndPoint);
                 }
                 else if (reasonException is not null)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -85,9 +85,12 @@ namespace System.Net.Http
             _maxHttp11Connections = Settings._maxConnectionsPerServer;
             _telemetryServerAddress = telemetryServerAddress;
 
-            // The only case where 'host' will not be set is if this is a Proxy connection pool.
+            // The only case where 'host' will not be set is if this is a Proxy connection pool. In that case the
+            // connection targets the proxy itself, so use the proxy's host and port for the origin authority.
             Debug.Assert(host is not null || (kind == HttpConnectionKind.Proxy && proxyUri is not null));
-            _originAuthority = new HttpAuthority(host ?? proxyUri!.IdnHost, port);
+            _originAuthority = host is not null
+                ? new HttpAuthority(host, port)
+                : new HttpAuthority(proxyUri!.IdnHost, proxyUri.Port);
 
             _http2Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version20;
 
@@ -560,12 +563,17 @@ namespace System.Net.Http
             }
         }
 
-        private async ValueTask<(Stream, TransportContext?, Activity?, IPEndPoint?)> ConnectAsync(HttpRequestMessage request, bool async, bool isForHttp2, CancellationToken cancellationToken)
+        private async ValueTask<(Stream, TransportContext?, Activity?, IPEndPoint?, long)> ConnectAsync(HttpRequestMessage request, bool async, bool isForHttp2, CancellationToken cancellationToken)
         {
             Stream? stream = null;
             IPEndPoint? remoteEndPoint = null;
             Exception? exception = null;
             TransportContext? transportContext = null;
+
+            // Allocate the connection id up front so it can be surfaced to a custom ConnectCallback (via
+            // SocketsHttpConnectionContext) and reused as the final connection's Id, allowing the caller to
+            // correlate connect-time state with the connection (e.g. in the ShouldEvictConnection callback).
+            long connectionId = HttpConnectionBase.GetNextConnectionId();
 
             Activity? activity = ConnectionSetupDistributedTracing.StartConnectionSetupActivity(IsSecure, _telemetryServerAddress, OriginAuthority.Port);
 
@@ -576,7 +584,7 @@ namespace System.Net.Http
                     case HttpConnectionKind.Http:
                     case HttpConnectionKind.Https:
                     case HttpConnectionKind.ProxyConnect:
-                        stream = await ConnectToTcpHostAsync(_originAuthority.IdnHost, _originAuthority.Port, request, async, cancellationToken).ConfigureAwait(false);
+                        stream = await ConnectToTcpHostAsync(_originAuthority.IdnHost, _originAuthority.Port, request, async, connectionId, cancellationToken).ConfigureAwait(false);
                         // remoteEndPoint is returned for diagnostic purposes.
                         remoteEndPoint = GetRemoteEndPoint(stream);
                         if (_kind == HttpConnectionKind.ProxyConnect && _sslOptionsProxy != null)
@@ -586,7 +594,7 @@ namespace System.Net.Http
                         break;
 
                     case HttpConnectionKind.Proxy:
-                        stream = await ConnectToTcpHostAsync(_proxyUri!.IdnHost, _proxyUri.Port, request, async, cancellationToken).ConfigureAwait(false);
+                        stream = await ConnectToTcpHostAsync(_proxyUri!.IdnHost, _proxyUri.Port, request, async, connectionId, cancellationToken).ConfigureAwait(false);
                         // remoteEndPoint is returned for diagnostic purposes.
                         remoteEndPoint = GetRemoteEndPoint(stream);
                         if (_sslOptionsProxy != null)
@@ -608,7 +616,7 @@ namespace System.Net.Http
 
                     case HttpConnectionKind.SocksTunnel:
                     case HttpConnectionKind.SslSocksTunnel:
-                        stream = await EstablishSocksTunnel(request, async, cancellationToken).ConfigureAwait(false);
+                        stream = await EstablishSocksTunnel(request, async, connectionId, cancellationToken).ConfigureAwait(false);
                         // remoteEndPoint is returned for diagnostic purposes.
                         remoteEndPoint = GetRemoteEndPoint(stream);
                         break;
@@ -647,12 +655,12 @@ namespace System.Net.Http
                 }
             }
 
-            return (stream, transportContext, activity, remoteEndPoint);
+            return (stream, transportContext, activity, remoteEndPoint, connectionId);
 
             static IPEndPoint? GetRemoteEndPoint(Stream stream) => (stream as NetworkStream)?.Socket?.RemoteEndPoint as IPEndPoint;
         }
 
-        private async ValueTask<Stream> ConnectToTcpHostAsync(string host, int port, HttpRequestMessage initialRequest, bool async, CancellationToken cancellationToken)
+        private async ValueTask<Stream> ConnectToTcpHostAsync(string host, int port, HttpRequestMessage initialRequest, bool async, long connectionId, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -663,7 +671,7 @@ namespace System.Net.Http
                 // If a ConnectCallback was supplied, use that to establish the connection.
                 if (Settings._connectCallback != null)
                 {
-                    ValueTask<Stream> streamTask = Settings._connectCallback(new SocketsHttpConnectionContext(endPoint, initialRequest), cancellationToken);
+                    ValueTask<Stream> streamTask = Settings._connectCallback(new SocketsHttpConnectionContext(endPoint, initialRequest, connectionId), cancellationToken);
 
                     if (!async && !streamTask.IsCompleted)
                     {
@@ -805,11 +813,11 @@ namespace System.Net.Http
             }
         }
 
-        private async ValueTask<Stream> EstablishSocksTunnel(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        private async ValueTask<Stream> EstablishSocksTunnel(HttpRequestMessage request, bool async, long connectionId, CancellationToken cancellationToken)
         {
             Debug.Assert(_proxyUri != null);
 
-            Stream stream = await ConnectToTcpHostAsync(_proxyUri.IdnHost, _proxyUri.Port, request, async, cancellationToken).ConfigureAwait(false);
+            Stream stream = await ConnectToTcpHostAsync(_proxyUri.IdnHost, _proxyUri.Port, request, async, connectionId, cancellationToken).ConfigureAwait(false);
 
             try
             {
@@ -887,10 +895,15 @@ namespace System.Net.Http
         {
             Debug.Assert(!HasSyncObjLock);
 
+            if (connection.MarkedForEviction)
+            {
+                return true;
+            }
+
             TimeSpan pooledConnectionLifetime = _poolManager.Settings._pooledConnectionLifetime;
             if (pooledConnectionLifetime != Timeout.InfiniteTimeSpan)
             {
-                return connection.GetLifetimeTicks(Environment.TickCount64) > pooledConnectionLifetime.TotalMilliseconds;
+                return connection.Age > pooledConnectionLifetime;
             }
 
             return false;
@@ -898,13 +911,104 @@ namespace System.Net.Http
 
         private bool CheckExpirationOnReturn(HttpConnectionBase connection)
         {
+            if (connection.MarkedForEviction)
+            {
+                return true;
+            }
+
             TimeSpan lifetime = _poolManager.Settings._pooledConnectionLifetime;
             if (lifetime != Timeout.InfiniteTimeSpan)
             {
-                return lifetime == TimeSpan.Zero || connection.GetLifetimeTicks(Environment.TickCount64) > lifetime.TotalMilliseconds;
+                return lifetime == TimeSpan.Zero || connection.Age > lifetime;
             }
 
             return false;
+        }
+
+        /// <summary>Guards against overlapping <see cref="EvaluateConnectionsForEvictionAsync"/> runs for this pool.</summary>
+        private bool _evictionEvaluationInProgress;
+
+        /// <summary>
+        /// Incremented at the start of each eviction evaluation pass. Connections record the generation at which they
+        /// were last evaluated, so an HTTP/1.1 connection that was busy during a pass (and therefore not visible to it)
+        /// can be re-evaluated in the background when it is returned to the pool.
+        /// </summary>
+        internal int EvictionGeneration { get; private set; }
+
+        /// <summary>
+        /// Invokes the user-supplied <see cref="SocketsHttpHandler.ShouldEvictConnection"/> callback for each
+        /// pooled connection and marks for eviction those the callback selects. List snapshots are taken under
+        /// the pool lock; the callback itself is always awaited outside the lock.
+        /// </summary>
+        private async Task EvaluateConnectionsForEvictionAsync()
+        {
+            Debug.Assert(!HasSyncObjLock);
+
+            if (Interlocked.Exchange(ref _evictionEvaluationInProgress, true))
+            {
+                return;
+            }
+
+            EvictionGeneration++;
+
+            try
+            {
+                // HTTP/1.1: the idle stack is lock-free and its enumerator returns a snapshot, so we can inspect
+                // connections without removing them. Connections currently in use (and therefore not on the stack)
+                // are evaluated by ReturnHttp11Connection when they are returned to the pool.
+                foreach (HttpConnection connection in _http11Connections)
+                {
+                    await connection.EvaluateForEvictionAsync().ConfigureAwait(false);
+                }
+
+                // HTTP/2: snapshot the available list under the lock, then evaluate outside of it.
+                Http2Connection[]? http2Connections = null;
+                lock (SyncObj)
+                {
+                    if (_availableHttp2Connections is { Count: > 0 } http2)
+                    {
+                        http2Connections = http2.ToArray();
+                    }
+                }
+
+                if (http2Connections is not null)
+                {
+                    foreach (Http2Connection connection in http2Connections)
+                    {
+                        await connection.EvaluateForEvictionAsync().ConfigureAwait(false);
+                    }
+                }
+
+                if (GlobalHttpSettings.SocketsHttpHandler.AllowHttp3)
+                {
+                    Http3Connection[]? http3Connections = null;
+                    lock (SyncObj)
+                    {
+                        if (_availableHttp3Connections is { Count: > 0 } http3)
+                        {
+                            http3Connections = http3.ToArray();
+                        }
+                    }
+
+                    if (http3Connections is not null)
+                    {
+                        foreach (Http3Connection connection in http3Connections)
+                        {
+                            await connection.EvaluateForEvictionAsync().ConfigureAwait(false);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.Fail($"Unexpected exception while evaluating connections for eviction: {e}");
+
+                if (NetEventSource.Log.IsEnabled()) Trace($"Unexpected exception while evaluating connections for eviction: {e}");
+            }
+            finally
+            {
+                _evictionEvaluationInProgress = false;
+            }
         }
 
         /// <summary>
@@ -980,6 +1084,15 @@ namespace System.Net.Http
             TimeSpan pooledConnectionLifetime = _poolManager.Settings._pooledConnectionLifetime;
             TimeSpan pooledConnectionIdleTimeout = _poolManager.Settings._pooledConnectionIdleTimeout;
             long nowTicks = Environment.TickCount64;
+
+            // If the user supplied an eviction callback, give them a chance to mark pooled connections for
+            // eviction before we scavenge. The callback is asynchronous and may be slow (e.g. perform a DNS
+            // lookup), so it runs off the maintenance timer thread; connections it evicts are retired by a later
+            // scavenge pass or by the get/return paths.
+            if (_poolManager.Settings._shouldEvictConnection is not null)
+            {
+                _ = EvaluateConnectionsForEvictionAsync();
+            }
 
             List<HttpConnectionBase>? toDispose = null;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -930,9 +930,6 @@ namespace System.Net.Http
             return false;
         }
 
-        /// <summary>Guards against overlapping <see cref="EvaluateConnectionsForEvictionAsync"/> runs for this pool.</summary>
-        private bool _evictionEvaluationInProgress;
-
         /// <summary>
         /// Incremented at the start of each eviction evaluation pass. Connections record the generation at which they
         /// were last evaluated, so an HTTP/1.1 connection that was busy during a pass (and therefore not visible to it)
@@ -943,27 +940,29 @@ namespace System.Net.Http
         /// <summary>
         /// Invokes the user-supplied <see cref="SocketsHttpHandler.ShouldEvictConnection"/> callback for each
         /// pooled connection and marks for eviction those the callback selects. List snapshots are taken under
-        /// the pool lock; the callback itself is always awaited outside the lock.
+        /// the pool lock; the per-connection checks are started outside the lock and intentionally not awaited.
         /// </summary>
-        private async Task EvaluateConnectionsForEvictionAsync()
+        private void EvaluateConnectionsForEviction()
         {
             Debug.Assert(!HasSyncObjLock);
-
-            if (Interlocked.Exchange(ref _evictionEvaluationInProgress, true))
-            {
-                return;
-            }
 
             EvictionGeneration++;
 
             try
             {
+                // Each connection's eviction check is started but deliberately not awaited. The user callback may
+                // block or take a long time, and awaiting the checks one by one would let a single slow callback
+                // stall the evaluation of every other connection (and every subsequent eviction pass). Each
+                // connection guards against overlapping runs of its own callback, so a connection whose callback is
+                // still pending is simply skipped by later passes. A callback that completes synchronously still
+                // completes inline here, so this only changes behavior when a callback does not complete promptly.
+
                 // HTTP/1.1: the idle stack is lock-free and its enumerator returns a snapshot, so we can inspect
                 // connections without removing them. Connections currently in use (and therefore not on the stack)
                 // are evaluated by ReturnHttp11Connection when they are returned to the pool.
                 foreach (HttpConnection connection in _http11Connections)
                 {
-                    await connection.EvaluateForEvictionAsync().ConfigureAwait(false);
+                    _ = connection.EvaluateForEvictionAsync();
                 }
 
                 // HTTP/2: snapshot the available list under the lock, then evaluate outside of it.
@@ -980,7 +979,7 @@ namespace System.Net.Http
                 {
                     foreach (Http2Connection connection in http2Connections)
                     {
-                        await connection.EvaluateForEvictionAsync().ConfigureAwait(false);
+                        _ = connection.EvaluateForEvictionAsync();
                     }
                 }
 
@@ -999,7 +998,7 @@ namespace System.Net.Http
                     {
                         foreach (Http3Connection connection in http3Connections)
                         {
-                            await connection.EvaluateForEvictionAsync().ConfigureAwait(false);
+                            _ = connection.EvaluateForEvictionAsync();
                         }
                     }
                 }
@@ -1009,10 +1008,6 @@ namespace System.Net.Http
                 Debug.Fail($"Unexpected exception while evaluating connections for eviction: {e}");
 
                 if (NetEventSource.Log.IsEnabled()) Trace($"Unexpected exception while evaluating connections for eviction: {e}");
-            }
-            finally
-            {
-                _evictionEvaluationInProgress = false;
             }
         }
 
@@ -1096,7 +1091,7 @@ namespace System.Net.Http
             // scavenge pass or by the get/return paths.
             if (_poolManager.Settings._shouldEvictConnection is not null)
             {
-                _ = EvaluateConnectionsForEvictionAsync();
+                EvaluateConnectionsForEviction();
             }
 
             List<HttpConnectionBase>? toDispose = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -403,6 +403,11 @@ namespace System.Net.Http
             int retryCount = 0;
             while (true)
             {
+                // Reset any connection id stamped by a previous attempt. Each connection sets it again in its
+                // SendAsync, so if this attempt is abandoned (e.g. we time out while waiting for the next
+                // connection after a graceful retry) the request won't point at a connection that didn't serve it.
+                request.ConnectionId = null;
+
                 HttpConnectionWaiter<HttpConnection>? http11ConnectionWaiter = null;
                 HttpConnectionWaiter<Http2Connection?>? http2ConnectionWaiter = null;
                 try

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -745,7 +745,7 @@ namespace System.Net.Http
             return _sslOptionsHttp11!;
         }
 
-        private async ValueTask<Stream> ApplyPlaintextFilterAsync(bool async, Stream stream, Version httpVersion, HttpRequestMessage request, CancellationToken cancellationToken)
+        private async ValueTask<Stream> ApplyPlaintextFilterAsync(bool async, Stream stream, Version httpVersion, HttpRequestMessage request, long connectionId, CancellationToken cancellationToken)
         {
             if (Settings._plaintextStreamFilter is null)
             {
@@ -755,7 +755,7 @@ namespace System.Net.Http
             Stream newStream;
             try
             {
-                ValueTask<Stream> streamTask = Settings._plaintextStreamFilter(new SocketsHttpPlaintextStreamFilterContext(stream, httpVersion, request), cancellationToken);
+                ValueTask<Stream> streamTask = Settings._plaintextStreamFilter(new SocketsHttpPlaintextStreamFilterContext(stream, httpVersion, request, connectionId), cancellationToken);
 
                 if (!async && !streamTask.IsCompleted)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -131,8 +131,8 @@ namespace System.Net.Http
         private long _keepAlivePingTimeoutTimestamp;
         private volatile KeepAliveState _keepAliveState;
 
-        public Http2Connection(HttpConnectionPool pool, Stream stream, Activity? connectionSetupActivity, IPEndPoint? remoteEndPoint)
-            : base(pool, connectionSetupActivity, remoteEndPoint)
+        public Http2Connection(HttpConnectionPool pool, Stream stream, Activity? connectionSetupActivity, IPEndPoint? remoteEndPoint, long connectionId)
+            : base(pool, connectionId, connectionSetupActivity, remoteEndPoint)
         {
             _stream = stream;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1999,6 +1999,8 @@ namespace System.Net.Http
 
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
+            request.ConnectionId = Id;
+
             Debug.Assert(async);
             Debug.Assert(!_pool.HasSyncObjLock);
             if (NetEventSource.Log.IsEnabled()) Trace($"Sending request: {request}");

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -70,7 +70,7 @@ namespace System.Net.Http
         }
 
         public Http3Connection(HttpConnectionPool pool, HttpAuthority authority, bool includeAltUsedHeader)
-            : base(pool)
+            : base(pool, GetNextConnectionId())
         {
             _authority = authority;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -263,6 +263,8 @@ namespace System.Net.Http
 
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, WaitForHttp3ConnectionActivity waitForConnectionActivity, bool streamAvailable, CancellationToken cancellationToken)
         {
+            request.ConnectionId = Id;
+
             // Allocate an active request
             QuicStream? quicStream = null;
             Http3RequestStream? requestStream = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -90,9 +90,11 @@ namespace System.Net.Http
             }
         }
 
-        public void InitQuicConnection(QuicConnection connection, Activity? connectionSetupActivity)
+        public void InitQuicConnection(QuicConnection connection, Activity? connectionSetupActivity, DnsEndPoint connectedEndPoint)
         {
-            MarkConnectionAsEstablished(connectionSetupActivity: connectionSetupActivity, remoteEndPoint: connection.RemoteEndPoint);
+            // Report the exact DnsEndPoint used to establish the QUIC connection (Alt-Svc may point it at an authority
+            // distinct from the pool's origin), consistent with the connection's RemoteEndPoint.
+            MarkConnectionAsEstablished(connectionSetupActivity: connectionSetupActivity, remoteEndPoint: connection.RemoteEndPoint, authority: _authority, connectedEndPoint: connectedEndPoint);
 
             _connection = connection;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -74,8 +74,9 @@ namespace System.Net.Http
             Stream stream,
             TransportContext? transportContext,
             Activity? connectionSetupActivity,
-            IPEndPoint? remoteEndPoint)
-            : base(pool, connectionSetupActivity, remoteEndPoint)
+            IPEndPoint? remoteEndPoint,
+            long connectionId)
+            : base(pool, connectionId, connectionSetupActivity, remoteEndPoint)
         {
             Debug.Assert(stream != null);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -532,6 +532,8 @@ namespace System.Net.Http
 
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
+            request.ConnectionId = Id;
+
             Debug.Assert(_currentRequest == null, $"Expected null {nameof(_currentRequest)}.");
             Debug.Assert(_readBuffer.ActiveLength == 0, "Unexpected data in read buffer");
             Debug.Assert(_readAheadTaskStatus != ReadAheadTask_Started,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -31,31 +30,86 @@ namespace System.Net.Http
         private readonly long _creationTickCount = Environment.TickCount64;
         private long? _idleSinceTickCount;
 
+        /// <summary>
+        /// The context passed to the <see cref="SocketsHttpHandler.ShouldEvictConnection"/> callback.
+        /// A single instance is reused to avoid allocating a new context for each eviction check.
+        /// </summary>
+        private SocketsHttpConnectionEvictionContext? _evictionContext;
+
+        /// <summary>
+        /// Allocated at establishment only when <see cref="SocketsHttpHandler.ShouldEvictConnection"/>
+        /// is configured, and canceled (but not disposed, so handed-out tokens stay valid) when the connection closes.
+        /// </summary>
+        private CancellationTokenSource? _connectionDisposalCts;
+
+        /// <summary>
+        /// The <see cref="HttpConnectionPool.EvictionGeneration"/> at which this connection was last evaluated by the
+        /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/> callback.
+        /// </summary>
+        private int _lastEvictionGeneration;
+
+        /// <summary>
+        /// Set while the <see cref="SocketsHttpHandler.ShouldEvictConnection"/> callback is running for this connection.
+        /// Ensures the callback is invoked for at most one caller at a time for a given connection.
+        /// </summary>
+        private bool _evictionCallbackInProgress;
+
+        private volatile bool _markedForEviction;
+
         /// <summary>Cached string for the last Date header received on this connection.</summary>
         private string? _lastDateHeaderValue;
         /// <summary>Cached string for the last Server header received on this connection.</summary>
         private string? _lastServerHeaderValue;
 
-        public long Id { get; } = Interlocked.Increment(ref s_connectionCounter);
+        /// <summary>Whether the connection has been marked for eviction by <see cref="SocketsHttpHandler.ShouldEvictConnection"/> and should no longer be used for new requests.</summary>
+        public bool MarkedForEviction => _markedForEviction;
+
+        public long Id { get; }
 
         public Activity? ConnectionSetupActivity { get; private set; }
 
-        public HttpConnectionBase(HttpConnectionPool pool)
+        public HttpConnectionBase(HttpConnectionPool pool, long connectionId)
         {
             Debug.Assert(this is HttpConnection or Http2Connection or Http3Connection);
             Debug.Assert(pool != null);
             _pool = pool;
+            Id = connectionId;
         }
 
-        public HttpConnectionBase(HttpConnectionPool pool, Activity? connectionSetupActivity, IPEndPoint? remoteEndPoint)
-            : this(pool)
+        public HttpConnectionBase(HttpConnectionPool pool, long connectionId, Activity? connectionSetupActivity, IPEndPoint? remoteEndPoint)
+            : this(pool, connectionId)
         {
             MarkConnectionAsEstablished(connectionSetupActivity, remoteEndPoint);
         }
 
+        /// <summary>Allocates the next unique connection id. Generated before the connection object exists so that
+        /// the same id can be surfaced to <see cref="SocketsHttpHandler.ConnectCallback"/> and telemetry.</summary>
+        internal static long GetNextConnectionId() => Interlocked.Increment(ref s_connectionCounter);
+
         protected void MarkConnectionAsEstablished(Activity? connectionSetupActivity, IPEndPoint? remoteEndPoint)
         {
             ConnectionSetupActivity = connectionSetupActivity;
+
+            // Baseline the eviction generation to the pool's current value so a freshly established connection isn't
+            // immediately re-evaluated; it becomes eligible once the next maintenance pass advances the generation.
+            _lastEvictionGeneration = _pool.EvictionGeneration;
+
+            // Only the ShouldEvictConnection callback consumes the disposal token, so the source is created only when
+            // such a callback is configured.
+            if (_pool.Settings._shouldEvictConnection is not null)
+            {
+                _connectionDisposalCts = new CancellationTokenSource();
+
+                HttpAuthority authority = _pool.OriginAuthority;
+
+                _evictionContext = new SocketsHttpConnectionEvictionContext(
+                    new DnsEndPoint(authority.IdnHost, authority.Port),
+                    remoteEndPoint,
+                    Id,
+                    this is HttpConnection ? HttpVersion.Version11 : this is Http2Connection ? HttpVersion.Version20 : HttpVersion.Version30,
+                    _creationTickCount);
+            }
+
             if (GlobalHttpSettings.MetricsHandler.IsGloballyEnabled)
             {
                 Debug.Assert(_pool.Settings._metrics is not null);
@@ -100,6 +154,10 @@ namespace System.Net.Http
 
         public void MarkConnectionAsClosed()
         {
+            // Cancel the disposal token used by the ShouldEvictConnection callback. The source is intentionally not
+            // disposed so tokens already handed to a running callback stay valid (and observe the cancellation).
+            _connectionDisposalCts?.Cancel();
+
             if (GlobalHttpSettings.MetricsHandler.IsGloballyEnabled) _connectionMetrics?.ConnectionClosed(durationMs: Environment.TickCount64 - _creationTickCount);
 
             if (HttpTelemetry.Log.IsEnabled())
@@ -170,7 +228,58 @@ namespace System.Net.Http
 
         public long GetLifetimeTicks(long nowTicks) => nowTicks - _creationTickCount;
 
+        /// <summary>The amount of time that has elapsed since the connection was established.</summary>
+        internal TimeSpan Age => TimeSpan.FromMilliseconds(GetLifetimeTicks(Environment.TickCount64));
+
         public long GetIdleTicks(long nowTicks) => _idleSinceTickCount is long idleSinceTickCount ? nowTicks - idleSinceTickCount : 0;
+
+        public void RunEvictionEvaluationIfNeeded()
+        {
+            if (_pool.EvictionGeneration != _lastEvictionGeneration)
+            {
+                _ = EvaluateForEvictionAsync();
+            }
+        }
+
+        /// <summary>
+        /// Runs the <see cref="SocketsHttpHandler.ShouldEvictConnection"/> callback for this connection
+        /// and marks the connection for eviction if the callback requests it. The callback runs at most
+        /// once at a time for this connection.
+        /// </summary>
+        public async Task EvaluateForEvictionAsync()
+        {
+            Debug.Assert(_pool.Settings._shouldEvictConnection is not null);
+            Debug.Assert(_connectionDisposalCts is not null);
+            Debug.Assert(_evictionContext is not null);
+
+            // There's a benign race condition here where we might run the callback more than once for a given generation.
+            if (Interlocked.Exchange(ref _evictionCallbackInProgress, true) ||
+                MarkedForEviction ||
+                _connectionDisposalCts.IsCancellationRequested)
+            {
+                return;
+            }
+
+            try
+            {
+                if (await _pool.Settings._shouldEvictConnection(_evictionContext, _connectionDisposalCts.Token).ConfigureAwait(false))
+                {
+                    _markedForEviction = true;
+
+                    if (NetEventSource.Log.IsEnabled()) Trace("Marking connection for eviction per ShouldEvictConnection callback.");
+                }
+            }
+            catch (Exception e)
+            {
+                // Don't let a misbehaving user callback take down pool maintenance.
+                if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(SocketsHttpHandler.ShouldEvictConnection)} threw an exception: {e}");
+            }
+            finally
+            {
+                _lastEvictionGeneration = _pool.EvictionGeneration;
+                _evictionCallbackInProgress = false;
+            }
+        }
 
         /// <summary>Check whether a connection is still usable, or should be scavenged.</summary>
         /// <returns>True if connection can be used.</returns>
@@ -223,6 +332,13 @@ namespace System.Net.Http
         /// </summary>
         public bool IsUsable(long nowTicks, TimeSpan pooledConnectionLifetime, TimeSpan pooledConnectionIdleTimeout)
         {
+            // The connection may have been marked for eviction by the ShouldEvictConnection callback.
+            if (MarkedForEviction)
+            {
+                if (NetEventSource.Log.IsEnabled()) Trace("Scavenging connection. Connection was evicted.");
+                return false;
+            }
+
             // Validate that the connection hasn't been idle in the pool for longer than is allowed.
             if (pooledConnectionIdleTimeout != Timeout.InfiniteTimeSpan)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
         // avoid decrementing the counter once it's closed in case telemetry was enabled in between.
         private bool _httpTelemetryMarkedConnectionAsOpened;
 
-        private readonly long _creationTickCount = Environment.TickCount64; // milliseconds from Environment.TickCount64, not TimeSpan ticks
+        private readonly long _creationTickCount = Environment.TickCount64;
         private long? _idleSinceTickCount;
 
         /// <summary>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -79,14 +79,15 @@ namespace System.Net.Http
         public HttpConnectionBase(HttpConnectionPool pool, long connectionId, Activity? connectionSetupActivity, IPEndPoint? remoteEndPoint)
             : this(pool, connectionId)
         {
-            MarkConnectionAsEstablished(connectionSetupActivity, remoteEndPoint);
+            // HTTP/1.1 and HTTP/2 connections always target the pool's origin authority.
+            MarkConnectionAsEstablished(connectionSetupActivity, remoteEndPoint, pool.OriginAuthority);
         }
 
         /// <summary>Allocates the next unique connection id. Generated before the connection object exists so that
         /// the same id can be surfaced to <see cref="SocketsHttpHandler.ConnectCallback"/> and telemetry.</summary>
         internal static long GetNextConnectionId() => Interlocked.Increment(ref s_connectionCounter);
 
-        protected void MarkConnectionAsEstablished(Activity? connectionSetupActivity, IPEndPoint? remoteEndPoint)
+        protected void MarkConnectionAsEstablished(Activity? connectionSetupActivity, IPEndPoint? remoteEndPoint, HttpAuthority authority, DnsEndPoint? connectedEndPoint = null)
         {
             ConnectionSetupActivity = connectionSetupActivity;
 
@@ -100,10 +101,11 @@ namespace System.Net.Http
 
                 _connectionDisposalCts = new CancellationTokenSource();
 
-                HttpAuthority authority = _pool.OriginAuthority;
-
+                // Report the endpoint this connection actually targets, consistent with remoteEndPoint. HTTP/3 passes
+                // the exact DnsEndPoint it used to establish the QuicConnection (which Alt-Svc may point at an authority
+                // distinct from the origin); HTTP/1.1 and HTTP/2 fall back to the pool's origin authority.
                 _evictionContext = new SocketsHttpConnectionEvictionContext(
-                    new DnsEndPoint(authority.IdnHost, authority.Port),
+                    connectedEndPoint ?? new DnsEndPoint(authority.IdnHost, authority.Port),
                     remoteEndPoint,
                     Id,
                     this is HttpConnection ? HttpVersion.Version11 : this is Http2Connection ? HttpVersion.Version20 : HttpVersion.Version30,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
         // avoid decrementing the counter once it's closed in case telemetry was enabled in between.
         private bool _httpTelemetryMarkedConnectionAsOpened;
 
-        private readonly long _creationTickCount = Environment.TickCount64;
+        private readonly long _creationTickCount = Environment.TickCount64; // milliseconds from Environment.TickCount64, not TimeSpan ticks
         private long? _idleSinceTickCount;
 
         /// <summary>
@@ -90,14 +90,14 @@ namespace System.Net.Http
         {
             ConnectionSetupActivity = connectionSetupActivity;
 
-            // Baseline the eviction generation to the pool's current value so a freshly established connection isn't
-            // immediately re-evaluated; it becomes eligible once the next maintenance pass advances the generation.
-            _lastEvictionGeneration = _pool.EvictionGeneration;
-
-            // Only the ShouldEvictConnection callback consumes the disposal token, so the source is created only when
-            // such a callback is configured.
+            // The eviction generation baseline and disposal token are only relevant when a ShouldEvictConnection
+            // callback is configured, so they're only set up in that case.
             if (_pool.Settings._shouldEvictConnection is not null)
             {
+                // Baseline the eviction generation to the pool's current value so a freshly established connection isn't
+                // immediately re-evaluated; it becomes eligible once the next maintenance pass advances the generation.
+                _lastEvictionGeneration = _pool.EvictionGeneration;
+
                 _connectionDisposalCts = new CancellationTokenSource();
 
                 HttpAuthority authority = _pool.OriginAuthority;
@@ -233,6 +233,12 @@ namespace System.Net.Http
 
         public long GetIdleTicks(long nowTicks) => _idleSinceTickCount is long idleSinceTickCount ? nowTicks - idleSinceTickCount : 0;
 
+        /// <summary>
+        /// Called when a connection is returned to the pool to run the eviction evaluation that may have been skipped
+        /// for it during a background pass. HTTP/1.1 connections that were in use at the time weren't visible in the
+        /// available list (they were checked out as pending), so the pass couldn't evaluate them. Comparing the
+        /// connection's last evaluated generation against the pool's current one detects that case and evaluates now.
+        /// </summary>
         public void RunEvictionEvaluationIfNeeded()
         {
             if (_pool.EvictionGeneration != _lastEvictionGeneration)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -94,6 +94,18 @@ namespace System.Net.Http
                     _cleanPoolTimeout = timerPeriod.TotalSeconds >= MinScavengeSeconds ? timerPeriod : TimeSpan.FromSeconds(MinScavengeSeconds);
                 }
 
+                // The connection eviction callback is invoked from this timer. If one is set, make sure the timer
+                // fires at least this often so eviction decisions happen on a predictable cadence, regardless of
+                // how large (or infinite) the idle timeout is, which would otherwise drive the period alone.
+                if (settings._shouldEvictConnection is not null)
+                {
+                    const int MaxEvictionIntervalSeconds = 5;
+                    if (_cleanPoolTimeout.TotalSeconds > MaxEvictionIntervalSeconds)
+                    {
+                        _cleanPoolTimeout = TimeSpan.FromSeconds(MaxEvictionIntervalSeconds);
+                    }
+                }
+
                 using (ExecutionContext.SuppressFlow()) // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever
                 {
                     // Create the timer.  Ensure the Timer has a weak reference to this manager; otherwise, it

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -66,6 +66,8 @@ namespace System.Net.Http
         internal Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>>? _connectCallback;
         internal Func<SocketsHttpPlaintextStreamFilterContext, CancellationToken, ValueTask<Stream>>? _plaintextStreamFilter;
 
+        internal Func<SocketsHttpConnectionEvictionContext, CancellationToken, Task<bool>>? _shouldEvictConnection;
+
         internal IDictionary<string, object?>? _properties;
 
         // Http2 flow control settings:
@@ -126,6 +128,7 @@ namespace System.Net.Http
                 _enableMultipleHttp3Connections = _enableMultipleHttp3Connections,
                 _connectCallback = _connectCallback,
                 _plaintextStreamFilter = _plaintextStreamFilter,
+                _shouldEvictConnection = _shouldEvictConnection,
                 _initialHttp2StreamWindowSize = _initialHttp2StreamWindowSize,
                 _activityHeadersPropagator = _activityHeadersPropagator,
                 _defaultCredentialsUsedForProxy = _proxy != null && (_proxy.Credentials == CredentialCache.DefaultCredentials || _defaultProxyCredentials == CredentialCache.DefaultCredentials),

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Tracing;
+
 namespace System.Net.Http
 {
     /// <summary>
@@ -10,11 +13,13 @@ namespace System.Net.Http
     {
         private readonly DnsEndPoint _dnsEndPoint;
         private readonly HttpRequestMessage _initialRequestMessage;
+        private readonly long _connectionId;
 
-        internal SocketsHttpConnectionContext(DnsEndPoint dnsEndPoint, HttpRequestMessage initialRequestMessage)
+        internal SocketsHttpConnectionContext(DnsEndPoint dnsEndPoint, HttpRequestMessage initialRequestMessage, long connectionId)
         {
             _dnsEndPoint = dnsEndPoint;
             _initialRequestMessage = initialRequestMessage;
+            _connectionId = connectionId;
         }
 
         /// <summary>
@@ -26,5 +31,15 @@ namespace System.Net.Http
         /// The initial HttpRequestMessage that is causing the connection to be created.
         /// </summary>
         public HttpRequestMessage InitialRequestMessage => _initialRequestMessage;
+
+        /// <summary>
+        /// The identifier that will be assigned to the connection being established. This matches the connection id
+        /// reported through <see cref="EventSource"/> telemetry, and the
+        /// <see cref="SocketsHttpConnectionEvictionContext.ConnectionId"/> passed to
+        /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/>. It can be used to associate caller state (for
+        /// example, the resolved address used) with the connection so it can be recovered when deciding on eviction.
+        /// </summary>
+        [Experimental(Experimentals.SocketsHttpHandlerConnectionEvictionDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public long ConnectionId => _connectionId;
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
@@ -34,10 +34,12 @@ namespace System.Net.Http
 
         /// <summary>
         /// The identifier that will be assigned to the connection being established. This matches the connection id
-        /// reported through <see cref="EventSource"/> telemetry, and the
+        /// reported through <see cref="EventSource"/> telemetry, the
         /// <see cref="SocketsHttpConnectionEvictionContext.ConnectionId"/> passed to
-        /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/>. It can be used to associate caller state (for
-        /// example, the resolved address used) with the connection so it can be recovered when deciding on eviction.
+        /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/>, and the
+        /// <see cref="HttpRequestMessage.ConnectionId"/> stamped on requests sent over the connection. It can be used
+        /// to associate caller state (for example, the resolved address used) with the connection and to correlate it
+        /// with the requests it serves, so that state can be recovered later (for example when deciding on eviction).
         /// </summary>
         [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
         public long ConnectionId => _connectionId;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
@@ -40,12 +40,14 @@ namespace System.Net.Http
         /// <see cref="HttpRequestMessage.ConnectionId"/> stamped on requests sent over the connection. It can be used
         /// to associate caller state (for example, the resolved address used) with the connection and to correlate it
         /// with the requests it serves, so that state can be recovered later (for example when deciding on eviction).
+        /// </summary>
+        /// <remarks>
         /// When establishing the transport for an HTTP CONNECT proxy tunnel, this id identifies that transport
         /// connection to the proxy; the tunneled connection layered over it serves the requests and carries a distinct
         /// id, which is the one reported to <see cref="SocketsHttpHandler.ShouldEvictConnection"/> and stamped on those
         /// requests. A <see cref="SocketsHttpHandler.PlaintextStreamFilter"/> runs on each hop and surfaces both: this
         /// (transport) id on the CONNECT hop and the tunneled connection's id on the subsequent hop.
-        /// </summary>
+        /// </remarks>
         [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
         public long ConnectionId => _connectionId;
     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
@@ -39,7 +39,7 @@ namespace System.Net.Http
         /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/>. It can be used to associate caller state (for
         /// example, the resolved address used) with the connection so it can be recovered when deciding on eviction.
         /// </summary>
-        [Experimental(Experimentals.SocketsHttpHandlerConnectionEvictionDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
         public long ConnectionId => _connectionId;
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionContext.cs
@@ -40,6 +40,11 @@ namespace System.Net.Http
         /// <see cref="HttpRequestMessage.ConnectionId"/> stamped on requests sent over the connection. It can be used
         /// to associate caller state (for example, the resolved address used) with the connection and to correlate it
         /// with the requests it serves, so that state can be recovered later (for example when deciding on eviction).
+        /// When establishing the transport for an HTTP CONNECT proxy tunnel, this id identifies that transport
+        /// connection to the proxy; the tunneled connection layered over it serves the requests and carries a distinct
+        /// id, which is the one reported to <see cref="SocketsHttpHandler.ShouldEvictConnection"/> and stamped on those
+        /// requests. A <see cref="SocketsHttpHandler.PlaintextStreamFilter"/> runs on each hop and surfaces both: this
+        /// (transport) id on the CONNECT hop and the tunneled connection's id on the subsequent hop.
         /// </summary>
         [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
         public long ConnectionId => _connectionId;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Tracing;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Represents the context passed to <see cref="SocketsHttpHandler.ShouldEvictConnection"/> when a pooled
+    /// connection is being considered for eviction.
+    /// </summary>
+    /// <remarks>
+    /// The instance is only valid for the duration of the callback invocation; it must not be cached or used after
+    /// the callback returns. <see cref="Age"/> reflects the elapsed time at the moment it is read.
+    /// </remarks>
+    [Experimental(Experimentals.SocketsHttpHandlerConnectionEvictionDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+    public sealed class SocketsHttpConnectionEvictionContext
+    {
+        private readonly long _creationTickCount;
+
+        internal SocketsHttpConnectionEvictionContext(
+            DnsEndPoint dnsEndPoint,
+            IPEndPoint? remoteEndPoint,
+            long connectionId,
+            Version httpVersion,
+            long creationTickCount)
+        {
+            DnsEndPoint = dnsEndPoint;
+            RemoteEndPoint = remoteEndPoint;
+            ConnectionId = connectionId;
+            HttpVersion = httpVersion;
+            _creationTickCount = creationTickCount;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Net.DnsEndPoint"/> identifying the origin (host and port) the connection targets.
+        /// </summary>
+        /// <remarks>
+        /// This is the logical destination the connection was created for, not necessarily the host the
+        /// transport is physically connected to (for example, when a proxy is in use). Use it together with
+        /// <see cref="RemoteEndPoint"/> to decide whether the connection still points at a desired address.
+        /// </remarks>
+        public DnsEndPoint DnsEndPoint { get; }
+
+        /// <summary>
+        /// Gets the remote <see cref="IPEndPoint"/> the connection's transport is connected to, when available.
+        /// </summary>
+        /// <remarks>
+        /// This is <see langword="null"/> when the remote endpoint is not known, for example when a custom
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/> returned a stream that is not backed by a socket.
+        /// </remarks>
+        public IPEndPoint? RemoteEndPoint { get; }
+
+        /// <summary>
+        /// Gets the identifier assigned to the connection. This matches the connection id reported through
+        /// <see cref="EventSource"/> telemetry, and the
+        /// <see cref="SocketsHttpConnectionContext.ConnectionId"/> seen by a custom
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/>, allowing the decision to be correlated with state the
+        /// caller associated with the connection at creation time.
+        /// </summary>
+        public long ConnectionId { get; }
+
+        /// <summary>
+        /// Gets the HTTP version negotiated for the connection (for example, 1.1, 2.0, or 3.0).
+        /// </summary>
+        public Version HttpVersion { get; }
+
+        /// <summary>
+        /// Gets the amount of time that has elapsed since the connection was established.
+        /// </summary>
+        public TimeSpan Age => TimeSpan.FromMilliseconds(Environment.TickCount64 - _creationTickCount);
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http
     /// The instance is only valid for the duration of the callback invocation; it must not be cached or used after
     /// the callback returns. <see cref="Age"/> reflects the elapsed time at the moment it is read.
     /// </remarks>
-    [Experimental(Experimentals.SocketsHttpHandlerConnectionEvictionDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+    [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
     public sealed class SocketsHttpConnectionEvictionContext
     {
         private readonly long _creationTickCount;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
@@ -57,13 +57,16 @@ namespace System.Net.Http
         /// <see cref="EventSource"/> telemetry and the <see cref="HttpRequestMessage.ConnectionId"/> stamped on
         /// requests sent over the connection. It also matches the
         /// <see cref="SocketsHttpConnectionContext.ConnectionId"/> seen by a custom
-        /// <see cref="SocketsHttpHandler.ConnectCallback"/>, except for an HTTP CONNECT proxy tunnel, where the
-        /// callback observes the underlying transport connection to the proxy while this id identifies the tunneled
-        /// connection that served the requests. Both ids remain observable through a
-        /// <see cref="SocketsHttpHandler.PlaintextStreamFilter"/>, which runs on each hop and reports the transport
-        /// id for the CONNECT hop and this id for the tunneled hop. It allows the eviction decision to be correlated
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/>. It allows the eviction decision to be correlated
         /// with the requests the connection served.
         /// </summary>
+        /// <remarks>
+        /// For an HTTP CONNECT proxy tunnel the id seen by a custom <see cref="SocketsHttpHandler.ConnectCallback"/>
+        /// differs from this one: the callback observes the underlying transport connection to the proxy while this id
+        /// identifies the tunneled connection that served the requests. Both ids remain observable through a
+        /// <see cref="SocketsHttpHandler.PlaintextStreamFilter"/>, which runs on each hop and reports the transport
+        /// id for the CONNECT hop and this id for the tunneled hop.
+        /// </remarks>
         public long ConnectionId { get; }
 
         /// <summary>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
@@ -17,7 +17,7 @@ namespace System.Net.Http
     [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
     public sealed class SocketsHttpConnectionEvictionContext
     {
-        private readonly long _creationTickCount;
+        private readonly long _creationTickCount; // milliseconds from Environment.TickCount64, not TimeSpan ticks
 
         internal SocketsHttpConnectionEvictionContext(
             DnsEndPoint dnsEndPoint,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
@@ -54,10 +54,11 @@ namespace System.Net.Http
 
         /// <summary>
         /// Gets the identifier assigned to the connection. This matches the connection id reported through
-        /// <see cref="EventSource"/> telemetry, and the
+        /// <see cref="EventSource"/> telemetry, the
         /// <see cref="SocketsHttpConnectionContext.ConnectionId"/> seen by a custom
-        /// <see cref="SocketsHttpHandler.ConnectCallback"/>, allowing the decision to be correlated with state the
-        /// caller associated with the connection at creation time.
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/>, and the <see cref="HttpRequestMessage.ConnectionId"/>
+        /// stamped on requests sent over the connection. It allows the eviction decision to be correlated both with
+        /// state the caller associated with the connection at creation time and with the requests it served.
         /// </summary>
         public long ConnectionId { get; }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpConnectionEvictionContext.cs
@@ -54,11 +54,15 @@ namespace System.Net.Http
 
         /// <summary>
         /// Gets the identifier assigned to the connection. This matches the connection id reported through
-        /// <see cref="EventSource"/> telemetry, the
+        /// <see cref="EventSource"/> telemetry and the <see cref="HttpRequestMessage.ConnectionId"/> stamped on
+        /// requests sent over the connection. It also matches the
         /// <see cref="SocketsHttpConnectionContext.ConnectionId"/> seen by a custom
-        /// <see cref="SocketsHttpHandler.ConnectCallback"/>, and the <see cref="HttpRequestMessage.ConnectionId"/>
-        /// stamped on requests sent over the connection. It allows the eviction decision to be correlated both with
-        /// state the caller associated with the connection at creation time and with the requests it served.
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/>, except for an HTTP CONNECT proxy tunnel, where the
+        /// callback observes the underlying transport connection to the proxy while this id identifies the tunneled
+        /// connection that served the requests. Both ids remain observable through a
+        /// <see cref="SocketsHttpHandler.PlaintextStreamFilter"/>, which runs on each hop and reports the transport
+        /// id for the CONNECT hop and this id for the tunneled hop. It allows the eviction decision to be correlated
+        /// with the requests the connection served.
         /// </summary>
         public long ConnectionId { get; }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -427,6 +427,41 @@ namespace System.Net.Http
         }
 
         /// <summary>
+        /// Gets or sets a callback that decides whether a pooled connection should be evicted.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When set, the callback is invoked for pooled connections with a
+        /// <see cref="SocketsHttpConnectionEvictionContext"/> describing the connection. Returning <see langword="true"/>
+        /// marks the connection for eviction: it will not be used to serve new requests and is retired once it
+        /// becomes idle (an in-flight request on the connection is allowed to complete first).
+        /// </para>
+        /// <para>
+        /// The callback is not guaranteed to run for every request, and it may run concurrently with the connection
+        /// serving requests as well as concurrently for different connections. Because it is asynchronous, a caller
+        /// may perform work such as a name resolution inside it; however, it is invoked for each pooled connection, so
+        /// keeping it inexpensive (for example, consulting a cached resolution result) is recommended. The supplied
+        /// <see cref="CancellationToken"/> is canceled if the connection is disposed while the callback is running.
+        /// </para>
+        /// <para>
+        /// This callback complements <see cref="PooledConnectionLifetime"/>. Because a caller can use it to evict
+        /// connections in response to their own DNS resolution, it makes it possible to set
+        /// <see cref="PooledConnectionLifetime"/> to <see cref="Timeout.InfiniteTimeSpan"/> and
+        /// retain otherwise healthy connections rather than recycling them purely to observe address changes.
+        /// </para>
+        /// </remarks>
+        [Experimental(Experimentals.SocketsHttpHandlerConnectionEvictionDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public Func<SocketsHttpConnectionEvictionContext, CancellationToken, Task<bool>>? ShouldEvictConnection
+        {
+            get => _settings._shouldEvictConnection;
+            set
+            {
+                CheckDisposedOrStarted();
+                _settings._shouldEvictConnection = value;
+            }
+        }
+
+        /// <summary>
         /// Gets a writable dictionary (that is, a map) of custom properties for the HttpClient requests. The dictionary is initialized empty; you can insert and query key-value pairs for your custom handlers and special processing.
         /// </summary>
         public IDictionary<string, object?> Properties =>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -450,7 +450,7 @@ namespace System.Net.Http
         /// retain otherwise healthy connections rather than recycling them purely to observe address changes.
         /// </para>
         /// </remarks>
-        [Experimental(Experimentals.SocketsHttpHandlerConnectionEvictionDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
         public Func<SocketsHttpConnectionEvictionContext, CancellationToken, Task<bool>>? ShouldEvictConnection
         {
             get => _settings._shouldEvictConnection;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpPlaintextStreamFilterContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpPlaintextStreamFilterContext.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Tracing;
 using System.IO;
 
 namespace System.Net.Http
@@ -13,12 +15,14 @@ namespace System.Net.Http
         private readonly Stream _plaintextStream;
         private readonly Version _negotiatedHttpVersion;
         private readonly HttpRequestMessage _initialRequestMessage;
+        private readonly long _connectionId;
 
-        internal SocketsHttpPlaintextStreamFilterContext(Stream plaintextStream, Version negotiatedHttpVersion, HttpRequestMessage initialRequestMessage)
+        internal SocketsHttpPlaintextStreamFilterContext(Stream plaintextStream, Version negotiatedHttpVersion, HttpRequestMessage initialRequestMessage, long connectionId)
         {
             _plaintextStream = plaintextStream;
             _negotiatedHttpVersion = negotiatedHttpVersion;
             _initialRequestMessage = initialRequestMessage;
+            _connectionId = connectionId;
         }
 
         /// <summary>
@@ -35,5 +39,17 @@ namespace System.Net.Http
         /// The initial HttpRequestMessage that is causing the stream to be used.
         /// </summary>
         public HttpRequestMessage InitialRequestMessage => _initialRequestMessage;
+
+        /// <summary>
+        /// The identifier of the connection whose stream is being filtered. This matches the connection id reported
+        /// through <see cref="EventSource"/> telemetry, the <see cref="SocketsHttpConnectionContext.ConnectionId"/>
+        /// surfaced to <see cref="SocketsHttpHandler.ConnectCallback"/>, the
+        /// <see cref="SocketsHttpConnectionEvictionContext.ConnectionId"/> passed to
+        /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/>, and the <see cref="HttpRequestMessage.ConnectionId"/>
+        /// stamped on requests sent over the connection. It can be used to associate caller state with the connection
+        /// and to correlate it with the requests it serves.
+        /// </summary>
+        [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public long ConnectionId => _connectionId;
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpPlaintextStreamFilterContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpPlaintextStreamFilterContext.cs
@@ -47,12 +47,15 @@ namespace System.Net.Http
         /// <see cref="SocketsHttpHandler.ConnectCallback"/>, the
         /// <see cref="SocketsHttpConnectionEvictionContext.ConnectionId"/> passed to
         /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/>, and the <see cref="HttpRequestMessage.ConnectionId"/>
-        /// stamped on requests sent over the connection. For an HTTP CONNECT proxy tunnel the filter runs once per hop:
-        /// on the CONNECT hop this is the transport connection's id (the one the ConnectCallback observed), and on the
-        /// tunneled hop it is the tunneled connection's id (the one passed to ShouldEvictConnection and stamped on
-        /// requests). It can be used to associate caller state with the connection and to correlate it with the
-        /// requests it serves.
+        /// stamped on requests sent over the connection. It can be used to associate caller state with the connection
+        /// and to correlate it with the requests it serves.
         /// </summary>
+        /// <remarks>
+        /// For an HTTP CONNECT proxy tunnel the filter runs once per hop: on the CONNECT hop this is the transport
+        /// connection's id (the one the <see cref="SocketsHttpHandler.ConnectCallback"/> observed), and on the
+        /// tunneled hop it is the tunneled connection's id (the one passed to
+        /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/> and stamped on requests).
+        /// </remarks>
         [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
         public long ConnectionId => _connectionId;
     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpPlaintextStreamFilterContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpPlaintextStreamFilterContext.cs
@@ -42,12 +42,16 @@ namespace System.Net.Http
 
         /// <summary>
         /// The identifier of the connection whose stream is being filtered. This matches the connection id reported
-        /// through <see cref="EventSource"/> telemetry, the <see cref="SocketsHttpConnectionContext.ConnectionId"/>
-        /// surfaced to <see cref="SocketsHttpHandler.ConnectCallback"/>, the
+        /// through <see cref="EventSource"/> telemetry for that connection. For a direct connection it also matches the
+        /// <see cref="SocketsHttpConnectionContext.ConnectionId"/> surfaced to
+        /// <see cref="SocketsHttpHandler.ConnectCallback"/>, the
         /// <see cref="SocketsHttpConnectionEvictionContext.ConnectionId"/> passed to
         /// <see cref="SocketsHttpHandler.ShouldEvictConnection"/>, and the <see cref="HttpRequestMessage.ConnectionId"/>
-        /// stamped on requests sent over the connection. It can be used to associate caller state with the connection
-        /// and to correlate it with the requests it serves.
+        /// stamped on requests sent over the connection. For an HTTP CONNECT proxy tunnel the filter runs once per hop:
+        /// on the CONNECT hop this is the transport connection's id (the one the ConnectCallback observed), and on the
+        /// tunneled hop it is the tunneled connection's id (the one passed to ShouldEvictConnection and stamped on
+        /// requests). It can be used to associate caller state with the connection and to correlate it with the
+        /// requests it serves.
         /// </summary>
         [Experimental(Experimentals.SocketsHttpHandlerExperimentalDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
         public long ConnectionId => _connectionId;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -154,6 +155,149 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(firstResponse.IsSuccessStatusCode);
 
             await AltSvc_Upgrade_Success(firstServer, secondServer, client);
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_Http3AltSvcConnection_ContextReportsAltAuthority()
+        {
+            using Http2LoopbackServer firstServer = Http2LoopbackServer.CreateServer();
+            using Http3LoopbackServer secondServer = CreateHttp3LoopbackServer();
+
+            SocketsHttpConnectionEvictionContext capturedContext = null;
+            var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            SocketsHttpHandler socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+            socketsHandler.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
+            socketsHandler.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4);
+            socketsHandler.ShouldEvictConnection = (context, _) =>
+            {
+                // The origin HTTP/2 connection is also evaluated; capture only the HTTP/3 (Alt-Svc) connection.
+                if (context.HttpVersion == HttpVersion.Version30)
+                {
+                    capturedContext ??= context;
+                    callbackInvoked.TrySetResult();
+                }
+                return Task.FromResult(false); // Never evict; we only want to observe the context.
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+            client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+            client.DefaultRequestVersion = HttpVersion.Version20;
+
+            // First request over HTTP/2 advertises an HTTP/3 alternative on secondServer, whose authority (port) differs
+            // from the origin.
+            Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
+            Task<HttpRequestData> firstServerTask = firstServer.HandleRequestAsync(headers: new[]
+            {
+                new HttpHeaderData("Alt-Svc", $"h3=\"{secondServer.Address.IdnHost}:{secondServer.Address.Port}\"")
+            });
+            await new Task[] { firstResponseTask, firstServerTask }.WhenAllOrAnyFailed(TestHelper.PassingTestTimeoutMilliseconds);
+            using (HttpResponseMessage firstResponse = firstResponseTask.Result)
+            {
+                Assert.True(firstResponse.IsSuccessStatusCode);
+            }
+
+            // Second request upgrades to HTTP/3 on the alt authority. Handle it at the stream level (no GOAWAY) so the
+            // connection stays open, pooled and idle, making it eligible for the eviction maintenance pass.
+            Task<HttpResponseMessage> secondResponseTask = client.GetAsync(firstServer.Address);
+            await using (GenericLoopbackConnection genericConnection = await secondServer.EstablishGenericConnectionAsync())
+            {
+                var h3Connection = (Http3LoopbackConnection)genericConnection;
+                Http3LoopbackStream stream = await h3Connection.AcceptRequestStreamAsync();
+                await stream.HandleRequestAsync();
+
+                using (HttpResponseMessage secondResponse = await secondResponseTask.WaitAsync(TestHelper.PassingTestTimeout))
+                {
+                    Assert.True(secondResponse.IsSuccessStatusCode);
+                }
+
+                await callbackInvoked.Task.WaitAsync(TestHelper.PassingTestTimeout);
+
+                Assert.NotNull(capturedContext);
+                // The connection targets the Alt-Svc authority, so the eviction context must report that authority
+                // (consistent with RemoteEndPoint), not the pool's origin authority. The alt authority uses a different port.
+                Assert.Equal(secondServer.Address.IdnHost, capturedContext.DnsEndPoint.Host);
+                Assert.Equal(secondServer.Address.Port, capturedContext.DnsEndPoint.Port);
+                Assert.NotEqual(firstServer.Address.Port, capturedContext.DnsEndPoint.Port);
+
+                // HTTP/3 always reports the remote endpoint (from the QUIC connection). It targets the alt authority, so
+                // its port matches the reported DnsEndPoint.
+                IPEndPoint remoteEndPoint = Assert.IsType<IPEndPoint>(capturedContext.RemoteEndPoint);
+                Assert.Equal(secondServer.Address.Port, remoteEndPoint.Port);
+            }
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_Http3AltSvcChangesAfterConnect_ContextReportsOriginalEndpoint()
+        {
+            using Http2LoopbackServer firstServer = Http2LoopbackServer.CreateServer();
+            using Http3LoopbackServer secondServer = CreateHttp3LoopbackServer();
+            // The Alt-Svc will later be changed to point at this authority; we never actually connect to it.
+            using Http3LoopbackServer thirdServer = CreateHttp3LoopbackServer();
+
+            SocketsHttpConnectionEvictionContext capturedContext = null;
+            var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            SocketsHttpHandler socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+            socketsHandler.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
+            socketsHandler.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4);
+            socketsHandler.ShouldEvictConnection = (context, _) =>
+            {
+                if (context.HttpVersion == HttpVersion.Version30)
+                {
+                    capturedContext ??= context;
+                    callbackInvoked.TrySetResult();
+                }
+                return Task.FromResult(false);
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+            client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+            client.DefaultRequestVersion = HttpVersion.Version20;
+
+            // First request over HTTP/2 advertises the HTTP/3 alternative on secondServer.
+            Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
+            Task<HttpRequestData> firstServerTask = firstServer.HandleRequestAsync(headers: new[]
+            {
+                new HttpHeaderData("Alt-Svc", $"h3=\"{secondServer.Address.IdnHost}:{secondServer.Address.Port}\"")
+            });
+            await new Task[] { firstResponseTask, firstServerTask }.WhenAllOrAnyFailed(TestHelper.PassingTestTimeoutMilliseconds);
+            using (HttpResponseMessage firstResponse = firstResponseTask.Result)
+            {
+                Assert.True(firstResponse.IsSuccessStatusCode);
+            }
+
+            // Second request upgrades to HTTP/3 on secondServer. Its response changes the advertised Alt-Svc to point at
+            // thirdServer (a different authority/port). The connection stays open, pooled and idle.
+            Task<HttpResponseMessage> secondResponseTask = client.GetAsync(firstServer.Address);
+            await using (GenericLoopbackConnection genericConnection = await secondServer.EstablishGenericConnectionAsync())
+            {
+                var h3Connection = (Http3LoopbackConnection)genericConnection;
+                Http3LoopbackStream stream = await h3Connection.AcceptRequestStreamAsync();
+                await stream.HandleRequestAsync(headers: new[]
+                {
+                    new HttpHeaderData("Alt-Svc", $"h3=\"{thirdServer.Address.IdnHost}:{thirdServer.Address.Port}\"")
+                });
+
+                using (HttpResponseMessage secondResponse = await secondResponseTask.WaitAsync(TestHelper.PassingTestTimeout))
+                {
+                    Assert.True(secondResponse.IsSuccessStatusCode);
+                }
+
+                await callbackInvoked.Task.WaitAsync(TestHelper.PassingTestTimeout);
+
+                Assert.NotNull(capturedContext);
+                // Even though Alt-Svc now points at thirdServer, the existing connection still reports the endpoint it
+                // was actually established to (secondServer) - captured at connection setup, not the pool's current alt
+                // authority.
+                Assert.Equal(secondServer.Address.IdnHost, capturedContext.DnsEndPoint.Host);
+                Assert.Equal(secondServer.Address.Port, capturedContext.DnsEndPoint.Port);
+                Assert.NotEqual(thirdServer.Address.Port, capturedContext.DnsEndPoint.Port);
+            }
         }
 
         private async Task AltSvc_Upgrade_Success(GenericLoopbackServer firstServer, Http3LoopbackServer secondServer, HttpClient client)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2045,6 +2045,355 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ShouldEvictConnection_CallbackReturnsTrue_ConnectionEvictedAndReplaced(bool useAsyncCallback)
+        {
+            var firstConnectionEvicted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var firstConnectionDisposalTokenCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            SocketsHttpConnectionEvictionContext capturedContext = null;
+            Uri serverUri = null;
+            var connectCallbackIds = new System.Collections.Concurrent.ConcurrentBag<long>();
+
+            using var handler = new SocketsHttpHandler
+            {
+                // Drive the pool maintenance timer (which invokes the eviction callback) to fire roughly once a
+                // second, while keeping the idle timeout long enough that idle expiry can't be what removes the
+                // connection during the test. Disable lifetime entirely so only eviction can retire a connection.
+                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4),
+                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
+            };
+
+            // The connection id surfaced to ConnectCallback is the same one passed to the eviction callback,
+            // so the caller can associate connect-time state with the connection and recover it on eviction.
+            handler.ConnectCallback = async (context, ct) =>
+            {
+                connectCallbackIds.Add(context.ConnectionId);
+                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                await socket.ConnectAsync(context.DnsEndPoint, ct);
+                return new NetworkStream(socket, ownsSocket: true);
+            };
+
+            handler.ShouldEvictConnection = async (context, cancellationToken) =>
+            {
+                // Only one connection is evaluated at a time in this test, so no synchronization is needed here.
+                if (useAsyncCallback)
+                {
+                    await Task.Yield(); // Exercise the path where the callback completes asynchronously.
+                }
+
+                capturedContext ??= context;
+                if (context.ConnectionId == capturedContext.ConnectionId)
+                {
+                    // The token is canceled when the connection is disposed (i.e. once it has been retired).
+                    cancellationToken.Register(static s => ((TaskCompletionSource)s).TrySetResult(), firstConnectionDisposalTokenCanceled);
+                    firstConnectionEvicted.TrySetResult();
+                    return true; // Evict only the first connection we observe.
+                }
+
+                return false;
+            };
+
+            using HttpClient client = new HttpClient(handler);
+
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                serverUri = uri;
+
+                // Connection A: serve request 1 with a keep-alive response, then block reading until the client
+                // tears the connection down. If anything other than eviction were to remove it, the read below
+                // would observe request 2 instead of EOF and the test's second accept would not be a new connection.
+                Task serverTaskA = server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "1");
+                    await connection.ReadLineAsync(); // Returns null (EOF) once the evicted connection is disposed.
+                });
+
+                Assert.Equal("1", await client.GetStringAsync(uri));
+
+                // Wait for the maintenance timer to invoke the eviction callback for connection A, then for the
+                // pool to actually retire it (serverTaskA's read completes at EOF once the client disposes it).
+                await firstConnectionEvicted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                await serverTaskA.WaitAsync(TimeSpan.FromSeconds(30));
+
+                // Disposing the retired connection cancels the token that was passed to the eviction callback.
+                await firstConnectionDisposalTokenCanceled.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+                // Request 2 must land on a brand new connection B, because A has been evicted.
+                Task<string> request2 = client.GetStringAsync(uri);
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "2");
+                });
+
+                Assert.Equal("2", await request2);
+            });
+
+            Assert.NotNull(capturedContext);
+            Assert.Equal(System.Net.HttpVersion.Version11, capturedContext.HttpVersion);
+            Assert.NotNull(capturedContext.RemoteEndPoint);
+            Assert.Equal(serverUri.Port, capturedContext.DnsEndPoint.Port);
+            Assert.Equal(serverUri.IdnHost, capturedContext.DnsEndPoint.Host);
+            // The evicted connection's id was observed by ConnectCallback when it was established.
+            Assert.Contains(capturedContext.ConnectionId, connectCallbackIds);
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_ConnectionKeptBusy_StillEvaluatedWhenReturnedToPool()
+        {
+            var connectionEvaluated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var handler = new SocketsHttpHandler
+            {
+                // A single pooled connection means concurrent requests queue behind it, so the connection is handed
+                // straight from one request to the next and never sits idle on the pool's idle stack where the
+                // maintenance pass could evaluate it. Eviction therefore has to be triggered from the connection-return
+                // path. Drive the maintenance timer to ~1s while disabling lifetime/idle expiry as a cause of retirement.
+                MaxConnectionsPerServer = 1,
+                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
+                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4),
+            };
+
+            handler.ShouldEvictConnection = (context, _) =>
+            {
+                connectionEvaluated.TrySetResult();
+                return Task.FromResult(false); // Don't evict; we only need to observe that it gets evaluated.
+            };
+
+            using HttpClient client = new HttpClient(handler);
+
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                using var stop = new CancellationTokenSource();
+
+                // Keep the single connection continuously busy with overlapping requests so there is always one queued
+                // when the connection is returned, leaving it no opportunity to become idle.
+                Task[] clientLoops = Enumerable.Range(0, 3).Select(_ => Task.Run(async () =>
+                {
+                    while (!stop.IsCancellationRequested)
+                    {
+                        try { await client.GetStringAsync(uri, stop.Token); }
+                        catch { }
+                    }
+                })).ToArray();
+
+                Task serverLoop = server.AcceptConnectionAsync(async connection =>
+                {
+                    try
+                    {
+                        while (!stop.IsCancellationRequested)
+                        {
+                            await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
+                        }
+                    }
+                    catch { } // The connection is torn down during cleanup.
+                });
+
+                // The connection is never idle during a maintenance pass, so it can only be evaluated when it is
+                // returned to the pool between requests. Without that path the callback would never run here.
+                await connectionEvaluated.Task.WaitAsync(TimeSpan.FromSeconds(60));
+
+                stop.Cancel();
+                await Task.WhenAny(Task.WhenAll(clientLoops), Task.Delay(TimeSpan.FromSeconds(10)));
+                await Task.WhenAny(serverLoop, Task.Delay(TimeSpan.FromSeconds(10)));
+            });
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_ProxyConnection_DnsEndPointHasProxyHostAndPort()
+        {
+            using LoopbackProxyServer proxyServer = LoopbackProxyServer.Create();
+
+            SocketsHttpConnectionEvictionContext capturedContext = null;
+            var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var handler = new SocketsHttpHandler
+            {
+                Proxy = new WebProxy(proxyServer.Uri),
+                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
+                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4),
+            };
+
+            handler.ShouldEvictConnection = (context, _) =>
+            {
+                capturedContext ??= context;
+                callbackInvoked.TrySetResult();
+                return Task.FromResult(false);
+            };
+
+            using HttpClient client = new HttpClient(handler);
+
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                // A plain (non-secure, non-tunneled) HTTP request through a proxy uses HttpConnectionKind.Proxy, whose
+                // pooled connection targets the proxy itself. The proxy forwards the request to the loopback server.
+                Task<string> request = client.GetStringAsync(uri);
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    // Keep-alive response (no "Connection: close") so the client pools the connection to the proxy.
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
+                });
+                Assert.Equal("hello", await request);
+
+                // The idle proxy connection is evaluated by the maintenance pass.
+                await callbackInvoked.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            });
+
+            Assert.NotNull(capturedContext);
+            // A forwarding proxy connection targets the proxy itself, so the context reports the proxy's host and port.
+            Assert.Equal(proxyServer.Uri.IdnHost, capturedContext.DnsEndPoint.Host);
+            Assert.Equal(proxyServer.Uri.Port, capturedContext.DnsEndPoint.Port);
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Theory]
+        [InlineData(false)] // The callback returns false.
+        [InlineData(true)]  // The callback throws.
+        public async Task ShouldEvictConnection_CallbackDoesNotEvict_ConnectionReused(bool callbackThrows)
+        {
+            int callbackInvocations = 0;
+            var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var handler = new SocketsHttpHandler
+            {
+                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4),
+                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
+            };
+
+            handler.ShouldEvictConnection = (context, _) =>
+            {
+                Interlocked.Increment(ref callbackInvocations);
+                callbackInvoked.TrySetResult();
+
+                // A throwing callback must be treated the same as one that declined to evict: the exception is
+                // swallowed and the connection is left in the pool.
+                if (callbackThrows)
+                {
+                    throw new InvalidOperationException("Eviction callback failure should not affect the pool.");
+                }
+
+                return Task.FromResult(false);
+            };
+
+            using HttpClient client = new HttpClient(handler);
+
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                Task<string> request1 = client.GetStringAsync(uri);
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "1");
+                    Assert.Equal("1", await request1);
+
+                    // Wait until the callback has been invoked at least once, proving the maintenance timer ran.
+                    await callbackInvoked.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+                    // Because nothing was evicted, the second request must be served on the same connection.
+                    Task<string> request2 = client.GetStringAsync(uri);
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "2");
+                    Assert.Equal("2", await request2);
+                });
+            });
+
+            Assert.True(callbackInvocations > 0);
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_Http2Connection_EvictedAndReplaced()
+        {
+            var firstConnectionEvicted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            SocketsHttpConnectionEvictionContext capturedContext = null;
+
+            await Http2LoopbackServerFactory.CreateServerAsync(async (server, url) =>
+            {
+                HttpClientHandler handler = CreateHttpClientHandler(HttpVersion.Version20);
+                SocketsHttpHandler s = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
+                s.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4);
+                s.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
+                s.ShouldEvictConnection = (context, _) =>
+                {
+                    // Only one connection is evaluated at a time in this test, so no synchronization is needed here.
+                    capturedContext ??= context;
+                    if (context.ConnectionId == capturedContext.ConnectionId)
+                    {
+                        firstConnectionEvicted.TrySetResult();
+                        return Task.FromResult(true); // Evict only the first connection we observe.
+                    }
+
+                    return Task.FromResult(false);
+                };
+
+                using HttpClient client = CreateHttpClient(handler);
+                client.DefaultRequestVersion = HttpVersion.Version20;
+
+                Task<string> request1 = client.GetStringAsync(url);
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+                int streamId = await connection.ReadRequestHeaderAsync();
+                await connection.SendDefaultResponseAsync(streamId);
+                await request1;
+
+                // Wait for the maintenance timer to mark the HTTP/2 connection for eviction.
+                await firstConnectionEvicted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+                // Detach the first connection's socket so its eviction-triggered teardown doesn't interfere.
+                (SocketWrapper socket, Stream stream) = connection.ResetNetwork();
+
+                // The second request must be served from a brand new connection because the first was evicted.
+                Task<string> request2 = client.GetStringAsync(url);
+                connection = await server.EstablishConnectionAsync();
+                streamId = await connection.ReadRequestHeaderAsync();
+                await connection.SendDefaultResponseAsync(streamId);
+                await request2;
+
+                await socket.CloseAsync();
+            });
+
+            Assert.NotNull(capturedContext);
+            Assert.Equal(System.Net.HttpVersion.Version20, capturedContext.HttpVersion);
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_InfiniteIdleTimeout_CallbackInvokedOnMinimumCadence()
+        {
+            var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var handler = new SocketsHttpHandler
+            {
+                // With both timeouts infinite, the maintenance timer would otherwise run only on its 30s default.
+                // Setting the eviction callback must shorten the timer period so the callback still runs promptly.
+                PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan,
+                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
+            };
+
+            handler.ShouldEvictConnection = (context, _) =>
+            {
+                callbackInvoked.TrySetResult();
+                return Task.FromResult(false); // Don't evict; we only care that the callback runs.
+            };
+
+            using HttpClient client = new HttpClient(handler);
+
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                Task<string> request1 = client.GetStringAsync(uri);
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "1");
+                    Assert.Equal("1", await request1);
+
+                    // The connection is now pooled. The callback must be invoked well before the 30s default that
+                    // an infinite idle timeout would otherwise impose.
+                    await callbackInvoked.Task.WaitAsync(TimeSpan.FromSeconds(20));
+                });
+            });
+        }
+
         [OuterLoop("Incurs a delay")]
         [Fact]
         public async Task ServerDisconnectsAfterInitialRequest_SubsequentRequestUsesDifferentConnection()
@@ -2543,6 +2892,22 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(TimeSpan.FromSeconds(1), handler.PooledConnectionLifetime);
 
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => handler.PooledConnectionLifetime = TimeSpan.FromSeconds(-2));
+            }
+        }
+
+        [Fact]
+        public void ShouldEvictConnection_GetSet_Roundtrips()
+        {
+            using (var handler = new SocketsHttpHandler())
+            {
+                Assert.Null(handler.ShouldEvictConnection);
+
+                Func<SocketsHttpConnectionEvictionContext, CancellationToken, Task<bool>> callback = static (_, _) => Task.FromResult(false);
+                handler.ShouldEvictConnection = callback;
+                Assert.Same(callback, handler.ShouldEvictConnection);
+
+                handler.ShouldEvictConnection = null;
+                Assert.Null(handler.ShouldEvictConnection);
             }
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2746,7 +2746,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
         [Fact]
-        public async Task ShouldEvictConnection_ThroughHttpsProxyTunnel_ReportsOriginAndRequestVersion()
+        public async Task ConnectTunnel_EndToEnd_ConnectionIdFlowsThroughCallbacksAndEviction()
         {
             if (UseVersion == HttpVersion.Version30)
             {
@@ -2761,6 +2761,13 @@ namespace System.Net.Http.Functional.Tests
             var evictionObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             SocketsHttpConnectionEvictionContext capturedContext = null;
 
+            // A CONNECT tunnel uses two connections: the transport to the proxy (the "tunnel", always HTTP/1.1 for the
+            // CONNECT) and a distinct connection layered over it that actually serves the request (the "inner"
+            // connection, e.g. HTTP/2). Capture each callback's connection id to verify how they flow end to end.
+            long connectCallbackId = -1;
+            var plaintextInvocations = new List<(Version Version, long ConnectionId)>();
+            long? requestConnectionId = null;
+
             using LoopbackProxyServer proxyServer = LoopbackProxyServer.Create();
 
             using HttpClientHandler handler = CreateHttpClientHandler();
@@ -2768,6 +2775,25 @@ namespace System.Net.Http.Functional.Tests
             socketsHandler.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
             socketsHandler.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4);
             handler.Proxy = new WebProxy(proxyServer.Uri);
+            socketsHandler.ConnectCallback = async (context, ct) =>
+            {
+                // The only transport a ConnectCallback establishes here is the tunnel to the proxy.
+                if (connectCallbackId == -1)
+                {
+                    connectCallbackId = context.ConnectionId;
+                }
+                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                await socket.ConnectAsync(context.DnsEndPoint, ct);
+                return new NetworkStream(socket, ownsSocket: true);
+            };
+            socketsHandler.PlaintextStreamFilter = (context, _) =>
+            {
+                lock (plaintextInvocations)
+                {
+                    plaintextInvocations.Add((context.NegotiatedHttpVersion, context.ConnectionId));
+                }
+                return ValueTask.FromResult(context.PlaintextStream);
+            };
             socketsHandler.ShouldEvictConnection = (context, _) =>
             {
                 capturedContext ??= context;
@@ -2784,11 +2810,30 @@ namespace System.Net.Http.Functional.Tests
                     using (HttpResponseMessage response = await client.SendAsync(TestAsync, request))
                     {
                         Assert.True(response.IsSuccessStatusCode);
+                        requestConnectionId = request.ConnectionId;
                     }
 
                     await evictionObserved.Task.WaitAsync(TestHelper.PassingTestTimeout);
 
+                    // The ConnectCallback saw the tunnel's transport connection to the proxy.
+                    Assert.NotEqual(-1, connectCallbackId);
+
+                    // The plaintext filter runs once per hop: first on the HTTP/1.1 CONNECT connection (the tunnel), then
+                    // on the connection negotiated with the origin over it (the inner connection, at the request version).
+                    Assert.Equal(2, plaintextInvocations.Count);
+                    Assert.Equal(HttpVersion.Version11, plaintextInvocations[0].Version);
+                    Assert.Equal(UseVersion, plaintextInvocations[1].Version);
+
+                    // The first filter hop and the ConnectCallback observe the same (tunnel) connection id...
+                    Assert.Equal(connectCallbackId, plaintextInvocations[0].ConnectionId);
+                    // ...while the second filter hop, the request, and the eviction context all observe the distinct
+                    // inner connection id that actually served the request.
+                    Assert.NotNull(requestConnectionId);
+                    Assert.Equal(requestConnectionId.Value, plaintextInvocations[1].ConnectionId);
+                    Assert.NotEqual(connectCallbackId, requestConnectionId.Value);
+
                     Assert.NotNull(capturedContext);
+                    Assert.Equal(requestConnectionId.Value, capturedContext.ConnectionId);
                     // The CONNECT tunnel to the proxy is always HTTP/1, but the reported version is the end-to-end
                     // request version, and the DnsEndPoint is the tunneled origin (not the proxy).
                     Assert.Equal(UseVersion, capturedContext.HttpVersion);
@@ -3178,6 +3223,100 @@ namespace System.Net.Http.Functional.Tests
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         await connection.ReadRequestHeaderAsync();
+                    });
+                });
+        }
+
+        [Fact]
+        public async Task ConnectionId_ForwardingProxy_MatchesConnectCallbackId()
+        {
+            using LoopbackProxyServer proxyServer = LoopbackProxyServer.Create();
+
+            long connectCallbackId = -1;
+
+            using var handler = new SocketsHttpHandler
+            {
+                Proxy = new WebProxy(proxyServer.Uri),
+            };
+            handler.ConnectCallback = async (context, ct) =>
+            {
+                // A plain (forwarding) proxy uses a single connection that targets the proxy itself and also serves
+                // the request, so the id observed here is the one that ends up on the request.
+                connectCallbackId = context.ConnectionId;
+                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                await socket.ConnectAsync(context.DnsEndPoint, ct);
+                return new NetworkStream(socket, ownsSocket: true);
+            };
+
+            using HttpClient client = new HttpClient(handler);
+
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+                Assert.Null(request.ConnectionId);
+
+                Task<HttpResponseMessage> requestTask = client.SendAsync(request);
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
+                });
+                using HttpResponseMessage response = await requestTask;
+
+                // The connection to the proxy is the one the ConnectCallback established and the one that serves the
+                // request, so the id reported on the request is exactly the one observable in the ConnectCallback.
+                Assert.NotEqual(-1, connectCallbackId);
+                Assert.NotNull(request.ConnectionId);
+                Assert.Equal(connectCallbackId, request.ConnectionId.Value);
+            });
+        }
+
+        [Fact]
+        public async Task ConnectionId_HttpsProxyTunnel_RequestReportsTunneledConnectionNotProxyTransport()
+        {
+            long connectCallbackId = -1;
+
+            await LoopbackServer.CreateClientAndServerAsync(
+                async proxyUri =>
+                {
+                    using var handler = new SocketsHttpHandler
+                    {
+                        Proxy = new WebProxy(proxyUri),
+                    };
+                    handler.SslOptions.RemoteCertificateValidationCallback = delegate { return true; };
+                    handler.ConnectCallback = async (context, ct) =>
+                    {
+                        // For an HTTPS origin the proxy hop is a CONNECT tunnel: the ConnectCallback establishes the
+                        // transport to the proxy, which carries the tunneled connection that actually serves the request.
+                        connectCallbackId = context.ConnectionId;
+                        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                        await socket.ConnectAsync(context.DnsEndPoint, ct);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    };
+
+                    using HttpClient client = new HttpClient(handler);
+
+                    using var request = new HttpRequestMessage(HttpMethod.Get, "https://foo.bar/");
+                    Assert.Null(request.ConnectionId);
+
+                    using HttpResponseMessage response = await client.SendAsync(request);
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    // The transport the ConnectCallback established is the CONNECT tunnel to the proxy; the request is
+                    // served by a distinct connection layered over that tunnel, so the request reports a different id.
+                    Assert.NotEqual(-1, connectCallbackId);
+                    Assert.NotNull(request.ConnectionId);
+                    Assert.NotEqual(connectCallbackId, request.ConnectionId.Value);
+                },
+                async server =>
+                {
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        // Read the plaintext CONNECT request and answer 200 to open the tunnel, then negotiate TLS
+                        // with the client over the tunnel and serve the actual request.
+                        await connection.ReadRequestHeaderAndSendResponseAsync();
+                        await using LoopbackServer.Connection sslConnection = await LoopbackServer.Connection.CreateAsync(
+                            null, connection.Stream, new LoopbackServer.Options { UseSsl = true });
+                        await sslConnection.ReadRequestHeaderAndSendResponseAsync();
                     });
                 });
         }
@@ -4741,6 +4880,54 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Equal(useSsl ? "https" : "http", schemeHeader.Value);
                     }
                 }, options: options);
+        }
+
+        [Fact]
+        public async Task PlaintextStreamFilter_HttpsProxyTunnel_RunsPerHopWithDistinctConnectionIds()
+        {
+            if (UseVersion == HttpVersion.Version30)
+            {
+                return; // HTTP/3 (QUIC) cannot be tunneled through an HTTP CONNECT proxy.
+            }
+
+            var invocations = new List<(Version Version, long ConnectionId)>();
+
+            using LoopbackProxyServer proxyServer = LoopbackProxyServer.Create();
+
+            using HttpClientHandler handler = CreateHttpClientHandler(allowAllCertificates: true);
+            var socketsHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
+            handler.Proxy = new WebProxy(proxyServer.Uri);
+            socketsHandler.PlaintextStreamFilter = (context, token) =>
+            {
+                lock (invocations)
+                {
+                    invocations.Add((context.NegotiatedHttpVersion, context.ConnectionId));
+                }
+                return ValueTask.FromResult(context.PlaintextStream);
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    using HttpResponseMessage response = await client.SendAsync(TestAsync, request);
+                    Assert.True(response.IsSuccessStatusCode);
+
+                    // The filter runs once per hop, each hop being a distinct connection: first the HTTP/1.1 CONNECT
+                    // connection to the proxy, then the connection negotiated with the origin over the tunnel (e.g.
+                    // HTTP/2). Only the latter serves the request, so only its id ends up on the request.
+                    Assert.Equal(2, invocations.Count);
+                    Assert.Equal(HttpVersion.Version11, invocations[0].Version);
+                    Assert.Equal(UseVersion, invocations[1].Version);
+                    Assert.NotEqual(invocations[0].ConnectionId, invocations[1].ConnectionId);
+                    Assert.NotNull(request.ConnectionId);
+                    Assert.Equal(request.ConnectionId.Value, invocations[1].ConnectionId);
+                },
+                server => server.HandleRequestAsync(),
+                // HTTPS origin forces an HTTP/1 CONNECT tunnel through the proxy.
+                options: new GenericLoopbackOptions() { UseSsl = true });
         }
 
         [Theory]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -4435,10 +4435,22 @@ namespace System.Net.Http.Functional.Tests
 
                     using HttpClientHandler handler = CreateHttpClientHandler(allowAllCertificates: true);
                     var socketsHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
+
+                    long connectCallbackConnectionId = -1;
+                    socketsHandler.ConnectCallback = (context, token) =>
+                    {
+                        connectCallbackConnectionId = context.ConnectionId;
+                        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                        socket.Connect(context.DnsEndPoint);
+                        return ValueTask.FromResult<Stream>(new NetworkStream(socket, ownsSocket: true));
+                    };
+
                     socketsHandler.PlaintextStreamFilter = async (context, token) =>
                     {
                         Assert.Equal(UseVersion, context.NegotiatedHttpVersion);
                         Assert.Equal(requestMessage, context.InitialRequestMessage);
+                        // The filter observes the same connection id surfaced to the ConnectCallback.
+                        Assert.Equal(connectCallbackConnectionId, context.ConnectionId);
 
                         if (!syncCallback)
                         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2054,7 +2054,6 @@ namespace System.Net.Http.Functional.Tests
             var firstConnectionEvicted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var firstConnectionDisposalTokenCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             SocketsHttpConnectionEvictionContext capturedContext = null;
-            Uri serverUri = null;
             var connectCallbackIds = new System.Collections.Concurrent.ConcurrentBag<long>();
 
             using var handler = new SocketsHttpHandler
@@ -2081,7 +2080,7 @@ namespace System.Net.Http.Functional.Tests
                 // Only one connection is evaluated at a time in this test, so no synchronization is needed here.
                 if (useAsyncCallback)
                 {
-                    await Task.Yield(); // Exercise the path where the callback completes asynchronously.
+                    await Task.Delay(10); // Exercise the path where the callback completes asynchronously.
                 }
 
                 capturedContext ??= context;
@@ -2100,8 +2099,6 @@ namespace System.Net.Http.Functional.Tests
 
             await LoopbackServer.CreateServerAsync(async (server, uri) =>
             {
-                serverUri = uri;
-
                 // Connection A: serve request 1 with a keep-alive response, then block reading until the client
                 // tears the connection down. If anything other than eviction were to remove it, the read below
                 // would observe request 2 instead of EOF and the test's second accept would not be a new connection.
@@ -2115,11 +2112,11 @@ namespace System.Net.Http.Functional.Tests
 
                 // Wait for the maintenance timer to invoke the eviction callback for connection A, then for the
                 // pool to actually retire it (serverTaskA's read completes at EOF once the client disposes it).
-                await firstConnectionEvicted.Task.WaitAsync(TimeSpan.FromSeconds(30));
-                await serverTaskA.WaitAsync(TimeSpan.FromSeconds(30));
+                await firstConnectionEvicted.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                await serverTaskA.WaitAsync(TestHelper.PassingTestTimeout);
 
                 // Disposing the retired connection cancels the token that was passed to the eviction callback.
-                await firstConnectionDisposalTokenCanceled.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                await firstConnectionDisposalTokenCanceled.Task.WaitAsync(TestHelper.PassingTestTimeout);
 
                 // Request 2 must land on a brand new connection B, because A has been evicted.
                 Task<string> request2 = client.GetStringAsync(uri);
@@ -2129,15 +2126,15 @@ namespace System.Net.Http.Functional.Tests
                 });
 
                 Assert.Equal("2", await request2);
-            });
 
-            Assert.NotNull(capturedContext);
-            Assert.Equal(System.Net.HttpVersion.Version11, capturedContext.HttpVersion);
-            Assert.NotNull(capturedContext.RemoteEndPoint);
-            Assert.Equal(serverUri.Port, capturedContext.DnsEndPoint.Port);
-            Assert.Equal(serverUri.IdnHost, capturedContext.DnsEndPoint.Host);
-            // The evicted connection's id was observed by ConnectCallback when it was established.
-            Assert.Contains(capturedContext.ConnectionId, connectCallbackIds);
+                Assert.NotNull(capturedContext);
+                Assert.Equal(System.Net.HttpVersion.Version11, capturedContext.HttpVersion);
+                Assert.NotNull(capturedContext.RemoteEndPoint);
+                Assert.Equal(uri.Port, capturedContext.DnsEndPoint.Port);
+                Assert.Equal(uri.IdnHost, capturedContext.DnsEndPoint.Host);
+                // The evicted connection's id was observed by ConnectCallback when it was established.
+                Assert.Contains(capturedContext.ConnectionId, connectCallbackIds);
+            });
         }
 
         [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
@@ -2187,6 +2184,7 @@ namespace System.Net.Http.Functional.Tests
                         while (!stop.IsCancellationRequested)
                         {
                             await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
+                            await Task.Delay(10, stop.Token); // Throttle the loop so the test doesn't spin the CPU while waiting for the callback.
                         }
                     }
                     catch { } // The connection is torn down during cleanup.
@@ -2194,7 +2192,7 @@ namespace System.Net.Http.Functional.Tests
 
                 // The connection is never idle during a maintenance pass, so it can only be evaluated when it is
                 // returned to the pool between requests. Without that path the callback would never run here.
-                await connectionEvaluated.Task.WaitAsync(TimeSpan.FromSeconds(60));
+                await connectionEvaluated.Task.WaitAsync(TestHelper.PassingTestTimeout);
 
                 stop.Cancel();
                 await Task.WhenAny(Task.WhenAll(clientLoops), Task.Delay(TimeSpan.FromSeconds(10)));
@@ -2240,13 +2238,16 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal("hello", await request);
 
                 // The idle proxy connection is evaluated by the maintenance pass.
-                await callbackInvoked.Task.WaitAsync(TimeSpan.FromSeconds(30));
-            });
+                await callbackInvoked.Task.WaitAsync(TestHelper.PassingTestTimeout);
 
-            Assert.NotNull(capturedContext);
-            // A forwarding proxy connection targets the proxy itself, so the context reports the proxy's host and port.
-            Assert.Equal(proxyServer.Uri.IdnHost, capturedContext.DnsEndPoint.Host);
-            Assert.Equal(proxyServer.Uri.Port, capturedContext.DnsEndPoint.Port);
+                Assert.NotNull(capturedContext);
+                // A forwarding proxy connection targets the proxy itself, so the context reports the proxy's host and port.
+                Assert.Equal(proxyServer.Uri.IdnHost, capturedContext.DnsEndPoint.Host);
+                Assert.Equal(proxyServer.Uri.Port, capturedContext.DnsEndPoint.Port);
+                // The reported version reflects the request that used the connection, not the proxy hop. A plain
+                // forwarding proxy connection speaks HTTP/1.1, which is also what the request used here.
+                Assert.Equal(HttpVersion.Version11, capturedContext.HttpVersion);
+            });
         }
 
         [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
@@ -2255,22 +2256,23 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true)]  // The callback throws.
         public async Task ShouldEvictConnection_CallbackDoesNotEvict_ConnectionReused(bool callbackThrows)
         {
-            int callbackInvocations = 0;
             var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using var handler = new SocketsHttpHandler
             {
-                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4),
+                // Use an infinite idle timeout so a slow/busy machine can't scavenge the connection for idleness in the
+                // window between the two requests. The eviction callback still runs promptly on the maintenance timer's
+                // minimum cadence (see ShouldEvictConnection_InfiniteIdleTimeout_CallbackInvokedOnMinimumCadence).
+                PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan,
                 PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
             };
 
             handler.ShouldEvictConnection = (context, _) =>
             {
-                Interlocked.Increment(ref callbackInvocations);
                 callbackInvoked.TrySetResult();
 
-                // A throwing callback must be treated the same as one that declined to evict: the exception is
-                // swallowed and the connection is left in the pool.
+                // A throwing callback is treated the same as one that declined to evict: the exception is
+                // swallowed and the connection is left in the pool. This is an implementation choice, not a guarantee.
                 if (callbackThrows)
                 {
                     throw new InvalidOperationException("Eviction callback failure should not affect the pool.");
@@ -2290,7 +2292,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Equal("1", await request1);
 
                     // Wait until the callback has been invoked at least once, proving the maintenance timer ran.
-                    await callbackInvoked.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                    await callbackInvoked.Task.WaitAsync(TestHelper.PassingTestTimeout);
 
                     // Because nothing was evicted, the second request must be served on the same connection.
                     Task<string> request2 = client.GetStringAsync(uri);
@@ -2298,8 +2300,6 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Equal("2", await request2);
                 });
             });
-
-            Assert.True(callbackInvocations > 0);
         }
 
         [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
@@ -2338,7 +2338,7 @@ namespace System.Net.Http.Functional.Tests
                 await request1;
 
                 // Wait for the maintenance timer to mark the HTTP/2 connection for eviction.
-                await firstConnectionEvicted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                await firstConnectionEvicted.Task.WaitAsync(TestHelper.PassingTestTimeout);
 
                 // Detach the first connection's socket so its eviction-triggered teardown doesn't interfere.
                 (SocketWrapper socket, Stream stream) = connection.ResetNetwork();
@@ -2351,10 +2351,10 @@ namespace System.Net.Http.Functional.Tests
                 await request2;
 
                 await socket.CloseAsync();
-            });
 
-            Assert.NotNull(capturedContext);
-            Assert.Equal(System.Net.HttpVersion.Version20, capturedContext.HttpVersion);
+                Assert.NotNull(capturedContext);
+                Assert.Equal(System.Net.HttpVersion.Version20, capturedContext.HttpVersion);
+            });
         }
 
         [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
@@ -2684,6 +2684,170 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
+    // Exercises the SocketsHttpHandler.ShouldEvictConnection eviction context across HTTP versions. The reported
+    // properties (version, endpoints, connection id) must reflect the actual connection, independent of protocol.
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+    [SkipOnPlatform(TestPlatforms.Wasi, "SocketsHttpHandler is not supported on WASI")]
+    public abstract class SocketsHttpHandler_ConnectionEviction_Test : HttpClientHandlerTestBase
+    {
+        public SocketsHttpHandler_ConnectionEviction_Test(ITestOutputHelper output) : base(output) { }
+
+        // Serves a single request and holds the connection open (idle and pooled on the client) until releaseSignal
+        // completes, so the pool's maintenance pass can evaluate it for eviction. Keep-alive handling is protocol
+        // specific, so each version supplies its own implementation.
+        protected abstract Task ServeRequestAndHoldConnectionAsync(GenericLoopbackServer server, Task releaseSignal);
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_Context_ReportsRequestVersionAndEndpoint()
+        {
+            var evictionObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            SocketsHttpConnectionEvictionContext capturedContext = null;
+
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            SocketsHttpHandler socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+            socketsHandler.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
+            socketsHandler.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4);
+            socketsHandler.ShouldEvictConnection = (context, _) =>
+            {
+                // Capture the context here (exceptions thrown from this callback are swallowed by the pool, so we
+                // assert on the client side instead).
+                capturedContext ??= context;
+                evictionObserved.TrySetResult();
+                return Task.FromResult(false); // Never evict; we only observe the context.
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    using (HttpResponseMessage response = await client.SendAsync(TestAsync, request))
+                    {
+                        Assert.True(response.IsSuccessStatusCode);
+                    }
+
+                    // The idle connection is evaluated by the pool maintenance pass.
+                    await evictionObserved.Task.WaitAsync(TestHelper.PassingTestTimeout);
+
+                    Assert.NotNull(capturedContext);
+                    // The context reports the version the request actually used and the endpoint it targeted.
+                    Assert.Equal(UseVersion, capturedContext.HttpVersion);
+                    Assert.Equal(uri.IdnHost, capturedContext.DnsEndPoint.Host);
+                    Assert.Equal(uri.Port, capturedContext.DnsEndPoint.Port);
+                    Assert.NotNull(capturedContext.RemoteEndPoint);
+                    // The id stamped on the request matches the eviction context's id: both refer to the same connection.
+                    Assert.Equal(request.ConnectionId, capturedContext.ConnectionId);
+                },
+                server => ServeRequestAndHoldConnectionAsync(server, evictionObserved.Task),
+                options: new GenericLoopbackOptions());
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_ThroughHttpsProxyTunnel_ReportsOriginAndRequestVersion()
+        {
+            if (UseVersion == HttpVersion.Version30)
+            {
+                return; // HTTP/3 (QUIC) cannot be tunneled through an HTTP CONNECT proxy.
+            }
+
+            if (UseVersion == HttpVersion.Version20 && !PlatformDetection.SupportsAlpn)
+            {
+                return; // HTTP/2 over TLS requires ALPN to negotiate.
+            }
+
+            var evictionObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            SocketsHttpConnectionEvictionContext capturedContext = null;
+
+            using LoopbackProxyServer proxyServer = LoopbackProxyServer.Create();
+
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            SocketsHttpHandler socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+            socketsHandler.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
+            socketsHandler.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4);
+            handler.Proxy = new WebProxy(proxyServer.Uri);
+            socketsHandler.ShouldEvictConnection = (context, _) =>
+            {
+                capturedContext ??= context;
+                evictionObserved.TrySetResult();
+                return Task.FromResult(false);
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using (HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true))
+                    using (HttpResponseMessage response = await client.SendAsync(TestAsync, request))
+                    {
+                        Assert.True(response.IsSuccessStatusCode);
+                    }
+
+                    await evictionObserved.Task.WaitAsync(TestHelper.PassingTestTimeout);
+
+                    Assert.NotNull(capturedContext);
+                    // The CONNECT tunnel to the proxy is always HTTP/1, but the reported version is the end-to-end
+                    // request version, and the DnsEndPoint is the tunneled origin (not the proxy).
+                    Assert.Equal(UseVersion, capturedContext.HttpVersion);
+                    Assert.Equal(uri.IdnHost, capturedContext.DnsEndPoint.Host);
+                    Assert.Equal(uri.Port, capturedContext.DnsEndPoint.Port);
+                },
+                server => ServeRequestAndHoldConnectionAsync(server, evictionObserved.Task),
+                // HTTPS origin forces the proxy hop to be an HTTP/1 CONNECT tunnel regardless of the request version.
+                options: new GenericLoopbackOptions { UseSsl = true });
+        }
+    }
+
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+    [SkipOnPlatform(TestPlatforms.Wasi, "SocketsHttpHandler is not supported on WASI")]
+    public sealed class SocketsHttpHandler_ConnectionEviction_Test_Http1 : SocketsHttpHandler_ConnectionEviction_Test
+    {
+        public SocketsHttpHandler_ConnectionEviction_Test_Http1(ITestOutputHelper output) : base(output) { }
+        protected override Version UseVersion => HttpVersion.Version11;
+
+        protected override Task ServeRequestAndHoldConnectionAsync(GenericLoopbackServer server, Task releaseSignal) =>
+            ((LoopbackServer)server).AcceptConnectionAsync(async connection =>
+            {
+                await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
+                await releaseSignal;
+            });
+    }
+
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+    [SkipOnPlatform(TestPlatforms.Wasi, "SocketsHttpHandler is not supported on WASI")]
+    public sealed class SocketsHttpHandler_ConnectionEviction_Test_Http2 : SocketsHttpHandler_ConnectionEviction_Test
+    {
+        public SocketsHttpHandler_ConnectionEviction_Test_Http2(ITestOutputHelper output) : base(output) { }
+        protected override Version UseVersion => HttpVersion.Version20;
+
+        protected override async Task ServeRequestAndHoldConnectionAsync(GenericLoopbackServer server, Task releaseSignal)
+        {
+            await using Http2LoopbackConnection connection = await ((Http2LoopbackServer)server).EstablishConnectionAsync();
+            int streamId = await connection.ReadRequestHeaderAsync();
+            await connection.SendDefaultResponseAsync(streamId);
+            await releaseSignal;
+        }
+    }
+
+    [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsHttp3Supported))]
+    [SkipOnPlatform(TestPlatforms.Wasi, "SocketsHttpHandler is not supported on WASI")]
+    public sealed class SocketsHttpHandler_ConnectionEviction_Test_Http3 : SocketsHttpHandler_ConnectionEviction_Test
+    {
+        public SocketsHttpHandler_ConnectionEviction_Test_Http3(ITestOutputHelper output) : base(output) { }
+        protected override Version UseVersion => HttpVersion.Version30;
+
+        protected override async Task ServeRequestAndHoldConnectionAsync(GenericLoopbackServer server, Task releaseSignal)
+        {
+            await using GenericLoopbackConnection connection = await server.EstablishGenericConnectionAsync();
+            Http3LoopbackStream stream = await ((Http3LoopbackConnection)connection).AcceptRequestStreamAsync();
+            await stream.HandleRequestAsync();
+            await releaseSignal;
+        }
+    }
+
     // System.Net.Sockets is not supported on this platform
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
     [SkipOnPlatform(TestPlatforms.Wasi, "SocketsHttpHandler is not supported on WASI")]
@@ -2929,35 +3093,42 @@ namespace System.Net.Http.Functional.Tests
 
             using HttpClient client = new HttpClient(handler);
 
-            await LoopbackServer.CreateServerAsync(async (server, uri) =>
-            {
-                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
-
-                Assert.Null(request.ConnectionId);
-
-                Task<HttpResponseMessage> requestTask = client.SendAsync(request);
-
-                if (requestFails)
+            await LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
                 {
-                    await server.AcceptConnectionAsync(async connection =>
+                    using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+                    Assert.Null(request.ConnectionId);
+
+                    if (requestFails)
                     {
-                        await connection.ReadRequestHeaderAsync();
-                        // A malformed status line makes the client throw a (non-retryable) HttpRequestException.
-                        await connection.SendResponseAsync("INVALID RESPONSE LINE\r\n\r\n");
-                    });
+                        await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
+                    }
+                    else
+                    {
+                        using HttpResponseMessage response = await client.SendAsync(request);
+                    }
 
-                    await Assert.ThrowsAsync<HttpRequestException>(() => requestTask);
-                }
-                else
+                    // The connection id is stamped on the request regardless of whether the send succeeded.
+                    Assert.NotNull(request.ConnectionId);
+                    Assert.Equal(connectCallbackId, request.ConnectionId.Value);
+                },
+                async server =>
                 {
-                    await server.AcceptConnectionSendResponseAndCloseAsync(content: "hello");
-                    using HttpResponseMessage response = await requestTask;
-                }
-
-                // The connection id is stamped on the request regardless of whether the send succeeded.
-                Assert.NotNull(request.ConnectionId);
-                Assert.Equal(connectCallbackId, request.ConnectionId.Value);
-            });
+                    if (requestFails)
+                    {
+                        await server.AcceptConnectionAsync(async connection =>
+                        {
+                            await connection.ReadRequestHeaderAsync();
+                            // A malformed status line makes the client throw a (non-retryable) HttpRequestException.
+                            await connection.SendResponseAsync("INVALID RESPONSE LINE\r\n\r\n");
+                        });
+                    }
+                    else
+                    {
+                        await server.AcceptConnectionSendResponseAndCloseAsync(content: "hello");
+                    }
+                });
         }
 
         [Fact]
@@ -2985,27 +3156,30 @@ namespace System.Net.Http.Functional.Tests
 
             using HttpClient client = new HttpClient(handler);
 
-            await LoopbackServer.CreateServerAsync(async (server, uri) =>
-            {
-                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                Task<HttpResponseMessage> requestTask = client.SendAsync(request, cts.Token);
-
-                // First attempt: read the request, then close the connection so the request is gracefully retried.
-                await server.AcceptConnectionAsync(async connection =>
+            await LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
                 {
-                    await connection.ReadRequestHeaderAsync();
+                    using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+                    Task<HttpResponseMessage> requestTask = client.SendAsync(request, cts.Token);
+
+                    // Wait until the request is stuck establishing the next connection, then cancel it.
+                    await retryConnecting.Task;
+                    cts.Cancel();
+
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
+
+                    // The first connection was abandoned by the graceful retry and the retry never produced a
+                    // connection, so the request must not still point at the first connection.
+                    Assert.Null(request.ConnectionId);
+                },
+                async server =>
+                {
+                    // First attempt: read the request, then close the connection so the request is gracefully retried.
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        await connection.ReadRequestHeaderAsync();
+                    });
                 });
-
-                // Wait until the request is stuck establishing the next connection, then cancel it.
-                await retryConnecting.Task;
-                cts.Cancel();
-
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
-
-                // The first connection was abandoned by the graceful retry and the retry never produced a
-                // connection, so the request must not still point at the first connection.
-                Assert.Null(request.ConnectionId);
-            });
         }
 
         [Fact]
@@ -3280,6 +3454,60 @@ namespace System.Net.Http.Functional.Tests
     public sealed class SocketsHttpHandlerTest_Http2 : HttpClientHandlerTest_Http2
     {
         public SocketsHttpHandlerTest_Http2(ITestOutputHelper output) : base(output) { }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [ConditionalFact(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
+        public async Task ShouldEvictConnection_Http2ConnectionAtStreamLimit_EvictedWhileInFlightRequestsComplete()
+        {
+            const int MaxConcurrentStreams = 2;
+
+            using Http2LoopbackServer server = Http2LoopbackServer.CreateServer();
+            server.AllowMultipleConnections = true;
+
+            var saturatedConnectionEvaluated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            long firstConnectionId = -1;
+
+            using SocketsHttpHandler handler = CreateHandler();
+            handler.ShouldEvictConnection = (context, _) =>
+            {
+                // Only one connection exists at this point, saturated with in-flight requests, so the first id we
+                // observe is it. Evicting it verifies the callback runs for a connection that has reached its stream
+                // limit and has active requests in flight (such a connection can no longer accept new streams, so the
+                // pool routes new requests elsewhere).
+                Interlocked.CompareExchange(ref firstConnectionId, context.ConnectionId, -1);
+                bool evict = context.ConnectionId == Interlocked.Read(ref firstConnectionId);
+                if (evict)
+                {
+                    saturatedConnectionEvaluated.TrySetResult();
+                }
+                return Task.FromResult(evict);
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+
+            // Establish a connection and fill all of its stream slots with in-flight (unanswered) requests.
+            var sendTasks = new List<Task<HttpResponseMessage>>();
+            Http2LoopbackConnection connection0 = await PrepareConnection(server, client, MaxConcurrentStreams).ConfigureAwait(false);
+            AcquireAllStreamSlots(server, client, sendTasks, MaxConcurrentStreams);
+            int[] streamIds0 = await AcceptRequests(connection0, MaxConcurrentStreams).ConfigureAwait(false);
+
+            // The connection is at its stream limit with active requests, yet the maintenance pass must still evaluate
+            // and evict it.
+            await saturatedConnectionEvaluated.Task.WaitAsync(TestHelper.PassingTestTimeout);
+
+            // Even though the connection was evicted, its in-flight requests must complete normally.
+            await SendResponses(connection0, streamIds0);
+            await VerifySendTasks(sendTasks);
+
+            // A subsequent request must be served on a brand new connection, because the first was evicted.
+            Task<HttpResponseMessage> nextTask = client.GetAsync(server.Address);
+            Http2LoopbackConnection connection1 = await server.EstablishConnectionAsync(timeout: null, ackTimeout: TimeSpan.FromSeconds(10),
+                new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = MaxConcurrentStreams }).WaitAsync(TestHelper.PassingTestTimeout);
+            (int nextStreamId, _) = await connection1.ReadAndParseRequestHeaderAsync().WaitAsync(TestHelper.PassingTestTimeout);
+            await connection1.SendDefaultResponseAsync(nextStreamId).WaitAsync(TestHelper.PassingTestTimeout);
+            using HttpResponseMessage nextResponse = await nextTask.WaitAsync(TestHelper.PassingTestTimeout);
+            Assert.True(nextResponse.IsSuccessStatusCode);
+        }
 
         [ConditionalFact(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
         public async Task Http2_MultipleConnectionsEnabled_ConnectionLimitNotReached_ConcurrentRequestsSuccessfullyHandled()

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2046,98 +2046,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task ShouldEvictConnection_CallbackReturnsTrue_ConnectionEvictedAndReplaced(bool useAsyncCallback)
-        {
-            var firstConnectionEvicted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var firstConnectionDisposalTokenCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            SocketsHttpConnectionEvictionContext capturedContext = null;
-            var connectCallbackIds = new System.Collections.Concurrent.ConcurrentBag<long>();
-
-            using var handler = new SocketsHttpHandler
-            {
-                // Drive the pool maintenance timer (which invokes the eviction callback) to fire roughly once a
-                // second, while keeping the idle timeout long enough that idle expiry can't be what removes the
-                // connection during the test. Disable lifetime entirely so only eviction can retire a connection.
-                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4),
-                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
-            };
-
-            // The connection id surfaced to ConnectCallback is the same one passed to the eviction callback,
-            // so the caller can associate connect-time state with the connection and recover it on eviction.
-            handler.ConnectCallback = async (context, ct) =>
-            {
-                connectCallbackIds.Add(context.ConnectionId);
-                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
-                await socket.ConnectAsync(context.DnsEndPoint, ct);
-                return new NetworkStream(socket, ownsSocket: true);
-            };
-
-            handler.ShouldEvictConnection = async (context, cancellationToken) =>
-            {
-                // Only one connection is evaluated at a time in this test, so no synchronization is needed here.
-                if (useAsyncCallback)
-                {
-                    await Task.Delay(10); // Exercise the path where the callback completes asynchronously.
-                }
-
-                capturedContext ??= context;
-                if (context.ConnectionId == capturedContext.ConnectionId)
-                {
-                    // The token is canceled when the connection is disposed (i.e. once it has been retired).
-                    cancellationToken.Register(static s => ((TaskCompletionSource)s).TrySetResult(), firstConnectionDisposalTokenCanceled);
-                    firstConnectionEvicted.TrySetResult();
-                    return true; // Evict only the first connection we observe.
-                }
-
-                return false;
-            };
-
-            using HttpClient client = new HttpClient(handler);
-
-            await LoopbackServer.CreateServerAsync(async (server, uri) =>
-            {
-                // Connection A: serve request 1 with a keep-alive response, then block reading until the client
-                // tears the connection down. If anything other than eviction were to remove it, the read below
-                // would observe request 2 instead of EOF and the test's second accept would not be a new connection.
-                Task serverTaskA = server.AcceptConnectionAsync(async connection =>
-                {
-                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "1");
-                    await connection.ReadLineAsync(); // Returns null (EOF) once the evicted connection is disposed.
-                });
-
-                Assert.Equal("1", await client.GetStringAsync(uri));
-
-                // Wait for the maintenance timer to invoke the eviction callback for connection A, then for the
-                // pool to actually retire it (serverTaskA's read completes at EOF once the client disposes it).
-                await firstConnectionEvicted.Task.WaitAsync(TestHelper.PassingTestTimeout);
-                await serverTaskA.WaitAsync(TestHelper.PassingTestTimeout);
-
-                // Disposing the retired connection cancels the token that was passed to the eviction callback.
-                await firstConnectionDisposalTokenCanceled.Task.WaitAsync(TestHelper.PassingTestTimeout);
-
-                // Request 2 must land on a brand new connection B, because A has been evicted.
-                Task<string> request2 = client.GetStringAsync(uri);
-                await server.AcceptConnectionAsync(async connection =>
-                {
-                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "2");
-                });
-
-                Assert.Equal("2", await request2);
-
-                Assert.NotNull(capturedContext);
-                Assert.Equal(System.Net.HttpVersion.Version11, capturedContext.HttpVersion);
-                Assert.NotNull(capturedContext.RemoteEndPoint);
-                Assert.Equal(uri.Port, capturedContext.DnsEndPoint.Port);
-                Assert.Equal(uri.IdnHost, capturedContext.DnsEndPoint.Host);
-                // The evicted connection's id was observed by ConnectCallback when it was established.
-                Assert.Contains(capturedContext.ConnectionId, connectCallbackIds);
-            });
-        }
-
-        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
         [Fact]
         public async Task ShouldEvictConnection_ConnectionKeptBusy_StillEvaluatedWhenReturnedToPool()
         {
@@ -2247,150 +2155,6 @@ namespace System.Net.Http.Functional.Tests
                 // The reported version reflects the request that used the connection, not the proxy hop. A plain
                 // forwarding proxy connection speaks HTTP/1.1, which is also what the request used here.
                 Assert.Equal(HttpVersion.Version11, capturedContext.HttpVersion);
-            });
-        }
-
-        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
-        [Theory]
-        [InlineData(false)] // The callback returns false.
-        [InlineData(true)]  // The callback throws.
-        public async Task ShouldEvictConnection_CallbackDoesNotEvict_ConnectionReused(bool callbackThrows)
-        {
-            var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            using var handler = new SocketsHttpHandler
-            {
-                // Use an infinite idle timeout so a slow/busy machine can't scavenge the connection for idleness in the
-                // window between the two requests. The eviction callback still runs promptly on the maintenance timer's
-                // minimum cadence (see ShouldEvictConnection_InfiniteIdleTimeout_CallbackInvokedOnMinimumCadence).
-                PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan,
-                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
-            };
-
-            handler.ShouldEvictConnection = (context, _) =>
-            {
-                callbackInvoked.TrySetResult();
-
-                // A throwing callback is treated the same as one that declined to evict: the exception is
-                // swallowed and the connection is left in the pool. This is an implementation choice, not a guarantee.
-                if (callbackThrows)
-                {
-                    throw new InvalidOperationException("Eviction callback failure should not affect the pool.");
-                }
-
-                return Task.FromResult(false);
-            };
-
-            using HttpClient client = new HttpClient(handler);
-
-            await LoopbackServer.CreateServerAsync(async (server, uri) =>
-            {
-                Task<string> request1 = client.GetStringAsync(uri);
-                await server.AcceptConnectionAsync(async connection =>
-                {
-                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "1");
-                    Assert.Equal("1", await request1);
-
-                    // Wait until the callback has been invoked at least once, proving the maintenance timer ran.
-                    await callbackInvoked.Task.WaitAsync(TestHelper.PassingTestTimeout);
-
-                    // Because nothing was evicted, the second request must be served on the same connection.
-                    Task<string> request2 = client.GetStringAsync(uri);
-                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "2");
-                    Assert.Equal("2", await request2);
-                });
-            });
-        }
-
-        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
-        [Fact]
-        public async Task ShouldEvictConnection_Http2Connection_EvictedAndReplaced()
-        {
-            var firstConnectionEvicted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            SocketsHttpConnectionEvictionContext capturedContext = null;
-
-            await Http2LoopbackServerFactory.CreateServerAsync(async (server, url) =>
-            {
-                HttpClientHandler handler = CreateHttpClientHandler(HttpVersion.Version20);
-                SocketsHttpHandler s = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
-                s.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4);
-                s.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
-                s.ShouldEvictConnection = (context, _) =>
-                {
-                    // Only one connection is evaluated at a time in this test, so no synchronization is needed here.
-                    capturedContext ??= context;
-                    if (context.ConnectionId == capturedContext.ConnectionId)
-                    {
-                        firstConnectionEvicted.TrySetResult();
-                        return Task.FromResult(true); // Evict only the first connection we observe.
-                    }
-
-                    return Task.FromResult(false);
-                };
-
-                using HttpClient client = CreateHttpClient(handler);
-                client.DefaultRequestVersion = HttpVersion.Version20;
-
-                Task<string> request1 = client.GetStringAsync(url);
-                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
-                int streamId = await connection.ReadRequestHeaderAsync();
-                await connection.SendDefaultResponseAsync(streamId);
-                await request1;
-
-                // Wait for the maintenance timer to mark the HTTP/2 connection for eviction.
-                await firstConnectionEvicted.Task.WaitAsync(TestHelper.PassingTestTimeout);
-
-                // Detach the first connection's socket so its eviction-triggered teardown doesn't interfere.
-                (SocketWrapper socket, Stream stream) = connection.ResetNetwork();
-
-                // The second request must be served from a brand new connection because the first was evicted.
-                Task<string> request2 = client.GetStringAsync(url);
-                connection = await server.EstablishConnectionAsync();
-                streamId = await connection.ReadRequestHeaderAsync();
-                await connection.SendDefaultResponseAsync(streamId);
-                await request2;
-
-                await socket.CloseAsync();
-
-                Assert.NotNull(capturedContext);
-                Assert.Equal(System.Net.HttpVersion.Version20, capturedContext.HttpVersion);
-            });
-        }
-
-        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
-        [Fact]
-        public async Task ShouldEvictConnection_InfiniteIdleTimeout_CallbackInvokedOnMinimumCadence()
-        {
-            var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            using var handler = new SocketsHttpHandler
-            {
-                // With both timeouts infinite, the maintenance timer would otherwise run only on its 30s default.
-                // Setting the eviction callback must shorten the timer period so the callback still runs promptly.
-                PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan,
-                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
-            };
-
-            handler.ShouldEvictConnection = (context, _) =>
-            {
-                callbackInvoked.TrySetResult();
-                return Task.FromResult(false); // Don't evict; we only care that the callback runs.
-            };
-
-            using HttpClient client = new HttpClient(handler);
-
-            await LoopbackServer.CreateServerAsync(async (server, uri) =>
-            {
-                Task<string> request1 = client.GetStringAsync(uri);
-                await server.AcceptConnectionAsync(async connection =>
-                {
-                    await connection.ReadRequestHeaderAndSendResponseAsync(content: "1");
-                    Assert.Equal("1", await request1);
-
-                    // The connection is now pooled. The callback must be invoked well before the 30s default that
-                    // an infinite idle timeout would otherwise impose.
-                    await callbackInvoked.Task.WaitAsync(TimeSpan.FromSeconds(20));
-                });
             });
         }
 
@@ -2697,6 +2461,18 @@ namespace System.Net.Http.Functional.Tests
         // specific, so each version supplies its own implementation.
         protected abstract Task ServeRequestAndHoldConnectionAsync(GenericLoopbackServer server, Task releaseSignal);
 
+        // Serves two sequential requests on a single, reused connection. If the client were to open a second
+        // connection (for example because the first was evicted), the single-connection server loop would never see
+        // the second request and the test would time out. Reuse semantics are protocol specific, so each version
+        // supplies its own implementation.
+        protected abstract Task ServeTwoRequestsOnSameConnectionAsync(GenericLoopbackServer server);
+
+        // Serves one request on a first connection, waits until the eviction callback has retired that connection
+        // (firstConnectionEvicted), then serves a second request on a brand new connection. Tearing down the retired
+        // connection without disrupting the fresh accept is protocol specific, so each version supplies its own
+        // implementation.
+        protected abstract Task ServeRequestThenReplaceOnNewConnectionAsync(GenericLoopbackServer server, Task firstConnectionEvicted);
+
         [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
         [Fact]
         public async Task ShouldEvictConnection_Context_ReportsRequestVersionAndEndpoint()
@@ -2844,6 +2620,211 @@ namespace System.Net.Http.Functional.Tests
                 // HTTPS origin forces the proxy hop to be an HTTP/1 CONNECT tunnel regardless of the request version.
                 options: new GenericLoopbackOptions { UseSsl = true });
         }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ShouldEvictConnection_CallbackReturnsTrue_ConnectionEvictedAndReplaced(bool useAsyncCallback)
+        {
+            var firstConnectionEvicted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var firstConnectionDisposalTokenCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            SocketsHttpConnectionEvictionContext capturedContext = null;
+
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            SocketsHttpHandler socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+            // Drive the pool maintenance timer (which invokes the eviction callback) to fire roughly once a second,
+            // while keeping the idle timeout long enough that idle expiry can't be what removes the connection during
+            // the test. Disable lifetime entirely so only eviction can retire a connection.
+            socketsHandler.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4);
+            socketsHandler.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
+            socketsHandler.ShouldEvictConnection = async (context, cancellationToken) =>
+            {
+                // Only one connection is evaluated at a time in this test, so no synchronization is needed here.
+                if (useAsyncCallback)
+                {
+                    await Task.Delay(10); // Exercise the path where the callback completes asynchronously.
+                }
+
+                capturedContext ??= context;
+                if (context.ConnectionId == capturedContext.ConnectionId)
+                {
+                    // The token is canceled when the connection is disposed (i.e. once it has been retired).
+                    cancellationToken.Register(static s => ((TaskCompletionSource)s).TrySetResult(), firstConnectionDisposalTokenCanceled);
+                    firstConnectionEvicted.TrySetResult();
+                    return true; // Evict only the first connection we observe.
+                }
+
+                return false;
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using (HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true))
+                    using (HttpResponseMessage response = await client.SendAsync(TestAsync, request))
+                    {
+                        Assert.True(response.IsSuccessStatusCode);
+                    }
+
+                    // Wait for the maintenance timer to invoke the eviction callback for the first connection, then for
+                    // the pool to actually retire it (its disposal cancels the token passed to the eviction callback).
+                    await firstConnectionEvicted.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    await firstConnectionDisposalTokenCanceled.Task.WaitAsync(TestHelper.PassingTestTimeout);
+
+                    // The next request must land on a brand new connection, because the first was evicted.
+                    using (HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true))
+                    using (HttpResponseMessage response = await client.SendAsync(TestAsync, request))
+                    {
+                        Assert.True(response.IsSuccessStatusCode);
+                    }
+
+                    Assert.NotNull(capturedContext);
+                    Assert.Equal(UseVersion, capturedContext.HttpVersion);
+                    Assert.NotNull(capturedContext.RemoteEndPoint);
+                    Assert.Equal(uri.IdnHost, capturedContext.DnsEndPoint.Host);
+                    Assert.Equal(uri.Port, capturedContext.DnsEndPoint.Port);
+                },
+                server => ServeRequestThenReplaceOnNewConnectionAsync(server, firstConnectionEvicted.Task),
+                options: new GenericLoopbackOptions());
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Theory]
+        [InlineData(false)] // The callback returns false.
+        [InlineData(true)]  // The callback throws.
+        public async Task ShouldEvictConnection_CallbackDoesNotEvict_ConnectionReused(bool callbackThrows)
+        {
+            var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            SocketsHttpHandler socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+            // Use an infinite idle timeout so a slow/busy machine can't scavenge the connection for idleness in the
+            // window between the two requests. The eviction callback still runs promptly on the maintenance timer's
+            // minimum cadence (see ShouldEvictConnection_InfiniteIdleTimeout_CallbackInvokedOnMinimumCadence).
+            socketsHandler.PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan;
+            socketsHandler.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
+            socketsHandler.ShouldEvictConnection = (context, _) =>
+            {
+                callbackInvoked.TrySetResult();
+
+                // A throwing callback is treated the same as one that declined to evict: the exception is
+                // swallowed and the connection is left in the pool. This is an implementation choice, not a guarantee.
+                if (callbackThrows)
+                {
+                    throw new InvalidOperationException("Eviction callback failure should not affect the pool.");
+                }
+
+                return Task.FromResult(false);
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    long firstConnectionId;
+                    using (HttpRequestMessage request1 = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true))
+                    using (HttpResponseMessage response1 = await client.SendAsync(TestAsync, request1))
+                    {
+                        Assert.True(response1.IsSuccessStatusCode);
+                        Assert.NotNull(request1.ConnectionId);
+                        firstConnectionId = request1.ConnectionId.Value;
+                    }
+
+                    // Wait until the callback has been invoked at least once, proving the maintenance timer ran.
+                    await callbackInvoked.Task.WaitAsync(TestHelper.PassingTestTimeout);
+
+                    // Because nothing was evicted, the second request must be served on the same connection.
+                    using (HttpRequestMessage request2 = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true))
+                    using (HttpResponseMessage response2 = await client.SendAsync(TestAsync, request2))
+                    {
+                        Assert.True(response2.IsSuccessStatusCode);
+                        Assert.Equal(firstConnectionId, request2.ConnectionId);
+                    }
+                },
+                server => ServeTwoRequestsOnSameConnectionAsync(server),
+                options: new GenericLoopbackOptions());
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_InfiniteIdleTimeout_CallbackInvokedOnMinimumCadence()
+        {
+            var callbackInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            SocketsHttpHandler socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+            // With both timeouts infinite, the maintenance timer would otherwise run only on its 30s default.
+            // Setting the eviction callback must shorten the timer period so the callback still runs promptly.
+            socketsHandler.PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan;
+            socketsHandler.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
+            socketsHandler.ShouldEvictConnection = (context, _) =>
+            {
+                callbackInvoked.TrySetResult();
+                return Task.FromResult(false); // Don't evict; we only care that the callback runs.
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using (HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true))
+                    using (HttpResponseMessage response = await client.SendAsync(TestAsync, request))
+                    {
+                        Assert.True(response.IsSuccessStatusCode);
+                    }
+
+                    // The connection is now pooled. The callback must be invoked well before the 30s default that
+                    // an infinite idle timeout would otherwise impose.
+                    await callbackInvoked.Task.WaitAsync(TimeSpan.FromSeconds(20));
+                },
+                server => ServeRequestAndHoldConnectionAsync(server, callbackInvoked.Task),
+                options: new GenericLoopbackOptions());
+        }
+
+        [Fact]
+        public async Task ConnectionId_SetOnRequest_MatchesConnectCallbackId()
+        {
+            if (UseVersion == HttpVersion.Version30)
+            {
+                return; // ConnectCallback is not invoked for HTTP/3 (QUIC), so there is no connect-time id to correlate.
+            }
+
+            long connectCallbackId = -1;
+
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            SocketsHttpHandler socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+            socketsHandler.ConnectCallback = async (context, ct) =>
+            {
+                connectCallbackId = context.ConnectionId;
+                return await DefaultConnectCallback(context.DnsEndPoint, ct);
+            };
+
+            using HttpClient client = CreateHttpClient(handler);
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    Assert.Null(request.ConnectionId);
+
+                    using (HttpResponseMessage response = await client.SendAsync(TestAsync, request))
+                    {
+                        Assert.True(response.IsSuccessStatusCode);
+                    }
+
+                    // The id observed by the ConnectCallback is exactly the one stamped on the request that used the connection.
+                    Assert.NotEqual(-1, connectCallbackId);
+                    Assert.NotNull(request.ConnectionId);
+                    Assert.Equal(connectCallbackId, request.ConnectionId.Value);
+                },
+                server => server.HandleRequestAsync(content: "hello"),
+                options: new GenericLoopbackOptions());
+        }
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
@@ -2859,6 +2840,28 @@ namespace System.Net.Http.Functional.Tests
                 await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
                 await releaseSignal;
             });
+
+        protected override Task ServeTwoRequestsOnSameConnectionAsync(GenericLoopbackServer server) =>
+            ((LoopbackServer)server).AcceptConnectionAsync(async connection =>
+            {
+                await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
+                await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
+            });
+
+        protected override async Task ServeRequestThenReplaceOnNewConnectionAsync(GenericLoopbackServer server, Task firstConnectionEvicted)
+        {
+            LoopbackServer loopbackServer = (LoopbackServer)server;
+            await loopbackServer.AcceptConnectionAsync(async connection =>
+            {
+                await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
+                // Returns null (EOF) once the evicted connection is disposed by the pool.
+                await connection.ReadLineAsync();
+            });
+            await loopbackServer.AcceptConnectionAsync(async connection =>
+            {
+                await connection.ReadRequestHeaderAndSendResponseAsync(content: "hello");
+            });
+        }
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
@@ -2875,6 +2878,36 @@ namespace System.Net.Http.Functional.Tests
             await connection.SendDefaultResponseAsync(streamId);
             await releaseSignal;
         }
+
+        protected override async Task ServeTwoRequestsOnSameConnectionAsync(GenericLoopbackServer server)
+        {
+            await using Http2LoopbackConnection connection = await ((Http2LoopbackServer)server).EstablishConnectionAsync();
+            int streamId = await connection.ReadRequestHeaderAsync();
+            await connection.SendDefaultResponseAsync(streamId);
+            streamId = await connection.ReadRequestHeaderAsync();
+            await connection.SendDefaultResponseAsync(streamId);
+        }
+
+        protected override async Task ServeRequestThenReplaceOnNewConnectionAsync(GenericLoopbackServer server, Task firstConnectionEvicted)
+        {
+            Http2LoopbackServer http2Server = (Http2LoopbackServer)server;
+
+            Http2LoopbackConnection connection = await http2Server.EstablishConnectionAsync();
+            int streamId = await connection.ReadRequestHeaderAsync();
+            await connection.SendDefaultResponseAsync(streamId);
+
+            await firstConnectionEvicted.WaitAsync(TestHelper.PassingTestTimeout);
+
+            // Detach the evicted connection's socket so its eviction-triggered teardown doesn't interfere with
+            // establishing the replacement connection.
+            (SocketWrapper socket, _) = connection.ResetNetwork();
+
+            connection = await http2Server.EstablishConnectionAsync();
+            streamId = await connection.ReadRequestHeaderAsync();
+            await connection.SendDefaultResponseAsync(streamId);
+
+            await socket.CloseAsync();
+        }
     }
 
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsHttp3Supported))]
@@ -2890,6 +2923,32 @@ namespace System.Net.Http.Functional.Tests
             Http3LoopbackStream stream = await ((Http3LoopbackConnection)connection).AcceptRequestStreamAsync();
             await stream.HandleRequestAsync();
             await releaseSignal;
+        }
+
+        protected override async Task ServeTwoRequestsOnSameConnectionAsync(GenericLoopbackServer server)
+        {
+            await using GenericLoopbackConnection connection = await server.EstablishGenericConnectionAsync();
+            var http3Connection = (Http3LoopbackConnection)connection;
+            Http3LoopbackStream stream = await http3Connection.AcceptRequestStreamAsync();
+            await stream.HandleRequestAsync();
+            stream = await http3Connection.AcceptRequestStreamAsync();
+            await stream.HandleRequestAsync();
+        }
+
+        protected override async Task ServeRequestThenReplaceOnNewConnectionAsync(GenericLoopbackServer server, Task firstConnectionEvicted)
+        {
+            await using (GenericLoopbackConnection connection = await server.EstablishGenericConnectionAsync())
+            {
+                Http3LoopbackStream stream = await ((Http3LoopbackConnection)connection).AcceptRequestStreamAsync();
+                await stream.HandleRequestAsync();
+                await firstConnectionEvicted.WaitAsync(TestHelper.PassingTestTimeout);
+            }
+
+            await using (GenericLoopbackConnection connection = await server.EstablishGenericConnectionAsync())
+            {
+                Http3LoopbackStream stream = await ((Http3LoopbackConnection)connection).AcceptRequestStreamAsync();
+                await stream.HandleRequestAsync();
+            }
         }
     }
 
@@ -3120,10 +3179,8 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Theory]
-        [InlineData(false)] // Successful response
-        [InlineData(true)]  // Malformed response produces an HttpRequestException
-        public async Task ConnectionId_SetOnRequest_MatchesConnectCallbackId(bool requestFails)
+        [Fact]
+        public async Task ConnectionId_StampedOnRequest_EvenWhenSendFails()
         {
             long connectCallbackId = -1;
 
@@ -3145,34 +3202,20 @@ namespace System.Net.Http.Functional.Tests
 
                     Assert.Null(request.ConnectionId);
 
-                    if (requestFails)
-                    {
-                        await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
-                    }
-                    else
-                    {
-                        using HttpResponseMessage response = await client.SendAsync(request);
-                    }
+                    await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
 
-                    // The connection id is stamped on the request regardless of whether the send succeeded.
+                    // The connection id is stamped on the request even though the send failed.
                     Assert.NotNull(request.ConnectionId);
                     Assert.Equal(connectCallbackId, request.ConnectionId.Value);
                 },
                 async server =>
                 {
-                    if (requestFails)
+                    await server.AcceptConnectionAsync(async connection =>
                     {
-                        await server.AcceptConnectionAsync(async connection =>
-                        {
-                            await connection.ReadRequestHeaderAsync();
-                            // A malformed status line makes the client throw a (non-retryable) HttpRequestException.
-                            await connection.SendResponseAsync("INVALID RESPONSE LINE\r\n\r\n");
-                        });
-                    }
-                    else
-                    {
-                        await server.AcceptConnectionSendResponseAndCloseAsync(content: "hello");
-                    }
+                        await connection.ReadRequestHeaderAsync();
+                        // A malformed status line makes the client throw a (non-retryable) HttpRequestException.
+                        await connection.SendResponseAsync("INVALID RESPONSE LINE\r\n\r\n");
+                    });
                 });
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
@@ -2156,6 +2157,74 @@ namespace System.Net.Http.Functional.Tests
                 // forwarding proxy connection speaks HTTP/1.1, which is also what the request used here.
                 Assert.Equal(HttpVersion.Version11, capturedContext.HttpVersion);
             });
+        }
+
+        [OuterLoop("Waits for the connection pool maintenance timer to fire.")]
+        [Fact]
+        public async Task ShouldEvictConnection_MultipleConnectionsBlockInCallback_AllStillEvaluated()
+        {
+            // The eviction callback is invoked as fire-and-forget, so a callback that blocks (or is slow) for one
+            // connection must not prevent the pool from invoking the callback for the other pooled connections.
+            var callbackConnectionIds = new ConcurrentDictionary<long, byte>();
+            var bothCallbacksEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseCallbacks = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var handler = new SocketsHttpHandler
+            {
+                // Keep the maintenance timer on its minimum cadence (setting the eviction callback shortens it) while
+                // preventing idle/lifetime scavenging from removing either connection while we wait for both callbacks.
+                PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan,
+                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
+            };
+
+            handler.ShouldEvictConnection = (context, _) =>
+            {
+                callbackConnectionIds[context.ConnectionId] = 0;
+                if (callbackConnectionIds.Count >= 2)
+                {
+                    bothCallbacksEntered.TrySetResult();
+                }
+
+                // Block "forever". If the pool awaited the callbacks one at a time, the first connection's callback
+                // would prevent the second connection's callback from ever running.
+                return releaseCallbacks.Task;
+            };
+
+            using HttpClient client = new HttpClient(handler);
+
+            try
+            {
+                await LoopbackServer.CreateServerAsync(async (server, uri) =>
+                {
+                    // Force two pooled connections: hold the first request's response open until a second request has
+                    // established its own connection, so the second request can't reuse the first connection.
+                    Task<string> request1 = client.GetStringAsync(uri);
+                    await server.AcceptConnectionAsync(async connection1 =>
+                    {
+                        await connection1.ReadRequestHeaderAsync();
+
+                        Task<string> request2 = client.GetStringAsync(uri);
+                        await server.AcceptConnectionAsync(async connection2 =>
+                        {
+                            await connection2.ReadRequestHeaderAndSendResponseAsync(content: "2");
+                        });
+                        Assert.Equal("2", await request2);
+
+                        // Complete the first request so that both connections are now idle and pooled.
+                        await connection1.SendResponseAsync(content: "1");
+                        Assert.Equal("1", await request1);
+
+                        // The maintenance pass must invoke the callback for BOTH idle connections, even though the
+                        // first callback it starts never completes.
+                        await bothCallbacksEntered.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                        Assert.Equal(2, callbackConnectionIds.Count);
+                    });
+                });
+            }
+            finally
+            {
+                releaseCallbacks.TrySetResult(false); // Unblock the fire-and-forget callback tasks so they complete.
+            }
         }
 
         [OuterLoop("Incurs a delay")]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2057,7 +2057,7 @@ namespace System.Net.Http.Functional.Tests
                 // A single pooled connection means concurrent requests queue behind it, so the connection is handed
                 // straight from one request to the next and never sits idle on the pool's idle stack where the
                 // maintenance pass could evaluate it. Eviction therefore has to be triggered from the connection-return
-                // path. Drive the maintenance timer to ~1s while disabling lifetime/idle expiry as a cause of retirement.
+                // path. Lifetime is infinite, and a 4s idle timeout drives the maintenance timer to fire roughly once a second.
                 MaxConnectionsPerServer = 1,
                 PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
                 PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4),
@@ -2702,9 +2702,8 @@ namespace System.Net.Http.Functional.Tests
 
             using HttpClientHandler handler = CreateHttpClientHandler();
             SocketsHttpHandler socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
-            // Drive the pool maintenance timer (which invokes the eviction callback) to fire roughly once a second,
-            // while keeping the idle timeout long enough that idle expiry can't be what removes the connection during
-            // the test. Disable lifetime entirely so only eviction can retire a connection.
+            // A 4s idle timeout drives the pool maintenance timer (which invokes the eviction callback) to fire
+            // roughly once a second. Lifetime is disabled so a connection isn't retired for age during the test.
             socketsHandler.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(4);
             socketsHandler.PooledConnectionLifetime = Timeout.InfiniteTimeSpan;
             socketsHandler.ShouldEvictConnection = async (context, cancellationToken) =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2911,6 +2911,103 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Theory]
+        [InlineData(false)] // Successful response
+        [InlineData(true)]  // Malformed response produces an HttpRequestException
+        public async Task ConnectionId_SetOnRequest_MatchesConnectCallbackId(bool requestFails)
+        {
+            long connectCallbackId = -1;
+
+            using var handler = new SocketsHttpHandler();
+            handler.ConnectCallback = async (context, ct) =>
+            {
+                connectCallbackId = context.ConnectionId;
+                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                await socket.ConnectAsync(context.DnsEndPoint, ct);
+                return new NetworkStream(socket, ownsSocket: true);
+            };
+
+            using HttpClient client = new HttpClient(handler);
+
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+                Assert.Null(request.ConnectionId);
+
+                Task<HttpResponseMessage> requestTask = client.SendAsync(request);
+
+                if (requestFails)
+                {
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        await connection.ReadRequestHeaderAsync();
+                        // A malformed status line makes the client throw a (non-retryable) HttpRequestException.
+                        await connection.SendResponseAsync("INVALID RESPONSE LINE\r\n\r\n");
+                    });
+
+                    await Assert.ThrowsAsync<HttpRequestException>(() => requestTask);
+                }
+                else
+                {
+                    await server.AcceptConnectionSendResponseAndCloseAsync(content: "hello");
+                    using HttpResponseMessage response = await requestTask;
+                }
+
+                // The connection id is stamped on the request regardless of whether the send succeeded.
+                Assert.NotNull(request.ConnectionId);
+                Assert.Equal(connectCallbackId, request.ConnectionId.Value);
+            });
+        }
+
+        [Fact]
+        public async Task ConnectionId_GracefulRetryTimesOutWhileConnecting_ConnectionIdCleared()
+        {
+            var retryConnecting = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            int connectAttempts = 0;
+            using var cts = new CancellationTokenSource();
+
+            using var handler = new SocketsHttpHandler();
+            handler.ConnectCallback = async (context, ct) =>
+            {
+                if (Interlocked.Increment(ref connectAttempts) == 1)
+                {
+                    var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                    await socket.ConnectAsync(context.DnsEndPoint, ct);
+                    return new NetworkStream(socket, ownsSocket: true);
+                }
+
+                // The retry's connection never completes: signal the test and block until the request is canceled.
+                retryConnecting.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct);
+                throw new UnreachableException();
+            };
+
+            using HttpClient client = new HttpClient(handler);
+
+            await LoopbackServer.CreateServerAsync(async (server, uri) =>
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+                Task<HttpResponseMessage> requestTask = client.SendAsync(request, cts.Token);
+
+                // First attempt: read the request, then close the connection so the request is gracefully retried.
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestHeaderAsync();
+                });
+
+                // Wait until the request is stuck establishing the next connection, then cancel it.
+                await retryConnecting.Task;
+                cts.Cancel();
+
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
+
+                // The first connection was abandoned by the graceful retry and the retry never produced a
+                // connection, so the request must not still point at the first connection.
+                Assert.Null(request.ConnectionId);
+            });
+        }
+
         [Fact]
         public void Properties_Roundtrips()
         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -9,6 +9,8 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-linux;$(NetCoreAppCurrent)-android;$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi;$(NetCoreAppCurrent)-osx</TargetFrameworks>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <!-- Tests exercise the experimental SocketsHttpHandler connection eviction control APIs. -->
+    <NoWarn>$(NoWarn);SYSLIB5007</NoWarn>
     <EventSourceSupport Condition="'$(TestNativeAot)' == 'true'">true</EventSourceSupport>
     <!-- https://github.com/dotnet/runtime/issues/126862 -->
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -9,8 +9,8 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-linux;$(NetCoreAppCurrent)-android;$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi;$(NetCoreAppCurrent)-osx</TargetFrameworks>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <!-- Tests exercise the experimental SocketsHttpHandler connection eviction control APIs. -->
-    <NoWarn>$(NoWarn);SYSLIB5007</NoWarn>
+    <!-- Tests exercise the experimental SocketsHttpHandler connection eviction control and HttpRequestMessage.ConnectionId (SYSLIB5008) APIs. -->
+    <NoWarn>$(NoWarn);SYSLIB5008</NoWarn>
     <EventSourceSupport Condition="'$(TestNativeAot)' == 'true'">true</EventSourceSupport>
     <!-- https://github.com/dotnet/runtime/issues/126862 -->
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -1039,6 +1039,83 @@ namespace System.Net.Http.Functional.Tests
             }, UseVersion.ToString(), useSsl.ToString()).DisposeAsync();
         }
 
+        [OuterLoop("Disposes the handler to force the connection closed.")]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public async Task EventSource_ConnectTunnel_LogsBothTransportAndTunnelConnections()
+        {
+            if (UseVersion.Major == 3)
+            {
+                return; // HTTP/3 (QUIC) cannot be tunneled through an HTTP CONNECT proxy.
+            }
+
+            await RemoteExecutor.Invoke(static async (string useVersionString) =>
+            {
+                Version version = Version.Parse(useVersionString);
+                using var listener = new TestEventListener("System.Net.Http", EventLevel.Verbose, eventCounterInterval: 0.1d);
+
+                var events = new ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)>();
+                long stampedConnectionId = -1;
+                Version requestVersion = null;
+
+                await listener.RunWithCallbackAsync(e => events.Enqueue((e, e.ActivityId)), async () =>
+                {
+                    using LoopbackProxyServer proxyServer = LoopbackProxyServer.Create();
+
+                    await GetFactoryForVersion(version).CreateClientAndServerAsync(
+                        async uri =>
+                        {
+                            using HttpClientHandler handler = CreateHttpClientHandler(useVersionString);
+                            handler.Proxy = new WebProxy(proxyServer.Uri);
+                            using HttpClient client = CreateHttpClient(handler, useVersionString);
+
+                            using var request = new HttpRequestMessage(HttpMethod.Get, uri)
+                            {
+                                Version = version,
+                                VersionPolicy = HttpVersionPolicy.RequestVersionExact
+                            };
+                            (await client.SendAsync(request)).Dispose();
+
+                            Assert.NotNull(request.ConnectionId);
+                            stampedConnectionId = request.ConnectionId.Value;
+                            requestVersion = request.Version;
+                            // Disposing the handler (end of this scope) closes the tunnel connection, emitting
+                            // ConnectionClosed while the listener is still capturing.
+                        },
+                        server => server.HandleRequestAsync(),
+                        // HTTPS origin forces an HTTP/1 CONNECT tunnel through the proxy.
+                        options: new GenericLoopbackOptions() { UseSsl = true });
+                });
+
+                EventWrittenEventArgs[] established = events.Select(e => e.Event).Where(e => e.EventName == "ConnectionEstablished").ToArray();
+                EventWrittenEventArgs[] closed = events.Select(e => e.Event).Where(e => e.EventName == "ConnectionClosed").ToArray();
+
+                // A CONNECT tunnel uses two connection objects over one transport: the HTTP/1.1 connection to the proxy
+                // that carries the CONNECT (the tunnel) and the connection negotiated with the origin over it (the inner
+                // connection) that serves the request. Both report their lifecycle, so two ConnectionEstablished and two
+                // ConnectionClosed events are logged, with distinct ids.
+                Assert.Equal(2, established.Length);
+                Assert.Equal(2, closed.Length);
+
+                long[] establishedIds = established.Select(e => (long)e.Payload[2]).ToArray();
+                Assert.Equal(2, establishedIds.Distinct().Count());
+                Assert.Equal(establishedIds.OrderBy(id => id).ToArray(), closed.Select(e => (long)e.Payload[2]).OrderBy(id => id).ToArray());
+
+                // The inner connection served the request: it carries the id stamped on the request, at the negotiated
+                // end-to-end version (e.g. HTTP/2).
+                EventWrittenEventArgs innerEstablished = Assert.Single(established, e => (long)e.Payload[2] == stampedConnectionId);
+                Assert.Equal((byte)requestVersion.Major, (byte)innerEstablished.Payload[0]); // versionMajor
+                Assert.Equal((byte)requestVersion.Minor, (byte)innerEstablished.Payload[1]); // versionMinor
+
+                // The other is the tunnel's transport connection to the proxy, always logged as HTTP/1.1.
+                EventWrittenEventArgs tunnelEstablished = Assert.Single(established, e => (long)e.Payload[2] != stampedConnectionId);
+                Assert.Equal((byte)1, (byte)tunnelEstablished.Payload[0]); // versionMajor
+                Assert.Equal((byte)1, (byte)tunnelEstablished.Payload[1]); // versionMinor
+
+                // The request itself uses the negotiated end-to-end version (e.g. HTTP/2).
+                Assert.Equal(version, requestVersion);
+            }, UseVersion.ToString()).DisposeAsync();
+        }
+
         protected static async Task WaitForEventCountersAsync(ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)> events)
         {
             DateTime startTime = DateTime.UtcNow;

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -415,6 +415,8 @@
              Link="Common\System\Text\ValueStringBuilder.AppendSpanFormattable.cs" />
     <Compile Include="$(CommonPath)System\Obsoletions.cs"
              Link="Common\System\Obsoletions.cs" />
+    <Compile Include="$(CommonPath)System\Experimentals.cs"
+             Link="Common\System\Experimentals.cs" />
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\FakeInterop.cs"
              Link="WinHttpHandler\UnitTests\FakeInterop.cs" />
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\FakeRegistry.cs"


### PR DESCRIPTION
Closes #130102
Closes #130108

Implements the new APIs from the two issues above (NO-MERGE while those are still going through API review).
More details around the intended behavior are in those issues.