### PR TITLE
Add integer to Half and BFloat16 conversion rounding tests

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
@@ -673,6 +673,122 @@ namespace System.Tests
             AssertExtensions.Equal(expected, h);
         }
 
+        public static IEnumerable<object[]> ExplicitConversion_FromInt32_TestData()
+        {
+            (int, Half)[] data =
+            {
+                (0, BitConverter.UInt16BitsToHalf(0x0000)),
+                (2048, BitConverter.UInt16BitsToHalf(0x6800)), // 2^11 exact
+                (2049, BitConverter.UInt16BitsToHalf(0x6800)), // rounds to even (lower)
+                (2050, BitConverter.UInt16BitsToHalf(0x6801)), // exact
+                (2051, BitConverter.UInt16BitsToHalf(0x6802)), // rounds to even (higher)
+                (4097, BitConverter.UInt16BitsToHalf(0x6C00)), // rounds lower
+                (4098, BitConverter.UInt16BitsToHalf(0x6C00)), // rounds to even
+                (4100, BitConverter.UInt16BitsToHalf(0x6C01)), // exact
+                (65504, BitConverter.UInt16BitsToHalf(0x7BFF)), // largest finite
+                (65519, BitConverter.UInt16BitsToHalf(0x7BFF)), // rounds down to largest finite
+                (65520, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+                (int.MaxValue, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+                (-2049, BitConverter.UInt16BitsToHalf(0xE800)), // rounds to even (toward zero)
+                (-65520, BitConverter.UInt16BitsToHalf(0xFC00)), // overflow to negative infinity
+                (int.MinValue, BitConverter.UInt16BitsToHalf(0xFC00)), // overflow to negative infinity
+            };
+
+            foreach ((int original, Half expected) in data)
+            {
+                yield return new object[] { original, expected };
+            }
+        }
+
+        [MemberData(nameof(ExplicitConversion_FromInt32_TestData))]
+        [Theory]
+        public static void ExplicitConversion_FromInt32(int i, Half expected)
+        {
+            Half h = (Half)i;
+            AssertExtensions.Equal(expected, h);
+        }
+
+        public static IEnumerable<object[]> ExplicitConversion_FromUInt32_TestData()
+        {
+            (uint, Half)[] data =
+            {
+                (0, BitConverter.UInt16BitsToHalf(0x0000)),
+                (2049, BitConverter.UInt16BitsToHalf(0x6800)), // rounds to even (lower)
+                (65504, BitConverter.UInt16BitsToHalf(0x7BFF)), // largest finite
+                (65519, BitConverter.UInt16BitsToHalf(0x7BFF)), // rounds down to largest finite
+                (65520, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+                (0x8000_0000, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+                (uint.MaxValue, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+            };
+
+            foreach ((uint original, Half expected) in data)
+            {
+                yield return new object[] { original, expected };
+            }
+        }
+
+        [MemberData(nameof(ExplicitConversion_FromUInt32_TestData))]
+        [Theory]
+        public static void ExplicitConversion_FromUInt32(uint i, Half expected)
+        {
+            Half h = (Half)i;
+            AssertExtensions.Equal(expected, h);
+        }
+
+        public static IEnumerable<object[]> ExplicitConversion_FromInt64_TestData()
+        {
+            (long, Half)[] data =
+            {
+                (0, BitConverter.UInt16BitsToHalf(0x0000)),
+                (2049, BitConverter.UInt16BitsToHalf(0x6800)), // rounds to even (lower)
+                (65519, BitConverter.UInt16BitsToHalf(0x7BFF)), // rounds down to largest finite
+                (65520, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+                (0x1_0000_0000, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+                (long.MaxValue, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+                (-2049, BitConverter.UInt16BitsToHalf(0xE800)), // rounds to even (toward zero)
+                (long.MinValue, BitConverter.UInt16BitsToHalf(0xFC00)), // overflow to negative infinity
+            };
+
+            foreach ((long original, Half expected) in data)
+            {
+                yield return new object[] { original, expected };
+            }
+        }
+
+        [MemberData(nameof(ExplicitConversion_FromInt64_TestData))]
+        [Theory]
+        public static void ExplicitConversion_FromInt64(long i, Half expected)
+        {
+            Half h = (Half)i;
+            AssertExtensions.Equal(expected, h);
+        }
+
+        public static IEnumerable<object[]> ExplicitConversion_FromUInt64_TestData()
+        {
+            (ulong, Half)[] data =
+            {
+                (0, BitConverter.UInt16BitsToHalf(0x0000)),
+                (2049, BitConverter.UInt16BitsToHalf(0x6800)), // rounds to even (lower)
+                (65519, BitConverter.UInt16BitsToHalf(0x7BFF)), // rounds down to largest finite
+                (65520, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+                (0x1_0000_0000, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+                (ulong.MaxValue, BitConverter.UInt16BitsToHalf(0x7C00)), // overflow to infinity
+            };
+
+            foreach ((ulong original, Half expected) in data)
+            {
+                yield return new object[] { original, expected };
+            }
+        }
+
+        [MemberData(nameof(ExplicitConversion_FromUInt64_TestData))]
+        [Theory]
+        public static void ExplicitConversion_FromUInt64(ulong i, Half expected)
+        {
+            Half h = (Half)i;
+            AssertExtensions.Equal(expected, h);
+        }
+
         public static IEnumerable<object[]> Parse_Valid_TestData()
         {
             NumberStyles defaultStyle = NumberStyles.Float | NumberStyles.AllowThousands;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
@@ -721,6 +721,132 @@ namespace System.Numerics.Tests
             AssertEqual(expected, b16);
         }
 
+        public static IEnumerable<object[]> ExplicitConversion_FromInt64_TestData()
+        {
+            (long, BFloat16)[] data =
+            {
+                (0, BFloat16.Zero),
+                // 25-bit value is inexact in float, so a two-step conversion would double-round
+                (0x100_FFFF, BitConverter.UInt16BitsToBFloat16(0x4B80)), // 16842752 - 1 rounds lower
+                (0x101_0000, BitConverter.UInt16BitsToBFloat16(0x4B80)), // 16842752 rounds to even
+                (0x101_0001, BitConverter.UInt16BitsToBFloat16(0x4B81)), // 16842752 + 1 rounds higher
+                // high-magnitude boundary near 2^62 (2^62 + 2^54)
+                (0x403F_FFFF_FFFF_FFFF, BitConverter.UInt16BitsToBFloat16(0x5E80)), // rounds lower
+                (0x4040_0000_0000_0000, BitConverter.UInt16BitsToBFloat16(0x5E80)), // rounds to even
+                (0x4040_0000_0000_0001, BitConverter.UInt16BitsToBFloat16(0x5E81)), // rounds higher
+                (long.MaxValue, BitConverter.UInt16BitsToBFloat16(0x5F00)),
+                (-0x4040_0000_0000_0001, BitConverter.UInt16BitsToBFloat16(0xDE81)), // rounds lower
+                (long.MinValue, BitConverter.UInt16BitsToBFloat16(0xDF00)),
+            };
+
+            foreach ((long original, BFloat16 expected) in data)
+            {
+                yield return new object[] { original, expected };
+            }
+        }
+
+        [MemberData(nameof(ExplicitConversion_FromInt64_TestData))]
+        [Theory]
+        public static void ExplicitConversion_FromInt64(long i, BFloat16 expected)
+        {
+            BFloat16 b16 = (BFloat16)i;
+            AssertEqual(expected, b16);
+        }
+
+        public static IEnumerable<object[]> ExplicitConversion_FromUInt64_TestData()
+        {
+            (ulong, BFloat16)[] data =
+            {
+                (0, BFloat16.Zero),
+                // 25-bit value is inexact in float, so a two-step conversion would double-round
+                (0x100_FFFF, BitConverter.UInt16BitsToBFloat16(0x4B80)), // 16842752 - 1 rounds lower
+                (0x101_0000, BitConverter.UInt16BitsToBFloat16(0x4B80)), // 16842752 rounds to even
+                (0x101_0001, BitConverter.UInt16BitsToBFloat16(0x4B81)), // 16842752 + 1 rounds higher
+                // high-magnitude boundary near 2^63 (2^63 + 2^55)
+                (0x807F_FFFF_FFFF_FFFF, BitConverter.UInt16BitsToBFloat16(0x5F00)), // rounds lower
+                (0x8080_0000_0000_0000, BitConverter.UInt16BitsToBFloat16(0x5F00)), // rounds to even
+                (0x8080_0000_0000_0001, BitConverter.UInt16BitsToBFloat16(0x5F01)), // rounds higher
+                (ulong.MaxValue, BitConverter.UInt16BitsToBFloat16(0x5F80)),
+            };
+
+            foreach ((ulong original, BFloat16 expected) in data)
+            {
+                yield return new object[] { original, expected };
+            }
+        }
+
+        [MemberData(nameof(ExplicitConversion_FromUInt64_TestData))]
+        [Theory]
+        public static void ExplicitConversion_FromUInt64(ulong i, BFloat16 expected)
+        {
+            BFloat16 b16 = (BFloat16)i;
+            AssertEqual(expected, b16);
+        }
+
+        public static IEnumerable<object[]> ExplicitConversion_FromInt128_TestData()
+        {
+            Int128 highBit = Int128.One << 100;
+            Int128 roundBit = Int128.One << 92;
+
+            (Int128, BFloat16)[] data =
+            {
+                (0, BFloat16.Zero),
+                // 25-bit value is inexact in float, so a two-step conversion would double-round
+                ((Int128)0x101_0001, BitConverter.UInt16BitsToBFloat16(0x4B81)), // rounds higher
+                // high-magnitude boundary near 2^100 (2^100 + 2^92)
+                (highBit + roundBit - 1, BitConverter.UInt16BitsToBFloat16(0x7180)), // rounds lower
+                (highBit + roundBit, BitConverter.UInt16BitsToBFloat16(0x7180)), // rounds to even
+                (highBit + roundBit + 1, BitConverter.UInt16BitsToBFloat16(0x7181)), // rounds higher
+                (Int128.MaxValue, BitConverter.UInt16BitsToBFloat16(0x7F00)),
+                (-(highBit + roundBit + 1), BitConverter.UInt16BitsToBFloat16(0xF181)), // rounds lower
+                (Int128.MinValue, BitConverter.UInt16BitsToBFloat16(0xFF00)),
+            };
+
+            foreach ((Int128 original, BFloat16 expected) in data)
+            {
+                yield return new object[] { original, expected };
+            }
+        }
+
+        [MemberData(nameof(ExplicitConversion_FromInt128_TestData))]
+        [Theory]
+        public static void ExplicitConversion_FromInt128(Int128 i, BFloat16 expected)
+        {
+            BFloat16 b16 = (BFloat16)i;
+            AssertEqual(expected, b16);
+        }
+
+        public static IEnumerable<object[]> ExplicitConversion_FromUInt128_TestData()
+        {
+            UInt128 highBit = UInt128.One << 127;
+            UInt128 roundBit = UInt128.One << 119;
+
+            (UInt128, BFloat16)[] data =
+            {
+                (0, BFloat16.Zero),
+                // 25-bit value is inexact in float, so a two-step conversion would double-round
+                ((UInt128)0x101_0001, BitConverter.UInt16BitsToBFloat16(0x4B81)), // rounds higher
+                // high-magnitude boundary near 2^127 (2^127 + 2^119)
+                (highBit + roundBit - 1, BitConverter.UInt16BitsToBFloat16(0x7F00)), // rounds lower
+                (highBit + roundBit, BitConverter.UInt16BitsToBFloat16(0x7F00)), // rounds to even
+                (highBit + roundBit + 1, BitConverter.UInt16BitsToBFloat16(0x7F01)), // rounds higher
+                (UInt128.MaxValue, BitConverter.UInt16BitsToBFloat16(0x7F80)), // overflow to infinity
+            };
+
+            foreach ((UInt128 original, BFloat16 expected) in data)
+            {
+                yield return new object[] { original, expected };
+            }
+        }
+
+        [MemberData(nameof(ExplicitConversion_FromUInt128_TestData))]
+        [Theory]
+        public static void ExplicitConversion_FromUInt128(UInt128 i, BFloat16 expected)
+        {
+            BFloat16 b16 = (BFloat16)i;
+            AssertEqual(expected, b16);
+        }
+
         public static IEnumerable<object[]> Parse_Valid_TestData()
         {
             NumberStyles defaultStyle = NumberStyles.Float | NumberStyles.AllowThousands;


### PR DESCRIPTION
﻿Adds test coverage proving that integer->`Half` and integer->`BFloat16` conversions round correctly and do not double-round through `float`. This is part of #112474.

`HalfTests` previously had no integer-conversion tests at all, and `BFloat16Tests` only covered `Int32`/`UInt32`. The integer conversions are already correct in the current tree (`BFloat16` uses direct `RoundFromSigned`/`RoundFromUnsigned`, and `Half` saturates below `2^17` so no integer can observably double-round); these tests guard that behavior against regressions.

## What's covered

- **`Half`**: `Int32`/`UInt32`/`Int64`/`UInt64`, exercising the 11-bit round-to-even boundary (2048/2049/2050/2051, 4097/4098/4100), the finite/overflow boundary (65504/65519/65520 -> inf), and large 64-bit magnitudes -> inf.
- **`BFloat16`**: `Int64`/`UInt64`/`Int128`/`UInt128`, exercising the mid-range double-rounding boundary (`0x101_0000`/`0x101_0001`/`0x100_FFFF` - the values that are inexact in `float`, so a two-step conversion would round the wrong way) plus high-magnitude round-to-even boundaries near `2^62`, `2^63`, `2^100`, and `2^127`, and `MaxValue`/`MinValue`.

## Validation

Every expected bit pattern was cross-checked against the single-step correctly-rounded `Half.Parse`/`BFloat16.Parse` oracle (integer decimal strings are exact). The discriminating case was confirmed to differ from a two-step result: `(BFloat16)0x101_0001` is `0x4B81` (correct, direct) whereas `(BFloat16)(float)0x101_0001` is `0x4B80` (double-rounded) - so these tests fail if the conversion is ever routed through `float`.

Test-only change. Both classes pass (1605 `Half`, 1571 `BFloat16`, 0 failures).

> [!NOTE]
> This PR description was generated by GitHub Copilot.
