### PR TITLE
Enable Enum.HasFlag box elision in Tier0

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3560,7 +3560,7 @@ void Compiler::impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken)
 
         // Avoid sharing in some tier 0 cases to, potentially, avoid boxing in Enum.HasFlag.
         if (shareBoxedTemps && varTypeIsIntegral(exprToBox) && !lvaHaveManyLocals() &&
-            (info.compCompHnd->isEnum(pResolvedToken->hClass, nullptr) != TypeCompareState::Must))
+            (info.compCompHnd->isEnum(pResolvedToken->hClass, nullptr) == TypeCompareState::Must))
         {
             shareBoxedTemps = false;
         }


### PR DESCRIPTION
The JIT can already elide the boxes generated for `Enum.HasFlag` in optimized (Tier1) code, but not in Tier0/minopts. This is the motivating case here: `Enum.HasFlag` at Tier0 allocates and boxes both the `this` value and the flag argument, then makes a real call, which is a lot of work for something that should fold to a couple of `and`/`cmp` instructions.

## Root cause

To keep the local count (and prolog zeroing) down, Tier0 shares a single "Reusable Box Helper" temp across boxes. Shared temps carry no exact type, so `gtOptimizeEnumHasFlag` cannot recover the underlying value and bails, leaving the box in place.

`impImportAndPushBox` has a carve-out that instead hands integral box values their own single-def *exact* temp precisely so this elision can fire (added in #89348). However, its condition included `isEnum(hClass) != TypeCompareState::Must`, which *excludes* actual enums, the exact case it was meant to enable. So enum boxes kept sharing a temp and never got their exact type.

## Fix

Correct the inverted guard from `!= TypeCompareState::Must` to `== TypeCompareState::Must` so the carve-out targets enum boxes, the case it was written for. This has two effects at Tier0:

1. **Enum boxes get a unique exact temp**, so `gtOptimizeEnumHasFlag` recovers the value and elides the box entirely. This is the allocation win and the motivating fix.
2. **Non-enum integral boxes go back to sharing a reusable temp** (their pre-#89348 behavior). This does not change which allocations happen; it only reuses a single ref-temp slot across boxes with non-overlapping lifetimes, which shrinks the Tier0 frame and prolog zeroing.

## Measured impact

SuperPMI, x64, checked JIT, vs clean `main`.

**Allocations.** The only heap allocations removed are the enum `HasFlag` boxes themselves (`CORINFO_HELP_NEWSFAST` 2 -> 0 on the `HasFlag` methods). Non-enum box allocation counts are invariant. A cross-collection `NEWSFAST`-delta scan confirmed this change never emits *more* allocations than base (it never reintroduces a box the base was eliding) — the receiver/flag temps are only shared across non-overlapping lifetimes, so a live boxed value is never clobbered.

**Code size (asmdiffs).** Net **-175,983 bytes** across 6,641 contexts:

| Collection | contexts | net bytes |
|---|--:|--:|
| aspnet2 | 53 | -2,174 |
| benchmarks.run_pgo | 141 | -3,850 |
| coreclr_tests | 1,363 | -37,656 |
| libraries_tests | 5,062 | -132,292 |
| libraries_tests_no_tiered | 22 | -11 |

That is -218,115 bytes of improvements over 4,583 methods against +42,132 bytes of regressions over 1,789 methods. The regressions are small (worst single method +47 bytes, clustered +6..+47) and are Tier0 prolog/`mov` zero-init churn from the different temp layout when a non-enum box reverts to the shared slot — no added allocations. The bulk of the win is the frame/prolog shrink from re-sharing non-enum integral box temps; the enum box elision itself is the smaller, allocation-reducing slice.

**JIT throughput (tpdiff).** MinOpts -0.06% (aspnet2) to ~-0.00/-0.01% overall; FullOpts unchanged (`shareBoxedTemps` is already false there). This is one import-time condition, so per-method JIT work is unchanged — effectively free on throughput.

**Tier0 repro.** `HasFlagConst` 103 -> 49 bytes, `HasFlagVar` 105 -> 59 bytes, with the `NEWSFAST`/`HasFlag` calls gone and correct runtime results.

Net: correcting the guard enables the enum box elision at Tier0 (the allocation win) and, as a side effect, restores shared non-enum integral box temps for a substantial additional code-size and PerfScore win, at effectively zero JIT throughput cost.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.