### PR TITLE
Pass down DJI and MethodDesc to avoid unnecessary PtrHashMap lookup

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1457,7 +1457,7 @@ bool DebuggerController::BindPatch(DebuggerControllerPatch *patch,
     _ASSERTE(g_patches != NULL);
 
     CORDB_ADDRESS_TYPE *addr = (CORDB_ADDRESS_TYPE *)
-                               CodeRegionInfo::GetCodeRegionInfo(NULL, NULL, startAddr).OffsetToAddress(patch->offset);
+                               CodeRegionInfo::GetCodeRegionInfo(info, pMD, startAddr).OffsetToAddress(patch->offset);
     g_patches->BindPatch(patch, addr);
 
     LOG((LF_CORDB, LL_INFO10000, "DC::BP:Binding patch at %p (off:0x%zx)\n", addr, patch->offset));


### PR DESCRIPTION
## Description

This ports the fix from #126247 to `main`. `DebuggerController::BindPatch` already has the `DebuggerJitInfo` and `MethodDesc` needed by `CodeRegionInfo::GetCodeRegionInfo`, so this change passes them through instead of forcing the fallback lookup path.

That keeps `main` aligned with the servicing fix and avoids an unnecessary `PtrHashMap` lookup while binding patches in `src/coreclr/debug/ee/controller.cpp`.

> [!NOTE]
> This PR description was generated with GitHub Copilot.