### PR TITLE
Disable LTCG for the nethost's minipal_objects

### DIFF
--- a/src/native/corehost/CMakeLists.txt
+++ b/src/native/corehost/CMakeLists.txt
@@ -93,6 +93,12 @@ if(NOT CLR_CMAKE_TARGET_BROWSER)
     endif()
 
     add_subdirectory(${CLR_SRC_NATIVE_DIR}/minipal minipal)
+
+    # minipal_objects is embedded into static libraries we ship for external
+    # consumption (libnethost, libhostfxr), so LTCG must be disabled to ensure
+    # that non-MSVC toolchains can work with them.
+    set_target_properties(minipal_objects PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
+
     add_subdirectory(hostcommon)
     add_subdirectory(hostmisc)
     add_subdirectory(nethost)


### PR DESCRIPTION
`libnethost` is shipped as static libraries for external consumption. With https://github.com/dotnet/runtime/pull/128420, it now includes minipal_objects, which was compiled with LTCG, producing object files that non-MSVC linkers such as lld-link reject with "is not a native COFF file".

Disable interprocedural optimization on the host's copy of minipal_objects. This mirrors the existing LTCG-disabling on libnethost itself (https://github.com/dotnet/runtime/issues/71056).

cc @dotnet/appmodel @AaronRobinsonMSFT 