### PR TITLE
[R2R] Align composite ManifestMetadata and ComponentAssemblies sections to 4 bytes

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -401,6 +401,93 @@ public class R2RTestSuites
         }
     }
 
+    /// <summary>
+    /// Regression test for an ARM32 alignment fault (SIGBUS / BUS_ADRALN) when loading a composite
+    /// Ready-to-Run image. The manifest metadata root (STORAGESIGNATURE/STORAGEHEADER/STORAGESTREAM)
+    /// and the component assembly table (READYTORUN_COMPONENT_ASSEMBLIES_ENTRY) are packed arrays of
+    /// DWORD fields that the runtime reads in place, so their sections must start on a 4-byte
+    /// boundary. When they landed on an unaligned RVA the runtime faulted on ARM32 (which does not
+    /// permit unaligned multi-word loads) during coreclr_initialize; x64/arm64 tolerated it.
+    /// </summary>
+    [Fact]
+    public void CompositeManifestSectionsAreAligned()
+    {
+        var compositeLib = new CompiledAssembly
+        {
+            AssemblyName = "CompositeLib",
+            SourceResourceNames = ["CrossModuleInlining/Dependencies/CompositeLib.cs"],
+        };
+        var compositeMain = new CompiledAssembly
+        {
+            AssemblyName = nameof(CompositeManifestSectionsAreAligned),
+            SourceResourceNames = ["CrossModuleInlining/CompositeBasic.cs"],
+            References = [compositeLib]
+        };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(CompositeManifestSectionsAreAligned),
+            [
+                new(nameof(CompositeManifestSectionsAreAligned),
+                [
+                    new CrossgenAssembly(compositeLib),
+                    new CrossgenAssembly(compositeMain),
+                ])
+                {
+                    Options = [Crossgen2Option.Composite, Crossgen2Option.Optimize],
+                    Validate = Validate,
+                },
+            ]));
+
+        static void Validate(ReadyToRunReader reader)
+        {
+            string diag;
+            Assert.True(R2RAssert.CompositeManifestSectionsAreAligned(reader, out diag), diag);
+        }
+    }
+
+    /// <summary>
+    /// Complements <see cref="CompositeManifestSectionsAreAligned"/> using the same trigger as the
+    /// MVID-table test: --pdb emits an odd-sized debug directory section that shifts the manifest
+    /// sections off a 4-byte boundary without the fix. Windows-only because it relies on Windows PDB
+    /// generation.
+    /// </summary>
+    [ConditionalFact(nameof(IsWindows))]
+    public void CompositeManifestSectionsArePaddedWhenPdbPresent()
+    {
+        var compositeLib = new CompiledAssembly
+        {
+            AssemblyName = "CompositeLib",
+            SourceResourceNames = ["CrossModuleInlining/Dependencies/CompositeLib.cs"],
+        };
+        var compositeMain = new CompiledAssembly
+        {
+            AssemblyName = nameof(CompositeManifestSectionsArePaddedWhenPdbPresent),
+            SourceResourceNames = ["CrossModuleInlining/CompositeBasic.cs"],
+            References = [compositeLib]
+        };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(CompositeManifestSectionsArePaddedWhenPdbPresent),
+            [
+                new(nameof(CompositeManifestSectionsArePaddedWhenPdbPresent),
+                [
+                    new CrossgenAssembly(compositeLib),
+                    new CrossgenAssembly(compositeMain),
+                ])
+                {
+                    Options = [Crossgen2Option.Composite, Crossgen2Option.Optimize],
+                    AdditionalArgs = ["--pdb"],
+                    Validate = Validate,
+                },
+            ]));
+
+        static void Validate(ReadyToRunReader reader)
+        {
+            string diag;
+            Assert.True(R2RAssert.CompositeManifestSectionsAreAligned(reader, out diag), diag);
+        }
+    }
+
     [Fact]
     public void RuntimeAsyncMethodEmission()
     {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RResultChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RResultChecker.cs
@@ -117,6 +117,26 @@ internal static class R2RAssert
     }
 
     /// <summary>
+    /// Returns true if the manifest metadata and component assembly tables in a composite image
+    /// start on 4-byte aligned RVAs. Both sections contain DWORD fields that the runtime reads
+    /// directly, so unaligned sections can fault on architectures such as 32-bit ARM.
+    /// </summary>
+    public static bool CompositeManifestSectionsAreAligned(ReadyToRunReader reader, out string diagnostic)
+    {
+        const int RequiredAlignment = 4;
+        var failures = new List<string>();
+
+        bool result = true;
+        result &= SectionRVAIsAligned(reader, ReadyToRunSectionType.ManifestMetadata, RequiredAlignment, failures);
+        result &= SectionRVAIsAligned(reader, ReadyToRunSectionType.ComponentAssemblies, RequiredAlignment, failures);
+
+        diagnostic = result
+            ? $"Composite manifest sections are {RequiredAlignment}-byte aligned."
+            : string.Join(Environment.NewLine, failures);
+        return result;
+    }
+
+    /// <summary>
     /// Returns true if the manifest assembly MVID table in a composite image is present, holds a
     /// whole number of 16-byte GUID entries, and starts on a 4-byte aligned RVA. The runtime reads
     /// each entry as a GUID by value, so the table must be 4-byte aligned to avoid alignment faults
@@ -148,6 +168,30 @@ internal static class R2RAssert
             ? $"ManifestAssemblyMvids table is {RequiredAlignment}-byte aligned ({section.Size / GuidByteSize} entries)."
             : string.Join(Environment.NewLine, failures);
         return failures.Count == 0;
+    }
+
+    private static bool SectionRVAIsAligned(ReadyToRunReader reader, ReadyToRunSectionType sectionType, int requiredAlignment, List<string> failures)
+    {
+        if (!reader.ReadyToRunHeader.Sections.TryGetValue(sectionType, out ReadyToRunSection section))
+        {
+            failures.Add($"Expected {sectionType} section not found.");
+            return false;
+        }
+
+        bool result = true;
+        if (section.Size <= 0)
+        {
+            failures.Add($"Expected {sectionType} section to be non-empty.");
+            result = false;
+        }
+
+        if ((section.RelativeVirtualAddress % requiredAlignment) != 0)
+        {
+            failures.Add($"{sectionType} section RVA 0x{section.RelativeVirtualAddress:X8} should be aligned to {requiredAlignment} bytes.");
+            result = false;
+        }
+
+        return result;
     }
 
     private static bool SectionRVAIsEven(ReadyToRunReader reader, ReadyToRunSectionType sectionType, List<string> failures)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AssemblyTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AssemblyTableNode.cs
@@ -39,6 +39,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.RequireInitialAlignment(sizeof(uint));
             builder.AddSymbol(this);
             foreach (AssemblyHeaderNode assemblyHeader in _assemblyHeaders)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
@@ -294,7 +294,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             if (relocsOnly)
             {
-                return new ObjectData(Array.Empty<byte>(), null, 1, null);
+                return new ObjectData(Array.Empty<byte>(), null, 4, null);
             }
 
             ComputeLastSetOfModuleIndices();
@@ -313,7 +313,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return new ObjectData(
                 data: _mutableModule.MetadataBlob,
                 relocs: Array.Empty<Relocation>(),
-                alignment: 1,
+                // Metadata stream headers contain DWORD fields and require 4-byte alignment.
+                alignment: 4,
                 definedSymbols: new ISymbolDefinitionNode[] { this });
         }
 


### PR DESCRIPTION
Follow-up to #129017.

## Summary

That PR fixed a 32-bit ARM `SIGBUS` (`BUS_ADRALN`) in composite Ready-to-Run images caused by emitting the manifest MVID table with `alignment: 1`. The adjacent `ManifestMetadataTableNode` (the metadata root) and `AssemblyTableNode` (`ComponentAssemblies`) have the identical latent bug: both are packed arrays of `DWORD`-typed fields that the CoreCLR runtime reads in place, but both are emitted with `alignment: 1`, so they can land on a non-4-aligned RVA. On ARM32 that faults with `BUS_ADRALN` (unaligned multi-word load); x64/arm64 tolerate it, so it stayed latent until android-arm composite R2R was exercised.

In the failing android-arm MAUI R2R crash (dotnet/android#12026) the MVID table was already aligned (thanks to #129017), but the **metadata root** landed on an odd RVA and faulted in `PEDecoder::CheckCorHeader` during `coreclr_initialize`. So #129017 was necessary but not sufficient for this configuration; this change completes it by aligning the remaining manifest-region sections.

## Root cause

Loading a composite image parses the metadata root via `PEDecoder::CheckCorHeader`, which walks `STORAGESTREAM` headers (`ULONG iOffset; ULONG iSize; char rcName[]`). The compiler coalesces the two adjacent `DWORD` reads (`iOffset`/`iSize`) into a single `LDRD`, which requires 4-byte alignment on ARM32:

```
Fatal signal 7 (SIGBUS), code 1 (BUS_ADRALN)
  #00 pc ... libcoreclr.so  PEDecoder::CheckCorHeader() const   (pedecoder.cpp)
  ...
  #23 pc ... libcoreclr.so  coreclr_initialize
```

`ComponentAssemblies` (`READYTORUN_COMPONENT_ASSEMBLIES_ENTRY`) is likewise a packed `DWORD` array read in place, and the regression test shows it landing unaligned without the fix.

## Provenance

`alignment: 1` on `ManifestMetadataTableNode` dates back to the initial population of crossgen2 from the CoreRT sources (`ac857a2e`, 2019) and was never a deliberate choice — no commit or discussion in the file's history addressed alignment; the value was carried verbatim through later refactors (e.g. #71271 only switched to named arguments). The sibling `ManifestAssemblyMvidHeaderNode` shared the same default and was corrected in #129017.

## Why 4, and why not configurable / a size concern

- The metadata root and component-assembly entries are all `DWORD` fields whose natural alignment is 4; ECMA-335 already pads the metadata version string so stream headers are 4-aligned within the blob. 4-byte section-start alignment is the correct requirement (same rationale as #129017's "GUID has a natural alignment of 4").
- No meaningful size impact: these are singleton sections (once per composite image), so the change adds at most 3 padding bytes per section.
- Not a user-facing knob: every other crossgen2 section uses a fixed natural alignment (RuntimeFunctions=4, GCRefMap=4, …); a configurable "may emit a misaligned image" switch would be a footgun, so this stays a fixed value.

## Testing

Mirrors #129017's test approach: a `CompositeManifestSectionsAreAligned(...)` checker in `R2RResultChecker`, driven by a plain `[Fact]` and a Windows-only `[ConditionalFact(IsWindows)]` `--pdb` variant that uses the same composite inputs.

## Validation

Mirrors #129017: the `--pdb` variant emits an odd-sized `NativeDebugDirectoryEntryNode` that, without the fix, shifts the manifest sections off a 4-byte boundary; with the fix they are padded to a 4-byte RVA. Verified end-to-end by building an android-arm CoreCLR composite R2R APK with the fixed crossgen2 — R2RDump confirms `ManifestMetadata`, `ComponentAssemblies`, and `ManifestAssemblyMvids` all start on 4-byte-aligned RVAs — resolving the crash reported in dotnet/android#12026.

cc @jtschuster (author of the sibling fix #129017)
