### PR TITLE
Treat Guid and Int128 types as bitwise equatable

### DIFF
--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -163,7 +163,7 @@ const char* CodeGen::genInsDisplayName(emitter::instrDesc* id)
 
     auto GetIntCmpOpName = [&](const char* suffix) -> const char* {
         static const char* const intCmpOpNames[] = {
-            "eq", "lt", "le", "neq", "false", "ge", "gt", "true",
+            "eq", "lt", "le", "false", "neq", "ge", "gt", "true",
         };
 
         uint8_t control = static_cast<uint8_t>(emit->emitGetInsSC(id));

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -94,10 +95,10 @@ namespace Internal.IL.Stubs
                 return false;
             }
 
-            ReadOnlySpan<byte> ns = type.Namespace;
+            Utf8Span ns = type.Namespace;
             if (ns == "System"u8)
             {
-                ReadOnlySpan<byte> name = type.Name;
+                Utf8Span name = type.Name;
                 return name == "Guid"u8 || name == "Int128"u8 || name == "UInt128"u8;
             }
             return ns == "System.Text"u8 && type.Name == "Rune"u8;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
@@ -57,8 +57,12 @@ namespace Internal.IL.Stubs
                         if (elementType is MetadataType mdType)
                         {
                             if (mdType.Module == mdType.Context.SystemModule &&
-                                mdType.Namespace == "System.Text"u8 &&
-                                mdType.Name == "Rune"u8)
+                                ((mdType.Namespace == "System"u8 &&
+                                  (mdType.Name == "Guid"u8 ||
+                                   mdType.Name == "Int128"u8 ||
+                                   mdType.Name == "UInt128"u8)) ||
+                                 (mdType.Namespace == "System.Text"u8 &&
+                                  mdType.Name == "Rune"u8)))
                             {
                                 result = true;
                             }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
@@ -89,7 +89,7 @@ namespace Internal.IL.Stubs
 
         private static bool IsKnownBitwiseEquatableType(MetadataType type)
         {
-            if (type.Module != type.Context.SystemModule)   
+            if (type.Module != type.Context.SystemModule)
             {
                 return false;
             }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
@@ -89,17 +89,18 @@ namespace Internal.IL.Stubs
 
         private static bool IsKnownBitwiseEquatableType(MetadataType type)
         {
-            if (type.Module != type.Context.SystemModule)
-                return false;
-
-            if (type.Namespace == "System"u8)
+            if (type.Module != type.Context.SystemModule)   
             {
-                return type.Name == "Guid"u8 ||
-                    type.Name == "Int128"u8 ||
-                    type.Name == "UInt128"u8;
+                return false;
             }
 
-            return type.Namespace == "System.Text"u8 && type.Name == "Rune"u8;
+            ReadOnlySpan<byte> ns = type.Namespace;
+            if (ns == "System"u8)
+            {
+                ReadOnlySpan<byte> name = type.Name;
+                return name == "Guid"u8 || name == "Int128"u8 || name == "UInt128"u8;
+            }
+            return ns == "System.Text"u8 && type.Name == "Rune"u8;
         }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
@@ -56,13 +56,7 @@ namespace Internal.IL.Stubs
                         result = false;
                         if (elementType is MetadataType mdType)
                         {
-                            if (mdType.Module == mdType.Context.SystemModule &&
-                                ((mdType.Namespace == "System"u8 &&
-                                  (mdType.Name == "Guid"u8 ||
-                                   mdType.Name == "Int128"u8 ||
-                                   mdType.Name == "UInt128"u8)) ||
-                                 (mdType.Namespace == "System.Text"u8 &&
-                                  mdType.Name == "Rune"u8)))
+                            if (IsKnownBitwiseEquatableType(mdType))
                             {
                                 result = true;
                             }
@@ -91,6 +85,21 @@ namespace Internal.IL.Stubs
             ILOpcode opcode = result ? ILOpcode.ldc_i4_1 : ILOpcode.ldc_i4_0;
 
             return new ILStubMethodIL(method, new byte[] { (byte)opcode, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), Array.Empty<object>());
+        }
+
+        private static bool IsKnownBitwiseEquatableType(MetadataType type)
+        {
+            if (type.Module != type.Context.SystemModule)
+                return false;
+
+            if (type.Namespace == "System"u8)
+            {
+                return type.Name == "Guid"u8 ||
+                    type.Name == "Int128"u8 ||
+                    type.Name == "UInt128"u8;
+            }
+
+            return type.Namespace == "System.Text"u8 && type.Name == "Rune"u8;
         }
     }
 }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -7349,6 +7349,7 @@ static bool getILIntrinsicImplementationForRuntimeHelpers(
             || methodTable == CoreLibBinder::GetClass(CLASS__UINT64)
             || methodTable == CoreLibBinder::GetClass(CLASS__INTPTR)
             || methodTable == CoreLibBinder::GetClass(CLASS__UINTPTR)
+            || methodTable == CoreLibBinder::GetClass(CLASS__GUID)
             || methodTable == CoreLibBinder::GetClass(CLASS__RUNE)
             || methodTable->IsEnum()
             || IsBitwiseEquatable(typeHandle, methodTable))

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -7347,6 +7347,8 @@ static bool getILIntrinsicImplementationForRuntimeHelpers(
             || methodTable == CoreLibBinder::GetClass(CLASS__UINT32)
             || methodTable == CoreLibBinder::GetClass(CLASS__INT64)
             || methodTable == CoreLibBinder::GetClass(CLASS__UINT64)
+            || methodTable == CoreLibBinder::GetClass(CLASS__INT128)
+            || methodTable == CoreLibBinder::GetClass(CLASS__UINT128)
             || methodTable == CoreLibBinder::GetClass(CLASS__INTPTR)
             || methodTable == CoreLibBinder::GetClass(CLASS__UINTPTR)
             || methodTable == CoreLibBinder::GetClass(CLASS__GUID)


### PR DESCRIPTION
Treat `Guid`, `Int128`, and `UInt128` as bitwise equatable, enabling `SequenceEqual` to use the existing memcmp unrolling. Also correct the integer comparison pseudo-name used by JitDisasm.

```csharp
void Foo(Guid g1, Guid g2)
{
    if (((Span<Guid>)[g1]).SequenceEqual((Span<Guid>)[g2]))
    {
        Console.WriteLine("Equal");
    }
}
```

```diff
-       lea      rdi, [rbp-0x30]
-       lea      rsi, [rbp-0x40]
-       mov      edx, 1
-       call     [System.SpanHelpers:SequenceEqual[System.Guid](byref,byref,int):bool]
-       test     eax, eax
+       vmovups  xmm0, xmmword ptr [rbp-0x30]
+       vpcmpnequq k1, xmm0, xmmword ptr [rbp-0x40]
+       kortestb k1, k1
+       sete     dil
+       movzx    rdi, dil
+       test     edi, edi
```
The goal is just to be able to theoretically implement `Guid.Equals` entirely in 100% memory safe code. It would be nice if C# could allow us to write it like this: `[g1].SequenceEqual([g2])`