### PR TITLE
Select STJ member accessor based on IsDynamicCodeCompiled

### DIFF
--- a/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
+++ b/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
@@ -104,17 +104,59 @@ namespace System.Text.Json.Reflection
 #if NET
             return ctorInfo.Invoke(BindingFlags.DoNotWrapExceptions, null, parameters, null);
 #else
-            object? result = null;
             try
             {
-                result = ctorInfo.Invoke(parameters);
+                return ctorInfo.Invoke(parameters);
             }
-            catch (TargetInvocationException ex)
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
             {
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw; // unreachable
             }
+#endif
+        }
 
-            return result;
+        /// <summary>
+        /// Invokes <paramref name="methodInfo"/> without wrapping any exception thrown by the
+        /// target method in a <see cref="TargetInvocationException"/>. This matches the behavior of
+        /// the Reflection.Emit-based accessor, which emits direct calls into user code.
+        /// </summary>
+        public static object? InvokeNoWrapExceptions(this MethodInfo methodInfo, object? obj, object?[]? parameters)
+        {
+#if NET
+            return methodInfo.Invoke(obj, BindingFlags.DoNotWrapExceptions, binder: null, parameters, culture: null);
+#else
+            try
+            {
+                return methodInfo.Invoke(obj, parameters);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw; // unreachable
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Invokes <paramref name="constructorInfo"/> without wrapping any exception thrown by the
+        /// constructor in a <see cref="TargetInvocationException"/>. This matches the behavior of
+        /// the Reflection.Emit-based accessor, which emits direct calls into user code.
+        /// </summary>
+        public static object InvokeNoWrapExceptions(this ConstructorInfo constructorInfo, object?[]? parameters)
+        {
+#if NET
+            return constructorInfo.Invoke(BindingFlags.DoNotWrapExceptions, binder: null, parameters, culture: null);
+#else
+            try
+            {
+                return constructorInfo.Invoke(parameters);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw; // unreachable
+            }
 #endif
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/MemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/MemberAccessor.cs
@@ -31,8 +31,13 @@ namespace System.Text.Json.Serialization.Metadata
                 {
                     MemberAccessor value =
 #if NET
-                        // if dynamic code isn't supported, fallback to reflection
-                        RuntimeFeature.IsDynamicCodeSupported ?
+                        // On platforms where dynamic code is supported but not compiled to native code
+                        // (e.g. the Mono interpreter, WASM and iOS), the IL emitted by the Reflection.Emit
+                        // based accessor is only interpreted, offering no throughput benefit over plain
+                        // reflection while still pulling in the Reflection.Emit stack. Gating on
+                        // IsDynamicCodeCompiled (rather than IsDynamicCodeSupported) keeps Reflection.Emit
+                        // on JIT-backed runtimes but lets the trimmer remove it everywhere else.
+                        RuntimeFeature.IsDynamicCodeCompiled ?
                             new ReflectionEmitCachingMemberAccessor() :
                             new ReflectionMemberAccessor();
 #elif NETFRAMEWORK

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionMemberAccessor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.Json.Reflection;
 
 namespace System.Text.Json.Serialization.Metadata
 {
@@ -33,7 +34,7 @@ namespace System.Text.Json.Serialization.Metadata
                     : null;
             }
 
-            return () => ctorInfo.Invoke(null);
+            return () => ctorInfo.InvokeNoWrapExceptions(null);
         }
 
         public override Func<object[], T> CreateParameterizedConstructor<T>(ConstructorInfo constructor)
@@ -56,17 +57,10 @@ namespace System.Text.Json.Serialization.Metadata
                     argsToPass[i] = arguments[i];
                 }
 
-                try
-                {
-                    return (T)constructor.Invoke(argsToPass);
-                }
-                catch (TargetInvocationException e)
-                {
-                    // Plumb ArgumentException through for tuples with more than 7 generic parameters, e.g.
-                    // System.ArgumentException : The last element of an eight element tuple must be a Tuple.
-                    // This doesn't apply to the method below as it supports a max of 4 constructor params.
-                    throw e.InnerException ?? e;
-                }
+                // Not wrapping in TargetInvocationException also plumbs ArgumentException through for
+                // tuples with more than 7 generic parameters, e.g.
+                // System.ArgumentException : The last element of an eight element tuple must be a Tuple.
+                return (T)constructor.InvokeNoWrapExceptions(argsToPass);
             };
         }
 
@@ -108,7 +102,7 @@ namespace System.Text.Json.Serialization.Metadata
                     }
                 }
 
-                return (T)constructor.Invoke(arguments);
+                return (T)constructor.InvokeNoWrapExceptions(arguments);
             };
         }
 
@@ -122,14 +116,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             return value =>
             {
-                try
-                {
-                    return (T)constructor.Invoke(new object?[] { value });
-                }
-                catch (TargetInvocationException e)
-                {
-                    throw e.InnerException ?? e;
-                }
+                return (T)constructor.InvokeNoWrapExceptions(new object?[] { value });
             };
         }
 
@@ -143,7 +130,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             return delegate (TCollection collection, object? element)
             {
-                addMethod.Invoke(collection, new object[] { element! });
+                addMethod.InvokeNoWrapExceptions(collection, new object[] { element! });
             };
         }
 
@@ -167,7 +154,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             return delegate (object obj)
             {
-                return (TProperty)getMethodInfo.Invoke(obj, null)!;
+                return (TProperty)getMethodInfo.InvokeNoWrapExceptions(obj, null)!;
             };
         }
 
@@ -177,7 +164,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             return delegate (TDeclaringType obj)
             {
-                return (TProperty)getMethodInfo.Invoke(obj, null)!;
+                return (TProperty)getMethodInfo.InvokeNoWrapExceptions(obj, null)!;
             };
         }
 
@@ -187,7 +174,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             return delegate (object obj, TProperty value)
             {
-                setMethodInfo.Invoke(obj, new object[] { value! });
+                setMethodInfo.InvokeNoWrapExceptions(obj, new object[] { value! });
             };
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ExceptionTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ExceptionTests.cs
@@ -3,8 +3,10 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text.Encodings.Web;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -631,6 +633,71 @@ namespace System.Text.Json.Serialization.Tests
 
             public override void Write(Utf8JsonWriter writer, PocoUsingCustomConverterThrowingJsonException value, JsonSerializerOptions options)
                 => throw new JsonException(ExceptionMessage, ExceptionPath, 0, 0);
+        }
+
+        [Fact]
+        public static void ThrowingMembers_PropagateOriginalException()
+        {
+            // Exercises the default member accessor (Reflection.Emit on runtimes that compile dynamic code).
+            AssertThrowingMembersPropagateOriginalException();
+        }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public static void ThrowingMembers_PropagateOriginalException_WithReflectionMemberAccessor()
+        {
+            // Disabling dynamic code support routes serialization through the reflection-based member
+            // accessor (as happens on WASM, iOS and the Mono interpreter) instead of the Reflection.Emit
+            // accessor. Exceptions thrown by user getters, setters and constructors must still propagate
+            // unwrapped rather than being surfaced as a TargetInvocationException.
+            var options = new RemoteInvokeOptions
+            {
+                RuntimeConfigurationOptions =
+                {
+                    ["System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported"] = false
+                }
+            };
+
+            RemoteExecutor.Invoke(static () =>
+            {
+                Assert.False(RuntimeFeature.IsDynamicCodeCompiled);
+                AssertThrowingMembersPropagateOriginalException();
+            }, options).Dispose();
+        }
+
+        private static void AssertThrowingMembersPropagateOriginalException()
+        {
+            InvalidOperationException ex;
+
+            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWithThrowingGetter()));
+            Assert.Equal(ThrowingMember_ExceptionMessage, ex.Message);
+
+            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithThrowingSetter>("""{"Value":1}"""));
+            Assert.Equal(ThrowingMember_ExceptionMessage, ex.Message);
+
+            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithThrowingConstructor>("{}"));
+            Assert.Equal(ThrowingMember_ExceptionMessage, ex.Message);
+        }
+
+        private const string ThrowingMember_ExceptionMessage = "Exception thrown from user code.";
+
+        public class ClassWithThrowingGetter
+        {
+            public int Value => throw new InvalidOperationException(ThrowingMember_ExceptionMessage);
+        }
+
+        public class ClassWithThrowingSetter
+        {
+            public int Value { get => 0; set => throw new InvalidOperationException(ThrowingMember_ExceptionMessage); }
+        }
+
+        public class ClassWithThrowingConstructor
+        {
+            [JsonConstructor]
+            public ClassWithThrowingConstructor(int value)
+                => throw new InvalidOperationException(ThrowingMember_ExceptionMessage);
+
+            public int Value { get; }
         }
     }
 }


### PR DESCRIPTION
Fixes #38693.

## Problem

`MemberAccessor` selects the `Reflection.Emit`-based accessor whenever `RuntimeFeature.IsDynamicCodeSupported` is `true`. On platforms where dynamic code is *supported but only interpreted* (the Mono interpreter, WASM, iOS), the emitted IL is interpreted anyway, so `Reflection.Emit` gives no throughput benefit while keeping the (~50KB) `Reflection.Emit` stack un-trimmable.

## Fix

Gate accessor selection on `RuntimeFeature.IsDynamicCodeCompiled` instead of `IsDynamicCodeSupported`. Because `IsDynamicCodeCompiled` is trim-substituted to a constant per platform (`false` on WASM/iOS, `true` on CoreCLR), the trimmer now removes the `Reflection.Emit` branch on interpreter-only platforms and keeps it on JIT-backed runtimes. This matches the pattern already used by `Microsoft.Extensions.DependencyInjection` (`ActivatorUtilities`, `ServiceProvider`) and `System.Text.RegularExpressions`.

| Runtime | Before | After |
|---|---|---|
| CoreCLR / Mono JIT | Reflection.Emit | Reflection.Emit (unchanged) |
| NativeAOT | Reflection | Reflection (unchanged) |
| WASM / iOS / Mono interpreter | Reflection.Emit (interpreted) | Reflection + Reflection.Emit trimmed |

The source generator remains the recommended escape hatch for throughput-sensitive WASM/iOS apps.

## Coupled fix: reflection accessor was wrapping user exceptions

Routing WASM/iOS to `ReflectionMemberAccessor` surfaced a latent bug: it invoked user getters, setters and constructors via `MethodInfo`/`ConstructorInfo.Invoke`, which wraps exceptions thrown by user code in `TargetInvocationException` — unlike the `Reflection.Emit` accessor, which emits direct calls and lets them propagate. This already affected NativeAOT (whose test suite is a subset, so it went unnoticed).

Added `InvokeNoWrapExceptions` helpers (`BindingFlags.DoNotWrapExceptions` on .NET, an `ExceptionDispatchInfo` polyfill downlevel) and routed all user-code invoke sites through them so exceptions propagate unwrapped on every accessor. As a drive-by, the sibling `CreateInstanceNoWrapExceptions` polyfill was aligned to guard a null `InnerException`.

## Tests

Added regression tests in `ExceptionTests.cs` asserting a throwing getter, setter and constructor propagate the original `InvalidOperationException` (not `TargetInvocationException`), both under the default (`Reflection.Emit`) accessor and — via `RemoteExecutor` forcing `IsDynamicCodeSupported=false` — under `ReflectionMemberAccessor`. Verified the `RemoteExecutor` test fails without the fix and passes with it.

Full `System.Text.Json` suite: **52710 passed** (default) / **52457 passed, 48 skipped** (reflection-forced), 0 failures.

> [!NOTE]
> This pull request was authored by GitHub Copilot.