### PR TITLE
Fix native EH in external shared libs on macOS

### DIFF
--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -13,6 +13,14 @@ endif()
 # Required to expose symbols for global symbol discovery.
 set(CLR_CMAKE_KEEP_NATIVE_SYMBOLS TRUE)
 
+if (CLR_CMAKE_HOST_APPLE)
+    # Prevent exporting symbols from corerun. This is necessary to avoid a problem with
+    # local typeinfo for standard C++ EH types like std::bad_alloc, std::out_of_range etc.
+    # being exposed for binding for external shared libraries and causing mismatch in
+    # catch type matching.
+    add_link_options(LINKER:-no_exported_symbols)
+endif()
+
 add_executable_clr(corerun
   corerun.cpp
   dotenv.cpp

--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -14,11 +14,11 @@ endif()
 set(CLR_CMAKE_KEEP_NATIVE_SYMBOLS TRUE)
 
 if (CLR_CMAKE_HOST_APPLE)
-    # Prevent exporting symbols from corerun. This is necessary to avoid a problem with
-    # local typeinfo for standard C++ EH types like std::bad_alloc, std::out_of_range etc.
-    # being exposed for binding for external shared libraries and causing mismatch in
-    # catch type matching.
-    add_link_options(LINKER:-no_exported_symbols)
+    # Prevent exporting symbols except for GetCurrentClrDetails from corerun. This is necessary
+    # to avoid a problem with local typeinfo for standard C++ EH types like std::bad_alloc,
+    # std::out_of_range etc. being exposed for binding for external shared libraries and causing
+    # mismatch in catch type matching.
+    add_link_options(LINKER:-exported_symbol,_GetCurrentClrDetails)
 endif()
 
 add_executable_clr(corerun

--- a/src/native/corehost/apphost/CMakeLists.txt
+++ b/src/native/corehost/apphost/CMakeLists.txt
@@ -1,4 +1,12 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
+if (CLR_CMAKE_HOST_APPLE)
+    # Prevent exporting symbols from apphost. This is necessary to avoid a problem with
+    # local typeinfo for standard C++ EH types like std::bad_alloc, std::out_of_range etc.
+    # being exposed for binding for external shared libraries and causing mismatch in
+    # catch type matching.
+    add_link_options(LINKER:-no_exported_symbols)
+endif()
+
 add_subdirectory(standalone)

--- a/src/native/corehost/dotnet/CMakeLists.txt
+++ b/src/native/corehost/dotnet/CMakeLists.txt
@@ -1,6 +1,14 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
+if (CLR_CMAKE_HOST_APPLE)
+    # Prevent exporting symbols from dotnet. This is necessary to avoid a problem with
+    # local typeinfo for standard C++ EH types like std::bad_alloc, std::out_of_range etc.
+    # being exposed for binding for external shared libraries and causing mismatch in
+    # catch type matching.
+    add_link_options(LINKER:-no_exported_symbols)
+endif()
+
 if(CLR_CMAKE_TARGET_WIN32)
     list(APPEND SOURCES
         dotnet.manifest

--- a/src/native/corehost/nethost/CMakeLists.txt
+++ b/src/native/corehost/nethost/CMakeLists.txt
@@ -1,14 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
-if (CLR_CMAKE_HOST_APPLE)
-    # Prevent exporting any symbol except _get_hostfxr_path from nethost. This is necessary
-    # to avoid a problem with local typeinfo for standard C++ EH types like std::bad_alloc,
-    # std::out_of_range etc. being exposed for binding for external shared libraries and
-    # causing mismatch in catch type matching.
-    add_link_options(LINKER:-exported_symbol,_get_hostfxr_path)
-endif()
-
 # CMake does not recommend using globbing since it messes with the freshness checks
 set(SOURCES
     nethost.cpp

--- a/src/native/corehost/nethost/CMakeLists.txt
+++ b/src/native/corehost/nethost/CMakeLists.txt
@@ -1,6 +1,14 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
+if (CLR_CMAKE_HOST_APPLE)
+    # Prevent exporting any symbol except _get_hostfxr_path from nethost. This is necessary
+    # to avoid a problem with local typeinfo for standard C++ EH types like std::bad_alloc,
+    # std::out_of_range etc. being exposed for binding for external shared libraries and
+    # causing mismatch in catch type matching.
+    add_link_options(LINKER:-exported_symbol,_get_hostfxr_path)
+endif()
+
 # CMake does not recommend using globbing since it messes with the freshness checks
 set(SOURCES
     nethost.cpp


### PR DESCRIPTION
There is an exception-handling issue on macOS when throwing and catching some standard C++ exceptions in a native C++ lib. The hosts (dotnet, apphost, corerun, nethost) get local copies of typeinfo for several of these exceptions and these copies are not hidden. When an external shared library is loaded, the linker resolves references to those typeinfo instances to the local copies in the host instead of the ones in the libc++. That results in failures matching these exception types in c++ catch.

The fix is to disable exporting symbols from these hosts (except for the _GetCurrentClrDetails from the nethost, which is needed)

Close #122445