### PR TITLE
Fix cDAC big-RVA field offset detection to mask packed type bits

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -2287,13 +2287,17 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
     uint IRuntimeTypeSystem.GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition? fieldDef)
     {
         Data.FieldDesc fieldDesc = _target.ProcessedData.GetOrAdd<Data.FieldDesc>(fieldDescPointer);
-        if (fieldDesc.DWord2 == _target.ReadGlobal<uint>(Constants.Globals.FieldOffsetBigRVA))
+        // DWord2 packs the 27-bit offset (low bits) with the 5-bit field type (high bits), so the offset
+        // must be masked out before comparing against the big-RVA sentinel. The native runtime compares the
+        // FieldDesc's m_dwOffset bitfield directly (see FieldDesc::GetOffset in src/coreclr/vm/field.h).
+        uint offset = fieldDesc.DWord2 & (uint)FieldDescFlags2.OffsetMask;
+        if (offset == _target.ReadGlobal<uint>(Constants.Globals.FieldOffsetBigRVA))
         {
             if (fieldDef is null)
                 throw new ArgumentNullException(nameof(fieldDef), "Field definition is required for big RVA fields");
             return (uint)fieldDef.Value.GetRelativeVirtualAddress();
         }
-        return fieldDesc.DWord2 & (uint)FieldDescFlags2.OffsetMask;
+        return offset;
     }
 
     TypeHandle IRuntimeTypeSystem.GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer)

--- a/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
@@ -3,7 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Microsoft.Diagnostics.DataContractReader.RuntimeTypeSystemHelpers;
@@ -28,6 +32,7 @@ public class MethodTableTests
             [DataType.ParamTypeDesc] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.ParamTypeDescLayout),
             [DataType.TypeVarTypeDesc] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.TypeVarTypeDescLayout),
             [DataType.GCCoverageInfo] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.GCCoverageInfoLayout),
+            [DataType.FieldDesc] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.FieldDescLayout),
             [DataType.ContinuationObject] = new Target.TypeInfo { Size = rtsBuilder.ContinuationObjectSize },
         };
 
@@ -41,6 +46,7 @@ public class MethodTableTests
             (nameof(Constants.Globals.MulticastDelegateMethodTable), rtsBuilder.MulticastDelegateMethodTableGlobalAddress),
             (nameof(Constants.Globals.MethodDescAlignment), rtsBuilder.MethodDescAlignment),
             (nameof(Constants.Globals.ArrayBaseSize), rtsBuilder.ArrayBaseSize),
+            (nameof(Constants.Globals.FieldOffsetBigRVA), MockRTS.FieldOffsetBigRVAValue),
         ];
 
     public static IEnumerable<object[]> StdArchBool()
@@ -1320,5 +1326,80 @@ public class MethodTableTests
             .AddGlobals(CreateContractGlobals(rtsBuilder))
             .AddContract<IRuntimeTypeSystem>(version: "c1")
             .Build();
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetFieldDescOffset_NonBigRVA_ReturnsMaskedOffset(MockTarget.Architecture arch)
+    {
+        const uint fieldOffset = 0x40;
+        TargetPointer fieldDescPtr = default;
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            // A normal (non-RVA) field with a non-zero type in the high bits of DWord2; the offset must be
+            // masked out of the packed word.
+            rtsBuilder => fieldDescPtr = rtsBuilder.AddFieldDesc(mtOfEnclosingClass: 0, CorElementType.Class, fieldOffset).Address);
+
+        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
+        Assert.Equal(fieldOffset, contract.GetFieldDescOffset(fieldDescPtr, fieldDef: null));
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetFieldDescOffset_BigRVA_ResolvesFromMetadata(MockTarget.Architecture arch)
+    {
+        // A big-RVA field packs the FIELD_OFFSET_BIG_RVA sentinel into DWord2's low 27 bits together with a
+        // non-zero type in the high 5 bits. Detection must mask off the type before comparing the sentinel,
+        // otherwise the branch is never taken and the sentinel leaks out as the offset.
+        const int rva = 0x1234;
+        byte[] metadata = BuildMetadataWithRvaField(rva, out FieldDefinitionHandle fieldHandle);
+        using MetadataReaderProvider provider = MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(metadata));
+        MetadataReader reader = provider.GetMetadataReader();
+        FieldDefinition fieldDef = reader.GetFieldDefinition(fieldHandle);
+
+        TargetPointer fieldDescPtr = default;
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            rtsBuilder => fieldDescPtr = rtsBuilder.AddFieldDesc(mtOfEnclosingClass: 0, CorElementType.I4, MockRTS.FieldOffsetBigRVAValue).Address);
+
+        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
+        Assert.Equal((uint)rva, contract.GetFieldDescOffset(fieldDescPtr, fieldDef));
+    }
+
+    // Builds a minimal metadata image containing a single static field with a FieldRVA row.
+    private static byte[] BuildMetadataWithRvaField(int rva, out FieldDefinitionHandle fieldHandle)
+    {
+        var mdBuilder = new MetadataBuilder();
+        mdBuilder.AddModule(
+            0,
+            mdBuilder.GetOrAddString("TestModule"),
+            mdBuilder.GetOrAddGuid(Guid.Empty),
+            default, default);
+        mdBuilder.AddAssembly(
+            mdBuilder.GetOrAddString("TestAssembly"),
+            new Version(1, 0, 0, 0),
+            default, default, 0,
+            AssemblyHashAlgorithm.None);
+
+        var fieldSig = new BlobBuilder();
+        new BlobEncoder(fieldSig).FieldSignature().Int32();
+        BlobHandle fieldSigHandle = mdBuilder.GetOrAddBlob(fieldSig);
+
+        fieldHandle = mdBuilder.AddFieldDefinition(
+            FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
+            mdBuilder.GetOrAddString("RvaField"),
+            fieldSigHandle);
+        mdBuilder.AddFieldRelativeVirtualAddress(fieldHandle, rva);
+
+        // The <Module> type owns the field (required first type row).
+        mdBuilder.AddTypeDefinition(
+            default, default,
+            mdBuilder.GetOrAddString("<Module>"),
+            default, fieldHandle, MetadataTokens.MethodDefinitionHandle(1));
+
+        var rootBuilder = new MetadataRootBuilder(mdBuilder);
+        var blobBuilder = new BlobBuilder();
+        rootBuilder.Serialize(blobBuilder, 0, 0);
+        return blobBuilder.ToArray();
     }
 }

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
@@ -211,6 +211,38 @@ internal class MockTypeDesc : TypedView
     }
 }
 
+internal sealed class MockFieldDesc : TypedView
+{
+    private const string DWord1FieldName = nameof(Data.FieldDesc.DWord1);
+    private const string DWord2FieldName = nameof(Data.FieldDesc.DWord2);
+    private const string MTOfEnclosingClassFieldName = nameof(Data.FieldDesc.MTOfEnclosingClass);
+
+    public static Layout<MockFieldDesc> CreateLayout(MockTarget.Architecture architecture)
+        => new SequentialLayoutBuilder("FieldDesc", architecture)
+            .AddUInt32Field(DWord1FieldName)
+            .AddUInt32Field(DWord2FieldName)
+            .AddPointerField(MTOfEnclosingClassFieldName)
+            .Build<MockFieldDesc>();
+
+    public uint DWord1
+    {
+        get => ReadUInt32Field(DWord1FieldName);
+        set => WriteUInt32Field(DWord1FieldName, value);
+    }
+
+    public uint DWord2
+    {
+        get => ReadUInt32Field(DWord2FieldName);
+        set => WriteUInt32Field(DWord2FieldName, value);
+    }
+
+    public ulong MTOfEnclosingClass
+    {
+        get => ReadPointerField(MTOfEnclosingClassFieldName);
+        set => WritePointerField(MTOfEnclosingClassFieldName, value);
+    }
+}
+
 internal sealed class MockFnPtrTypeDesc : MockTypeDesc
 {
     private const string NumArgsFieldName = nameof(Data.FnPtrTypeDesc.NumArgs);
@@ -324,6 +356,7 @@ internal partial class MockDescriptors
         internal Layout<MockFnPtrTypeDesc> FnPtrTypeDescLayout { get; }
         internal Layout<MockParamTypeDesc> ParamTypeDescLayout { get; }
         internal Layout<MockTypeVarTypeDesc> TypeVarTypeDescLayout { get; }
+        internal Layout<MockFieldDesc> FieldDescLayout { get; }
         internal Layout<MockGCCoverageInfo> GCCoverageInfoLayout { get; }
 
         internal MockEEClass SystemObjectEEClass { get; private set; } = null!;
@@ -359,6 +392,7 @@ internal partial class MockDescriptors
             FnPtrTypeDescLayout = MockFnPtrTypeDesc.CreateLayout(Builder.TargetTestHelpers.Arch);
             ParamTypeDescLayout = MockParamTypeDesc.CreateLayout(Builder.TargetTestHelpers.Arch);
             TypeVarTypeDescLayout = MockTypeVarTypeDesc.CreateLayout(Builder.TargetTestHelpers.Arch);
+            FieldDescLayout = MockFieldDesc.CreateLayout(Builder.TargetTestHelpers.Arch);
             GCCoverageInfoLayout = MockGCCoverageInfo.CreateLayout(Builder.TargetTestHelpers.Arch);
 
             AddGlobalPointers();
@@ -492,6 +526,20 @@ internal partial class MockDescriptors
 
         internal MockTypeVarTypeDesc AddTypeVarTypeDesc()
             => Add(TypeVarTypeDescLayout, "TypeVarTypeDesc");
+
+        // Value of the native FieldDesc::m_dwOffset sentinel FIELD_OFFSET_BIG_RVA (FIELD_OFFSET_MAX - 5,
+        // where FIELD_OFFSET_MAX == (1 << 27) - 1). See src/coreclr/vm/field.h.
+        internal const uint FieldOffsetBigRVAValue = ((1u << 27) - 1) - 5;
+
+        // Allocates a FieldDesc whose packed DWord2 stores the given 5-bit field type and 27-bit offset.
+        internal MockFieldDesc AddFieldDesc(ulong mtOfEnclosingClass, CorElementType type, uint offset, uint memberDef = 0)
+        {
+            MockFieldDesc fieldDesc = Add(FieldDescLayout, "FieldDesc");
+            fieldDesc.MTOfEnclosingClass = mtOfEnclosingClass;
+            fieldDesc.DWord1 = memberDef & 0x00ffffff; // low 24 bits hold the token RID
+            fieldDesc.DWord2 = ((uint)type << 27) | (offset & 0x07ffffff);
+            return fieldDesc;
+        }
 
         private TView Add<TView>(Layout<TView> layout, string name)
             where TView : TypedView, new()


### PR DESCRIPTION
## Summary
Fixes a bug in the cDAC's `RuntimeTypeSystem` contract where big-RVA field offsets were never resolved from metadata.

`FieldDesc::DWord2` packs the **27-bit field offset** in its low bits and the **5-bit field type** in its high bits (`m_dwOffset : 27` / `m_type : 5`, see `src/coreclr/vm/field.h`). `GetFieldDescOffset` compared the **full `DWord2`** against the `FIELD_OFFSET_BIG_RVA` sentinel:

```csharp
if (fieldDesc.DWord2 == _target.ReadGlobal<uint>(Constants.Globals.FieldOffsetBigRVA))
```

But the sentinel is a 27-bit offset value (`FIELD_OFFSET_MAX - 5`). Every real field has a non-zero type in the high 5 bits, so `DWord2` can never equal the 27-bit sentinel. The big-RVA branch was therefore dead, and callers received the sentinel value back as the field offset instead of the RVA read from metadata.

## Fix
Mask off the type bits before comparing, matching the native runtime, which compares the `m_dwOffset` bitfield directly (`FieldDesc::GetOffset`):

```csharp
uint offset = fieldDesc.DWord2 & (uint)FieldDescFlags2.OffsetMask;
if (offset == _target.ReadGlobal<uint>(Constants.Globals.FieldOffsetBigRVA))
```

This also mirrors the sibling `IsFieldDescEnCNew`, which already masks with `OffsetMask` before comparing its sentinel — good evidence this was a simple oversight in `GetFieldDescOffset`.

## Testing
- Added `MethodTableTests.GetFieldDescOffset_BigRVA_ResolvesFromMetadata` and `GetFieldDescOffset_NonBigRVA_ReturnsMaskedOffset`, plus a `MockFieldDesc` helper in the RuntimeTypeSystem mock.
- Verified the big-RVA test **fails without the fix** (returns `0x07FFFFFA`, the leaked sentinel) and **passes with it** (returns the RVA `0x1234`).
- Full `MethodTableTests` suite (136 tests) passes.

**Note on dump tests:** a real big-RVA field requires an RVA static whose offset exceeds `FIELD_OFFSET_MAX` (~128 MB), which isn't reproducible in a debuggee/dump test, so this is validated via unit tests instead.

> [!NOTE]
> This PR was created with GitHub Copilot.
