### PR TITLE
DCS: Add more formal BOM-detection to Json encoding stream wrappers.

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -327,52 +327,42 @@ namespace System.Runtime.Serialization.Json
         {
             bomLength = 0;
 
+            // Not enough characters for a BON
             if (data.Length < 2)
             {
                 // A single-byte (or empty) JSON document is necessarily UTF-8.
                 return SupportedEncoding.UTF8;
             }
 
-            if (data[0] == 0xFF && data[1] == 0xFE)
+            switch ((data[0], data[1]))
             {
-                bomLength = 2;
-                return SupportedEncoding.UTF16LE;
-            }
-            if (data[0] == 0xFE && data[1] == 0xFF)
-            {
-                bomLength = 2;
-                return SupportedEncoding.UTF16BE;
-            }
-            if (data.Length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF)
-            {
-                bomLength = 3;
-                return SupportedEncoding.UTF8;
-            }
+                // Detect known BOM's
+                case(0xFF, 0xFE):
+                    bomLength = 2;
+                    return SupportedEncoding.UTF16LE;
+                case(0xFE, 0xFF):
+                    bomLength = 2;
+                    return SupportedEncoding.UTF16BE;
+                case(0xEF, 0xBB):
+                    if (data.Length >= 3 && data[2] == 0xBF) {
+                        bomLength = 3;
+                        return SupportedEncoding.UTF16LE;
+                    }
+                    break;
 
-            // No byte order mark: infer the encoding from the leading ASCII character.
-            return ReadEncoding(data[0], data[1]);
-        }
+                // No byte order mark or inference from the leading ASCII character.
+                case (0x00, not 0x00):
+                    return SupportedEncoding.UTF16BE;
+                case (not 0x00, 0x00):
+                    return SupportedEncoding.UTF16LE;
 
-        private static SupportedEncoding ReadEncoding(byte b1, byte b2)
-        {
-            if (b1 == 0x00 && b2 != 0x00)
-            {
-                return SupportedEncoding.UTF16BE;
-            }
-            else if (b1 != 0x00 && b2 == 0x00)
-            {
-                // 857 It's possible to misdetect UTF-32LE as UTF-16LE, but that's OK.
-                return SupportedEncoding.UTF16LE;
-            }
-            else if (b1 == 0x00 && b2 == 0x00)
-            {
                 // UTF-32BE not supported
-                throw new XmlException(SR.JsonInvalidBytes);
+                case (0x00, 0x00):
+                    throw new XmlException(SR.JsonInvalidBytes);
             }
-            else
-            {
-                return SupportedEncoding.UTF8;
-            }
+
+            // No BOM detected or inferred. Assume UTF8
+            return SupportedEncoding.UTF8;
         }
 
         private static void ThrowExpectedEncodingMismatch(SupportedEncoding expEnc, SupportedEncoding actualEnc)
@@ -510,12 +500,10 @@ namespace System.Runtime.Serialization.Json
 
             // Read whatever bytes are immediately available, up to the three occupied by the longest
             // byte order mark. A single Read is used deliberately instead of ReadAtLeast: Read performs
-            // one underlying read and returns however many bytes were available, whereas ReadAtLeast
-            // loops until it has accumulated the requested count. That loop would block a consumer
-            // waiting for bytes an untrusted producer may never send (for example, one that transmits a
-            // single byte and then stalls without closing the stream). Detecting from however many bytes
-            // arrive - and defaulting to UTF-8 when there are too few - avoids that hang while still
-            // recognizing every mark whenever the leading bytes are present.
+            // one underlying read and returns however many bytes were available. If it's enough for
+            // BOM detection, we will try to determine encoding. If not, we continue BOM-less.
+            // `_stream` here is buffered, so `Read()` should be able to return a full BOM if it's there.
+            // We need 3 bytes for full ASCII/UTF-8/16 detection.
             Span<byte> leading = stackalloc byte[3];
             int read = _stream.Read(leading);
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -337,13 +337,13 @@ namespace System.Runtime.Serialization.Json
             switch ((data[0], data[1]))
             {
                 // Detect known BOM's
-                case(0xFF, 0xFE):
+                case (0xFF, 0xFE):
                     bomLength = 2;
                     return SupportedEncoding.UTF16LE;
-                case(0xFE, 0xFF):
+                case (0xFE, 0xFF):
                     bomLength = 2;
                     return SupportedEncoding.UTF16BE;
-                case(0xEF, 0xBB):
+                case (0xEF, 0xBB):
                     if (data.Length >= 3 && data[2] == 0xBF) {
                         bomLength = 3;
                         return SupportedEncoding.UTF16LE;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -122,15 +122,12 @@ namespace System.Runtime.Serialization.Json
             try
             {
                 SupportedEncoding expectedEnc = GetSupportedEncoding(encoding);
-                SupportedEncoding dataEnc;
-                if (count < 2)
-                {
-                    dataEnc = SupportedEncoding.UTF8;
-                }
-                else
-                {
-                    dataEnc = ReadEncoding(buffer[offset], buffer[offset + 1]);
-                }
+                SupportedEncoding dataEnc = DetectEncoding(buffer.AsSpan(offset, count), out int bomLength);
+
+                // Skip past any byte order mark; it is not part of the document.
+                offset += bomLength;
+                count -= bomLength;
+
                 if ((expectedEnc != SupportedEncoding.None) && (expectedEnc != dataEnc))
                 {
                     ThrowExpectedEncodingMismatch(expectedEnc, dataEnc);
@@ -320,6 +317,42 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
+        // Determines the encoding of a JSON document from its leading bytes. A leading byte order
+        // mark, when present, authoritatively selects the encoding and its length is reported via
+        // bomLength so callers can skip past it. When no BOM is present, the encoding is inferred
+        // from the position of the zero byte in the leading (always ASCII) JSON character. Both the
+        // stream and the buffer code paths funnel through this single method so the detection logic
+        // lives in one place.
+        private static SupportedEncoding DetectEncoding(ReadOnlySpan<byte> data, out int bomLength)
+        {
+            bomLength = 0;
+
+            if (data.Length < 2)
+            {
+                // A single-byte (or empty) JSON document is necessarily UTF-8.
+                return SupportedEncoding.UTF8;
+            }
+
+            if (data[0] == 0xFF && data[1] == 0xFE)
+            {
+                bomLength = 2;
+                return SupportedEncoding.UTF16LE;
+            }
+            if (data[0] == 0xFE && data[1] == 0xFF)
+            {
+                bomLength = 2;
+                return SupportedEncoding.UTF16BE;
+            }
+            if (data.Length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF)
+            {
+                bomLength = 3;
+                return SupportedEncoding.UTF8;
+            }
+
+            // No byte order mark: infer the encoding from the leading ASCII character.
+            return ReadEncoding(data[0], data[1]);
+        }
+
         private static SupportedEncoding ReadEncoding(byte b1, byte b2)
         {
             if (b1 == 0x00 && b2 != 0x00)
@@ -473,31 +506,19 @@ namespace System.Runtime.Serialization.Json
 
         private SupportedEncoding ReadEncoding()
         {
-            int b1 = _stream.ReadByte();
-            int b2 = _stream.ReadByte();
-
             EnsureByteBuffer();
 
-            SupportedEncoding e;
+            // Read up to the first three bytes so a byte order mark (at most three bytes long) can
+            // be detected. Fewer bytes are read only when the stream ends early.
+            Span<byte> leading = stackalloc byte[3];
+            int read = _stream.ReadAtLeast(leading, leading.Length, throwOnEndOfStream: false);
 
-            if (b1 == -1)
-            {
-                e = SupportedEncoding.UTF8;
-                _byteCount = 0;
-            }
-            else if (b2 == -1)
-            {
-                e = SupportedEncoding.UTF8;
-                _bytes[0] = (byte)b1;
-                _byteCount = 1;
-            }
-            else
-            {
-                e = ReadEncoding((byte)b1, (byte)b2);
-                _bytes[0] = (byte)b1;
-                _bytes[1] = (byte)b2;
-                _byteCount = 2;
-            }
+            SupportedEncoding e = DetectEncoding(leading.Slice(0, read), out int bomLength);
+
+            // Preserve any bytes that follow the byte order mark; they belong to the document.
+            int preserve = read - bomLength;
+            leading.Slice(bomLength, preserve).CopyTo(_bytes);
+            _byteCount = preserve;
 
             return e;
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -508,10 +508,16 @@ namespace System.Runtime.Serialization.Json
         {
             EnsureByteBuffer();
 
-            // Read up to the first three bytes so a byte order mark (at most three bytes long) can
-            // be detected. Fewer bytes are read only when the stream ends early.
+            // Read whatever bytes are immediately available, up to the three occupied by the longest
+            // byte order mark. A single Read is used deliberately instead of ReadAtLeast: Read performs
+            // one underlying read and returns however many bytes were available, whereas ReadAtLeast
+            // loops until it has accumulated the requested count. That loop would block a consumer
+            // waiting for bytes an untrusted producer may never send (for example, one that transmits a
+            // single byte and then stalls without closing the stream). Detecting from however many bytes
+            // arrive - and defaulting to UTF-8 when there are too few - avoids that hang while still
+            // recognizing every mark whenever the leading bytes are present.
             Span<byte> leading = stackalloc byte[3];
-            int read = _stream.ReadAtLeast(leading, leading.Length, throwOnEndOfStream: false);
+            int read = _stream.Read(leading);
 
             SupportedEncoding e = DetectEncoding(leading.Slice(0, read), out int bomLength);
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -327,7 +327,7 @@ namespace System.Runtime.Serialization.Json
         {
             bomLength = 0;
 
-            // Not enough characters for a BON
+            // Not enough characters for a BOM
             if (data.Length < 2)
             {
                 // A single-byte (or empty) JSON document is necessarily UTF-8.
@@ -336,7 +336,7 @@ namespace System.Runtime.Serialization.Json
 
             switch ((data[0], data[1]))
             {
-                // Detect known BOM's
+                // Detect known BOMs
                 case (0xFF, 0xFE):
                     bomLength = 2;
                     return SupportedEncoding.UTF16LE;
@@ -344,9 +344,10 @@ namespace System.Runtime.Serialization.Json
                     bomLength = 2;
                     return SupportedEncoding.UTF16BE;
                 case (0xEF, 0xBB):
-                    if (data.Length >= 3 && data[2] == 0xBF) {
+                    if (data.Length >= 3 && data[2] == 0xBF)
+                    {
                         bomLength = 3;
-                        return SupportedEncoding.UTF16LE;
+                        return SupportedEncoding.UTF8;
                     }
                     break;
 

--- a/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2319,6 +2319,71 @@ public static partial class DataContractJsonSerializerTests
         }
     }
 
+    public static IEnumerable<object[]> ByteOrderMarkEncodings()
+    {
+        yield return new object[] { new UnicodeEncoding(bigEndian: false, byteOrderMark: true) }; // UTF-16LE with BOM
+        yield return new object[] { new UnicodeEncoding(bigEndian: true, byteOrderMark: true) };  // UTF-16BE with BOM
+        yield return new object[] { new UTF8Encoding(encoderShouldEmitUTF8Identifier: true) };    // UTF-8 with BOM
+    }
+
+    [Theory]
+    [MemberData(nameof(ByteOrderMarkEncodings))]
+    public static void DCJS_DeserializeStreamWithByteOrderMark(Encoding encoding)
+    {
+        var serializer = new DataContractJsonSerializer(typeof(Person1));
+        var value = new Person1 { Name = "John", Age = 42 };
+        byte[] bytes = GetJsonBytesWithByteOrderMark(serializer, value, encoding);
+
+        // Auto-detected encoding (no encoding specified). This is the scenario from the bug report.
+        using (var stream = new MemoryStream(bytes))
+        {
+            var result = (Person1)serializer.ReadObject(stream);
+            Assert.Equal(value.Name, result.Name);
+            Assert.Equal(value.Age, result.Age);
+        }
+
+        // Encoding explicitly specified and matching the byte order mark.
+        using (var stream = new MemoryStream(bytes))
+        {
+            XmlDictionaryReader reader = JsonReaderWriterFactory.CreateJsonReader(stream, encoding, XmlDictionaryReaderQuotas.Max, null);
+            var result = (Person1)serializer.ReadObject(reader);
+            Assert.Equal(value.Name, result.Name);
+            Assert.Equal(value.Age, result.Age);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ByteOrderMarkEncodings))]
+    public static void DCJS_DeserializeBufferWithByteOrderMark(Encoding encoding)
+    {
+        var serializer = new DataContractJsonSerializer(typeof(Person1));
+        var value = new Person1 { Name = "John", Age = 42 };
+        byte[] bytes = GetJsonBytesWithByteOrderMark(serializer, value, encoding);
+
+        XmlDictionaryReader reader = JsonReaderWriterFactory.CreateJsonReader(bytes, 0, bytes.Length, XmlDictionaryReaderQuotas.Max);
+        var result = (Person1)serializer.ReadObject(reader);
+        Assert.Equal(value.Name, result.Name);
+        Assert.Equal(value.Age, result.Age);
+    }
+
+    private static byte[] GetJsonBytesWithByteOrderMark(DataContractJsonSerializer serializer, object value, Encoding encoding)
+    {
+        string json;
+        using (var utf8Stream = new MemoryStream())
+        {
+            serializer.WriteObject(utf8Stream, value);
+            json = Encoding.UTF8.GetString(utf8Stream.ToArray());
+        }
+
+        byte[] preamble = encoding.GetPreamble();
+        Assert.NotEmpty(preamble);
+        byte[] body = encoding.GetBytes(json);
+        byte[] bytes = new byte[preamble.Length + body.Length];
+        preamble.CopyTo(bytes, 0);
+        body.CopyTo(bytes, preamble.Length);
+        return bytes;
+    }
+
     [Fact]
     public static void DCJS_MyISerializableType()
     {


### PR DESCRIPTION
This pull request improves the handling of JSON byte order marks (BOM) in the DataContractJsonSerializer by centralizing and enhancing encoding detection logic, and adds comprehensive tests to ensure correct behavior when processing streams and buffers with BOMs.

**Encoding detection improvements:**

* Introduced a new `DetectEncoding` method to reliably detect the encoding of a JSON document by examining its leading bytes for BOMs or inferring from initial bytes when no BOM is present, consolidating logic previously duplicated across code paths.
* Updated the buffer and stream processing logic in `JsonEncodingStreamWrapper` to use the new `DetectEncoding` method, ensuring BOMs are correctly skipped and only the actual JSON payload is processed. [[1]](diffhunk://#diff-fe40d359bf1f623cc0a044d35715a5a013d2957a9d36ea534faba7c178bcb1cfL125-R130) [[2]](diffhunk://#diff-fe40d359bf1f623cc0a044d35715a5a013d2957a9d36ea534faba7c178bcb1cfL476-R521)

**Test coverage enhancements:**

* Added new parameterized tests to verify that deserialization works correctly for streams and buffers containing UTF-8, UTF-16LE, and UTF-16BE BOMs, both when encoding is auto-detected and when explicitly specified.
* Provided a helper method to generate JSON byte arrays with the appropriate BOM for use in the new tests.

Fixes #80160