### PR TITLE
Emit per-binary ASan telemetry (BinSkim BA2032) from runtime-sanitized

### DIFF
--- a/eng/pipelines/runtime-sanitized.yml
+++ b/eng/pipelines/runtime-sanitized.yml
@@ -48,6 +48,23 @@ extends:
                   scenarios:
                     - normal
                     - no_tiered_compilation
+              # Emit per-binary ASan usage telemetry (BinSkim BA2032). Windows-only.
+              - task: BinSkim@4
+                displayName: 'Emit ASan usage telemetry (BinSkim BA2032)'
+                condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
+                inputs:
+                  TargetPattern: guardianGlob
+                  AnalyzeTargetGlob: +:f|$(Build.SourcesDirectory)\artifacts\bin\**\*.exe;+:f|$(Build.SourcesDirectory)\artifacts\bin\**\*.dll
+                  toolVersion: '4.4.9'
+                env:
+                  GDN_BINSKIM_RUNONLYRULES: BA2032
+                  GDN_BINSKIM_KIND: Fail;Pass;Informational
+              - task: PostAnalysis@2
+                displayName: 'Guardian: upload SDL results (BA2032)'
+                condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
+                inputs:
+                  GdnBreakAllTools: false
+                  GdnBreakGdnToolBinSkim: false
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
                 parameters:
@@ -80,6 +97,23 @@ extends:
                   creator: dotnet-bot
                   testBuildArgs: nativeaot tree nativeaot
                   liveLibrariesBuildConfig: Release
+              # Emit per-binary ASan usage telemetry (BinSkim BA2032). Windows-only.
+              - task: BinSkim@4
+                displayName: 'Emit ASan usage telemetry (BinSkim BA2032)'
+                condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
+                inputs:
+                  TargetPattern: guardianGlob
+                  AnalyzeTargetGlob: +:f|$(Build.SourcesDirectory)\artifacts\bin\**\*.exe;+:f|$(Build.SourcesDirectory)\artifacts\bin\**\*.dll
+                  toolVersion: '4.4.9'
+                env:
+                  GDN_BINSKIM_RUNONLYRULES: BA2032
+                  GDN_BINSKIM_KIND: Fail;Pass;Informational
+              - task: PostAnalysis@2
+                displayName: 'Guardian: upload SDL results (BA2032)'
+                condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
+                inputs:
+                  GdnBreakAllTools: false
+                  GdnBreakGdnToolBinSkim: false
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
                 parameters:


### PR DESCRIPTION
**Context:** The MSVC ASan team ( 👋 ) is interested in capturing ASan-usage telemetry listing what binaries got instrumented with ASan. As the .NET runtime is a flagship customer, we're very interested in seeing this repo be a part of that effort.

The way we capture this telemetry is through a new opt-in BinSkim rule: BA2032. That rule is a no-fail rule that simply writes to kusto (when the pipeline environment is set up for Guardian telemetry, as most internal pipelines are) when an asanized binary is detected.

**This PR** attempts to add that telemetry for this repo. We may need help queue'ing the pipeline a few times to confirm this is working as expected. Thanks!