### PR TITLE
Fix config binding generator CS0103 for required/init property with matching ctor param

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -359,8 +359,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     EmitStartBlock(returnExpression);
                     foreach (PropertySpec property in initOnlyProps)
                     {
-                        string propertyName = property.Name;
-                        _writer.WriteLine($@"{propertyName} = {propertyName},");
+                        // Properties bound through a matching constructor parameter don't have a local of their
+                        // own; their bound value lives in the local named after the parameter.
+                        string valueExpr = property.MatchingCtorParam?.Name ?? property.Name;
+                        _writer.WriteLine($@"{property.Name} = {valueExpr},");
                     }
                     EmitEndBlock(endBraceTrailingSource: ";");
                 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -196,6 +196,27 @@ namespace Microsoft.Extensions
             }
         }
 
+        public class ClassWithMatchingParametersAndProperties_DifferentlyCasedCtorParam
+        {
+            private readonly string _color;
+
+            public ClassWithMatchingParametersAndProperties_DifferentlyCasedCtorParam(string color, int length)
+            {
+                _color = color;
+                this.ColorFromCtor = color;
+                this.Length = length;
+            }
+
+            public int Length { get; set; }
+
+            public string ColorFromCtor { get; }
+            public string Color
+            {
+                get => _color;
+                init => _color = "the color is " + value;
+            }
+        }
+
         public sealed class TreeElement : Dictionary<string, TreeElement>;
 
         public record TypeWithRecursionThroughCollections

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1646,6 +1646,24 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             Assert.Equal("the color is Green", options.Color);
         }
 
+        [Fact]
+        public void CanBindOnParametersAndProperties_DifferentlyCasedConstructorParameter()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Length", "42"},
+                {"Color", "Green"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = config.Get<ClassWithMatchingParametersAndProperties_DifferentlyCasedCtorParam>();
+            Assert.Equal(42, options.Length);
+            Assert.Equal("Green", options.ColorFromCtor);
+            Assert.Equal("the color is Green", options.Color);
+        }
+
         /// <summary>
         /// This test to ensure the binding of the constructor/property array is done once and not duplicating values in the array.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
@@ -206,17 +206,15 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             return assemblies;
         }
 
-        public static byte[] CreateAssemblyImage(Compilation compilation)
+        private static void AssertCanCreateAssemblyImage(Compilation compilation)
         {
-            MemoryStream ms = new MemoryStream();
-            var emitResult = compilation.Emit(ms);
+            var emitResult = compilation.Emit(Stream.Null);
             if (!emitResult.Success)
             {
                 // Explicit failures to include in the test output.
                 string errorMessage = string.Join(Environment.NewLine, emitResult.Diagnostics.Select(d => d.ToString()));
                 throw new InvalidOperationException(errorMessage);
             }
-            return ms.ToArray();
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -296,6 +296,65 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Assert.NotNull(emittedAssemblyImage);
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        // Required, settable property whose value flows through a constructor marked [SetsRequiredMembers]
+        // whose parameter name differs only in casing from the property.
+        [InlineData("""
+            [method: SetsRequiredMembers]
+            public class GreetSettings(string name)
+            {
+                public string Greeting { get; set; } = "Hello";
+                public required string Name { get; set; } = name;
+            }
+            """)]
+        // Same as above, but the constructor parameter name matches the property name exactly.
+        [InlineData("""
+            [method: SetsRequiredMembers]
+            public class GreetSettings(string Name)
+            {
+                public string Greeting { get; set; } = "Hello";
+                public required string Name { get; set; } = Name;
+            }
+            """)]
+        // Required property set via a constructor parameter, but the constructor does not set required
+        // members, so the property must still be assigned through the object initializer.
+        [InlineData("""
+            public class GreetSettings(string name)
+            {
+                public string Greeting { get; set; } = "Hello";
+                public required string Name { get; set; } = name;
+            }
+            """)]
+        public async Task RequiredPropertyWithMatchingConstructorParameter(string greetSettingsType)
+        {
+            string source = $$"""
+                using System.Diagnostics.CodeAnalysis;
+                using Microsoft.Extensions.Configuration;
+
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        ConfigurationBuilder configurationBuilder = new();
+                        IConfiguration config = configurationBuilder.Build();
+
+                        GreetSettings settings = config.GetSection("Settings").Get<GreetSettings>()!;
+                    }
+                }
+
+                {{greetSettingsType}}
+                """;
+
+            ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source, assemblyReferences: GetAssemblyRefsWithAdditional(typeof(ConfigurationBuilder)));
+            Assert.NotNull(result.GeneratedSource);
+            Assert.Empty(result.Diagnostics);
+
+            // Ensure the generated code can be compiled.
+            // If there is any compilation error, exception will be thrown with the list of the errors in the exception message.
+            byte[] emittedAssemblyImage = CreateAssemblyImage(result.OutputCompilation);
+            Assert.NotNull(emittedAssemblyImage);
+        }
+
         [Fact]
         public async Task BindingToCollectionOnlyTest()
         {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -290,10 +290,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Assert.NotNull(result.GeneratedSource);
             Assert.Empty(result.Diagnostics);
 
-            // Ensure the generated code can be compiled.
-            // If there is any compilation error, exception will be thrown with the list of the errors in the exception message.
-            byte[] emittedAssemblyImage = CreateAssemblyImage(result.OutputCompilation);
-            Assert.NotNull(emittedAssemblyImage);
+            AssertCanCreateAssemblyImage(result.OutputCompilation);
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
@@ -349,10 +346,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Assert.NotNull(result.GeneratedSource);
             Assert.Empty(result.Diagnostics);
 
-            // Ensure the generated code can be compiled.
-            // If there is any compilation error, exception will be thrown with the list of the errors in the exception message.
-            byte[] emittedAssemblyImage = CreateAssemblyImage(result.OutputCompilation);
-            Assert.NotNull(emittedAssemblyImage);
+            AssertCanCreateAssemblyImage(result.OutputCompilation);
         }
 
         [Fact]
@@ -381,10 +375,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Assert.NotNull(result.GeneratedSource);
             Assert.Empty(result.Diagnostics);
 
-            // Ensure the generated code can be compiled.
-            // If there is any compilation error, exception will be thrown with the list of the errors in the exception message.
-            byte[] emittedAssemblyImage = CreateAssemblyImage(result.OutputCompilation);
-            Assert.NotNull(emittedAssemblyImage);
+            AssertCanCreateAssemblyImage(result.OutputCompilation);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

The Configuration Binding source generator produced non-compiling code (`CS0103`) for a `required`/`init` property that is bound through a matching constructor parameter whose name differs from the property (for example only in casing: parameter `name` vs. property `Name`).

Fixes #128390.

## Root cause

In the generated `Initialize` method, a `required`/`init` property that also has a matching constructor parameter is deliberately re-assigned in the object initializer so any custom `init`/`set` accessor logic runs *after* the constructor (the behavior covered by `CanBindOnParametersAndProperties_PropertiesAreSetAfterTheConstructor`).

The emitter used the **property** name as the value expression:

```csharp
return new GreetSettings(name)
{
    Name = Name, // CS0103: no local named `Name`
};
```

but the bound value lives in the local named after the **constructor parameter** (`name`). When the two names matched exactly (e.g. positional records, or the existing `ClassWithMatchingParametersAndProperties`) the code happened to compile; when they differed it did not.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
