### PR TITLE
Enable ArrayPool buffer pooling in Apple/Android SslStream PALs

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
@@ -87,6 +87,7 @@ namespace System.Net.Security
             int trailerSize)
         {
             ProtocolToken token = default;
+            token.RentBuffer = true;
             Debug.Assert(input.Length > 0, $"{nameof(input.Length)} > 0 since {nameof(CanEncryptEmptyMessage)} is false");
 
             try
@@ -218,6 +219,7 @@ namespace System.Net.Security
             SslAuthenticationOptions sslAuthenticationOptions)
         {
             ProtocolToken token = default;
+            token.RentBuffer = true;
             consumed = 0;
 
             try

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -151,6 +151,7 @@ namespace System.Net.Security
             SafeDeleteSslContext sslContext = (SafeDeleteSslContext)securityContext;
 
             ProtocolToken token = default;
+            token.RentBuffer = true;
 
             try
             {
@@ -357,6 +358,7 @@ namespace System.Net.Security
             SslAuthenticationOptions sslAuthenticationOptions)
         {
             ProtocolToken token = default;
+            token.RentBuffer = true;
             consumed = 0;
 
             try

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -367,10 +367,10 @@ namespace System.Net.Security.Tests
 
         // Regression test for buffer-pool reuse on the encrypted write/handshake output path
         // (SslStreamPal.*.EncryptMessage / HandshakeInternal -> ProtocolToken.SetPayload).
-        // Exercises many back-to-back writes of varying sizes -- including sizes that force
-        // token buffer growth via EnsureAvailableSpace -- and verifies data integrity across
-        // pooled-buffer reuse, so any accidental data bleed between reused rented buffers,
-        // truncation, or double-return corruption would be caught.
+        // Exercises many back-to-back writes of varying sizes -- including sizes much larger
+        // than typical, to exercise pooled payload buffers of different rented sizes -- and
+        // verifies data integrity across pooled-buffer reuse, so any accidental data bleed
+        // between reused rented buffers, truncation, or double-return corruption would be caught.
         [Fact]
         public async Task SslStream_StreamToStream_RepeatedVariableSizeWrites_RoundTripsCorrectly()
         {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -365,6 +365,45 @@ namespace System.Net.Security.Tests
             return expectedBuffer.SequenceEqual(actualBuffer);
         }
 
+        // Regression test for buffer-pool reuse on the encrypted write/handshake output path
+        // (SslStreamPal.*.EncryptMessage / HandshakeInternal -> ProtocolToken.SetPayload).
+        // Exercises many back-to-back writes of varying sizes -- including sizes that force
+        // token buffer growth via EnsureAvailableSpace -- and verifies data integrity across
+        // pooled-buffer reuse, so any accidental data bleed between reused rented buffers,
+        // truncation, or double-return corruption would be caught.
+        [Fact]
+        public async Task SslStream_StreamToStream_RepeatedVariableSizeWrites_RoundTripsCorrectly()
+        {
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
+            using (var client = new SslStream(stream1, false, AllowAnyServerCertificate))
+            using (var server = new SslStream(stream2, false, delegate { return true; }))
+            {
+                await DoHandshake(client, server);
+
+                int[] sizes = { 1, 2, 7, 64, 255, 1024, 4096, 16 * 1024, 64 * 1024, 3, 1, 65 * 1024 };
+                var rng = new Random(12345);
+
+                foreach (int size in sizes)
+                {
+                    byte[] expected = new byte[size];
+                    rng.NextBytes(expected);
+
+                    await WriteAsync(client, expected, 0, expected.Length);
+
+                    byte[] actual = new byte[size];
+                    int totalRead = 0;
+                    while (totalRead < size)
+                    {
+                        int n = await ReadAsync(server, actual, totalRead, size - totalRead);
+                        Assert.True(n > 0, "Unexpected EOF while reading round-tripped data.");
+                        totalRead += n;
+                    }
+
+                    Assert.True(VerifyOutput(actual, expected), $"Data mismatch for size {size}.");
+                }
+            }
+        }
+
         protected bool AllowAnyServerCertificate(
             object sender,
             X509Certificate certificate,

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -360,13 +360,8 @@ namespace System.Net.Security.Tests
             }
         }
 
-        private bool VerifyOutput(byte[] actualBuffer, byte[] expectedBuffer)
-        {
-            return expectedBuffer.SequenceEqual(actualBuffer);
-        }
-
-        // Regression test for buffer-pool reuse on the encrypted write/handshake output path
-        // (SslStreamPal.*.EncryptMessage / HandshakeInternal -> ProtocolToken.SetPayload).
+        // Regression test for buffer-pool reuse on the encrypted write path
+        // (SslStreamPal.*.EncryptMessage -> ProtocolToken.SetPayload).
         // Exercises many back-to-back writes of varying sizes -- including sizes much larger
         // than typical, to exercise pooled payload buffers of different rented sizes -- and
         // verifies data integrity across pooled-buffer reuse, so any accidental data bleed
@@ -399,7 +394,47 @@ namespace System.Net.Security.Tests
                         totalRead += n;
                     }
 
-                    Assert.True(VerifyOutput(actual, expected), $"Data mismatch for size {size}.");
+                    Assert.Equal(expected, actual);
+                }
+            }
+        }
+
+        // Regression test for buffer-pool reuse on the handshake output path
+        // (SslStreamPal.*.HandshakeInternal -> ProtocolToken.SetPayload). Runs several
+        // independent handshakes (each on its own SslStream/connection pair) back-to-back so
+        // that rented handshake-token buffers are returned and re-rented across connections,
+        // and verifies each handshake still round-trips application data correctly afterward --
+        // catching any accidental cross-connection data bleed or premature pool-return/reuse
+        // corruption of handshake buffers.
+        [Fact]
+        public async Task SslStream_RepeatedIndependentHandshakes_RoundTripCorrectlyAfterEach()
+        {
+            const int HandshakeCount = 8;
+            var rng = new Random(54321);
+
+            for (int i = 0; i < HandshakeCount; i++)
+            {
+                (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
+                using (var client = new SslStream(stream1, false, AllowAnyServerCertificate))
+                using (var server = new SslStream(stream2, false, delegate { return true; }))
+                {
+                    await DoHandshake(client, server);
+
+                    byte[] expected = new byte[4096];
+                    rng.NextBytes(expected);
+
+                    await WriteAsync(client, expected, 0, expected.Length);
+
+                    byte[] actual = new byte[expected.Length];
+                    int totalRead = 0;
+                    while (totalRead < actual.Length)
+                    {
+                        int n = await ReadAsync(server, actual, totalRead, actual.Length - totalRead);
+                        Assert.True(n > 0, "Unexpected EOF while reading round-tripped data.");
+                        totalRead += n;
+                    }
+
+                    Assert.Equal(expected, actual);
                 }
             }
         }


### PR DESCRIPTION
I am running an experiment - full analysis to follow. Contact @artl93

## Motivation

`ProtocolToken` already supports pooled (`ArrayPool<byte>.Shared`) payload buffers via a `RentBuffer` flag, consumed correctly by `ReleasePayload()`. The Windows (SChannel) and OpenSSL/Unix (Linux) `SslStream` PALs already set this flag. The Apple (Secure Transport: macOS/iOS/tvOS/Mac Catalyst) and Android PALs never did — every encrypted handshake/write token on those two PALs was allocated fresh instead of rented, for no apparent functional reason (confirmed via `git blame`/history: `RentBuffer` simply wasn't threaded through when those two PALs were added, `#87874` per @bartonjs; @wfurt confirmed these PALs "were never in center of attention" and flagged buffer-lifetime/leak risk as the reason to be cautious about rental in general).

## Change

Two lines, two files — set the existing `RentBuffer = true` flag at the two token-allocation call sites in:
- `src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs`
- `src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs`

No new code path is introduced — `ProtocolToken.ReleasePayload()` already gates pool-return on this per-token flag and is already exercised by the Windows/OpenSSL PALs in production today. This only activates a pre-existing, already-tested pattern for the two PALs that were missing it.

## Evidence

### Exact-parent A/B (this session — fully-matched Release config, both host/libs/runtime)

- Baseline (exact parent, pre-fix): `c1b09d933f7d720f7ae50f80b4ec6980bb93d96f`
- Candidate (fix commit): `982805085b2b7225b2fe5ff113e0a6a65d5084e6`
- Hardware: Apple M5 Pro (18 cores), macOS 26.5.2 (Darwin 25.5.0) arm64, 48 GiB RAM
- SDK/runtime: `11.0.100-preview.6.26352.110` SDK, `11.0.0` runtime, both sides built with **identical** `./build.sh clr+libs -rc release -lc release -hc release` (this corrects an earlier internal pass that mixed a Debug testhost/host config with Release libraries — matching all three configs removes that variable)
- Method: separate `git worktree` per commit, isolated `.dotnet`/`artifacts`; a self-contained console harness executed via `<testhost>/dotnet exec` against each side's own testhost (swaps the shared-framework `System.Net.Security.dll` cleanly — confirmed different SHA-256 hashes, `2afb0fb4...` candidate vs `0bfb9c8d...` baseline); 3 process launches per side, 5 in-process warm-up iterations + 10 measured trials each = **n=30 trials/scenario/side**, baseline/candidate runs alternated per round; allocation measured via `GC.GetTotalAllocatedBytes(precise: true)` (process-wide — `GetAllocatedBytesForCurrentThread` is unreliable across `await` continuations that resume on a different thread-pool thread, confirmed by a discarded first attempt yielding nonsensical negative deltas)

| Scenario | Base ms (median) | Cand ms (median) | Time Δ | Base B (median) | Cand B (median) | Bytes Δ |
|---|---:|---:|---:|---:|---:|---:|
| Handshake | 12.14 | 11.76 | −3.1% | 40,736 | 39,072 | **−4.1%** |
| MutualHandshake (mTLS) | 21.48 | 21.34 | −0.6% | 65,792 | 63,072 | **−4.1%** |
| Record round-trip 1B | 11.46 | 11.89 | +3.7%† | 41,024 | 39,304 | **−4.2%** |
| Record round-trip 1KiB | 11.44 | 11.78 | +3.0%† | 43,064 | 40,320 | **−6.4%** |
| Record round-trip 16KiB | 11.42 | 11.80 | +3.3%† | 106,664 | 88,560 | **−17.0%** |
| Record round-trip 64KiB | 11.55 | 11.91 | +3.1%† | 221,720 | 154,344 | **−30.4%** |
| Pooled c=1, 4KiB | 11.43 | 11.33 | −0.9% | 57,656 | 51,840 | **−10.1%** |
| Pooled c=16, 4KiB | 140.75 | 142.06 | +0.9%† | 920,976 | 827,692 | **−10.1%** |
| Pooled c=64, 4KiB | 543.25 | 552.35 | +1.7%† | 3,685,936 | 3,317,028 | **−10.0%** |

† Time deltas of a few percent at these absolute magnitudes (TCP-loopback + RSA/AES/SHA-dominated) are within run-to-run noise for a whole-connection benchmark; this change targets allocations, not raw handshake/record latency. Allocation reduction is the reproducible signal, scales with record size as expected (bigger records ⇒ bigger rented buffers ⇒ proportionally larger savings), and the pooled/concurrent scenarios (representative of a reused, `HttpClient`-style connection) show a consistent ~10% reduction.

**These end-to-end whole-connection percentages are intentionally more conservative than an earlier isolated-component pass** (which measured the touched allocation call sites directly and saw −69%/−97%/−98% at 1 KiB/16 KiB/64 KiB, and ~−89% pooled). Both are correct for what they measure: the isolated number answers "how much did the touched code improve," the end-to-end number above answers "how much does a full connection improve" once diluted by everything else a handshake/record round-trip allocates (sockets, the `SslStream` object graph, cert parsing, TLS state machine, task continuations). Both point the same direction and are mutually consistent.

### EgorBot

Requested (`-amd -osx_arm64`) in a [follow-up comment](#issuecomment-5018018134) with a self-contained BenchmarkDotNet harness covering the same 9 scenarios (Handshake, MutualHandshake, Record_1B/1KiB/16KiB/64KiB, Pooled_C1/C16/C64_4KiB). Results pending — will be posted to this PR by the bot once its run completes.

## Validation

- Functional (`System.Net.Security.Tests`, candidate HEAD): **4978 total, 0 failed, 20 skipped** (macOS: TLS 1.3/renegotiation/null-encryption tests correctly skip — platform doesn't support those, unrelated to this change).
- Unit (`System.Net.Security.Unit.Tests`): **132 total, 0 failed, 3 skipped**.
- Added a differential regression test (`SslStreamStreamToStreamTest.SslStream_StreamToStream_RepeatedVariableSizeWrites_RoundTripsCorrectly`) exercising many back-to-back writes across a range of payload sizes — including large payloads that force different rented-buffer sizes — verifying data integrity across pooled-buffer reuse, so accidental data bleed between reused buffers, truncation, or double-return corruption would be caught.

## Risks / limitations

- **Buffer lifetime risk (raised by @wfurt)**: mitigated by reusing the *existing*, already-production-tested `RentBuffer`/`ReleasePayload()` mechanism rather than introducing new pooling logic — the same code path Windows/OpenSSL PALs rely on today. No new disposal/ownership contract is introduced.
- **Platform coverage**: Apple-PAL numbers above are measured directly on macOS/Apple Silicon. Android uses the identical code pattern but has not been independently measured on-device in this pass — same-pattern parity with the tested Apple/Windows/OpenSSL PALs is the basis for extending the change there, not independent Android measurement.
- **TLS 1.3**: this local macOS Secure Transport testhost does not negotiate TLS 1.3 in the harness as written; not investigated further in this pass (tracked as a known gap, not a blocker for this specific buffer-pooling change, which is protocol-version-independent).
- As with any `ArrayPool` consumer, if a caller ever accessed a `ProtocolToken`'s buffer past its `ReleasePayload()` call, that would now retrieve pool-recycled memory rather than a discarded array — this pattern is already relied upon by the other two PALs and the test suite exercises repeated encrypt/decrypt cycles, but this is the class of risk @wfurt flagged and worth explicit reviewer attention.

> [!NOTE]
> This PR description, evidence, and validation were prepared with AI assistance (GitHub Copilot CLI) under human supervision. Still a work in progress — not yet ready for review (see final PR comment for current status).
