### PR TITLE
WIP: DO NOT REVIEW — NO-GO: Histogram striping experiment

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
@@ -38,6 +38,7 @@ namespace System.Diagnostics.Metrics
         private const int ExponentGroupShift = 6;
         private const int ExponentGroupSize = 1 << ExponentGroupShift;
         private const int ExponentGroupMask = ExponentGroupSize - 1;
+        private const int ContentionSampleSlots = 64;
         private const int ContentionSampleMask = 0x3F;
         private const int ContentionThreshold = 64;
         private const int MaxStripeCount = 8;
@@ -46,13 +47,16 @@ namespace System.Diagnostics.Metrics
         private const int PositiveIntAndNan = ExponentArraySize / 2 - 1;
         private const int NegativeIntAndNan = ExponentArraySize - 1;
 
+        private static int s_nextContentionSampleSlot;
+
         [ThreadStatic]
-        private static uint t_contentionSample;
+        private static int[]? t_contentionSamples;
 
         [ThreadStatic]
         private static int t_stripeIndex;
 
         private readonly QuantileAggregation _config;
+        private readonly int _contentionSampleSlot;
         private readonly object _singleLock = new object();
         private readonly HistogramStripe[] _stripes;
         private int[]?[]? _singleCounters = new int[ExponentArraySize][];
@@ -164,6 +168,7 @@ namespace System.Diagnostics.Metrics
         public ExponentialHistogramAggregator(QuantileAggregation config)
         {
             _config = config;
+            _contentionSampleSlot = (Interlocked.Increment(ref s_nextContentionSampleSlot) - 1) & (ContentionSampleSlots - 1);
             if (_config.MaxRelativeError < MinRelativeError)
             {
                 // Ensure that we don't create enormous histograms trying to get overly high precision
@@ -430,19 +435,10 @@ namespace System.Diagnostics.Metrics
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool ShouldSampleContention()
+        private bool ShouldSampleContention()
         {
-            uint sample = t_contentionSample;
-            if (sample == 0)
-            {
-                sample = (uint)Environment.CurrentManagedThreadId;
-            }
-
-            sample ^= sample << 13;
-            sample ^= sample >> 17;
-            sample ^= sample << 5;
-            t_contentionSample = sample;
-            return (sample & ContentionSampleMask) == 0;
+            int[] samples = t_contentionSamples ??= new int[ContentionSampleSlots];
+            return (++samples[_contentionSampleSlot] & ContentionSampleMask) == 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace System.Diagnostics.Metrics
 {
@@ -26,28 +28,35 @@ namespace System.Diagnostics.Metrics
     // Note: we should be able to refine this to return the bucket midpoint rather than bucket lower bound, halving the number of
     // buckets to achieve the same error bound.
     //
-    // Implementation: The histogram buckets are implemented as an array of arrays (a tree). The top level has a fixed 4096 entries
-    // corresponding to every possible sign+exponent in the encoding of a double (IEEE 754 spec). The 2nd level has variable size
-    // depending on how many buckets are needed to achieve the error bounds. For ease of insertion we round the 2nd level size up to
-    // the nearest power of 2. This lets us mask off the first k bits in the mantissa to map a measurement to one of 2^k 2nd level
-    // buckets. The top level array is pre-allocated but the 2nd level arrays are created on demand.
-    //
-    // PERF Note: This histogram has a fast Update() but the _counters array has a sizable memory footprint (32KB+ on 64 bit)
-    // It is probably well suited for tracking 10s or maybe 100s of histograms but if we wanted to go higher
-    // we probably want to trade a little more CPU cost in Update() + code complexity to avoid eagerly allocating 4096
-    // top level entries.
+    // The uncontended implementation uses a 4096-entry array indexed by the sign and exponent from the IEEE 754 representation,
+    // with mantissa bucket arrays allocated on demand. After repeated contention it switches permanently to a bounded set of
+    // stripes. Each stripe uses a sparse two-level exponent tree so that parallelism does not multiply the 32KB top-level array.
+    // Collect locks all active state, atomically detaches the interval, and merges the stripes outside the locks.
     internal sealed class ExponentialHistogramAggregator : Aggregator
     {
         private const int ExponentArraySize = 4096;
+        private const int ExponentGroupShift = 6;
+        private const int ExponentGroupSize = 1 << ExponentGroupShift;
+        private const int ExponentGroupMask = ExponentGroupSize - 1;
+        private const int ContentionThreshold = 64;
+        private const int MaxStripeCount = 8;
         private const int ExponentShift = 52;
         private const double MinRelativeError = 0.0001;
         private const int PositiveIntAndNan = ExponentArraySize / 2 - 1;
         private const int NegativeIntAndNan = ExponentArraySize - 1;
 
+        [ThreadStatic]
+        private static int t_stripeIndex;
+
         private readonly QuantileAggregation _config;
-        private int[]?[] _counters;
-        private int _count;
-        private double _sum;
+        private readonly object _singleLock = new object();
+        private readonly HistogramStripe[] _stripes;
+        private int[]?[]? _singleCounters = new int[ExponentArraySize][];
+        private int _singleCount;
+        private double _singleSum;
+        private int _contentionCount;
+        private bool _collecting;
+        private bool _useStripes;
         private readonly int _mantissaMax;
         private readonly int _mantissaMask;
         private readonly int _mantissaShift;
@@ -63,10 +72,72 @@ namespace System.Diagnostics.Metrics
             public int Count;
         }
 
+        private sealed class HistogramStripe
+        {
+            public HistogramBuckets? Buckets;
+            public int Count;
+            public double Sum;
+        }
+
+        private sealed class ExponentGroup
+        {
+            public readonly int[]?[] Exponents = new int[ExponentGroupSize][];
+        }
+
+        private sealed class HistogramBuckets
+        {
+            private readonly ExponentGroup?[] _groups = new ExponentGroup[ExponentArraySize / ExponentGroupSize];
+            private readonly int _mantissaMax;
+
+            public HistogramBuckets(int mantissaMax)
+            {
+                _mantissaMax = mantissaMax;
+            }
+
+            public void Increment(int exponent, int mantissa)
+            {
+                ExponentGroup group = _groups[exponent >> ExponentGroupShift] ??= new ExponentGroup();
+                ref int[]? counts = ref group.Exponents[exponent & ExponentGroupMask];
+                counts ??= new int[_mantissaMax];
+                counts[mantissa]++;
+            }
+
+            public int[]? GetCounts(int exponent) =>
+                _groups[exponent >> ExponentGroupShift]?.Exponents[exponent & ExponentGroupMask];
+
+            public void MergeFrom(HistogramBuckets source)
+            {
+                for (int groupIndex = 0; groupIndex < source._groups.Length; groupIndex++)
+                {
+                    ExponentGroup? sourceGroup = source._groups[groupIndex];
+                    if (sourceGroup is null)
+                    {
+                        continue;
+                    }
+
+                    ExponentGroup targetGroup = _groups[groupIndex] ??= new ExponentGroup();
+                    for (int exponentIndex = 0; exponentIndex < sourceGroup.Exponents.Length; exponentIndex++)
+                    {
+                        int[]? sourceCounts = sourceGroup.Exponents[exponentIndex];
+                        if (sourceCounts is null)
+                        {
+                            continue;
+                        }
+
+                        ref int[]? targetCounts = ref targetGroup.Exponents[exponentIndex];
+                        targetCounts ??= new int[_mantissaMax];
+                        for (int mantissa = 0; mantissa < sourceCounts.Length; mantissa++)
+                        {
+                            targetCounts[mantissa] += sourceCounts[mantissa];
+                        }
+                    }
+                }
+            }
+        }
+
         public ExponentialHistogramAggregator(QuantileAggregation config)
         {
             _config = config;
-            _counters = new int[ExponentArraySize][];
             if (_config.MaxRelativeError < MinRelativeError)
             {
                 // Ensure that we don't create enormous histograms trying to get overly high precision
@@ -76,21 +147,79 @@ namespace System.Diagnostics.Metrics
             _mantissaShift = 52 - mantissaBits;
             _mantissaMax = 1 << mantissaBits;
             _mantissaMask = _mantissaMax - 1;
+
+            _stripes = new HistogramStripe[Math.Min(Environment.ProcessorCount, MaxStripeCount)];
+            for (int i = 0; i < _stripes.Length; i++)
+            {
+                _stripes[i] = new HistogramStripe();
+            }
         }
 
         public override IAggregationStatistics Collect()
         {
-            int[]?[] counters;
-            int count;
-            double sum;
-            lock (this)
+            int[]?[]? singleCounters = null;
+            HistogramBuckets?[] snapshots = new HistogramBuckets?[_stripes.Length];
+            int count = 0;
+            double sum = 0;
+            bool singleLockTaken = false;
+            int locksTaken = 0;
+            Volatile.Write(ref _collecting, true);
+            try
             {
-                counters = _counters;
-                count = _count;
-                sum = _sum;
-                _counters = new int[ExponentArraySize][];
-                _count = 0;
-                _sum = 0;
+                Monitor.Enter(_singleLock, ref singleLockTaken);
+                for (; locksTaken < _stripes.Length; locksTaken++)
+                {
+                    Monitor.Enter(_stripes[locksTaken]);
+                }
+
+                singleCounters = _singleCounters;
+                count = _singleCount;
+                sum = _singleSum;
+                _singleCounters = Volatile.Read(ref _useStripes) ? null : new int[ExponentArraySize][];
+                _singleCount = 0;
+                _singleSum = 0;
+                _contentionCount = 0;
+
+                for (int i = 0; i < _stripes.Length; i++)
+                {
+                    HistogramStripe stripe = _stripes[i];
+                    snapshots[i] = stripe.Buckets;
+                    count += stripe.Count;
+                    sum += stripe.Sum;
+                    stripe.Buckets = null;
+                    stripe.Count = 0;
+                    stripe.Sum = 0;
+                }
+            }
+            finally
+            {
+                while (locksTaken != 0)
+                {
+                    Monitor.Exit(_stripes[--locksTaken]);
+                }
+
+                if (singleLockTaken)
+                {
+                    Monitor.Exit(_singleLock);
+                }
+
+                Volatile.Write(ref _collecting, false);
+            }
+
+            HistogramBuckets? counters = null;
+            foreach (HistogramBuckets? snapshot in snapshots)
+            {
+                if (snapshot is not null)
+                {
+                    if (counters is null)
+                    {
+                        counters = snapshot;
+                    }
+                    else
+                    {
+                        counters.MergeFrom(snapshot);
+                    }
+                }
             }
 
             QuantileValue[] quantiles = new QuantileValue[_config.Quantiles.Length];
@@ -107,7 +236,13 @@ namespace System.Diagnostics.Metrics
 
             // the total number of entries in all buckets iterated so far
             int cur = 0;
-            foreach (Bucket b in IterateBuckets(counters))
+            if (singleCounters is null && counters is null)
+            {
+                Debug.Assert(count == 0);
+                return new HistogramStatistics(Array.Empty<QuantileValue>(), count, sum);
+            }
+
+            foreach (Bucket b in IterateBuckets(singleCounters, counters))
             {
                 cur += b.Count;
                 while (cur > target)
@@ -127,21 +262,22 @@ namespace System.Diagnostics.Metrics
             return new HistogramStatistics(Array.Empty<QuantileValue>(), count, sum);
         }
 
-        private IEnumerable<Bucket> IterateBuckets(int[]?[] counters)
+        private IEnumerable<Bucket> IterateBuckets(int[]?[]? singleCounters, HistogramBuckets? counters)
         {
             // iterate over the negative exponent buckets
             const int LowestNegativeOffset = ExponentArraySize / 2;
             // exponent = ExponentArraySize-1 encodes infinity and NaN, which we want to ignore
             for (int exponent = ExponentArraySize - 2; exponent >= LowestNegativeOffset; exponent--)
             {
-                int[]? mantissaCounts = counters[exponent];
-                if (mantissaCounts == null)
+                int[]? singleMantissaCounts = singleCounters?[exponent];
+                int[]? stripedMantissaCounts = counters?.GetCounts(exponent);
+                if (singleMantissaCounts is null && stripedMantissaCounts is null)
                 {
                     continue;
                 }
                 for (int mantissa = _mantissaMax - 1; mantissa >= 0; mantissa--)
                 {
-                    int count = mantissaCounts[mantissa];
+                    int count = (singleMantissaCounts?[mantissa] ?? 0) + (stripedMantissaCounts?[mantissa] ?? 0);
                     if (count > 0)
                     {
                         yield return new Bucket(GetBucketCanonicalValue(exponent, mantissa), count);
@@ -153,14 +289,15 @@ namespace System.Diagnostics.Metrics
             // exponent = lowestNegativeOffset-1 encodes infinity and NaN, which we want to ignore
             for (int exponent = 0; exponent < LowestNegativeOffset - 1; exponent++)
             {
-                int[]? mantissaCounts = counters[exponent];
-                if (mantissaCounts == null)
+                int[]? singleMantissaCounts = singleCounters?[exponent];
+                int[]? stripedMantissaCounts = counters?.GetCounts(exponent);
+                if (singleMantissaCounts is null && stripedMantissaCounts is null)
                 {
                     continue;
                 }
                 for (int mantissa = 0; mantissa < _mantissaMax; mantissa++)
                 {
-                    int count = mantissaCounts[mantissa];
+                    int count = (singleMantissaCounts?[mantissa] ?? 0) + (stripedMantissaCounts?[mantissa] ?? 0);
                     if (count > 0)
                     {
                         yield return new Bucket(GetBucketCanonicalValue(exponent, mantissa), count);
@@ -171,26 +308,93 @@ namespace System.Diagnostics.Metrics
 
         public override void Update(double measurement)
         {
-            lock (this)
+            // This is relying on the bit representation of IEEE 754 to decompose
+            // the double. The sign bit + exponent bits land in exponent, the
+            // remainder lands in mantissa.
+            // the bucketing precision comes entirely from how many significant
+            // bits of the mantissa are preserved.
+            ulong bits = (ulong)BitConverter.DoubleToInt64Bits(measurement);
+            int exponent = (int)(bits >> ExponentShift);
+            int mantissa = (int)(bits >> _mantissaShift) & _mantissaMask;
+
+            if (!Volatile.Read(ref _useStripes))
             {
-                // This is relying on the bit representation of IEEE 754 to decompose
-                // the double. The sign bit + exponent bits land in exponent, the
-                // remainder lands in mantissa.
-                // the bucketing precision comes entirely from how many significant
-                // bits of the mantissa are preserved.
-                ulong bits = (ulong)BitConverter.DoubleToInt64Bits(measurement);
-                int exponent = (int)(bits >> ExponentShift);
-                int mantissa = (int)(bits >> _mantissaShift) & _mantissaMask;
-                ref int[]? mantissaCounts = ref _counters[exponent];
-                mantissaCounts ??= new int[_mantissaMax];
-                mantissaCounts[mantissa]++;
+                bool lockTaken = false;
+                try
+                {
+                    Monitor.TryEnter(_singleLock, ref lockTaken);
+                    if (lockTaken && !Volatile.Read(ref _useStripes))
+                    {
+                        UpdateSingle(exponent, mantissa, measurement);
+                        return;
+                    }
+                }
+                finally
+                {
+                    if (lockTaken)
+                    {
+                        Monitor.Exit(_singleLock);
+                    }
+                }
+
+                if (Volatile.Read(ref _collecting))
+                {
+                    lock (_singleLock)
+                    {
+                        if (!Volatile.Read(ref _useStripes))
+                        {
+                            UpdateSingle(exponent, mantissa, measurement);
+                            return;
+                        }
+                    }
+                }
+                else if (Interlocked.Increment(ref _contentionCount) < ContentionThreshold)
+                {
+                    lock (_singleLock)
+                    {
+                        if (!Volatile.Read(ref _useStripes))
+                        {
+                            UpdateSingle(exponent, mantissa, measurement);
+                            return;
+                        }
+                    }
+                }
+
+                Volatile.Write(ref _useStripes, true);
+            }
+
+            int stripeIndex = t_stripeIndex;
+            if (stripeIndex == 0)
+            {
+                stripeIndex = t_stripeIndex = (Environment.CurrentManagedThreadId % MaxStripeCount) + 1;
+            }
+
+            HistogramStripe stripe = _stripes[(stripeIndex - 1) % _stripes.Length];
+
+            lock (stripe)
+            {
+                (stripe.Buckets ??= new HistogramBuckets(_mantissaMax)).Increment(exponent, mantissa);
 
                 // Don't increase the count if there are any NaN or +/-Infinity values that were logged
                 if (exponent != PositiveIntAndNan && exponent != NegativeIntAndNan)
                 {
-                    _count++;
-                    _sum += measurement;
+                    stripe.Count++;
+                    stripe.Sum += measurement;
                 }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void UpdateSingle(int exponent, int mantissa, double measurement)
+        {
+            ref int[]? mantissaCounts = ref _singleCounters![exponent];
+            mantissaCounts ??= new int[_mantissaMax];
+            mantissaCounts[mantissa]++;
+
+            if (exponent != PositiveIntAndNan && exponent != NegativeIntAndNan)
+            {
+                _singleCount++;
+                _singleSum += measurement;
             }
         }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
@@ -77,6 +77,7 @@ namespace System.Diagnostics.Metrics
             public HistogramBuckets? Buckets;
             public int Count;
             public double Sum;
+            public bool Dirty;
         }
 
         private sealed class ExponentGroup
@@ -133,6 +134,27 @@ namespace System.Diagnostics.Metrics
                     }
                 }
             }
+
+            public void Clear()
+            {
+                foreach (ExponentGroup? group in _groups)
+                {
+                    if (group is not null)
+                    {
+                        foreach (int[]? counts in group.Exponents)
+                        {
+                            if (counts is not null)
+                            {
+#if NET
+                                Array.Clear(counts);
+#else
+                                Array.Clear(counts, 0, counts.Length);
+#endif
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         public ExponentialHistogramAggregator(QuantileAggregation config)
@@ -158,7 +180,7 @@ namespace System.Diagnostics.Metrics
         public override IAggregationStatistics Collect()
         {
             int[]?[]? singleCounters = null;
-            HistogramBuckets?[] snapshots = new HistogramBuckets?[_stripes.Length];
+            HistogramBuckets? counters = null;
             int count = 0;
             double sum = 0;
             bool singleLockTaken = false;
@@ -183,10 +205,30 @@ namespace System.Diagnostics.Metrics
                 for (int i = 0; i < _stripes.Length; i++)
                 {
                     HistogramStripe stripe = _stripes[i];
-                    snapshots[i] = stripe.Buckets;
+                    if (stripe.Dirty)
+                    {
+                        if (stripe.Buckets is HistogramBuckets stripeBuckets)
+                        {
+                            // Merge while updates are blocked so that the sparse stripe storage can be
+                            // cleared and reused without allocating a replacement on every interval.
+                            if (stripe.Count != 0)
+                            {
+                                (counters ??= new HistogramBuckets(_mantissaMax)).MergeFrom(stripeBuckets);
+                            }
+
+                            stripeBuckets.Clear();
+                        }
+
+                        stripe.Dirty = false;
+                    }
+                    else
+                    {
+                        // Release storage retained by a stripe that remained inactive for a full interval.
+                        stripe.Buckets = null;
+                    }
+
                     count += stripe.Count;
                     sum += stripe.Sum;
-                    stripe.Buckets = null;
                     stripe.Count = 0;
                     stripe.Sum = 0;
                 }
@@ -204,22 +246,6 @@ namespace System.Diagnostics.Metrics
                 }
 
                 Volatile.Write(ref _collecting, false);
-            }
-
-            HistogramBuckets? counters = null;
-            foreach (HistogramBuckets? snapshot in snapshots)
-            {
-                if (snapshot is not null)
-                {
-                    if (counters is null)
-                    {
-                        counters = snapshot;
-                    }
-                    else
-                    {
-                        counters.MergeFrom(snapshot);
-                    }
-                }
             }
 
             QuantileValue[] quantiles = new QuantileValue[_config.Quantiles.Length];
@@ -373,6 +399,7 @@ namespace System.Diagnostics.Metrics
 
             lock (stripe)
             {
+                stripe.Dirty = true;
                 (stripe.Buckets ??= new HistogramBuckets(_mantissaMax)).Increment(exponent, mantissa);
 
                 // Don't increase the count if there are any NaN or +/-Infinity values that were logged

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
@@ -38,12 +38,16 @@ namespace System.Diagnostics.Metrics
         private const int ExponentGroupShift = 6;
         private const int ExponentGroupSize = 1 << ExponentGroupShift;
         private const int ExponentGroupMask = ExponentGroupSize - 1;
+        private const int ContentionSampleMask = 0x3F;
         private const int ContentionThreshold = 64;
         private const int MaxStripeCount = 8;
         private const int ExponentShift = 52;
         private const double MinRelativeError = 0.0001;
         private const int PositiveIntAndNan = ExponentArraySize / 2 - 1;
         private const int NegativeIntAndNan = ExponentArraySize - 1;
+
+        [ThreadStatic]
+        private static uint t_contentionSample;
 
         [ThreadStatic]
         private static int t_stripeIndex;
@@ -345,25 +349,7 @@ namespace System.Diagnostics.Metrics
 
             if (!Volatile.Read(ref _useStripes))
             {
-                bool lockTaken = false;
-                try
-                {
-                    Monitor.TryEnter(_singleLock, ref lockTaken);
-                    if (lockTaken && !Volatile.Read(ref _useStripes))
-                    {
-                        UpdateSingle(exponent, mantissa, measurement);
-                        return;
-                    }
-                }
-                finally
-                {
-                    if (lockTaken)
-                    {
-                        Monitor.Exit(_singleLock);
-                    }
-                }
-
-                if (Volatile.Read(ref _collecting))
+                if (!ShouldSampleContention())
                 {
                     lock (_singleLock)
                     {
@@ -374,19 +360,51 @@ namespace System.Diagnostics.Metrics
                         }
                     }
                 }
-                else if (Interlocked.Increment(ref _contentionCount) < ContentionThreshold)
+                else
                 {
-                    lock (_singleLock)
+                    bool lockTaken = false;
+                    try
                     {
-                        if (!Volatile.Read(ref _useStripes))
+                        Monitor.TryEnter(_singleLock, ref lockTaken);
+                        if (lockTaken && !Volatile.Read(ref _useStripes))
                         {
                             UpdateSingle(exponent, mantissa, measurement);
                             return;
                         }
                     }
-                }
+                    finally
+                    {
+                        if (lockTaken)
+                        {
+                            Monitor.Exit(_singleLock);
+                        }
+                    }
 
-                Volatile.Write(ref _useStripes, true);
+                    if (Volatile.Read(ref _collecting))
+                    {
+                        lock (_singleLock)
+                        {
+                            if (!Volatile.Read(ref _useStripes))
+                            {
+                                UpdateSingle(exponent, mantissa, measurement);
+                                return;
+                            }
+                        }
+                    }
+                    else if (Interlocked.Increment(ref _contentionCount) < ContentionThreshold)
+                    {
+                        lock (_singleLock)
+                        {
+                            if (!Volatile.Read(ref _useStripes))
+                            {
+                                UpdateSingle(exponent, mantissa, measurement);
+                                return;
+                            }
+                        }
+                    }
+
+                    Volatile.Write(ref _useStripes, true);
+                }
             }
 
             int stripeIndex = t_stripeIndex;
@@ -409,6 +427,22 @@ namespace System.Diagnostics.Metrics
                     stripe.Sum += measurement;
                 }
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ShouldSampleContention()
+        {
+            uint sample = t_contentionSample;
+            if (sample == 0)
+            {
+                sample = (uint)Environment.CurrentManagedThreadId;
+            }
+
+            sample ^= sample << 13;
+            sample ^= sample >> 17;
+            sample ^= sample << 5;
+            t_contentionSample = sample;
+            return (sample & ContentionSampleMask) == 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ExponentialHistogramAggregator.cs
@@ -31,7 +31,8 @@ namespace System.Diagnostics.Metrics
     // The uncontended implementation uses a 4096-entry array indexed by the sign and exponent from the IEEE 754 representation,
     // with mantissa bucket arrays allocated on demand. After repeated contention it switches permanently to a bounded set of
     // stripes. Each stripe uses a sparse two-level exponent tree so that parallelism does not multiply the 32KB top-level array.
-    // Collect locks all active state, atomically detaches the interval, and merges the stripes outside the locks.
+    // Collect locks all active state, merges and clears the exact interval under those locks, then calculates quantiles after
+    // releasing them.
     internal sealed class ExponentialHistogramAggregator : Aggregator
     {
         private const int ExponentArraySize = 4096;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/Base2ExponentialHistogramAggregatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/Base2ExponentialHistogramAggregatorTests.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -647,6 +648,90 @@ namespace System.Diagnostics.Metrics
             stats = histogram.Collect() as Base2ExponentialHistogramStatistics;
             ValidateStats(stats, expectedCount: 5, expectedZeroCount: 0, expectedScale: -2, expectedSum: currentSum, expectedMin: 1.1, expectedMax: 1000_000.5, [2, 1, 1, 0, 1]);
             ValidateHistogram(histogram, expectedScale: -2, expectedSum: 0, expectedCount: 0, expectedZeroCount: 0, expectedMin: double.MaxValue, expectedMax: double.MinValue);
+        }
+
+        [Fact]
+        public void ConcurrentUpdatesAndDeltaCollectsPreserveEveryBucket()
+        {
+            const int Iterations = 20_000;
+            int producerCount = Math.Min(Environment.ProcessorCount * 2, 32);
+            Base2ExponentialHistogramAggregator histogram = new(reportDeltas: true);
+            using Barrier barrier = new(producerCount + 1);
+            int producersRemaining = producerCount;
+            long collectedCount = 0;
+            double collectedSum = 0;
+            Exception? collectorException = null;
+            Exception? producerException = null;
+
+            Thread collector = new(() =>
+            {
+                try
+                {
+                    barrier.SignalAndWait();
+                    while (Volatile.Read(ref producersRemaining) != 0)
+                    {
+                        Collect();
+                        Thread.Yield();
+                    }
+
+                    Collect();
+                }
+                catch (Exception e)
+                {
+                    collectorException = e;
+                }
+
+                void Collect()
+                {
+                    Base2ExponentialHistogramStatistics stats = (Base2ExponentialHistogramStatistics)histogram.Collect();
+                    Assert.Equal(stats.Count, stats.PositiveBuckets.Sum());
+                    Assert.Equal(stats.Count, stats.Sum);
+                    collectedCount += stats.Count;
+                    collectedSum += stats.Sum;
+                }
+            });
+
+            Thread[] producers = new Thread[producerCount];
+            for (int i = 0; i < producers.Length; i++)
+            {
+                producers[i] = new(() =>
+                {
+                    try
+                    {
+                        barrier.SignalAndWait();
+                        for (int j = 0; j < Iterations; j++)
+                        {
+                            histogram.Update(1);
+                        }
+
+                        histogram.Update(-1);
+                        histogram.Update(double.NaN);
+                        histogram.Update(double.PositiveInfinity);
+                        histogram.Update(double.NegativeInfinity);
+                    }
+                    catch (Exception e)
+                    {
+                        Interlocked.CompareExchange(ref producerException, e, null);
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref producersRemaining);
+                    }
+                });
+                producers[i].Start();
+            }
+
+            collector.Start();
+            foreach (Thread producer in producers)
+            {
+                producer.Join();
+            }
+            collector.Join();
+
+            Assert.Null(collectorException);
+            Assert.Null(producerException);
+            Assert.Equal(producerCount * Iterations, collectedCount);
+            Assert.Equal(collectedCount, collectedSum);
         }
 
         [Theory]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
@@ -373,5 +373,94 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(0, stats.Count);
             Assert.Equal(0, stats.Sum);
         }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(32)]
+        public void ConcurrentUpdatesAndCollectsPreserveEveryMeasurement(int producerCount)
+        {
+            const int Iterations = 20_000;
+            ExponentialHistogramAggregator aggregator = new(new QuantileAggregation(0, 0.5, 1));
+            using Barrier barrier = new(producerCount + 1);
+            int producersRemaining = producerCount;
+            int collectedCount = 0;
+            double collectedSum = 0;
+            Exception? collectorException = null;
+            Exception? producerException = null;
+
+            Thread collector = new(() =>
+            {
+                try
+                {
+                    barrier.SignalAndWait();
+                    while (Volatile.Read(ref producersRemaining) != 0)
+                    {
+                        Collect();
+                        Thread.Yield();
+                    }
+
+                    Collect();
+                }
+                catch (Exception e)
+                {
+                    collectorException = e;
+                }
+
+                void Collect()
+                {
+                    HistogramStatistics stats = (HistogramStatistics)aggregator.Collect();
+                    if (stats.Count != 0)
+                    {
+                        Assert.All(stats.Quantiles, quantile => Assert.Equal(1, quantile.Value));
+                        Assert.Equal(stats.Count, stats.Sum);
+                    }
+
+                    collectedCount += stats.Count;
+                    collectedSum += stats.Sum;
+                }
+            });
+
+            Thread[] producers = new Thread[producerCount];
+            for (int i = 0; i < producers.Length; i++)
+            {
+                producers[i] = new(() =>
+                {
+                    try
+                    {
+                        barrier.SignalAndWait();
+                        for (int j = 0; j < Iterations; j++)
+                        {
+                            aggregator.Update(1);
+                        }
+
+                        aggregator.Update(double.NaN);
+                        aggregator.Update(double.PositiveInfinity);
+                        aggregator.Update(double.NegativeInfinity);
+                    }
+                    catch (Exception e)
+                    {
+                        Interlocked.CompareExchange(ref producerException, e, null);
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref producersRemaining);
+                    }
+                });
+                producers[i].Start();
+            }
+
+            collector.Start();
+            foreach (Thread producer in producers)
+            {
+                producer.Join();
+            }
+            collector.Join();
+
+            Assert.Null(collectorException);
+            Assert.Null(producerException);
+            Assert.Equal(producerCount * Iterations, collectedCount);
+            Assert.Equal(collectedCount, collectedSum);
+        }
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
@@ -462,5 +462,96 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(producerCount * Iterations, collectedCount);
             Assert.Equal(collectedCount, collectedSum);
         }
+
+        [Fact]
+        public void ConcurrentUpdatesThenIdleCollectionsAndReuse()
+        {
+            const int ProducerCount = 32;
+            const int Iterations = 10_000;
+            ExponentialHistogramAggregator aggregator = new(new QuantileAggregation(0.5));
+            using Barrier barrier = new(ProducerCount + 1);
+            Exception? producerException = null;
+
+            Thread[] producers = new Thread[ProducerCount];
+            for (int i = 0; i < producers.Length; i++)
+            {
+                producers[i] = new(() =>
+                {
+                    try
+                    {
+                        barrier.SignalAndWait();
+                        for (int j = 0; j < Iterations; j++)
+                        {
+                            aggregator.Update(1);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Interlocked.CompareExchange(ref producerException, e, null);
+                    }
+                });
+                producers[i].Start();
+            }
+
+            barrier.SignalAndWait();
+            foreach (Thread producer in producers)
+            {
+                producer.Join();
+            }
+
+            Assert.Null(producerException);
+            Assert.True(GetUseStripes(aggregator));
+
+            HistogramStatistics stats = (HistogramStatistics)aggregator.Collect();
+            Assert.Equal(ProducerCount * Iterations, stats.Count);
+            Assert.Equal(stats.Count, stats.Sum);
+            Assert.Single(stats.Quantiles);
+            Assert.Equal(1, stats.Quantiles[0].Value);
+
+            object?[] retainedBuckets = GetStripeFields(aggregator, "Buckets");
+            Assert.Contains(retainedBuckets, bucket => bucket is not null);
+
+            aggregator.Update(2);
+            object?[] dirtyFlags = GetStripeFields(aggregator, "Dirty");
+            int dirtyStripe = Array.FindIndex(dirtyFlags, dirty => (bool)dirty!);
+            Assert.NotEqual(-1, dirtyStripe);
+            object?[] reusedBuckets = GetStripeFields(aggregator, "Buckets");
+            Assert.Same(retainedBuckets[dirtyStripe], reusedBuckets[dirtyStripe]);
+
+            stats = (HistogramStatistics)aggregator.Collect();
+            Assert.Equal(1, stats.Count);
+            Assert.Equal(2, stats.Sum);
+            Assert.Single(stats.Quantiles);
+            Assert.Equal(2, stats.Quantiles[0].Value);
+
+            Assert.Contains(GetStripeFields(aggregator, "Buckets"), bucket => bucket is not null);
+            stats = (HistogramStatistics)aggregator.Collect();
+            Assert.Equal(0, stats.Count);
+            Assert.Equal(0, stats.Sum);
+            Assert.Empty(stats.Quantiles);
+            Assert.All(GetStripeFields(aggregator, "Buckets"), Assert.Null);
+
+            static bool GetUseStripes(ExponentialHistogramAggregator aggregator) =>
+                (bool)typeof(ExponentialHistogramAggregator)
+                    .GetField("_useStripes", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .GetValue(aggregator)!;
+
+            static object?[] GetStripeFields(ExponentialHistogramAggregator aggregator, string fieldName)
+            {
+                Array stripes = (Array)typeof(ExponentialHistogramAggregator)
+                    .GetField("_stripes", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .GetValue(aggregator)!;
+                object?[] values = new object?[stripes.Length];
+                for (int i = 0; i < stripes.Length; i++)
+                {
+                    object stripe = stripes.GetValue(i)!;
+                    values[i] = stripe.GetType()
+                        .GetField(fieldName, BindingFlags.Instance | BindingFlags.Public)!
+                        .GetValue(stripe);
+                }
+
+                return values;
+            }
+        }
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
@@ -537,18 +537,22 @@ namespace System.Diagnostics.Metrics.Tests
         {
             const int AggregatorCount = 4;
             const int Iterations = 10_000;
-            FieldInfo sampleField = typeof(ExponentialHistogramAggregator)
-                .GetField("t_contentionSample", BindingFlags.Static | BindingFlags.NonPublic)!;
+            FieldInfo samplesField = typeof(ExponentialHistogramAggregator)
+                .GetField("t_contentionSamples", BindingFlags.Static | BindingFlags.NonPublic)!;
             MethodInfo shouldSample = typeof(ExponentialHistogramAggregator)
-                .GetMethod("ShouldSampleContention", BindingFlags.Static | BindingFlags.NonPublic)!;
-            sampleField.SetValue(null, 1u);
+                .GetMethod("ShouldSampleContention", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            ExponentialHistogramAggregator[] aggregators = Enumerable.Range(0, AggregatorCount)
+                .Select(_ => new ExponentialHistogramAggregator(new QuantileAggregation(0.5)))
+                .ToArray();
+            samplesField.SetValue(null, null);
             int[] samples = new int[AggregatorCount];
 
             for (int i = 0; i < Iterations; i++)
             {
-                if ((bool)shouldSample.Invoke(null, null)!)
+                int aggregator = i % AggregatorCount;
+                if ((bool)shouldSample.Invoke(aggregators[aggregator], null)!)
                 {
-                    samples[i % AggregatorCount]++;
+                    samples[aggregator]++;
                 }
             }
 
@@ -557,23 +561,14 @@ namespace System.Diagnostics.Metrics.Tests
 
         private static void ForceStripeTransition(ExponentialHistogramAggregator aggregator)
         {
-            FieldInfo sampleField = typeof(ExponentialHistogramAggregator)
-                .GetField("t_contentionSample", BindingFlags.Static | BindingFlags.NonPublic)!;
-            MethodInfo shouldSample = typeof(ExponentialHistogramAggregator)
-                .GetMethod("ShouldSampleContention", BindingFlags.Static | BindingFlags.NonPublic)!;
-            uint sample = 1;
-            while (true)
-            {
-                sampleField.SetValue(null, sample);
-                if ((bool)shouldSample.Invoke(null, null)!)
-                {
-                    break;
-                }
-
-                sample++;
-            }
-
-            sampleField.SetValue(null, sample);
+            int sampleSlot = (int)typeof(ExponentialHistogramAggregator)
+                .GetField("_contentionSampleSlot", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(aggregator)!;
+            int[] samples = new int[64];
+            samples[sampleSlot] = 63;
+            typeof(ExponentialHistogramAggregator)
+                .GetField("t_contentionSamples", BindingFlags.Static | BindingFlags.NonPublic)!
+                .SetValue(null, samples);
             typeof(ExponentialHistogramAggregator)
                 .GetField("_contentionCount", BindingFlags.Instance | BindingFlags.NonPublic)!
                 .SetValue(aggregator, 63);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
@@ -469,6 +469,7 @@ namespace System.Diagnostics.Metrics.Tests
             const int ProducerCount = 32;
             const int Iterations = 10_000;
             ExponentialHistogramAggregator aggregator = new(new QuantileAggregation(0.5));
+            ForceStripeTransition(aggregator);
             using Barrier barrier = new(ProducerCount + 1);
             Exception? producerException = null;
 
@@ -498,9 +499,8 @@ namespace System.Diagnostics.Metrics.Tests
             {
                 producer.Join();
             }
-
             Assert.Null(producerException);
-            Assert.True(GetUseStripes(aggregator));
+            Assert.Null(producerException);
 
             HistogramStatistics stats = (HistogramStatistics)aggregator.Collect();
             Assert.Equal(ProducerCount * Iterations, stats.Count);
@@ -530,28 +530,104 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(0, stats.Sum);
             Assert.Empty(stats.Quantiles);
             Assert.All(GetStripeFields(aggregator, "Buckets"), Assert.Null);
+        }
 
-            static bool GetUseStripes(ExponentialHistogramAggregator aggregator) =>
-                (bool)typeof(ExponentialHistogramAggregator)
-                    .GetField("_useStripes", BindingFlags.Instance | BindingFlags.NonPublic)!
-                    .GetValue(aggregator)!;
+        [Fact]
+        public void ContentionSamplingDoesNotPhaseAlignAggregators()
+        {
+            const int AggregatorCount = 4;
+            const int Iterations = 10_000;
+            FieldInfo sampleField = typeof(ExponentialHistogramAggregator)
+                .GetField("t_contentionSample", BindingFlags.Static | BindingFlags.NonPublic)!;
+            MethodInfo shouldSample = typeof(ExponentialHistogramAggregator)
+                .GetMethod("ShouldSampleContention", BindingFlags.Static | BindingFlags.NonPublic)!;
+            sampleField.SetValue(null, 1u);
+            int[] samples = new int[AggregatorCount];
 
-            static object?[] GetStripeFields(ExponentialHistogramAggregator aggregator, string fieldName)
+            for (int i = 0; i < Iterations; i++)
             {
-                Array stripes = (Array)typeof(ExponentialHistogramAggregator)
-                    .GetField("_stripes", BindingFlags.Instance | BindingFlags.NonPublic)!
-                    .GetValue(aggregator)!;
-                object?[] values = new object?[stripes.Length];
-                for (int i = 0; i < stripes.Length; i++)
+                if ((bool)shouldSample.Invoke(null, null)!)
                 {
-                    object stripe = stripes.GetValue(i)!;
-                    values[i] = stripe.GetType()
-                        .GetField(fieldName, BindingFlags.Instance | BindingFlags.Public)!
-                        .GetValue(stripe);
+                    samples[i % AggregatorCount]++;
+                }
+            }
+
+            Assert.All(samples, count => Assert.True(count > 0));
+        }
+
+        private static void ForceStripeTransition(ExponentialHistogramAggregator aggregator)
+        {
+            FieldInfo sampleField = typeof(ExponentialHistogramAggregator)
+                .GetField("t_contentionSample", BindingFlags.Static | BindingFlags.NonPublic)!;
+            MethodInfo shouldSample = typeof(ExponentialHistogramAggregator)
+                .GetMethod("ShouldSampleContention", BindingFlags.Static | BindingFlags.NonPublic)!;
+            uint sample = 1;
+            while (true)
+            {
+                sampleField.SetValue(null, sample);
+                if ((bool)shouldSample.Invoke(null, null)!)
+                {
+                    break;
                 }
 
-                return values;
+                sample++;
             }
+
+            sampleField.SetValue(null, sample);
+            typeof(ExponentialHistogramAggregator)
+                .GetField("_contentionCount", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(aggregator, 63);
+            object singleLock = typeof(ExponentialHistogramAggregator)
+                .GetField("_singleLock", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(aggregator)!;
+            using ManualResetEventSlim lockAcquired = new();
+            using ManualResetEventSlim releaseLock = new();
+            Thread lockHolder = new(() =>
+            {
+                lock (singleLock)
+                {
+                    lockAcquired.Set();
+                    releaseLock.Wait();
+                }
+            });
+            lockHolder.Start();
+            lockAcquired.Wait();
+            try
+            {
+                aggregator.Update(1);
+            }
+            finally
+            {
+                releaseLock.Set();
+                lockHolder.Join();
+            }
+
+            Assert.True(GetUseStripes(aggregator));
+            HistogramStatistics transitionStats = (HistogramStatistics)aggregator.Collect();
+            Assert.Equal(1, transitionStats.Count);
+            Assert.Equal(1, transitionStats.Sum);
+        }
+
+        private static bool GetUseStripes(ExponentialHistogramAggregator aggregator) =>
+            (bool)typeof(ExponentialHistogramAggregator)
+                .GetField("_useStripes", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(aggregator)!;
+
+        private static object?[] GetStripeFields(ExponentialHistogramAggregator aggregator, string fieldName)
+        {
+            Array stripes = (Array)typeof(ExponentialHistogramAggregator)
+                .GetField("_stripes", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(aggregator)!;
+            object?[] values = new object?[stripes.Length];
+            for (int i = 0; i < stripes.Length; i++)
+            {
+                object stripe = stripes.GetValue(i)!;
+                values[i] = stripe.GetType()
+                    .GetField(fieldName, BindingFlags.Instance | BindingFlags.Public)!
+                    .GetValue(stripe);
+            }
+
+            return values;
         }
     }
 }


### PR DESCRIPTION
## Readiness decision: NO-GO — withdrawal recommended

This draft should **not** be promoted for review. Re-evaluation against current `dotnet/runtime` main (`2a4fd645e6f53049318842754986d07a775c1ab1`) confirms that the original single-lock histogram bottleneck still exists, but this candidate trades it for unresolved regressions and correctness/performance risks.

### Blocking findings

- **Single-producer regression:** the exact sustained tagged request workload regresses approximately **6–7%** with one producer.
- **Memory cost:** approximately **+96 KiB per active striped histogram** in the low-cardinality workload and about **+50 KiB per active time series** at cardinality 64. Idle release works, but peak active memory remains material.
- **Sampler collision:** the 64 contention-sampling slots wrap. In fixed update order, colliding aggregators can phase-align so one receives sampled probes while another is starved and never transitions.
- **Low-core stripe bias:** stripe selection seeds modulo 8 and then applies modulo stripe count, producing uneven distribution on 3/5/6/7-core systems.
- **Cardinality misses:** two representative higher-cardinality cases improve only **1.39–1.47x**, below the intended 1.5x bar.
- **Validation gap:** evidence is from one Arm64 macOS system. No clean current-main A/B, Linux/x64 many-core validation, or EgorBot run exists for a viable candidate.
- **PR state:** CI is red and review threads remain unresolved. The branch merge base is `7aa830a03599a8255c2c4abf2947afc5b346cc6f`, far behind current main.

### What the experiment established

The diagnosis is valid: with 18 producers and three histograms, the parent trace attributes 76.6% inclusive time to `ExponentialHistogramAggregator.Update` and 75.5% to `Lock.TryEnterSlow`. Striping can produce large low-cardinality concurrency gains and reduce exporter allocation/GC pressure, but the tested adaptive design is not a mergeable net win.

### Preserved evidence

Exact local evidence compared parent `7aa830a03599a8255c2c4abf2947afc5b346cc6f` with measured implementation `918d588c45d0d3a512ad5dd2d093a9be6905036e`:

- five interleaved custom A/B passes at 1/2/4/8/16/18 producers;
- repeated latency and active/idle memory matrices;
- full BenchmarkDotNet runs;
- exact CPU and GC-verbose traces;
- 452 passing unit/stress tests and four isolated passing outer-loop cases.

The raw harnesses, commands, binaries, JSONL, BDN reports, traces, XML/logs, and checksums are preserved outside this PR.

### Recommended next owner actions

1. **Withdraw/close this draft** rather than rebase or promote it.
2. Start a fresh design from current main that has collision-free contention detection with no serial regression.
3. Map threads directly over the actual stripe count and validate 1/3/5/6/7/8+ core configurations.
4. Establish an explicit memory budget for active tagged time series.
5. Before opening a replacement PR, require current-main exact A/B, full BDN, `@EgorBot -linux_amd -osx_arm64`, focused concurrency/snapshot/Base2 tests, clean CI, and skeptical concurrency review.

This PR remains draft solely as an experimental record.

> [!NOTE]
> This readiness assessment was generated with GitHub Copilot.