### PR TITLE
Fix EventSource WriteEvent varargs overloads dropped from EventPipe

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -466,7 +466,14 @@ namespace System.Diagnostics.Tracing
         {
             WriteEventErrorCode status = WriteEventErrorCode.NoError;
 
-            if (IsEnabled(eventDescriptor.Level, eventDescriptor.Keywords))
+            // The event descriptor's keywords are OR'd with the reserved session-mask bits when the
+            // manifest is created (see EventSource). Strip those bits before the keyword check so this
+            // mirrors EventSource.IsEnabledByDefault/IsEnabledCommon, which compare against the
+            // session-mask-cleared keywords. Without this, an event declared with keyword 0 never
+            // matches the keywords == 0 fast path below because its descriptor keyword is non-zero.
+            long keywords = eventDescriptor.Keywords & unchecked((long)~SessionMask.All.ToEventKeywords());
+
+            if (IsEnabled(eventDescriptor.Level, keywords))
             {
                 int argCount = eventPayload.Length;
 
@@ -1190,11 +1197,11 @@ namespace System.Diagnostics.Tracing
                 //
                 // Check if Keyword is enabled
                 //
-                // A session that specifies an "any" keyword mask of 0 matches all keywords,
-                // which mirrors the convention used by EventSource.IsEnabledCommon. Without this,
-                // events written through the object[] varargs path (EventProvider.WriteEvent) are
-                // dropped for EventPipe sessions enabled with keyword 0, even though the manifest
-                // (specialized) write path emits them.
+                // An "any" keyword mask of 0 matches all keywords. This mirrors the convention used by
+                // EventSource.IsEnabledCommon and native ETW's MatchAnyKeyword == 0 semantics, so events
+                // reach every sink consistently. In particular, EventPipe/dotnet-trace enable named
+                // providers with keyword 0; without this an event declared with a non-zero keyword would
+                // be dropped here even though the outer IsEnabledCommon gate already enabled it.
                 //
                 if ((keywords == 0) ||
                     ((_anyKeywordMask == 0 || (keywords & _anyKeywordMask) != 0) &&

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -1190,9 +1190,14 @@ namespace System.Diagnostics.Tracing
                 //
                 // Check if Keyword is enabled
                 //
-
+                // A session that specifies an "any" keyword mask of 0 matches all keywords,
+                // which mirrors the convention used by EventSource.IsEnabledCommon. Without this,
+                // events written through the object[] varargs path (EventProvider.WriteEvent) are
+                // dropped for EventPipe sessions enabled with keyword 0, even though the manifest
+                // (specialized) write path emits them.
+                //
                 if ((keywords == 0) ||
-                    (((keywords & _anyKeywordMask) != 0) &&
+                    ((_anyKeywordMask == 0 || (keywords & _anyKeywordMask) != 0) &&
                      ((keywords & _allKeywordMask) == _allKeywordMask)))
                 {
                     return true;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -210,20 +210,6 @@ namespace System.Diagnostics.Tracing
             return _eventProvider.IsEnabled();
         }
 
-        /// <summary>
-        /// IsEnabled, method used to test if event is enabled
-        /// </summary>
-        /// <param name="level">
-        /// Level  to test
-        /// </param>
-        /// <param name="keywords">
-        /// Keyword  to test
-        /// </param>
-        public bool IsEnabled(byte level, long keywords)
-        {
-            return _eventProvider.IsEnabled(level, keywords);
-        }
-
         public static WriteEventErrorCode GetLastWriteEventError()
         {
             return s_returnCode;
@@ -465,185 +451,175 @@ namespace System.Diagnostics.Tracing
         internal unsafe bool WriteEvent(ref EventDescriptor eventDescriptor, IntPtr eventHandle, Guid* activityID, Guid* childActivityID, object?[] eventPayload)
         {
             WriteEventErrorCode status = WriteEventErrorCode.NoError;
+            int argCount = eventPayload.Length;
 
-            // The event descriptor's keywords are OR'd with the reserved session-mask bits when the
-            // manifest is created (see EventSource). Strip those bits before the keyword check so this
-            // mirrors EventSource.IsEnabledByDefault/IsEnabledCommon, which compare against the
-            // session-mask-cleared keywords.
-            long keywords = eventDescriptor.Keywords & unchecked((long)~SessionMask.All.ToEventKeywords());
-
-            if (IsEnabled(eventDescriptor.Level, keywords))
+            if (argCount > EtwMaxNumberArguments)
             {
-                int argCount = eventPayload.Length;
+                s_returnCode = WriteEventErrorCode.TooManyArgs;
+                return false;
+            }
 
-                if (argCount > EtwMaxNumberArguments)
+            uint totalEventSize = 0;
+            int index;
+            int refObjIndex = 0;
+
+            Debug.Assert(EtwAPIMaxRefObjCount == 8, $"{nameof(EtwAPIMaxRefObjCount)} must equal the number of fields in {nameof(InlineArray8<>)}");
+            InlineArray8<object?> eightObjectStack = default;
+            Span<int> refObjPosition = stackalloc int[EtwAPIMaxRefObjCount];
+            Span<object?> dataRefObj = eightObjectStack;
+
+            EventData* userData = stackalloc EventData[2 * argCount];
+            for (int i = 0; i < 2 * argCount; i++)
+                userData[i] = default;
+
+            EventData* userDataPtr = userData;
+            byte* dataBuffer = stackalloc byte[BasicTypeAllocationBufferSize * 2 * argCount]; // Assume 16 chars for non-string argument
+            byte* currentBuffer = dataBuffer;
+
+            //
+            // The loop below goes through all the arguments and fills in the data
+            // descriptors. For strings save the location in the dataString array.
+            // Calculates the total size of the event by adding the data descriptor
+            // size value set in EncodeObject method.
+            //
+            bool hasNonStringRefArgs = false;
+            for (index = 0; index < eventPayload.Length; index++)
+            {
+                if (eventPayload[index] != null)
                 {
-                    s_returnCode = WriteEventErrorCode.TooManyArgs;
-                    return false;
-                }
+                    object? supportedRefObj = EncodeObject(ref eventPayload[index], ref userDataPtr, ref currentBuffer, ref totalEventSize);
 
-                uint totalEventSize = 0;
-                int index;
-                int refObjIndex = 0;
-
-                Debug.Assert(EtwAPIMaxRefObjCount == 8, $"{nameof(EtwAPIMaxRefObjCount)} must equal the number of fields in {nameof(InlineArray8<>)}");
-                InlineArray8<object?> eightObjectStack = default;
-                Span<int> refObjPosition = stackalloc int[EtwAPIMaxRefObjCount];
-                Span<object?> dataRefObj = eightObjectStack;
-
-                EventData* userData = stackalloc EventData[2 * argCount];
-                for (int i = 0; i < 2 * argCount; i++)
-                    userData[i] = default;
-
-                EventData* userDataPtr = userData;
-                byte* dataBuffer = stackalloc byte[BasicTypeAllocationBufferSize * 2 * argCount]; // Assume 16 chars for non-string argument
-                byte* currentBuffer = dataBuffer;
-
-                //
-                // The loop below goes through all the arguments and fills in the data
-                // descriptors. For strings save the location in the dataString array.
-                // Calculates the total size of the event by adding the data descriptor
-                // size value set in EncodeObject method.
-                //
-                bool hasNonStringRefArgs = false;
-                for (index = 0; index < eventPayload.Length; index++)
-                {
-                    if (eventPayload[index] != null)
+                    if (supportedRefObj != null)
                     {
-                        object? supportedRefObj = EncodeObject(ref eventPayload[index], ref userDataPtr, ref currentBuffer, ref totalEventSize);
-
-                        if (supportedRefObj != null)
+                        // EncodeObject advanced userDataPtr to the next empty slot
+                        int idx = (int)(userDataPtr - userData - 1);
+                        if (supportedRefObj is not string)
                         {
-                            // EncodeObject advanced userDataPtr to the next empty slot
-                            int idx = (int)(userDataPtr - userData - 1);
-                            if (supportedRefObj is not string)
+                            if (eventPayload.Length + idx + 1 - index > EtwMaxNumberArguments)
                             {
-                                if (eventPayload.Length + idx + 1 - index > EtwMaxNumberArguments)
-                                {
-                                    s_returnCode = WriteEventErrorCode.TooManyArgs;
-                                    return false;
-                                }
-                                hasNonStringRefArgs = true;
+                                s_returnCode = WriteEventErrorCode.TooManyArgs;
+                                return false;
                             }
-
-                            if (refObjIndex >= dataRefObj.Length)
-                            {
-                                Span<object?> newDataRefObj = new object?[dataRefObj.Length * 2];
-                                dataRefObj.CopyTo(newDataRefObj);
-                                dataRefObj = newDataRefObj;
-
-                                Span<int> newRefObjPosition = new int[refObjPosition.Length * 2];
-                                refObjPosition.CopyTo(newRefObjPosition);
-                                refObjPosition = newRefObjPosition;
-                            }
-
-                            dataRefObj[refObjIndex] = supportedRefObj;
-                            refObjPosition[refObjIndex] = idx;
-                            refObjIndex++;
+                            hasNonStringRefArgs = true;
                         }
-                    }
-                    else
-                    {
-                        s_returnCode = WriteEventErrorCode.NullInput;
-                        return false;
-                    }
-                }
 
-                // update argCount based on actual number of arguments written to 'userData'
-                argCount = (int)(userDataPtr - userData);
-
-                if (totalEventSize > TraceEventMaximumSize)
-                {
-                    s_returnCode = WriteEventErrorCode.EventTooBig;
-                    return false;
-                }
-
-                // the optimized path (using "fixed" instead of allocating pinned GCHandles
-                if (!hasNonStringRefArgs && (refObjIndex <= EtwAPIMaxRefObjCount))
-                {
-                    // Fast path: at most 8 string arguments
-
-                    // ensure we have at least s_etwAPIMaxStringCount in dataString, so that
-                    // the "fixed" statement below works
-                    while (refObjIndex < EtwAPIMaxRefObjCount)
-                    {
-                        dataRefObj[refObjIndex] = null;
-                        refObjPosition[refObjIndex] = -1;
-                        ++refObjIndex;
-                    }
-
-                    //
-                    // now fix any string arguments and set the pointer on the data descriptor
-                    //
-                    fixed (char* v0 = (string?)dataRefObj[0], v1 = (string?)dataRefObj[1], v2 = (string?)dataRefObj[2], v3 = (string?)dataRefObj[3],
-                            v4 = (string?)dataRefObj[4], v5 = (string?)dataRefObj[5], v6 = (string?)dataRefObj[6], v7 = (string?)dataRefObj[7])
-                    {
-                        userDataPtr = userData;
-                        if (dataRefObj[0] != null)
+                        if (refObjIndex >= dataRefObj.Length)
                         {
-                            userDataPtr[refObjPosition[0]].Ptr = (ulong)v0;
-                        }
-                        if (dataRefObj[1] != null)
-                        {
-                            userDataPtr[refObjPosition[1]].Ptr = (ulong)v1;
-                        }
-                        if (dataRefObj[2] != null)
-                        {
-                            userDataPtr[refObjPosition[2]].Ptr = (ulong)v2;
-                        }
-                        if (dataRefObj[3] != null)
-                        {
-                            userDataPtr[refObjPosition[3]].Ptr = (ulong)v3;
-                        }
-                        if (dataRefObj[4] != null)
-                        {
-                            userDataPtr[refObjPosition[4]].Ptr = (ulong)v4;
-                        }
-                        if (dataRefObj[5] != null)
-                        {
-                            userDataPtr[refObjPosition[5]].Ptr = (ulong)v5;
-                        }
-                        if (dataRefObj[6] != null)
-                        {
-                            userDataPtr[refObjPosition[6]].Ptr = (ulong)v6;
-                        }
-                        if (dataRefObj[7] != null)
-                        {
-                            userDataPtr[refObjPosition[7]].Ptr = (ulong)v7;
+                            Span<object?> newDataRefObj = new object?[dataRefObj.Length * 2];
+                            dataRefObj.CopyTo(newDataRefObj);
+                            dataRefObj = newDataRefObj;
+
+                            Span<int> newRefObjPosition = new int[refObjPosition.Length * 2];
+                            refObjPosition.CopyTo(newRefObjPosition);
+                            refObjPosition = newRefObjPosition;
                         }
 
-                        status = _eventProvider.EventWriteTransfer(in eventDescriptor, eventHandle, activityID, childActivityID, argCount, userData);
+                        dataRefObj[refObjIndex] = supportedRefObj;
+                        refObjPosition[refObjIndex] = idx;
+                        refObjIndex++;
                     }
                 }
                 else
                 {
-                    // Slow path: use pinned handles
-                    userDataPtr = userData;
+                    s_returnCode = WriteEventErrorCode.NullInput;
+                    return false;
+                }
+            }
 
-                    GCHandle[] rgGCHandle = new GCHandle[refObjIndex];
-                    for (int i = 0; i < refObjIndex; ++i)
+            // update argCount based on actual number of arguments written to 'userData'
+            argCount = (int)(userDataPtr - userData);
+
+            if (totalEventSize > TraceEventMaximumSize)
+            {
+                s_returnCode = WriteEventErrorCode.EventTooBig;
+                return false;
+            }
+
+            // the optimized path (using "fixed" instead of allocating pinned GCHandles
+            if (!hasNonStringRefArgs && (refObjIndex <= EtwAPIMaxRefObjCount))
+            {
+                // Fast path: at most 8 string arguments
+
+                // ensure we have at least s_etwAPIMaxStringCount in dataString, so that
+                // the "fixed" statement below works
+                while (refObjIndex < EtwAPIMaxRefObjCount)
+                {
+                    dataRefObj[refObjIndex] = null;
+                    refObjPosition[refObjIndex] = -1;
+                    ++refObjIndex;
+                }
+
+                //
+                // now fix any string arguments and set the pointer on the data descriptor
+                //
+                fixed (char* v0 = (string?)dataRefObj[0], v1 = (string?)dataRefObj[1], v2 = (string?)dataRefObj[2], v3 = (string?)dataRefObj[3],
+                        v4 = (string?)dataRefObj[4], v5 = (string?)dataRefObj[5], v6 = (string?)dataRefObj[6], v7 = (string?)dataRefObj[7])
+                {
+                    userDataPtr = userData;
+                    if (dataRefObj[0] != null)
                     {
-                        // below we still use "fixed" to avoid taking dependency on the offset of the first field
-                        // in the object (the way we would need to if we used GCHandle.AddrOfPinnedObject)
-                        rgGCHandle[i] = GCHandle.Alloc(dataRefObj[i], GCHandleType.Pinned);
-                        if (dataRefObj[i] is string)
-                        {
-                            fixed (char* p = (string?)dataRefObj[i])
-                                userDataPtr[refObjPosition[i]].Ptr = (ulong)p;
-                        }
-                        else
-                        {
-                            fixed (byte* p = (byte[]?)dataRefObj[i])
-                                userDataPtr[refObjPosition[i]].Ptr = (ulong)p;
-                        }
+                        userDataPtr[refObjPosition[0]].Ptr = (ulong)v0;
+                    }
+                    if (dataRefObj[1] != null)
+                    {
+                        userDataPtr[refObjPosition[1]].Ptr = (ulong)v1;
+                    }
+                    if (dataRefObj[2] != null)
+                    {
+                        userDataPtr[refObjPosition[2]].Ptr = (ulong)v2;
+                    }
+                    if (dataRefObj[3] != null)
+                    {
+                        userDataPtr[refObjPosition[3]].Ptr = (ulong)v3;
+                    }
+                    if (dataRefObj[4] != null)
+                    {
+                        userDataPtr[refObjPosition[4]].Ptr = (ulong)v4;
+                    }
+                    if (dataRefObj[5] != null)
+                    {
+                        userDataPtr[refObjPosition[5]].Ptr = (ulong)v5;
+                    }
+                    if (dataRefObj[6] != null)
+                    {
+                        userDataPtr[refObjPosition[6]].Ptr = (ulong)v6;
+                    }
+                    if (dataRefObj[7] != null)
+                    {
+                        userDataPtr[refObjPosition[7]].Ptr = (ulong)v7;
                     }
 
                     status = _eventProvider.EventWriteTransfer(in eventDescriptor, eventHandle, activityID, childActivityID, argCount, userData);
+                }
+            }
+            else
+            {
+                // Slow path: use pinned handles
+                userDataPtr = userData;
 
-                    for (int i = 0; i < refObjIndex; ++i)
+                GCHandle[] rgGCHandle = new GCHandle[refObjIndex];
+                for (int i = 0; i < refObjIndex; ++i)
+                {
+                    // below we still use "fixed" to avoid taking dependency on the offset of the first field
+                    // in the object (the way we would need to if we used GCHandle.AddrOfPinnedObject)
+                    rgGCHandle[i] = GCHandle.Alloc(dataRefObj[i], GCHandleType.Pinned);
+                    if (dataRefObj[i] is string)
                     {
-                        rgGCHandle[i].Free();
+                        fixed (char* p = (string?)dataRefObj[i])
+                            userDataPtr[refObjPosition[i]].Ptr = (ulong)p;
                     }
+                    else
+                    {
+                        fixed (byte* p = (byte[]?)dataRefObj[i])
+                            userDataPtr[refObjPosition[i]].Ptr = (ulong)p;
+                    }
+                }
+
+                status = _eventProvider.EventWriteTransfer(in eventDescriptor, eventHandle, activityID, childActivityID, argCount, userData);
+
+                for (int i = 0; i < refObjIndex; ++i)
+                {
+                    rgGCHandle[i].Free();
                 }
             }
 
@@ -1168,47 +1144,6 @@ namespace System.Diagnostics.Tracing
         public bool IsEnabled()
         {
             return _enabled;
-        }
-
-        /// <summary>
-        /// IsEnabled, method used to test if event is enabled
-        /// </summary>
-        /// <param name="level">
-        /// Level  to test
-        /// </param>
-        /// <param name="keywords">
-        /// Keyword  to test
-        /// </param>
-        public bool IsEnabled(byte level, long keywords)
-        {
-            //
-            // If not enabled at all, return false.
-            //
-            if (!_enabled)
-            {
-                return false;
-            }
-
-            // This also covers the case of Level == 0.
-            if ((level <= _level) ||
-                (_level == 0))
-            {
-                //
-                // Check if Keyword is enabled
-                //
-                // An "any" keyword mask of 0 means "match all keywords", matching
-                // EventSource.IsEnabledCommon and ETW's MatchAnyKeyword == 0 semantics. The final
-                // keyword filtering is still enforced per-session (e.g. by EventPipe natively).
-                //
-                if ((keywords == 0) ||
-                    ((_anyKeywordMask == 0 || (keywords & _anyKeywordMask) != 0) &&
-                     ((keywords & _allKeywordMask) == _allKeywordMask)))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         internal void Enable(byte level, long anyKeyword, long allKeyword)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -469,8 +469,7 @@ namespace System.Diagnostics.Tracing
             // The event descriptor's keywords are OR'd with the reserved session-mask bits when the
             // manifest is created (see EventSource). Strip those bits before the keyword check so this
             // mirrors EventSource.IsEnabledByDefault/IsEnabledCommon, which compare against the
-            // session-mask-cleared keywords. Without this, an event declared with keyword 0 never
-            // matches the keywords == 0 fast path below because its descriptor keyword is non-zero.
+            // session-mask-cleared keywords.
             long keywords = eventDescriptor.Keywords & unchecked((long)~SessionMask.All.ToEventKeywords());
 
             if (IsEnabled(eventDescriptor.Level, keywords))
@@ -1197,11 +1196,9 @@ namespace System.Diagnostics.Tracing
                 //
                 // Check if Keyword is enabled
                 //
-                // An "any" keyword mask of 0 matches all keywords. This mirrors the convention used by
-                // EventSource.IsEnabledCommon and native ETW's MatchAnyKeyword == 0 semantics, so events
-                // reach every sink consistently. In particular, EventPipe/dotnet-trace enable named
-                // providers with keyword 0; without this an event declared with a non-zero keyword would
-                // be dropped here even though the outer IsEnabledCommon gate already enabled it.
+                // An "any" keyword mask of 0 means "match all keywords", matching
+                // EventSource.IsEnabledCommon and ETW's MatchAnyKeyword == 0 semantics. The final
+                // keyword filtering is still enforced per-session (e.g. by EventPipe natively).
                 //
                 if ((keywords == 0) ||
                     ((_anyKeywordMask == 0 || (keywords & _anyKeywordMask) != 0) &&

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2036,33 +2036,30 @@ namespace System.Diagnostics.Tracing
                             childActivityID = &relatedActivityId;
                     }
 
-                    if (metadata.EnabledForETW
+                    if (!SelfDescribingEvents)
+                    {
+                        if (metadata.EnabledForETW && !m_etwProvider.WriteEvent(ref metadata.Descriptor, metadata.EventHandle, pActivityId, childActivityID, args))
+                            ThrowEventSourceException(metadata.Name);
+#if FEATURE_PERFTRACING
+                        if (metadata.EnabledForEventPipe && !m_eventPipeProvider.WriteEvent(ref metadata.Descriptor, metadata.EventHandle, pActivityId, childActivityID, args))
+                            ThrowEventSourceException(metadata.Name);
+#endif // FEATURE_PERFTRACING
+                    }
+                    else if (metadata.EnabledForETW
 #if FEATURE_PERFTRACING
                             || metadata.EnabledForEventPipe
 #endif // FEATURE_PERFTRACING
                         )
                     {
-                        if (!SelfDescribingEvents)
+                        // TODO: activity ID support
+                        EventSourceOptions opt = new EventSourceOptions
                         {
-                            if (!m_etwProvider.WriteEvent(ref metadata.Descriptor, metadata.EventHandle, pActivityId, childActivityID, args))
-                                ThrowEventSourceException(metadata.Name);
-#if FEATURE_PERFTRACING
-                            if (!m_eventPipeProvider.WriteEvent(ref metadata.Descriptor, metadata.EventHandle, pActivityId, childActivityID, args))
-                                ThrowEventSourceException(metadata.Name);
-#endif // FEATURE_PERFTRACING
-                        }
-                        else
-                        {
-                            // TODO: activity ID support
-                            EventSourceOptions opt = new EventSourceOptions
-                            {
-                                Keywords = (EventKeywords)metadata.Descriptor.Keywords,
-                                Level = (EventLevel)metadata.Descriptor.Level,
-                                Opcode = (EventOpcode)metadata.Descriptor.Opcode
-                            };
+                            Keywords = (EventKeywords)metadata.Descriptor.Keywords,
+                            Level = (EventLevel)metadata.Descriptor.Level,
+                            Opcode = (EventOpcode)metadata.Descriptor.Opcode
+                        };
 
-                            WriteMultiMerge(metadata.Name, ref opt, metadata.TraceLoggingEventTypes, pActivityId, childActivityID, args);
-                        }
+                        WriteMultiMerge(metadata.Name, ref opt, metadata.TraceLoggingEventTypes, pActivityId, childActivityID, args);
                     }
 
                     if (m_Dispatchers != null && metadata.EnabledForAnyListener)

--- a/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.cs
+++ b/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.cs
@@ -23,22 +23,17 @@ namespace Tracing.Tests.WriteEventVarargs
             public const EventKeywords MyKeyword = (EventKeywords)0x1;
         }
 
-        // Resolves to the strongly-typed WriteEvent(int, int, string) overload, which
-        // writes to EventPipe based on the per-event EnabledForEventPipe flag.
-        [Event(1)]
-        public void SpecializedEvent(int id, string name) => WriteEvent(1, id, name);
-
         // Boxing the arguments forces the WriteEvent(int, params object?[]) overload, which
         // serializes through EventProvider.WriteEvent(object[]). This path was dropped for
         // EventPipe sessions enabled with keyword 0 because the keyword check did not treat
         // an "any" keyword mask of 0 as "match all keywords".
-        [Event(2)]
-        public void VarargsEvent(int id, string name) => WriteEvent(2, (object)id, (object)name);
+        [Event(1)]
+        public void VarargsEvent(int id, string name) => WriteEvent(1, (object)id, (object)name);
 
         // A varargs event declared with a non-zero keyword, used to validate that the varargs
         // path still flows when a session's keyword mask matches the event's keyword.
-        [Event(3, Keywords = Keywords.MyKeyword)]
-        public void KeywordVarargsEvent(int id, string name) => WriteEvent(3, (object)id, (object)name);
+        [Event(2, Keywords = Keywords.MyKeyword)]
+        public void KeywordVarargsEvent(int id, string name) => WriteEvent(2, (object)id, (object)name);
     }
 
     public class WriteEventVarargs
@@ -55,134 +50,65 @@ namespace Tracing.Tests.WriteEventVarargs
             return RunKeywordMatchScenario();
         }
 
-        private const int Iterations = 100_000;
-
-        // A session enabled with keyword 0 means "match all keywords". Both the specialized and the
-        // object[] varargs overloads must be written to it. Prior to the fix the varargs overload
-        // was dropped because the keyword check did not treat an "any" keyword mask of 0 as match-all.
+        // A session enabled with keyword 0 means "match all keywords". The object[] varargs overload
+        // must be written to it. Prior to the fix this path was dropped
+        // because the keyword check did not treat an "any" keyword mask of 0 as match-all.
         private static int RunKeywordZeroScenario()
         {
-            Logger.logger.Log("=== Scenario: provider enabled with keyword 0 ===");
-
-            var providers = new List<EventPipeProvider>()
-            {
-                new EventPipeProvider("WriteEventVarargsEventSource", EventLevel.Verbose, keywords: 0),
-                new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Verbose)
-            };
-
-            var expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
-            {
-                { "WriteEventVarargsEventSource", new ExpectedEventCount(2 * Iterations, 0.30f) },
-                { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
-                { "Microsoft-DotNETCore-SampleProfiler", -1 }
-            };
-
-            Action eventGeneratingAction = () =>
-            {
-                for (int i = 0; i < Iterations; i++)
-                {
-                    if (i % 10_000 == 0)
-                        Logger.logger.Log($"Fired events {i:N0}/{Iterations:N0} times...");
-
-                    WriteEventVarargsEventSource.Log.SpecializedEvent(i, "specialized");
-                    WriteEventVarargsEventSource.Log.VarargsEvent(i, "varargs");
-                }
-            };
-
-            // Explicitly validate that the varargs (object[]) event is present in the stream.
-            // Without the fix this count is 0 even though the specialized event is emitted.
-            Func<EventPipeEventSource, Func<int>> optionalTraceValidator = (source) =>
-            {
-                int specializedCount = 0;
-                int varargsCount = 0;
-
-                source.Dynamic.All += (eventData) =>
-                {
-                    if (eventData.ProviderName != "WriteEventVarargsEventSource")
-                        return;
-
-                    if (eventData.EventName == "SpecializedEvent")
-                        specializedCount++;
-                    else if (eventData.EventName == "VarargsEvent")
-                        varargsCount++;
-                };
-
-                return () =>
-                {
-                    Logger.logger.Log($"SpecializedEvent count: {specializedCount}");
-                    Logger.logger.Log($"VarargsEvent count: {varargsCount}");
-
-                    if (varargsCount == 0)
-                    {
-                        Logger.logger.Log("VarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
-                        return -1;
-                    }
-
-                    // Both overloads fire the same number of times, so they should have comparable
-                    // counts. Allow generous slack for buffered-event loss under load.
-                    if (Math.Abs(varargsCount - specializedCount) > specializedCount * 0.30f)
-                    {
-                        Logger.logger.Log("VarargsEvent count diverged too far from SpecializedEvent count.");
-                        return -1;
-                    }
-
-                    return 100;
-                };
-            };
-
-            return IpcTraceTest.RunAndValidateEventCounts(expectedEventCounts, eventGeneratingAction, providers, 1024, optionalTraceValidator);
+            return RunScenario(
+                "=== Scenario: provider enabled with keyword 0 ===",
+                sessionKeywords: 0,
+                expectedEventName: nameof(WriteEventVarargsEventSource.VarargsEvent),
+                emitEvent: () => WriteEventVarargsEventSource.Log.VarargsEvent(1, "varargs"),
+                missingEventMessage: "VarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
         }
 
         // A session enabled with a non-zero keyword that matches the event's keyword must also see
         // the varargs overload. This guards the regular (non-zero) keyword path of the varargs write.
         private static int RunKeywordMatchScenario()
         {
-            Logger.logger.Log("=== Scenario: provider enabled with a matching non-zero keyword ===");
+            return RunScenario(
+                "=== Scenario: provider enabled with a matching non-zero keyword ===",
+                sessionKeywords: (long)WriteEventVarargsEventSource.Keywords.MyKeyword,
+                expectedEventName: nameof(WriteEventVarargsEventSource.KeywordVarargsEvent),
+                emitEvent: () => WriteEventVarargsEventSource.Log.KeywordVarargsEvent(1, "keyword"),
+                missingEventMessage: "KeywordVarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
+        }
+
+        private static int RunScenario(string scenarioName, long sessionKeywords, string expectedEventName, Action emitEvent, string missingEventMessage)
+        {
+            Logger.logger.Log(scenarioName);
 
             var providers = new List<EventPipeProvider>()
             {
-                new EventPipeProvider("WriteEventVarargsEventSource", EventLevel.Verbose, keywords: (long)WriteEventVarargsEventSource.Keywords.MyKeyword),
-                new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Verbose)
+                new EventPipeProvider("WriteEventVarargsEventSource", EventLevel.Verbose, keywords: sessionKeywords)
             };
 
             var expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
             {
-                { "WriteEventVarargsEventSource", new ExpectedEventCount(Iterations, 0.30f) },
-                { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
-                { "Microsoft-DotNETCore-SampleProfiler", -1 }
-            };
-
-            Action eventGeneratingAction = () =>
-            {
-                for (int i = 0; i < Iterations; i++)
-                {
-                    if (i % 10_000 == 0)
-                        Logger.logger.Log($"Fired events {i:N0}/{Iterations:N0} times...");
-
-                    WriteEventVarargsEventSource.Log.KeywordVarargsEvent(i, "keyword");
-                }
+                { "WriteEventVarargsEventSource", -1 }
             };
 
             Func<EventPipeEventSource, Func<int>> optionalTraceValidator = (source) =>
             {
-                int keywordVarargsCount = 0;
+                int count = 0;
 
                 source.Dynamic.All += (eventData) =>
                 {
                     if (eventData.ProviderName != "WriteEventVarargsEventSource")
                         return;
 
-                    if (eventData.EventName == "KeywordVarargsEvent")
-                        keywordVarargsCount++;
+                    if (eventData.EventName == expectedEventName)
+                        count++;
                 };
 
                 return () =>
                 {
-                    Logger.logger.Log($"KeywordVarargsEvent count: {keywordVarargsCount}");
+                    Logger.logger.Log($"{expectedEventName} count: {count}");
 
-                    if (keywordVarargsCount == 0)
+                    if (count == 0)
                     {
-                        Logger.logger.Log("KeywordVarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
+                        Logger.logger.Log(missingEventMessage);
                         return -1;
                     }
 
@@ -190,7 +116,7 @@ namespace Tracing.Tests.WriteEventVarargs
                 };
             };
 
-            return IpcTraceTest.RunAndValidateEventCounts(expectedEventCounts, eventGeneratingAction, providers, 1024, optionalTraceValidator);
+            return IpcTraceTest.RunAndValidateEventCounts(expectedEventCounts, emitEvent, providers, 1024, optionalTraceValidator);
         }
     }
 }

--- a/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.cs
+++ b/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.cs
@@ -23,17 +23,17 @@ namespace Tracing.Tests.WriteEventVarargs
             public const EventKeywords MyKeyword = (EventKeywords)0x1;
         }
 
-        // Boxing the arguments forces the WriteEvent(int, params object?[]) overload, which
-        // serializes through EventProvider.WriteEvent(object[]). This path was dropped for
+        // Using the EventSourcePrimitive varargs overload funnels through WriteEventVarargs /
+        // EventProvider.WriteEvent(object[]). This path was dropped for
         // EventPipe sessions enabled with keyword 0 because the keyword check did not treat
         // an "any" keyword mask of 0 as "match all keywords".
         [Event(1)]
-        public void VarargsEvent(int id, string name) => WriteEvent(1, (object)id, (object)name);
+        public void VarargsEvent(int id, string name) => WriteEvent(1, new EventSource.EventSourcePrimitive[] { id, name });
 
         // A varargs event declared with a non-zero keyword, used to validate that the varargs
         // path still flows when a session's keyword mask matches the event's keyword.
         [Event(2, Keywords = Keywords.MyKeyword)]
-        public void KeywordVarargsEvent(int id, string name) => WriteEvent(2, (object)id, (object)name);
+        public void KeywordVarargsEvent(int id, string name) => WriteEvent(2, new EventSource.EventSourcePrimitive[] { id, name });
     }
 
     public class WriteEventVarargs
@@ -47,7 +47,11 @@ namespace Tracing.Tests.WriteEventVarargs
             if (ret != 100)
                 return ret;
 
-            return RunKeywordMatchScenario();
+            ret = RunKeywordMatchScenario();
+            if (ret != 100)
+                return ret;
+
+            return RunNonZeroKeywordScenarioWithKeywordlessAndKeywordedEvents();
         }
 
         // A session enabled with keyword 0 means "match all keywords". The object[] varargs overload
@@ -60,7 +64,7 @@ namespace Tracing.Tests.WriteEventVarargs
                 sessionKeywords: 0,
                 expectedEventName: nameof(WriteEventVarargsEventSource.VarargsEvent),
                 emitEvent: () => WriteEventVarargsEventSource.Log.VarargsEvent(1, "varargs"),
-                missingEventMessage: "VarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
+                missingEventMessage: "VarargsEvent (EventSourcePrimitive[] WriteEvent overload) was not written to EventPipe.");
         }
 
         // A session enabled with a non-zero keyword that matches the event's keyword must also see
@@ -72,7 +76,69 @@ namespace Tracing.Tests.WriteEventVarargs
                 sessionKeywords: (long)WriteEventVarargsEventSource.Keywords.MyKeyword,
                 expectedEventName: nameof(WriteEventVarargsEventSource.KeywordVarargsEvent),
                 emitEvent: () => WriteEventVarargsEventSource.Log.KeywordVarargsEvent(1, "keyword"),
-                missingEventMessage: "KeywordVarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
+                missingEventMessage: "KeywordVarargsEvent (EventSourcePrimitive[] WriteEvent overload) was not written to EventPipe.");
+        }
+
+        // Under a non-zero session keyword, keywordless events (Keywords=0) should still pass
+        // keyword filtering, while keyworded events should continue to match normally.
+        private static int RunNonZeroKeywordScenarioWithKeywordlessAndKeywordedEvents()
+        {
+            Logger.logger.Log("=== Scenario: non-zero keyword session still includes keywordless events ===");
+
+            var providers = new List<EventPipeProvider>()
+            {
+                new EventPipeProvider("WriteEventVarargsEventSource", EventLevel.Verbose, keywords: (long)WriteEventVarargsEventSource.Keywords.MyKeyword)
+            };
+
+            var expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
+            {
+                { "WriteEventVarargsEventSource", -1 }
+            };
+
+            Action emitEvent = () =>
+            {
+                WriteEventVarargsEventSource.Log.VarargsEvent(1, "varargs");
+                WriteEventVarargsEventSource.Log.KeywordVarargsEvent(2, "keyword");
+            };
+
+            Func<EventPipeEventSource, Func<int>> optionalTraceValidator = (source) =>
+            {
+                int varargsCount = 0;
+                int keywordVarargsCount = 0;
+
+                source.Dynamic.All += (eventData) =>
+                {
+                    if (eventData.ProviderName != "WriteEventVarargsEventSource")
+                        return;
+
+                    if (eventData.EventName == nameof(WriteEventVarargsEventSource.VarargsEvent))
+                        varargsCount++;
+                    else if (eventData.EventName == nameof(WriteEventVarargsEventSource.KeywordVarargsEvent))
+                        keywordVarargsCount++;
+                };
+
+                return () =>
+                {
+                    Logger.logger.Log($"VarargsEvent count: {varargsCount}");
+                    Logger.logger.Log($"KeywordVarargsEvent count: {keywordVarargsCount}");
+
+                    if (varargsCount == 0)
+                    {
+                        Logger.logger.Log("VarargsEvent (keywordless event) was not written under non-zero session keywords.");
+                        return -1;
+                    }
+
+                    if (keywordVarargsCount == 0)
+                    {
+                        Logger.logger.Log("KeywordVarargsEvent was not written under matching non-zero session keywords.");
+                        return -1;
+                    }
+
+                    return 100;
+                };
+            };
+
+            return IpcTraceTest.RunAndValidateEventCounts(expectedEventCounts, emitEvent, providers, 1024, optionalTraceValidator);
         }
 
         private static int RunScenario(string scenarioName, long sessionKeywords, string expectedEventName, Action emitEvent, string missingEventMessage)

--- a/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.cs
+++ b/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.cs
@@ -18,6 +18,11 @@ namespace Tracing.Tests.WriteEventVarargs
         private WriteEventVarargsEventSource() { }
         public static WriteEventVarargsEventSource Log = new WriteEventVarargsEventSource();
 
+        public static class Keywords
+        {
+            public const EventKeywords MyKeyword = (EventKeywords)0x1;
+        }
+
         // Resolves to the strongly-typed WriteEvent(int, int, string) overload, which
         // writes to EventPipe based on the per-event EnabledForEventPipe flag.
         [Event(1)]
@@ -29,6 +34,11 @@ namespace Tracing.Tests.WriteEventVarargs
         // an "any" keyword mask of 0 as "match all keywords".
         [Event(2)]
         public void VarargsEvent(int id, string name) => WriteEvent(2, (object)id, (object)name);
+
+        // A varargs event declared with a non-zero keyword, used to validate that the varargs
+        // path still flows when a session's keyword mask matches the event's keyword.
+        [Event(3, Keywords = Keywords.MyKeyword)]
+        public void KeywordVarargsEvent(int id, string name) => WriteEvent(3, (object)id, (object)name);
     }
 
     public class WriteEventVarargs
@@ -38,9 +48,21 @@ namespace Tracing.Tests.WriteEventVarargs
         [Fact]
         public static int TestEntryPoint()
         {
-            // This test validates that both the specialized and the object[] varargs
-            // WriteEvent overloads are written to an EventPipe session that is enabled
-            // with a keyword of 0 (which means "match all keywords").
+            int ret = RunKeywordZeroScenario();
+            if (ret != 100)
+                return ret;
+
+            return RunKeywordMatchScenario();
+        }
+
+        private const int Iterations = 100_000;
+
+        // A session enabled with keyword 0 means "match all keywords". Both the specialized and the
+        // object[] varargs overloads must be written to it. Prior to the fix the varargs overload
+        // was dropped because the keyword check did not treat an "any" keyword mask of 0 as match-all.
+        private static int RunKeywordZeroScenario()
+        {
+            Logger.logger.Log("=== Scenario: provider enabled with keyword 0 ===");
 
             var providers = new List<EventPipeProvider>()
             {
@@ -48,73 +70,127 @@ namespace Tracing.Tests.WriteEventVarargs
                 new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Verbose)
             };
 
-            var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _optionalTraceValidator);
-            if (ret < 0)
-                return ret;
-            else
-                return 100;
+            var expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
+            {
+                { "WriteEventVarargsEventSource", new ExpectedEventCount(2 * Iterations, 0.30f) },
+                { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
+                { "Microsoft-DotNETCore-SampleProfiler", -1 }
+            };
+
+            Action eventGeneratingAction = () =>
+            {
+                for (int i = 0; i < Iterations; i++)
+                {
+                    if (i % 10_000 == 0)
+                        Logger.logger.Log($"Fired events {i:N0}/{Iterations:N0} times...");
+
+                    WriteEventVarargsEventSource.Log.SpecializedEvent(i, "specialized");
+                    WriteEventVarargsEventSource.Log.VarargsEvent(i, "varargs");
+                }
+            };
+
+            // Explicitly validate that the varargs (object[]) event is present in the stream.
+            // Without the fix this count is 0 even though the specialized event is emitted.
+            Func<EventPipeEventSource, Func<int>> optionalTraceValidator = (source) =>
+            {
+                int specializedCount = 0;
+                int varargsCount = 0;
+
+                source.Dynamic.All += (eventData) =>
+                {
+                    if (eventData.ProviderName != "WriteEventVarargsEventSource")
+                        return;
+
+                    if (eventData.EventName == "SpecializedEvent")
+                        specializedCount++;
+                    else if (eventData.EventName == "VarargsEvent")
+                        varargsCount++;
+                };
+
+                return () =>
+                {
+                    Logger.logger.Log($"SpecializedEvent count: {specializedCount}");
+                    Logger.logger.Log($"VarargsEvent count: {varargsCount}");
+
+                    if (varargsCount == 0)
+                    {
+                        Logger.logger.Log("VarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
+                        return -1;
+                    }
+
+                    // Both overloads fire the same number of times, so they should have comparable
+                    // counts. Allow generous slack for buffered-event loss under load.
+                    if (Math.Abs(varargsCount - specializedCount) > specializedCount * 0.30f)
+                    {
+                        Logger.logger.Log("VarargsEvent count diverged too far from SpecializedEvent count.");
+                        return -1;
+                    }
+
+                    return 100;
+                };
+            };
+
+            return IpcTraceTest.RunAndValidateEventCounts(expectedEventCounts, eventGeneratingAction, providers, 1024, optionalTraceValidator);
         }
 
-        private const int Iterations = 100_000;
-
-        private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
+        // A session enabled with a non-zero keyword that matches the event's keyword must also see
+        // the varargs overload. This guards the regular (non-zero) keyword path of the varargs write.
+        private static int RunKeywordMatchScenario()
         {
-            { "WriteEventVarargsEventSource", new ExpectedEventCount(2 * Iterations, 0.30f) },
-            { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
-            { "Microsoft-DotNETCore-SampleProfiler", -1 }
-        };
+            Logger.logger.Log("=== Scenario: provider enabled with a matching non-zero keyword ===");
 
-        private static Action _eventGeneratingAction = () =>
-        {
-            for (int i = 0; i < Iterations; i++)
+            var providers = new List<EventPipeProvider>()
             {
-                if (i % 10_000 == 0)
-                    Logger.logger.Log($"Fired events {i:N0}/{Iterations:N0} times...");
-
-                WriteEventVarargsEventSource.Log.SpecializedEvent(i, "specialized");
-                WriteEventVarargsEventSource.Log.VarargsEvent(i, "varargs");
-            }
-        };
-
-        // Explicitly validate that the varargs (object[]) event is present in the stream.
-        // Without the fix this count is 0 even though the specialized event is emitted.
-        private static Func<EventPipeEventSource, Func<int>> _optionalTraceValidator = (source) =>
-        {
-            int specializedCount = 0;
-            int varargsCount = 0;
-
-            source.Dynamic.All += (eventData) =>
-            {
-                if (eventData.ProviderName != "WriteEventVarargsEventSource")
-                    return;
-
-                if (eventData.EventName == "SpecializedEvent")
-                    specializedCount++;
-                else if (eventData.EventName == "VarargsEvent")
-                    varargsCount++;
+                new EventPipeProvider("WriteEventVarargsEventSource", EventLevel.Verbose, keywords: (long)WriteEventVarargsEventSource.Keywords.MyKeyword),
+                new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Verbose)
             };
 
-            return () =>
+            var expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
             {
-                Logger.logger.Log($"SpecializedEvent count: {specializedCount}");
-                Logger.logger.Log($"VarargsEvent count: {varargsCount}");
-
-                if (varargsCount == 0)
-                {
-                    Logger.logger.Log("VarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
-                    return -1;
-                }
-
-                // Both overloads fire the same number of times, so they should have comparable
-                // counts. Allow generous slack for buffered-event loss under load.
-                if (Math.Abs(varargsCount - specializedCount) > specializedCount * 0.30f)
-                {
-                    Logger.logger.Log("VarargsEvent count diverged too far from SpecializedEvent count.");
-                    return -1;
-                }
-
-                return 100;
+                { "WriteEventVarargsEventSource", new ExpectedEventCount(Iterations, 0.30f) },
+                { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
+                { "Microsoft-DotNETCore-SampleProfiler", -1 }
             };
-        };
+
+            Action eventGeneratingAction = () =>
+            {
+                for (int i = 0; i < Iterations; i++)
+                {
+                    if (i % 10_000 == 0)
+                        Logger.logger.Log($"Fired events {i:N0}/{Iterations:N0} times...");
+
+                    WriteEventVarargsEventSource.Log.KeywordVarargsEvent(i, "keyword");
+                }
+            };
+
+            Func<EventPipeEventSource, Func<int>> optionalTraceValidator = (source) =>
+            {
+                int keywordVarargsCount = 0;
+
+                source.Dynamic.All += (eventData) =>
+                {
+                    if (eventData.ProviderName != "WriteEventVarargsEventSource")
+                        return;
+
+                    if (eventData.EventName == "KeywordVarargsEvent")
+                        keywordVarargsCount++;
+                };
+
+                return () =>
+                {
+                    Logger.logger.Log($"KeywordVarargsEvent count: {keywordVarargsCount}");
+
+                    if (keywordVarargsCount == 0)
+                    {
+                        Logger.logger.Log("KeywordVarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
+                        return -1;
+                    }
+
+                    return 100;
+                };
+            };
+
+            return IpcTraceTest.RunAndValidateEventCounts(expectedEventCounts, eventGeneratingAction, providers, 1024, optionalTraceValidator);
+        }
     }
 }

--- a/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.cs
+++ b/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Tracing;
+using Tracing.Tests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
+using Xunit;
+using TestLibrary;
+
+namespace Tracing.Tests.WriteEventVarargs
+{
+    [EventSource(Name = "WriteEventVarargsEventSource")]
+    public sealed class WriteEventVarargsEventSource : EventSource
+    {
+        private WriteEventVarargsEventSource() { }
+        public static WriteEventVarargsEventSource Log = new WriteEventVarargsEventSource();
+
+        // Resolves to the strongly-typed WriteEvent(int, int, string) overload, which
+        // writes to EventPipe based on the per-event EnabledForEventPipe flag.
+        [Event(1)]
+        public void SpecializedEvent(int id, string name) => WriteEvent(1, id, name);
+
+        // Boxing the arguments forces the WriteEvent(int, params object?[]) overload, which
+        // serializes through EventProvider.WriteEvent(object[]). This path was dropped for
+        // EventPipe sessions enabled with keyword 0 because the keyword check did not treat
+        // an "any" keyword mask of 0 as "match all keywords".
+        [Event(2)]
+        public void VarargsEvent(int id, string name) => WriteEvent(2, (object)id, (object)name);
+    }
+
+    public class WriteEventVarargs
+    {
+        [ActiveIssue("WASM doesn't support diagnostics tracing", TestPlatforms.Browser)]
+        [ActiveIssue("Can't find file dotnet-diagnostic-{pid}-*-socket", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsRiscv64Process))]
+        [Fact]
+        public static int TestEntryPoint()
+        {
+            // This test validates that both the specialized and the object[] varargs
+            // WriteEvent overloads are written to an EventPipe session that is enabled
+            // with a keyword of 0 (which means "match all keywords").
+
+            var providers = new List<EventPipeProvider>()
+            {
+                new EventPipeProvider("WriteEventVarargsEventSource", EventLevel.Verbose, keywords: 0),
+                new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Verbose)
+            };
+
+            var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _optionalTraceValidator);
+            if (ret < 0)
+                return ret;
+            else
+                return 100;
+        }
+
+        private const int Iterations = 100_000;
+
+        private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
+        {
+            { "WriteEventVarargsEventSource", new ExpectedEventCount(2 * Iterations, 0.30f) },
+            { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
+            { "Microsoft-DotNETCore-SampleProfiler", -1 }
+        };
+
+        private static Action _eventGeneratingAction = () =>
+        {
+            for (int i = 0; i < Iterations; i++)
+            {
+                if (i % 10_000 == 0)
+                    Logger.logger.Log($"Fired events {i:N0}/{Iterations:N0} times...");
+
+                WriteEventVarargsEventSource.Log.SpecializedEvent(i, "specialized");
+                WriteEventVarargsEventSource.Log.VarargsEvent(i, "varargs");
+            }
+        };
+
+        // Explicitly validate that the varargs (object[]) event is present in the stream.
+        // Without the fix this count is 0 even though the specialized event is emitted.
+        private static Func<EventPipeEventSource, Func<int>> _optionalTraceValidator = (source) =>
+        {
+            int specializedCount = 0;
+            int varargsCount = 0;
+
+            source.Dynamic.All += (eventData) =>
+            {
+                if (eventData.ProviderName != "WriteEventVarargsEventSource")
+                    return;
+
+                if (eventData.EventName == "SpecializedEvent")
+                    specializedCount++;
+                else if (eventData.EventName == "VarargsEvent")
+                    varargsCount++;
+            };
+
+            return () =>
+            {
+                Logger.logger.Log($"SpecializedEvent count: {specializedCount}");
+                Logger.logger.Log($"VarargsEvent count: {varargsCount}");
+
+                if (varargsCount == 0)
+                {
+                    Logger.logger.Log("VarargsEvent (object[] WriteEvent overload) was not written to EventPipe.");
+                    return -1;
+                }
+
+                // Both overloads fire the same number of times, so they should have comparable
+                // counts. Allow generous slack for buffered-event loss under load.
+                if (Math.Abs(varargsCount - specializedCount) > specializedCount * 0.30f)
+                {
+                    Logger.logger.Log("VarargsEvent count diverged too far from SpecializedEvent count.");
+                    return -1;
+                }
+
+                return 100;
+            };
+        };
+    }
+}

--- a/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.csproj
+++ b/src/tests/tracing/eventpipe/writeeventvarargs/writeeventvarargs.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for GCStressIncompatible, UnloadabilityIncompatible, JitOptimizationSensitive -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/eventpipe_common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes varargs `WriteEvent` delivery semantics for EventPipe/ETW by aligning the varargs path with the existing typed-event path in `EventSource`.

## Problem

The varargs path (`WriteEventVarargs` -> `EventProvider.WriteEvent(..., object?[])`) applied its own provider-level keyword filtering, which diverged from the typed-event call path and caused incorrect behavior for some keyword/session combinations.

## Fix

1. Move backend gating for varargs writes into `EventSource.WriteEventVarargs`, matching the typed overload pattern:
   - ETW call only when `metadata.EnabledForETW`
   - EventPipe call only when `metadata.EnabledForEventPipe`
2. Remove redundant provider-side filtering from `EventProvider.WriteEvent(..., object?[])`.
3. Remove now-unused `IsEnabled(byte level, long keywords)` helper methods in `EventProvider` / `EventProviderImpl`.

## Tests

`writeeventvarargs` regression coverage now validates:
- provider enabled with keyword `0`
- provider enabled with a matching non-zero keyword
- provider enabled with non-zero keyword where both keywordless and keyworded varargs events are emitted, asserting keywordless events are not uniquely dropped

Fixes dotnet/runtime#124518