### PR TITLE
[iOS] Respect user numeric format overrides

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.Locale.iOS.cs
+++ b/src/libraries/Common/src/Interop/Interop.Locale.iOS.cs
@@ -11,16 +11,29 @@ internal static partial class Interop
         internal static partial string GetDefaultLocaleNameNative();
 
         [LibraryImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetLocaleInfoStringNative", StringMarshalling = StringMarshalling.Utf8)]
-        internal static partial string GetLocaleInfoStringNative(string localeName, uint localeStringData, string? uiLocaleName = null);
+        internal static partial string GetLocaleInfoStringNative(
+            string localeName,
+            uint localeStringData,
+            string? uiLocaleName = null,
+            [MarshalAs(UnmanagedType.Bool)] bool useUserOverride = false);
 
         [LibraryImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetLocaleInfoIntNative", StringMarshalling = StringMarshalling.Utf8)]
-        internal static partial int GetLocaleInfoIntNative(string localeName, uint localeNumberData);
+        internal static partial int GetLocaleInfoIntNative(
+            string localeName,
+            uint localeNumberData,
+            [MarshalAs(UnmanagedType.Bool)] bool useUserOverride = false);
 
         [LibraryImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetLocaleInfoPrimaryGroupingSizeNative", StringMarshalling = StringMarshalling.Utf8)]
-        internal static partial int GetLocaleInfoPrimaryGroupingSizeNative(string localeName, uint localeGroupingData);
+        internal static partial int GetLocaleInfoPrimaryGroupingSizeNative(
+            string localeName,
+            uint localeGroupingData,
+            [MarshalAs(UnmanagedType.Bool)] bool useUserOverride = false);
 
         [LibraryImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetLocaleInfoSecondaryGroupingSizeNative", StringMarshalling = StringMarshalling.Utf8)]
-        internal static partial int GetLocaleInfoSecondaryGroupingSizeNative(string localeName, uint localeGroupingData);
+        internal static partial int GetLocaleInfoSecondaryGroupingSizeNative(
+            string localeName,
+            uint localeGroupingData,
+            [MarshalAs(UnmanagedType.Bool)] bool useUserOverride = false);
 
         [LibraryImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetLocaleNameNative", StringMarshalling = StringMarshalling.Utf8)]
         internal static partial string GetLocaleNameNative(string localeName);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2311,7 +2311,7 @@ namespace System.Globalization
             if (GlobalizationMode.Invariant)
                 return 0;
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type) : IcuGetLocaleInfo(type);
+            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type, useUserOverride: _bUseOverrides) : IcuGetLocaleInfo(type);
 #else
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
 #endif
@@ -2324,7 +2324,7 @@ namespace System.Globalization
                 return null!;
 
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type) : IcuGetLocaleInfo(type);
+            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type, useUserOverride: _bUseOverrides) : IcuGetLocaleInfo(type);
 #else
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
 #endif
@@ -2363,7 +2363,7 @@ namespace System.Globalization
                 return null!;
 
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type) : IcuGetLocaleInfo(type);
+            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type, useUserOverride: _bUseOverrides) : IcuGetLocaleInfo(type);
 #else
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2311,7 +2311,7 @@ namespace System.Globalization
             if (GlobalizationMode.Invariant)
                 return 0;
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type, useUserOverride: _bUseOverrides) : IcuGetLocaleInfo(type);
+            return GetLocaleInfoNative(type, useUserOverride: _bUseOverrides);
 #else
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
 #endif
@@ -2324,7 +2324,7 @@ namespace System.Globalization
                 return null!;
 
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type, useUserOverride: _bUseOverrides) : IcuGetLocaleInfo(type);
+            return GetLocaleInfoNative(type, useUserOverride: _bUseOverrides);
 #else
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
 #endif
@@ -2363,7 +2363,7 @@ namespace System.Globalization
                 return null!;
 
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type, useUserOverride: _bUseOverrides) : IcuGetLocaleInfo(type);
+            return GetLocaleInfoNative(type, useUserOverride: _bUseOverrides);
 #else
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2311,7 +2311,7 @@ namespace System.Globalization
             if (GlobalizationMode.Invariant)
                 return 0;
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            return GetLocaleInfoNative(type, useUserOverride: _bUseOverrides);
+            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type, useUserOverride: _bUseOverrides) : IcuGetLocaleInfo(type);
 #else
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
 #endif
@@ -2324,7 +2324,7 @@ namespace System.Globalization
                 return null!;
 
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            return GetLocaleInfoNative(type, useUserOverride: _bUseOverrides);
+            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type, useUserOverride: _bUseOverrides) : IcuGetLocaleInfo(type);
 #else
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
 #endif
@@ -2363,7 +2363,7 @@ namespace System.Globalization
                 return null!;
 
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-            return GetLocaleInfoNative(type, useUserOverride: _bUseOverrides);
+            return GlobalizationMode.Hybrid ? GetLocaleInfoNative(type, useUserOverride: _bUseOverrides) : IcuGetLocaleInfo(type);
 #else
             return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.iOS.cs
@@ -14,8 +14,6 @@ namespace System.Globalization
 
         internal static CultureData? GetUserDefaultCultureData(string localeName)
         {
-            Debug.Assert(GlobalizationMode.Hybrid);
-
             if (GlobalizationMode.PredefinedCulturesOnly && !IcuIsEnsurePredefinedLocaleName(localeName))
             {
                 return null;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.iOS.cs
@@ -12,24 +12,42 @@ namespace System.Globalization
             return Interop.Globalization.GetLocaleNameNative(localeName);
         }
 
-        private string GetLocaleInfoNative(LocaleStringData type, string? uiLocaleName = null)
+        internal static CultureData? GetUserDefaultCultureData(string localeName)
+        {
+            Debug.Assert(GlobalizationMode.Hybrid);
+
+            if (GlobalizationMode.PredefinedCulturesOnly && !IcuIsEnsurePredefinedLocaleName(localeName))
+            {
+                return null;
+            }
+
+            CultureData? cultureData = CreateCultureData(localeName, useUserOverride: true);
+            if (cultureData is not null && !cultureData.IsInvariantCulture)
+            {
+                cultureData._bUseOverrides = true;
+            }
+
+            return cultureData;
+        }
+
+        private string GetLocaleInfoNative(LocaleStringData type, string? uiLocaleName = null, bool useUserOverride = false)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(_sWindowsName != null, "[CultureData.GetLocaleInfoNative] Expected _sWindowsName to be populated already");
 
-            return GetLocaleInfoNative(_sWindowsName, type, uiLocaleName);
+            return GetLocaleInfoNative(_sWindowsName, type, uiLocaleName, useUserOverride);
         }
 
         // For LOCALE_SPARENT we need the option of using the "real" name (forcing neutral names) instead of the
         // "windows" name, which can be specific for downlevel (< windows 7) os's.
-        private static string GetLocaleInfoNative(string localeName, LocaleStringData type, string? uiLocaleName = null)
+        private static string GetLocaleInfoNative(string localeName, LocaleStringData type, string? uiLocaleName = null, bool useUserOverride = false)
         {
             Debug.Assert(localeName != null, "[CultureData.GetLocaleInfoNative] Expected localeName to be not be null");
 
-            return Interop.Globalization.GetLocaleInfoStringNative(localeName, (uint)type, uiLocaleName);
+            return Interop.Globalization.GetLocaleInfoStringNative(localeName, (uint)type, uiLocaleName, useUserOverride);
         }
 
-        private int GetLocaleInfoNative(LocaleNumberData type)
+        private int GetLocaleInfoNative(LocaleNumberData type, bool useUserOverride = false)
         {
             Debug.Assert(_sWindowsName != null, "[CultureData.GetLocaleInfoNative(LocaleNumberData)] Expected _sWindowsName to be populated already");
 
@@ -37,7 +55,7 @@ namespace System.Globalization
             if (type == LocaleNumberData.CalendarType)
                 return 0;
 
-            int value = Interop.Globalization.GetLocaleInfoIntNative(_sWindowsName, (uint)type);
+            int value = Interop.Globalization.GetLocaleInfoIntNative(_sWindowsName, (uint)type, useUserOverride);
             const int DEFAULT_VALUE = 0;
             if (value < 0)
             {
@@ -48,12 +66,12 @@ namespace System.Globalization
             return value;
         }
 
-        private int[] GetLocaleInfoNative(LocaleGroupingData type)
+        private int[] GetLocaleInfoNative(LocaleGroupingData type, bool useUserOverride = false)
         {
             Debug.Assert(_sWindowsName != null, "[CultureData.GetLocaleInfoNative(LocaleGroupingData)] Expected _sWindowsName to be populated already");
 
-            int primaryGroupingSize = Interop.Globalization.GetLocaleInfoPrimaryGroupingSizeNative(_sWindowsName, (uint)type);
-            int secondaryGroupingSize = Interop.Globalization.GetLocaleInfoSecondaryGroupingSizeNative(_sWindowsName, (uint)type);
+            int primaryGroupingSize = Interop.Globalization.GetLocaleInfoPrimaryGroupingSizeNative(_sWindowsName, (uint)type, useUserOverride);
+            int secondaryGroupingSize = Interop.Globalization.GetLocaleInfoSecondaryGroupingSizeNative(_sWindowsName, (uint)type, useUserOverride);
 
             if (secondaryGroupingSize == 0)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.Unix.cs
@@ -16,7 +16,17 @@ namespace System.Globalization
             if (CultureData.GetDefaultLocaleName(out string? localeName))
             {
                 Debug.Assert(localeName != null);
-                cultureInfo = GetCultureByName(localeName);
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+                if (GlobalizationMode.Hybrid)
+                {
+                    CultureData? cultureData = CultureData.GetUserDefaultCultureData(localeName);
+                    cultureInfo = cultureData is null ? InvariantCulture : new CultureInfo(cultureData, isReadOnly: true);
+                }
+                else
+#endif
+                {
+                    cultureInfo = GetCultureByName(localeName);
+                }
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.Unix.cs
@@ -17,16 +17,11 @@ namespace System.Globalization
             {
                 Debug.Assert(localeName != null);
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-                if (GlobalizationMode.Hybrid)
-                {
-                    CultureData? cultureData = CultureData.GetUserDefaultCultureData(localeName);
-                    cultureInfo = cultureData is null ? InvariantCulture : new CultureInfo(cultureData, isReadOnly: true);
-                }
-                else
+                CultureData? cultureData = CultureData.GetUserDefaultCultureData(localeName);
+                cultureInfo = cultureData is null ? InvariantCulture : new CultureInfo(cultureData, isReadOnly: true);
+#else
+                cultureInfo = GetCultureByName(localeName);
 #endif
-                {
-                    cultureInfo = GetCultureByName(localeName);
-                }
             }
             else
             {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Tests;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
@@ -43,6 +44,101 @@ namespace System.Globalization.Tests
             Assert.NotEqual(CultureInfo.CurrentCulture, CultureInfo.InvariantCulture);
             Assert.NotEqual(CultureInfo.CurrentUICulture, CultureInfo.InvariantCulture);
         }
+
+        private static bool CurrentLocaleHasNumberFormatOverride =>
+            PlatformDetection.IsAppleMobile &&
+            (GetCurrentLocaleValue("decimalSeparator") != GetNamedLocaleValue(CultureInfo.CurrentCulture.Name, "decimalSeparator") ||
+             GetCurrentLocaleValue("groupingSeparator") != GetNamedLocaleValue(CultureInfo.CurrentCulture.Name, "groupingSeparator"));
+
+        [ConditionalFact(nameof(CurrentLocaleHasNumberFormatOverride))]
+        [PlatformSpecific(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
+        public void CurrentCulture_NumberFormat_UsesCurrentLocale()
+        {
+            Assert.Equal(GetCurrentLocaleValue("decimalSeparator"), CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+            Assert.Equal(GetCurrentLocaleValue("groupingSeparator"), CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
+        public void CultureWithoutUserOverrides_NumberFormat_UsesNamedLocale()
+        {
+            CultureInfo culture = new CultureInfo(CultureInfo.CurrentCulture.Name, useUserOverride: false);
+
+            Assert.Equal(GetNamedLocaleValue(culture.Name, "decimalSeparator"), culture.NumberFormat.NumberDecimalSeparator);
+            Assert.Equal(GetNamedLocaleValue(culture.Name, "groupingSeparator"), culture.NumberFormat.NumberGroupSeparator);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
+        public void CurrentNamedCulture_NumberFormat_UsesNamedLocale()
+        {
+            CultureInfo culture = new CultureInfo(CultureInfo.CurrentCulture.Name);
+
+            Assert.Equal(GetNamedLocaleValue(culture.Name, "decimalSeparator"), culture.NumberFormat.NumberDecimalSeparator);
+            Assert.Equal(GetNamedLocaleValue(culture.Name, "groupingSeparator"), culture.NumberFormat.NumberGroupSeparator);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
+        public void NonCurrentCulture_NumberFormat_UsesNamedLocale()
+        {
+            CultureInfo culture = new CultureInfo(CultureInfo.CurrentCulture.Name == "fr-FR" ? "en-US" : "fr-FR");
+
+            Assert.Equal(GetNamedLocaleValue(culture.Name, "decimalSeparator"), culture.NumberFormat.NumberDecimalSeparator);
+            Assert.Equal(GetNamedLocaleValue(culture.Name, "groupingSeparator"), culture.NumberFormat.NumberGroupSeparator);
+        }
+
+        private static string GetCurrentLocaleValue(string selectorName)
+        {
+            IntPtr localeClass = objc_getClass("NSLocale");
+            IntPtr currentLocale = objc_msgSend(localeClass, sel_registerName("currentLocale"));
+
+            return GetLocaleValue(currentLocale, selectorName);
+        }
+
+        private static string GetNamedLocaleValue(string localeName, string selectorName)
+        {
+            IntPtr localeNameUtf8 = Marshal.StringToCoTaskMemUTF8(localeName);
+            try
+            {
+                IntPtr localeClass = objc_getClass("NSLocale");
+                IntPtr stringClass = objc_getClass("NSString");
+                IntPtr nativeLocaleName = objc_msgSend(stringClass, sel_registerName("stringWithUTF8String:"), localeNameUtf8);
+                IntPtr locale = objc_msgSend(objc_msgSend(localeClass, sel_registerName("alloc")), sel_registerName("initWithLocaleIdentifier:"), nativeLocaleName);
+                try
+                {
+                    return GetLocaleValue(locale, selectorName);
+                }
+                finally
+                {
+                    objc_msgSend(locale, sel_registerName("release"));
+                }
+            }
+            finally
+            {
+                Marshal.FreeCoTaskMem(localeNameUtf8);
+            }
+        }
+
+        private static string GetLocaleValue(IntPtr locale, string selectorName)
+        {
+            IntPtr value = objc_msgSend(locale, sel_registerName(selectorName));
+            IntPtr utf8Value = objc_msgSend(value, sel_registerName("UTF8String"));
+
+            return Marshal.PtrToStringUTF8(utf8Value)!;
+        }
+
+        [DllImport("/usr/lib/libobjc.A.dylib")]
+        private static extern IntPtr objc_getClass(string name);
+
+        [DllImport("/usr/lib/libobjc.A.dylib")]
+        private static extern IntPtr sel_registerName(string selectorName);
+
+        [DllImport("/usr/lib/libobjc.A.dylib")]
+        private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [DllImport("/usr/lib/libobjc.A.dylib", EntryPoint = "objc_msgSend")]
+        private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr argument);
 
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Tests;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
@@ -44,101 +43,6 @@ namespace System.Globalization.Tests
             Assert.NotEqual(CultureInfo.CurrentCulture, CultureInfo.InvariantCulture);
             Assert.NotEqual(CultureInfo.CurrentUICulture, CultureInfo.InvariantCulture);
         }
-
-        private static bool CurrentLocaleHasNumberFormatOverride =>
-            PlatformDetection.IsAppleMobile &&
-            (GetCurrentLocaleValue("decimalSeparator") != GetNamedLocaleValue(CultureInfo.CurrentCulture.Name, "decimalSeparator") ||
-             GetCurrentLocaleValue("groupingSeparator") != GetNamedLocaleValue(CultureInfo.CurrentCulture.Name, "groupingSeparator"));
-
-        [ConditionalFact(nameof(CurrentLocaleHasNumberFormatOverride))]
-        [PlatformSpecific(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
-        public void CurrentCulture_NumberFormat_UsesCurrentLocale()
-        {
-            Assert.Equal(GetCurrentLocaleValue("decimalSeparator"), CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
-            Assert.Equal(GetCurrentLocaleValue("groupingSeparator"), CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator);
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
-        public void CultureWithoutUserOverrides_NumberFormat_UsesNamedLocale()
-        {
-            CultureInfo culture = new CultureInfo(CultureInfo.CurrentCulture.Name, useUserOverride: false);
-
-            Assert.Equal(GetNamedLocaleValue(culture.Name, "decimalSeparator"), culture.NumberFormat.NumberDecimalSeparator);
-            Assert.Equal(GetNamedLocaleValue(culture.Name, "groupingSeparator"), culture.NumberFormat.NumberGroupSeparator);
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
-        public void CurrentNamedCulture_NumberFormat_UsesNamedLocale()
-        {
-            CultureInfo culture = new CultureInfo(CultureInfo.CurrentCulture.Name);
-
-            Assert.Equal(GetNamedLocaleValue(culture.Name, "decimalSeparator"), culture.NumberFormat.NumberDecimalSeparator);
-            Assert.Equal(GetNamedLocaleValue(culture.Name, "groupingSeparator"), culture.NumberFormat.NumberGroupSeparator);
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
-        public void NonCurrentCulture_NumberFormat_UsesNamedLocale()
-        {
-            CultureInfo culture = new CultureInfo(CultureInfo.CurrentCulture.Name == "fr-FR" ? "en-US" : "fr-FR");
-
-            Assert.Equal(GetNamedLocaleValue(culture.Name, "decimalSeparator"), culture.NumberFormat.NumberDecimalSeparator);
-            Assert.Equal(GetNamedLocaleValue(culture.Name, "groupingSeparator"), culture.NumberFormat.NumberGroupSeparator);
-        }
-
-        private static string GetCurrentLocaleValue(string selectorName)
-        {
-            IntPtr localeClass = objc_getClass("NSLocale");
-            IntPtr currentLocale = objc_msgSend(localeClass, sel_registerName("currentLocale"));
-
-            return GetLocaleValue(currentLocale, selectorName);
-        }
-
-        private static string GetNamedLocaleValue(string localeName, string selectorName)
-        {
-            IntPtr localeNameUtf8 = Marshal.StringToCoTaskMemUTF8(localeName);
-            try
-            {
-                IntPtr localeClass = objc_getClass("NSLocale");
-                IntPtr stringClass = objc_getClass("NSString");
-                IntPtr nativeLocaleName = objc_msgSend(stringClass, sel_registerName("stringWithUTF8String:"), localeNameUtf8);
-                IntPtr locale = objc_msgSend(objc_msgSend(localeClass, sel_registerName("alloc")), sel_registerName("initWithLocaleIdentifier:"), nativeLocaleName);
-                try
-                {
-                    return GetLocaleValue(locale, selectorName);
-                }
-                finally
-                {
-                    objc_msgSend(locale, sel_registerName("release"));
-                }
-            }
-            finally
-            {
-                Marshal.FreeCoTaskMem(localeNameUtf8);
-            }
-        }
-
-        private static string GetLocaleValue(IntPtr locale, string selectorName)
-        {
-            IntPtr value = objc_msgSend(locale, sel_registerName(selectorName));
-            IntPtr utf8Value = objc_msgSend(value, sel_registerName("UTF8String"));
-
-            return Marshal.PtrToStringUTF8(utf8Value)!;
-        }
-
-        [DllImport("/usr/lib/libobjc.A.dylib")]
-        private static extern IntPtr objc_getClass(string name);
-
-        [DllImport("/usr/lib/libobjc.A.dylib")]
-        private static extern IntPtr sel_registerName(string selectorName);
-
-        [DllImport("/usr/lib/libobjc.A.dylib")]
-        private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [DllImport("/usr/lib/libobjc.A.dylib", EntryPoint = "objc_msgSend")]
-        private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr argument);
 
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -134,13 +134,27 @@ static const char* getISO3LanguageByLangCode(const char* langCode)
     return LANGUAGES_3[offset];
 }
 
-const char* GlobalizationNative_GetLocaleInfoStringNative(const char* localeName, LocaleStringData localeStringData, const char* currentUILocaleName)
+static NSLocale* GetNativeLocale(const char* localeName, int32_t useUserOverride)
+{
+    if (useUserOverride)
+    {
+        return [NSLocale currentLocale];
+    }
+
+    NSString *locName = [[NSString alloc] initWithUTF8String:localeName];
+    return [[NSLocale alloc] initWithLocaleIdentifier:locName];
+}
+
+const char* GlobalizationNative_GetLocaleInfoStringNative(
+    const char* localeName,
+    LocaleStringData localeStringData,
+    const char* currentUILocaleName,
+    int32_t useUserOverride)
 {
     @autoreleasepool
     {
         NSString *value;
-        NSString *locName = [[NSString alloc] initWithUTF8String:localeName];
-        NSLocale *currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:locName];
+        NSLocale *currentLocale = GetNativeLocale(localeName, useUserOverride);
         NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
         numberFormatter.locale = currentLocale;
         NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
@@ -521,7 +535,10 @@ static int32_t GetValueForNumberFormat(NSLocale *currentLocale, LocaleNumberData
     return value;
 }
 
-int32_t GlobalizationNative_GetLocaleInfoIntNative(const char* localeName, LocaleNumberData localeNumberData)
+int32_t GlobalizationNative_GetLocaleInfoIntNative(
+    const char* localeName,
+    LocaleNumberData localeNumberData,
+    int32_t useUserOverride)
 {
     @autoreleasepool
     {
@@ -529,8 +546,7 @@ int32_t GlobalizationNative_GetLocaleInfoIntNative(const char* localeName, Local
         bool isSuccess = true;
 #endif
         int32_t value;
-        NSString *locName = [[NSString alloc] initWithUTF8String:localeName];
-        NSLocale *currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:locName];
+        NSLocale *currentLocale = GetNativeLocale(localeName, useUserOverride);
 
         switch (localeNumberData)
         {
@@ -632,12 +648,14 @@ GlobalizationNative_GetLocaleInfoPrimaryGroupingSizeNative
 
 Returns primary grouping size for decimal and currency
 */
-int32_t GlobalizationNative_GetLocaleInfoPrimaryGroupingSizeNative(const char* localeName, LocaleNumberData localeGroupingData)
+int32_t GlobalizationNative_GetLocaleInfoPrimaryGroupingSizeNative(
+    const char* localeName,
+    LocaleNumberData localeGroupingData,
+    int32_t useUserOverride)
 {
     @autoreleasepool
     {
-        NSString *locName = [[NSString alloc] initWithUTF8String:localeName];
-        NSLocale *currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:locName];
+        NSLocale *currentLocale = GetNativeLocale(localeName, useUserOverride);
         NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
         numberFormatter.locale = currentLocale;
 
@@ -663,12 +681,14 @@ GlobalizationNative_GetLocaleInfoSecondaryGroupingSizeNative
 
 Returns secondary grouping size for decimal and currency
 */
-int32_t GlobalizationNative_GetLocaleInfoSecondaryGroupingSizeNative(const char* localeName, LocaleNumberData localeGroupingData)
+int32_t GlobalizationNative_GetLocaleInfoSecondaryGroupingSizeNative(
+    const char* localeName,
+    LocaleNumberData localeGroupingData,
+    int32_t useUserOverride)
 {
     @autoreleasepool
     {
-        NSString *locName = [[NSString alloc] initWithUTF8String:localeName];
-        NSLocale *currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:locName];
+        NSLocale *currentLocale = GetNativeLocale(localeName, useUserOverride);
         NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
         numberFormatter.locale = currentLocale;
 
@@ -839,4 +859,3 @@ int32_t GlobalizationNative_IsPredefinedLocaleNative(const char* localeName)
     }
 }
 #endif
-

--- a/src/native/libs/System.Globalization.Native/pal_localeNumberData.h
+++ b/src/native/libs/System.Globalization.Native/pal_localeNumberData.h
@@ -44,11 +44,14 @@ PALEXPORT int32_t GlobalizationNative_GetLocaleInfoGroupingSizes(const UChar* lo
                                                                  int32_t* secondaryGroupSize);
 #if defined(APPLE_HYBRID_GLOBALIZATION)
 PALEXPORT int32_t GlobalizationNative_GetLocaleInfoIntNative(const char* localeName,
-                                                             LocaleNumberData localeNumberData);
+                                                             LocaleNumberData localeNumberData,
+                                                             int32_t useUserOverride);
 
 PALEXPORT int32_t GlobalizationNative_GetLocaleInfoPrimaryGroupingSizeNative(const char* localeName,
-                                                                      LocaleNumberData localeGroupingData);
+                                                                            LocaleNumberData localeGroupingData,
+                                                                            int32_t useUserOverride);
 
 PALEXPORT int32_t GlobalizationNative_GetLocaleInfoSecondaryGroupingSizeNative(const char* localeName,
-                                                                           LocaleNumberData localeGroupingData);
+                                                                              LocaleNumberData localeGroupingData,
+                                                                              int32_t useUserOverride);
 #endif

--- a/src/native/libs/System.Globalization.Native/pal_localeStringData.h
+++ b/src/native/libs/System.Globalization.Native/pal_localeStringData.h
@@ -49,6 +49,9 @@ PALEXPORT int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeNam
                                                           int32_t valueLength,
                                                           const UChar* uiLocaleName);
 #if defined(APPLE_HYBRID_GLOBALIZATION)
-PALEXPORT const char* GlobalizationNative_GetLocaleInfoStringNative(const char* localeName, LocaleStringData localeStringData, const char* currentUILocaleName);
+PALEXPORT const char* GlobalizationNative_GetLocaleInfoStringNative(
+    const char* localeName,
+    LocaleStringData localeStringData,
+    const char* currentUILocaleName,
+    int32_t useUserOverride);
 #endif  
-


### PR DESCRIPTION
Fixes #110430

## Summary

- create dedicated user-default culture data for Apple mobile
- use `NSLocale.currentLocale` for overrideable locale values while keeping explicitly named cultures identifier-based
- thread user-override selection through the Apple native locale interop
- preserve `PredefinedCulturesOnly` validation for the user-default locale

> [!NOTE]
> This pull request description was generated with GitHub Copilot.