### PR TITLE
Don't emit ELT callbacks for P/Invoke methods

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10920,7 +10920,9 @@ static CORJIT_FLAGS GetCompileFlags(PrepareCodeConfig* prepareConfig, MethodDesc
 #endif
 
 #ifdef PROFILING_SUPPORTED
-    if (CORProfilerTrackEnterLeave() && !ftn->IsNoMetadata())
+    // P/Invokes are surfaced to profilers via ManagedToUnmanaged/UnmanagedToManaged
+    // transition callbacks, not Enter/Leave, so exclude them from ELT.
+    if (CORProfilerTrackEnterLeave() && !ftn->IsNoMetadata() && !ftn->IsPInvoke())
         flags.Set(CORJIT_FLAGS::CORJIT_FLAG_PROF_ENTERLEAVE);
 
     if (CORProfilerTrackTransitions())

--- a/src/tests/profiler/elttransitions/elttransitions.cs
+++ b/src/tests/profiler/elttransitions/elttransitions.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Profiler.Tests
+{
+    // Regression test for https://github.com/dotnet/runtime/issues/130242.
+    //
+    // Runs a forward P/Invoke (into the profiler's native DoPInvoke) which calls back into a
+    // managed [UnmanagedCallersOnly] target. The profiler enables both ELT and code-transition
+    // monitoring and asserts that the forward P/Invoke is reported only via transition callbacks
+    // (never ELT), while the reverse P/Invoke target still receives ELT.
+    unsafe class EltTransitions
+    {
+        static readonly string PInvokeExpectedNameEnvVar = "PInvoke_Transition_Expected_Name";
+        static readonly string ReversePInvokeExpectedNameEnvVar = "ReversePInvoke_Transition_Expected_Name";
+        static readonly Guid EltTransitionsGuid = new Guid("C7A0B5D1-9E3F-4A21-8B77-1C2D3E4F5061");
+
+        [DllImport("Profiler")]
+        public static extern void DoPInvoke(delegate* unmanaged<int, int> callback, int i);
+
+        [UnmanagedCallersOnly]
+        private static int DoReversePInvoke(int i)
+        {
+            return i;
+        }
+
+        public static int BlittablePInvokeToUnmanagedCallersOnly()
+        {
+            DoPInvoke(&DoReversePInvoke, 13);
+
+            return 100;
+        }
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 1 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
+            {
+                switch (args[1])
+                {
+                    case nameof(BlittablePInvokeToUnmanagedCallersOnly):
+                        return BlittablePInvokeToUnmanagedCallersOnly();
+                }
+            }
+
+            if (!RunProfilerTest(nameof(BlittablePInvokeToUnmanagedCallersOnly), nameof(DoPInvoke), nameof(DoReversePInvoke)))
+            {
+                return 101;
+            }
+
+            return 100;
+        }
+
+        private static bool RunProfilerTest(string testName, string pInvokeExpectedName, string reversePInvokeExpectedName)
+        {
+            try
+            {
+                return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
+                                          testName: "EltTransitions",
+                                          profilerClsid: EltTransitionsGuid,
+                                          profileeArguments: testName,
+                                          envVars: new Dictionary<string, string>
+                                          {
+                                              { PInvokeExpectedNameEnvVar, pInvokeExpectedName },
+                                              { ReversePInvokeExpectedNameEnvVar, reversePInvokeExpectedName },
+                                          }) == 100;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+            return false;
+        }
+    }
+}

--- a/src/tests/profiler/elttransitions/elttransitions.csproj
+++ b/src/tests/profiler/elttransitions/elttransitions.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Temporarily disabled due to https://github.com/dotnet/runtime/issues/106243 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+    <ProjectReference Include="../common/profiler_common.csproj" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/profiler/native/CMakeLists.txt
+++ b/src/tests/profiler/native/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     classload/classload.cpp
     dynamicjitoptimization/dynamicjitoptimization.cpp
     eltprofiler/slowpatheltprofiler.cpp
+    elttransitions/elttransitions.cpp
     enumthreadsprofiler/enumthreadsprofiler.cpp
     eventpipeprofiler/eventpipereadingprofiler.cpp
     eventpipeprofiler/eventpipewritingprofiler.cpp

--- a/src/tests/profiler/native/classfactory.cpp
+++ b/src/tests/profiler/native/classfactory.cpp
@@ -3,6 +3,7 @@
 
 #include "classfactory.h"
 #include "eltprofiler/slowpatheltprofiler.h"
+#include "elttransitions/elttransitions.h"
 #include "enumthreadsprofiler/enumthreadsprofiler.h"
 #include "eventpipeprofiler/eventpipereadingprofiler.h"
 #include "eventpipeprofiler/eventpipewritingprofiler.h"
@@ -112,6 +113,10 @@ HRESULT STDMETHODCALLTYPE ClassFactory::CreateInstance(IUnknown *pUnkOuter, REFI
     else if (clsid == SlowPathELTProfiler::GetClsid())
     {
         profiler = new SlowPathELTProfiler();
+    }
+    else if (clsid == EltTransitions::GetClsid())
+    {
+        profiler = new EltTransitions();
     }
     else if (clsid == GCProfiler::GetClsid())
     {

--- a/src/tests/profiler/native/elttransitions/elttransitions.cpp
+++ b/src/tests/profiler/native/elttransitions/elttransitions.cpp
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "elttransitions.h"
+#include <iostream>
+
+using std::wcout;
+using std::endl;
+
+std::shared_ptr<EltTransitions> EltTransitions::s_profiler;
+
+#define PROFILER_STUB static void STDMETHODCALLTYPE
+
+PROFILER_STUB EnterStub(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo)
+{
+    SHUTDOWNGUARD_RETVOID();
+    EltTransitions::s_profiler->EnterCallback(functionId, eltInfo);
+}
+
+PROFILER_STUB LeaveStub(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo)
+{
+    SHUTDOWNGUARD_RETVOID();
+    EltTransitions::s_profiler->LeaveCallback(functionId, eltInfo);
+}
+
+PROFILER_STUB TailcallStub(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo)
+{
+    SHUTDOWNGUARD_RETVOID();
+    EltTransitions::s_profiler->TailcallCallback(functionId, eltInfo);
+}
+
+GUID EltTransitions::GetClsid()
+{
+    // {C7A0B5D1-9E3F-4A21-8B77-1C2D3E4F5061}
+    GUID clsid = { 0xC7A0B5D1, 0x9E3F, 0x4A21, { 0x8B, 0x77, 0x1C, 0x2D, 0x3E, 0x4F, 0x50, 0x61 } };
+    return clsid;
+}
+
+HRESULT EltTransitions::Initialize(IUnknown* pICorProfilerInfoUnk)
+{
+    Profiler::Initialize(pICorProfilerInfoUnk);
+
+    EltTransitions::s_profiler = std::shared_ptr<EltTransitions>(this);
+
+    HRESULT hr = S_OK;
+    constexpr ULONG bufferSize = 1024;
+    ULONG envVarLen = 0;
+    WCHAR envVar[bufferSize];
+    if (FAILED(hr = pCorProfilerInfo->GetEnvironmentVariable(WCHAR("PInvoke_Transition_Expected_Name"), bufferSize, &envVarLen, envVar)))
+    {
+        _failures++;
+        printf("FAIL: could not read PInvoke_Transition_Expected_Name hr=0x%x\n", hr);
+        return E_FAIL;
+    }
+    _expectedPinvokeName = envVar;
+
+    if (FAILED(hr = pCorProfilerInfo->GetEnvironmentVariable(WCHAR("ReversePInvoke_Transition_Expected_Name"), bufferSize, &envVarLen, envVar)))
+    {
+        _failures++;
+        printf("FAIL: could not read ReversePInvoke_Transition_Expected_Name hr=0x%x\n", hr);
+        return E_FAIL;
+    }
+    _expectedReversePInvokeName = envVar;
+
+    // The slow-path WithInfo hooks require the FUNCTION_ARGS/FUNCTION_RETVAL/FRAME_INFO flags.
+    if (FAILED(hr = pCorProfilerInfo->SetEventMask2(COR_PRF_MONITOR_ENTERLEAVE
+                                                    | COR_PRF_ENABLE_FUNCTION_ARGS
+                                                    | COR_PRF_ENABLE_FUNCTION_RETVAL
+                                                    | COR_PRF_ENABLE_FRAME_INFO
+                                                    | COR_PRF_MONITOR_CODE_TRANSITIONS
+                                                    | COR_PRF_DISABLE_INLINING,
+                                                    0)))
+    {
+        _failures++;
+        printf("FAIL: SetEventMask2() failed hr=0x%x\n", hr);
+        return hr;
+    }
+
+    if (FAILED(hr = pCorProfilerInfo->SetEnterLeaveFunctionHooks3WithInfo(EnterStub, LeaveStub, TailcallStub)))
+    {
+        _failures++;
+        printf("FAIL: SetEnterLeaveFunctionHooks3WithInfo() failed hr=0x%x\n", hr);
+        return hr;
+    }
+
+    return S_OK;
+}
+
+HRESULT EltTransitions::Shutdown()
+{
+    Profiler::Shutdown();
+
+    // The forward P/Invoke must have transitioned managed->unmanaged (CALL) then back (RETURN).
+    bool pinvokeTransitioned = _pinvokeManagedToUnmanaged == COR_PRF_TRANSITION_CALL
+                            && _pinvokeUnmanagedToManaged == COR_PRF_TRANSITION_RETURN;
+
+    // The regression: the forward P/Invoke must never be reported via ELT.
+    bool noSpuriousElt = _pinvokeEltCount == 0;
+
+    // Guard against an over-broad fix: the reverse P/Invoke target is a managed method and
+    // must still receive ELT.
+    bool reversePinvokeGotElt = _reversePinvokeEltCount > 0;
+
+    if (_failures == 0 && pinvokeTransitioned && noSpuriousElt && reversePinvokeGotElt)
+    {
+        printf("PROFILER TEST PASSES\n");
+    }
+    else
+    {
+        auto boolFmt = [](bool b) { return b ? "true" : "false"; };
+        printf("Test failed _failures=%d pinvokeTransitioned=%s noSpuriousElt=%s (pinvokeEltCount=%d) reversePinvokeGotElt=%s\n",
+               _failures.load(), boolFmt(pinvokeTransitioned), boolFmt(noSpuriousElt),
+               _pinvokeEltCount.load(), boolFmt(reversePinvokeGotElt));
+    }
+    fflush(stdout);
+    return S_OK;
+}
+
+void EltTransitions::EnterCallback(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo)
+{
+    String name = GetFunctionIDName(functionId.functionID);
+    if (name == _expectedPinvokeName)
+    {
+        _pinvokeEltCount++;
+    }
+    else if (name == _expectedReversePInvokeName)
+    {
+        _reversePinvokeEltCount++;
+    }
+}
+
+void EltTransitions::LeaveCallback(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo)
+{
+    String name = GetFunctionIDName(functionId.functionID);
+    if (name == _expectedPinvokeName)
+    {
+        _pinvokeEltCount++;
+    }
+}
+
+void EltTransitions::TailcallCallback(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo)
+{
+    String name = GetFunctionIDName(functionId.functionID);
+    if (name == _expectedPinvokeName)
+    {
+        _pinvokeEltCount++;
+    }
+}
+
+HRESULT EltTransitions::ManagedToUnmanagedTransition(FunctionID functionID, COR_PRF_TRANSITION_REASON reason)
+{
+    SHUTDOWNGUARD();
+
+    String name = GetFunctionIDName(functionID);
+    if (name == _expectedPinvokeName)
+    {
+        _pinvokeManagedToUnmanaged = reason;
+    }
+
+    return S_OK;
+}
+
+HRESULT EltTransitions::UnmanagedToManagedTransition(FunctionID functionID, COR_PRF_TRANSITION_REASON reason)
+{
+    SHUTDOWNGUARD();
+
+    String name = GetFunctionIDName(functionID);
+    if (name == _expectedPinvokeName)
+    {
+        _pinvokeUnmanagedToManaged = reason;
+    }
+
+    return S_OK;
+}

--- a/src/tests/profiler/native/elttransitions/elttransitions.h
+++ b/src/tests/profiler/native/elttransitions/elttransitions.h
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "../profiler.h"
+#include <memory>
+
+#define NO_TRANSITION ((COR_PRF_TRANSITION_REASON)-1)
+
+// Regression test for https://github.com/dotnet/runtime/issues/130242.
+//
+// Enables BOTH Enter/Leave/Tailcall (ELT) hooks and code-transition monitoring, then
+// verifies that a forward P/Invoke is surfaced only through the ManagedToUnmanaged/
+// UnmanagedToManaged transition callbacks and never through ELT. Before the fix, forward
+// P/Invokes (JIT-compiled from transient IL on the P/Invoke MethodDesc) incorrectly passed
+// the ELT gate in GetCompileFlags and fired spurious enter/leave callbacks that corrupted
+// the profiler shadow stack. The reverse P/Invoke target is a managed method and must still
+// receive ELT, which guards against an over-broad fix.
+class EltTransitions : public Profiler
+{
+public:
+    static std::shared_ptr<EltTransitions> s_profiler;
+
+    EltTransitions() = default;
+    virtual ~EltTransitions() = default;
+
+    static GUID GetClsid();
+    virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk);
+    virtual HRESULT STDMETHODCALLTYPE Shutdown();
+
+    virtual HRESULT STDMETHODCALLTYPE ManagedToUnmanagedTransition(FunctionID functionID, COR_PRF_TRANSITION_REASON reason);
+    virtual HRESULT STDMETHODCALLTYPE UnmanagedToManagedTransition(FunctionID functionID, COR_PRF_TRANSITION_REASON reason);
+
+    void EnterCallback(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);
+    void LeaveCallback(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);
+    void TailcallCallback(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);
+
+private:
+    std::atomic<int> _failures{0};
+
+    // Forward P/Invoke must NOT receive ELT (this count must stay 0).
+    std::atomic<int> _pinvokeEltCount{0};
+    // Reverse P/Invoke target (a managed method) must still receive ELT.
+    std::atomic<int> _reversePinvokeEltCount{0};
+
+    COR_PRF_TRANSITION_REASON _pinvokeManagedToUnmanaged{NO_TRANSITION};
+    COR_PRF_TRANSITION_REASON _pinvokeUnmanagedToManaged{NO_TRANSITION};
+
+    String _expectedPinvokeName;
+    String _expectedReversePInvokeName;
+};


### PR DESCRIPTION
Fixes #130242

## Problem

Since forward P/Invokes became backed by transient IL that is JIT-compiled
directly on the P/Invoke `MethodDesc` (#126509), they started firing spurious
profiler Enter/Leave/Tailcall (ELT) callbacks. These interleaved with the
`ManagedToUnmanaged`/`UnmanagedToManaged` transition callbacks and corrupted the
profiler shadow stack. The corruption is most visible via the runtime-internal
`StubHelpers.ProfilerBeginTransitionCallback` / `ProfilerEndTransitionCallback`
QCalls, which also began appearing as ELT enter/leave events.

## Root cause

The ELT gate in `GetCompileFlags` (`jitinterface.cpp`) only excluded
`IsNoMetadata()` methods:

```cpp
if (CORProfilerTrackEnterLeave() && !ftn->IsNoMetadata())
    flags.Set(CORJIT_FLAG_PROF_ENTERLEAVE);
```

Previously, forward P/Invokes were backed by `NoMetadata` `DynamicMethodDesc`
IL stubs, so they were excluded. Now that they are compiled on the `mcPInvoke`
`MethodDesc` (which has metadata), they pass the gate and get ELT hooks.
P/Invokes are meant to be surfaced to profilers through transition callbacks,
not ELT.

## Fix

Exclude `IsPInvoke()` `MethodDesc`s from the ELT gate. This is correctly scoped:
`UnmanagedCallersOnly` / reverse P/Invoke targets are `mcIL` managed methods
(not `mcPInvoke`) and keep their ELT hooks; varargs P/Invokes remain excluded
via `IsNoMetadata()`.

## Testing

Added a profiler regression test (`profiler/elttransitions`) that enables both
ELT hooks and code-transition monitoring, then asserts:
- the forward P/Invoke is surfaced only via M2U/U2M transition callbacks and
  never via ELT, and
- the reverse P/Invoke target (an `UnmanagedCallersOnly` managed method) still
  receives ELT (guards against an over-broad fix).

The test fails without this change (the forward P/Invoke receives two spurious
ELT callbacks) and passes with it.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.
