### PR TITLE
[wasm] Bump helix V8 image and re-enable exnref CI legs (#129849)

### DIFF
--- a/eng/pipelines/common/templates/wasm-runtime-tests.yml
+++ b/eng/pipelines/common/templates/wasm-runtime-tests.yml
@@ -48,10 +48,5 @@ jobs:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_$(_BuildConfig)
             testBuildArgs: /p:InstallV8ForTests=false
-            # Build the runtime tests for browser, but don't send them to Helix to run on V8: the
-            # V8 baked into the helix-webassembly container doesn't support exnref
-            # yet, so the tests abort at startup. Re-enable the run once the new V8 image is
-            # available. See ActiveIssue https://github.com/dotnet/runtime/issues/129849
-            sendToHelix: false
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -70,9 +70,9 @@ jobs:
     # Browser wasm
     - ${{ if eq(parameters.platform, 'browser_wasm') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - (Ubuntu.2604.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:3ef1314b50ac039078f6406d649d5ac72715deccd07bcbfe3dd43fa438be3fbd
+        - (Ubuntu.2604.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:73db6e433bb7e9ef8546b35688b727f2f559b9ac5fea21c77d56795b74b197b8
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - (Ubuntu.2604.Amd64)AzureLinux.3.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:3ef1314b50ac039078f6406d649d5ac72715deccd07bcbfe3dd43fa438be3fbd
+        - (Ubuntu.2604.Amd64)AzureLinux.3.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:73db6e433bb7e9ef8546b35688b727f2f559b9ac5fea21c77d56795b74b197b8
 
     # iOS devices
     - ${{ if in(parameters.platform, 'ios_arm64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -170,15 +170,15 @@ jobs:
 
     # WASI
     - ${{ if eq(parameters.platform, 'wasi_wasm') }}:
-      - (Ubuntu.2604.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:3ef1314b50ac039078f6406d649d5ac72715deccd07bcbfe3dd43fa438be3fbd
+      - (Ubuntu.2604.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:73db6e433bb7e9ef8546b35688b727f2f559b9ac5fea21c77d56795b74b197b8
 
     # Browser WebAssembly
     - ${{ if eq(parameters.platform, 'browser_wasm') }}:
-      - (Ubuntu.2604.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:3ef1314b50ac039078f6406d649d5ac72715deccd07bcbfe3dd43fa438be3fbd
+      - (Ubuntu.2604.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:73db6e433bb7e9ef8546b35688b727f2f559b9ac5fea21c77d56795b74b197b8
 
     # Browser WebAssembly Firefox
     - ${{ if eq(parameters.platform, 'browser_wasm_firefox') }}:
-      - (Ubuntu.2604.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:3ef1314b50ac039078f6406d649d5ac72715deccd07bcbfe3dd43fa438be3fbd
+      - (Ubuntu.2604.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-26.04-helix-webassembly-amd64@sha256:73db6e433bb7e9ef8546b35688b727f2f559b9ac5fea21c77d56795b74b197b8
 
     # Browser WebAssembly windows
     - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:

--- a/eng/pipelines/performance/runtime-wasm-perf.yml
+++ b/eng/pipelines/performance/runtime-wasm-perf.yml
@@ -4,11 +4,15 @@
 
 trigger: none
 
-# Disabled: the perf wasm v8 job installs V8 via jsvu, and the V8 binary it currently
-# installs does not support exnref yet, so the MicroBenchmarks Helix
-# job aborts at startup. Re-enable once an exnref-capable V8 is pinned. See
-# ActiveIssue https://github.com/dotnet/runtime/issues/129849
-pr: none
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - eng/pipelines/performance/*
+    - eng/testing/performance/*
+    - eng/testing/BrowserVersions.props
 
 resources:
   repositories:

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -135,11 +135,5 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
                 parameters:
-                    # Publish the trimmed browser apps, but don't run them on V8: the V8 baked into
-                    # the helix-webassembly container doesn't support exnref yet,
-                    # so run-v8.sh aborts at startup. SkipTrimmingTestsRun keeps the build/publish
-                    # coverage and only skips ExecuteApplications. Re-enable the run once the new V8
-                    # image is available. See
-                    # ActiveIssue https://github.com/dotnet/runtime/issues/129849
-                    extraTestArgs: '/p:WasmBuildNative=false /p:RuntimeFlavor=Mono /p:ToolsConfiguration=Debug /p:SkipTrimmingTestsRun=true'
+                    extraTestArgs: '/p:WasmBuildNative=false /p:RuntimeFlavor=Mono /p:ToolsConfiguration=Debug'
                     runAotTests: false

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1009,8 +1009,7 @@ extends:
           extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           scenarios:
             - WasmTestOnFirefox
-            # ActiveIssue https://github.com/dotnet/runtime/issues/129849
-            # - WasmTestOnV8
+            - WasmTestOnV8
 
       # EAT Library tests - only run on linux
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -25,6 +25,11 @@ public partial class UpdateChromeVersions : MBU.Task
     private const string s_v8CanaryBaseUrl = "https://storage.googleapis.com/chromium-v8/official/canary";
     private const int s_versionCheckThresholdDays = 1;
 
+    // The V8 used for testing must support the standardized exnref exception-handling proposal.
+    // Chrome milestones can map to older V8 builds, so never downgrade the pinned V8 below this
+    // floor. See https://github.com/dotnet/runtime/issues/129849
+    private static readonly Version s_minV8Version = new(15, 1, 103);
+
     private static readonly HttpClient s_httpClient = new();
 
     [GeneratedRegex("#define V8_BUILD_NUMBER (\\d+)")]
@@ -215,23 +220,24 @@ public partial class UpdateChromeVersions : MBU.Task
 
         string foundV8Version = await FindV8VersionFromChromeVersion(foundRelease.version).ConfigureAwait(false);
 
+        // Never downgrade V8 below the exnref-capable floor, even if the Chrome milestone maps to an older build.
+        if (Version.TryParse(foundV8Version, out Version? candidateV8Version) && candidateV8Version < s_minV8Version)
+        {
+            string existingV8Version = GetExistingV8Version(osIdentifier);
+            Log.LogWarning($"Computed V8 version {foundV8Version} for {osIdentifier} is below the minimum " +
+                            $"exnref-capable version {s_minV8Version} — keeping the existing V8 version {existingV8Version}.");
+            foundV8Version = existingV8Version;
+            if (string.IsNullOrEmpty(foundV8Version))
+                throw new LogAsErrorException($"Computed V8 version for {osIdentifier} is below {s_minV8Version} and no existing version found in {ChromeVersionsPath}");
+        }
         // Validate that a prebuilt V8 binary exists on the CDN that jsvu uses for downloading.
-        if (!await IsV8BinaryAvailableAsync(osPrefix, foundV8Version).ConfigureAwait(false))
+        else if (!await IsV8BinaryAvailableAsync(osPrefix, foundV8Version).ConfigureAwait(false))
         {
             string v8BinaryUrl = GetV8BinaryUrl(osPrefix, foundV8Version);
             Log.LogWarning($"V8 binary not available at {v8BinaryUrl} — keeping the existing V8 version for {osIdentifier}.");
 
             // Fall back to the existing V8 version from BrowserVersions.props
-            XmlDocument existingDoc = new XmlDocument();
-            existingDoc.Load(ChromeVersionsPath);
-            string existingV8VersionNodeName = string.Equals(osIdentifier, "linux", StringComparison.OrdinalIgnoreCase)
-                ? "linux_V8Version"
-                : string.Equals(osIdentifier, "windows", StringComparison.OrdinalIgnoreCase)
-                    ? "win_V8Version"
-                    : string.Equals(osIdentifier, "Mac", StringComparison.OrdinalIgnoreCase)
-                        ? "macos_V8Version"
-                        : throw new LogAsErrorException($"Unknown OS identifier '{osIdentifier}' for V8 version fallback");
-            foundV8Version = GetNodeValue(existingDoc, existingV8VersionNodeName);
+            foundV8Version = GetExistingV8Version(osIdentifier);
             if (string.IsNullOrEmpty(foundV8Version))
                 throw new LogAsErrorException($"V8 binary for {osIdentifier} not available on CDN and no existing version found in {ChromeVersionsPath}");
         }
@@ -277,6 +283,20 @@ public partial class UpdateChromeVersions : MBU.Task
                 throw new LogAsErrorException($"Failed to parse chrome version '{chromeVersion}' to extract the milestone: {ex.Message}");
             }
         }
+    }
+
+    private string GetExistingV8Version(string osIdentifier)
+    {
+        XmlDocument existingDoc = new XmlDocument();
+        existingDoc.Load(ChromeVersionsPath);
+        string existingV8VersionNodeName = string.Equals(osIdentifier, "linux", StringComparison.OrdinalIgnoreCase)
+            ? "linux_V8Version"
+            : string.Equals(osIdentifier, "windows", StringComparison.OrdinalIgnoreCase)
+                ? "win_V8Version"
+                : string.Equals(osIdentifier, "Mac", StringComparison.OrdinalIgnoreCase)
+                    ? "macos_V8Version"
+                    : throw new LogAsErrorException($"Unknown OS identifier '{osIdentifier}' for V8 version fallback");
+        return GetNodeValue(existingDoc, existingV8VersionNodeName);
     }
 
     private static string GetV8BinaryUrl(string osPrefix, string v8Version)


### PR DESCRIPTION
Fixes #129849

## Background

The exnref migration (#129851) exposed CI failures on the WASM legs. 
#130142 fixed — `wasm-feature-detect`'s `exceptionsFinal()` used `atob`.

## Changes

**Bump the Linux Helix WebAssembly image to an exnref-capable V8**
- `ubuntu-26.04-helix-webassembly-amd64` → `@sha256:73db6e43…` (V8 **15.2.47**, verified locally by pulling the image and running `d8`). Previous pin baked V8 15.0.243.
- Updated in `eng/pipelines/coreclr/templates/helix-queues-setup.yml` and `eng/pipelines/libraries/helix-queues-setup.yml`.
- The Windows Helix digests and the azurelinux build container (V8 15.1.103) were already current, so they are unchanged.

**Re-enable the CI legs disabled against this issue**
- `eng/pipelines/common/templates/wasm-runtime-tests.yml` — removed `sendToHelix: false` (Mono runtime tests run on Helix again).
- `eng/pipelines/runtime-linker-tests.yml` — removed `SkipTrimmingTestsRun=true` (trimming tests execute on V8 again).
- `eng/pipelines/performance/runtime-wasm-perf.yml` — restored the original `pr:` trigger (was `pr: none`).
- `eng/pipelines/runtime.yml` — re-enabled the CoreCLR `WasmTestOnV8` smoke scenario.

**Harden the Chrome/V8 auto-updater**
- `src/tasks/WasmBuildTasks/UpdateChromeVersions.cs` — add a minimum-version guard so a Chrome-milestone-derived V8 can no longer silently downgrade the pinned `*_V8Version` below the exnref floor (15.1.103), which had already reverted the pins once via the automated bump. When the recomputed value would drop below the floor, the existing version is kept (mirroring the existing CDN-unavailable fallback).
