### PR TITLE
[wasm][coreCLR] Switch to preemptive GC mode before `DetachThread` in `RuntimeThreadShutdown`

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1680,6 +1680,16 @@ static void RuntimeThreadShutdown(void* thread)
             GCX_COOP_NO_DTOR_END();
         }
 
+#ifdef TARGET_WASM
+        // On wasm the thread can still be in cooperative GC mode at shutdown (for example when the
+        // process exits from managed code): unlike other OSes, the thread-local destructor that
+        // drives this path runs without the thread first returning to native/preemptive code.
+        // DetachThread requires preemptive mode (it asserts !PreemptiveGCDisabled()). The frame was
+        // reset to FRAME_TOP above, so the dying thread has no GC-scannable frames and it is safe to
+        // switch to preemptive here (no restore needed - the thread is being detached).
+        GCX_PREEMP_NO_DTOR();
+#endif // TARGET_WASM
+
         pThread->DetachThread(TRUE);
     }
     else


### PR DESCRIPTION
## Summary

On wasm (CoreCLR interpreter), a thread can reach `RuntimeThreadShutdown` → `Thread::DetachThread(TRUE)`
while still in **cooperative** GC mode. `DetachThread` requires **preemptive** mode and asserts it:

```
ASSERT FAILED
	Expression: !PreemptiveGCDisabled()
	Location:   src/coreclr/vm/threads.cpp:877
	Function:   DetachThread
Aborted(native code called abort())
```

This is a Debug/Checked-only `_ASSERTE`, so it aborts the process on **Debug and Checked** wasm/CoreCLR runtimes.
This change transitions the thread to preemptive before `DetachThread` on wasm, matching what the sibling
`DestroyThread` path already does.

## Root cause

Managed code on wasm executes in the interpreter, which runs in **cooperative** GC mode. The thread transitions
into cooperative mode at the reverse-pinvoke / `UnmanagedCallersOnly` boundary in `ExecuteInterpretedMethod`
(`src/coreclr/vm/prestub.cpp`):

```cpp
GCX_MAYBE_COOP(pInterpreterCode->Method->unmanagedCallersOnly);
```

