### PR TITLE
Fix extra negative sign when a value rounds to zero in a two-section custom format

### DIFF
--- a/src/libraries/Common/src/System/Number.Formatting.Common.cs
+++ b/src/libraries/Common/src/System/Number.Formatting.Common.cs
@@ -522,10 +522,10 @@ namespace System
             // negative zero -- it can fall back to the first section (for example -0.001 or -0.0
             // with "+0.00;-0.00"). In that case the first section already contains the caller's
             // desired representation and we must not emit an extra sign, which would otherwise
-            // produce output such as "-+0.00".
-            bool signHandledBySection = number.IsNegative && FindSection(format, 1) != 0;
-
-            if (number.IsNegative && (section == 0) && (number.Scale != 0) && !signHandledBySection)
+            // produce output such as "-+0.00". This only matters when 'section == 0', so
+            // 'HasNegativeSection' is evaluated lazily behind that check to avoid an extra format
+            // scan on the common path where the negative section is used directly ('section != 0').
+            if (number.IsNegative && (section == 0) && (number.Scale != 0) && !HasNegativeSection(format))
             {
                 vlb.Append(info.NegativeSignTChar<TChar>());
             }
@@ -713,7 +713,7 @@ namespace System
                 }
             }
 
-            if (number.IsNegative && (section == 0) && (number.Scale == 0) && (vlb.Length > 0) && !signHandledBySection)
+            if (number.IsNegative && (section == 0) && (number.Scale == 0) && (vlb.Length > 0) && !HasNegativeSection(format))
             {
                 vlb.Insert(0, info.NegativeSignTChar<TChar>());
             }
@@ -1129,6 +1129,11 @@ namespace System
                 return digit >= '5';
             }
         }
+
+        // A distinct negative section always begins after the first ';', so its offset is > 0.
+        // FindSection returns 0 both for the first section and when no such section exists, so a
+        // non-zero result reliably indicates the format defines a dedicated negative section.
+        private static bool HasNegativeSection(ReadOnlySpan<char> format) => FindSection(format, 1) != 0;
 
         private static unsafe int FindSection(ReadOnlySpan<char> format, int section)
         {

--- a/src/libraries/Common/src/System/Number.Formatting.Common.cs
+++ b/src/libraries/Common/src/System/Number.Formatting.Common.cs
@@ -517,7 +517,15 @@ namespace System
                 }
             }
 
-            if (number.IsNegative && (section == 0) && (number.Scale != 0))
+            // A dedicated negative section (the portion after the first ';') is responsible for
+            // emitting the sign of negative values. When a negative value rounds to zero -- or is
+            // negative zero -- it can fall back to the first section (for example -0.001 or -0.0
+            // with "+0.00;-0.00"). In that case the first section already contains the caller's
+            // desired representation and we must not emit an extra sign, which would otherwise
+            // produce output such as "-+0.00".
+            bool signHandledBySection = number.IsNegative && FindSection(format, 1) != 0;
+
+            if (number.IsNegative && (section == 0) && (number.Scale != 0) && !signHandledBySection)
             {
                 vlb.Append(info.NegativeSignTChar<TChar>());
             }
@@ -705,7 +713,7 @@ namespace System
                 }
             }
 
-            if (number.IsNegative && (section == 0) && (number.Scale == 0) && (vlb.Length > 0))
+            if (number.IsNegative && (section == 0) && (number.Scale == 0) && (vlb.Length > 0) && !signHandledBySection)
             {
                 vlb.Insert(0, info.NegativeSignTChar<TChar>());
             }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.cs
@@ -1030,6 +1030,27 @@ namespace System.Tests
             Assert.Throws<FormatException>(() => d.ToString("E000001000000000"));
         }
 
+        [Theory]
+        // A value that rounds to zero in a two-section format falls back to the first (positive)
+        // section, which supplies the sign. The formatter must not also emit its own sign.
+        [InlineData(-0.001, "+0.00;-0.00", "+0.00")]
+        [InlineData(-0.0, "+0.00;-0.00", "+0.00")]
+        [InlineData(0.0, "+0.00;-0.00", "+0.00")]
+        [InlineData(0.001, "+0.00;-0.00", "+0.00")]
+        [InlineData(1.5, "+0.00;-0.00", "+1.50")]
+        [InlineData(-1.5, "+0.00;-0.00", "-1.50")]
+        // A two-section format whose first section is unsigned must not gain a leading sign on fallback.
+        [InlineData(-0.001, "0.00;minus 0.00", "0.00")]
+        // A single-section format still emits the sign for negative values that round to zero (by design).
+        [InlineData(-0.001, "0.00", "-0.00")]
+        [InlineData(-0.0, "0.00", "-0.00")]
+        // A three-section format routes rounds-to-zero values to the dedicated zero section.
+        [InlineData(-0.001, "+0.00;-0.00;zero", "zero")]
+        public static void ToString_SectionSeparator(double d, string format, string expected)
+        {
+            Assert.Equal(expected, d.ToString(format, NumberFormatInfo.InvariantInfo));
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))] // Requires a lot of memory
         [OuterLoop("Takes a long time, allocates a lot of memory")]
         [SkipOnMono("Frequently throws OOM on Mono")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/70460

A negative value that rounds to zero -- or is negative zero -- when formatted with a two-section custom numeric format such as `+0.00;-0.00` was gaining an extra leading sign, producing output like `-+0.00`:

```csharp
(-0.001).ToString("+0.00;-0.00"); // "-+0.00", expected "+0.00"
```

`NumberToStringFormat` auto-emits a negative sign at two sites whenever `IsNegative && section == 0`. When a negative value rounds to zero (or is `-0.0`) in a two-section format, it correctly falls back to the first section (`section` becomes `0`), but `IsNegative` is still `true`, so the formatter injected an extra sign on top of the section's own `+`. This has been the behavior since .NET Core 3.0 (it produced `+0.00` on .NET Framework and .NET Core 2.1).

The fix gates both sign-append sites on whether the format actually defines a dedicated negative section (the portion after the first `;`). When it does, that section owns the sign, so no extra sign is auto-injected on fallback. Single-section formats keep the by-design `-0.00` behavior from #32237.

`----------`

Verified the added regression theory fails on the fallback cases without the fix and passes with it. Full `DoubleTests`, `DecimalTests`, `SingleTests`, and `HalfTests` pass (the change lives in shared `Number.Formatting.Common.cs`, covering every numeric type).

> [!NOTE]
> This PR description and the changes were drafted with GitHub Copilot.