### PR TITLE
Improve integer CopySign with branchless bit-twiddling

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -1209,28 +1209,19 @@ namespace System
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static Int128 CopySign(Int128 value, Int128 sign)
         {
-            // Int128 isn't hardware accelerated, so we operate on the halves directly and compute the
-            // sign mask once rather than materializing the intermediate Int128 values that the general
-            // `(value ^ signMask) - signMask` form would produce.
-
             // signMask is all-bits-set when value and sign differ in sign, in which case value needs to be negated.
-            ulong signMask = (ulong)((long)(value._upper ^ sign._upper) >> 63);
+            Int128 signMask = (value ^ sign) >> 127;
 
             // Branchless conditional negate: (x ^ -1) - (-1) == -x; (x ^ 0) - 0 == x
-            ulong lower = value._lower ^ signMask;
-            ulong upper = value._upper ^ signMask;
+            Int128 result = (value ^ signMask) - signMask;
 
-            ulong resultLower = lower - signMask;
-            ulong borrow = (resultLower > lower) ? 1UL : 0UL;
-            ulong resultUpper = upper - signMask - borrow;
-
-            if (((long)sign._upper >= 0) && ((long)resultUpper < 0))
+            if (IsPositive(sign) && IsNegative(result))
             {
                 // value was Int128.MinValue and a non-negative result was requested, which is unrepresentable.
                 Math.ThrowNegateTwosCompOverflow();
             }
 
-            return new Int128(resultUpper, resultLower);
+            return result;
         }
 
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -1209,22 +1209,28 @@ namespace System
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static Int128 CopySign(Int128 value, Int128 sign)
         {
-            Int128 absValue = value;
+            // Int128 isn't hardware accelerated, so we operate on the halves directly and compute the
+            // sign mask once rather than materializing the intermediate Int128 values that the general
+            // `(value ^ signMask) - signMask` form would produce.
 
-            if (IsNegative(absValue))
+            // signMask is all-bits-set when value and sign differ in sign, in which case value needs to be negated.
+            ulong signMask = (ulong)((long)(value._upper ^ sign._upper) >> 63);
+
+            // Branchless conditional negate: (x ^ -1) - (-1) == -x; (x ^ 0) - 0 == x
+            ulong lower = value._lower ^ signMask;
+            ulong upper = value._upper ^ signMask;
+
+            ulong resultLower = lower - signMask;
+            ulong borrow = (resultLower > lower) ? 1UL : 0UL;
+            ulong resultUpper = upper - signMask - borrow;
+
+            if (((long)sign._upper >= 0) && ((long)resultUpper < 0))
             {
-                absValue = -absValue;
+                // value was Int128.MinValue and a non-negative result was requested, which is unrepresentable.
+                Math.ThrowNegateTwosCompOverflow();
             }
 
-            if (IsPositive(sign))
-            {
-                if (IsNegative(absValue))
-                {
-                    Math.ThrowNegateTwosCompOverflow();
-                }
-                return absValue;
-            }
-            return -absValue;
+            return new Int128(resultUpper, resultLower);
         }
 
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -609,24 +609,17 @@ namespace System
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static short CopySign(short value, short sign)
         {
-            short absValue = value;
+            // signMask is all-bits-set when value and sign differ in sign, in which case value needs to be negated.
+            int signMask = (value ^ sign) >> 31;
+            short result = (short)((value ^ signMask) - signMask);
 
-            if (absValue < 0)
+            if ((sign >= 0) && (result < 0))
             {
-                absValue = (short)(-absValue);
+                // value was short.MinValue and a non-negative result was requested, which is unrepresentable.
+                Math.ThrowNegateTwosCompOverflow();
             }
 
-            if (sign >= 0)
-            {
-                if (absValue < 0)
-                {
-                    Math.ThrowNegateTwosCompOverflow();
-                }
-
-                return absValue;
-            }
-
-            return (short)(-absValue);
+            return result;
         }
 
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -651,24 +651,17 @@ namespace System
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static int CopySign(int value, int sign)
         {
-            int absValue = value;
+            // signMask is all-bits-set when value and sign differ in sign, in which case value needs to be negated.
+            int signMask = (value ^ sign) >> 31;
+            int result = (value ^ signMask) - signMask;
 
-            if (absValue < 0)
+            if ((sign >= 0) && (result < 0))
             {
-                absValue = -absValue;
+                // value was int.MinValue and a non-negative result was requested, which is unrepresentable.
+                Math.ThrowNegateTwosCompOverflow();
             }
 
-            if (sign >= 0)
-            {
-                if (absValue < 0)
-                {
-                    Math.ThrowNegateTwosCompOverflow();
-                }
-
-                return absValue;
-            }
-
-            return -absValue;
+            return result;
         }
 
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -648,24 +648,17 @@ namespace System
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static long CopySign(long value, long sign)
         {
-            long absValue = value;
+            // signMask is all-bits-set when value and sign differ in sign, in which case value needs to be negated.
+            long signMask = (value ^ sign) >> 63;
+            long result = (value ^ signMask) - signMask;
 
-            if (absValue < 0)
+            if ((sign >= 0) && (result < 0))
             {
-                absValue = -absValue;
+                // value was long.MinValue and a non-negative result was requested, which is unrepresentable.
+                Math.ThrowNegateTwosCompOverflow();
             }
 
-            if (sign >= 0)
-            {
-                if (absValue < 0)
-                {
-                    Math.ThrowNegateTwosCompOverflow();
-                }
-
-                return absValue;
-            }
-
-            return -absValue;
+            return result;
         }
 
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -667,24 +667,17 @@ namespace System
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static nint CopySign(nint value, nint sign)
         {
-            nint absValue = value;
+            // signMask is all-bits-set when value and sign differ in sign, in which case value needs to be negated.
+            nint signMask = (value ^ sign) >> ((Size * 8) - 1);
+            nint result = (value ^ signMask) - signMask;
 
-            if (absValue < 0)
+            if ((sign >= 0) && (result < 0))
             {
-                absValue = -absValue;
+                // value was nint.MinValue and a non-negative result was requested, which is unrepresentable.
+                Math.ThrowNegateTwosCompOverflow();
             }
 
-            if (sign >= 0)
-            {
-                if (absValue < 0)
-                {
-                    Math.ThrowNegateTwosCompOverflow();
-                }
-
-                return absValue;
-            }
-
-            return -absValue;
+            return result;
         }
 
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -588,24 +588,17 @@ namespace System
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         public static sbyte CopySign(sbyte value, sbyte sign)
         {
-            sbyte absValue = value;
+            // signMask is all-bits-set when value and sign differ in sign, in which case value needs to be negated.
+            int signMask = (value ^ sign) >> 31;
+            sbyte result = (sbyte)((value ^ signMask) - signMask);
 
-            if (absValue < 0)
+            if ((sign >= 0) && (result < 0))
             {
-                absValue = (sbyte)(-absValue);
+                // value was sbyte.MinValue and a non-negative result was requested, which is unrepresentable.
+                Math.ThrowNegateTwosCompOverflow();
             }
 
-            if (sign >= 0)
-            {
-                if (absValue < 0)
-                {
-                    Math.ThrowNegateTwosCompOverflow();
-                }
-
-                return absValue;
-            }
-
-            return (sbyte)(-absValue);
+            return result;
         }
 
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int128Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int128Tests.GenericMath.cs
@@ -1396,6 +1396,24 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void CopySignTest()
+        {
+            Assert.Equal(Zero, NumberHelper<Int128>.CopySign(Zero, One));
+            Assert.Equal(One, NumberHelper<Int128>.CopySign(One, One));
+            Assert.Equal(MaxValue, NumberHelper<Int128>.CopySign(MaxValue, One));
+            Assert.Equal(One, NumberHelper<Int128>.CopySign(NegativeOne, One));
+
+            Assert.Equal(Zero, NumberHelper<Int128>.CopySign(Zero, NegativeOne));
+            Assert.Equal(NegativeOne, NumberHelper<Int128>.CopySign(One, NegativeOne));
+            Assert.Equal(new Int128(0x8000_0000_0000_0000, 0x0000_0000_0000_0001), NumberHelper<Int128>.CopySign(MaxValue, NegativeOne));
+            Assert.Equal(MinValue, NumberHelper<Int128>.CopySign(MinValue, NegativeOne));
+            Assert.Equal(NegativeOne, NumberHelper<Int128>.CopySign(NegativeOne, NegativeOne));
+
+            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CopySign(MinValue, Zero));
+            Assert.Throws<OverflowException>(() => NumberHelper<Int128>.CopySign(MinValue, One));
+        }
+
+        [Fact]
         public static void MaxTest()
         {
             Assert.Equal(One, NumberHelper<Int128>.Max(Zero, 1));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int16Tests.GenericMath.cs
@@ -1323,6 +1323,24 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void CopySignTest()
+        {
+            Assert.Equal((short)0x0000, NumberHelper<short>.CopySign((short)0x0000, 1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.CopySign((short)0x0001, 1));
+            Assert.Equal((short)0x7FFF, NumberHelper<short>.CopySign((short)0x7FFF, 1));
+            Assert.Equal((short)0x0001, NumberHelper<short>.CopySign(unchecked((short)0xFFFF), 1));
+
+            Assert.Equal((short)0x0000, NumberHelper<short>.CopySign((short)0x0000, -1));
+            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CopySign((short)0x0001, -1));
+            Assert.Equal(unchecked((short)0x8001), NumberHelper<short>.CopySign((short)0x7FFF, -1));
+            Assert.Equal(unchecked((short)0x8000), NumberHelper<short>.CopySign(unchecked((short)0x8000), -1));
+            Assert.Equal(unchecked((short)0xFFFF), NumberHelper<short>.CopySign(unchecked((short)0xFFFF), -1));
+
+            Assert.Throws<OverflowException>(() => NumberHelper<short>.CopySign(unchecked((short)0x8000), 0));
+            Assert.Throws<OverflowException>(() => NumberHelper<short>.CopySign(unchecked((short)0x8000), 1));
+        }
+
+        [Fact]
         public static void MaxTest()
         {
             Assert.Equal((short)0x0001, NumberHelper<short>.Max((short)0x0000, (short)1));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int32Tests.GenericMath.cs
@@ -1338,6 +1338,24 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void CopySignTest()
+        {
+            Assert.Equal((int)0x00000000, NumberHelper<int>.CopySign((int)0x00000000, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.CopySign((int)0x00000001, 1));
+            Assert.Equal((int)0x7FFFFFFF, NumberHelper<int>.CopySign((int)0x7FFFFFFF, 1));
+            Assert.Equal((int)0x00000001, NumberHelper<int>.CopySign(unchecked((int)0xFFFFFFFF), 1));
+
+            Assert.Equal((int)0x00000000, NumberHelper<int>.CopySign((int)0x00000000, -1));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CopySign((int)0x00000001, -1));
+            Assert.Equal(unchecked((int)0x80000001), NumberHelper<int>.CopySign((int)0x7FFFFFFF, -1));
+            Assert.Equal(unchecked((int)0x80000000), NumberHelper<int>.CopySign(unchecked((int)0x80000000), -1));
+            Assert.Equal(unchecked((int)0xFFFFFFFF), NumberHelper<int>.CopySign(unchecked((int)0xFFFFFFFF), -1));
+
+            Assert.Throws<OverflowException>(() => NumberHelper<int>.CopySign(unchecked((int)0x80000000), 0));
+            Assert.Throws<OverflowException>(() => NumberHelper<int>.CopySign(unchecked((int)0x80000000), 1));
+        }
+
+        [Fact]
         public static void MaxTest()
         {
             Assert.Equal((int)0x00000001, NumberHelper<int>.Max((int)0x00000000, 1));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int64Tests.GenericMath.cs
@@ -1351,6 +1351,24 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void CopySignTest()
+        {
+            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CopySign((long)0x0000000000000000, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CopySign((long)0x0000000000000001, 1));
+            Assert.Equal((long)0x7FFFFFFFFFFFFFFF, NumberHelper<long>.CopySign((long)0x7FFFFFFFFFFFFFFF, 1));
+            Assert.Equal((long)0x0000000000000001, NumberHelper<long>.CopySign(unchecked((long)0xFFFFFFFFFFFFFFFF), 1));
+
+            Assert.Equal((long)0x0000000000000000, NumberHelper<long>.CopySign((long)0x0000000000000000, -1));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CopySign((long)0x0000000000000001, -1));
+            Assert.Equal(unchecked((long)0x8000000000000001), NumberHelper<long>.CopySign((long)0x7FFFFFFFFFFFFFFF, -1));
+            Assert.Equal(unchecked((long)0x8000000000000000), NumberHelper<long>.CopySign(unchecked((long)0x8000000000000000), -1));
+            Assert.Equal(unchecked((long)0xFFFFFFFFFFFFFFFF), NumberHelper<long>.CopySign(unchecked((long)0xFFFFFFFFFFFFFFFF), -1));
+
+            Assert.Throws<OverflowException>(() => NumberHelper<long>.CopySign(unchecked((long)0x8000000000000000), 0));
+            Assert.Throws<OverflowException>(() => NumberHelper<long>.CopySign(unchecked((long)0x8000000000000000), 1));
+        }
+
+        [Fact]
         public static void MaxTest()
         {
             Assert.Equal((long)0x0000000000000001, NumberHelper<long>.Max((long)0x0000000000000000, 1));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/IntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/IntPtrTests.GenericMath.cs
@@ -1990,6 +1990,43 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void CopySignTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CopySign(unchecked((nint)0x0000000000000000), 1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CopySign(unchecked((nint)0x0000000000000001), 1));
+                Assert.Equal(unchecked((nint)0x7FFFFFFFFFFFFFFF), NumberHelper<nint>.CopySign(unchecked((nint)0x7FFFFFFFFFFFFFFF), 1));
+                Assert.Equal(unchecked((nint)0x0000000000000001), NumberHelper<nint>.CopySign(unchecked((nint)0xFFFFFFFFFFFFFFFF), 1));
+
+                Assert.Equal(unchecked((nint)0x0000000000000000), NumberHelper<nint>.CopySign(unchecked((nint)0x0000000000000000), -1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CopySign(unchecked((nint)0x0000000000000001), -1));
+                Assert.Equal(unchecked((nint)0x8000000000000001), NumberHelper<nint>.CopySign(unchecked((nint)0x7FFFFFFFFFFFFFFF), -1));
+                Assert.Equal(unchecked((nint)0x8000000000000000), NumberHelper<nint>.CopySign(unchecked((nint)0x8000000000000000), -1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFFFFFFFFFF), NumberHelper<nint>.CopySign(unchecked((nint)0xFFFFFFFFFFFFFFFF), -1));
+
+                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CopySign(unchecked((nint)0x8000000000000000), 0));
+                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CopySign(unchecked((nint)0x8000000000000000), 1));
+            }
+            else
+            {
+                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CopySign((nint)0x00000000, 1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CopySign((nint)0x00000001, 1));
+                Assert.Equal((nint)0x7FFFFFFF, NumberHelper<nint>.CopySign((nint)0x7FFFFFFF, 1));
+                Assert.Equal((nint)0x00000001, NumberHelper<nint>.CopySign(unchecked((nint)0xFFFFFFFF), 1));
+
+                Assert.Equal((nint)0x00000000, NumberHelper<nint>.CopySign((nint)0x00000000, -1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CopySign((nint)0x00000001, -1));
+                Assert.Equal(unchecked((nint)0x80000001), NumberHelper<nint>.CopySign((nint)0x7FFFFFFF, -1));
+                Assert.Equal(unchecked((nint)0x80000000), NumberHelper<nint>.CopySign(unchecked((nint)0x80000000), -1));
+                Assert.Equal(unchecked((nint)0xFFFFFFFF), NumberHelper<nint>.CopySign(unchecked((nint)0xFFFFFFFF), -1));
+
+                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CopySign(unchecked((nint)0x80000000), 0));
+                Assert.Throws<OverflowException>(() => NumberHelper<nint>.CopySign(unchecked((nint)0x80000000), 1));
+            }
+        }
+
+        [Fact]
         public static void MaxTest()
         {
             if (Environment.Is64BitProcess)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/SByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/SByteTests.GenericMath.cs
@@ -1315,6 +1315,24 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void CopySignTest()
+        {
+            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CopySign((sbyte)0x00, 1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CopySign((sbyte)0x01, 1));
+            Assert.Equal((sbyte)0x7F, NumberHelper<sbyte>.CopySign((sbyte)0x7F, 1));
+            Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.CopySign(unchecked((sbyte)0xFF), 1));
+
+            Assert.Equal((sbyte)0x00, NumberHelper<sbyte>.CopySign((sbyte)0x00, -1));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CopySign((sbyte)0x01, -1));
+            Assert.Equal(unchecked((sbyte)0x81), NumberHelper<sbyte>.CopySign((sbyte)0x7F, -1));
+            Assert.Equal(unchecked((sbyte)0x80), NumberHelper<sbyte>.CopySign(unchecked((sbyte)0x80), -1));
+            Assert.Equal(unchecked((sbyte)0xFF), NumberHelper<sbyte>.CopySign(unchecked((sbyte)0xFF), -1));
+
+            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CopySign(unchecked((sbyte)0x80), 0));
+            Assert.Throws<OverflowException>(() => NumberHelper<sbyte>.CopySign(unchecked((sbyte)0x80), 1));
+        }
+
+        [Fact]
         public static void MaxTest()
         {
             Assert.Equal((sbyte)0x01, NumberHelper<sbyte>.Max((sbyte)0x00, (sbyte)1));


### PR DESCRIPTION
Fixes #77579

The signed integer `CopySign` implementations used a data-dependent abs-then-negate sequence with two branches on the hot path. This replaces it with the standard branchless conditional negate:

```
signMask = (value ^ sign) >> (width - 1)   // all-ones iff the signs differ
result   = (value ^ signMask) - signMask   // (x ^ -1) - (-1) == -x; (x ^ 0) - 0 == x
```

which produces `value` with the sign of `sign` in a handful of ALU ops. A single predicted-not-taken branch is kept to preserve the `OverflowException` that `CopySign(MinValue, non-negative)` must still throw (the only case where `result` comes back negative for a non-negative `sign`).

Applied to `sbyte`, `short`, `int`, `long`, `nint`, and `Int128`. `Int128` uses the same general form; a manual per-limb variant was measured and lowered identically, so the clearer form is used.

The floating-point and `decimal` `CopySign` paths already use bit/flag manipulation (or `Vector128.ConditionalSelect`), so they're unchanged.

Correctness of the transform (including the overflow-throw case) was verified exhaustively over the full 8-bit domain and, for `Int128`, against the width-generic reference over edge values plus randomized 128-bit inputs. Added `CopySignTest` coverage to the generic-math tests for each signed integer type.

----------

**Performance** (array-loop over random inputs; ratio is new/old, lower is better):

| Type | arm64 (Apple M4) | x64 |
|---|---|---|
| `int` | ~2.0x faster | ~1.1x faster |
| `long` | ~2.0x faster | ~1.3x faster |
| `Int128` | ~1.7x faster | roughly neutral (µarch-dependent) |

The scalar types improve on every platform measured. `Int128` is a solid win on arm64; on x64 it's roughly neutral and microarchitecture-dependent (measured a small gain on Intel Emerald Rapids and a small regression on AMD EPYC Turin), which is expected since x64 absorbs the original well-predicted branch cheaply and `Int128` isn't hardware accelerated. A separate A/B run confirmed the general form matches the manual per-limb form and beats a compute-both-and-select alternative.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.