### PR TITLE
[wasm] Harden ReferenceNewAssemblyRebuildTest against dependency-closure changes

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/NativeRebuildTests/ReferenceNewAssemblyRebuildTest.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NativeRebuildTests/ReferenceNewAssemblyRebuildTest.cs
@@ -25,7 +25,13 @@ namespace Wasm.Build.NativeRebuild.Tests
         [MemberData(nameof(NativeBuildData))]
         public async Task ReferenceNewAssembly(Configuration config, bool aot, bool nativeRelink, bool invariant)
         {
-            ProjectInfo info = CopyTestAsset(config, aot, TestAsset.WasmBasicTestApp, "rebuild_tasks");     
+            // Reference a dedicated first-party library that the default app does not use, so it is
+            // trimmed away on the first build and only enters the AOT module set once the swapped
+            // entry point references it. Relying on a specific BCL assembly being absent from the
+            // closure is fragile (it has silently regressed as the base app's dependencies grew).
+            string extraItems = @"<ProjectReference Include=""..\Library\Library.csproj"" />";
+            ProjectInfo info = CopyTestAsset(config, aot, TestAsset.WasmBasicTestApp, "rebuild_tasks", extraItems: extraItems);
+            ReplaceFile(Path.Combine("..", "Library", "Library.cs"), Path.Combine(BuildEnvironment.TestAssetsPath, "EntryPoints", "NativeRebuildReferencedLibrary.cs"));
             BuildPaths paths = await FirstNativeBuildAndRun(info, config, aot, nativeRelink, invariant);
 
             var pathsDict = GetFilesTable(info.ProjectName, aot, paths, unchanged: false);

--- a/src/mono/wasm/testassets/EntryPoints/NativeRebuildNewAssembly.cs
+++ b/src/mono/wasm/testassets/EntryPoints/NativeRebuildNewAssembly.cs
@@ -1,17 +1,10 @@
-using System;
-using System.Security.Cryptography;
-using System.Text;
+// Reference a dedicated first-party library ("Library") that is not part of
+// the WasmBasicTestApp's default assembly closure. This guarantees the rebuild
+// pulls in a genuinely new AOT module, regardless of which BCL assemblies the
+// base app happens to root.
+using NativeRebuildReferencedLibrary;
+
 public class Test
 {
-    public static int Main()
-    {
-        string input = "Hello, world!";
-        using (SHA256 sha256 = SHA256.Create())
-        {
-            byte[] inputBytes = Encoding.UTF8.GetBytes(input);
-            byte[] hashBytes = sha256.ComputeHash(inputBytes);
-            Console.WriteLine($"Hash of {input}: {Convert.ToBase64String(hashBytes)}");
-        }
-        return 42;
-    }
+    public static int Main() => NewlyReferencedType.GetValue();
 }

--- a/src/mono/wasm/testassets/EntryPoints/NativeRebuildReferencedLibrary.cs
+++ b/src/mono/wasm/testassets/EntryPoints/NativeRebuildReferencedLibrary.cs
@@ -1,0 +1,6 @@
+namespace NativeRebuildReferencedLibrary;
+
+public static class NewlyReferencedType
+{
+    public static int GetValue() => 42;
+}


### PR DESCRIPTION
## Summary

`Wasm.Build.NativeRebuild.Tests.ReferenceNewAssemblyRebuildTest` has been failing on the browser-wasm AOT leg (Known Build Error #130540, "Expected changed file: driver-gen.c"). This hardens the test so it no longer depends on the app's incidental dependency closure.

## Root cause

The test replaces the app's entry point with one that references a "new" assembly, then asserts that `driver-gen.c` — the AOT modules table, one `mono_aot_register_module` line per AOT'd assembly — changes because a new module was added.

It relied on `System.Security.Cryptography` being **absent** from `WasmBasicTestApp`'s AOT closure (the swapped entry point used `SHA256`). That assumption broke when #122093 ("Add Zip Archives password support") added an unconditional `System.Security.Cryptography` `ProjectReference` to `System.IO.Compression`. The app always compiles `ZipArchiveInteropTest.cs` (uses `System.IO.Compression`), so crypto is now always in the closure and always AOT'd. The swapped entry point therefore adds no new module, `driver-gen.c` is byte-identical between build and rebuild, `MonoAOTCompiler`'s `CopyIfDifferent` skips the write, the timestamp is unchanged, and `CompareStat` fails.

This is the **second** time the test rotted this way — #109069 previously switched it from `Json` to `System.Security.Cryptography` for the same reason ("Json lib was already referenced before the change in the test").

## Fix

Stop guessing which BCL assembly happens to be absent. Instead reference the existing dedicated first-party `Library` test project (an empty library not referenced by the default app), following the same pattern already used by `PInvokeTableGeneratorTests`:

- Inject `<ProjectReference Include="..\Library\Library.csproj" />` via `CopyTestAsset(extraItems: ...)`.
- Populate `Library.cs` with a small type via `ReplaceFile`.
- Point the swapped entry point (`NativeRebuildNewAssembly.cs`) at that type instead of `SHA256`.

`Library` is unused in the first build → trimmed away → absent from the AOT module set. The swapped entry point uses it → rooted → new module in the rebuild → `driver-gen.c` changes. Because `Library` is first-party and the test fully controls whether it is referenced, the new-assembly signal is deterministic and immune to future changes in the app's dependency closure.

Fixes #130540.

## Related

The underlying dependency regression (crypto rooted into every trimmed app that uses `ZipArchive`, a browser-wasm size concern) is tracked separately in #130650.

## Testing

Not built/run locally — WBT requires a browser-wasm runtime baseline + emscripten and executes in a browser via the Helix/xharness harness. Relying on CI (the failing AOT leg exercises exactly this test) to validate.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.