### PR TITLE
[release/10.0] Fix a series of possible race conditions in thread static variable initialization

### DIFF
--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -164,6 +164,7 @@ PTR_MethodTable LookupMethodTableAndFlagForThreadStatic(TLSIndex index, bool *pI
     }
     CONTRACTL_END;
 
+    // This method is called without the g_TLSCrst lock being held
     PTR_MethodTable retVal;
     if (index.GetTLSIndexType() == TLSIndexType::NonCollectible)
     {
@@ -173,7 +174,7 @@ PTR_MethodTable LookupMethodTableAndFlagForThreadStatic(TLSIndex index, bool *pI
     {
         *pIsGCStatic = false;
         *pIsCollectible = false;
-        retVal = g_pMethodTablesForDirectThreadLocalData[IndexOffsetToDirectThreadLocalIndex(index.GetIndexOffset())];
+        retVal = VolatileLoadWithoutBarrier(&g_pMethodTablesForDirectThreadLocalData[IndexOffsetToDirectThreadLocalIndex(index.GetIndexOffset())]);
     }
     else
     {
@@ -230,8 +231,8 @@ void TLSIndexToMethodTableMap::Set(TLSIndex index, PTR_MethodTable pMT, bool isG
             memcpy(newMap, pMap, m_maxIndex * sizeof(TADDR));
             // Don't delete the old map in case some other thread is reading from it, this won't waste significant amounts of memory, since this map cannot grow indefinitely
         }
-        pMap = newMap;
-        m_maxIndex = newSize;
+        VolatileStore(&pMap, newMap); // Use a volatile store, so that the memcpy is guaranteed to be visible before the new pMap is visible on other threads.  This is paired with VolatileLoad in the Lookup functions although it probably could be a VolatileLoadWithoutBarrier and take advantage of data dependency.
+        VolatileStore(&m_maxIndex, newSize); // Use a volatile store so that any thread that reads the size will also have a consistent view of a map at least as big as newSize. This is paired with VolatileLoad in the Lookup functions.
     }
 
     TADDR rawValue = dac_cast<TADDR>(pMT);
@@ -245,7 +246,12 @@ void TLSIndexToMethodTableMap::Set(TLSIndex index, PTR_MethodTable pMT, bool isG
         m_collectibleEntries++;
     }
     _ASSERTE(pMap[index.GetIndexOffset()] == 0 || IsClearedValue(pMap[index.GetIndexOffset()]));
-    pMap[index.GetIndexOffset()] = rawValue;
+    // This VolatileStore does not have a clear consumer-producer relationship. Notably, the MethodTable is always considered to have been
+    // fully published by the time its pointer is stored in the map, so there is no need for a memory barrier to ensure visibility of the MethodTable's contents.
+    // However, we have had issues with race safety in this codebase, and we fixed them by adding several VolatileStore which we believe are actually critical
+    // but this is a scenario which AI indicated should also have a VolatileStore. We've chosen to add the VolatileStore as a defensive measure, as this is very
+    // rarely run code.
+    VolatileStore(&pMap[index.GetIndexOffset()], rawValue); 
 }
 
 void TLSIndexToMethodTableMap::Clear(TLSIndex index, uint8_t whenCleared)
@@ -265,7 +271,7 @@ void TLSIndexToMethodTableMap::Clear(TLSIndex index, uint8_t whenCleared)
     {
         m_collectibleEntries--;
     }
-    pMap[index.GetIndexOffset()] = (whenCleared << 2) | 0x3;
+    VolatileStore(&pMap[index.GetIndexOffset()], (TADDR)((whenCleared << 2) | 0x3));
     _ASSERTE(GetClearedMarker(pMap[index.GetIndexOffset()]) == whenCleared);
     _ASSERTE(IsClearedValue(pMap[index.GetIndexOffset()]));
 }
@@ -748,7 +754,7 @@ void GetTLSIndexForThreadStatic(MethodTable* pMT, bool gcStatic, TLSIndex* pInde
                 usedDirectOnThreadLocalDataPath = true;
             }
             if (usedDirectOnThreadLocalDataPath)
-                VolatileStoreWithoutBarrier(&g_pMethodTablesForDirectThreadLocalData[IndexOffsetToDirectThreadLocalIndex(newTLSIndex.GetIndexOffset())], pMT);
+                VolatileStore(&g_pMethodTablesForDirectThreadLocalData[IndexOffsetToDirectThreadLocalIndex(newTLSIndex.GetIndexOffset())], pMT);
         }
 
         if (!usedDirectOnThreadLocalDataPath)
@@ -771,7 +777,7 @@ void GetTLSIndexForThreadStatic(MethodTable* pMT, bool gcStatic, TLSIndex* pInde
         pMT->GetLoaderAllocator()->GetTLSIndexList().Append(newTLSIndex);
     }
 
-    *pIndex = newTLSIndex;
+    pIndex->VolatileStore(newTLSIndex); // Use a volatile store so that any other thread that sees the allocated index will also see the writes throughout this path.
 }
 
 void FreeTLSIndicesForLoaderAllocator(LoaderAllocator *pLoaderAllocator)

--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -62,6 +62,7 @@ struct TLSIndex
     static TLSIndex Unallocated() { LIMITED_METHOD_DAC_CONTRACT; return TLSIndex(0xFFFFFFFF); }
     bool operator == (TLSIndex index) const { LIMITED_METHOD_DAC_CONTRACT; return TLSIndexRawIndex == index.TLSIndexRawIndex; }
     bool operator != (TLSIndex index) const { LIMITED_METHOD_DAC_CONTRACT; return TLSIndexRawIndex != index.TLSIndexRawIndex; }
+    void VolatileStore(const TLSIndex &other) { LIMITED_METHOD_CONTRACT; ::VolatileStore(&TLSIndexRawIndex, other.TLSIndexRawIndex); }
 };
 
 // Used to store access to TLS data for a single index when the TLS is accessed while the class constructor is running
@@ -122,6 +123,7 @@ public:
     PTR_MethodTable Lookup(TLSIndex index, bool *isGCStatic, bool *isCollectible) const
     {
         LIMITED_METHOD_CONTRACT;
+        // This method is called without the g_TLSCrst lock being held
         *isGCStatic = false;
         *isCollectible = false;
         if (index.GetIndexOffset() < VolatileLoad(&m_maxIndex))
@@ -141,6 +143,7 @@ public:
     PTR_MethodTable LookupTlsIndexKnownToBeAllocated(TLSIndex index) const
     {
         LIMITED_METHOD_CONTRACT;
+        // This method is called without the g_TLSCrst lock being held
         if (index.GetIndexOffset() < VolatileLoad(&m_maxIndex))
         {
             TADDR rawValue = VolatileLoadWithoutBarrier(&VolatileLoad(&pMap)[index.GetIndexOffset()]);
@@ -164,9 +167,14 @@ public:
 
     entry Lookup(TLSIndex index) const
     {
+        // This method is called with the g_TLSCrst lock held, so we don't actually
+        // need all of these volatile loads, but using VolatileLoad is more similar to the other
+        // paths, and the performance penalty is negligible, so we keep them.
+
         LIMITED_METHOD_CONTRACT;
         entry e(index);
-        if (index.GetIndexOffset() < VolatileLoad(&m_maxIndex))
+        int32_t maxIndex = VolatileLoad(&m_maxIndex); // This VolatileLoad pairs with a VolatileStore in TLSIndexToMethodTableMap::Set to ensure that if we read a maxIndex that is large enough to contain our index
+        if (index.GetIndexOffset() < maxIndex)
         {
             TADDR rawValue = VolatileLoadWithoutBarrier(&VolatileLoad(&pMap)[index.GetIndexOffset()]);
             if (!IsClearedValue(rawValue))
@@ -183,7 +191,7 @@ public:
         }
         else
         {
-            e.TlsIndex = TLSIndex(m_indexType, m_maxIndex);
+            e.TlsIndex = TLSIndex(m_indexType, maxIndex);
         }
         return e;
     }


### PR DESCRIPTION
Backport of #127843 to release/10.0. Fixes the thread-static publication race tracked in #127776.

/cc @davidwrighton

## Customer Impact

- [x] Customer reported

Intermittent SIGSEGV in `GetThreadLocalStaticBase` / JIT'd code touching thread-statics under parallel load on weakly-ordered arm64, plus occasional silent state corruption in concurrent code consistent with the same publication race. Reported against Microsoft's own dotnet/sdk CI on macOS arm64 in #127776. The race is latent in the thread-static infrastructure and becomes readily observable on modern many-core arm64 hardware.

> Correction: this PR was originally opened citing our production linux-arm64 CI crash (#130496). Further investigation traced that specific crash to a **distinct** race — generic-dictionary layout publication (#129763), backported separately in #130548 and validated 5-vs-0 on arm64. #127843 fixes the thread-static race per #127776; it is **not** the fix for #130496.

## Regression

- [ ] Yes
- [x] No

The race has been present in the thread-static infrastructure; modern many-core arm64 hardware makes it observable.

## Testing

The cherry-pick applies cleanly to release/10.0 (memory-ordering-only change, no conflicts). We were not able to reproduce the thread-static race in isolation on our hardware (NVIDIA GB10, Ubuntu 24.04 arm64) — every crash we captured under a parallel build/test loop turned out to be the generic-dictionary race (#130548) — so this backport rests on the analysis and repro in #127776/#127843 and on the fact that the change is a pure memory-ordering strengthening rather than on an independent repro from us.

## Risk

Low. The change only strengthens memory-ordering guarantees (VolatileStore on TLS index map resize, entry updates and index allocation) with no algorithmic changes, and has been in `main` since 2026-05-13 (.NET 11 previews) without follow-up issues.
