### PR TITLE
cDAC review instructions: require doc updates for contract/data-descriptor changes

### DIFF
--- a/.github/instructions/cdac.instructions.md
+++ b/.github/instructions/cdac.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "src/native/managed/cdac/**"
+applyTo: "src/native/managed/cdac/**,docs/design/datacontracts/**,src/coreclr/**/datadescriptor/**"
 ---
 
 # cDAC — Folder-Specific Guidance
@@ -32,3 +32,17 @@ When porting `HRESULT`-returning APIs to throw exceptions, the following mapping
 - `ArgumentException` → for `E_INVALIDARG`
 - `NullReferenceException` → for `E_POINTER`
 - `InvalidCastException` → for `E_NOINTERFACE`
+
+## Documentation updates (ALL branches)
+
+`docs/design/datacontracts/<Name>.md` is the authoritative spec of each contract (1:1 with `Abstractions/Contracts/I<Name>.cs`). If the PR changes any of the following without also updating the doc, **MUST** flag it as an error citing the exact doc file:
+
+- **`Abstractions/Contracts/I<Name>.cs`** — added, removed, or renamed methods, or new exposed types/enums.
+- **`Contracts/Contracts/<Name>_<N>.cs`** — a new version file (needs a new `## Version N` section), or a semantic change to an existing version's algorithm. Pure refactors don't need doc updates.
+- **New contract** (new `I<Name>.cs` + `<Name>_1.cs`) — needs a new `docs/design/datacontracts/<Name>.md`.
+- **`src/coreclr/**/datadescriptor/**`** — every consuming contract's doc must reflect added/removed/renamed types, fields, or globals.
+- **New `Contracts/Data/<Type>.cs`** or new `Target.ReadGlobal*` in a contract impl — the consuming contract's doc must document it.
+
+Do **NOT** require doc updates for pure refactors, test-only changes, bug fixes that restore documented behavior, `Legacy/**` (SOSDacImpl, DacDbi shim), or build/CI changes.
+
+

--- a/.github/instructions/cdac.instructions.md
+++ b/.github/instructions/cdac.instructions.md
@@ -40,8 +40,7 @@ When porting `HRESULT`-returning APIs to throw exceptions, the following mapping
 - **`Abstractions/Contracts/I<Name>.cs`** — added, removed, or renamed methods, or new exposed types/enums.
 - **`Contracts/Contracts/<Name>_<N>.cs`** — a new version file (needs a new `## Version N` section), or a semantic change to an existing version's algorithm. Pure refactors don't need doc updates.
 - **New contract** (new `I<Name>.cs` + `<Name>_1.cs`) — needs a new `docs/design/datacontracts/<Name>.md`.
-- **`src/coreclr/**/datadescriptor/**`** — every consuming contract's doc must reflect added/removed/renamed types, fields, or globals.
-- **New `Contracts/Data/<Type>.cs`** or new `Target.ReadGlobal*` in a contract impl — the consuming contract's doc must document it.
+- **`src/coreclr/**/datadescriptor/**`** — added, removed, or renamed types, fields, or globals may need a matching update in every consuming contract's doc; check whichever contracts' algorithms are affected.
 
 Do **NOT** require doc updates for pure refactors, test-only changes, bug fixes that restore documented behavior, `Legacy/**` (SOSDacImpl, DacDbi shim), or build/CI changes.
 


### PR DESCRIPTION
Improves the cDAC Copilot PR-review instructions so reviews consistently flag missing doc updates for contract and data-descriptor changes.

## Motivation

Copilot PR reviews on cDAC changes have repeatedly missed cases where `docs/design/datacontracts/<Name>.md` should have been updated alongside the code. The doc under `docs/design/datacontracts/` is the authoritative spec of each contract (1:1 with `Abstractions/Contracts/I<Name>.cs`) and it drifts silently when reviewers don't check it.

## Change

Two edits to `.github/instructions/cdac.instructions.md`:

1. **Broaden `applyTo`** so these instructions load for PRs that touch:
   - `src/native/managed/cdac/**` (existing)
   - `docs/design/datacontracts/**` (new)
   - `src/coreclr/**/datadescriptor/**` (new -- catches all three datadescriptor dirs: `vm/`, `gc/`, `nativeaot/Runtime/`)

2. **Add a "Documentation updates" section** with a short list of change patterns that MUST have a matching doc update:
   - `Abstractions/Contracts/I<Name>.cs` -- add/remove/rename methods, new exposed types/enums
   - `Contracts/Contracts/<Name>_<N>.cs` -- new version file, or semantic change to an existing version's algorithm (pure refactors excluded)
   - New contract entirely -- new `docs/design/datacontracts/<Name>.md`
   - `src/coreclr/**/datadescriptor/**` -- consuming contract's doc may need to reflect the change; check affected algorithms

   With an explicit exclusion list (pure refactors, test-only, restored-behavior bug fixes, `Legacy/**`, build/CI).

Kept the section deliberately short (~11 lines) -- shorter instruction blocks have produced better reviewer behavior than longer ones.

> [!NOTE]
> This PR was drafted with assistance from GitHub Copilot.
