### PR TITLE
Reuse reflection argument arrays in ConfigurationBinder BindDictionary/BindCollection

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -770,7 +770,7 @@ namespace Microsoft.Extensions.Configuration
             MethodInfo tryGetValue = dictionaryType.GetMethod("TryGetValue", DeclaredOnlyLookup)!;
             PropertyInfo indexerProperty = dictionaryType.GetProperty("Item", DeclaredOnlyLookup)!;
 
-            object?[] indexerArguments = new object?[1];
+            object?[]? indexerArguments = null;
 
             foreach (IConfigurationSection child in config.GetChildren())
             {
@@ -795,6 +795,7 @@ namespace Microsoft.Extensions.Configuration
                         true);
                     if (valueBindingPoint.HasNewValue)
                     {
+                        indexerArguments ??= new object?[1];
                         indexerArguments[0] = key;
                         indexerProperty.SetValue(dictionary, valueBindingPoint.Value, indexerArguments);
                     }
@@ -821,7 +822,7 @@ namespace Microsoft.Extensions.Configuration
             // ICollection<T> is guaranteed to have exactly one parameter
             Type itemType = collectionType.GenericTypeArguments[0];
             MethodInfo? addMethod = collectionType.GetMethod("Add", DeclaredOnlyLookup);
-            object?[]? addArguments = addMethod is not null ? new object?[1] : null;
+            object?[]? addArguments = null;
 
             foreach (IConfigurationSection section in config.GetChildren())
             {
@@ -834,10 +835,11 @@ namespace Microsoft.Extensions.Configuration
                         config: section,
                         options: options,
                         true);
-                    if (itemBindingPoint.HasNewValue && addArguments is not null)
+                    if (itemBindingPoint.HasNewValue && addMethod is not null)
                     {
+                        addArguments ??= new object?[1];
                         addArguments[0] = itemBindingPoint.Value;
-                        addMethod!.Invoke(collection, addArguments);
+                        addMethod.Invoke(collection, addArguments);
                     }
                 }
                 catch (Exception ex)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -770,6 +770,8 @@ namespace Microsoft.Extensions.Configuration
             MethodInfo tryGetValue = dictionaryType.GetMethod("TryGetValue", DeclaredOnlyLookup)!;
             PropertyInfo indexerProperty = dictionaryType.GetProperty("Item", DeclaredOnlyLookup)!;
 
+            object?[] indexerArguments = new object?[1];
+
             foreach (IConfigurationSection child in config.GetChildren())
             {
                 try
@@ -793,7 +795,8 @@ namespace Microsoft.Extensions.Configuration
                         true);
                     if (valueBindingPoint.HasNewValue)
                     {
-                        indexerProperty.SetValue(dictionary, valueBindingPoint.Value, new object[] { key });
+                        indexerArguments[0] = key;
+                        indexerProperty.SetValue(dictionary, valueBindingPoint.Value, indexerArguments);
                     }
                 }
                 catch (Exception ex)
@@ -818,6 +821,7 @@ namespace Microsoft.Extensions.Configuration
             // ICollection<T> is guaranteed to have exactly one parameter
             Type itemType = collectionType.GenericTypeArguments[0];
             MethodInfo? addMethod = collectionType.GetMethod("Add", DeclaredOnlyLookup);
+            object?[]? addArguments = addMethod is not null ? new object?[1] : null;
 
             foreach (IConfigurationSection section in config.GetChildren())
             {
@@ -830,9 +834,10 @@ namespace Microsoft.Extensions.Configuration
                         config: section,
                         options: options,
                         true);
-                    if (itemBindingPoint.HasNewValue)
+                    if (itemBindingPoint.HasNewValue && addArguments is not null)
                     {
-                        addMethod?.Invoke(collection, new[] { itemBindingPoint.Value });
+                        addArguments[0] = itemBindingPoint.Value;
+                        addMethod!.Invoke(collection, addArguments);
                     }
                 }
                 catch (Exception ex)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
@@ -2446,6 +2446,93 @@ namespace Microsoft.Extensions
             Assert.Equal(0, dictionary.Count);
         }
 
+        // Verifies that binding a custom ICollection<T> invokes Add exactly once per configuration
+        // child, in configuration-child order, with the correct per-item value. This guards the
+        // reflection binder's reuse of a single argument array across Add invocations.
+        [ConditionalFact(typeof(TestHelpers), nameof(TestHelpers.NotSourceGenMode))]
+        public void CustomCollectionBindingPreservesAddOrderAndValues()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"Items:0", "10"},
+                {"Items:1", "20"},
+                {"Items:2", "30"},
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var options = new OrderRecordingCollectionOptions();
+            config.Bind(options);
+
+            Assert.Equal(new[] { 10, 20, 30 }, options.Items.AddOrder);
+            Assert.Equal(3, options.Items.Count);
+        }
+
+        // Verifies that binding a custom IDictionary<TKey, TValue> sets the indexer exactly once per
+        // configuration child, in configuration-child order, overwrites an existing key, and passes
+        // the correct per-key value. This guards the reflection binder's reuse of a single indexer
+        // argument array across SetValue invocations.
+        [ConditionalFact(typeof(TestHelpers), nameof(TestHelpers.NotSourceGenMode))]
+        public void CustomDictionaryBindingPreservesSetOrderValuesAndOverwrite()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"Items:a", "1"},
+                {"Items:b", "2"},
+                {"Items:c", "3"},
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var options = new OrderRecordingDictionaryOptions();
+            options.Items["a"] = 99; // pre-existing value that binding must overwrite
+            options.Items.SetOrder.Clear(); // ignore the pre-seed; record only binding-driven sets
+
+            config.Bind(options);
+
+            Assert.Equal(
+                new[]
+                {
+                    new KeyValuePair<string, int>("a", 1),
+                    new KeyValuePair<string, int>("b", 2),
+                    new KeyValuePair<string, int>("c", 3),
+                },
+                options.Items.SetOrder);
+            Assert.Equal(1, options.Items["a"]);
+            Assert.Equal(2, options.Items["b"]);
+            Assert.Equal(3, options.Items["c"]);
+        }
+
+        // Verifies exception timing/wrapping is unchanged: a failed item conversion is swallowed by
+        // default (item skipped) but rethrown wrapped in InvalidOperationException when
+        // ErrorOnUnknownConfiguration is enabled.
+        [ConditionalFact(typeof(TestHelpers), nameof(TestHelpers.NotSourceGenMode))]
+        public void CustomCollectionBindingRespectsErrorOnUnknownConfiguration()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"Items:0", "10"},
+                {"Items:1", "notAnInt"},
+                {"Items:2", "30"},
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var defaultOptions = new OrderRecordingCollectionOptions();
+            config.Bind(defaultOptions);
+            Assert.Equal(new[] { 10, 30 }, defaultOptions.Items.AddOrder);
+
+            var strictOptions = new OrderRecordingCollectionOptions();
+            Assert.Throws<InvalidOperationException>(
+                () => config.Bind(strictOptions, o => o.ErrorOnUnknownConfiguration = true));
+        }
+
         // Test behavior for root level arrays.
 
         // Tests for TypeConverter usage.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.Collections.cs
@@ -507,5 +507,75 @@ namespace Microsoft.Extensions
 
             bool IReadOnlyDictionary<string, string>.TryGetValue(string key, out string value) => _dictionary.TryGetValue(key, out value);
         }
+
+        public class OrderRecordingCollectionOptions
+        {
+            public OrderRecordingCollection Items { get; set; } = new();
+        }
+
+        // A concrete ICollection<int> whose Add records the exact value it received, in call order.
+        // Used to prove the reflection binder overwrites the reused argument array correctly per item.
+        public sealed class OrderRecordingCollection : ICollection<int>
+        {
+            private readonly List<int> _items = new();
+
+            public List<int> AddOrder { get; } = new();
+
+            public void Add(int item)
+            {
+                AddOrder.Add(item);
+                _items.Add(item);
+            }
+
+            public int Count => _items.Count;
+            public bool IsReadOnly => false;
+            public void Clear() => _items.Clear();
+            public bool Contains(int item) => _items.Contains(item);
+            public void CopyTo(int[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+            public bool Remove(int item) => _items.Remove(item);
+            public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+        }
+
+        public class OrderRecordingDictionaryOptions
+        {
+            public OrderRecordingDictionary Items { get; set; } = new();
+        }
+
+        // A concrete IDictionary<string, int> whose indexer setter records each (key, value) set,
+        // in call order. Used to prove the reflection binder overwrites the reused indexer argument
+        // array correctly per key and preserves overwrite semantics.
+        public sealed class OrderRecordingDictionary : IDictionary<string, int>
+        {
+            private readonly Dictionary<string, int> _dictionary = new();
+
+            public List<KeyValuePair<string, int>> SetOrder { get; } = new();
+
+            public int this[string key]
+            {
+                get => _dictionary[key];
+                set
+                {
+                    SetOrder.Add(new KeyValuePair<string, int>(key, value));
+                    _dictionary[key] = value;
+                }
+            }
+
+            public ICollection<string> Keys => _dictionary.Keys;
+            public ICollection<int> Values => _dictionary.Values;
+            public int Count => _dictionary.Count;
+            public bool IsReadOnly => false;
+            public void Add(string key, int value) => _dictionary.Add(key, value);
+            public void Add(KeyValuePair<string, int> item) => _dictionary.Add(item.Key, item.Value);
+            public void Clear() => _dictionary.Clear();
+            public bool Contains(KeyValuePair<string, int> item) => ((ICollection<KeyValuePair<string, int>>)_dictionary).Contains(item);
+            public bool ContainsKey(string key) => _dictionary.ContainsKey(key);
+            public void CopyTo(KeyValuePair<string, int>[] array, int arrayIndex) => ((ICollection<KeyValuePair<string, int>>)_dictionary).CopyTo(array, arrayIndex);
+            public bool Remove(string key) => _dictionary.Remove(key);
+            public bool Remove(KeyValuePair<string, int> item) => ((ICollection<KeyValuePair<string, int>>)_dictionary).Remove(item);
+            public bool TryGetValue(string key, out int value) => _dictionary.TryGetValue(key, out value);
+            public IEnumerator<KeyValuePair<string, int>> GetEnumerator() => _dictionary.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => _dictionary.GetEnumerator();
+        }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> **Draft / experiment — please do not merge yet.** Kept in draft while independent hardware A/B ([@EgorBot](#egorbot)) is pending. Contact @artl93.

## Motivation

Configuration binding runs at app **startup** and again on every **options reload** (an `IOptionsMonitor` change token re-binds the options graph). In the reflection binder, every bound dictionary entry and every bound collection item allocates a throwaway one-element `object[]` to carry the reflection argument. Apps that bind large or numerous collections/dictionaries (feature-flag maps, endpoint lists, per-tenant settings) pay that per-item allocation on every bind, adding steady-state Gen0 pressure in long-running services.

## Change

Hoist a single `object?[1]` argument array out of the child loop in `BindDictionary` and `BindCollection` and overwrite slot 0 each iteration, instead of allocating a fresh array per child. This mirrors the pattern the sibling `BindSet` method has used for years. The array is allocated **lazily on the first successful bind** (`indexerArguments ??= new object?[1]` / `addArguments ??= new object?[1]`), so routes that are entered but bind zero items (all-invalid values swallowed, or an empty/absent section) allocate nothing — there is no zero-success regression. In `BindCollection` the lazy allocation is gated on the presence of an `Add` method, so the no-`Add` interface path stays allocation-neutral. Source generator is untouched.

**Why the reuse is safe:** `PropertyInfo.SetValue` / `MethodInfo.Invoke` are synchronous and copy the argument array by value into the target frame before returning (`MethodBaseInvoker.CheckArguments` copies each element into separate invocation storage; `PropertyInfo.SetValue` allocates its own setter-argument array and copies the index into it). The private, method-local array never escapes, is never read after the call, and is distinct per (recursive) invocation, so overwriting slot 0 on the next iteration is unobservable. Exception type/timing/order is unchanged: the array is only touched on the success path after conversion and recursion have already completed.

## Benchmarks (canonical: BenchmarkDotNet exact-parent A/B) + EgorBot

**BenchmarkDotNet 0.14.0**, `MemoryDiagnoser`, `InProcessEmitToolchain`, WarmupCount=4, IterationCount=12. macOS 26.5.2, Apple M5 Pro, .NET SDK 11.0.100-preview.6, .NET 11.0.0 Arm64 RyuJIT. Each arm force-loads the freshly-built binder for that revision; the harness records the SHA-256 of the loaded `Microsoft.Extensions.Configuration.Binder.dll` at runtime and asserts the two arms differ while `Configuration` / `Abstractions` / `Primitives` are byte-identical:

- candidate binder `1e173d8b…` (this PR, `3888f0b`) vs baseline binder `b389076e…` (exact parent `7aa830a`)
- shared deps identical both arms: configuration `4f4f167e…`, abstractions `da91bc1f…`, primitives `d3fcdb36…`

Δ = candidate − baseline, **Allocated bytes/op**:

| items N | List&lt;int&gt; Δ | Dict&lt;string,int&gt; Δ |
|--------:|------:|------:|
| 0    | 0 | 0 |
| 1    | 0 | 0 |
| 10   | −288 | −286 |
| 100  | −3,168 | −3,169 |
| 1000 | −31,979 | −31,954 |

**Model: Δ ≈ −32 × (N − 1) bytes/op** for N ≥ 1 (one `object[1]` per successfully bound child eliminated; the single reused array is still allocated once, lazily, so N=1 nets zero). Mean times are within run-to-run noise — this is purely an allocation reduction with no throughput change.

Fixed-shape @N=100 (Allocated Δ): `Dict<string,int>` −3,169 · `Dict<string,Color>` (enum) −3,169 · `HashSet<int>` −3,168 · nested `Dict<string,List<int>>` −3,172. Options-reload ×10 @100: List −31,691, Dict −31,688.

**Controls — Δ = 0 (byte-identical):** `int[]` and `IReadOnlyList<int>` (BindArray), `ISet<int>` and `IReadOnlySet<int>` (BindSet), scalar POCO (BindProperties). The change is confined to the two touched routes.

**Zero-success negative controls — Δ = 0 (no regression):** when a changed route is *entered* but binds **zero** items (all values fail conversion and are swallowed, or a missing/absent section), lazy allocation means the array is never created: `List<int>`@100 all-invalid, `Dict<string,int>`@100 all-invalid, and List/Dict missing-section are all **0**. (An earlier eager-allocation variant showed +32 B/op here; lazy-init eliminates it.)

A custom in-process `GC.GetAllocatedBytesForCurrentThread` allocation probe (warmup=300, iters=4000) corroborates the same deltas within ±0.5 %.

<a name="egorbot"></a>Independent hardware confirmation via `@EgorBot -amd -osx_arm64` (targeting head `3888f0b`) is requested in a comment below. **Blocked-gate caveat:** `Microsoft.Extensions.Configuration.Binder` is an **out-of-band** NuGet package, not part of the shared framework. EgorBot's runtime-diff harness diffs the *shared framework* between two commits, so it will load the **released** binder in *both* arms and cannot exercise this change — an expected **~0 delta there means "not measured", not "no effect".** The authoritative measurement is the local exact-parent binder-swap BDN above, which is proven to load distinct binders per arm.

## Validation

- Reflection `Microsoft.Extensions.Configuration.Binder.Tests`: **304 passed / 0 failed / 0 skipped**, including 3 added `NotSourceGenMode` tests (custom-collection add order; custom-dictionary set order + overwrite; `ErrorOnUnknownConfiguration` timing).
- Source-gen `Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests`: **326 passed / 0 failed / 31 skipped** (generator untouched; matches baseline).
- Covered: dictionary overwrite, child ordering, null item values, custom vs interface dispatch, invalid conversion, and no argument-array mutation/aliasing across nested binds.

## Risks

- **No measured allocation regression** in any scenario (the only prior concern, a +32 B zero-success case in an eager variant, is eliminated by lazy allocation).
- BDN numbers are Release-built and self-controlled with runtime-verified binder substitution, but are a local machine A/B, **not** an official dotnet/performance lab run — allocation deltas are exact counts; treat timings as directional.
- CI is green; no Configuration.Binder test failures.

## Lineage

- Base (exact parent, per-item allocation): `7aa830a03599a8255c2c4abf2947afc5b346cc6f`
- Candidate (lazy-init reuse): `3888f0bea6f492ebfd76baba37349832f9332a8e`

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.