### PR TITLE
Vectorize safe ASCII runs in web encoders

### DIFF
--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/OptimizedInboxTextEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/OptimizedInboxTextEncoder.cs
@@ -180,7 +180,7 @@ namespace System.Text.Encodings.Web
 
                 dstIdx = dstIdxTemp;
                 srcIdx++;
-                continue;
+                goto ScalarProcessed;
 
             NotAscii:
 
@@ -229,6 +229,28 @@ namespace System.Text.Encodings.Web
 
                 dstIdx += charsWrittenJustNow;
                 srcIdx += scalarValue.Utf16SequenceLength;
+
+            ScalarProcessed:
+
+#if NET
+                int sourceRemaining = source.Length - srcIdx;
+                int destinationRemaining = destination.Length - dstIdx;
+                int asciiSearchLength = Math.Min(sourceRemaining, destinationRemaining);
+
+                if (asciiSearchLength >= 8)
+                {
+                    int asciiRunLength = source.Slice(srcIdx, asciiSearchLength).IndexOfAnyExcept(_allowedAsciiChars);
+                    if (asciiRunLength < 0)
+                    {
+                        asciiRunLength = asciiSearchLength;
+                    }
+
+                    source.Slice(srcIdx, asciiRunLength).CopyTo(destination.Slice(dstIdx));
+                    srcIdx += asciiRunLength;
+                    dstIdx += asciiRunLength;
+                }
+#endif
+                continue;
             }
 
             // And at this point, we're done!
@@ -276,9 +298,14 @@ namespace System.Text.Encodings.Web
 
                 if (BinaryPrimitives.TryWriteUInt64LittleEndian(destination.Slice(dstIdx), preescapedEntry))
                 {
-                    dstIdx += (int)(preescapedEntry >> 56); // predicted taken
+                    int preescapedBytesWritten = (int)(preescapedEntry >> 56);
+                    dstIdx += preescapedBytesWritten; // predicted taken
                     srcIdx++;
-                    continue;
+                    if (preescapedBytesWritten == 1)
+                    {
+                        continue;
+                    }
+                    goto ScalarProcessed;
                 }
 
                 // We don't have enough space to hold a single QWORD copy, so let's write byte-by-byte
@@ -297,7 +324,7 @@ namespace System.Text.Encodings.Web
 
                 dstIdx = dstIdxTemp;
                 srcIdx++;
-                continue;
+                goto ScalarProcessed;
 
             NotAscii:
 
@@ -336,6 +363,28 @@ namespace System.Text.Encodings.Web
 
                 dstIdx += bytesWrittenJustNow;
                 srcIdx += bytesConsumedJustNow;
+
+            ScalarProcessed:
+
+#if NET
+                int sourceRemaining = source.Length - srcIdx;
+                int destinationRemaining = destination.Length - dstIdx;
+                int asciiSearchLength = Math.Min(sourceRemaining, destinationRemaining);
+
+                if (asciiSearchLength >= 8)
+                {
+                    int asciiRunLength = source.Slice(srcIdx, asciiSearchLength).IndexOfAnyExcept(_allowedAsciiBytes);
+                    if (asciiRunLength < 0)
+                    {
+                        asciiRunLength = asciiSearchLength;
+                    }
+
+                    source.Slice(srcIdx, asciiRunLength).CopyTo(destination.Slice(dstIdx));
+                    srcIdx += asciiRunLength;
+                    dstIdx += asciiRunLength;
+                }
+#endif
+                continue;
             }
 
             // And at this point, we're done!

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/OptimizedInboxTextEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/OptimizedInboxTextEncoder.cs
@@ -324,7 +324,7 @@ namespace System.Text.Encodings.Web
 
                 dstIdx = dstIdxTemp;
                 srcIdx++;
-                goto ScalarProcessed;
+                continue;
 
             NotAscii:
 

--- a/src/libraries/System.Text.Encodings.Web/tests/InboxEncoderCommonTests.cs
+++ b/src/libraries/System.Text.Encodings.Web/tests/InboxEncoderCommonTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.Unicode;
 using Xunit;
 
 namespace System.Text.Encodings.Web.Tests
@@ -424,6 +426,255 @@ namespace System.Text.Encodings.Web.Tests
             };
 
             _RunEncodeUtf8_Battery(inputs, expectedOutputs);
+        }
+    }
+
+    public class InboxEncoderBulkAsciiRunTests
+    {
+        [Fact]
+        public void Encode_AllDestinationBoundariesMatchScalarReference()
+        {
+            foreach ((TextEncoder encoder, string input) in GetUtf16Inputs())
+            {
+                string expectedOutput = encoder.Encode(input);
+
+                for (int destinationLength = 0; destinationLength <= expectedOutput.Length + 1; destinationLength++)
+                {
+                    char[] destination = new char[destinationLength];
+                    OperationStatus status = encoder.Encode(input, destination, out int charsConsumed, out int charsWritten);
+                    (OperationStatus expectedStatus, int expectedCharsConsumed, string expectedPrefix) =
+                        EncodeUtf16ScalarByScalar(encoder, input, destinationLength, isFinalBlock: true);
+
+                    Assert.Equal(expectedStatus, status);
+                    Assert.True(expectedCharsConsumed == charsConsumed,
+                        $"{encoder.GetType().Name}, destinationLength: {destinationLength}, input: {input}");
+                    Assert.Equal(expectedPrefix.Length, charsWritten);
+                    Assert.Equal(expectedPrefix, destination.AsSpan(0, charsWritten).ToString());
+                }
+
+                Assert.Throws<ArgumentNullException>(() => encoder.Encode((string)null!));
+            }
+        }
+
+        [Fact]
+        public void EncodeUtf8_AllDestinationBoundariesMatchScalarReference()
+        {
+            foreach ((TextEncoder encoder, byte[] input) in GetUtf8Inputs())
+            {
+                byte[] expectedOutput = EncodeUtf8ScalarByScalar(encoder, input, int.MaxValue, isFinalBlock: true).Output;
+
+                for (int destinationLength = 0; destinationLength <= expectedOutput.Length + 1; destinationLength++)
+                {
+                    byte[] destination = new byte[destinationLength];
+                    OperationStatus status = encoder.EncodeUtf8(input, destination, out int bytesConsumed, out int bytesWritten);
+                    (OperationStatus expectedStatus, int expectedBytesConsumed, byte[] expectedPrefix) =
+                        EncodeUtf8ScalarByScalar(encoder, input, destinationLength, isFinalBlock: true);
+
+                    Assert.Equal(expectedStatus, status);
+                    Assert.True(expectedBytesConsumed == bytesConsumed,
+                        $"{encoder.GetType().Name}, destinationLength: {destinationLength}");
+                    Assert.Equal(expectedPrefix.Length, bytesWritten);
+                    Assert.Equal(expectedPrefix, destination.AsSpan(0, bytesWritten).ToArray());
+                }
+            }
+        }
+
+        [Fact]
+        public void Encode_IncompleteFinalScalarMatchesScalarReference()
+        {
+            foreach ((TextEncoder encoder, string input) in GetUtf16Inputs())
+            {
+                string incompleteInput = input + '\uD800';
+                int expectedOutputLength = EncodeUtf16ScalarByScalar(
+                    encoder, incompleteInput, int.MaxValue, isFinalBlock: false).Output.Length;
+
+                for (int destinationLength = 0; destinationLength <= expectedOutputLength; destinationLength++)
+                {
+                    char[] destination = new char[destinationLength];
+                    OperationStatus status = encoder.Encode(incompleteInput, destination, out int charsConsumed, out int charsWritten, isFinalBlock: false);
+                    (OperationStatus expectedStatus, int expectedCharsConsumed, string expectedPrefix) =
+                        EncodeUtf16ScalarByScalar(encoder, incompleteInput, destination.Length, isFinalBlock: false);
+
+                    Assert.Equal(expectedStatus, status);
+                    Assert.Equal(expectedCharsConsumed, charsConsumed);
+                    Assert.Equal(expectedPrefix.Length, charsWritten);
+                    Assert.Equal(expectedPrefix, destination.AsSpan(0, charsWritten).ToString());
+                }
+            }
+        }
+
+        [Fact]
+        public void EncodeUtf8_IncompleteFinalScalarMatchesScalarReference()
+        {
+            foreach ((TextEncoder encoder, byte[] input) in GetUtf8Inputs())
+            {
+                byte[] incompleteInput = input.Concat(new byte[] { 0xF0, 0x9F, 0x99 }).ToArray();
+                int expectedOutputLength = EncodeUtf8ScalarByScalar(
+                    encoder, incompleteInput, int.MaxValue, isFinalBlock: false).Output.Length;
+
+                for (int destinationLength = 0; destinationLength <= expectedOutputLength; destinationLength++)
+                {
+                    byte[] destination = new byte[destinationLength];
+                    OperationStatus status = encoder.EncodeUtf8(incompleteInput, destination, out int bytesConsumed, out int bytesWritten, isFinalBlock: false);
+                    (OperationStatus expectedStatus, int expectedBytesConsumed, byte[] expectedPrefix) =
+                        EncodeUtf8ScalarByScalar(encoder, incompleteInput, destination.Length, isFinalBlock: false);
+
+                    Assert.Equal(expectedStatus, status);
+                    Assert.Equal(expectedBytesConsumed, bytesConsumed);
+                    Assert.Equal(expectedPrefix.Length, bytesWritten);
+                    Assert.Equal(expectedPrefix, destination.AsSpan(0, bytesWritten).ToArray());
+                }
+            }
+        }
+
+        [Fact]
+        public void Encode_IncompleteFinalScalarAfterFullAsciiRun_ReturnsNeedMoreData()
+        {
+            string input = "&" + new string('a', 8) + '\uD800';
+            Span<char> destination = stackalloc char[13];
+
+            OperationStatus status = HtmlEncoder.Default.Encode(
+                input, destination, out int charsConsumed, out int charsWritten, isFinalBlock: false);
+
+            Assert.Equal(OperationStatus.NeedMoreData, status);
+            Assert.Equal(9, charsConsumed);
+            Assert.Equal(13, charsWritten);
+        }
+
+        [Fact]
+        public void EncodeUtf8_IncompleteFinalScalarAfterFullAsciiRun_ReturnsNeedMoreData()
+        {
+            byte[] input = "<"u8.ToArray().Concat(new byte[8].Select(_ => (byte)'a')).Append((byte)0xC3).ToArray();
+            Span<byte> destination = stackalloc byte[12];
+
+            OperationStatus status = HtmlEncoder.Default.EncodeUtf8(
+                input, destination, out int bytesConsumed, out int bytesWritten, isFinalBlock: false);
+
+            Assert.Equal(OperationStatus.NeedMoreData, status);
+            Assert.Equal(9, bytesConsumed);
+            Assert.Equal(12, bytesWritten);
+        }
+
+        [Fact]
+        public void Encode_MalformedDataBetweenAsciiRuns()
+        {
+            foreach ((TextEncoder encoder, string input) in GetUtf16Inputs())
+            {
+                int firstScalarLength = Rune.DecodeFromUtf16(input, out _, out int charsConsumed) == OperationStatus.Done
+                    ? charsConsumed
+                    : 1;
+                string malformedInput = input.Substring(0, firstScalarLength) + "ascii\uD800trailing";
+                string expectedOutput = encoder.Encode(malformedInput);
+                char[] destination = new char[expectedOutput.Length - 1];
+
+                OperationStatus status = encoder.Encode(malformedInput, destination, out int actualCharsConsumed, out int charsWritten);
+
+                Assert.Equal(OperationStatus.DestinationTooSmall, status);
+                Assert.Equal(malformedInput.Length - 1, actualCharsConsumed);
+                Assert.Equal(expectedOutput.Length - 1, charsWritten);
+                Assert.Equal(expectedOutput.AsSpan(0, expectedOutput.Length - 1).ToArray(), destination);
+            }
+        }
+
+        private static IEnumerable<(TextEncoder Encoder, string Input)> GetUtf16Inputs()
+        {
+            TextEncoderSettings customSettings = new(UnicodeRanges.BasicLatin, UnicodeRanges.Latin1Supplement);
+            customSettings.ForbidCharacters('!', '"', '&', '<', '>');
+
+            foreach ((TextEncoder encoder, char characterToEncode) in new[]
+            {
+                ((TextEncoder)HtmlEncoder.Default, '&'),
+                (JavaScriptEncoder.Default, '"'),
+                (JavaScriptEncoder.UnsafeRelaxedJsonEscaping, '"'),
+                (UrlEncoder.Default, '?'),
+                (JavaScriptEncoder.Create(customSettings), '!'),
+            })
+            {
+                yield return (encoder, characterToEncode + new string('a', 63));
+                yield return (encoder, new string('a', 31) + characterToEncode + new string('b', 32));
+                yield return (encoder, string.Concat(Enumerable.Repeat($"{characterToEncode}abcdefg", 8)));
+                yield return (encoder, $"{characterToEncode}ascii\u00E9ascii\U0001F642ascii");
+            }
+        }
+
+        private static IEnumerable<(TextEncoder Encoder, byte[] Input)> GetUtf8Inputs()
+        {
+            foreach ((TextEncoder encoder, string input) in GetUtf16Inputs())
+            {
+                yield return (encoder, Encoding.UTF8.GetBytes(input));
+            }
+        }
+
+        private static (OperationStatus Status, int CharsConsumed, string Output) EncodeUtf16ScalarByScalar(
+            TextEncoder encoder,
+            string source,
+            int destinationLength,
+            bool isFinalBlock)
+        {
+            int charsConsumed = 0;
+            StringBuilder output = new();
+
+            while (charsConsumed < source.Length)
+            {
+                OperationStatus status = Rune.DecodeFromUtf16(source.AsSpan(charsConsumed), out Rune scalarValue, out int charsConsumedJustNow);
+                if (status == OperationStatus.NeedMoreData && !isFinalBlock)
+                {
+                    return (OperationStatus.NeedMoreData, charsConsumed, output.ToString());
+                }
+
+                if (status != OperationStatus.Done)
+                {
+                    scalarValue = Rune.ReplacementChar;
+                    charsConsumedJustNow = 1;
+                }
+
+                string encodedScalar = encoder.Encode(scalarValue.ToString());
+                if (encodedScalar.Length > destinationLength - output.Length)
+                {
+                    return (OperationStatus.DestinationTooSmall, charsConsumed, output.ToString());
+                }
+
+                output.Append(encodedScalar);
+                charsConsumed += charsConsumedJustNow;
+            }
+
+            return (OperationStatus.Done, charsConsumed, output.ToString());
+        }
+
+        private static (OperationStatus Status, int BytesConsumed, byte[] Output) EncodeUtf8ScalarByScalar(
+            TextEncoder encoder,
+            byte[] source,
+            int destinationLength,
+            bool isFinalBlock)
+        {
+            int bytesConsumed = 0;
+            List<byte> output = new();
+
+            while (bytesConsumed < source.Length)
+            {
+                OperationStatus status = Rune.DecodeFromUtf8(source.AsSpan(bytesConsumed), out Rune scalarValue, out int bytesConsumedJustNow);
+                if (status == OperationStatus.NeedMoreData && !isFinalBlock)
+                {
+                    return (OperationStatus.NeedMoreData, bytesConsumed, output.ToArray());
+                }
+
+                if (status != OperationStatus.Done)
+                {
+                    scalarValue = Rune.ReplacementChar;
+                    bytesConsumedJustNow = 1;
+                }
+
+                byte[] encodedScalar = Encoding.UTF8.GetBytes(encoder.Encode(scalarValue.ToString()));
+                if (encodedScalar.Length > destinationLength - output.Count)
+                {
+                    return (OperationStatus.DestinationTooSmall, bytesConsumed, output.ToArray());
+                }
+
+                output.AddRange(encodedScalar);
+                bytesConsumed += bytesConsumedJustNow;
+            }
+
+            return (OperationStatus.Done, bytesConsumed, output.ToArray());
         }
     }
 


### PR DESCRIPTION
## Motivation

`TextEncoder` already vector-scans and copies input before the first scalar that requires escaping. After entering the scalar core loop, however, later safe ASCII was classified and copied one scalar at a time. This is common in JSON/HTML text with an early quote or markup character followed by ordinary ASCII.

## Change

After an actual escape, reuse the encoder's existing `SearchValues` allow-list to find and copy the next maximal safe ASCII run. The scan is bounded by source and destination; disallowed ASCII, non-ASCII, malformed input, and short tails continue through the existing scalar path. No public API changes.

## Performance

Canonical local BenchmarkDotNet 0.15.8 runs used normal out-of-process `DefaultJob` on .NET 10.0.9, Apple M5 Pro arm64. Exact-parent/final DLL SHA-256 values were verified before shared-framework substitution.

| Input | Before | After | Ratio |
|---|---:|---:|---:|
| UTF-16, 512 chars, escape first | 254.33 ns | 31.53 ns | 8.07x |
| UTF-16, 4096 chars, escape first | 1554.60 ns | 232.11 ns | 6.70x |
| UTF-8, 512 bytes, escape first | 258.48 ns | 23.02 ns | 11.23x |
| UTF-8, 4096 bytes, escape first | 1985.78 ns | 161.14 ns | 12.32x |
| ~697 KiB JSON serialization | 1.042 ms | 137.6 μs | 7.57x |

Allocations were unchanged. HTML, URL, custom allow/block lists, repeated escapes, end-position controls, and allowed non-ASCII controls were also measured. A 16-byte UTF-8 beginning-escape case was statistically neutral/slightly slower (13.554 ns → 13.746 ns; confidence intervals overlap).

Cross-platform EgorBot benchmark requested for Linux AMD64 and macOS arm64: https://github.com/dotnet/runtime/pull/130600#issuecomment-5016910959. EgorBot has not acknowledged the request yet; recent requests on other runtime PRs are also unanswered.

## Validation

- `dotnet build -c Release` for `System.Text.Encodings.Web`
- `dotnet build /t:test tests/System.Text.Encodings.Web.Tests.csproj`: 617 passed
- Differential tests cover all destination sizes, exact output/consumed/written counts, `Done`, `DestinationTooSmall`, `NeedMoreData`, malformed UTF-8/UTF-16, surrogate pairs, built-in encoders, relaxed JavaScript, and custom settings.
- Runtime CI was green on the original commit across libraries, WASM, Android, Apple, Windows, Linux, Mono, CoreCLR, and NativeAOT lanes; refreshed CI for the review-fix commit is in progress.

## Risks and limits

- No claim for all-ASCII/no-escape input; that already uses the outer fast path.
- Benefit requires an escaped scalar followed by at least eight safe ASCII elements.
- Dense escapes/non-ASCII remain scalar-dominated.
- The PR remains draft until refreshed CI and cross-platform performance validation are complete.

> [!NOTE]
> This PR description was generated with GitHub Copilot.