### PR TITLE
[wasm] Fix ReferenceNewAssembly rebuild test: driver-gen.c regeneration and stale-native comparison

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/ProjectProviderBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/ProjectProviderBase.cs
@@ -129,9 +129,19 @@ public abstract class ProjectProviderBase(ITestOutputHelper _testOutput, string?
                         if (!match.Success)
                             return true;
 
-                        actual[expectedFilename] = new(ExpectedFilename: expectedFilename,
-                                                       Hash: match.Groups[1].Value,
-                                                       ActualPath: actualFile);
+                        // Multiple fingerprinted variants of the same logical file can coexist when
+                        // republishing into an existing output directory: the previous publish's
+                        // fingerprinted copy is not removed, and a rebuild that changes the file's
+                        // content produces a new fingerprint alongside the stale one. Keep the newest
+                        // file so the assertion compares against the current (re)build output instead
+                        // of picking a stale artifact by filename ordering.
+                        if (!actual.TryGetValue(expectedFilename, out DotNetFileName? existingMatch) ||
+                            File.GetLastWriteTimeUtc(actualFile) >= File.GetLastWriteTimeUtc(existingMatch.ActualPath))
+                        {
+                            actual[expectedFilename] = new(ExpectedFilename: expectedFilename,
+                                                           Hash: match.Groups[1].Value,
+                                                           ActualPath: actualFile);
+                        }
                     }
                     else
                     {

--- a/src/mono/wasm/testassets/EntryPoints/NativeRebuildNewAssembly.cs
+++ b/src/mono/wasm/testassets/EntryPoints/NativeRebuildNewAssembly.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 public class Test
 {
     public static int Main()
@@ -12,6 +13,13 @@ public class Test
             byte[] hashBytes = sha256.ComputeHash(inputBytes);
             Console.WriteLine($"Hash of {input}: {Convert.ToBase64String(hashBytes)}");
         }
+
+        // Also reference System.Text.RegularExpressions, which is not otherwise part of
+        // the test app's closure, so that rebuilding pulls in a *new* assembly. This
+        // ensures native artifacts that depend on the set of assemblies (e.g. the AOT
+        // modules table driver-gen.c) are regenerated on rebuild.
+        bool isMatch = Regex.IsMatch(input, "[A-Za-z]+");
+        Console.WriteLine($"Input '{input}' matches: {isMatch}");
         return 42;
     }
 }


### PR DESCRIPTION
Fixes #130540

This PR fixes `Wasm.Build.NativeRebuild.Tests.ReferenceNewAssemblyRebuildTest.ReferenceNewAssembly`, which had two independent problems: the AOT case (`driver-gen.c` not regenerated) and, once that was fixed, the relink case (`dotnet.native.wasm` size mismatch against a stale published file).

## Fix 1 — `driver-gen.c` not regenerated (AOT case)

### Problem

`ReferenceNewAssembly(config: Release, aot: True, ...)` fails deterministically with:

```
CompareStat failed:
[Expected changed file: driver-gen.c]
```

### Root cause

`driver-gen.c` is the AOT modules table, written by `MonoAOTCompiler.GenerateAotModulesTable` via `Utils.CopyIfDifferent(..., useHash: false)`. It is only rewritten (its timestamp bumped) when the **content** differs. The content is the ordered list of `mono_aot_module__info` symbols — i.e. the set of AOT-compiled assemblies.

The test replaces `Common/Program.cs` with `NativeRebuildNewAssembly.cs`, which used `System.Security.Cryptography` (SHA256), expecting that to add a **new** assembly to the AOT set so `driver-gen.c` would be regenerated.

However, `WasmBasicTestApp` **already** pulls `System.Security.Cryptography` into its closure in *both* builds, via `HttpTest.cs` (`[JSExport]` `HttpClient` → `System.Net.Http` → crypto) and `ZipArchiveInteropTest.cs` (`System.IO.Compression` → crypto, added by #122093). So the AOT assembly set is identical before and after the change, `driver-gen.c` content is byte-identical, `CopyIfDifferent` leaves the old timestamp, and the `unchanged: false` assertion for `driver-gen.c` fails.

### Fix

`NativeRebuildNewAssembly.cs` now additionally references `System.Text.RegularExpressions` (`Regex`), which is **not** otherwise part of the app's closure (verified: it is absent from the actual failing build's AOT list, and no other source in `WasmBasicTestApp` uses it). The rebuild therefore genuinely adds a new AOT module, `driver-gen.c` is regenerated, and the assertion passes. A framework assembly was chosen (rather than a local `ProjectReference`) because it is simply never pulled in the first build when unused, making it reliably absent. The original crypto usage is kept as-is.

## Fix 2 — stale published `dotnet.native.wasm` picked in the relink case

### Problem

With Fix 1 in place, the AOT case passes, but the relink case (`aot: False, invariant: False`) then fails:

```
File sizes don't match for
  obj/.../wasm/for-publish/dotnet.native.wasm (3066497)
  publish/wwwroot/_framework/dotnet.native.r26owxu9r7.wasm (3066264)
```

This looked flaky (the Windows leg passed while Linux failed), but it is deterministic — it depends on the alphabetical order of two content-hash fingerprints.

### Root cause

The test publishes twice into the **same** `wwwroot/_framework`:

1. `FirstNativeBuildAndRun` publishes the baseline app → `dotnet.native.<fpA>.wasm`.
2. `Rebuild` (now genuinely referencing a new assembly) relinks `dotnet.native.wasm` to a larger, differently-fingerprinted file → `dotnet.native.<fpB>.wasm`, copied into the same directory.

`_PublishCopyStaticWebAssetsPreserveNewest` never deletes the first publish's fingerprinted copy, so both files coexist. `ProjectProviderBase.FindAndAssertDotnetFiles` globbed `dotnet.*`, consumed **both** matches, and kept the alphabetically-last one — which could be the **stale** first-publish file — then compared it against the freshly relinked `obj` output, producing the size mismatch. This latent test-infra bug was previously masked because the test failed earlier (Fix 1) before the relink assertion ran.

### Fix

When multiple fingerprinted variants of the same logical file are present, `FindAndAssertDotnetFiles` now keeps the **newest** one by last-write time. The rebuild always writes a newer timestamp (guaranteed by the existing 5s delay in `NativeRebuildTestsBase.Rebuild`), so the assertion reliably compares against the current build output.

## Validation

All five `ReferenceNewAssembly` cases pass locally against a Mono browser-wasm Release build with workloads:

```
Wasm.Build.Tests  Total: 5, Errors: 0, Failed: 0, Skipped: 0
```

> [!NOTE]
> This PR description and change were generated with the assistance of GitHub Copilot.