### PR TITLE
Enable NativeAOT CMake on additional architectures

### DIFF
--- a/eng/pipelines/runtime-community.yml
+++ b/eng/pipelines/runtime-community.yml
@@ -44,7 +44,6 @@ extends:
       jobs:
 
       #
-      # dummy
       # s390x & PPC64 little endian
       # Build the whole product using Mono and run libraries tests
       #

--- a/eng/pipelines/runtime-community.yml
+++ b/eng/pipelines/runtime-community.yml
@@ -44,6 +44,7 @@ extends:
       jobs:
 
       #
+      # dummy
       # s390x & PPC64 little endian
       # Build the whole product using Mono and run libraries tests
       #

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -177,9 +177,7 @@ if ((NOT CLR_CMAKE_TARGET_BROWSER AND NOT CLR_CMAKE_TARGET_WASI) OR CLR_CROSS_CO
 endif ()
 
 if(NOT CLR_CROSS_COMPONENTS_BUILD)
-  # NativeAOT is buildable for all CoreCLR-supported configurations except a known reject list.
-  # Keep this in sync with the NativeAotSupported reject list in eng/common/native/NativeAotSupported.props.
-  if(NOT (CLR_CMAKE_HOST_ARCH_WASM OR CLR_CMAKE_HOST_ARCH_S390X OR CLR_CMAKE_HOST_ARCH_POWERPC64 OR (CLR_CMAKE_HOST_ARCH_I386 AND NOT CLR_CMAKE_HOST_WIN32)))
+  if(NOT CLR_CMAKE_HOST_ARCH_WASM)
     add_subdirectory(nativeaot)
   endif()
 endif(NOT CLR_CROSS_COMPONENTS_BUILD)

--- a/src/coreclr/nativeaot/Runtime/i386/DispatchResolve.S
+++ b/src/coreclr/nativeaot/Runtime/i386/DispatchResolve.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/i386/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/i386/GcProbe.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/ppc64le/AsmMacros_Shared.h
+++ b/src/coreclr/nativeaot/Runtime/ppc64le/AsmMacros_Shared.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This file is used to allow sharing of assembly code between NativeAOT and CoreCLR, which have different conventions about how to ensure that constants offsets are accessible
+
+#include <unixasmmacros.inc>
+#include "AsmOffsets.inc"

--- a/src/coreclr/nativeaot/Runtime/ppc64le/DispatchResolve.S
+++ b/src/coreclr/nativeaot/Runtime/ppc64le/DispatchResolve.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/ppc64le/ExceptionHandling.S
+++ b/src/coreclr/nativeaot/Runtime/ppc64le/ExceptionHandling.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/ppc64le/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/ppc64le/GcProbe.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/ppc64le/InteropThunksHelpers.S
+++ b/src/coreclr/nativeaot/Runtime/ppc64le/InteropThunksHelpers.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/ppc64le/MiscStubs.S
+++ b/src/coreclr/nativeaot/Runtime/ppc64le/MiscStubs.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/ppc64le/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/ppc64le/PInvoke.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/ppc64le/UniversalTransition.S
+++ b/src/coreclr/nativeaot/Runtime/ppc64le/UniversalTransition.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/s390x/AsmMacros_Shared.h
+++ b/src/coreclr/nativeaot/Runtime/s390x/AsmMacros_Shared.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This file is used to allow sharing of assembly code between NativeAOT and CoreCLR, which have different conventions about how to ensure that constants offsets are accessible
+
+#include <unixasmmacros.inc>
+#include "AsmOffsets.inc"

--- a/src/coreclr/nativeaot/Runtime/s390x/DispatchResolve.S
+++ b/src/coreclr/nativeaot/Runtime/s390x/DispatchResolve.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/s390x/ExceptionHandling.S
+++ b/src/coreclr/nativeaot/Runtime/s390x/ExceptionHandling.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/s390x/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/s390x/GcProbe.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/s390x/InteropThunksHelpers.S
+++ b/src/coreclr/nativeaot/Runtime/s390x/InteropThunksHelpers.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/s390x/MiscStubs.S
+++ b/src/coreclr/nativeaot/Runtime/s390x/MiscStubs.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/s390x/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/s390x/PInvoke.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/nativeaot/Runtime/s390x/UniversalTransition.S
+++ b/src/coreclr/nativeaot/Runtime/s390x/UniversalTransition.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>

--- a/src/coreclr/runtime/ppc64le/AllocFast.S
+++ b/src/coreclr/runtime/ppc64le/AllocFast.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "AsmMacros_Shared.h"

--- a/src/coreclr/runtime/ppc64le/StubDispatch.S
+++ b/src/coreclr/runtime/ppc64le/StubDispatch.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "AsmMacros_Shared.h"

--- a/src/coreclr/runtime/ppc64le/WriteBarriers.S
+++ b/src/coreclr/runtime/ppc64le/WriteBarriers.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "AsmMacros_Shared.h"

--- a/src/coreclr/runtime/s390x/AllocFast.S
+++ b/src/coreclr/runtime/s390x/AllocFast.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "AsmMacros_Shared.h"

--- a/src/coreclr/runtime/s390x/StubDispatch.S
+++ b/src/coreclr/runtime/s390x/StubDispatch.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "AsmMacros_Shared.h"

--- a/src/coreclr/runtime/s390x/WriteBarriers.S
+++ b/src/coreclr/runtime/s390x/WriteBarriers.S
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "AsmMacros_Shared.h"


### PR DESCRIPTION
Add placeholder assembly sources required by NativeAOT CMake for s390x, ppc64le, and Unix x86.
