### PR TITLE
Compare CredentialCache prefix path case-sensitively

### DIFF
--- a/src/libraries/Common/src/System/Net/CredentialCacheKey.cs
+++ b/src/libraries/Common/src/System/Net/CredentialCacheKey.cs
@@ -70,9 +70,15 @@ namespace System.Net
                 return false;
             }
 
-            // The path on the server may be case-sensitive, so compare the path portion of the
-            // prefix case-sensitively (scheme, host, and port are already matched above).
-            return uri.AbsolutePath.AsSpan(0, UriPrefixLength).Equals(uriPrefix.AbsolutePath.AsSpan(0, UriPrefixLength), StringComparison.Ordinal);
+            // Compare the path prefix including the trailing '/' delimiter (UriPrefixLength points at
+            // the last '/' in the prefix path). Including that delimiter ensures the prefix only matches
+            // at a path-segment boundary, so a prefix such as "/admin/" does not incorrectly match a
+            // sibling path like "/administrator/...".
+            //
+            // The path on the server may be case-sensitive, so the path portion is compared
+            // case-sensitively (scheme, host, and port are already matched above).
+            int compareLength = UriPrefixLength + 1;
+            return uri.AbsolutePath.AsSpan(0, compareLength).Equals(uriPrefix.AbsolutePath.AsSpan(0, compareLength), StringComparison.Ordinal);
         }
 
         public override int GetHashCode() =>

--- a/src/libraries/Common/src/System/Net/CredentialCacheKey.cs
+++ b/src/libraries/Common/src/System/Net/CredentialCacheKey.cs
@@ -70,7 +70,9 @@ namespace System.Net
                 return false;
             }
 
-            return uri.AbsolutePath.AsSpan(0, UriPrefixLength).Equals(uriPrefix.AbsolutePath.AsSpan(0, UriPrefixLength), StringComparison.OrdinalIgnoreCase);
+            // The path on the server may be case-sensitive, so compare the path portion of the
+            // prefix case-sensitively (scheme, host, and port are already matched above).
+            return uri.AbsolutePath.AsSpan(0, UriPrefixLength).Equals(uriPrefix.AbsolutePath.AsSpan(0, UriPrefixLength), StringComparison.Ordinal);
         }
 
         public override int GetHashCode() =>

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -287,10 +287,12 @@ namespace System.Net.Primitives.Functional.Tests
         public static void GetCredential_PathCaseMismatch_ReturnsNull()
         {
             CredentialCache cc = new CredentialCache();
-            cc.Add(new Uri("http://microsoft:80/CaseSensitivePath"), authenticationType1, credential1);
+            // Use a multi-segment path so the compared prefix (everything up to the last '/')
+            // is non-empty and includes characters whose case can differ.
+            cc.Add(new Uri("http://microsoft:80/CaseSensitive/path"), authenticationType1, credential1);
 
             // The path is compared case-sensitively, so a differently-cased path must not match.
-            NetworkCredential nc = cc.GetCredential(new Uri("http://microsoft:80/casesensitivepath"), authenticationType1);
+            NetworkCredential nc = cc.GetCredential(new Uri("http://microsoft:80/casesensitive/path"), authenticationType1);
             Assert.Null(nc);
         }
 
@@ -298,9 +300,10 @@ namespace System.Net.Primitives.Functional.Tests
         public static void GetCredential_PathCaseMatch_ReturnsCredential()
         {
             CredentialCache cc = new CredentialCache();
-            cc.Add(new Uri("http://microsoft:80/CaseSensitivePath"), authenticationType1, credential1);
+            cc.Add(new Uri("http://microsoft:80/CaseSensitive/path"), authenticationType1, credential1);
 
-            NetworkCredential nc = cc.GetCredential(new Uri("http://microsoft:80/CaseSensitivePath"), authenticationType1);
+            // Exact-case prefix match, including a longer request URI to exercise prefix matching.
+            NetworkCredential nc = cc.GetCredential(new Uri("http://microsoft:80/CaseSensitive/path/resource"), authenticationType1);
             Assert.Equal(credential1, nc);
         }
 
@@ -308,11 +311,11 @@ namespace System.Net.Primitives.Functional.Tests
         public static void GetCredential_HostCaseInsensitivePathCaseSensitive()
         {
             CredentialCache cc = new CredentialCache();
-            cc.Add(new Uri("http://MICROSOFT:80/CaseSensitivePath"), authenticationType1, credential1);
+            cc.Add(new Uri("http://MICROSOFT:80/CaseSensitive/path"), authenticationType1, credential1);
 
             // Host comparison remains case-insensitive while the path portion is case-sensitive.
-            Assert.Equal(credential1, cc.GetCredential(new Uri("http://microsoft:80/CaseSensitivePath"), authenticationType1));
-            Assert.Null(cc.GetCredential(new Uri("http://microsoft:80/casesensitivepath"), authenticationType1));
+            Assert.Equal(credential1, cc.GetCredential(new Uri("http://microsoft:80/CaseSensitive/path/resource"), authenticationType1));
+            Assert.Null(cc.GetCredential(new Uri("http://microsoft:80/casesensitive/path/resource"), authenticationType1));
         }
 
         [Fact]

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -284,6 +284,38 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
+        public static void GetCredential_PathCaseMismatch_ReturnsNull()
+        {
+            CredentialCache cc = new CredentialCache();
+            cc.Add(new Uri("http://microsoft:80/CaseSensitivePath"), authenticationType1, credential1);
+
+            // The path is compared case-sensitively, so a differently-cased path must not match.
+            NetworkCredential nc = cc.GetCredential(new Uri("http://microsoft:80/casesensitivepath"), authenticationType1);
+            Assert.Null(nc);
+        }
+
+        [Fact]
+        public static void GetCredential_PathCaseMatch_ReturnsCredential()
+        {
+            CredentialCache cc = new CredentialCache();
+            cc.Add(new Uri("http://microsoft:80/CaseSensitivePath"), authenticationType1, credential1);
+
+            NetworkCredential nc = cc.GetCredential(new Uri("http://microsoft:80/CaseSensitivePath"), authenticationType1);
+            Assert.Equal(credential1, nc);
+        }
+
+        [Fact]
+        public static void GetCredential_HostCaseInsensitivePathCaseSensitive()
+        {
+            CredentialCache cc = new CredentialCache();
+            cc.Add(new Uri("http://MICROSOFT:80/CaseSensitivePath"), authenticationType1, credential1);
+
+            // Host comparison remains case-insensitive while the path portion is case-sensitive.
+            Assert.Equal(credential1, cc.GetCredential(new Uri("http://microsoft:80/CaseSensitivePath"), authenticationType1));
+            Assert.Null(cc.GetCredential(new Uri("http://microsoft:80/casesensitivepath"), authenticationType1));
+        }
+
+        [Fact]
         public static void GetCredential_UriAuthenticationType_Invalid()
         {
             CredentialCache cc = new CredentialCache();

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -319,6 +319,28 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
+        public static void GetCredential_SiblingPath_ReturnsNull()
+        {
+            CredentialCache cc = new CredentialCache();
+            cc.Add(new Uri("http://microsoft:80/admin/"), authenticationType1, credential1);
+
+            // A prefix of "/admin/" must only match resources under that directory, not a sibling
+            // path such as "/administrator/..." that merely shares a leading substring.
+            Assert.Null(cc.GetCredential(new Uri("http://microsoft:80/administrator/something"), authenticationType1));
+        }
+
+        [Fact]
+        public static void GetCredential_ChildAndExactPath_ReturnsCredential()
+        {
+            CredentialCache cc = new CredentialCache();
+            cc.Add(new Uri("http://microsoft:80/admin/"), authenticationType1, credential1);
+
+            // The directory itself and resources under it must still match.
+            Assert.Equal(credential1, cc.GetCredential(new Uri("http://microsoft:80/admin/"), authenticationType1));
+            Assert.Equal(credential1, cc.GetCredential(new Uri("http://microsoft:80/admin/something"), authenticationType1));
+        }
+
+        [Fact]
         public static void GetCredential_UriAuthenticationType_Invalid()
         {
             CredentialCache cc = new CredentialCache();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/130667
Fixes https://github.com/dotnet/runtime/issues/130672.

The path portion of a URI can be case-sensitive on the server, but `CredentialCache.GetCredential` performed prefix matching case-insensitively. This means credentials registered for one path could be returned for a request to a differently-cased path.

This changes the path comparison in the prefix match (`CredentialCacheKey.IsPrefix`) from `StringComparison.OrdinalIgnoreCase` to `StringComparison.Ordinal`, so the path portion of the prefix is compared case-sensitively. Scheme, host, and port matching are unchanged (host remains case-insensitive via `Uri` normalization).

Added functional tests covering case-sensitive path matching.