### PR TITLE
[cDAC] Align data-contract docs with merged FieldDesc offset and HandleData changes

### DIFF
--- a/docs/design/datacontracts/GC.md
+++ b/docs/design/datacontracts/GC.md
@@ -839,7 +839,6 @@ private HandleData CreateHandleData(TargetPointer handleAddress, byte uBlock, ui
     HandleData handleData = default;
     handleData.Handle = handleAddress;
     handleData.Type = GetInternalHandleType(type);
-    handleData.JupiterRefCount = 0;
     handleData.IsPegged = false;
     handleData.StrongReference = IsStrongReference(type);
     if (HasSecondary(type))

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -2282,13 +2282,17 @@ uint GetFieldDescType(TargetPointer fieldDescPointer)
 uint GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition? fieldDef)
 {
     uint DWord2 = target.Read<uint>(fieldDescPointer + /* FieldDesc::DWord2 offset */);
-    if (DWord2 == _target.ReadGlobal<uint>("FieldOffsetBigRVA"))
+    // DWord2 packs the 27-bit offset (low bits) with the 5-bit field type (high bits), so the offset
+    // must be masked out before comparing against the big-RVA sentinel. The native runtime compares the
+    // FieldDesc's m_dwOffset bitfield directly (see FieldDesc::GetOffset in src/coreclr/vm/field.h).
+    uint offset = DWord2 & (uint)FieldDescFlags2.OffsetMask;
+    if (offset == _target.ReadGlobal<uint>("FieldOffsetBigRVA"))
     {
         if (fieldDef is null)
             throw new ArgumentNullException(nameof(fieldDef), "Field definition is required for big RVA fields");
         return (uint)fieldDef.Value.GetRelativeVirtualAddress();
     }
-    return DWord2 & (uint)FieldDescFlags2.OffsetMask;
+    return offset;
 }
 
 TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer, bool unboxValueTypes = true)

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -2219,7 +2219,7 @@ The FieldDesc APIs of RuntimeTypeSystem version 1 depend on the following global
 
 | Global name | Meaning |
 | --- | --- |
-| `FieldOffsetBigRVA` | Sentinel value of `FieldDesc::DWord2` indicating the field is an RVA static whose offset is too large to encode in the bitfield; the real offset must be read from the field's metadata (`FieldDefinition.GetRelativeVirtualAddress`). |
+| `FieldOffsetBigRVA` | Sentinel value of `FieldDesc`'s offset bitfield (`m_dwOffset`, i.e. `DWord2 & OffsetMask`) indicating the field is an RVA static whose offset is too large to encode in the bitfield; the real offset must be read from the field's metadata (`FieldDefinition.GetRelativeVirtualAddress`). |
 | `FieldOffsetNewEnc` | Sentinel value of `FieldDesc`'s offset bitfield indicating the field was added via Edit-and-Continue and does not yet have backing storage. |
 
 The FieldDesc APIs of RuntimeTypeSystem version 1 depend on the following data descriptors:


### PR DESCRIPTION
## Summary
Small docs-only follow-up aligning the cDAC data-contract documentation with two recently merged changes that updated the contract implementations but not their docs.

### 1. `RuntimeTypeSystem.md` -- big-RVA offset masking (follow-up to #130501)
#130501 fixed big-RVA field-offset detection by masking the packed type bits before comparing `FieldDesc::DWord2` against the `FIELD_OFFSET_BIG_RVA` sentinel, but left the `GetFieldDescOffset` pseudocode showing the old unmasked comparison. Updated the pseudocode to mask the offset out of the packed `DWord2` (27-bit offset + 5-bit type) before the sentinel check, matching the shipped implementation and native `FieldDesc::GetOffset`.

### 2. `GC.md` -- `JupiterRefCount` removal (follow-up to #130448)
#130448 removed the vestigial `JupiterRefCount` field from the cDAC `HandleData` contract, but left the `CreateHandleData` pseudocode setting it. Removed the stale `handleData.JupiterRefCount = 0;` assignment. (The COM ABI struct still exposes the field and reports `0`, unchanged.)

Docs-only change.
