### PR TITLE
Fix rounding of BigInteger conversions to floating-point types

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2031,7 +2031,14 @@ namespace System.Numerics
             return checked((decimal)(Int128)value);
         }
 
-        public static explicit operator double(BigInteger value)
+        public static explicit operator double(BigInteger value) => ConvertToDouble(value, roundToOdd: false);
+
+        // Converts a big integer to an IEEE 754 double. When `roundToOdd` is false the result is the
+        // correctly rounded (round-to-nearest, ties-to-even) double. When it is true the result is
+        // instead rounded to odd: the mantissa's least significant bit is forced set whenever any
+        // information is discarded. Re-rounding such a value to a narrower type (float, Half,
+        // BFloat16) then yields the correctly rounded narrow value, avoiding double rounding.
+        private static double ConvertToDouble(BigInteger value, bool roundToOdd)
         {
             int sign = value._sign;
             nuint[]? bits = value._bits;
@@ -2053,42 +2060,100 @@ namespace System.Numerics
                 return sign == 1 ? double.PositiveInfinity : double.NegativeInfinity;
             }
 
-            ulong h, m, l;
-            int z, exp;
+            // Gather the top 64 significant bits of the magnitude into `man`, with the most
+            // significant set bit at bit 63, the position of that bit within the full magnitude
+            // in `topBit`, and whether any lower (uncaptured) bits are set in `sticky`. These are
+            // everything needed to round to the nearest double using round-to-nearest, ties-to-even.
+            // `man` must be 64 bits wide regardless of the limb width, since a single 32-bit limb
+            // cannot hold the full significand. The top limb is always non-zero, so the leading
+            // zero count is strictly less than the limb width.
             ulong man;
+            int topBit;
+            bool sticky;
 
             if (nint.Size == 8)
             {
-                h = bits[length - 1];
-                m = length > 1 ? bits[length - 2] : 0;
+                ulong h = bits[length - 1];
+                ulong m = length > 1 ? bits[length - 2] : 0;
 
-                z = BitOperations.LeadingZeroCount(h);
-                exp = (length - 1) * 64 - z;
+                int z = BitOperations.LeadingZeroCount(h);
+                topBit = (length - 1) * 64 + (63 - z);
                 man = z == 0 ? h : (h << z) | (m >> (64 - z));
+
+                // Any bits of `m` not captured in `man`, plus all lower limbs, are sticky.
+                ulong mLow = z == 0 ? m : (m & ((1UL << (64 - z)) - 1));
+                sticky = mLow != 0 || (length > 2 && bits.AsSpan(0, length - 2).ContainsAnyExcept((nuint)0));
             }
             else
             {
-                h = (uint)bits[length - 1];
-                m = length > 1 ? (uint)bits[length - 2] : 0;
-                l = length > 2 ? (uint)bits[length - 3] : 0;
+                ulong h = (uint)bits[length - 1];
+                ulong m = length > 1 ? (uint)bits[length - 2] : 0;
+                ulong l = length > 2 ? (uint)bits[length - 3] : 0;
 
-                z = BitOperations.LeadingZeroCount((uint)h);
-                exp = (length - 2) * 32 - z;
-                man = (h << 32 + z) | (m << z) | (l >> 32 - z);
+                int z = BitOperations.LeadingZeroCount((uint)h);
+                topBit = (length - 1) * 32 + (31 - z);
+                man = (h << (32 + z)) | (m << z) | (l >> (32 - z));
+
+                // Any bits of `l` not captured in `man`, plus all lower limbs, are sticky.
+                ulong lLow = l & ((1UL << (32 - z)) - 1);
+                sticky = lLow != 0 || (length > 3 && bits.AsSpan(0, length - 3).ContainsAnyExcept((nuint)0));
             }
 
-            return NumericsHelpers.GetDoubleFromParts(sign, exp, man);
+            // `man` holds 64 bits with the leading 1 at bit 63; a double keeps 53 significant
+            // bits, so bits [63:11] form the significand, bit 10 is the round bit, and bits
+            // [9:0] (together with `sticky`) determine whether we round up.
+            sticky |= (man & 0x3FF) != 0;
+            ulong roundBit = (man >> 10) & 1;
+            ulong mantissa = man >> 11;
+
+            if (roundToOdd)
+            {
+                // Force the least significant bit set whenever anything was discarded. This never
+                // carries, so `topBit` is unchanged and the value stays normalized.
+                if (roundBit != 0 || sticky)
+                {
+                    mantissa |= 1;
+                }
+            }
+            else if (roundBit != 0 && (sticky || (mantissa & 1) != 0))
+            {
+                mantissa++;
+
+                if ((mantissa >> 53) != 0)
+                {
+                    // Rounding carried into a new leading bit; renormalize.
+                    mantissa >>= 1;
+                    topBit++;
+                }
+            }
+
+            int biasedExp = topBit + 1023;
+
+            if (biasedExp >= 0x7FF)
+            {
+                // The rounded value is too large to represent as a finite double.
+                return sign == 1 ? double.PositiveInfinity : double.NegativeInfinity;
+            }
+
+            ulong result = (mantissa & 0x000F_FFFF_FFFF_FFFF) | ((ulong)biasedExp << 52);
+
+            if (sign < 0)
+            {
+                result |= 0x8000_0000_0000_0000;
+            }
+
+            return BitConverter.UInt64BitsToDouble(result);
         }
 
         /// <summary>Explicitly converts a big integer to a <see cref="Half" /> value.</summary>
         /// <param name="value">The value to convert.</param>
         /// <returns><paramref name="value" /> converted to <see cref="Half" /> value.</returns>
-        public static explicit operator Half(BigInteger value) => (Half)(double)value;
+        public static explicit operator Half(BigInteger value) => (Half)ConvertToDouble(value, roundToOdd: true);
 
         /// <summary>Explicitly converts a big integer to a <see cref="BFloat16" /> value.</summary>
         /// <param name="value">The value to convert.</param>
         /// <returns><paramref name="value" /> converted to <see cref="BFloat16" /> value.</returns>
-        public static explicit operator BFloat16(BigInteger value) => (BFloat16)(double)value;
+        public static explicit operator BFloat16(BigInteger value) => (BFloat16)ConvertToDouble(value, roundToOdd: true);
 
         public static explicit operator short(BigInteger value) => checked((short)((int)value));
 
@@ -2213,7 +2278,7 @@ namespace System.Numerics
         [CLSCompliant(false)]
         public static explicit operator sbyte(BigInteger value) => checked((sbyte)((int)value));
 
-        public static explicit operator float(BigInteger value) => (float)((double)value);
+        public static explicit operator float(BigInteger value) => (float)ConvertToDouble(value, roundToOdd: true);
 
         [CLSCompliant(false)]
         public static explicit operator ushort(BigInteger value) => checked((ushort)((int)value));

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Runtime.Intrinsics;
 
 namespace System.Numerics
@@ -36,69 +35,6 @@ namespace System.Numerics
                 man |= 0x0010000000000000;
                 exp -= 1075;
             }
-        }
-
-        public static double GetDoubleFromParts(int sign, int exp, ulong man)
-        {
-            ulong bits;
-
-            if (man == 0)
-            {
-                bits = 0;
-            }
-            else
-            {
-                // Normalize so that 0x0010 0000 0000 0000 is the highest bit set.
-                int cbitShift = BitOperations.LeadingZeroCount(man) - 11;
-                if (cbitShift < 0)
-                {
-                    man >>= -cbitShift;
-                }
-                else
-                {
-                    man <<= cbitShift;
-                }
-
-                exp -= cbitShift;
-                Debug.Assert((man & 0xFFF0000000000000) == 0x0010000000000000);
-
-                // Move the point to just behind the leading 1: 0x001.0 0000 0000 0000
-                // (52 bits) and skew the exponent (by 0x3FF == 1023).
-                exp += 1075;
-
-                if (exp >= 0x7FF)
-                {
-                    // Infinity.
-                    bits = 0x7FF0000000000000;
-                }
-                else if (exp <= 0)
-                {
-                    // Denormalized.
-                    exp--;
-                    if (exp < -52)
-                    {
-                        // Underflow to zero.
-                        bits = 0;
-                    }
-                    else
-                    {
-                        bits = man >> -exp;
-                        Debug.Assert(bits != 0);
-                    }
-                }
-                else
-                {
-                    // Mask off the implicit high bit.
-                    bits = (man & 0x000FFFFFFFFFFFFF) | ((ulong)exp << 52);
-                }
-            }
-
-            if (sign < 0)
-            {
-                bits |= 0x8000000000000000;
-            }
-
-            return BitConverter.UInt64BitsToDouble(bits);
         }
 
         /// <summary>Performs an in-place two's complement. Use with care for immutable types.</summary>

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
@@ -574,6 +574,97 @@ namespace System.Numerics.Tests
             VerifyDoubleExplicitCastFromBigInteger(-9007199254740992, bigInteger);
         }
 
+        [Theory]
+        // The conversion must round to the nearest double using round-to-nearest, ties-to-even,
+        // matching a direct integer-to-double conversion rather than truncating toward zero.
+        [InlineData("4611686018427387903", 4611686018427387904.0)] // long.MaxValue / 2, rounds up
+        [InlineData("9223372036854775807", 9223372036854775808.0)] // long.MaxValue, rounds up
+        [InlineData("9007199254740993", 9007199254740992.0)]       // 2^53 + 1, rounds down
+        [InlineData("18014398509481986", 18014398509481984.0)]     // 2^54 + 2, halfway, ties to even (down)
+        [InlineData("18014398509481990", 18014398509481992.0)]     // 2^54 + 6, halfway, ties to even (up)
+        [InlineData("18014398509481987", 18014398509481988.0)]     // 2^54 + 3, above halfway, rounds up
+        public static void RunDoubleExplicitCastFromBigIntegerRoundingTests(string value, double expected)
+        {
+            BigInteger bigInteger = BigInteger.Parse(value);
+
+            Assert.Equal(expected, (double)bigInteger);
+            Assert.Equal(-expected, (double)(-bigInteger));
+        }
+
+        [Fact]
+        public static void RunDoubleExplicitCastFromBigIntegerBoundaryTests()
+        {
+            // A set bit far below the captured mantissa window (i.e. in a lower limb) must still act
+            // as a sticky bit and break what would otherwise be an exact halfway tie.
+            BigInteger tieDown = (BigInteger.One << 128) + (BigInteger.One << 75); // exact halfway, ties to even (down)
+            BigInteger roundUp = tieDown + 1;                                      // deep sticky bit forces round up
+
+            Assert.Equal(Math.ScaleB(1.0, 128), (double)tieDown);
+            Assert.Equal(Math.ScaleB(1.0, 128) + Math.ScaleB(1.0, 76), (double)roundUp);
+
+            // Rounding can carry all the way out of the finite range and overflow to infinity.
+            BigInteger overflowTie = (BigInteger.One << 1024) - (BigInteger.One << 970); // halfway between MaxValue and 2^1024
+
+            Assert.Equal(double.PositiveInfinity, (double)overflowTie);          // ties to even (infinity)
+            Assert.Equal(double.NegativeInfinity, (double)(-overflowTie));
+            Assert.Equal(double.MaxValue, (double)(overflowTie - 1));            // just below the midpoint rounds down
+            Assert.Equal(double.MinValue, (double)(-(overflowTie - 1)));
+        }
+
+        [Theory]
+        // Converting via double as an intermediate can double-round, so these must match a direct
+        // correctly-rounded BigInteger -> float conversion. 9007199791611905 (2^53 + 536870913) sits
+        // just above a float midpoint that is itself a double halfway case: rounding to double first
+        // ties to even (down onto the midpoint), then rounding to float ties to even (down again),
+        // landing 1 ULP below the correctly-rounded value.
+        [InlineData("9007199791611905", 9007200328482816f)] // 2^53 + 536870913, rounds up (double rounding would round down)
+        [InlineData("16777217", 16777216f)]                 // 2^24 + 1, halfway, ties to even (down)
+        [InlineData("16777219", 16777220f)]                 // 2^24 + 3, halfway, ties to even (up)
+        public static void RunSingleExplicitCastFromBigIntegerRoundingTests(string value, float expected)
+        {
+            BigInteger bigInteger = BigInteger.Parse(value);
+
+            Assert.Equal(expected, (float)bigInteger);
+            Assert.Equal(-expected, (float)(-bigInteger));
+        }
+
+        [Theory]
+        // Half has an 11-bit significand; integers up to Half.MaxValue are exact in double, so these
+        // are single-rounded and cannot double-round, but they still exercise ties-to-even rounding.
+        [InlineData("2049", 2048)] // 2^11 + 1, halfway, ties to even (down)
+        [InlineData("2051", 2052)] // 2^11 + 3, halfway, ties to even (up)
+        public static void RunHalfExplicitCastFromBigIntegerRoundingTests(string value, int expected)
+        {
+            BigInteger bigInteger = BigInteger.Parse(value);
+
+            Assert.Equal((Half)expected, (Half)bigInteger);
+            Assert.Equal((Half)(-expected), (Half)(-bigInteger));
+        }
+
+        [Fact]
+        public static void RunHalfExplicitCastFromBigIntegerOverflowTests()
+        {
+            // Halfway between Half.MaxValue (65504) and 2^16; ties to even, overflowing to infinity.
+            BigInteger overflowTie = 65520;
+
+            Assert.Equal(Half.PositiveInfinity, (Half)overflowTie);
+            Assert.Equal(Half.NegativeInfinity, (Half)(-overflowTie));
+        }
+
+        [Fact]
+        public static void RunBFloat16ExplicitCastFromBigIntegerRoundingTests()
+        {
+            // Like float, BFloat16 has a wider exponent range than its 8-bit significand can represent
+            // exactly in double, so it is prone to double rounding. 2^53 + 2^45 + 1 sits just above a
+            // BFloat16 midpoint (2^53 + 2^45) that is itself an exact double halfway case: rounding to
+            // double ties to even (down onto the midpoint), then rounding to BFloat16 ties to even
+            // (down again), landing 1 ULP below the correctly-rounded value.
+            BigInteger value = (BigInteger.One << 53) + (BigInteger.One << 45) + 1;
+
+            Assert.Equal((BFloat16)9077567998918656L, (BFloat16)value); // 2^53 + 2^46, rounds up
+            Assert.Equal((BFloat16)(-9077567998918656L), (BFloat16)(-value));
+        }
+
         [Fact]
         [OuterLoop]
         public static void RunDoubleExplicitCastFromLargeBigIntegerTests()


### PR DESCRIPTION
Fixes #49611
Fixes #125837

## `(double)BigInteger`

The `explicit operator double(BigInteger)` truncated toward zero rather than rounding. It gathered the top mantissa bits and passed them to `NumericsHelpers.GetDoubleFromParts`, which masked off the low bits (truncation) and never observed the lower limbs (no sticky bit). So `(double)(BigInteger)(long.MaxValue / 2)` gave `4611686018427387392` where the direct `(double)(long)(long.MaxValue / 2)` correctly gives `4611686018427387904`.

The conversion now performs IEEE round-to-nearest, ties-to-even: it builds the top 64 significant bits (`man`, MSB at bit 63), the top-bit position, and a `sticky` flag from any uncaptured lower bits/limbs, then keeps 53 bits using the round bit + sticky, handling the rounding carry and overflow to infinity. Both the 64-bit and 32-bit limb paths are covered. A `BigInteger` backed by a `bits[]` array is always a normal double magnitude, so there is no denormal/zero handling.

----------

## `(float)`, `(Half)`, `(BFloat16)`

These operators previously converted via `double` as an intermediate, which double-rounds and can be off by 1 ULP. In a sweep, `float` had hundreds of such errors; `BFloat16` shares `float`'s exponent range and is affected the same way. `Half` is not (every finite `Half`-range integer is exact in `double`), but is routed through the shared path anyway for uniformity.

The fix routes all three through a shared `ConvertToDouble(value, roundToOdd: true)` helper that rounds to odd at 53 bits. A round-to-odd intermediate is always innocuous when re-rounded to a narrower type, so the narrow result is correctly rounded.

This resolves the `BigInteger` portion of #112474; the `Integer -> Half`, `Decimal -> FP`, and `Decimal32/64/128 -> FP` items there remain out of scope.

## Tests

Added rounding coverage to `cast_from.cs`: `double` ties-to-even boundaries, a deep lower-limb sticky bit, carry overflow to infinity, and `float`/`Half`/`BFloat16` cases (the `float`/`BFloat16` ones fail without the round-to-odd routing).

Breaking-change documentation: [dotnet/docs#55743](https://github.com/dotnet/docs/issues/55743).

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot.
