### PR TITLE
[iOS] Optimize CompareStringNative performance

### DIFF
--- a/src/native/libs/System.Globalization.Native/pal_collation.m
+++ b/src/native/libs/System.Globalization.Native/pal_collation.m
@@ -101,13 +101,6 @@ int32_t GlobalizationNative_CompareStringNative(const uint16_t* localeName, int3
             targetStrPrecomposed = ConvertToKatakana(targetStrPrecomposed);
         }
 
-        if (comparisonOptions != 0 && comparisonOptions != StringSort)
-        {
-            NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions((CompareOptions)comparisonOptions, false);
-            sourceStrPrecomposed = [sourceStrPrecomposed stringByFoldingWithOptions:options locale:currentLocale];
-            targetStrPrecomposed = [targetStrPrecomposed stringByFoldingWithOptions:options locale:currentLocale];
-        }
-
         NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions((CompareOptions)comparisonOptions, true);
         NSRange comparisonRange = NSMakeRange(0, sourceStrPrecomposed.length);
         return (int32_t)[sourceStrPrecomposed compare:targetStrPrecomposed


### PR DESCRIPTION
Help with #121204

## Problem

String sorting on iOS is significantly slower than other platforms. Profiling `CompareStringNative` shows `stringByFoldingWithOptions` consumes ~9% of native time — but it's redundant because `compare:options:range:locale:` with `NSLiteralSearch` already handles `NSCaseInsensitiveSearch`, `NSDiacriticInsensitiveSearch`, and `NSWidthInsensitiveSearch` on precomposed strings.

## Root Cause

The folding step was added in PR #96002 (IgnoreKanaType support, Dec 2023) as a structural refactoring to make `CompareStringNative` parallel the pattern in `GetSortKeyNative`. The original working implementation (PR #86895, May 2023) had no folding and passed CI.

## Change

Remove the redundant `stringByFoldingWithOptions` call from `CompareStringNative`. The `compare:options:range:locale:` API already applies all the comparison options directly.

Verified with 20 edge-case tests covering: IgnoreCase, IgnoreNonSpace (diacritics: é/e, ñ/n, À/A, combining marks), IgnoreWidth (fullwidth/halfwidth katakana), dakuten (ガ/カ), and all option combinations — zero mismatches between the fold+compare and direct compare approaches.