### PR TITLE
Handle CDATA in unknown extension data (IExtensibleDataObject)

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -722,6 +722,7 @@ namespace System.Runtime.Serialization
             switch (xmlReader.NodeType)
             {
                 case XmlNodeType.Text:
+                case XmlNodeType.CDATA:
                     return ReadPrimitiveExtensionDataValue(xmlReader, dataContractName, dataContractNamespace);
                 case XmlNodeType.Element:
                     if (xmlReader.NamespaceURI.StartsWith(Globals.DataContractXsdBaseNamespace, StringComparison.Ordinal))
@@ -905,7 +906,7 @@ namespace System.Runtime.Serialization
             List<XmlNode>? xmlChildNodes = null;
 
             XmlNodeType nodeType = xmlReader.MoveToContent();
-            if (nodeType != XmlNodeType.Text)
+            if (nodeType != XmlNodeType.Text && nodeType != XmlNodeType.CDATA)
             {
                 while (xmlReader.MoveToNextAttribute())
                 {

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2878,6 +2878,39 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
+    public static void DCS_ExtensionData_UnknownElementWithCData()
+    {
+        // An unknown member that carries its value in a CDATA section, as can be produced by a
+        // newer contract version or an external system.
+        string sourceXml =
+            "<CdataVersioned xmlns=\"http://example.com/cdata\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+            "<Prop1>hello</Prop1>" +
+            "<Prop2><![CDATA[<InnerTag2></InnerTag2>]]></Prop2>" +
+            "</CdataVersioned>";
+
+        // A version that knows Prop2 reads the CDATA content as the member value.
+        var directReader = XmlDictionaryReader.CreateTextReader(Encoding.UTF8.GetBytes(sourceXml), XmlDictionaryReaderQuotas.Max);
+        var direct = (CdataVersionedV2)new DataContractSerializer(typeof(CdataVersionedV2)).ReadObject(directReader);
+        Assert.Equal("<InnerTag2></InnerTag2>", direct.Prop2);
+
+        // A down-level version stores the unknown Prop2 (with CDATA) in ExtensionData. This used to
+        // throw a SerializationException because CDATA content was not handled while reading extension data.
+        var serV1 = new DataContractSerializer(typeof(CdataVersionedV1));
+        var v1Reader = XmlDictionaryReader.CreateTextReader(Encoding.UTF8.GetBytes(sourceXml), XmlDictionaryReaderQuotas.Max);
+        var v1 = (CdataVersionedV1)serV1.ReadObject(v1Reader);
+        Assert.Equal("hello", v1.Prop1);
+        Assert.NotNull(v1.ExtensionData);
+
+        // Round-trip the down-level object and read it back as the new version; Prop2 is preserved.
+        var ms = new MemoryStream();
+        serV1.WriteObject(ms, v1);
+        ms.Position = 0;
+        var v2 = (CdataVersionedV2)new DataContractSerializer(typeof(CdataVersionedV2)).ReadObject(ms);
+        Assert.Equal("hello", v2.Prop1);
+        Assert.Equal("<InnerTag2></InnerTag2>", v2.Prop2);
+    }
+
+    [Fact]
     public static void DCS_ExtensionDataObjectTest()
     {
         var p2 = new PersonV2();

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -3023,6 +3023,27 @@ class PersonV2 : IExtensibleDataObject
     }
 }
 
+[DataContract(Name = "CdataVersioned", Namespace = "http://example.com/cdata")]
+class CdataVersionedV1 : IExtensibleDataObject
+{
+    [DataMember(Order = 0)]
+    public string Prop1 { get; set; }
+
+    public ExtensionDataObject ExtensionData { get; set; }
+}
+
+[DataContract(Name = "CdataVersioned", Namespace = "http://example.com/cdata")]
+class CdataVersionedV2 : IExtensibleDataObject
+{
+    [DataMember(Order = 0)]
+    public string Prop1 { get; set; }
+
+    [DataMember(Order = 1)]
+    public string Prop2 { get; set; }
+
+    public ExtensionDataObject ExtensionData { get; set; }
+}
+
 [DataContract]
 public class Name
 {


### PR DESCRIPTION
DataContractSerializer threw a SerializationException when deserializing an unknown element whose value is carried in a CDATA section into ExtensionData (types implementing IExtensibleDataObject). ReadExtensionDataValue's NodeType switch handled Text/Element/EndElement but not CDATA, and MoveToContent stops on CDATA rather than folding it into Text, so the value hit the default case and threw. ReadUnknownXmlData similarly special-cased only Text and would drop leading CDATA content.

Treat CDATA like Text in both places. The content is captured as a string node and replays as escaped text on re-serialization, preserving round-trip semantics.

Fixes #59123