### PR TITLE
[release/10.0] Use volatile access for CoreCLR dictionary layout publication

### DIFF
--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -1533,7 +1533,7 @@ public:
     {
         SUPPORTS_DAC;
         WRAPPER_NO_CONTRACT;
-        return HasOptionalFields() ? GetOptionalFields()->m_pDictLayout : NULL;
+        return HasOptionalFields() ? VolatileLoad(&GetOptionalFields()->m_pDictLayout) : NULL;
     }
 
     void SetDictionaryLayout(PTR_DictionaryLayout pLayout)
@@ -1541,7 +1541,7 @@ public:
         SUPPORTS_DAC;
         WRAPPER_NO_CONTRACT;
         _ASSERTE(HasOptionalFields());
-        GetOptionalFields()->m_pDictLayout = pLayout;
+        VolatileStore(&GetOptionalFields()->m_pDictLayout, pLayout);
     }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -3570,7 +3570,7 @@ public:
     PTR_DictionaryLayout GetDictLayoutRaw()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        return m_pDictLayout;
+        return VolatileLoad(&m_pDictLayout);
     }
 
     PTR_MethodDesc IMD_GetWrappedMethodDesc()
@@ -3589,10 +3589,10 @@ public:
         if (IMD_IsWrapperStubWithInstantiations() && IMD_HasMethodInstantiation())
         {
             InstantiatedMethodDesc* pIMD = IMD_GetWrappedMethodDesc()->AsInstantiatedMethodDesc();
-            return pIMD->m_pDictLayout;
+            return VolatileLoad(&pIMD->m_pDictLayout);
         }
         else if (IMD_IsSharedByGenericMethodInstantiations())
-            return m_pDictLayout;
+            return VolatileLoad(&m_pDictLayout);
         else
             return NULL;
     }
@@ -3603,11 +3603,11 @@ public:
         if (IMD_IsWrapperStubWithInstantiations() && IMD_HasMethodInstantiation())
         {
             InstantiatedMethodDesc* pIMD = IMD_GetWrappedMethodDesc()->AsInstantiatedMethodDesc();
-            pIMD->m_pDictLayout = pNewLayout;
+            VolatileStore(&pIMD->m_pDictLayout, pNewLayout);
         }
         else if (IMD_IsSharedByGenericMethodInstantiations())
         {
-            m_pDictLayout = pNewLayout;
+            VolatileStore(&m_pDictLayout, pNewLayout);
         }
     }
 #endif // !DACCESS_COMPILE


### PR DESCRIPTION
Backport of #129763 to release/10.0.

## Customer Impact
Intermittent SIGSEGV in `dotnet build`/test/`testhost` on arm64 under parallel load: the runtime faults in generic dictionary/method resolution (`GenericsHelpers.GenericHandleWorker` → `ClassWithSlotAndModule`) due to a racing, non-volatile publication of the dictionary-layout pointer (`m_pDictLayout`). Reproduces reliably on NVIDIA DGX Spark (GB10, 20-core arm64) — roughly 1 in 30 heavily-parallel `dotnet build` runs. Not fixed in release/10.0 (10.0.926 / current SDKs); #129763 is main-only.

## Regression?
No. Long-standing; exposed by weakly-ordered arm64 hardware under high parallelism.

## Testing
Built release/10.0 with and without this change, overlaid only `libcoreclr.so` (JIT and `System.Private.CoreLib.dll` byte-identical between the two arms), and ran parallel `dotnet build -c Release` of a large solution on 2× GB10 under production CI load:

| release/10.0 runtime | runs | SIGSEGV |
| --- | --- | --- |
| unpatched          | 166  | 5 |
| + this backport    | 165  | 0 |

All five crashes symbolized to the dictionary-layout resolution path (`GenericHandleWorker`/`ClassWithSlotAndModule`), called from `ImmutableDictionary<__Canon,…>` enumeration. Probability the patched side's zero is chance, given the unpatched rate, ≈ e⁻⁵ ≈ 0.007.

## Risk
Low. Narrow change — only the `m_pDictLayout` accessors in `class.h` (`EEClass`) and `method.hpp` (`InstantiatedMethodDesc`) switch to `VolatileLoad`/`VolatileStore`; no behavior change outside dictionary-layout publication.
