### PR TITLE
Fix intermittent teardown crash in the cDAC GC stress framework

### DIFF
--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -105,6 +105,7 @@ pr:
     - eng/pipelines/**
     - src/native/managed/cdac/**
     - src/coreclr/debug/runtimeinfo/**
+    - src/coreclr/vm/cdacstress.cpp
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/src/coreclr/vm/cdacstress.cpp
+++ b/src/coreclr/vm/cdacstress.cpp
@@ -566,6 +566,9 @@ void CdacStressPolicy::Shutdown()
     if (!s_initialized)
         return;
 
+    CrstHolder cdacLock(&s_cdacLock);
+    s_initialized = false;
+
     // Print summary to stderr so results are always visible
     LONG totalVerifications = s_passCount + s_failCount + s_knownIssueCount;
     fprintf(stderr,
@@ -652,7 +655,6 @@ void CdacStressPolicy::Shutdown()
         s_cdacHandle = 0;
     }
 
-    s_initialized = false;
     s_cdacStressLevel = 0;
     LOG((LF_GCROOTS, LL_INFO10, "CDAC GC Stress: Shutdown complete\n"));
 }
@@ -1776,13 +1778,15 @@ static void VerifyArgIteratorOnStack(Thread* pThread)
 
 static void VerifyAtStressPoint(Thread* pThread, PCONTEXT regs)
 {
-    _ASSERTE(s_initialized);
     _ASSERTE(pThread != nullptr);
     _ASSERTE(regs != nullptr);
 
     // Serialize cDAC access — the cDAC's ProcessedData cache and COM interfaces
     // are not thread-safe, and GC stress can fire on multiple threads.
     CrstHolder cdacLock(&s_cdacLock);
+
+    if (!s_initialized)
+        return;
 
     DWORD osThreadId = pThread->GetOSThreadId();
 


### PR DESCRIPTION
## Summary

Fixes an intermittent crash at process teardown in the cDAC GC stress framework, seen on arm/arm64 as `exit 139` (SIGSEGV). Each affected run **completes all verifications and prints its summary** (e.g. MultiThread ARGITER `84 pass / 0 fail`), then crashes during shutdown -- so the fault is in teardown, not in the verification logic.

Split out of #130447 so it can land independently.

## Root cause

`CdacStressPolicy::Shutdown` runs from `EEShutDownHelper` before the finalizer/thread rendezvous, so background threads can still be **allocating** (the MultiThread debuggee spins up worker threads). Such a thread can pass the `IsEnabled()` gate and enter `VerifyAtStressPoint`, which uses the cDAC reader and cached COM interfaces, exactly as `Shutdown` releases/frees them -- a use-after-release.

## Fix

`Shutdown` holds `s_cdacLock` across the whole teardown and clears `s_initialized` under it. `VerifyAtStressPoint` re-checks `s_initialized` under the same lock and bails, so no verification runs against state being torn down. `cdac_reader_free` is still called as before.

## Testing

The crash is arm/arm64-only (does not reproduce on x64), so only CI can validate it. An x64 MultiThread stress soak (80 runs) passes with summaries intact and this change does not alter the x64 behavior.

> [!NOTE]
> This PR description and change were produced with the assistance of GitHub Copilot.
