### PR TITLE
Remove invalid live-target assert in cDAC DacEnumerableHash

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DacEnumerableHash.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DacEnumerableHash.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
@@ -45,8 +44,14 @@ internal sealed class DacEnumerableHash
             entries.AddRange(elements);
         }
 
-        Debug.Assert(Count == entries.Count);
-
+        // Note: we intentionally do NOT assert that Count equals the number of
+        // walked entries. Count and the bucket chains are only guaranteed
+        // consistent for a quiescent table (the frozen-dump case the native DAC
+        // walker assumes). The cDAC stress framework reads this table from a
+        // LIVE process where the runtime may be concurrently inserting entries
+        // or growing the table (allocating a new bucket array chained via
+        // SLOT_NEXT and migrating entries), so the stored Count legitimately
+        // diverges from what a single-snapshot bucket walk observes.
         Entries = entries;
     }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DacEnumerableHash.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DacEnumerableHash.cs
@@ -44,7 +44,8 @@ internal sealed class DacEnumerableHash
             entries.AddRange(elements);
         }
 
-        // In STRESS testing, we may stop while this table is resizing.
+        // In STRESS testing, we may stop while this table is resizing, so we
+        // can't assert that Count equals the number of walked entries.
         Entries = entries;
     }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DacEnumerableHash.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DacEnumerableHash.cs
@@ -44,14 +44,7 @@ internal sealed class DacEnumerableHash
             entries.AddRange(elements);
         }
 
-        // Note: we intentionally do NOT assert that Count equals the number of
-        // walked entries. Count and the bucket chains are only guaranteed
-        // consistent for a quiescent table (the frozen-dump case the native DAC
-        // walker assumes). The cDAC stress framework reads this table from a
-        // LIVE process where the runtime may be concurrently inserting entries
-        // or growing the table (allocating a new bucket array chained via
-        // SLOT_NEXT and migrating entries), so the stored Count legitimately
-        // diverges from what a single-snapshot bucket walk observes.
+        // In STRESS testing, we may stop while this table is resizing.
         Entries = entries;
     }
 


### PR DESCRIPTION
## Summary

Removes an invalid `Debug.Assert(Count == entries.Count)` in the cDAC `DacEnumerableHash` reader. One of a cluster of cDAC GC stress-test robustness fixes split out of #130447.

## The bug

`Count` and the bucket chains are only guaranteed consistent for a **quiescent** table -- the frozen-dump case the native DAC walker assumes. The cDAC stress harness reads this hash from a **live** process where the runtime may be concurrently inserting entries or growing the table (allocating a new bucket array chained via `SLOT_NEXT` and migrating entries), so the stored `Count` legitimately diverges from what a single-snapshot bucket walk observes.

This only affects Debug/Checked cDAC builds (the stress harness itself runs a Release cDAC). The assert is replaced with an explanatory comment.

> [!NOTE]
> This PR description and the changes were produced with the assistance of GitHub Copilot.
