### PR TITLE
Fix CORECLR_NOTIFICATION_PROFILERS dropping entries without trailing ';'

### DIFF
--- a/src/coreclr/vm/profilinghelper.cpp
+++ b/src/coreclr/vm/profilinghelper.cpp
@@ -790,47 +790,70 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerList()
     }
 
     SString profilerList{wszProfilerList};
+    SString::Iterator listEnd = profilerList.End();
 
     HRESULT storedHr = S_OK;
-    for (SString::Iterator sectionStart = profilerList.Begin(), sectionEnd = profilerList.Begin();
-        profilerList.Find(sectionEnd, W(';'));
-        sectionStart = ++sectionEnd)
+    for (SString::Iterator sectionStart = profilerList.Begin(); sectionStart != listEnd; )
     {
+        // The current section spans from sectionStart up to the next ';', or to the end
+        // of the list if no ';' remains. Using Find as a loop condition (as was done
+        // previously) silently drops the final entry when it has no trailing ';'.
+        SString::Iterator sectionEnd = sectionStart;
+        if (!profilerList.Find(sectionEnd, W(';')))
+        {
+            sectionEnd = listEnd;
+        }
+
+        // Skip empty sections produced by consecutive or trailing ';'.
+        if (sectionStart == sectionEnd)
+        {
+            sectionStart = sectionEnd + 1;
+            continue;
+        }
+
         SString::Iterator pathEnd = sectionStart;
         if (!profilerList.Find(pathEnd, W('=')) || pathEnd > sectionEnd)
         {
             ProfilingAPIUtility::LogProfError(IDS_E_PROF_BAD_PATH);
             storedHr = E_FAIL;
-            continue;
         }
-        SString::Iterator clsidStart = pathEnd + 1;
-
-        PathString path{profilerList, sectionStart, pathEnd};
-        StackSString clsidString{profilerList, clsidStart, sectionEnd};
-        CLSID clsid;
-        hr = ProfilingAPIUtility::ProfilerCLSIDFromString(clsidString.GetUnicode(), &clsid);
-        if (FAILED(hr))
+        else
         {
-            // ProfilerCLSIDFromString already logged an event if there was a failure
-            storedHr = hr;
-            continue;
+            SString::Iterator clsidStart = pathEnd + 1;
+
+            PathString path{profilerList, sectionStart, pathEnd};
+            StackSString clsidString{profilerList, clsidStart, sectionEnd};
+            CLSID clsid;
+            hr = ProfilingAPIUtility::ProfilerCLSIDFromString(clsidString.GetUnicode(), &clsid);
+            if (FAILED(hr))
+            {
+                // ProfilerCLSIDFromString already logged an event if there was a failure
+                storedHr = hr;
+            }
+            else
+            {
+                char clsidUtf8[MINIPAL_GUID_BUFFER_LEN];
+                minipal_guid_as_string(clsid, clsidUtf8, MINIPAL_GUID_BUFFER_LEN);
+                hr = LoadProfiler(
+                    kStartupLoad,
+                    &clsid,
+                    (LPCSTR)clsidUtf8,
+                    path.GetUnicode(),
+                    NULL,               // No client data for startup load
+                    0);                 // No client data for startup load
+                if (FAILED(hr))
+                {
+                    // LoadProfiler already logged if there was an error
+                    storedHr = hr;
+                }
+            }
         }
 
-        char clsidUtf8[MINIPAL_GUID_BUFFER_LEN];
-        minipal_guid_as_string(clsid, clsidUtf8, MINIPAL_GUID_BUFFER_LEN);
-        hr = LoadProfiler(
-            kStartupLoad,
-            &clsid,
-            (LPCSTR)clsidUtf8,
-            path.GetUnicode(),
-            NULL,               // No client data for startup load
-            0);                 // No client data for startup load
-        if (FAILED(hr))
+        if (sectionEnd == listEnd)
         {
-            // LoadProfiler already logged if there was an error
-            storedHr = hr;
-            continue;
+            break;
         }
+        sectionStart = sectionEnd + 1;
     }
 
     return storedHr;

--- a/src/coreclr/vm/profilinghelper.cpp
+++ b/src/coreclr/vm/profilinghelper.cpp
@@ -796,8 +796,7 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerList()
     for (SString::Iterator sectionStart = profilerList.Begin(); sectionStart != listEnd; )
     {
         // The current section spans from sectionStart up to the next ';', or to the end
-        // of the list if no ';' remains. Using Find as a loop condition (as was done
-        // previously) silently drops the final entry when it has no trailing ';'.
+        // of the list if no ';' remains.
         SString::Iterator sectionEnd = sectionStart;
         if (!profilerList.Find(sectionEnd, W(';')))
         {

--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -32,6 +32,7 @@ namespace Profiler.Tests
                               string reverseServerName = null,
                               bool loadAsNotification = false,
                               int notificationCopies = 1,
+                              bool appendNotificationSeparator = true,
                               string envVarProfilerPrefix = "DOTNET")
         {
             string arguments;
@@ -55,11 +56,22 @@ namespace Profiler.Tests
                     StringBuilder builder = new StringBuilder();
                     for (int i = 0; i < notificationCopies; ++i)
                     {
+                        if (i > 0)
+                        {
+                            builder.Append(";");
+                        }
+
                         builder.Append(profilerPath);
                         builder.Append("=");
                         builder.Append("{");
                         builder.Append(profilerClsid.ToString());
                         builder.Append("}");
+                    }
+
+                    // A trailing separator is optional. Omitting it exercises the common
+                    // real-world form where the final (or only) entry has no trailing ';'.
+                    if (appendNotificationSeparator)
+                    {
                         builder.Append(";");
                     }
 

--- a/src/tests/profiler/multiple/multiple.cs
+++ b/src/tests/profiler/multiple/multiple.cs
@@ -61,33 +61,25 @@ namespace Profiler.Tests
                                    envVarProfilerPrefix: "CORECLR");
 
             Console.WriteLine($"Running the test using environment variables with DOTNET prefix.");
-            int result = ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
-                                          testName: "MultiplyLoaded",
-                                          profilerClsid: MultipleProfilerGuid,
-                                          loadAsNotification: true,
-                                          notificationCopies: 2,
-                                          envVarProfilerPrefix: "DOTNET");
-            if (result != 100)
-            {
-                return result;
-            }
+            ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
+                                   testName: "MultiplyLoaded",
+                                   profilerClsid: MultipleProfilerGuid,
+                                   loadAsNotification: true,
+                                   notificationCopies: 2,
+                                   envVarProfilerPrefix: "DOTNET");
 
             // A notification profiler list whose final entry has no trailing ';' must still
             // load every entry. A parser that treats the last entry as terminated only by a
             // trailing ';' would silently drop it, leaving only one notification profiler
             // loaded and hanging this test.
             Console.WriteLine($"Running the test with no trailing separator (CORECLR prefix).");
-            result = ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
+            ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
                                    testName: "MultiplyLoaded",
                                    profilerClsid: MultipleProfilerGuid,
                                    loadAsNotification: true,
                                    notificationCopies: 2,
                                    appendNotificationSeparator: false,
                                    envVarProfilerPrefix: "CORECLR");
-            if (result != 100)
-            {
-                return result;
-            }
 
             Console.WriteLine($"Running the test with no trailing separator (DOTNET prefix).");
             return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,

--- a/src/tests/profiler/multiple/multiple.cs
+++ b/src/tests/profiler/multiple/multiple.cs
@@ -61,12 +61,42 @@ namespace Profiler.Tests
                                    envVarProfilerPrefix: "CORECLR");
 
             Console.WriteLine($"Running the test using environment variables with DOTNET prefix.");
-            return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
+            int result = ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
                                           testName: "MultiplyLoaded",
                                           profilerClsid: MultipleProfilerGuid,
                                           loadAsNotification: true,
                                           notificationCopies: 2,
                                           envVarProfilerPrefix: "DOTNET");
+            if (result != 100)
+            {
+                return result;
+            }
+
+            // A notification profiler list whose final entry has no trailing ';' must still
+            // load every entry. A parser that treats the last entry as terminated only by a
+            // trailing ';' would silently drop it, leaving only one notification profiler
+            // loaded and hanging this test.
+            Console.WriteLine($"Running the test with no trailing separator (CORECLR prefix).");
+            result = ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
+                                   testName: "MultiplyLoaded",
+                                   profilerClsid: MultipleProfilerGuid,
+                                   loadAsNotification: true,
+                                   notificationCopies: 2,
+                                   appendNotificationSeparator: false,
+                                   envVarProfilerPrefix: "CORECLR");
+            if (result != 100)
+            {
+                return result;
+            }
+
+            Console.WriteLine($"Running the test with no trailing separator (DOTNET prefix).");
+            return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
+                                   testName: "MultiplyLoaded",
+                                   profilerClsid: MultipleProfilerGuid,
+                                   loadAsNotification: true,
+                                   notificationCopies: 2,
+                                   appendNotificationSeparator: false,
+                                   envVarProfilerPrefix: "DOTNET");
         }
     }
 }

--- a/src/tests/profiler/multiple/multiple.cs
+++ b/src/tests/profiler/multiple/multiple.cs
@@ -69,9 +69,7 @@ namespace Profiler.Tests
                                    envVarProfilerPrefix: "DOTNET");
 
             // A notification profiler list whose final entry has no trailing ';' must still
-            // load every entry. A parser that treats the last entry as terminated only by a
-            // trailing ';' would silently drop it, leaving only one notification profiler
-            // loaded and hanging this test.
+            // load every entry.
             Console.WriteLine($"Running the test with no trailing separator (CORECLR prefix).");
             ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
                                    testName: "MultiplyLoaded",


### PR DESCRIPTION
AttemptLoadProfilerList used SString::Find as the loop condition, so any profiler list section not followed by ';' - the last or only entry - was never processed. This silently dropped single-entry lists and the final entry of multi-entry lists, a regression from the .NET 8 wcstok_s-based parser.

Restructure the loop so each section runs up to the next ';' or to the end of the list, and skip empty sections produced by consecutive or trailing separators. This also stops the previous code from reporting a spurious bad-path error for empty sections.

Add a regression test: ProfilerTestRunner gains an optional appendNotificationSeparator flag (default preserves existing behavior), and the multiple profiler test now also runs with no trailing separator for both the CORECLR and DOTNET env var prefixes.

Fixes https://github.com/dotnet/runtime/issues/126197