### PR TITLE
Fix for 130437

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2161,7 +2161,9 @@ void CodeGen::instGen_Set_Reg_To_Base_Plus_Imm(emitAttr       size,
     else
     {
         instGen_Set_Reg_To_Imm(size, dstReg, imm);
-        GetEmitter()->emitIns_R_R_R(INS_add, size, dstReg, dstReg, baseReg);
+        // baseReg might be SP, which must be reg2
+        // an "add R0, R1, SP" is not encodable
+        GetEmitter()->emitIns_R_R_R(INS_add, size, dstReg, baseReg, dstReg);
     }
 }
 


### PR DESCRIPTION
Assertion failed 'isGeneralRegister(reg3)' in jitstress-random.

`STRESS_SPLIT_TREES_RANDOMLY` forced both a mask and a 4096b struct into locals that get spilled.

Hit assertion when we try to spill the mask to [SP+4120].  4120 isn't encodable for a predicate store, so we need `instGen_Set_Reg_To_Base_Plus_Imm`.  This tried to create an add where SP was the last operand - this is not allowed to be encoded.

Fix to swap the order of the operands on the add.  We get this now:

```
IN001d:             mov     xip1, #0x1018
IN001e:             add     xip1, sp, xip1
IN001f:             str     p0, [xip1]	// [V33 rat0]
```