### PR TITLE
WIP: DO NOT REVIEW Vectorize eligible leading/fixed-distance set scans in the regex interpreter

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
@@ -261,10 +261,24 @@ namespace System.Text.RegularExpressions
 
                         // Store the sets, and compute which mode to use.
                         FixedDistanceSets = fixedDistanceSets;
+
+                        // Only the interpreter has a scalar fallback for leading-set searches, so unlike the
+                        // compiled/source-generated engines it can choose *not* to vectorize when doing so would
+                        // be a net loss. A vectorized IndexOfAny(SearchValues) scan pays a fixed per-call setup
+                        // cost and only wins when it can skip long runs of non-matching characters; when the
+                        // leading set is composed of characters that are common in typical text (e.g. [a-zA-Z]),
+                        // it matches so frequently that each call advances only a couple of characters, and the
+                        // per-call overhead makes it slower than the scalar CharInClass loop. Gate on the same
+                        // HasHighFrequencyChars heuristic the compiled engine uses to judge IndexOfAny a poor
+                        // filter: vectorize only when the set has more than a handful of characters that are rare
+                        // enough in typical text for the scan to reliably skip large regions. This keeps the large
+                        // wins on sparse/no-match scans (rare and non-ASCII sets) while guaranteeing the default
+                        // engine never regresses relative to its existing scalar path on common-character sets.
                         bool useSearchValues =
                             interpreter &&
                             LeadingAnchor != RegexNodeKind.Bol &&
-                            fixedDistanceSets[0].Chars is { Length: > 5 };
+                            fixedDistanceSets[0].Chars is { Length: > 5 } &&
+                            !HasHighFrequencyChars(fixedDistanceSets[0]);
                         FindMode = (fixedDistanceSets.Count == 1 && fixedDistanceSets[0].Distance == 0, useSearchValues) switch
                         {
                             (true, false) => FindNextStartingPositionMode.LeadingSet_LeftToRight,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
@@ -3,6 +3,7 @@
 
 #if SYSTEM_TEXT_REGULAREXPRESSIONS
 using System.Buffers;
+using System.Threading;
 #endif
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -14,6 +15,11 @@ namespace System.Text.RegularExpressions
     {
         /// <summary>Lookup table used for optimizing ASCII when doing set queries.</summary>
         private readonly uint[]?[]? _asciiLookups;
+
+#if SYSTEM_TEXT_REGULAREXPRESSIONS
+        /// <summary>Search values lazily created when the primary set is too large for specialized IndexOfAny overloads.</summary>
+        private SearchValues<char>? _searchValues;
+#endif
 
         public static RegexFindOptimizations Create(RegexNode root, RegexOptions options)
         {
@@ -255,9 +261,17 @@ namespace System.Text.RegularExpressions
 
                         // Store the sets, and compute which mode to use.
                         FixedDistanceSets = fixedDistanceSets;
-                        FindMode = (fixedDistanceSets.Count == 1 && fixedDistanceSets[0].Distance == 0) ?
-                            FindNextStartingPositionMode.LeadingSet_LeftToRight :
-                            FindNextStartingPositionMode.FixedDistanceSets_LeftToRight;
+                        bool useSearchValues =
+                            interpreter &&
+                            LeadingAnchor != RegexNodeKind.Bol &&
+                            fixedDistanceSets[0].Chars is { Length: > 5 };
+                        FindMode = (fixedDistanceSets.Count == 1 && fixedDistanceSets[0].Distance == 0, useSearchValues) switch
+                        {
+                            (true, false) => FindNextStartingPositionMode.LeadingSet_LeftToRight,
+                            (true, true) => FindNextStartingPositionMode.LeadingSet_SearchValues_LeftToRight,
+                            (false, false) => FindNextStartingPositionMode.FixedDistanceSets_LeftToRight,
+                            (false, true) => FindNextStartingPositionMode.FixedDistanceSets_SearchValues_LeftToRight,
+                        };
                         _asciiLookups = new uint[fixedDistanceSets.Count][];
                     }
                     return;
@@ -866,6 +880,107 @@ namespace System.Text.RegularExpressions
                     return true;
             }
         }
+
+        /// <summary>Interpreter entry point that handles its lazily initialized search values before shared find modes.</summary>
+        public bool TryFindNextStartingPositionLeftToRightInterpreter(ReadOnlySpan<char> textSpan, ref int pos, int start)
+        {
+            if (FindMode is FindNextStartingPositionMode.LeadingSet_SearchValues_LeftToRight or
+                FindNextStartingPositionMode.FixedDistanceSets_SearchValues_LeftToRight)
+            {
+                if (pos > textSpan.Length - MinRequiredLength)
+                {
+                    pos = textSpan.Length;
+                    return false;
+                }
+
+                return FindMode == FindNextStartingPositionMode.LeadingSet_SearchValues_LeftToRight ?
+                    TryFindLeadingSetWithSearchValues(textSpan, ref pos) :
+                    TryFindFixedDistanceSetsWithSearchValues(textSpan, ref pos);
+            }
+
+            return TryFindNextStartingPositionLeftToRight(textSpan, ref pos, start);
+        }
+
+        /// <summary>Gets or creates the cached search values for the primary fixed-distance set.</summary>
+        private SearchValues<char> GetOrCreateSearchValues()
+        {
+            char[] chars = FixedDistanceSets![0].Chars!;
+            Debug.Assert(chars.Length > 5);
+
+            SearchValues<char>? searchValues = Volatile.Read(ref _searchValues);
+            if (searchValues is null)
+            {
+                SearchValues<char> newSearchValues = SearchValues.Create(chars);
+                searchValues = Interlocked.CompareExchange(ref _searchValues, newSearchValues, null) ?? newSearchValues;
+            }
+
+            return searchValues;
+        }
+
+        private bool TryFindLeadingSetWithSearchValues(ReadOnlySpan<char> textSpan, ref int pos)
+        {
+            FixedDistanceSet primarySet = FixedDistanceSets![0];
+            Debug.Assert(primarySet.Chars is { Length: > 5 });
+
+            ReadOnlySpan<char> span = textSpan.Slice(pos);
+            SearchValues<char> searchValues = GetOrCreateSearchValues();
+            int i = primarySet.Negated ? span.IndexOfAnyExcept(searchValues) : span.IndexOfAny(searchValues);
+            if (i >= 0)
+            {
+                pos += i;
+                return true;
+            }
+
+            pos = textSpan.Length;
+            return false;
+        }
+
+        private bool TryFindFixedDistanceSetsWithSearchValues(ReadOnlySpan<char> textSpan, ref int pos)
+        {
+            List<FixedDistanceSet> sets = FixedDistanceSets!;
+            FixedDistanceSet primarySet = sets[0];
+            Debug.Assert(primarySet.Chars is { Length: > 5 });
+
+            int endMinusRequiredLength = textSpan.Length - Math.Max(1, MinRequiredLength);
+            SearchValues<char> searchValues = GetOrCreateSearchValues();
+
+            for (int inputPosition = pos; inputPosition <= endMinusRequiredLength; inputPosition++)
+            {
+                int offset = inputPosition + primarySet.Distance;
+                ReadOnlySpan<char> textSpanAtOffset = textSpan.Slice(offset);
+                int index = primarySet.Negated ? textSpanAtOffset.IndexOfAnyExcept(searchValues) : textSpanAtOffset.IndexOfAny(searchValues);
+                if (index < 0)
+                {
+                    break;
+                }
+
+                index += offset;
+                inputPosition = index - primarySet.Distance;
+                if (inputPosition > endMinusRequiredLength)
+                {
+                    break;
+                }
+
+                for (int i = 1; i < sets.Count; i++)
+                {
+                    FixedDistanceSet nextSet = sets[i];
+                    char c = textSpan[inputPosition + nextSet.Distance];
+                    if (!RegexCharClass.CharInClass(c, nextSet.Set, ref _asciiLookups![i]))
+                    {
+                        goto Bumpalong;
+                    }
+                }
+
+                pos = inputPosition;
+                return true;
+
+            Bumpalong:;
+            }
+
+            pos = textSpan.Length;
+            return false;
+        }
+
 #endif
 
         /// <summary>
@@ -969,6 +1084,11 @@ namespace System.Text.RegularExpressions
 
         /// <summary>A literal (single character, multi-char string, or set with small number of characters) after a non-overlapping set loop at the start of the pattern.</summary>
         LiteralAfterLoop_LeftToRight,
+
+        /// <summary>A set starting the pattern searched with SearchValues.</summary>
+        LeadingSet_SearchValues_LeftToRight,
+        /// <summary>One or more sets at a fixed distance from the start of the pattern searched with SearchValues.</summary>
+        FixedDistanceSets_SearchValues_LeftToRight,
 
         /// <summary>Nothing to search for. Nop.</summary>
         NoSearch,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -348,7 +348,7 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                while (_code.FindOptimizations.TryFindNextStartingPositionLeftToRight(text, ref runtextpos, runtextstart))
+                while (_code.FindOptimizations.TryFindNextStartingPositionLeftToRightInterpreter(text, ref runtextpos, runtextstart))
                 {
                     CheckTimeout();
 

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -52,6 +52,23 @@ namespace System.Text.RegularExpressions.Tests
             yield return ("ab\uFFFE", "ab\uFFFE", RegexOptions.None, 0, 3, true, "ab\uFFFE");
             yield return ("[\u2028\u2029\uFFFE]", "x\u2029y", RegexOptions.None, 0, 3, true, "\u2029");
 
+            // Leading sets large enough to use SearchValues in find optimizations.
+            yield return (@"[acegik]", "xxxxxxxxa", RegexOptions.None, 0, 9, true, "a");
+            yield return (@"[acegik]", "xxxxxxxxx", RegexOptions.None, 0, 9, false, string.Empty);
+            yield return (@".[acegik]", "xxxxxxxxa", RegexOptions.None, 0, 9, true, "xa");
+            yield return (@".[acegik]", "xxxxxxxxx", RegexOptions.None, 0, 9, false, string.Empty);
+            yield return (@"[^acegik]", "aaaaaaaax", RegexOptions.None, 0, 9, true, "x");
+            yield return (@"[^acegik]", "aaaaaaaaa", RegexOptions.None, 0, 9, false, string.Empty);
+            yield return (@"[αγεηικμ]", "ΩΩΩΩΩΩΩΩα", RegexOptions.None, 0, 9, true, "α");
+            yield return (@"[acegik]", "xxxxxxxxA", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, 0, 9, true, "A");
+            yield return (@"([acegik])", "xxxxxxxxa", RegexOptions.None, 2, 7, true, "a");
+            yield return (@"(?m)^[acegik]", "x\nx\na", RegexOptions.None, 0, 5, true, "a");
+            if (!RegexHelpers.IsNonBacktracking(engine))
+            {
+                yield return (@"[acegik]", "xxxxxxxxa", RegexOptions.ECMAScript, 0, 9, true, "a");
+                yield return (@"[acegik](?![\s\S])", "axxxxxxxa", RegexOptions.None, 0, 9, true, "a");
+            }
+
             // Using long loop prefix
             yield return (@"a{10}", new string('a', 10), RegexOptions.None, 0, 10, true, new string('a', 10));
             yield return (@"a{100}", new string('a', 100), RegexOptions.None, 0, 100, true, new string('a', 100));
@@ -1421,6 +1438,66 @@ namespace System.Text.RegularExpressions.Tests
                                 }
                             }
                         }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void LargeSet_InterpreterMatchesCompiled()
+        {
+            (string Pattern, RegexOptions Options, string Culture)[] cases =
+            [
+                (@"[acegik]", RegexOptions.None, ""),
+                (@".[acegik]", RegexOptions.None, ""),
+                (@"[^acegik]", RegexOptions.None, ""),
+                (@"([acegik])", RegexOptions.None, ""),
+                (@"[αγεηικμ]", RegexOptions.None, ""),
+                (@"[acegik](?![\s\S])", RegexOptions.None, ""),
+                (@"[acegik]", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, ""),
+                (@"[acegik]", RegexOptions.ECMAScript, ""),
+                (@"[iİıIacegk]", RegexOptions.IgnoreCase, "tr-TR"),
+                (@"(?m)^[acegik]", RegexOptions.None, ""),
+                (@"[acegik]", RegexOptions.RightToLeft, ""),
+                (@"\w", RegexOptions.None, ""),
+            ];
+
+            const string Alphabet = "acegikACEGIKxyzαγεηικμΩıİ!";
+            var random = new Random(42);
+
+            foreach ((string pattern, RegexOptions options, string culture) in cases)
+            {
+                using var _ = new ThreadCultureChange(culture.Length == 0 ? CultureInfo.InvariantCulture : new CultureInfo(culture));
+                var interpreter = new Regex(pattern, options, TimeSpan.FromSeconds(1));
+                var compiled = new Regex(pattern, options | RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+
+                for (int iteration = 0; iteration < 100; iteration++)
+                {
+                    char[] chars = new char[random.Next(129)];
+                    for (int i = 0; i < chars.Length; i++)
+                    {
+                        chars[i] = Alphabet[random.Next(Alphabet.Length)];
+                    }
+
+                    string input = new(chars);
+                    int startAt = random.Next(input.Length + 1);
+                    Match expected = interpreter.Match(input, startAt);
+                    Match actual = compiled.Match(input, startAt);
+
+                    Assert.Equal(expected.Success, actual.Success);
+                    Assert.Equal(expected.Index, actual.Index);
+                    Assert.Equal(expected.Length, actual.Length);
+                    Assert.Equal(expected.Value, actual.Value);
+                    Assert.Equal(expected.Groups.Count, actual.Groups.Count);
+                    for (int groupIndex = 0; groupIndex < expected.Groups.Count; groupIndex++)
+                    {
+                        Group expectedGroup = expected.Groups[groupIndex];
+                        Group actualGroup = actual.Groups[groupIndex];
+                        Assert.Equal(expectedGroup.Success, actualGroup.Success);
+                        Assert.Equal(expectedGroup.Index, actualGroup.Index);
+                        Assert.Equal(expectedGroup.Length, actualGroup.Length);
+                        Assert.Equal(expectedGroup.Value, actualGroup.Value);
+                        Assert.Equal(expectedGroup.Captures.Count, actualGroup.Captures.Count);
                     }
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -52,13 +52,19 @@ namespace System.Text.RegularExpressions.Tests
             yield return ("ab\uFFFE", "ab\uFFFE", RegexOptions.None, 0, 3, true, "ab\uFFFE");
             yield return ("[\u2028\u2029\uFFFE]", "x\u2029y", RegexOptions.None, 0, 3, true, "\u2029");
 
-            // Leading sets large enough to use SearchValues in find optimizations.
+            // Leading sets in interpreter find optimizations. Rare-character and non-ASCII sets are vectorized
+            // via SearchValues; common-character and negated sets keep the scalar path. All must match identically.
             yield return (@"[acegik]", "xxxxxxxxa", RegexOptions.None, 0, 9, true, "a");
             yield return (@"[acegik]", "xxxxxxxxx", RegexOptions.None, 0, 9, false, string.Empty);
             yield return (@".[acegik]", "xxxxxxxxa", RegexOptions.None, 0, 9, true, "xa");
             yield return (@".[acegik]", "xxxxxxxxx", RegexOptions.None, 0, 9, false, string.Empty);
             yield return (@"[^acegik]", "aaaaaaaax", RegexOptions.None, 0, 9, true, "x");
             yield return (@"[^acegik]", "aaaaaaaaa", RegexOptions.None, 0, 9, false, string.Empty);
+            // Rare-character set (vectorized in the interpreter): exercises the SearchValues scan path.
+            yield return (@"[BFGHJK]", "xxxxxxxxB", RegexOptions.None, 0, 9, true, "B");
+            yield return (@"[BFGHJK]", "xxxxxxxxx", RegexOptions.None, 0, 9, false, string.Empty);
+            yield return (@".[BFGHJK]", "xxxxxxxxK", RegexOptions.None, 0, 9, true, "xK");
+            // Non-ASCII set (always vectorized): characters fall outside the typical-text frequency table.
             yield return (@"[αγεηικμ]", "ΩΩΩΩΩΩΩΩα", RegexOptions.None, 0, 9, true, "α");
             yield return (@"[acegik]", "xxxxxxxxA", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, 0, 9, true, "A");
             yield return (@"([acegik])", "xxxxxxxxa", RegexOptions.None, 2, 7, true, "a");
@@ -67,6 +73,7 @@ namespace System.Text.RegularExpressions.Tests
             {
                 yield return (@"[acegik]", "xxxxxxxxa", RegexOptions.ECMAScript, 0, 9, true, "a");
                 yield return (@"[acegik](?![\s\S])", "axxxxxxxa", RegexOptions.None, 0, 9, true, "a");
+                yield return (@"[BFGHJK](?![\s\S])", "Kxxxxxxxx", RegexOptions.None, 0, 9, false, string.Empty);
             }
 
             // Using long loop prefix

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
@@ -230,6 +230,8 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [InlineData(@"[ab]", 0, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "ab")]
+        [InlineData(@"[acegik]", 0, (int)FindNextStartingPositionMode.LeadingSet_SearchValues_LeftToRight, "acegik")]
+        [InlineData(@"[^acegik]", 0, (int)FindNextStartingPositionMode.LeadingSet_SearchValues_LeftToRight, "acegik")]
         [InlineData(@"[Aa]", 0, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "Aa")]
         [InlineData(@"a", (int)RegexOptions.IgnoreCase, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "Aa")]
         [InlineData(@"ab|cd|ef|gh", 0, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "aceg")]
@@ -252,6 +254,16 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(1, opts.FixedDistanceSets.Count);
             Assert.Equal(0, opts.FixedDistanceSets[0].Distance);
             Assert.Equal(expectedChars, new string(opts.FixedDistanceSets[0].Chars));
+        }
+
+        [Fact]
+        public void FixedDistanceSet_UsesSearchValues()
+        {
+            RegexFindOptimizations opts = ComputeOptimizations(@".[acegik]", RegexOptions.None);
+
+            Assert.Equal(FindNextStartingPositionMode.FixedDistanceSets_SearchValues_LeftToRight, opts.FindMode);
+            Assert.Equal(1, opts.FixedDistanceSets[0].Distance);
+            Assert.Equal("acegik", new string(opts.FixedDistanceSets[0].Chars));
         }
 
         [Theory]

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
@@ -230,8 +230,17 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [InlineData(@"[ab]", 0, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "ab")]
-        [InlineData(@"[acegik]", 0, (int)FindNextStartingPositionMode.LeadingSet_SearchValues_LeftToRight, "acegik")]
-        [InlineData(@"[^acegik]", 0, (int)FindNextStartingPositionMode.LeadingSet_SearchValues_LeftToRight, "acegik")]
+        // Rare-character sets (low typical-text frequency) are vectorized in the interpreter: the scan
+        // reliably skips large non-matching regions, so IndexOfAny(SearchValues) is a net win.
+        [InlineData(@"[BFGHJK]", 0, (int)FindNextStartingPositionMode.LeadingSet_SearchValues_LeftToRight, "BFGHJK")]
+        // Non-ASCII sets are always eligible: their characters never appear in the typical-text frequency
+        // table, so they are treated as rare and vectorized.
+        [InlineData("[\u03b1\u03b3\u03b5\u03b7\u03b9\u03ba\u03bc]", 0, (int)FindNextStartingPositionMode.LeadingSet_SearchValues_LeftToRight, "\u03b1\u03b3\u03b5\u03b7\u03b9\u03ba\u03bc")]
+        // High-frequency sets (common letters) are NOT vectorized: IndexOfAny would match too often and the
+        // per-call overhead loses to the scalar CharInClass loop, so the interpreter keeps its scalar path.
+        [InlineData(@"[acegik]", 0, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "acegik")]
+        // Negated sets match most characters, so they are inherently high-frequency and stay scalar.
+        [InlineData(@"[^acegik]", 0, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "acegik")]
         [InlineData(@"[Aa]", 0, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "Aa")]
         [InlineData(@"a", (int)RegexOptions.IgnoreCase, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "Aa")]
         [InlineData(@"ab|cd|ef|gh", 0, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, "aceg")]
@@ -259,11 +268,21 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void FixedDistanceSet_UsesSearchValues()
         {
-            RegexFindOptimizations opts = ComputeOptimizations(@".[acegik]", RegexOptions.None);
+            RegexFindOptimizations opts = ComputeOptimizations(@".[BFGHJK]", RegexOptions.None);
 
             Assert.Equal(FindNextStartingPositionMode.FixedDistanceSets_SearchValues_LeftToRight, opts.FindMode);
             Assert.Equal(1, opts.FixedDistanceSets[0].Distance);
-            Assert.Equal("acegik", new string(opts.FixedDistanceSets[0].Chars));
+            Assert.Equal("BFGHJK", new string(opts.FixedDistanceSets[0].Chars));
+        }
+
+        [Fact]
+        public void FixedDistanceSet_HighFrequency_StaysScalar()
+        {
+            // The primary set [acegik] is composed of common letters, so the interpreter keeps its scalar
+            // fixed-distance path rather than vectorizing a poor filter.
+            RegexFindOptimizations opts = ComputeOptimizations(@".[acegik]", RegexOptions.None);
+
+            Assert.Equal(FindNextStartingPositionMode.FixedDistanceSets_LeftToRight, opts.FindMode);
         }
 
         [Theory]


### PR DESCRIPTION
I am running an experiment - full analysis to follow. Contact @artl93

---

## WIP — experimental. Do not review.

This PR brings the vectorized `SearchValues<char>` / `IndexOfAny`-style set scanning already used by the **compiled** and **source-generated** regex engines to selected hot paths in the **default (interpreted)** engine, with a guard that preserves the interpreter's scalar advantage on common-character sets.

### What changes
In `RegexFindOptimizations`, when the interpreter scans for a leading or fixed-distance character **set** (`RegexNodeKind.Set`), it previously always walked the input character-by-character calling `CharInClass`. Compiled/source-gen already lower eligible sets to a vectorized `IndexOfAny(SearchValues)` scan. This PR lets the interpreter take the same vectorized path — but **only for eligible sets**:

- Set has **> 5** characters (below that, scalar is already competitive).
- Set is **not** high-frequency (`!HasHighFrequencyChars(set)` — the same pre-existing heuristic). Negated sets and sets dominated by common ASCII letters stay scalar.
- Not gated behind a BOL anchor; starting position, RTL, captures, timeout cadence, culture/`IgnoreCase`, `ECMAScript`, and Unicode categories are all unchanged — the vectorized scan only replaces the *search-for-candidate-start* loop, then normal matching proceeds.

The guard exists because the interpreter, unlike compiled/source-gen, **has a cheap scalar fallback**. On dense common-character text (e.g. `[a-zA-Z]{3}`), the vectorized scan produces tiny per-call advances and SIMD setup overhead loses. The guard makes the interpreter decline vectorization exactly where it would be a net loss.

### Scope of impact — broad Regex vs. eligible interpreter patterns (important)
This is an honest characterization, because it matters for reviewing the value:

- **Broad Regex reach:** the interpreter is the *default* engine (`RegexOptions.None`), so the code path is on the most common Regex usage.
- **Narrow eligible surface (under the guard):** in practice only **non-ASCII sets** and **rare (>5 low-frequency ASCII char) sets** are vectorized. Common realistic ASCII sets — e.g. `[a-zA-Z]{3}` (common) and the negated `[^A-Za-z0-9_]` sanitizer — are **guard-excluded → scalar parity**. So the dramatic wins apply to a specific slice, not to every interpreted set.

### Canonical A/B (drift-corrected, interleaved)
Measurement method (see caveat below): two SHA-bound `corerun` processes (exact parent `7aa830a0359` scalar vs final `369e6e94e30` guard), BenchmarkDotNet InProcess, 4 interleaved rounds, medians; identical-code control benchmarks averaged **1.016×** (ideal 1.0), so ratios below are drift-corrected. Apple M-series, .NET 11 preview.

| Scenario | Set | parent → guard | Ratio | Note |
|---|---|---|---|---|
| UnicodeNoMatch (long) | Greek (non-ASCII) | 50296 → 1104 ns | **~40–45×** | eligible |
| RareAscii NoMatch Long/Huge | `[BFGHJKQVWXZ]` | 1971 → ~138 ns | **~14–19×** | eligible |
| RareAscii NoMatch Medium | `[BFGHJKQVWXZ]` | — | **~12×** | eligible |
| RareAscii Short (16) | `[BFGHJKQVWXZ]` | — | **~2.1×** | eligible |
| Letters3 (`[a-zA-Z]{3}`) | common ASCII | 5312 → 5025 ns | **~1.05×** | guard-excluded (parity) |
| IdSanitize (`[^A-Za-z0-9_]`) | negated | 1982 → 2025 ns | **~1.06×** | guard-excluded (parity) |
| Controls (≤5-char, categories, ranges, RTL, NonBacktracking, Compiled, source-gen) | — | — | ~1.0× | unchanged |

Steady-state allocation on the scan path is **0 B**; an eligible set pays a one-time `SearchValues` construction cost only.

### 3-way regression justification (why the guard is there)
Rebuilt a third **pre-guard** binary (`3491e696608`, vectorize-all, md5 `e2e80327…`) and ran parent (scalar) / pre-guard (vectorize-all) / guard side-by-side (ns, medians):

| Scenario | parent (scalar) | pre-guard (vec-all) | guard | Reading |
|---|---|---|---|---|
| `[a-zA-Z]{3}` (common) | 5312 | **13907 (2.6× SLOWER)** | 5025 | guard **prevents** a real regression ✅ |
| `[BFGHJKQVWXZ]` (rare) | 1971 | 143 | 138 | eligible win kept ✅ |
| Greek (non-ASCII) | 50296 | 1141 | 1104 | eligible win kept ✅ |
| `[^A-Za-z0-9_]` (negated) | 1982 | **160 (~12× faster)** | 2025 | guard is **conservative** — see below ⚠️ |

**Honest trade-off:** the guard's blanket "negated → scalar" rule cleanly kills the `[a-zA-Z]{3}` regression, but on this input it also **forgoes a measured ~12× win** on the negated identifier-sanitizer `[^A-Za-z0-9_]` (input is all word-chars, so `IndexOfAnyExcept` skips the whole span in one call). Negated-set behavior is input-dependent (dense-match inputs would not win), so the current conservative exclusion is *safe but leaves value on the table*. Refining the guard to admit sparse negated sets — without reintroducing the common-set regression — is a reviewable follow-up, deliberately **not** done in this WIP to keep the change safe.

### Tests (this build, guard DLL md5 `92014a34…`)
- **Unit** (`System.Text.RegularExpressions.Unit.Tests`, incl. find-mode guard assertions): **1071 passed / 0 failed**.
- **Functional** (`System.Text.RegularExpressions.Tests`, all engines/cultures/`ECMAScript`/RTL/theories): **32,151 passed / 0 failed**.
- Timeout stress (100 MB input, 50 ms / 1 ms timeouts): vectorized skip does not delay timeout observation (validated locally).

### Semantics preserved exactly
Culture and `IgnoreCase` (set contents already reflect case folding at build time), `ECMAScript`, RTL, capture semantics, Unicode category membership, negation, starting position, and timeout-check cadence. The vectorized scan only chooses *where* matching starts; subsequent match logic is untouched.

### Provenance & measurement caveats
- **SHA→binary is byte-reproducible:** rebuilding the two changed files from each pinned SHA reproduces exact md5s — scalar `7aa830a0359`→`5bfe8d53…`, guard `369e6e94e30`→`92014a34…`, pre-guard `3491e696608`→`e2e80327…`.
- **BDN net11 out-of-process blocker:** BenchmarkDotNet's out-of-process/CoreRun toolchain throws `NotImplementedException: GetRuntimeVersion not implemented for NotRecognized` on the `net11` moniker, so a standard out-of-process job is currently impossible here. The A/B therefore uses two independent SHA-bound `corerun` processes each running BDN InProcess (OS-level isolation), with ratios computed from the CSVs and thermal drift cancelled by interleaving. The initial PR numbers (5.2×–46.3×) came from a pre-guard/rare-set matrix; the drift-corrected eligible range above (**~2.1× short → ~40× long**) supersedes them.
- Raw Markdown/CSV/JSON, harness, runners, and SHA-bound DLLs are preserved as local session evidence (the `artifacts/` harness is gitignored; it rebuilds deterministically from the pinned SHAs).
- Durable benchmarks belong in `dotnet/performance`; a self-contained proposal (`Perf.Regex.SearchValues.cs`, guarded/eligible + control scenarios) is prepared for a companion PR at `src/benchmarks/micro/libraries/System.Text.RegularExpressions/`.

Full analysis to follow. **This remains work in progress — please do not review.**

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot (AI-generated). Contact @artl93.