### PR TITLE
Implement IXmlNamespaceResolver in XmlDictionaryReader, use in XmlDictionaryWriter

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
@@ -22,7 +22,7 @@ namespace System.Xml
     // Optimize StringHandle.CompareTo
     // Fix FixXmlAttribute - Temporary until we actually write an XmlAttribute node
 
-    internal abstract class XmlBaseReader : XmlDictionaryReader
+    internal abstract class XmlBaseReader : XmlDictionaryReader, IXmlNamespaceResolver
     {
         private readonly XmlBufferReader _bufferReader;
         private XmlNode _node;
@@ -678,6 +678,21 @@ namespace System.Xml
             if (prefix == xmlns)
                 return xmlnsNamespace;
             return null;
+        }
+
+        IDictionary<string, string> IXmlNamespaceResolver.GetNamespacesInScope(XmlNamespaceScope scope)
+        {
+            return _nsMgr.GetNamespacesInScope(scope, NameTable);
+        }
+
+        string? IXmlNamespaceResolver.LookupNamespace(string prefix)
+        {
+            return LookupNamespace(prefix);
+        }
+
+        string? IXmlNamespaceResolver.LookupPrefix(string namespaceName)
+        {
+            return _nsMgr.LookupPrefix(namespaceName, NameTable);
         }
 
         protected Namespace LookupNamespace(PrefixHandleType prefix)
@@ -2950,6 +2965,58 @@ namespace System.Xml
                 }
                 if (prefix == "xml")
                     return XmlNamespace;
+                return null;
+            }
+
+            public Dictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope, XmlNameTable nameTable)
+            {
+                Dictionary<string, string> namespaces = new Dictionary<string, string>();
+                if (scope == XmlNamespaceScope.Local)
+                {
+                    for (int i = 0; i < _nsCount; i++)
+                    {
+                        Namespace nameSpace = _namespaces![i];
+                        if (nameSpace.Depth == _depth)
+                            namespaces[nameSpace.Prefix.GetString(nameTable)] = nameSpace.Uri.GetString(nameTable);
+                    }
+                }
+                else
+                {
+                    // _namespaces[0.._nsCount) holds every binding currently in scope, outermost first.
+                    // A later entry shadows an earlier one for the same prefix, so overwriting as we go
+                    // leaves the closest in-scope binding for each prefix.
+                    for (int i = 0; i < _nsCount; i++)
+                    {
+                        Namespace nameSpace = _namespaces![i];
+                        string prefix = nameSpace.Prefix.GetString(nameTable);
+                        string uri = nameSpace.Uri.GetString(nameTable);
+                        if (prefix.Length == 0 && uri.Length == 0)
+                            namespaces.Remove(prefix); // xmlns="" undeclares the default namespace
+                        else
+                            namespaces[prefix] = uri;
+                    }
+                    if (scope == XmlNamespaceScope.All)
+                        namespaces["xml"] = xmlNamespace;
+                }
+                return namespaces;
+            }
+
+            public string? LookupPrefix(string namespaceUri, XmlNameTable nameTable)
+            {
+                ArgumentNullException.ThrowIfNull(namespaceUri);
+                for (int i = _nsCount - 1; i >= 0; i--)
+                {
+                    Namespace nameSpace = _namespaces![i];
+                    if (nameSpace.IsUri(namespaceUri))
+                    {
+                        string prefix = nameSpace.Prefix.GetString(nameTable);
+                        // Ensure the prefix isn't shadowed by a closer binding to a different namespace.
+                        if (LookupNamespace(prefix) == nameSpace)
+                            return prefix;
+                    }
+                }
+                if (namespaceUri == xmlNamespace)
+                    return xml;
                 return null;
             }
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -1309,7 +1310,7 @@ namespace System.Xml
             return ReadArray(XmlDictionaryString.GetString(localName), XmlDictionaryString.GetString(namespaceUri), array, offset, count);
         }
 
-        private sealed class XmlWrappedReader : XmlDictionaryReader, IXmlLineInfo
+        private sealed class XmlWrappedReader : XmlDictionaryReader, IXmlLineInfo, IXmlNamespaceResolver
         {
             private readonly XmlReader _reader;
             private XmlNamespaceManager? _nsMgr;
@@ -1428,6 +1429,27 @@ namespace System.Xml
             public override string? LookupNamespace(string namespaceUri)
             {
                 return _reader.LookupNamespace(namespaceUri);
+            }
+
+            IDictionary<string, string> IXmlNamespaceResolver.GetNamespacesInScope(XmlNamespaceScope scope)
+            {
+                return _reader is IXmlNamespaceResolver resolver
+                    ? resolver.GetNamespacesInScope(scope)
+                    : new Dictionary<string, string>();
+            }
+
+            string? IXmlNamespaceResolver.LookupNamespace(string prefix)
+            {
+                return _reader is IXmlNamespaceResolver resolver
+                    ? resolver.LookupNamespace(prefix)
+                    : _reader.LookupNamespace(prefix);
+            }
+
+            string? IXmlNamespaceResolver.LookupPrefix(string namespaceName)
+            {
+                return _reader is IXmlNamespaceResolver resolver
+                    ? resolver.LookupPrefix(namespaceName)
+                    : null;
             }
 
             public override void MoveToAttribute(int index)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
@@ -240,6 +240,11 @@ namespace System.Xml
 
         private void WriteElementNode(XmlDictionaryReader reader, bool defattr)
         {
+            WriteElementNode(reader, defattr, inScopeNamespaces: null);
+        }
+
+        private void WriteElementNode(XmlDictionaryReader reader, bool defattr, IXmlNamespaceResolver? inScopeNamespaces)
+        {
             XmlDictionaryString? localName;
             XmlDictionaryString? namespaceUri;
             if (reader.TryGetLocalNameAsDictionaryString(out localName) && reader.TryGetNamespaceUriAsDictionaryString(out namespaceUri))
@@ -281,9 +286,33 @@ namespace System.Xml
                     reader.MoveToElement();
                 }
             }
+            // Re-declare any namespaces that are in scope at the source but would otherwise be
+            // lost during the copy (e.g. a prefix used only inside content such as an xsi:type
+            // value). This is opt-in via WriteNode(..., preserveNamespacesInScope: true).
+            if (inScopeNamespaces is not null)
+            {
+                WriteInScopeNamespaces(inScopeNamespaces);
+            }
             if (reader.IsEmptyElement)
             {
                 WriteEndElement();
+            }
+        }
+
+        private void WriteInScopeNamespaces(IXmlNamespaceResolver inScopeNamespaces)
+        {
+            foreach (KeyValuePair<string, string> pair in inScopeNamespaces.GetNamespacesInScope(XmlNamespaceScope.ExcludeXml))
+            {
+                string prefix = pair.Key;
+                string namespaceUri = pair.Value;
+                // Skip declarations the writer has already emitted (for example the prefixes
+                // used by this element's own name and attributes). LookupPrefix returns the
+                // prefix currently bound to the namespace in the writer's scope.
+                if (LookupPrefix(namespaceUri) == prefix)
+                {
+                    continue;
+                }
+                WriteXmlnsAttribute(prefix, namespaceUri);
             }
         }
 
@@ -384,6 +413,24 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(reader);
 
+            WriteNodeCore(reader, defattr, preserveNamespacesInScope: false);
+        }
+
+        public void WriteNode(XmlDictionaryReader reader, bool defattr, bool preserveNamespacesInScope)
+        {
+            ArgumentNullException.ThrowIfNull(reader);
+
+            WriteNodeCore(reader, defattr, preserveNamespacesInScope);
+        }
+
+        private void WriteNodeCore(XmlDictionaryReader reader, bool defattr, bool preserveNamespacesInScope)
+        {
+            // When preserving namespaces, capture the namespaces in scope at the source so they can
+            // be re-declared on the root of the copied subtree. Descendant elements inherit them and
+            // don't need their own copy, so this is only applied to the first element written.
+            IXmlNamespaceResolver? rootNamespaces =
+                preserveNamespacesInScope ? reader as IXmlNamespaceResolver : null;
+
             int d = (reader.NodeType == XmlNodeType.None ? -1 : reader.Depth);
             do
             {
@@ -404,7 +451,8 @@ namespace System.Xml
                     switch (nodeType)
                     {
                         case XmlNodeType.Element:
-                            WriteElementNode(reader, defattr);
+                            WriteElementNode(reader, defattr, rootNamespaces);
+                            rootNamespaces = null;
                             break;
                         case XmlNodeType.CDATA:
                             WriteCData(reader.Value);

--- a/src/libraries/System.Runtime.Serialization.Xml/ref/System.Runtime.Serialization.Xml.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/ref/System.Runtime.Serialization.Xml.cs
@@ -588,6 +588,7 @@ namespace System.Xml
         public void WriteElementString(string? prefix, System.Xml.XmlDictionaryString localName, System.Xml.XmlDictionaryString? namespaceUri, string? value) { }
         public void WriteElementString(System.Xml.XmlDictionaryString localName, System.Xml.XmlDictionaryString? namespaceUri, string? value) { }
         public virtual void WriteNode(System.Xml.XmlDictionaryReader reader, bool defattr) { }
+        public void WriteNode(System.Xml.XmlDictionaryReader reader, bool defattr, bool preserveNamespacesInScope) { }
         public override void WriteNode(System.Xml.XmlReader reader, bool defattr) { }
         public virtual void WriteQualifiedName(System.Xml.XmlDictionaryString localName, System.Xml.XmlDictionaryString? namespaceUri) { }
         public virtual void WriteStartAttribute(string? prefix, System.Xml.XmlDictionaryString localName, System.Xml.XmlDictionaryString? namespaceUri) { }

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -40,6 +40,79 @@ public static class XmlDictionaryWriterTest
         Assert.Equal(expect, actual);
     }
 
+    public static IEnumerable<object[]> WriteNode_ReaderKinds()
+    {
+        yield return new object[] { "wrapped" };
+        yield return new object[] { "text" };
+    }
+
+    // Source document where the "my" prefix (bound on the ancestor) is referenced only from
+    // content: the xsi:type attribute value and the element text. A plain copy therefore drops
+    // xmlns:my; the opt-in preserveNamespacesInScope re-declares it on the copied root.
+    private const string WriteNode_SourceXml =
+        "<s:sourceRoot xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+        "xmlns:s=\"common-schema\" xmlns:my=\"my-custom-schema\">" +
+        "<s:target xsi:type=\"my:customType\">my:otherType</s:target>" +
+        "</s:sourceRoot>";
+
+    [Theory]
+    [MemberData(nameof(WriteNode_ReaderKinds))]
+    public static void WriteNode_PreserveNamespacesInScope_ReDeclaresContentOnlyNamespace(string readerKind)
+    {
+        string copied = WriteNode_CopyTargetElement(readerKind, preserveNamespacesInScope: true);
+
+        Assert.Contains("xmlns:my=\"my-custom-schema\"", copied);
+
+        // The xsi:type value can now be resolved in the copied fragment.
+        using XmlReader verify = XmlReader.Create(new StringReader(copied));
+        verify.MoveToContent();
+        Assert.Equal("my-custom-schema", verify.LookupNamespace("my"));
+    }
+
+    [Theory]
+    [MemberData(nameof(WriteNode_ReaderKinds))]
+    public static void WriteNode_Default_DropsContentOnlyNamespace(string readerKind)
+    {
+        string copied = WriteNode_CopyTargetElement(readerKind, preserveNamespacesInScope: false);
+
+        // Prefixes used by element/attribute names are still declared...
+        Assert.Contains("common-schema", copied);
+        Assert.Contains("http://www.w3.org/2001/XMLSchema-instance", copied);
+        // ...but the content-only namespace is dropped (documents the long-standing behavior).
+        Assert.DoesNotContain("my-custom-schema", copied);
+    }
+
+    private static string WriteNode_CopyTargetElement(string readerKind, bool preserveNamespacesInScope)
+    {
+        var sb = new StringBuilder();
+        using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(
+            XmlWriter.Create(sb, new XmlWriterSettings { OmitXmlDeclaration = true })))
+        using (XmlDictionaryReader reader = WriteNode_CreateReader(readerKind))
+        {
+            reader.MoveToContent();   // s:sourceRoot
+            reader.Read();            // s:target
+            Assert.Equal("target", reader.LocalName);
+
+            if (preserveNamespacesInScope)
+                writer.WriteNode(reader, defattr: true, preserveNamespacesInScope: true);
+            else
+                writer.WriteNode(reader, defattr: true);
+
+            writer.Flush();
+        }
+
+        return sb.ToString();
+    }
+
+    private static XmlDictionaryReader WriteNode_CreateReader(string readerKind) => readerKind switch
+    {
+        // Exercises XmlWrappedReader delegating to an inner IXmlNamespaceResolver.
+        "wrapped" => XmlDictionaryReader.CreateDictionaryReader(XmlReader.Create(new StringReader(WriteNode_SourceXml))),
+        // Exercises the native XmlBaseReader NamespaceManager path.
+        "text" => XmlDictionaryReader.CreateTextReader(Encoding.UTF8.GetBytes(WriteNode_SourceXml), XmlDictionaryReaderQuotas.Max),
+        _ => throw new ArgumentOutOfRangeException(nameof(readerKind)),
+    };
+
     [Fact]
     public static void XmlBaseWriter_WriteBinHex()
     {


### PR DESCRIPTION
## Summary

`XmlDictionaryWriter.WriteNode(XmlDictionaryReader, bool)` copies an element subtree from a reader to the writer, but it only re-emits namespace declarations that appear as *local* `xmlns` attributes on the copied elements. Namespace bindings that are inherited from an ancestor **and referenced only from content** — the classic case being a QName in an `xsi:type` value or in element/attribute text — are silently dropped. The copied fragment is still namespace-well-formed, but any QName-in-content that relied on the inherited prefix can no longer be resolved at the destination.

Fixes #49010.

### Repro

Source document (reader positioned at `<s:target>`):

```xml
<s:sourceRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xmlns:s="common-schema"
              xmlns:my="my-custom-schema">
  <s:target xsi:type="my:customType">my:otherType</s:target>
</s:sourceRoot>
```

`WriteNode(reader, defattr: true)` produces:

```xml
<s:target xmlns:s="common-schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="my:customType">my:otherType</s:target>
```

`xmlns:my` is gone, so `xsi:type="my:customType"` (and the `my:otherType` text) is now unresolvable.

## Is this a bug?

Strictly, no — it is spec-conformant. The XML Namespaces machinery governs only element and attribute **names**; it says nothing about prefixes that appear inside attribute *values* or text content (QNames-in-content are an application-level convention, and the W3C TAG finding on "QNames as Identifiers" explicitly cautions against relying on them). The copied output remains namespace-well-formed and namespace-valid. So this is **unspecified behavior**, not a spec violation.

But it is a real and repeatedly-reported usability sharp edge: DCS/WCF payloads use `xsi:type` heavily, and "copy this element somewhere else" losing the type annotation is surprising and hard to diagnose. This change makes the correct-for-content behavior available **opt-in**, without changing any existing default.

Note this is **not** DCS-specific — the base `System.Xml.XmlWriter.WriteNode(XmlReader, bool)` has the identical gap. This PR scopes the fix to `XmlDictionaryWriter` only (see "Scope" below).

## Approach

Two coordinated pieces:

1. **Reader side (no public API change):** the internal DCS readers learn to report their in-scope namespaces by implementing `System.Xml.IXmlNamespaceResolver`:
   - `XmlBaseReader` (native text/binary readers) — backed by its existing nested `NamespaceManager`, which already tracks the full in-scope binding stack. Two helpers were added: `GetNamespacesInScope` and `LookupPrefix`.
   - `XmlWrappedReader` (the `CreateDictionaryReader(XmlReader)` wrapper) — delegates to the wrapped reader when it is itself an `IXmlNamespaceResolver` (the core `System.Private.Xml` readers are), and degrades gracefully otherwise.

2. **Writer side (one new public overload):** a new opt-in
   ```csharp
   public void WriteNode(XmlDictionaryReader reader, bool defattr, bool preserveNamespacesInScope)
   ```
   When `preserveNamespacesInScope` is `true`, the writer captures the reader's in-scope namespaces (via `reader as IXmlNamespaceResolver`) and re-declares them on the **root element of the copied subtree**. Declarations the writer has already emitted for the element's own name/attributes are skipped (guarded by `LookupPrefix`), so there is no duplication. Descendants inherit the root re-declarations, and any namespace declared *inside* the subtree is still copied as a local attribute as before — so the root is the only place that needs the extra declarations.

The default two-argument `WriteNode` path is completely unchanged.

## Design decisions & tradeoffs

This section pre-answers the design questions that tend to come up.

### Why implement `IXmlNamespaceResolver` on the concrete internal readers, not on public `XmlDictionaryReader`?

- **The abstract base has no namespace state to implement it with.** `XmlDictionaryReader : XmlReader` is a pure abstraction; all in-scope tracking lives in the concrete readers (`XmlBaseReader.NamespaceManager`, or the reader wrapped by `XmlWrappedReader`). A base-level implementation would have nothing to implement *from* and would have to either throw or return empty — i.e., lie about the capability.
- **It keeps the reviewable public surface to a single member.** Putting `IXmlNamespaceResolver` on the public base is the alternative "option 1" from the issue: it's a second public API addition and it would contractually obligate *every* existing and third-party `XmlDictionaryReader` subclass to satisfy it. Implementing on the `internal` concretes means the only public change to review is the one `WriteNode` overload.
- **Honesty about capability.** Consumers can do `reader is IXmlNamespaceResolver` and get a truthful answer for the reader they actually have, rather than a base type that always advertises the capability but sometimes returns nothing.
- **It mirrors core `System.Xml`.** `XmlReader` itself does not implement `IXmlNamespaceResolver`; only concrete readers such as `XmlTextReaderImpl` do. This change follows the same shape.

**Tradeoff:** the cost of not putting it on the base is that `preserveNamespacesInScope: true` is a silent no-op for any reader outside these two internal hierarchies (e.g. a custom `XmlDictionaryReader`, or `XmlWrappedReader` wrapping a reader that isn't an `IXmlNamespaceResolver`). That is an acceptable, well-defined degradation for an opt-in flag, and it's documented on the API.

### Why a per-call `WriteNode` parameter instead of a writer construction-time option/settings object?

- **The behavior is a property of the copy operation, not of the writer.** Namespace re-declaration only means something while copying a subtree *from a reader*. A writer that writes directly, or copies from several readers, has no single "namespace preservation" identity. A per-call flag expresses the intent exactly where it applies.
- **`WriteNode` already parameterizes copy fidelity with a bool.** The existing `defattr` argument already controls *how much* of the source is copied; `preserveNamespacesInScope` is the natural, consistent second copy-fidelity flag. It also lines up with base `XmlWriter.WriteNode(XmlReader, bool)`. And there is direct precedent for "preserve in-scope namespaces during a copy" already in the framework: the `WriteNode(XPathNavigator, bool)` overload re-declares in-scope namespaces (because the navigator exposes them). So "preserve namespaces on copy" is already a `WriteNode`-level concept, not a writer-level one.
- **`XmlDictionaryWriter` has no natural construction seam.** It is abstract with only a `protected` ctor and is built through 11 factory overloads (`CreateTextWriter`, `CreateBinaryWriter`, `CreateMtomWriter`, `CreateDictionaryWriter`), with no `XmlWriterSettings`-style object. A construction-time option would require threading a parameter through all those factories or inventing a settings type — a much larger API addition for a coarser result.
- **Per-call control is genuinely useful, including outside DCS/WCF.** Re-declaring namespaces is pure overhead (and output noise) when the destination already declares them or when the copied fragment has no QNames-in-content. Whether to pay that cost can legitimately differ between adjacent copies within a single writer's lifetime (e.g. copying a trusted internal fragment vs. an arbitrary user-supplied one). A writer-global switch cannot express that; a per-call bool can. And because `XmlDictionaryWriter.WriteNode` is public and used standalone for message/fragment plumbing, non-DCS callers hit the same QName-in-content problem.
- **It costs DCS nothing.** DCS owns its `WriteNode` call sites, so opting in per-call is trivial where it wants the behavior — while external callers gain strictly more control than a global setting would give them.

### Why not just change the default?

Rejected. Changing the default two-arg behavior would be a silent output/behavioral change for every existing `WriteNode` caller, would add declarations (and cost) that most callers don't need, and would risk breaking consumers that depend on the current exact output. Opt-in preserves compatibility.

### Scope

This PR intentionally fixes only `XmlDictionaryWriter`. The base `System.Xml.XmlWriter.WriteNode` has the same gap and would need a separate, base-library change (and its own API review); it is out of scope here.

## Public API

```csharp
namespace System.Xml
{
    public abstract partial class XmlDictionaryWriter : XmlWriter
    {
        public void WriteNode(XmlDictionaryReader reader, bool defattr, bool preserveNamespacesInScope);
    }
}
```

> ⚠️ **API review status:** this new overload has **not** been through API review. Issue #49010 is not `api-approved`. This PR is opened for design visibility and discussion; the API would need approval (or the overload would need to be `internal`) before it could merge.

**Open sub-decision for reviewers:** the existing `WriteNode(XmlDictionaryReader, bool)` is `virtual`; the new overload is currently non-virtual. Non-virtual is functionally fine (it decomposes through the virtual `Write*` primitives, so `XmlDictionaryAsyncCheckWriter` and subclasses still see every write), but reviewers may prefer `virtual` for parity.
