### PR TITLE
[cDAC] Remove GetClassPointer from the public IRuntimeTypeSystem surface

### DIFF
--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -41,9 +41,6 @@ partial interface IRuntimeTypeSystem : IContract
     // A canonical method table is either the MethodTable itself, or in the case of a generic instantiation, it is the
     // MethodTable of the prototypical instance.
     public virtual TargetPointer GetCanonicalMethodTable(TypeHandle typeHandle);
-    // Returns the EEClass pointer for this MethodTable. For non-canonical MTs, follows the tagged pointer
-    // to the canonical MT and returns its EEClass.
-    public virtual TargetPointer GetClassPointer(TypeHandle typeHandle);
     // True if this MethodTable is the canonical MethodTable (i.e., EEClassOrCanonMT points directly to the EEClass)
     public virtual bool IsCanonicalMethodTable(TypeHandle typeHandle);
     public virtual TargetPointer GetParentMethodTable(TypeHandle typeHandle);
@@ -82,6 +79,10 @@ partial interface IRuntimeTypeSystem : IContract
     public virtual bool TryGetHFAElementSize(TypeHandle typeHandle, out int elementSize);
     // True if the type requires 8-byte alignment on platforms that don't 8-byte align by default (FEATURE_64BIT_ALIGNMENT)
     public virtual bool RequiresAlign8(TypeHandle typeHandle);
+    // Returns the cached SystemV AMD64 eightbyte register-passing classification for a value type
+    // (used to decide how a struct is passed in registers), or false if the type has no such
+    // classification (not applicable, or the runtime was not built with UNIX_AMD64_ABI).
+    public virtual bool TryGetSystemVAmd64EightByteClassification(TypeHandle typeHandle, out SystemVAmd64EightByteClassification classification);
     // True if the MethodTable represents a continuation type used by the async continuation feature
     public virtual bool IsContinuationWithoutMetadata(TypeHandle typeHandle);
     // Returns the GC pointer runs for the method table as (offset, size) pairs. Each
@@ -547,6 +548,13 @@ The contract additionally depends on these data descriptors
 | `EEClass` | `NumStaticFields` | Count of static fields of the EEClass |
 | `EEClass` | `NumThreadStaticFields` | Count of threadstatic fields of the EEClass |
 | `EEClass` | `FieldDescList` | A list of fields in the type |
+| `EEClass` | `OptionalFields` | Pointer to the `EEClassOptionalFields` for this type, or null if it has none |
+| `EEClassOptionalFields` | `EightByteRegistersInfo` | Inline `SystemVEightByteRegistersInfo` describing the SystemV AMD64 register-passing classification (only populated on UNIX_AMD64_ABI builds) |
+| `SystemVEightByteRegistersInfo` | `NumEightBytes` | Number of eightbyte slots used to pass the value type in registers (0 if not passed in registers) |
+| `SystemVEightByteRegistersInfo` | `EightByteClassification0` | Register classification of the first eightbyte |
+| `SystemVEightByteRegistersInfo` | `EightByteClassification1` | Register classification of the second eightbyte |
+| `SystemVEightByteRegistersInfo` | `EightByteSize0` | Byte size of the first eightbyte |
+| `SystemVEightByteRegistersInfo` | `EightByteSize1` | Byte size of the second eightbyte |
 | `TypeDesc` | `TypeAndFlags` | The lower 8 bits are the CorElementType of the `TypeDesc`, the upper 24 bits are reserved for flags |
 | `ParamTypeDesc` | `TypeArg` | Associated type argument |
 | `TypeVarTypeDesc` | `Module` | Pointer to module which defines the type variable |
@@ -638,7 +646,7 @@ Contracts used:
 
     public uint GetComponentSize(TypeHandle TypeHandle) =>!typeHandle.IsMethodTable() ? (uint)0 :  GetComponentSize(_methodTables[TypeHandle.Address]);
 
-    public TargetPointer GetClassPointer(TypeHandle TypeHandle)
+    internal TargetPointer GetClassPointer(TypeHandle TypeHandle)
     {
         // Returns TargetPointer.Null if not a MethodTable.
         // If EEClassOrCanonMT points directly to an EEClass, returns that pointer.
@@ -650,6 +658,36 @@ Contracts used:
     {
         TargetPointer eeClassPtr = GetClassPointer(TypeHandle);
         ... // read Data.EEClass data from eeClassPtr
+    }
+
+    public bool TryGetSystemVAmd64EightByteClassification(TypeHandle typeHandle, out SystemVAmd64EightByteClassification classification)
+    {
+        classification = default;
+
+        TargetPointer eeClassPtr = GetClassPointer(typeHandle);
+        if (eeClassPtr == TargetPointer.Null)
+            return false;
+
+        Data.EEClass eeClass = ... // read Data.EEClass from eeClassPtr
+        if (eeClass.OptionalFields == TargetPointer.Null)
+            return false;
+
+        Data.EEClassOptionalFields optFields = ... // read Data.EEClassOptionalFields from eeClass.OptionalFields
+        // EightByteRegistersInfo is only populated on UNIX_AMD64_ABI builds.
+        if (optFields.EightByteRegistersInfo is not Data.SystemVEightByteRegistersInfo info || info.NumEightBytes == 0)
+            return false;
+
+        // The underlying data only stores two eightbyte slots; treat an out-of-range count as invalid.
+        if (info.NumEightBytes > 2)
+            return false;
+
+        SystemVAmd64EightByte first = new((SystemVAmd64Classification)info.EightByteClassification0, info.EightByteSize0);
+        SystemVAmd64EightByte? second = info.NumEightBytes > 1
+            ? new SystemVAmd64EightByte((SystemVAmd64Classification)info.EightByteClassification1, info.EightByteSize1)
+            : null;
+
+        classification = new SystemVAmd64EightByteClassification(first, second);
+        return true;
     }
 
     public bool IsFreeObjectMethodTable(TypeHandle TypeHandle) => FreeObjectMethodTablePointer == TypeHandle.Address;

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -646,7 +646,7 @@ Contracts used:
 
     public uint GetComponentSize(TypeHandle TypeHandle) =>!typeHandle.IsMethodTable() ? (uint)0 :  GetComponentSize(_methodTables[TypeHandle.Address]);
 
-    internal TargetPointer GetClassPointer(TypeHandle TypeHandle)
+    private TargetPointer GetClassPointer(TypeHandle TypeHandle)
     {
         // Returns TargetPointer.Null if not a MethodTable.
         // If EEClassOrCanonMT points directly to an EEClass, returns that pointer.
@@ -663,31 +663,26 @@ Contracts used:
     public bool TryGetSystemVAmd64EightByteClassification(TypeHandle typeHandle, out SystemVAmd64EightByteClassification classification)
     {
         classification = default;
-
-        TargetPointer eeClassPtr = GetClassPointer(typeHandle);
-        if (eeClassPtr == TargetPointer.Null)
+        if (!typeHandle.IsMethodTable())
             return false;
 
-        Data.EEClass eeClass = ... // read Data.EEClass from eeClassPtr
-        if (eeClass.OptionalFields == TargetPointer.Null)
+        // The SystemV eightbyte register classification lives in the EEClass optional fields and is
+        // only present on UNIX_AMD64_ABI builds; return false if the type has no optional fields.
+        TargetPointer optionalFields = GetClassData(typeHandle).OptionalFields;
+        if (optionalFields == TargetPointer.Null)
             return false;
 
-        Data.EEClassOptionalFields optFields = ... // read Data.EEClassOptionalFields from eeClass.OptionalFields
-        // EightByteRegistersInfo is only populated on UNIX_AMD64_ABI builds.
-        if (optFields.EightByteRegistersInfo is not Data.SystemVEightByteRegistersInfo info || info.NumEightBytes == 0)
+        TargetPointer eightByteInfo = optionalFields + /* EEClassOptionalFields::EightByteRegistersInfo offset */;
+        byte numEightBytes = target.Read<byte>(eightByteInfo + /* SystemVEightByteRegistersInfo::NumEightBytes offset */);
+
+        // The underlying data only stores two eightbyte slots; treat a count of 0 or > 2 as no classification.
+        if (numEightBytes == 0 || numEightBytes > 2)
             return false;
 
-        // The underlying data only stores two eightbyte slots; treat an out-of-range count as invalid.
-        if (info.NumEightBytes > 2)
-            return false;
-
-        SystemVAmd64EightByte first = new((SystemVAmd64Classification)info.EightByteClassification0, info.EightByteSize0);
-        SystemVAmd64EightByte? second = info.NumEightBytes > 1
-            ? new SystemVAmd64EightByte((SystemVAmd64Classification)info.EightByteClassification1, info.EightByteSize1)
-            : null;
-
-        classification = new SystemVAmd64EightByteClassification(first, second);
-        return true;
+        // For each eightbyte read its classification and size at the corresponding offsets:
+        //   EightByteClassification0/1 and EightByteSize0/1
+        // and populate 'classification' with one SystemVAmd64EightByte per eightbyte (First is always
+        // present; Second is present only when numEightBytes > 1). Return true.
     }
 
     public bool IsFreeObjectMethodTable(TypeHandle TypeHandle) => FreeObjectMethodTablePointer == TypeHandle.Address;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -182,22 +182,14 @@ public interface IRuntimeTypeSystem : IContract
     // to 4, 8, or 16. Returns false otherwise (including on targets that don't
     // define FEATURE_HFA). Mirrors MethodTable::GetHFAType in
     // src/coreclr/vm/class.cpp.
-    bool TryGetHFAElementSize(TypeHandle typeHandle, out int elementSize)
-    {
-        elementSize = 0;
-        throw new NotImplementedException();
-    }
+    bool TryGetHFAElementSize(TypeHandle typeHandle, out int elementSize) => throw new NotImplementedException();
     // True if the type requires 8-byte alignment on platforms that don't 8-byte align by default (FEATURE_64BIT_ALIGNMENT)
     bool RequiresAlign8(TypeHandle typeHandle) => throw new NotImplementedException();
     // Returns the cached SystemV AMD64 eightbyte register-passing classification for a value type
     // (used to decide how a struct is passed in registers), or false if the type has no such
     // classification (not applicable, or the runtime was not built with UNIX_AMD64_ABI). Mirrors
     // the EEClass::GetSystemVAmd64EightByteInfo runtime data used by the JIT.
-    bool TryGetSystemVAmd64EightByteClassification(TypeHandle typeHandle, out SystemVAmd64EightByteClassification classification)
-    {
-        classification = default;
-        throw new NotImplementedException();
-    }
+    bool TryGetSystemVAmd64EightByteClassification(TypeHandle typeHandle, out SystemVAmd64EightByteClassification classification) => throw new NotImplementedException();
     // True if the MethodTable represents a continuation subtype that has no metadata of its own
     bool IsContinuationWithoutMetadata(TypeHandle typeHandle) => throw new NotImplementedException();
     /// <summary>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -109,6 +109,35 @@ public enum WellKnownMethodTable
     Canon,
 }
 
+// cDAC-owned representation of a SystemV AMD64 eightbyte register classification. The values mirror
+// the ABI classification (see the runtime's Internal.JitInterface.SystemVClassificationType), but the
+// enum is owned by the cDAC contract surface so consumers don't depend on runtime-internal types.
+public enum SystemVAmd64Classification : byte
+{
+    Unknown = 0,
+    Struct = 1,
+    NoClass = 2,
+    Memory = 3,
+    Integer = 4,
+    IntegerReference = 5,
+    IntegerByRef = 6,
+    SSE = 7,
+}
+
+// A single SystemV AMD64 eightbyte register-passing slot for a value type: how that eightbyte is
+// classified and how many of its bytes are occupied (1-8; the final eightbyte may be partial).
+public readonly record struct SystemVAmd64EightByte(
+    SystemVAmd64Classification Classification,
+    byte Size);
+
+// SystemV AMD64 eightbyte register-passing classification for a value type, read from the type's
+// EEClass optional fields (populated only on UNIX_AMD64_ABI builds). A value type is passed in at
+// most two eightbytes (CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS): First is always
+// present, Second is present only when the value spans a second eightbyte.
+public readonly record struct SystemVAmd64EightByteClassification(
+    SystemVAmd64EightByte First,
+    SystemVAmd64EightByte? Second);
+
 
 public interface IRuntimeTypeSystem : IContract
 {
@@ -122,9 +151,6 @@ public interface IRuntimeTypeSystem : IContract
     // A canonical method table is either the MethodTable itself, or in the case of a generic instantiation, it is the
     // MethodTable of the prototypical instance.
     TargetPointer GetCanonicalMethodTable(TypeHandle typeHandle) => throw new NotImplementedException();
-    // Returns the EEClass pointer for this MethodTable. For non-canonical MTs, follows the tagged pointer
-    // to the canonical MT and returns its EEClass.
-    TargetPointer GetClassPointer(TypeHandle typeHandle) => throw new NotImplementedException();
     // True if this MethodTable is the canonical MethodTable (i.e., EEClassOrCanonMT points directly to the EEClass)
     bool IsCanonicalMethodTable(TypeHandle typeHandle) => throw new NotImplementedException();
     TargetPointer GetParentMethodTable(TypeHandle typeHandle) => throw new NotImplementedException();
@@ -163,6 +189,15 @@ public interface IRuntimeTypeSystem : IContract
     }
     // True if the type requires 8-byte alignment on platforms that don't 8-byte align by default (FEATURE_64BIT_ALIGNMENT)
     bool RequiresAlign8(TypeHandle typeHandle) => throw new NotImplementedException();
+    // Returns the cached SystemV AMD64 eightbyte register-passing classification for a value type
+    // (used to decide how a struct is passed in registers), or false if the type has no such
+    // classification (not applicable, or the runtime was not built with UNIX_AMD64_ABI). Mirrors
+    // the EEClass::GetSystemVAmd64EightByteInfo runtime data used by the JIT.
+    bool TryGetSystemVAmd64EightByteClassification(TypeHandle typeHandle, out SystemVAmd64EightByteClassification classification)
+    {
+        classification = default;
+        throw new NotImplementedException();
+    }
     // True if the MethodTable represents a continuation subtype that has no metadata of its own
     bool IsContinuationWithoutMetadata(TypeHandle typeHandle) => throw new NotImplementedException();
     /// <summary>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
@@ -127,43 +127,40 @@ internal readonly struct CdacTypeHandle : ITypeHandle
         if (_typeHandle.IsNull)
             return;
 
-        // Read the runtime-cached classification from EEClassOptionalFields;
-        // mirrors SystemVRegDescriptorFromSystemVEightByteRegistersInfo in
-        // jitinterface.cpp. Field only populated on UNIX_AMD64_ABI builds.
-        TargetPointer eeClassPtr = Rts.GetClassPointer(_typeHandle);
-        if (eeClassPtr == TargetPointer.Null)
-            return;
-
-        Data.EEClass eeClass = _target.ProcessedData.GetOrAdd<Data.EEClass>(eeClassPtr);
-        if (eeClass.OptionalFields == TargetPointer.Null)
-            return;
-
-        Data.EEClassOptionalFields optFields = _target.ProcessedData.GetOrAdd<Data.EEClassOptionalFields>(eeClass.OptionalFields);
-        if (optFields.EightByteRegistersInfo is not Data.SystemVEightByteRegistersInfo info)
-            return;
-
-        if (info.NumEightBytes == 0)
-            return;
-
-        // Runtime contract: at most CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS (2)
-        // eightbytes. Treat a corrupted / out-of-range count as "not passed in
-        // registers" so downstream loops keyed off eightByteCount can't overrun.
-        if (info.NumEightBytes > 2)
+        // Read the runtime-cached classification from the type system; mirrors
+        // SystemVRegDescriptorFromSystemVEightByteRegistersInfo in jitinterface.cpp.
+        // Only populated on UNIX_AMD64_ABI builds.
+        if (!Rts.TryGetSystemVAmd64EightByteClassification(_typeHandle, out SystemVAmd64EightByteClassification info))
             return;
 
         descriptor.passedInRegisters = true;
-        descriptor.eightByteCount = info.NumEightBytes;
-        descriptor.eightByteClassifications0 = (SystemVClassificationType)info.EightByteClassification0;
-        descriptor.eightByteSizes0 = info.EightByteSize0;
+        descriptor.eightByteCount = 1;
+        descriptor.eightByteClassifications0 = ToSystemVClassificationType(info.First.Classification);
+        descriptor.eightByteSizes0 = info.First.Size;
         descriptor.eightByteOffsets0 = 0;
 
-        if (info.NumEightBytes > 1)
+        if (info.Second is SystemVAmd64EightByte second)
         {
-            descriptor.eightByteClassifications1 = (SystemVClassificationType)info.EightByteClassification1;
-            descriptor.eightByteSizes1 = info.EightByteSize1;
+            descriptor.eightByteCount = 2;
+            descriptor.eightByteClassifications1 = ToSystemVClassificationType(second.Classification);
+            descriptor.eightByteSizes1 = second.Size;
             descriptor.eightByteOffsets1 = SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR.SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES;
         }
     }
+
+    private static SystemVClassificationType ToSystemVClassificationType(SystemVAmd64Classification classification)
+        => classification switch
+        {
+            SystemVAmd64Classification.Unknown => SystemVClassificationType.SystemVClassificationTypeUnknown,
+            SystemVAmd64Classification.Struct => SystemVClassificationType.SystemVClassificationTypeStruct,
+            SystemVAmd64Classification.NoClass => SystemVClassificationType.SystemVClassificationTypeNoClass,
+            SystemVAmd64Classification.Memory => SystemVClassificationType.SystemVClassificationTypeMemory,
+            SystemVAmd64Classification.Integer => SystemVClassificationType.SystemVClassificationTypeInteger,
+            SystemVAmd64Classification.IntegerReference => SystemVClassificationType.SystemVClassificationTypeIntegerReference,
+            SystemVAmd64Classification.IntegerByRef => SystemVClassificationType.SystemVClassificationTypeIntegerByRef,
+            SystemVAmd64Classification.SSE => SystemVClassificationType.SystemVClassificationTypeSSE,
+            _ => SystemVClassificationType.SystemVClassificationTypeUnknown,
+        };
 
     public FpStructInRegistersInfo GetFpStructInRegistersInfo(Internal.TypeSystem.TargetArchitecture architecture)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -554,7 +554,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
     public uint GetComponentSize(TypeHandle typeHandle) => !typeHandle.IsMethodTable() ? (uint)0 : _methodTables[typeHandle.Address].Flags.ComponentSize;
 
-    public TargetPointer GetClassPointer(TypeHandle typeHandle)
+    internal TargetPointer GetClassPointer(TypeHandle typeHandle)
     {
         if (!typeHandle.IsMethodTable())
             return TargetPointer.Null;
@@ -571,6 +571,37 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             default:
                 throw new InvalidOperationException();
         }
+    }
+
+    public bool TryGetSystemVAmd64EightByteClassification(TypeHandle typeHandle, out SystemVAmd64EightByteClassification classification)
+    {
+        classification = default;
+
+        TargetPointer eeClassPtr = GetClassPointer(typeHandle);
+        if (eeClassPtr == TargetPointer.Null)
+            return false;
+
+        Data.EEClass eeClass = _target.ProcessedData.GetOrAdd<Data.EEClass>(eeClassPtr);
+        if (eeClass.OptionalFields == TargetPointer.Null)
+            return false;
+
+        Data.EEClassOptionalFields optFields = _target.ProcessedData.GetOrAdd<Data.EEClassOptionalFields>(eeClass.OptionalFields);
+        if (optFields.EightByteRegistersInfo is not Data.SystemVEightByteRegistersInfo info || info.NumEightBytes == 0)
+            return false;
+
+        // The underlying data only stores two eightbyte slots
+        // (CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS). Treat a corrupted / out-of-range
+        // count as "no classification" so consumers can't read beyond the two stored slots.
+        if (info.NumEightBytes > 2)
+            return false;
+
+        SystemVAmd64EightByte first = new((SystemVAmd64Classification)info.EightByteClassification0, info.EightByteSize0);
+        SystemVAmd64EightByte? second = info.NumEightBytes > 1
+            ? new SystemVAmd64EightByte((SystemVAmd64Classification)info.EightByteClassification1, info.EightByteSize1)
+            : null;
+
+        classification = new SystemVAmd64EightByteClassification(first, second);
+        return true;
     }
 
     // only called on validated method tables, so we don't need to re-validate the EEClass

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -554,7 +554,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
     public uint GetComponentSize(TypeHandle typeHandle) => !typeHandle.IsMethodTable() ? (uint)0 : _methodTables[typeHandle.Address].Flags.ComponentSize;
 
-    internal TargetPointer GetClassPointer(TypeHandle typeHandle)
+    private TargetPointer GetClassPointer(TypeHandle typeHandle)
     {
         if (!typeHandle.IsMethodTable())
             return TargetPointer.Null;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -4459,21 +4459,12 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             {
                 IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
                 TargetPointer mt = _target.Contracts.Object.GetMethodTableAddress(new TargetPointer(obj));
-                TypeHandle th = rts.GetTypeHandle(mt);
-                TargetPointer canonMT = rts.GetCanonicalMethodTable(th);
 
-                if (mt == canonMT)
-                {
-                    isValid = Interop.BOOL.TRUE;
-                }
-                else if (!rts.IsCanonicalMethodTable(th) || rts.IsContinuationWithoutMetadata(th))
-                {
-                    TargetPointer cls = rts.GetClassPointer(th);
-                    TypeHandle canonTh = rts.GetTypeHandle(canonMT);
-                    TargetPointer canonCls = rts.GetClassPointer(canonTh);
-                    if (canonCls == cls)
-                        isValid = Interop.BOOL.TRUE;
-                }
+                // GetTypeHandle validation performs the MethodTable -> EEClass -> MethodTable
+                // round-trip check (the port of MethodTable::ValidateWithPossibleAV), so a
+                // successfully resolved type handle means the object's MethodTable is self-consistent.
+                rts.GetTypeHandle(mt);
+                isValid = Interop.BOOL.TRUE;
             }
             catch (System.Exception)
             {

--- a/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
@@ -652,12 +652,6 @@ public class MethodTableTests
 
         TypeHandle nonCanonTh = contract.GetTypeHandle(nonCanonicalMethodTablePtr);
         Assert.False(contract.IsCanonicalMethodTable(nonCanonTh));
-
-        // Both canonical and non-canonical MTs should resolve to the same EEClass
-        TargetPointer canonClass = contract.GetClassPointer(canonTh);
-        TargetPointer nonCanonClass = contract.GetClassPointer(nonCanonTh);
-        Assert.NotEqual(TargetPointer.Null, canonClass);
-        Assert.Equal(canonClass, nonCanonClass);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

`IRuntimeTypeSystem.GetClassPointer` returned a raw `EEClass*` — a CoreCLR-internal structure with no meaning outside the runtime type system — on the public cDAC contract surface. This PR removes it from the interface and makes it `internal` to `RuntimeTypeSystem_1`, in line with the principle that contracts should expose what a diagnostic consumer needs rather than runtime internals.

It had only two consumers outside the `RuntimeTypeSystem` implementation, both of which used it indirectly:

- **`DacDbiImpl.IsValidObject`** re-implemented the `MethodTable -> EEClass -> MethodTable` self-consistency check (a port of the runtime's `MethodTable::ValidateWithPossibleAV`). `GetTypeHandle` already performs exactly this validation, so `IsValidObject` now simply relies on `GetTypeHandle` succeeding.
- **`CdacTypeHandle`** (CallingConvention) read the `EEClass` optional fields to obtain the SystemV AMD64 eightbyte register-passing classification. That is now exposed through a semantic, cDAC-owned API on `IRuntimeTypeSystem`.

## Changes

- Remove `GetClassPointer` from `IRuntimeTypeSystem`; keep it as an `internal` helper on `RuntimeTypeSystem_1`.
- Add `bool TryGetSystemVAmd64EightByteClassification(TypeHandle, out SystemVAmd64EightByteClassification)` with cDAC-owned result types:
  - `SystemVAmd64Classification` enum (mirrors the ABI classification; consumers no longer cast raw bytes to the runtime-internal `SystemVClassificationType`).
  - Layered `SystemVAmd64EightByte { Classification, Size }`, with `SystemVAmd64EightByteClassification { First, Second? }` — the optional second eightbyte replaces a separate count, making invalid states unrepresentable.
- Simplify `DacDbiImpl.IsValidObject` to rely on `GetTypeHandle` validation.
- Map the cDAC classification enum to the shared JIT `SystemVClassificationType` explicitly at the CallingConvention adapter boundary.
- Remove the now-internal `GetClassPointer` assertions from `MethodTableTests` (the surrounding `IsCanonicalMethodTable` coverage remains).
- Update `docs/design/datacontracts/RuntimeTypeSystem.md` (API listing, data-descriptor table for `EEClass.OptionalFields` / `EEClassOptionalFields` / `SystemVEightByteRegistersInfo`, and pseudocode).

## Testing

- `dotnet build src/native/managed/cdac/cdac.slnx -c Debug` — succeeds, 0 warnings/errors.
- cDAC unit tests: 2693 passed, 0 failed, 16 skipped.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
