### PR TITLE
Remove obsolete Apple ICU data bundling

### DIFF
--- a/docs/design/features/globalization-hybrid-mode.md
+++ b/docs/design/features/globalization-hybrid-mode.md
@@ -1,15 +1,10 @@
 # Hybrid Globalization
 
-`HybridGlobalization` mode uses platform-native internationalization APIs where possible. On Apple mobile platforms (iOS/tvOS/MacCatalyst), Hybrid is always active: the runtime primarily uses Foundation/NSLocale APIs and links against the system `icucore` library for remaining ICU-backed operations, including IDN mapping; no app-local ICU data file is loaded. Invariant mode takes precedence over Hybrid on all platforms.
-
-Hybrid has lower priority than Invariant. To switch on the mode set the property in the build file:
-```
-<HybridGlobalization>true</HybridGlobalization>
-```
+`HybridGlobalization` mode uses platform-native internationalization APIs where possible. On Apple mobile platforms (iOS/tvOS/MacCatalyst), Hybrid is always active unless Invariant mode is enabled. The `HybridGlobalization` build property is retained for linker and native-build compatibility; it does not enable Hybrid mode or app-local ICU data on these platforms.
 
 ## Behavioral differences
 
-Hybrid mode does not use ICU data for some functions connected with globalization but relies on functions native to the platform. Because native APIs do not fully cover all the functionalities we currently support and because ICU data can be excluded from the ICU datafile only in batches defined by ICU filters, not all functions will work the same way or not all will be supported. To see what to expect after switching on `HybridGlobalization`, read the following paragraphs.
+Hybrid mode does not use ICU data for some functions connected with globalization but relies on functions native to the platform. Because native APIs do not fully cover all the functionality currently supported, behavior can differ from ICU-based platforms and some functionality is unsupported. The following sections describe these differences.
 
 ### Apple platforms
 
@@ -129,7 +124,7 @@ Not covered case:
 
 - Some letters consist of more than one grapheme.
 
-   Apple Native Api does not guarantee that string will be segmented by letters but by graphemes. E.g. in `cs-CZ` and `sk-SK` "ch" is 1 letter, 2 graphemes. The following code with `HybridGlobalization` switched off returns -1 (not found) while with `HybridGlobalization` switched on, it returns 1.
+   Apple Native Api does not guarantee that string will be segmented by letters but by graphemes. E.g. in `cs-CZ` and `sk-SK` "ch" is 1 letter, 2 graphemes. The following code returns -1 (not found) on ICU-based platforms and 1 on Apple mobile platforms.
 
    ``` C#
    new CultureInfo("sk-SK").CompareInfo.IndexOf("ch", "h"); // -1 or 1
@@ -138,7 +133,7 @@ Not covered case:
 - Some graphemes have multi-grapheme equivalents.
    E.g. in `de-DE` ß (%u00DF) is one letter and one grapheme and "ss" is one letter and is recognized as two graphemes. Apple Native API's equivalent of `IgnoreNonSpace` treats them as the same letter when comparing. Similar case: ǳ (%u01F3) and dz.
 
-   Using `IgnoreNonSpace` for these two with `HybridGlobalization` off, also returns 0 (they are equal). However, the workaround used in `HybridGlobalization` will compare them grapheme-by-grapheme and will return -1.
+   Using `IgnoreNonSpace` for these two on ICU-based platforms also returns 0 (they are equal). However, the Apple mobile implementation compares them grapheme-by-grapheme and returns -1.
 
    ``` C#
    new CultureInfo("de-DE").CompareInfo.IndexOf("strasse", "stra\u00DFe", 0, CompareOptions.IgnoreNonSpace); // 0 or -1

--- a/docs/design/features/globalization-hybrid-mode.md
+++ b/docs/design/features/globalization-hybrid-mode.md
@@ -1,6 +1,6 @@
 # Hybrid Globalization
 
-Originally, internalization data is loaded from ICU data files. In `HybridGlobalization` mode we are leveraging the platform-native internationalization APIs, where it is possible, to allow for loading smaller ICU data files. We still need to rely on ICU files because for a bunch of globalization data no API equivalent is available. For some existing equivalents, the behavior does not fully match the original. The differences you can expect after switching on the mode are listed in this document. Expected size savings can be found under each platform section below.
+`HybridGlobalization` mode uses platform-native internationalization APIs where possible. On Apple mobile platforms (iOS/tvOS/MacCatalyst), Hybrid is always active: the runtime primarily uses Foundation/NSLocale APIs and links against the system `icucore` library for remaining ICU-backed operations, including IDN mapping; no app-local ICU data file is loaded. Invariant mode takes precedence over Hybrid on all platforms.
 
 Hybrid has lower priority than Invariant. To switch on the mode set the property in the build file:
 ```
@@ -13,7 +13,7 @@ Hybrid mode does not use ICU data for some functions connected with globalizatio
 
 ### Apple platforms
 
-For Apple platforms (iOS/tvOS/maccatalyst) we are using native apis instead of ICU data.
+On Apple mobile platforms (iOS/tvOS/MacCatalyst), Hybrid globalization is always enabled. The runtime primarily uses Apple-native APIs and links against the system `icucore` library for remaining ICU-backed operations, including IDN mapping; no app-local ICU data file (`icudt*.dat`) is bundled or loaded. Invariant mode (`InvariantGlobalization=true`) takes precedence.
 
 ## String comparison
 

--- a/docs/design/features/globalization-hybrid-mode.md
+++ b/docs/design/features/globalization-hybrid-mode.md
@@ -124,7 +124,7 @@ Not covered case:
 
 - Some letters consist of more than one grapheme.
 
-   Apple Native Api does not guarantee that string will be segmented by letters but by graphemes. E.g. in `cs-CZ` and `sk-SK` "ch" is 1 letter, 2 graphemes. The following code returns -1 (not found) on ICU-based platforms and 1 on Apple mobile platforms.
+   Apple Native API does not guarantee that string will be segmented by letters but by graphemes. E.g. in `cs-CZ` and `sk-SK` "ch" is 1 letter, 2 graphemes. The following code returns -1 (not found) on ICU-based platforms and 1 on Apple mobile platforms.
 
    ``` C#
    new CultureInfo("sk-SK").CompareInfo.IndexOf("ch", "h"); // -1 or 1

--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -109,17 +109,6 @@
       <BundleFiles Include="@(_NativeAotHelixLinkInputs)" TargetDir="publish\nativeaot-link-inputs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(UseNativeAOTRuntime)' == 'true' and '$(HybridGlobalization)' == 'false'" >
-      <BundleFiles Include="$(MicrosoftNetCoreAppRuntimePackDir)/runtimes/$(TargetOS)-$(TargetArchitecture)/native/icudt.dat"
-                                                                TargetDir="publish" />
-      <BundleFiles Include="$(MicrosoftNetCoreAppRuntimePackDir)/runtimes/$(TargetOS)-$(TargetArchitecture)/native/libicudata.a"
-                                                                TargetDir="publish" />
-      <BundleFiles Include="$(MicrosoftNetCoreAppRuntimePackDir)/runtimes/$(TargetOS)-$(TargetArchitecture)/native/libicuuc.a"
-                                                                TargetDir="publish" />
-      <BundleFiles Include="$(MicrosoftNetCoreAppRuntimePackDir)/runtimes/$(TargetOS)-$(TargetArchitecture)/native/libicui18n.a"
-                                                                TargetDir="publish" />
-    </ItemGroup>
-
     <ItemGroup Condition="'$(DebuggerSupport)' == 'true'">
       <!-- Add any pdb files, if available -->
       <BundleFiles Include="@(ApplePdbsToBundle)" TargetDir="publish" Condition="Exists(%(ApplePdbsToBundle.Identity))" />
@@ -206,7 +195,7 @@
     <WriteLinesToFile File="$(PublishDir)xunit-excludes.txt" Lines="$(XunitExcludesTxtFileContent)" Overwrite="true" />
 
     <PropertyGroup>
-    <!-- Default for now. If we can remove our ICU and rely on the system one, then HybridGlobalization becomes the default and we can remove checks for it -->
+    <!-- Apple mobile globalization always uses Apple-native APIs and system icucore. HybridGlobalization is kept enabled for linker feature substitution. -->
       <HybridGlobalization>true</HybridGlobalization>
       <IncludesTestRunner Condition="'$(IncludesTestRunner)' == ''">true</IncludesTestRunner>
       <Optimized Condition="'$(Configuration)' == 'Release'">true</Optimized>

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -159,7 +159,12 @@ public class AppleAppBuilderTask : Task
     public bool InvariantGlobalization { get; set; }
 
     /// <summary>
-    /// Forces the runtime to use hybrid(icu files + native functions) mode
+    /// Emits the legacy <c>HYBRID_GLOBALIZATION</c> preprocessor define in the generated native Xcode project
+    /// for compatibility with direct or out-of-tree native source consumers.
+    /// On Apple mobile platforms, the runtime primarily uses Apple-native APIs and links system <c>icucore</c>
+    /// for remaining ICU-backed operations; no app-local ICU data file is loaded.
+    /// Invariant mode still takes precedence when
+    /// <see cref="InvariantGlobalization"/> is set.
     /// </summary>
     public bool HybridGlobalization { get; set; }
 

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -159,12 +159,9 @@ public class AppleAppBuilderTask : Task
     public bool InvariantGlobalization { get; set; }
 
     /// <summary>
-    /// Emits the legacy <c>HYBRID_GLOBALIZATION</c> preprocessor define in the generated native Xcode project
-    /// for compatibility with direct or out-of-tree native source consumers.
-    /// On Apple mobile platforms, the runtime primarily uses Apple-native APIs and links system <c>icucore</c>
-    /// for remaining ICU-backed operations; no app-local ICU data file is loaded.
-    /// Invariant mode still takes precedence when
-    /// <see cref="InvariantGlobalization"/> is set.
+    /// Adds the legacy <c>HYBRID_GLOBALIZATION</c> preprocessor define to the generated native Xcode project.
+    /// This property does not control Apple mobile globalization; Hybrid mode is always used unless
+    /// <see cref="InvariantGlobalization"/> is enabled.
     /// </summary>
     public bool HybridGlobalization { get; set; }
 

--- a/src/tasks/AppleAppBuilder/Templates/runtime-coreclr.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime-coreclr.m
@@ -156,10 +156,6 @@ mono_ios_runtime_init (void)
     setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", TRUE);
 #endif
 
-#if HYBRID_GLOBALIZATION
-    setenv ("DOTNET_SYSTEM_GLOBALIZATION_HYBRID", "1", TRUE);
-#endif
-
     // build using DiagnosticPorts property in AppleAppBuilder
     // or set DOTNET_DiagnosticPorts env via mlaunch, xharness when undefined.
     // NOTE, using DOTNET_DiagnosticPorts requires app build using AppleAppBuilder and RuntimeComponents=diagnostics_tracing
@@ -177,15 +173,6 @@ mono_ios_runtime_init (void)
     const char* bundle = get_bundle_path ();
     chdir (bundle);
 
-    char icu_dat_path [1024];
-    int res;
-#if defined(HYBRID_GLOBALIZATION)
-    res = snprintf (icu_dat_path, sizeof (icu_dat_path) - 1, "%s/%s", bundle, "icudt_hybrid.dat");
-#else
-    res = snprintf (icu_dat_path, sizeof (icu_dat_path) - 1, "%s/%s", bundle, "icudt.dat");
-#endif
-    assert (res > 0);
-
     // Contract lasts the lifetime of the app. The app exists before the end of this function.
     struct host_runtime_contract host_contract = {
         .size = sizeof(struct host_runtime_contract),
@@ -196,11 +183,7 @@ mono_ios_runtime_init (void)
     char contract_str[19]; // 0x + 16 hex digits + '\0'
     snprintf(contract_str, 19, "0x%zx", (size_t)(&host_contract));
 
-#if defined(INVARIANT_GLOBALIZATION)
-#define PROPERTY_COUNT %AppContextPropertyCount_InvariantGlobalization%
-#else
 #define PROPERTY_COUNT %AppContextPropertyCount%
-#endif
 
     // Hardcoded properties + runtime config properties (generated at build time)
     const char *appctx_keys[PROPERTY_COUNT];
@@ -208,9 +191,6 @@ mono_ios_runtime_init (void)
     appctx_keys[1] = "APP_CONTEXT_BASE_DIRECTORY";
     appctx_keys[2] = "TRUSTED_PLATFORM_ASSEMBLIES";
     appctx_keys[3] = "HOST_RUNTIME_CONTRACT";
-#if !defined(INVARIANT_GLOBALIZATION)
-    appctx_keys[4] = "ICU_DAT_FILE_PATH";
-#endif
 %AppContextKeys%
 
     const char *appctx_values[PROPERTY_COUNT];
@@ -218,9 +198,6 @@ mono_ios_runtime_init (void)
     appctx_values[1] = bundle;
     appctx_values[2] = compute_trusted_platform_assemblies();
     appctx_values[3] = contract_str;
-#if !defined(INVARIANT_GLOBALIZATION)
-    appctx_values[4] = icu_dat_path;
-#endif
 %AppContextValues%
 
     const char* executable = "%EntryPointLibName%";
@@ -229,6 +206,7 @@ mono_ios_runtime_init (void)
     void *coreclr_handle = NULL;
 
     char path [1024];
+    int res;
     res = snprintf (path, sizeof (path) - 1, "%s/%s", bundle, executable);
     assert (res > 0);
 

--- a/src/tasks/AppleAppBuilder/Templates/runtime-librarymode.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime-librarymode.m
@@ -57,10 +57,6 @@ library_mode_init (void)
     setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", TRUE);
 #endif
 
-#if HYBRID_GLOBALIZATION
-    setenv ("DOTNET_SYSTEM_GLOBALIZATION_HYBRID", "1", TRUE);
-#endif
-
 #if ENABLE_RUNTIME_LOGGING && !USE_NATIVE_AOT
     setenv ("MONO_LOG_LEVEL", "debug", TRUE);
     setenv ("MONO_LOG_MASK", "all", TRUE);

--- a/src/tasks/AppleAppBuilder/Templates/runtime.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime.m
@@ -284,29 +284,16 @@ mono_ios_runtime_init (void)
     char pinvoke_override[1024];
     snprintf(pinvoke_override, sizeof(pinvoke_override) - 1, "%p", &handle_pinvoke_override);
 
-    char icu_dat_path [1024];
-    int res;
-#if !defined(HYBRID_GLOBALIZATION)
-    res = snprintf (icu_dat_path, sizeof (icu_dat_path) - 1, "%s/%s", bundle, "icudt.dat");
-    assert (res > 0);
-#endif
-
     // TODO: set TRUSTED_PLATFORM_ASSEMBLIES, APP_PATHS and NATIVE_DLL_SEARCH_DIRECTORIES
     const char *appctx_keys [] = {
         "RUNTIME_IDENTIFIER",
         "APP_CONTEXT_BASE_DIRECTORY",
         "PINVOKE_OVERRIDE",
-#if !defined(INVARIANT_GLOBALIZATION) && !defined(HYBRID_GLOBALIZATION)
-        "ICU_DAT_FILE_PATH"
-#endif
     };
     const char *appctx_values [] = {
         APPLE_RUNTIME_IDENTIFIER,
         bundle,
         pinvoke_override,
-#if !defined(INVARIANT_GLOBALIZATION) && !defined(HYBRID_GLOBALIZATION)
-        icu_dat_path
-#endif
     };
 
     char *file_name = RUNTIMECONFIG_BIN_FILE;
@@ -386,7 +373,7 @@ mono_ios_runtime_init (void)
     assert (assembly);
     os_log_info (OS_LOG_DEFAULT, "Executable: %{public}s", executable);
 
-    res = mono_jit_exec (mono_domain_get (), assembly, (int)argi, managed_argv);
+    int res = mono_jit_exec (mono_domain_get (), assembly, (int)argi, managed_argv);
     // Print this so apps parsing logs can detect when we exited
     os_log_info (OS_LOG_DEFAULT, EXIT_CODE_TAG ": %d", res);
 

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -304,8 +304,7 @@ internal sealed class Xcode
         }
 
         string[] resources = Directory.GetFileSystemEntries(workspace, "", SearchOption.TopDirectoryOnly)
-            .Where(f => !predefinedExcludes.Any(e => (!e.EndsWith('*') && f.EndsWith(e, StringComparison.InvariantCultureIgnoreCase)) || (e.EndsWith('*') && Path.GetFileName(f).StartsWith(e.TrimEnd('*'), StringComparison.InvariantCultureIgnoreCase) &&
-            !(!hybridGlobalization && Path.GetFileName(f) == "icudt.dat"))))
+            .Where(f => !predefinedExcludes.Any(e => (!e.EndsWith('*') && f.EndsWith(e, StringComparison.InvariantCultureIgnoreCase)) || (e.EndsWith('*') && Path.GetFileName(f).StartsWith(e.TrimEnd('*'), StringComparison.InvariantCultureIgnoreCase))))
             .ToArray();
 
         if (string.IsNullOrEmpty(nativeMainSource))
@@ -622,7 +621,7 @@ internal sealed class Xcode
                 File.WriteAllText(Path.Combine(binDir, "host_runtime_contract.h"),
                     Utils.GetEmbeddedResource("host_runtime_contract.h"));
 
-                var (appContextKeys, appContextValues, propertyCount, propertyCountInvariant) = RenderCoreClrRuntimeConfigProperties(workspace);
+                var (appContextKeys, appContextValues, propertyCount) = RenderCoreClrRuntimeConfigProperties(workspace);
 
                 // NOTE: Library mode is not supported yet
                 File.WriteAllText(Path.Combine(binDir, "runtime.m"),
@@ -631,7 +630,6 @@ internal sealed class Xcode
                         .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib))
                         .Replace("%EnvVariables%", envVariables)
                         .Replace("%AppContextPropertyCount%", propertyCount.ToString())
-                        .Replace("%AppContextPropertyCount_InvariantGlobalization%", propertyCountInvariant.ToString())
                         .Replace("%AppContextKeys%", appContextKeys)
                         .Replace("%AppContextValues%", appContextValues));
             }
@@ -764,15 +762,12 @@ internal sealed class Xcode
         return Path.Combine(appDirectory, Path.GetFileNameWithoutExtension(xcodePrjPath) + ".app");
     }
 
-    private (string appContextKeys, string appContextValues, int propertyCount, int propertyCountInvariant) RenderCoreClrRuntimeConfigProperties(string workspace)
+    private (string appContextKeys, string appContextValues, int propertyCount) RenderCoreClrRuntimeConfigProperties(string workspace)
     {
         Dictionary<string, string> configProperties = ParseRuntimeConfigProperties(workspace);
 
-        // Hardcoded properties count:
-        // - RUNTIME_IDENTIFIER, APP_CONTEXT_BASE_DIRECTORY, TRUSTED_PLATFORM_ASSEMBLIES, HOST_RUNTIME_CONTRACT = 4
-        // - ICU_DAT_FILE_PATH (only when !INVARIANT_GLOBALIZATION) = 1
-        const int hardcodedPropertiesWithIcu = 5;
-        const int hardcodedPropertiesWithoutIcu = 4;
+        // Hardcoded properties count: RUNTIME_IDENTIFIER, APP_CONTEXT_BASE_DIRECTORY, TRUSTED_PLATFORM_ASSEMBLIES, HOST_RUNTIME_CONTRACT = 4
+        const int hardcodedProperties = 4;
 
         var appContextKeys = new StringBuilder();
         var appContextValues = new StringBuilder();
@@ -780,24 +775,14 @@ internal sealed class Xcode
         int i = 0;
         foreach ((string key, string value) in configProperties)
         {
-            appContextKeys.AppendLine($"#if defined(INVARIANT_GLOBALIZATION)");
-            appContextKeys.AppendLine($"    appctx_keys[{i + hardcodedPropertiesWithoutIcu}] = \"{key}\";");
-            appContextKeys.AppendLine($"#else");
-            appContextKeys.AppendLine($"    appctx_keys[{i + hardcodedPropertiesWithIcu}] = \"{key}\";");
-            appContextKeys.AppendLine($"#endif");
-
-            appContextValues.AppendLine($"#if defined(INVARIANT_GLOBALIZATION)");
-            appContextValues.AppendLine($"    appctx_values[{i + hardcodedPropertiesWithoutIcu}] = \"{value}\";");
-            appContextValues.AppendLine($"#else");
-            appContextValues.AppendLine($"    appctx_values[{i + hardcodedPropertiesWithIcu}] = \"{value}\";");
-            appContextValues.AppendLine($"#endif");
+            appContextKeys.AppendLine($"    appctx_keys[{i + hardcodedProperties}] = \"{key}\";");
+            appContextValues.AppendLine($"    appctx_values[{i + hardcodedProperties}] = \"{value}\";");
             i++;
         }
 
-        int propertyCount = hardcodedPropertiesWithIcu + configProperties.Count;
-        int propertyCountInvariant = hardcodedPropertiesWithoutIcu + configProperties.Count;
+        int propertyCount = hardcodedProperties + configProperties.Count;
 
-        return (appContextKeys.ToString().TrimEnd(), appContextValues.ToString().TrimEnd(), propertyCount, propertyCountInvariant);
+        return (appContextKeys.ToString().TrimEnd(), appContextValues.ToString().TrimEnd(), propertyCount);
     }
 
     private Dictionary<string, string> ParseRuntimeConfigProperties(string workspace)


### PR DESCRIPTION
## Summary

- stop AppleAppBuilder from bundling `icudt*.dat` or configuring `ICU_DAT_FILE_PATH` for Apple CoreCLR and Mono apps
- remove the stale NativeAOT Apple test payload copies of `icudt.dat` and static ICU libraries while preserving compatibility globalization switches
- clarify that Apple mobile hybrid globalization uses Apple-native APIs and system `icucore`, without app-local ICU data