### PR TITLE
[CoreCLR] Fix macOS jitdump discovery by Samply

### DIFF
--- a/src/coreclr/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/pal/src/misc/perfjitdump.cpp
@@ -35,6 +35,14 @@
 #include <x86intrin.h>
 #endif
 
+#if defined(TARGET_OSX)
+// The runtime globally aliases open to open$NOCANCEL, but Samply discovers jitdump files by
+// interposing the regular open symbol. Bind this call directly to that symbol.
+extern "C" int JitDumpOpen(const char* path, int flags, ...) __asm("_open");
+#else
+#define JitDumpOpen open
+#endif
+
 SET_DEFAULT_DEBUG_CHANNEL(MISC);
 
 namespace
@@ -211,7 +219,7 @@ struct PerfJitDumpState
         if (result >= PATH_MAX)
             return FatalError();
 
-        result = open(jitdumpPath, O_CREAT|O_TRUNC|O_RDWR|O_CLOEXEC, S_IRUSR|S_IWUSR );
+        result = JitDumpOpen(jitdumpPath, O_CREAT|O_TRUNC|O_RDWR|O_CLOEXEC, S_IRUSR|S_IWUSR);
 
         if (result == -1)
             return FatalError();


### PR DESCRIPTION
On macOS, the runtime-wide `__DARWIN_NON_CANCELABLE` setting maps `open` to `open$NOCANCEL`. Samply discovers jitdump files by interposing regular `open`, so it stopped seeing CoreCLR jitdump output after #117330.

Bind only jitdump creation to plain `_open` on macOS. Linux and Apple mobile are unchanged.

### Example usage of Samply:

![Mixed native and managed stacks in Samply](https://raw.githubusercontent.com/EgorBo/runtime-1/pr-assets/pr-assets/macos-samply-jitdump.png)

This restores mixed native/managed stacks and annotated managed assembly, for example:

```asm
uint64 ManagedPipeline::ManagedHash(uint32,uint32)

   self%  samples  offset   instruction
     0.00        0  +0x0028  mov w3, #0x30
>>   1.72        2  +0x002c  eor x0, x0, x0, lsr #29
     0.00        0  +0x0030  mul x0, x0, x1
>>   6.03        7  +0x0034  ror x0, x0, #0x2f
     0.00        0  +0x0038  add x0, x0, w2
     0.00        0  +0x003c  mov w4, #0x79b9
     0.00        0  +0x0040  movk w4, #0x9e37, lsl #16
>>   7.76        9  +0x0044  add w2, w2, w4
>>  81.90       95  +0x0048  sub w3, w3, #0x1
     0.00        0  +0x004c  cbnz w3, $-0x20
>>   2.59        3  +0x0050  ldp x29, x30, [sp], #0x10
     0.00        0  +0x0054  ret
```

Validated with a Release CoreCLR build and Samply 0.13.1 on macOS arm64.
