### PR TITLE
Preserve Android NativeAOT single-file test results

### DIFF
--- a/src/libraries/Common/tests/SingleFileTestRunner/SingleFileTestRunner.cs
+++ b/src/libraries/Common/tests/SingleFileTestRunner/SingleFileTestRunner.cs
@@ -77,7 +77,10 @@ public class SingleFileTestRunner : XunitTestFramework
         discoverer.Find(false, discoverySink, TestFrameworkOptions.ForDiscovery(assemblyConfig));
         discoverySink.Finished.WaitOne();
 
-        string xmlResultFileName = null;
+        string testResultsDirectory = Environment.GetEnvironmentVariable("TEST_RESULTS_DIR");
+        string xmlResultFileName = string.IsNullOrEmpty(testResultsDirectory)
+            ? null
+            : Path.Combine(testResultsDirectory, "testResults.xml");
         XunitFilters filters = new XunitFilters();
         // Quick hack wo much validation to get args that are passed (notrait, xml)
         Dictionary<string, List<string>> noTraits = new Dictionary<string, List<string>>();


### PR DESCRIPTION
## Description

This makes `SingleFileTestRunner` write `testResults.xml` to `TEST_RESULTS_DIR` when no explicit `-xml` path is provided. The Android runner already sets this directory and reports that file to XHarness, but NativeAOT single-file tests previously emitted failures only to logcat. In https://dev.azure.com/dnceng-public/public/_build/results?buildId=1507526 the failing WebSockets test could not be identified because logcat evicted the failure and no structured result file was produced. An explicit `-xml` argument continues to override the environment-derived path.