### PR TITLE
JIT: Coalesce stores from struct copies

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1397,6 +1397,12 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                             indirFlags |= GTF_IND_TGT_NOT_HEAP;
                         }
                     }
+                    if (m_store->OperIsCopyBlkOp() && !varTypeIsGC(srcType))
+                    {
+                        // This store is one piece of copying an entire struct from source to destination.
+                        // Our memory model allows us to do this in a non-atomic way, so we can mark this store as such.
+                        indirFlags |= GTF_IND_ALLOW_NON_ATOMIC;
+                    }
                     dstFldStore = m_compiler->gtNewStoreIndNode(srcType, fldAddr, srcFld, indirFlags);
                 }
             }

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1190,6 +1190,11 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
         return tree;
     };
 
+    auto getCopyIndirFlags = [](var_types type) {
+        // These accesses are pieces of a whole struct copy, so non-GC accesses do not need to be atomic.
+        return varTypeIsGC(type) ? GTF_EMPTY : GTF_IND_ALLOW_NON_ATOMIC;
+    };
+
     auto grabAddr = [=, &result](unsigned offs) {
         GenTree* addrClone = nullptr;
         // Need address of the source.
@@ -1337,7 +1342,7 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                     else
                     {
                         GenTree* fldAddr = grabAddr(fldOffset);
-                        srcFld           = m_compiler->gtNewIndir(destType, fldAddr);
+                        srcFld           = m_compiler->gtNewIndir(destType, fldAddr, getCopyIndirFlags(destType));
                     }
                 }
             }
@@ -1388,20 +1393,14 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                 else
                 {
                     GenTree*     fldAddr    = grabAddr(srcFieldOffset);
-                    GenTreeFlags indirFlags = GTF_EMPTY;
+                    GenTreeFlags indirFlags = getCopyIndirFlags(srcType);
                     if (m_store->OperIs(GT_STORE_BLK, GT_STOREIND))
                     {
-                        indirFlags = m_store->gtFlags & (GTF_IND_TGT_NOT_HEAP | GTF_IND_TGT_HEAP);
+                        indirFlags |= m_store->gtFlags & (GTF_IND_TGT_NOT_HEAP | GTF_IND_TGT_HEAP);
                         if (m_store->OperIs(GT_STORE_BLK) && m_store->AsBlk()->GetLayout()->IsStackOnly(m_compiler))
                         {
                             indirFlags |= GTF_IND_TGT_NOT_HEAP;
                         }
-                    }
-                    if (m_store->OperIsCopyBlkOp() && !varTypeIsGC(srcType))
-                    {
-                        // This store is one piece of copying an entire struct from source to destination.
-                        // Our memory model allows us to do this in a non-atomic way, so we can mark this store as such.
-                        indirFlags |= GTF_IND_ALLOW_NON_ATOMIC;
                     }
                     dstFldStore = m_compiler->gtNewStoreIndNode(srcType, fldAddr, srcFld, indirFlags);
                 }

--- a/src/coreclr/jit/promotiondecomposition.cpp
+++ b/src/coreclr/jit/promotiondecomposition.cpp
@@ -1159,12 +1159,19 @@ private:
         //
         GenTreeFlags GetIndirFlags(var_types type)
         {
-            if (genTypeSize(type) == 1)
+            GenTreeFlags flags = m_indirFlags;
+            if (!varTypeIsGC(type))
             {
-                return m_indirFlags & ~GTF_IND_UNALIGNED;
+                // These accesses are pieces of a whole struct copy, so they do not need to be atomic.
+                flags |= GTF_IND_ALLOW_NON_ATOMIC;
             }
 
-            return m_indirFlags;
+            if (genTypeSize(type) == 1)
+            {
+                flags &= ~GTF_IND_UNALIGNED;
+            }
+
+            return flags;
         }
     };
 


### PR DESCRIPTION
Allows existing store coalescing to merge non-GC field stores produced by struct copies.

```cs
Int128 _fld;

void Foo1(out Int128 x) => x = new Int128(2L, 1L);

void Foo2() => _fld = 123456789;
```

```diff
 Foo1:
- mov      qword ptr [rdx], 1
- mov      qword ptr [rdx+0x08], 2
+ vmovups  xmm0, xmmword ptr [reloc @RWD00]
+ vmovups  xmmword ptr [rdx], xmm0

 Foo2:
- mov      qword ptr [rcx+0x08], 0x75BCD15
- xor      eax, eax
- mov      qword ptr [rcx+0x10], rax
+ vmovss   xmm0, dword ptr [reloc @RWD00]
+ vmovups  xmmword ptr [rcx+0x08], xmm0
```
