### PR TITLE
Remove unnecessary DisablePackageBaselineValidation from projects

### DIFF
--- a/docs/coding-guidelines/project-guidelines.md
+++ b/docs/coding-guidelines/project-guidelines.md
@@ -78,7 +78,7 @@ By default, packable project (mostly source projects) have APICompat package val
 This also includes _package baseline validation_ which automatically restores a previously produced package version (from the NuGet feeds) of the project and compares the public API to guard against breaking changes.
 
 When adding a brand new library, package baseline validation needs to be disabled temporarily as there's no previously produced package available yet. This should be done
-by setting the `DisablePackageBaselineValidation` property to true: https://github.com/dotnet/runtime/blob/634641c806b129bd6892e071aece3f4916ea519d/src/libraries/System.Linq.AsyncEnumerable/src/System.Linq.AsyncEnumerable.csproj#L14-L17
+by setting the `DisablePackageBaselineValidation` property to true.
 
 ## TargetFramework conditions
 `TargetFramework` conditions should be avoided in the first PropertyGroup as that causes DesignTimeBuild issues: https://github.com/dotnet/project-system/issues/6143

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System.Linq.AsyncEnumerable.csproj
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System.Linq.AsyncEnumerable.csproj
@@ -10,11 +10,6 @@
     <!-- Due to heavy use of callbacks, ConfigureAwait(false) should not be used.
          The callbacks should be allowed to run in the original context. -->
     <NoWarn>$(NoWarn);CA2007</NoWarn>
-
-    <!-- Disabling baseline validation since this is a brand new package.
-         Once this package has shipped a stable version, the following line
-         should be removed in order to re-enable validation. -->
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
+++ b/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
@@ -17,6 +17,7 @@
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <IsPackable>true</IsPackable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <!-- This template package uses a different PackageId per major version so we can't validate it against the baseline -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <!-- TODO: Add package readme -->
     <EnableDefaultPackageReadmeFile>false</EnableDefaultPackageReadmeFile>

--- a/src/tools/illink/src/linker/Mono.Linker.csproj
+++ b/src/tools/illink/src/linker/Mono.Linker.csproj
@@ -9,10 +9,6 @@
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
     <PackageId>Microsoft.NET.ILLink</PackageId>
-    <!-- Disabling baseline validation since this is a brand new package.
-       Once this package has shipped a stable version, the following line
-       should be removed in order to re-enable validation. -->
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <!-- There are currently no translations, so the satellite assemblies are a waste of space. -->
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NoWarn);CS8524</NoWarn>


### PR DESCRIPTION
- System.Linq.AsyncEnumerable already shipped a stable version
- Microsoft.NET.Runtime.WebAssembly.Templates can't be validated
- Mono.Linker doesn't actually ship and we already set DisablePackageBaselineValidation in that case in eng/packaging.targets