### PR TITLE
Allow trimming NativeRuntimeEventSource

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -562,7 +562,8 @@ namespace System.Threading
                 Interlocked.Increment(ref s_contentionCount);
 
                 long waitStartTimeTicks = 0;
-                if (areContentionEventsEnabled)
+                // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+                if (areContentionEventsEnabled && NativeRuntimeEventSource.Log.IsEnabled())
                 {
                     NativeRuntimeEventSource.Log.ContentionStart(this);
                     waitStartTimeTicks = Stopwatch.GetTimestamp();
@@ -634,7 +635,8 @@ namespace System.Threading
                     Debug.Assert(_recursionCount == 0);
                     _owningThreadId = currentThreadId;
 
-                    if (areContentionEventsEnabled)
+                    // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+                    if (areContentionEventsEnabled && NativeRuntimeEventSource.Log.IsEnabled())
                     {
                         double waitDurationNs =
                             (Stopwatch.GetTimestamp() - waitStartTimeTicks) * 1_000_000_000.0 / Stopwatch.Frequency;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
@@ -170,7 +170,8 @@ namespace System.Threading
                         }
                     }
 
-                    if (sendWaitEvents)
+                    // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+                    if (sendWaitEvents && NativeRuntimeEventSource.Log.IsEnabled())
                     {
                         NativeRuntimeEventSource.Log.WaitHandleWaitStart(waitSource, associatedObject ?? this);
                     }
@@ -184,7 +185,8 @@ namespace System.Threading
                             useTrivialWaits);
                     }
 
-                    if (sendWaitEvents)
+                    // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+                    if (sendWaitEvents && NativeRuntimeEventSource.Log.IsEnabled())
                     {
                         NativeRuntimeEventSource.Log.WaitHandleWaitStop();
                     }
@@ -423,7 +425,8 @@ namespace System.Threading
                 }
             }
 
-            if (sendWaitEvents)
+            // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+            if (sendWaitEvents && NativeRuntimeEventSource.Log.IsEnabled())
             {
                 NativeRuntimeEventSource.Log.WaitHandleWaitStart();
             }
@@ -434,7 +437,8 @@ namespace System.Threading
                 waitResult = WaitMultipleIgnoringSyncContextCore(handles, waitAll, millisecondsTimeout);
             }
 
-            if (sendWaitEvents)
+            // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+            if (sendWaitEvents && NativeRuntimeEventSource.Log.IsEnabled())
             {
                 NativeRuntimeEventSource.Log.WaitHandleWaitStop();
             }


### PR DESCRIPTION
Constant propagation cannot see through the local assignments/reassignments.

Matches the existing patterns at https://github.com/dotnet/runtime/blob/f2b30309fd488f1c3fd41c18723a7c80a81f4c67/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs#L696-L697