### PR TITLE
Add Windows dnx.cmd shim to dotnet-host (sharedhost) package

### DIFF
--- a/src/installer/pkg/sfx/installers/dnx.cmd
+++ b/src/installer/pkg/sfx/installers/dnx.cmd
@@ -1,0 +1,23 @@
+:: Licensed to the .NET Foundation under one or more agreements.
+:: The .NET Foundation licenses this file to you under the MIT license.
+
+@echo off
+setlocal enableextensions
+
+set "DOTNET=%~dp0dotnet.exe"
+
+set "SDK_VERSION="
+for /f "tokens=1" %%i in ('"%DOTNET%" --list-sdks') do (
+    set "SDK_VERSION=%%i"
+)
+
+if not defined SDK_VERSION (
+    echo Error: dnx requires a .NET SDK to be installed, but none was found. 1>&2
+    exit /b 1
+)
+
+set "SDK_PATH=%~dp0sdk\%SDK_VERSION%\dotnet.dll"
+
+"%DOTNET%" exec "%SDK_PATH%" dnx %*
+
+endlocal

--- a/src/installer/pkg/sfx/installers/dnx.cmd
+++ b/src/installer/pkg/sfx/installers/dnx.cmd
@@ -20,4 +20,4 @@ set "SDK_PATH=%~dp0sdk\%SDK_VERSION%\dotnet.dll"
 
 "%DOTNET%" exec "%SDK_PATH%" dnx %*
 
-endlocal
+endlocal & exit /b %ERRORLEVEL%

--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -51,6 +51,9 @@
       <FilesToPublish Include="$(MSBuildThisFileDirectory)dnx"
             Destination="$(OutputPath)dnx"
             Condition="'$(TargetsUnix)' == 'true'" />
+      <FilesToPublish Include="$(MSBuildThisFileDirectory)dnx.cmd"
+            Destination="$(OutputPath)dnx.cmd"
+            Condition="'$(TargetsUnix)' != 'true'" />
     </ItemGroup>
 
     <Copy SourceFiles="@(FilesToPublish)"

--- a/src/installer/pkg/sfx/installers/host.wxs
+++ b/src/installer/pkg/sfx/installers/host.wxs
@@ -25,6 +25,12 @@
           <CopyFile Id="copyFileCoreHostExe" DestinationDirectory="PROGRAMFILES_DOTNET" />
         </File>
       </Component>
+
+      <Component Id="cmpDnxCmd" Directory="DOTNETHOME" Guid="{BD6B9661-33D5-4BAE-A581-A0BCD0369B2A}">
+        <File Id="fileDnxCmd" KeyPath="yes" Source="$(var.HostSrc)\dnx.cmd">
+          <CopyFile Id="copyFileDnxCmd" DestinationDirectory="PROGRAMFILES_DOTNET" />
+        </File>
+      </Component>
         
       <Component Id="cmpSharedHostVersionRegistry" Directory="DOTNETHOME">
         <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedhost">


### PR DESCRIPTION
## Why

Today on Windows, the `dnx` launcher is shipped only by the SDK `dev` MSI; the sharedhost MSI does not ship it. That leaves `dnx` owned by a different installer than `dotnet.exe`, so the two can target different roots and drift out of sync (see dotnet/sdk#55116).

This moves ownership of the Windows `dnx` launcher to the sharedhost MSI, so `dnx` ships and uninstalls alongside `dotnet.exe` in every root the host is installed to. It is the Windows follow-up to the Unix `dnx` shim added in #129258.

## What

- Adds `src/installer/pkg/sfx/installers/dnx.cmd`, a Windows batch mirror of the existing Unix `dnx` shim: it resolves `dotnet.exe` next to itself, picks the newest installed SDK from `dotnet --list-sdks`, and dispatches `dotnet exec sdk\<version>\dotnet.dll dnx %*`. It ends with `endlocal & exit /b %ERRORLEVEL%` so it propagates `dnx`'s exit code.
- `dotnet-host.proj`: publishes `dnx.cmd` on Windows only (`TargetsUnix != 'true'`), as a sibling to the existing Unix `dnx` entry. No `chmod` is applied (that remains Unix-only).
- `host.wxs`: adds a new `cmpDnxCmd` component that installs `dnx.cmd` into `DOTNETHOME` and `CopyFile`s it to `PROGRAMFILES_DOTNET`, mirroring how `cmpCoreHost` handles `dotnet.exe` so `dnx` lands in both roots.

## Notes for reviewers

- This must ship in the same release as the paired dotnet/sdk change (dotnet/sdk#55268), which stops the SDK `dev` MSI from shipping `dnx.cmd` on Windows. The two changes must land together: adding it here without the SDK removal would give `dnx.cmd` two owners (a silent cross-MSI overlap, since Windows MSI does not hard-fail on it), while merging the SDK removal without this change would leave Windows with no `dnx` at all.
- Unlike the SDK's original `dnx.cmd`, this version adds a missing-SDK guard (`if not defined SDK_VERSION ... exit /b 1`). That matches the Unix shim's behavior and is the correct choice for the host package, which can be installed without any SDK present.
- The component GUID is fixed for install/upgrade stability.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
