### PR TITLE
Remove dead net9 code

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -392,7 +392,7 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="$(CommonPath)Polyfills\StopwatchPolyfills.cs" Link="Common\Polyfills\StopwatchPolyfills.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp' or $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '9.0'))">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <!-- Dependencies for System.Collections.Generic.OrderedDictionary -->
     <Compile Include="$(CoreLibSharedDir)System\Collections\HashHelpers.cs" Link="Common\System\Collections\HashHelpers.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Collections\Generic\DebugViewDictionaryItem.cs" Link="Common\System\Collections\Generic\DebugViewDictionaryItem.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.IDictionary.cs
@@ -58,12 +58,7 @@ namespace System.Text.Json.Nodes
             {
                 ThrowHelper.ThrowArgumentNullException(nameof(propertyName));
             }
-#if NET9_0
-            bool success = Dictionary.TryAdd(propertyName, value);
-            index = success ? Dictionary.Count - 1 : Dictionary.IndexOf(propertyName);
-#else
             bool success = Dictionary.TryAdd(propertyName, value, out index);
-#endif
             if (success)
             {
                 value?.AssignParent(this);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -142,19 +142,7 @@ namespace System.Text.Json.Nodes
         {
             ArgumentNullException.ThrowIfNull(propertyName);
 
-#if NET9_0
-            index = Dictionary.IndexOf(propertyName);
-            if (index < 0)
-            {
-                jsonNode = null;
-                return false;
-            }
-
-            jsonNode = Dictionary.GetAt(index).Value;
-            return true;
-#else
             return Dictionary.TryGetValue(propertyName, out jsonNode, out index);
-#endif
         }
 
         /// <inheritdoc/>
@@ -287,17 +275,8 @@ namespace System.Text.Json.Nodes
 
             OrderedDictionary<string, JsonNode?> dict = Dictionary;
 
-            if (
-#if NET9_0
-                !dict.TryAdd(propertyName, value)
-#else
-                !dict.TryAdd(propertyName, value, out int index)
-#endif
-                )
+            if (!dict.TryAdd(propertyName, value, out int index))
             {
-#if NET9_0
-                int index = dict.IndexOf(propertyName);
-#endif
                 Debug.Assert(index >= 0);
                 JsonNode? replacedValue = dict.GetAt(index).Value;
 


### PR DESCRIPTION
Since https://github.com/dotnet/runtime/pull/121853, `NetCoreAppMinimum` is net10. 