### PR TITLE
Move GetHashCode nullcheck to managed

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -237,13 +237,18 @@ namespace System.Runtime.CompilerServices
         /// returned.
         /// </summary>
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern int TryGetHashCode(object? o);
+        internal static extern int TryGetHashCode(object o);
 
         [LibraryImport(QCall, EntryPoint = "ObjectNative_GetHashCodeSlow")]
         private static partial int GetHashCodeSlow(ObjectHandleOnStack o);
 
         public static int GetHashCode(object? o)
         {
+            if (o is null)
+            {
+                return 0;
+            }
+
             int hashCode = TryGetHashCode(o);
             if (hashCode == 0)
             {
@@ -254,10 +259,6 @@ namespace System.Runtime.CompilerServices
             [MethodImpl(MethodImplOptions.NoInlining)]
             static int GetHashCodeWorker(object? o)
             {
-                if (o is null)
-                {
-                    return 0;
-                }
                 return GetHashCodeSlow(ObjectHandleOnStack.Create(ref o));
             }
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -242,7 +242,6 @@ namespace System.Runtime.CompilerServices
         [LibraryImport(QCall, EntryPoint = "ObjectNative_GetHashCodeSlow")]
         private static partial int GetHashCodeSlow(ObjectHandleOnStack o);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetHashCode(object? o)
         {
             if (o is null)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -242,6 +242,7 @@ namespace System.Runtime.CompilerServices
         [LibraryImport(QCall, EntryPoint = "ObjectNative_GetHashCodeSlow")]
         private static partial int GetHashCodeSlow(ObjectHandleOnStack o);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetHashCode(object? o)
         {
             if (o is null)

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -1585,8 +1585,7 @@ FCIMPL1(INT32, ObjectNative::TryGetHashCode, Object* obj)
 {
     FCALL_CONTRACT;
 
-    if (obj == NULL)
-        return 0;
+    _ASSERTE(obj != NULL);
 
     OBJECTREF objRef = ObjectToOBJECTREF(obj);
     return objRef->TryGetHashCode();


### PR DESCRIPTION
Should make it cheaper for GetHashCode on null due to not doublechecking and fcalling while keeping same perf (or better due to JIT folding away the check) for non null.