### PR TITLE
[clr-ios] Increase MacCatalyst CoreCLR job timeouts

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
@@ -104,7 +104,7 @@ jobs:
       testGroup: innerloop
       nameSuffix: AllSubsets_CoreCLR
       buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=adhoc /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=false /p:EnableAggressiveTrimming=true
-      timeoutInMinutes: 240
+      timeoutInMinutes: 360
       # extra steps, run tests
       postBuildSteps:
         - template: /eng/pipelines/libraries/helix.yml
@@ -142,7 +142,7 @@ jobs:
       testGroup: innerloop
       nameSuffix: AllSubsets_CoreCLR_RuntimeTests
       buildArgs: -s clr+libs -c $(_BuildConfig)
-      timeoutInMinutes: 360
+      timeoutInMinutes: 480
       # extra steps, run tests
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml


### PR DESCRIPTION
## Description

This increases the MacCatalyst CoreCLR library job timeout from 240 to 360 minutes and the runtime test job timeout from 360 to 480 minutes. In https://dev.azure.com/dnceng-public/public/_build/results?buildId=1507526 the Azure Pipelines job reached its current limit while Helix work was still running, so the pipeline terminated valid test execution before completion.