### PR TITLE
Suppress EDI delimiter for async frames in NativeAOT stack traces

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/StackTraceMetadataCallbacks.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/StackTraceMetadataCallbacks.cs
@@ -17,7 +17,7 @@ namespace Internal.Runtime.Augments
     [CLSCompliant(false)]
     public abstract class StackTraceMetadataCallbacks
     {
-        public abstract string TryGetMethodStackFrameInfo(IntPtr methodStartAddress, int offset, bool needsFileInfo, out string owningType, out string genericArgs, out string methodSignature, out bool isStackTraceHidden, out string fileName, out int lineNumber);
+        public abstract string TryGetMethodStackFrameInfo(IntPtr methodStartAddress, int offset, bool needsFileInfo, out string owningType, out string genericArgs, out string methodSignature, out bool isStackTraceHidden, out bool isAsync, out string fileName, out int lineNumber);
 
         public abstract DiagnosticMethodInfo TryGetDiagnosticMethodInfoFromStartAddress(IntPtr methodStartAddress);
     }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
@@ -40,6 +40,13 @@ namespace System.Diagnostics
 
         private bool _isStackTraceHidden;
 
+        /// <summary>
+        /// Will be true if this frame corresponds to a runtime-async method or the MoveNext method of a
+        /// compiler-generated async state machine. Used to suppress the "--- End of stack trace from
+        /// previous location ---" delimiter.
+        /// </summary>
+        private bool _isAsync;
+
         // If stack trace metadata is available, _methodOwningType is the namespace-qualified name of the owning type,
         // _methodName is the name of the method, _methodGenericArgs are generic arguments, and _methodSignature is the list of parameters
         // without braces. StackTrace will format this as `{_methodOwningType}.{_methodName}<{_genericArgs}>({_methodSignature}).
@@ -122,7 +129,7 @@ namespace System.Diagnostics
                 StackTraceMetadataCallbacks stackTraceCallbacks = RuntimeAugments.StackTraceCallbacksIfAvailable;
                 if (stackTraceCallbacks != null)
                 {
-                    _methodName = stackTraceCallbacks.TryGetMethodStackFrameInfo(methodStartAddress, _nativeOffset, needFileInfo, out _methodOwningType, out _methodGenericArgs, out _methodSignature, out _isStackTraceHidden, out _fileName, out _lineNumber);
+                    _methodName = stackTraceCallbacks.TryGetMethodStackFrameInfo(methodStartAddress, _nativeOffset, needFileInfo, out _methodOwningType, out _methodGenericArgs, out _methodSignature, out _isStackTraceHidden, out _isAsync, out _fileName, out _lineNumber);
                 }
 
                 if (_methodName == null)
@@ -230,7 +237,7 @@ namespace System.Diagnostics
                     builder.AppendLine();
                 }
             }
-            if (_isLastFrameFromForeignExceptionStackTrace)
+            if (_isLastFrameFromForeignExceptionStackTrace && !_isAsync)
             {
                 // Passing default for Exception_EndStackTraceFromPreviousThrow in case SR.UsingResourceKeys is set.
                 builder.AppendLine(SR.UsingResourceKeys() ?

--- a/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
+++ b/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
@@ -50,7 +50,7 @@ namespace Internal.StackTraceMetadata
         /// <summary>
         /// Locate the containing module for a method and try to resolve its name based on start address.
         /// </summary>
-        public static unsafe string GetMethodNameFromStartAddressIfAvailable(IntPtr methodStartAddress, out string owningTypeName, out string genericArgs, out string methodSignature, out bool isStackTraceHidden, out int hashCodeForLineInfo)
+        public static unsafe string GetMethodNameFromStartAddressIfAvailable(IntPtr methodStartAddress, out string owningTypeName, out string genericArgs, out string methodSignature, out bool isStackTraceHidden, out bool isAsync, out int hashCodeForLineInfo)
         {
             IntPtr moduleStartAddress = RuntimeAugments.GetOSModuleFromPointer(methodStartAddress);
             int rva = (int)((byte*)methodStartAddress - (byte*)moduleStartAddress);
@@ -62,6 +62,7 @@ namespace Internal.StackTraceMetadata
                     if (resolver.TryGetStackTraceData(rva, out var data))
                     {
                         isStackTraceHidden = data.IsHidden;
+                        isAsync = data.IsAsync;
                         if (data.OwningType.IsNil)
                         {
                             Debug.Assert(data.Name.IsNil && data.Signature.IsNil);
@@ -80,6 +81,7 @@ namespace Internal.StackTraceMetadata
             }
 
             isStackTraceHidden = false;
+            isAsync = false;
 
             // We haven't found information in the stack trace metadata tables, but maybe reflection will have this
             if (ReflectionExecution.TryGetMethodMetadataFromStartAddress(methodStartAddress,
@@ -331,9 +333,9 @@ namespace Internal.StackTraceMetadata
                 return GetDiagnosticMethodInfoFromStartAddressIfAvailable(methodStartAddress);
             }
 
-            public override string TryGetMethodStackFrameInfo(IntPtr methodStartAddress, int offset, bool needsFileInfo, out string owningType, out string genericArgs, out string methodSignature, out bool isStackTraceHidden, out string fileName, out int lineNumber)
+            public override string TryGetMethodStackFrameInfo(IntPtr methodStartAddress, int offset, bool needsFileInfo, out string owningType, out string genericArgs, out string methodSignature, out bool isStackTraceHidden, out bool isAsync, out string fileName, out int lineNumber)
             {
-                string methodName = GetMethodNameFromStartAddressIfAvailable(methodStartAddress, out owningType, out genericArgs, out methodSignature, out isStackTraceHidden, out int hashCode);
+                string methodName = GetMethodNameFromStartAddressIfAvailable(methodStartAddress, out owningType, out genericArgs, out methodSignature, out isStackTraceHidden, out isAsync, out int hashCode);
 
                 if (needsFileInfo)
                 {
@@ -474,6 +476,7 @@ namespace Internal.StackTraceMetadata
                     {
                         Rva = methodRva,
                         IsHidden = (command & StackTraceDataCommand.IsStackTraceHidden) != 0,
+                        IsAsync = (command & StackTraceDataCommand.IsAsync) != 0,
                         OwningType = currentOwningType,
                         Name = currentName,
                         Signature = currentSignature,
@@ -516,25 +519,36 @@ namespace Internal.StackTraceMetadata
             public struct StackTraceData : IComparable<StackTraceData>
             {
                 private const int IsHiddenFlag = 0x2;
+                private const int IsAsyncFlag = 0x1;
+                private const int FlagsMask = IsHiddenFlag | IsAsyncFlag;
 
-                private readonly int _rvaAndIsHiddenBit;
+                private readonly int _rvaAndFlags;
 
                 public int Rva
                 {
-                    get => _rvaAndIsHiddenBit & ~IsHiddenFlag;
+                    get => _rvaAndFlags & ~FlagsMask;
                     init
                     {
-                        Debug.Assert((value & IsHiddenFlag) == 0);
-                        _rvaAndIsHiddenBit = value | (_rvaAndIsHiddenBit & IsHiddenFlag);
+                        Debug.Assert((value & FlagsMask) == 0);
+                        _rvaAndFlags = value | (_rvaAndFlags & FlagsMask);
                     }
                 }
                 public bool IsHidden
                 {
-                    get => (_rvaAndIsHiddenBit & IsHiddenFlag) != 0;
+                    get => (_rvaAndFlags & IsHiddenFlag) != 0;
                     init
                     {
                         if (value)
-                            _rvaAndIsHiddenBit |= IsHiddenFlag;
+                            _rvaAndFlags |= IsHiddenFlag;
+                    }
+                }
+                public bool IsAsync
+                {
+                    get => (_rvaAndFlags & IsAsyncFlag) != 0;
+                    init
+                    {
+                        if (value)
+                            _rvaAndFlags |= IsAsyncFlag;
                     }
                 }
                 public Handle OwningType { get; init; }

--- a/src/coreclr/tools/Common/Internal/Runtime/StackTraceData.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/StackTraceData.cs
@@ -11,5 +11,6 @@ namespace Internal.Runtime
         public const byte UpdateGenericSignature = 0x08; // Just a shortcut - sig metadata has the info
 
         public const byte IsStackTraceHidden = 0x10;
+        public const byte IsAsync = 0x20;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StackTraceMethodMappingNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StackTraceMethodMappingNode.cs
@@ -124,6 +124,11 @@ namespace ILCompiler.DependencyAnalysis
                     command |= StackTraceDataCommand.IsStackTraceHidden;
                 }
 
+                if ((entry.Flags & StackTraceRecordFlags.IsAsync) != 0)
+                {
+                    command |= StackTraceDataCommand.IsAsync;
+                }
+
                 objData.EmitByte(commandReservation, command);
                 objData.EmitReloc(factory.MethodEntrypoint(entry.Method), RelocType.IMAGE_REL_BASED_RELPTR32);
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -780,6 +780,8 @@ namespace ILCompiler
                     flags |= StackTraceRecordFlags.IsHidden;
                 if ((stackVisibility & MethodStackTraceVisibilityFlags.HasLineNumbers) != 0)
                     flags |= StackTraceRecordFlags.HasLineNumbers;
+                if ((stackVisibility & MethodStackTraceVisibilityFlags.IsAsync) != 0)
+                    flags |= StackTraceRecordFlags.IsAsync;
 
                 if ((stackVisibility & MethodStackTraceVisibilityFlags.HasMetadata) != 0)
                 {
@@ -1351,6 +1353,7 @@ namespace ILCompiler
         None = 0,
         IsHidden = 1,
         HasLineNumbers = 2,
+        IsAsync = 4,
     }
 
     public readonly struct StackTraceRecordData

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/StackTraceEmissionPolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/StackTraceEmissionPolicy.cs
@@ -29,6 +29,8 @@ namespace ILCompiler
     public class EcmaMethodStackTraceEmissionPolicy : StackTraceEmissionPolicy
     {
         private readonly MethodStackTraceVisibilityFlags _flags;
+        private MetadataType _iAsyncStateMachineType;
+        private bool _iAsyncStateMachineTypeComputed;
 
         public EcmaMethodStackTraceEmissionPolicy(bool includeLineNumbers)
         {
@@ -46,9 +48,53 @@ namespace ILCompiler
                 result |= MethodStackTraceVisibilityFlags.IsHidden;
             }
 
+            if (IsAsyncFrame(method))
+            {
+                result |= MethodStackTraceVisibilityFlags.IsAsync;
+            }
+
             return (method.GetTypicalMethodDefinition() is Internal.TypeSystem.Ecma.EcmaMethod || (method.IsAsync && method.IsAsyncCall()))
                 ? result | MethodStackTraceVisibilityFlags.HasMetadata
                 : result;
+        }
+
+        // Determines whether a frame for this method should be treated as "async" when formatting a
+        // stack trace. Async frames suppress the "--- End of stack trace from previous location ---"
+        // delimiter. This covers both runtime-async (V2) methods and the MoveNext method of a
+        // compiler-generated (V1) async state machine.
+        private bool IsAsyncFrame(MethodDesc method)
+        {
+            if (method.IsAsync)
+            {
+                return true;
+            }
+
+            // Async state machines only expose their exception-throwing code through IAsyncStateMachine.MoveNext.
+            if (method.Name != "MoveNext"u8)
+            {
+                return false;
+            }
+
+            if (!_iAsyncStateMachineTypeComputed)
+            {
+                _iAsyncStateMachineType = method.Context.SystemModule.GetType("System.Runtime.CompilerServices"u8, "IAsyncStateMachine"u8, throwIfNotFound: false);
+                _iAsyncStateMachineTypeComputed = true;
+            }
+
+            if (_iAsyncStateMachineType == null)
+            {
+                return false;
+            }
+
+            foreach (DefType interfaceType in method.OwningType.RuntimeInterfaces)
+            {
+                if (interfaceType == _iAsyncStateMachineType)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 
@@ -58,5 +104,6 @@ namespace ILCompiler
         HasMetadata = 0x1,
         IsHidden = 0x2,
         HasLineNumbers = 0x4,
+        IsAsync = 0x8,
     }
 }

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -709,11 +709,7 @@ namespace System.Diagnostics.Tests
                 startIndex = match.Index + match.Length;
             }
 
-            // [ActiveIssue("https://github.com/dotnet/runtime/issues/129155", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
-            if (!PlatformDetection.IsNativeAot)
-            {
-                Assert.DoesNotContain("--- End of stack trace from previous location ---", exceptionText);
-            }
+            Assert.DoesNotContain("--- End of stack trace from previous location ---", exceptionText);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Classic (state-machine) async methods that throw emitted an extraneous "--- End of stack trace from previous location ---" delimiter under NativeAOT, whereas CoreCLR suppresses it for async frames. NativeAOT has no reflection available when formatting a stack trace, so the "is async" information must be baked into the stack trace metadata at compile time.

Plumb a new IsAsync flag through the AOT stack trace metadata pipeline, mirroring the existing IsHidden flag: the emission policy detects runtime-async (V2) methods and the MoveNext method of a compiler-generated (V1) IAsyncStateMachine, the flag flows through MetadataManager and the stack trace mapping node into the runtime decode, and StackFrame honors it by skipping the delimiter for async frames.

Fixes #129155