### PR TITLE
Fix HFA/HVA by-value argument marshalling on ARM64 in CallTargetWorker

### DIFF
--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -401,6 +401,15 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
                 argDest.CopyStructToRegisters(pSrc, th.AsMethodTable()->GetNumInstanceFieldBytes(), 0);
             }
             else
+#elif defined(TARGET_ARM64)
+            if (argDest.IsHFA())
+            {
+                // An HFA/HVA struct argument is enregistered with each field in its own
+                // floating-point/vector register. Expand the packed struct data into the
+                // register slots instead of copying it verbatim.
+                argDest.CopyHFAStructToRegister(pSrc, stackSize);
+            }
+            else
 #elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
             if (argDest.IsStructPassedInRegs())
             {


### PR DESCRIPTION
MethodDescCallSite::CallTargetWorker manually marshals arguments into the register save area. The branch that expands a struct-passed-in-registers into individual register slots was gated to UNIX_AMD64_ABI / LOONGARCH64 / RISCV64 only. On ARM64, HFA/HVA structs passed by value in FP registers fell through to the default packed CopyMemory, which lays the fields out contiguously instead of placing each field in its own NEON register slot. The callee then read {field0, field2, garbage, ...}.

Add a TARGET_ARM64 branch that calls the existing
ArgDestination::CopyHFAStructToRegister when the argument is an HFA, matching the pattern already used in CopyValueClassArgUnchecked. Non-HFA structs (and HFAs spilled to the stack) keep IsHFA() == false and fall through to the unchanged default copy.

This manifested as "vector math broken in the debugger only" because normal JIT-emitted calls and reflection invoke stubs do not use this manual marshalling path, but debugger func-eval does.

Fixes #126564