### PR TITLE
[wasm] Fix CoreCLR P/Invoke EntryCount for libSystem.Globalization.Native

### DIFF
--- a/src/coreclr/vm/wasm/browser/callhelpers-pinvoke.cpp
+++ b/src/coreclr/vm/wasm/browser/callhelpers-pinvoke.cpp
@@ -323,7 +323,7 @@ typedef struct PInvokeTable {
 } PInvokeTable;
 
 static PInvokeTable s_PInvokeTables[] = {
-    {"libSystem.Globalization.Native", s_libSystem_Globalization_Native, 33},
+    {"libSystem.Globalization.Native", s_libSystem_Globalization_Native, 34},
     {"libSystem.IO.Compression.Native", s_libSystem_IO_Compression_Native, 9},
     {"libSystem.Native", s_libSystem_Native, 94},
     {"libSystem.Native.Browser", s_libSystem_Native_Browser, 1},

--- a/src/coreclr/vm/wasm/wasi/callhelpers-pinvoke.cpp
+++ b/src/coreclr/vm/wasm/wasi/callhelpers-pinvoke.cpp
@@ -423,7 +423,7 @@ typedef struct PInvokeTable {
 } PInvokeTable;
 
 static PInvokeTable s_PInvokeTables[] = {
-    {"libSystem.Globalization.Native", s_libSystem_Globalization_Native, 33},
+    {"libSystem.Globalization.Native", s_libSystem_Globalization_Native, 34},
     {"libSystem.IO.Compression.Native", s_libSystem_IO_Compression_Native, 8},
     {"libSystem.Native", s_libSystem_Native, 146},
     {"wasi:clocks/monotonic-clock@0.2.8", s_wasi_3A_clocks_2F_monotonic_clock_40_0_2_8, 4},


### PR DESCRIPTION
## Summary

Fixes the browser-wasm **CoreCLR** library test leg (`WasmTestOnChrome-CLR` → `System.Globalization.Extensions.Tests`), failing on `main` since 2026-07-09 with:

```
System.DllNotFoundException : Unable to load shared library 'libSystem.Globalization.Native' ...
dynamic linking not enabled
   at Interop.Globalization.ToUnicode(...)
   at System.Globalization.IdnMapping.IcuTryGetUnicodeCore(...)
```

Tracked by #130479 (`blocking-clean-ci`).

## Root cause

#130140 added `GlobalizationNative_InitOrdinalLowerCasingPage` to the generated `callhelpers-pinvoke.cpp` P/Invoke tables (browser + wasi) — correctly inserting the sorted entry and its `extern "C"` declaration — but did **not** update the hard-coded `EntryCount` in `s_PInvokeTables` (left at `33`, now `34` entries).

`minipal_resolve_dllimport` (`src/native/minipal/entrypoints.h`) linearly scans `entries[0 .. count-1]`. With `count = 33` over the 34-entry table, the **last** entry — `GlobalizationNative_ToUnicode` — became unreachable, so its P/Invoke resolved to `NULL` and fell back to `dlopen` (unsupported for CoreCLR-wasm) → `DllNotFoundException`. This is why **only** `IdnMapping.GetUnicode`/`ToUnicode` tests failed while `GetAscii` (`ToAscii`, index 32, still in range) kept passing.

The generator emits this count from the table length, so `34` is exactly what a regeneration produces; #130140 hand-edited the generated file without re-running it.

## Fix

Bump the `libSystem.Globalization.Native` `EntryCount` from `33` → `34` in both:
- `src/coreclr/vm/wasm/browser/callhelpers-pinvoke.cpp`
- `src/coreclr/vm/wasm/wasi/callhelpers-pinvoke.cpp`

All other module counts already match their tables (verified in both files).

## Regression window (bisected on `main`, definition 129)

| Build | SHA | `LibraryTestsCoreCLR` |
|---|---|---|
| 1500867 (Jul 9 08:00) | `0f907bfa` (no #130140) | ✅ pass |
| 1502091 (Jul 9 20:00) | `6c584914` (has #130140) | ❌ fail — same signature |

Emscripten 5.0.6/LLVM23 (Jun 25) and -O3 (#130111, Jul 2) were ruled out — the leg stayed green with both for two weeks.

## Verification

- Native reproduction against the real `minipal/entrypoints.h`: `ToUnicode` resolves `NULL` at count 33 and `FOUND` at count 34; `ToAscii` resolves at 33 (matches the observed pass/fail split).
- The browser-wasm CoreCLR `WasmTestOnChrome-CLR` CI leg exercises this end-to-end.

cc @tarekgh @pavelsavara @lewing

> [!NOTE]
> Root-cause investigation and this fix were produced with GitHub Copilot.