### PR TITLE
(WIP) Pool WriteStack/ReadStack frame arrays via ArrayPool<T>

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpUnionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpUnionConverter.cs
@@ -144,8 +144,15 @@ namespace System.Text.Json.Serialization.Converters
             state.Initialize(jsonTypeInfo);
             state.Push();
 
-            OnTryRead(ref reader, typeToConvert, options, ref state, out T? value);
-            return value!;
+            try
+            {
+                OnTryRead(ref reader, typeToConvert, options, ref state, out T? value);
+                return value!;
+            }
+            finally
+            {
+                state.Dispose();
+            }
         }
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out T? value)
@@ -404,6 +411,10 @@ namespace System.Text.Json.Serialization.Converters
             {
                 state.DisposePendingDisposablesOnException();
                 throw;
+            }
+            finally
+            {
+                state.Dispose();
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
@@ -24,8 +24,15 @@ namespace System.Text.Json.Serialization
             JsonTypeInfo jsonTypeInfo = options.GetTypeInfoInternal(typeToConvert);
             state.Initialize(jsonTypeInfo);
 
-            TryRead(ref reader, typeToConvert, options, ref state, out T? value, out _);
-            return value;
+            try
+            {
+                TryRead(ref reader, typeToConvert, options, ref state, out T? value, out _);
+                return value;
+            }
+            finally
+            {
+                state.Dispose();
+            }
         }
 
         public sealed override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
@@ -45,6 +52,10 @@ namespace System.Text.Json.Serialization
             {
                 state.DisposePendingDisposablesOnException();
                 throw;
+            }
+            finally
+            {
+                state.Dispose();
             }
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Pipe.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Pipe.cs
@@ -363,6 +363,7 @@ namespace System.Text.Json
                 finally
                 {
                     bufferState.Dispose();
+                    readStack.Dispose();
                 }
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -142,11 +142,18 @@ namespace System.Text.Json
             ReadStack state = default;
             state.Initialize(jsonTypeInfo);
 
-            TValue? value = jsonTypeInfo.Deserialize(ref reader, ref state);
+            try
+            {
+                TValue? value = jsonTypeInfo.Deserialize(ref reader, ref state);
 
-            // The reader should have thrown if we have remaining bytes, unless AllowMultipleValues is true.
-            Debug.Assert(reader.BytesConsumed == (actualByteCount ?? utf8Json.Length) || reader.CurrentState.Options.AllowMultipleValues);
-            return value;
+                // The reader should have thrown if we have remaining bytes, unless AllowMultipleValues is true.
+                Debug.Assert(reader.BytesConsumed == (actualByteCount ?? utf8Json.Length) || reader.CurrentState.Options.AllowMultipleValues);
+                return value;
+            }
+            finally
+            {
+                state.Dispose();
+            }
         }
 
         private static object? ReadFromSpanAsObject(ReadOnlySpan<byte> utf8Json, JsonTypeInfo jsonTypeInfo, int? actualByteCount = null)
@@ -159,11 +166,18 @@ namespace System.Text.Json
             ReadStack state = default;
             state.Initialize(jsonTypeInfo);
 
-            object? value = jsonTypeInfo.DeserializeAsObject(ref reader, ref state);
+            try
+            {
+                object? value = jsonTypeInfo.DeserializeAsObject(ref reader, ref state);
 
-            // The reader should have thrown if we have remaining bytes, unless AllowMultipleValues is true.
-            Debug.Assert(reader.BytesConsumed == (actualByteCount ?? utf8Json.Length) || reader.CurrentState.Options.AllowMultipleValues);
-            return value;
+                // The reader should have thrown if we have remaining bytes, unless AllowMultipleValues is true.
+                Debug.Assert(reader.BytesConsumed == (actualByteCount ?? utf8Json.Length) || reader.CurrentState.Options.AllowMultipleValues);
+                return value;
+            }
+            finally
+            {
+                state.Dispose();
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -520,6 +520,7 @@ namespace System.Text.Json
                 finally
                 {
                     bufferState.Dispose();
+                    readStack.Dispose();
                 }
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -290,6 +290,10 @@ namespace System.Text.Json
                 reader = restore;
                 throw;
             }
+            finally
+            {
+                state.Dispose();
+            }
         }
 
         private static object? ReadAsObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo)
@@ -314,6 +318,10 @@ namespace System.Text.Json
             {
                 reader = restore;
                 throw;
+            }
+            finally
+            {
+                state.Dispose();
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
@@ -52,6 +52,7 @@ namespace System.Text.Json.Serialization.Metadata
             finally
             {
                 bufferState.Dispose();
+                readStack.Dispose();
             }
         }
 
@@ -98,6 +99,7 @@ namespace System.Text.Json.Serialization.Metadata
             finally
             {
                 bufferState.Dispose();
+                readStack.Dispose();
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
@@ -53,9 +53,16 @@ namespace System.Text.Json.Serialization.Metadata
                 WriteStack state = default;
                 state.Initialize(this, rootValueBoxed);
 
-                bool success = EffectiveConverter.WriteCore(writer, rootValue, Options, ref state);
-                Debug.Assert(success);
-                writer.Flush();
+                try
+                {
+                    bool success = EffectiveConverter.WriteCore(writer, rootValue, Options, ref state);
+                    Debug.Assert(success);
+                    writer.Flush();
+                }
+                finally
+                {
+                    state.Dispose();
+                }
             }
         }
 
@@ -239,6 +246,8 @@ namespace System.Text.Json.Serialization.Metadata
                     {
                         disposable.Dispose();
                     }
+
+                    state.Dispose();
                 }
             }
         }
@@ -327,6 +336,7 @@ namespace System.Text.Json.Serialization.Metadata
                 finally
                 {
                     Utf8JsonWriterCache.ReturnWriterAndBuffer(writer, bufferWriter);
+                    state.Dispose();
                 }
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -91,11 +92,28 @@ namespace System.Text.Json
         {
             if (_stack is null)
             {
-                _stack = new ReadStackFrame[4];
+                _stack = ArrayPool<ReadStackFrame>.Shared.Rent(4);
             }
             else if (_count - 1 == _stack.Length)
             {
-                Array.Resize(ref _stack, 2 * _stack.Length);
+                ReadStackFrame[] newStack = ArrayPool<ReadStackFrame>.Shared.Rent(2 * _stack.Length);
+                Array.Copy(_stack, newStack, _stack.Length);
+                ArrayPool<ReadStackFrame>.Shared.Return(_stack, clearArray: true);
+                _stack = newStack;
+            }
+        }
+
+        /// <summary>
+        /// Returns the pooled backing array (if any) to the shared <see cref="ArrayPool{T}"/>.
+        /// Must be called exactly once per top-level (de)serialization operation, after the
+        /// <see cref="ReadStack"/> is no longer in use, including on exceptional code paths.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_stack is not null)
+            {
+                ArrayPool<ReadStackFrame>.Shared.Return(_stack, clearArray: true);
+                _stack = null!;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -105,8 +105,8 @@ namespace System.Text.Json
 
         /// <summary>
         /// Returns the pooled backing array (if any) to the shared <see cref="ArrayPool{T}"/>.
-        /// Must be called exactly once per top-level (de)serialization operation, after the
-        /// <see cref="ReadStack"/> is no longer in use, including on exceptional code paths.
+        /// Call after the <see cref="ReadStack"/> is no longer in use, including on exceptional
+        /// deserialization paths. Calling multiple times has no effect.
         /// </summary>
         public void Dispose()
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -15,6 +15,8 @@ namespace System.Text.Json
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal struct ReadStack
     {
+        private const int InitialStackCapacity = 4;
+
         /// <summary>
         /// Exposes the stack frame that is currently active.
         /// </summary>
@@ -92,7 +94,7 @@ namespace System.Text.Json
         {
             if (_stack is null)
             {
-                _stack = ArrayPool<ReadStackFrame>.Shared.Rent(4);
+                _stack = ArrayPool<ReadStackFrame>.Shared.Rent(InitialStackCapacity);
             }
             else if (_count - 1 == _stack.Length)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -141,8 +141,8 @@ namespace System.Text.Json
 
         /// <summary>
         /// Returns the pooled backing array (if any) to the shared <see cref="ArrayPool{T}"/>.
-        /// Must be called exactly once per top-level (de)serialization operation, after the
-        /// <see cref="WriteStack"/> is no longer in use, including on exceptional code paths.
+        /// Call after the <see cref="WriteStack"/> is no longer in use, including on exceptional
+        /// serialization paths. Calling multiple times has no effect.
         /// </summary>
         public void Dispose()
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections;
 using System.Diagnostics;
 using System.IO.Pipelines;
@@ -127,11 +128,28 @@ namespace System.Text.Json
         {
             if (_stack is null)
             {
-                _stack = new WriteStackFrame[4];
+                _stack = ArrayPool<WriteStackFrame>.Shared.Rent(4);
             }
             else if (_count - _indexOffset == _stack.Length)
             {
-                Array.Resize(ref _stack, 2 * _stack.Length);
+                WriteStackFrame[] newStack = ArrayPool<WriteStackFrame>.Shared.Rent(2 * _stack.Length);
+                Array.Copy(_stack, newStack, _stack.Length);
+                ArrayPool<WriteStackFrame>.Shared.Return(_stack, clearArray: true);
+                _stack = newStack;
+            }
+        }
+
+        /// <summary>
+        /// Returns the pooled backing array (if any) to the shared <see cref="ArrayPool{T}"/>.
+        /// Must be called exactly once per top-level (de)serialization operation, after the
+        /// <see cref="WriteStack"/> is no longer in use, including on exceptional code paths.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_stack is not null)
+            {
+                ArrayPool<WriteStackFrame>.Shared.Return(_stack, clearArray: true);
+                _stack = null!;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -18,6 +18,8 @@ namespace System.Text.Json
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal struct WriteStack
     {
+        private const int InitialStackCapacity = 4;
+
         public readonly int CurrentDepth => _count;
 
         /// <summary>
@@ -128,7 +130,7 @@ namespace System.Text.Json
         {
             if (_stack is null)
             {
-                _stack = ArrayPool<WriteStackFrame>.Shared.Rent(4);
+                _stack = ArrayPool<WriteStackFrame>.Shared.Rent(InitialStackCapacity);
             }
             else if (_count - _indexOffset == _stack.Length)
             {


### PR DESCRIPTION
I am running an experiment - full analysis to follow. Contact @artl93

## Summary

Pool the auxiliary `WriteStackFrame[]` and `ReadStackFrame[]` arrays used by `JsonSerializer`'s stack-based converter pipeline.

The first frame remains inline in `Current`. An array is rented only when an operation needs additional stack frames, then returned with `clearArray: true` from an outer `finally`. All 15 current root owners follow this cleanup pattern, including Stream, PipeReader, and async-enumerable paths.

## Scope

- The measured scenarios use reflection metadata with nested objects and collections.
- Source-generated metadata paths use the same converter infrastructure and may also benefit. Generated serialization fast-path handlers bypass `WriteStack` and do not.
- Flat operations that remain within the inline frame do not rent an array and do not benefit.
- The saving is fixed per affected operation, not per property or collection item. Relative savings therefore shrink as payload work grows.
- This changes allocation behavior only. No wall-clock, throughput, latency, or ASP.NET Core end-to-end improvement has been demonstrated.

**Compatibility:** No consumer action is required. `ReadStack` and `WriteStack` are internal operation-scoped state; this change adds internal resource cleanup without changing the public `JsonSerializer` or custom-converter contract.

### Why is the initial capacity 4?

This PR preserves the value used by the previous `new ReadStackFrame[4]` and `new WriteStackFrame[4]` allocations. It originated in the 2021 stack rewrite in #54420, where the author explained that it reused `List<T>`'s default initial capacity as a reasonable expected depth. No benchmark-derived tuning for this value was documented.

`4` is an initial minimum request, not a nesting limit. `ArrayPool<T>.Rent(4)` may return a larger array; subsequent growth uses the returned array's actual length. The code now names this value `InitialStackCapacity` rather than leaving it as a literal.

## Allocation measurements

Measured with an exact-parent (`7aa830a0359`) vs implementation (`b7d3757ab83`) DLL swap, using the same harness and three alternating-order trials. Later commits only clarify documentation and name the unchanged capacity value.

| Reflection scenario | Parent | Candidate | Difference |
|---|---:|---:|---:|
| Serialize small nested object | 1,256 B | 944 B | **-312 B (-24.8%)** |
| Deserialize small nested object from `byte[]` | 3,264 B | 2,792 B | **-472 B (-14.5%)** |
| Deserialize small nested object from `Stream` | 3,328 B | 2,856 B | **-472 B (-14.2%)** |
| Deserialize small nested object from `PipeReader` | 3,616 B | 3,145 B | **-472 B (-13.0%)** |
| Deserialize 5-item async enumerable from `Stream` | 15,152 B | 14,680 B | **-472 B (-3.1%)** |
| Deserialize 5-item async enumerable from `PipeReader` | 15,473 B | 15,002 B | **-471 B (-3.0%)** |
| Serialize large collection | 50,920 B | 50,608 B | **-312 B (-0.6%)** |
| Deserialize large collection | 158,104 B | 157,632 B | **-472 B (-0.3%)** |

These are component allocation results, not throughput results.

## Validation

- Release runtime/libraries baseline and `System.Text.Json` build succeeded.
- `System.Text.Json.Tests`: **52,124 passed, 0 failed** on current HEAD.
- The owner audit found four cleanup paths missing from the initial commit; `b7d3757ab83` added them. Success, exception, and cancellation exits now return rented arrays from `finally` blocks.

## Caveats

- No completed BenchmarkDotNet/EgorBot result is available yet. The EgorBot request remains in the PR discussion.
- Pool rent/return and clearing add CPU work; current evidence demonstrates allocation reduction only.
- This remains a draft experiment and is not ready for review or merge.

> [!NOTE]
> This PR description was generated with GitHub Copilot and edited from measured results.