### PR TITLE
Ensure float to BFloat16 conversion keeps NaN as NaN

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BFloat16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BFloat16.cs
@@ -586,8 +586,12 @@ namespace System.Numerics
             uint bits = BitConverter.SingleToUInt32Bits(value);
             uint roundedBits = RoundMidpointToEven(bits, 16);
 
-            // Only do rounding for non-NaN
-            return new BFloat16((ushort)(!float.IsNaN(value) ? roundedBits : (bits >> 16)));
+            // Only do rounding for non-NaN. For NaN we truncate to the top 16 bits, but that can
+            // zero out all of BFloat16's significand bits (e.g. 0x7F80_0001 -> 0x7F80, which is
+            // +Infinity), silently turning the NaN into an Infinity. Force the MSB of the significand
+            // (the quiet bit) so the result stays a NaN while preserving the sign and any surviving payload.
+            const uint QuietBit = 1u << (TrailingSignificandLength - 1);
+            return new BFloat16((ushort)(!float.IsNaN(value) ? roundedBits : ((bits >> 16) | QuietBit)));
         }
 
         private static unsafe BFloat16 RoundFromUnsigned<TInteger>(TInteger value)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
@@ -472,8 +472,8 @@ namespace System.Numerics.Tests
                 (float.NegativeInfinity, BFloat16.NegativeInfinity), // Overflow
                 (float.NaN, BFloat16.NaN), // Quiet Negative NaN
                 (BitConverter.UInt32BitsToSingle(0x7FC00000), BitConverter.UInt16BitsToBFloat16(0b0_11111111_1000000)), // Quiet Positive NaN
-                (BitConverter.UInt32BitsToSingle(0xFFD55555), BitConverter.UInt16BitsToBFloat16(0b1_11111111_1010101)), // Signalling Negative NaN
-                (BitConverter.UInt32BitsToSingle(0x7FD55555), BitConverter.UInt16BitsToBFloat16(0b0_11111111_1010101)), // Signalling Positive NaN
+                (BitConverter.UInt32BitsToSingle(0xFFD55555), BitConverter.UInt16BitsToBFloat16(0b1_11111111_1010101)), // Quiet Negative NaN with payload
+                (BitConverter.UInt32BitsToSingle(0x7FD55555), BitConverter.UInt16BitsToBFloat16(0b0_11111111_1010101)), // Quiet Positive NaN with payload
                 (BitConverter.UInt32BitsToSingle(0x7F800001), BitConverter.UInt16BitsToBFloat16(0b0_11111111_1000000)), // Positive NaN with payload only in the low 16 bits (must stay NaN, not Infinity)
                 (BitConverter.UInt32BitsToSingle(0xFF800001), BitConverter.UInt16BitsToBFloat16(0b1_11111111_1000000)), // Negative NaN with payload only in the low 16 bits (must stay NaN, not Infinity)
                 (BitConverter.UInt32BitsToSingle(0x7FA00000), BitConverter.UInt16BitsToBFloat16(0b0_11111111_1100000)), // Signalling Positive NaN with surviving high payload bit

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
@@ -474,6 +474,9 @@ namespace System.Numerics.Tests
                 (BitConverter.UInt32BitsToSingle(0x7FC00000), BitConverter.UInt16BitsToBFloat16(0b0_11111111_1000000)), // Quiet Positive NaN
                 (BitConverter.UInt32BitsToSingle(0xFFD55555), BitConverter.UInt16BitsToBFloat16(0b1_11111111_1010101)), // Signalling Negative NaN
                 (BitConverter.UInt32BitsToSingle(0x7FD55555), BitConverter.UInt16BitsToBFloat16(0b0_11111111_1010101)), // Signalling Positive NaN
+                (BitConverter.UInt32BitsToSingle(0x7F800001), BitConverter.UInt16BitsToBFloat16(0b0_11111111_1000000)), // Positive NaN with payload only in the low 16 bits (must stay NaN, not Infinity)
+                (BitConverter.UInt32BitsToSingle(0xFF800001), BitConverter.UInt16BitsToBFloat16(0b1_11111111_1000000)), // Negative NaN with payload only in the low 16 bits (must stay NaN, not Infinity)
+                (BitConverter.UInt32BitsToSingle(0x7FA00000), BitConverter.UInt16BitsToBFloat16(0b0_11111111_1100000)), // Signalling Positive NaN with surviving high payload bit
                 (float.Epsilon, BitConverter.UInt16BitsToBFloat16(0)), // Underflow
                 (-float.Epsilon, BitConverter.UInt16BitsToBFloat16(0b1_00000000_0000000)), // Underflow
                 (1f, BitConverter.UInt16BitsToBFloat16(0b0_01111111_0000000)), // 1


### PR DESCRIPTION
The `float`->`BFloat16` narrowing conversion could silently turn a NaN into an Infinity, violating IEEE 754 (a NaN must stay a NaN across narrowing conversions).

The NaN path in `explicit operator BFloat16(float)` simply truncated the top 16 bits via `bits >> 16`. A `BFloat16` significand is only 7 bits (the top 7 of the `float` significand), so for any NaN whose set payload bits live entirely in the low 16 bits -- i.e. a signaling NaN like `0x7F80_0001` -- the top 7 significand bits are zero and the result is `0x7F80` = `+Infinity`.

This only affected signaling NaNs; quiet NaNs already have the significand MSB (`0x0040_0000`) set, which maps directly to `BFloat16`'s quiet bit and survives the shift.

## Fix

Force the significand's quiet bit (`1 << (TrailingSignificandLength - 1)` = `0x0040`) on the NaN path so the result stays a NaN while preserving the sign and any surviving upper payload bits. This quiets the NaN, matching the existing `double`->`BFloat16` path in the same file (whose comment notes it is "just setting the MSB of fraction") and `Half`'s `explicit operator Half(float)`. IEEE 754 permits returning a quiet NaN from a narrowing conversion.

Note that "always round" is **not** a valid alternative here: plain round-to-nearest-ties-to-even still rounds low-payload NaNs to Infinity, and can carry an all-ones-significand NaN out through the (already all-ones) exponent into the sign bit, producing `+/-0.0`.

## Test

Added three cases to the existing `ExplicitConversion_FromSingle` theory in `BFloat16Tests.cs` (bit-strict, already gated for the WASM/Mono NaN-canonicalization quirk):

| input | expected |
|---|---|
| `0x7F800001` | `0x7FC0` (payload only in low 16 bits) |
| `0xFF800001` | `0xFFC0` (negative variant) |
| `0x7FA00000` | `0x7FE0` (surviving upper payload bit + quiet bit) |

Verified on Windows x64: with the fix the full `BFloat16Tests` class passes (1542/1542); reverting the fix reproduces exactly these 3 failures (one showing `Expected: NaN, Actual: -Infinity`).

> [!NOTE]
> This PR description was drafted by GitHub Copilot on @tannergooding's behalf.
