### PR TITLE
Fix cDAC byref-like GCRefMap recursion dropping nested unloaded generic fields

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -310,6 +310,18 @@ public interface IRuntimeTypeSystem : IContract
     CorElementType GetFieldDescType(TargetPointer fieldDescPointer) => throw new NotImplementedException();
     uint GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition? fieldDef) => throw new NotImplementedException();
     TypeHandle GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer) => throw new NotImplementedException();
+
+    /// <summary>
+    /// Like <see cref="GetFieldDescApproxTypeHandle"/>, but when the field's type is a
+    /// generic instantiation whose exact closed MethodTable is not loaded (so the normal
+    /// lookup returns a null handle), returns the field type's open generic MethodTable
+    /// instead. The open generic exposes byref/pointer/interior fields at the same
+    /// instantiation-independent offsets, which is sufficient for GCRefMap/interior-pointer
+    /// computation. Non-generic and resolvable fields behave identically to
+    /// <see cref="GetFieldDescApproxTypeHandle"/>.
+    /// </summary>
+    TypeHandle GetFieldDescApproxTypeHandleAllowOpenGeneric(TargetPointer fieldDescPointer) => throw new NotImplementedException();
+
     TargetPointer GetFieldDescByName(TypeHandle typeHandle, string fieldName) => throw new NotImplementedException();
     TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer, bool unboxValueTypes = true) => throw new NotImplementedException();
     TargetPointer GetFieldDescThreadStaticAddress(TargetPointer fieldDescPointer, TargetPointer thread, bool unboxValueTypes = true) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CallingConvention_1.cs
@@ -912,6 +912,16 @@ internal sealed class CallingConvention_1 : ICallingConvention
                 // in ByRefPointerOffsetsReporter).
                 TypeHandle nested = rts.GetFieldDescApproxTypeHandle(fdPtr);
                 if (nested.Address == TargetPointer.Null)
+                {
+                    // The field's exact closed instantiation isn't loaded (common for
+                    // cross-module Span<T> / ReadOnlySpan<T> fields). Fall back to the
+                    // open generic MethodTable, which carries the interior/byref fields
+                    // at the same instantiation-independent offsets. This mirrors the
+                    // top-level OpenGenericType fallback; without it the nested field's
+                    // interior pointer(s) are silently dropped from the GCRefMap.
+                    nested = rts.GetFieldDescApproxTypeHandleAllowOpenGeneric(fdPtr);
+                }
+                if (nested.Address == TargetPointer.Null)
                     continue;
                 bool nestedByRefLike;
                 try { nestedByRefLike = rts.IsByRefLike(nested); }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata.Ecma335;
 using Microsoft.Diagnostics.DataContractReader.RuntimeTypeSystemHelpers;
 using Microsoft.Diagnostics.DataContractReader.Data;
+using Microsoft.Diagnostics.DataContractReader.SignatureHelpers;
 using System.Reflection.Metadata;
 using System.Collections.Immutable;
 using System.Reflection;
@@ -2301,6 +2302,12 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
     }
 
     TypeHandle IRuntimeTypeSystem.GetFieldDescApproxTypeHandle(TargetPointer fieldDescPointer)
+        => GetFieldDescApproxTypeHandleCore(fieldDescPointer, allowOpenGenericFallback: false);
+
+    TypeHandle IRuntimeTypeSystem.GetFieldDescApproxTypeHandleAllowOpenGeneric(TargetPointer fieldDescPointer)
+        => GetFieldDescApproxTypeHandleCore(fieldDescPointer, allowOpenGenericFallback: true);
+
+    private TypeHandle GetFieldDescApproxTypeHandleCore(TargetPointer fieldDescPointer, bool allowOpenGenericFallback)
     {
         try
         {
@@ -2321,7 +2328,17 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             FieldDefinitionHandle fieldDefHandle = (FieldDefinitionHandle)MetadataTokens.Handle((int)memberDef);
             FieldDefinition fieldDef = mdReader.GetFieldDefinition(fieldDefHandle);
 
-            return _target.Contracts.Signature.DecodeFieldSignature(fieldDef.Signature, moduleHandle, enclosingType);
+            if (!allowOpenGenericFallback)
+                return _target.Contracts.Signature.DecodeFieldSignature(fieldDef.Signature, moduleHandle, enclosingType);
+
+            // Decode with an open-generic fallback so a nested generic value-type field
+            // whose exact closed instantiation isn't loaded still resolves to the (loaded)
+            // open generic MethodTable. Interior/byref/pointer field offsets are
+            // instantiation-independent, so this yields the correct GCRefMap offsets.
+            OpenGenericFallbackSignatureTypeProvider<TypeHandle> provider = new(_target, moduleHandle);
+            BlobReader blobReader = mdReader.GetBlobReader(fieldDef.Signature);
+            RuntimeSignatureDecoder<TypeHandle, TypeHandle> decoder = new(provider, _target, mdReader, enclosingType);
+            return decoder.DecodeFieldSignature(ref blobReader);
         }
         catch
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Signature/OpenGenericFallbackSignatureTypeProvider.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Signature/OpenGenericFallbackSignatureTypeProvider.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+
+namespace Microsoft.Diagnostics.DataContractReader.SignatureHelpers;
+
+/// <summary>
+/// A <see cref="SignatureTypeProvider{T}"/> that, when a generic instantiation's
+/// exact closed <see cref="TypeHandle"/> is not loaded (so <c>GetConstructedType</c>
+/// yields a null handle), falls back to the open generic type's handle.
+/// </summary>
+/// <remarks>
+/// This mirrors the top-level open-generic fallback in
+/// <c>CallingConvention_1</c>: the open generic (e.g. <c>Span&lt;T&gt;</c>) is a real,
+/// loaded MethodTable whose FieldDescList exposes byref/pointer/interior fields at
+/// the same, instantiation-independent, in-struct offsets. Recursing into the open
+/// generic therefore yields the correct interior-pointer offsets even when the exact
+/// instantiation (e.g. cross-module <c>Span&lt;byte&gt;</c>) isn't registered in the
+/// searched module.
+/// </remarks>
+internal sealed class OpenGenericFallbackSignatureTypeProvider<T> : SignatureTypeProvider<T>
+{
+    public OpenGenericFallbackSignatureTypeProvider(Target target, Contracts.ModuleHandle moduleHandle)
+        : base(target, moduleHandle)
+    {
+    }
+
+    public override TypeHandle GetGenericInstantiation(TypeHandle genericType, ImmutableArray<TypeHandle> typeArguments)
+    {
+        TypeHandle constructed = base.GetGenericInstantiation(genericType, typeArguments);
+        return constructed.Address != TargetPointer.Null ? constructed : genericType;
+    }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Signature/SignatureTypeProvider.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Signature/SignatureTypeProvider.cs
@@ -34,7 +34,7 @@ public class SignatureTypeProvider<T> : IRuntimeSignatureTypeProvider<TypeHandle
     public TypeHandle GetFunctionPointerType(MethodSignature<TypeHandle> signature)
         => GetPrimitiveType(PrimitiveTypeCode.IntPtr);
 
-    public TypeHandle GetGenericInstantiation(TypeHandle genericType, ImmutableArray<TypeHandle> typeArguments)
+    public virtual TypeHandle GetGenericInstantiation(TypeHandle genericType, ImmutableArray<TypeHandle> typeArguments)
         => _runtimeTypeSystem.GetConstructedType(genericType, CorElementType.GenericInst, 0, typeArguments);
 
     public TypeHandle GetGenericMethodParameter(T context, int index)


### PR DESCRIPTION
## Summary

Fixes a cDAC out-of-process reader bug in the by-value byref-like struct GCRefMap computation: the interior pointer(s) of a nested value-type field are silently dropped when that field's type is a generic instantiation whose exact closed `MethodTable` isn't loaded (common for cross-module `Span<T>`/`ReadOnlySpan<T>`). The runtime reports `INTERIOR`; the cDAC reported `SKIP`.

This is one of a cluster of cDAC GC stress-test robustness fixes split out of #130447.

## The bug

The top level of the arg GCRefMap computation already had an open-generic fallback (`arg.OpenGenericType`), but `EmitByRefLikeInteriorRecursive` bailed with `if (nested.Address == Null) continue;` -- so a nested generic field whose closed instantiation wasn't loaded lost its interior pointer(s).

The fix gives the recursion the same fallback via a new `IRuntimeTypeSystem.GetFieldDescApproxTypeHandleAllowOpenGeneric` plus an `OpenGenericFallbackSignatureTypeProvider`: when the closed instantiation isn't loaded, recurse into the open generic `MethodTable`, whose byref/interior fields sit at the same instantiation-independent offsets.

`GetFieldDescApproxTypeHandleAllowOpenGeneric` is added to the `IRuntimeTypeSystem` contract interface as a default-interface method, consistent with the other `FieldDesc` inspection APIs on that interface. The Abstractions/Contracts assemblies are internal transport (`IsShipping=false`), not part of the shipping ref-pack public API surface.

## Regression coverage

Observed via the existing `CrossModule` stress debuggee's `TakeCrossModuleRefStruct(CrossModuleRefStruct)` (a `Span<byte>` field): `INTERIOR @ [sp+8]` (runtime) vs empty map (cDAC) before the fix. Both GCREFS and ARGITER exercise it.

> [!NOTE]
> This PR description and the changes were produced with the assistance of GitHub Copilot.
