### PR TITLE
Don't throw from TensorPrimitives.Clamp when min is greater than max

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
+++ b/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
@@ -234,9 +234,6 @@
   <data name="Argument_CannotReshapeNonContiguousOrDense" xml:space="preserve">
     <value>The Tensor provided is either non-contiguous or non-dense. Reshape only works with contigous and dense memory. You may need to Broadcast or Copy the data to be contigous.</value>
   </data>
-  <data name="Argument_MinGreaterThanMax" xml:space="preserve">
-    <value>A minimum value may not be greater than a maximum value.</value>
-  </data>
   <data name="Arithmetic_NaN" xml:space="preserve">
     <value>Function does not accept floating point Not-a-Number values.</value>
   </data>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
@@ -21,6 +21,7 @@ namespace System.Numerics.Tensors
         /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <exception cref="ArgumentException"><paramref name="min"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <exception cref="ArgumentException"><paramref name="max"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
+        /// <exception cref="ArgumentException">An element-wise <paramref name="min" /> is greater than <paramref name="max" /> and <typeparamref name="T" /> is not a vectorizable type.</exception>
         /// <remarks>
         /// <para>
         /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />[i], <paramref name="min" />[i]), <paramref name="max" />[i])</c>.
@@ -49,6 +50,7 @@ namespace System.Numerics.Tensors
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <exception cref="ArgumentException"><paramref name="min"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
+        /// <exception cref="ArgumentException">An element-wise <paramref name="min" /> is greater than <paramref name="max" /> and <typeparamref name="T" /> is not a vectorizable type.</exception>
         /// <remarks>
         /// <para>
         /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />[i], <paramref name="min" />[i]), <paramref name="max" />)</c>.
@@ -77,6 +79,7 @@ namespace System.Numerics.Tensors
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <exception cref="ArgumentException"><paramref name="max"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
+        /// <exception cref="ArgumentException">An element-wise <paramref name="min" /> is greater than <paramref name="max" /> and <typeparamref name="T" /> is not a vectorizable type.</exception>
         /// <remarks>
         /// <para>
         /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />[i], <paramref name="min" />), <paramref name="max" />[i])</c>.
@@ -105,6 +108,7 @@ namespace System.Numerics.Tensors
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="min"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <exception cref="ArgumentException"><paramref name="max"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
+        /// <exception cref="ArgumentException">An element-wise <paramref name="min" /> is greater than <paramref name="max" /> and <typeparamref name="T" /> is not a vectorizable type.</exception>
         /// <remarks>
         /// <para>
         /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />, <paramref name="min" />[i]), <paramref name="max" />[i])</c>.
@@ -131,6 +135,7 @@ namespace System.Numerics.Tensors
         /// <param name="destination">The destination tensor, represented as a span.</param>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
+        /// <exception cref="ArgumentException"><paramref name="min" /> is greater than <paramref name="max" /> and <typeparamref name="T" /> is not a vectorizable type.</exception>
         /// <remarks>
         /// <para>
         /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />[i], <paramref name="min" />), <paramref name="max" />)</c>.
@@ -157,6 +162,7 @@ namespace System.Numerics.Tensors
         /// <param name="destination">The destination tensor, represented as a span.</param>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="min"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
+        /// <exception cref="ArgumentException">An element-wise <paramref name="min" /> is greater than <paramref name="max" /> and <typeparamref name="T" /> is not a vectorizable type.</exception>
         /// <remarks>
         /// <para>
         /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />, <paramref name="min" />[i]), <paramref name="max" />)</c>.
@@ -183,6 +189,7 @@ namespace System.Numerics.Tensors
         /// <param name="destination">The destination tensor, represented as a span.</param>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="max"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
+        /// <exception cref="ArgumentException">An element-wise <paramref name="min" /> is greater than <paramref name="max" /> and <typeparamref name="T" /> is not a vectorizable type.</exception>
         /// <remarks>
         /// <para>
         /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />, <paramref name="min" />), <paramref name="max" />[i])</c>.

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
@@ -205,9 +205,11 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
-            // Follows the same behavior as Vector128/256/512.Clamp, which do not validate that min <= max
-            // and instead compute Min(Max(x, min), max) (matching HLSL) when the bounds are unordered.
-            public static T Invoke(T x, T min, T max) => T.Min(T.Max(x, min), max);
+            // When T is vector accelerated, the scalar remainder must match the vectorized Vector128/256/512.Clamp
+            // path, which follows HLSL and computes Min(Max(x, min), max) without validating that min <= max. When T
+            // is not vector accelerated, every element flows through this scalar path, so we defer to T.Clamp, which
+            // throws when min > max.
+            public static T Invoke(T x, T min, T max) => Vector128<T>.IsSupported ? T.Min(T.Max(x, min), max) : T.Clamp(x, min, max);
 
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> min, Vector128<T> max) => Vector128.Clamp(x, min, max);
             public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> min, Vector256<T> max) => Vector256.Clamp(x, min, max);
@@ -220,7 +222,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
-            public static T Invoke(T min, T max, T x) => T.Min(T.Max(x, min), max);
+            public static T Invoke(T min, T max, T x) => Vector128<T>.IsSupported ? T.Min(T.Max(x, min), max) : T.Clamp(x, min, max);
 
             public static Vector128<T> Invoke(Vector128<T> min, Vector128<T> max, Vector128<T> x) => Vector128.Clamp(x, min, max);
             public static Vector256<T> Invoke(Vector256<T> min, Vector256<T> max, Vector256<T> x) => Vector256.Clamp(x, min, max);
@@ -233,7 +235,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
-            public static T Invoke(T max, T x, T min) => T.Min(T.Max(x, min), max);
+            public static T Invoke(T max, T x, T min) => Vector128<T>.IsSupported ? T.Min(T.Max(x, min), max) : T.Clamp(x, min, max);
 
             public static Vector128<T> Invoke(Vector128<T> max, Vector128<T> x, Vector128<T> min) => Vector128.Clamp(x, min, max);
             public static Vector256<T> Invoke(Vector256<T> max, Vector256<T> x, Vector256<T> min) => Vector256.Clamp(x, min, max);

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
@@ -212,11 +212,12 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
-            // When T is vector accelerated, the scalar remainder must match the vectorized Vector128/256/512.Clamp
-            // path, which follows HLSL and computes Min(Max(x, min), max) without validating that min <= max. When T
-            // is not vector accelerated, every element flows through this scalar path, so we defer to T.Clamp, which
-            // throws when min > max.
-            public static T Invoke(T x, T min, T max) => Vector128<T>.IsSupported ? T.Min(T.Max(x, min), max) : T.Clamp(x, min, max);
+            // When T is vectorizable, the scalar remainder must match the vectorized Vector128/256/512.Clamp path,
+            // which follows HLSL and computes Min(Max(x, min), max) without validating that min <= max. Half is also
+            // vectorizable here via the Half-as-Int16 path (see TryTernaryInvokeHalfAsInt16), so it uses the same
+            // formula to stay consistent regardless of length. Every other T flows entirely through this scalar path,
+            // so we defer to T.Clamp, which throws when min > max.
+            public static T Invoke(T x, T min, T max) => Vector128<T>.IsSupported || typeof(T) == typeof(Half) ? T.Min(T.Max(x, min), max) : T.Clamp(x, min, max);
 
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> min, Vector128<T> max) => Vector128.Clamp(x, min, max);
             public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> min, Vector256<T> max) => Vector256.Clamp(x, min, max);
@@ -229,7 +230,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
-            public static T Invoke(T min, T max, T x) => Vector128<T>.IsSupported ? T.Min(T.Max(x, min), max) : T.Clamp(x, min, max);
+            public static T Invoke(T min, T max, T x) => Vector128<T>.IsSupported || typeof(T) == typeof(Half) ? T.Min(T.Max(x, min), max) : T.Clamp(x, min, max);
 
             public static Vector128<T> Invoke(Vector128<T> min, Vector128<T> max, Vector128<T> x) => Vector128.Clamp(x, min, max);
             public static Vector256<T> Invoke(Vector256<T> min, Vector256<T> max, Vector256<T> x) => Vector256.Clamp(x, min, max);
@@ -242,7 +243,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
-            public static T Invoke(T max, T x, T min) => Vector128<T>.IsSupported ? T.Min(T.Max(x, min), max) : T.Clamp(x, min, max);
+            public static T Invoke(T max, T x, T min) => Vector128<T>.IsSupported || typeof(T) == typeof(Half) ? T.Min(T.Max(x, min), max) : T.Clamp(x, min, max);
 
             public static Vector128<T> Invoke(Vector128<T> max, Vector128<T> x, Vector128<T> min) => Vector128.Clamp(x, min, max);
             public static Vector256<T> Invoke(Vector256<T> max, Vector256<T> x, Vector256<T> min) => Vector256.Clamp(x, min, max);

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
@@ -16,7 +16,6 @@ namespace System.Numerics.Tensors
         /// <param name="min">The tensor of inclusive lower bounds, represented as a span.</param>
         /// <param name="max">The tensor of inclusive upper bounds, represented as a span.</param>
         /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">An element-wise <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
         /// <exception cref="ArgumentException">Length of <paramref name="x" /> must be same as length of <paramref name="min" /> and the length of <paramref name="max" />.</exception>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
@@ -24,7 +23,7 @@ namespace System.Numerics.Tensors
         /// <exception cref="ArgumentException"><paramref name="max"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <remarks>
         /// <para>
-        /// This method effectively computes <c><paramref name="destination" />[i] = T.Clamp(<paramref name="x" />[i], <paramref name="min" />[i], <paramref name="max" />[i])</c>.
+        /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />[i], <paramref name="min" />[i]), <paramref name="max" />[i])</c>.
         /// </para>
         /// </remarks>
         public static void Clamp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> min, ReadOnlySpan<T> max, Span<T> destination)
@@ -46,14 +45,13 @@ namespace System.Numerics.Tensors
         /// <param name="min">The tensor of inclusive lower bounds, represented as a span.</param>
         /// <param name="max">The tensor of inclusive upper bounds, represented as a scalar.</param>
         /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">An element-wise <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
         /// <exception cref="ArgumentException">Length of <paramref name="x" /> must be same as length of <paramref name="min" />.</exception>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <exception cref="ArgumentException"><paramref name="min"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <remarks>
         /// <para>
-        /// This method effectively computes <c><paramref name="destination" />[i] = T.Clamp(<paramref name="x" />[i], <paramref name="min" />[i], <paramref name="max" />)</c>.
+        /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />[i], <paramref name="min" />[i]), <paramref name="max" />)</c>.
         /// </para>
         /// </remarks>
         public static void Clamp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> min, T max, Span<T> destination)
@@ -75,14 +73,13 @@ namespace System.Numerics.Tensors
         /// <param name="min">The tensor of inclusive lower bounds, represented as a scalar.</param>
         /// <param name="max">The tensor of inclusive upper bounds, represented as a span.</param>
         /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">An element-wise <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
         /// <exception cref="ArgumentException">Length of <paramref name="x" /> must be same as length of <paramref name="max" />.</exception>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <exception cref="ArgumentException"><paramref name="max"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <remarks>
         /// <para>
-        /// This method effectively computes <c><paramref name="destination" />[i] = T.Clamp(<paramref name="x" />[i], <paramref name="min" />, <paramref name="max" />[i])</c>.
+        /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />[i], <paramref name="min" />), <paramref name="max" />[i])</c>.
         /// </para>
         /// </remarks>
         public static void Clamp<T>(ReadOnlySpan<T> x, T min, ReadOnlySpan<T> max, Span<T> destination)
@@ -104,14 +101,13 @@ namespace System.Numerics.Tensors
         /// <param name="min">The tensor of inclusive lower bounds, represented as a span.</param>
         /// <param name="max">The tensor of inclusive upper bounds, represented as a span.</param>
         /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">An element-wise <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
         /// <exception cref="ArgumentException">Length of <paramref name="min" /> must be same as length of <paramref name="max" />.</exception>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="min"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <exception cref="ArgumentException"><paramref name="max"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <remarks>
         /// <para>
-        /// This method effectively computes <c><paramref name="destination" />[i] = T.Clamp(<paramref name="x" />, <paramref name="min" />[i], <paramref name="max" />[i])</c>.
+        /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />, <paramref name="min" />[i]), <paramref name="max" />[i])</c>.
         /// </para>
         /// </remarks>
         public static void Clamp<T>(T x, ReadOnlySpan<T> min, ReadOnlySpan<T> max, Span<T> destination)
@@ -133,22 +129,16 @@ namespace System.Numerics.Tensors
         /// <param name="min">The tensor of inclusive lower bounds, represented as a scalar.</param>
         /// <param name="max">The tensor of inclusive upper bounds, represented as a scalar.</param>
         /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException"><paramref name="min"/> is greater than <paramref name="max"/>.</exception>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <remarks>
         /// <para>
-        /// This method effectively computes <c><paramref name="destination" />[i] = T.Clamp(<paramref name="x" />[i], <paramref name="min" />, <paramref name="max" />)</c>.
+        /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />[i], <paramref name="min" />), <paramref name="max" />)</c>.
         /// </para>
         /// </remarks>
         public static void Clamp<T>(ReadOnlySpan<T> x, T min, T max, Span<T> destination)
             where T : INumber<T>
         {
-            if (min > max)
-            {
-                ThrowHelper.ThrowArgument_MinGreaterThanMax();
-            }
-
             if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
             {
                 return;
@@ -165,12 +155,11 @@ namespace System.Numerics.Tensors
         /// <param name="min">The tensor of inclusive lower bounds, represented as a span.</param>
         /// <param name="max">The tensor of inclusive upper bounds, represented as a scalar.</param>
         /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">An element-wise <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="min"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <remarks>
         /// <para>
-        /// This method effectively computes <c><paramref name="destination" />[i] = T.Clamp(<paramref name="x" />, <paramref name="min" />[i], <paramref name="max" />)</c>.
+        /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />, <paramref name="min" />[i]), <paramref name="max" />)</c>.
         /// </para>
         /// </remarks>
         public static void Clamp<T>(T x, ReadOnlySpan<T> min, T max, Span<T> destination)
@@ -192,12 +181,11 @@ namespace System.Numerics.Tensors
         /// <param name="min">The tensor of inclusive lower bounds, represented as a scalar.</param>
         /// <param name="max">The tensor of inclusive upper bounds, represented as a span.</param>
         /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">An element-wise <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <exception cref="ArgumentException"><paramref name="max"/> and <paramref name="destination"/> reference overlapping memory locations and do not begin at the same location.</exception>
         /// <remarks>
         /// <para>
-        /// This method effectively computes <c><paramref name="destination" />[i] = T.Clamp(<paramref name="x" />, <paramref name="min" />, <paramref name="max" />[i])</c>.
+        /// This method effectively computes <c><paramref name="destination" />[i] = <typeparamref name="T" />.Min(<typeparamref name="T" />.Max(<paramref name="x" />, <paramref name="min" />), <paramref name="max" />[i])</c>.
         /// </para>
         /// </remarks>
         public static void Clamp<T>(T x, T min, ReadOnlySpan<T> max, Span<T> destination)
@@ -211,40 +199,41 @@ namespace System.Numerics.Tensors
             InvokeSpanScalarScalarIntoSpan<T, ClampOperatorMaxXMin<T>>(max, x, min, destination);
         }
 
-        /// <summary>T.Clamp(x, min, max)</summary>
+        /// <summary>Min(Max(x, min), max)</summary>
         internal readonly struct ClampOperatorXMinMax<T> : ITernaryOperator<T>
             where T : INumber<T>
         {
             public static bool Vectorizable => true;
 
-            public static T Invoke(T x, T min, T max) => T.Clamp(x, min, max);
+            // Follows the same behavior as Vector128/256/512.Clamp, which do not validate that min <= max
+            // and instead compute Min(Max(x, min), max) (matching HLSL) when the bounds are unordered.
+            public static T Invoke(T x, T min, T max) => T.Min(T.Max(x, min), max);
 
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> min, Vector128<T> max) => Vector128.Clamp(x, min, max);
             public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> min, Vector256<T> max) => Vector256.Clamp(x, min, max);
             public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> min, Vector512<T> max) => Vector512.Clamp(x, min, max);
         }
 
-        /// <summary>T.Clamp(min, max, x)</summary>
+        /// <summary>Min(Max(x, min), max)</summary>
         internal readonly struct ClampOperatorMinMaxX<T> : ITernaryOperator<T>
             where T : INumber<T>
         {
             public static bool Vectorizable => true;
 
-            public static T Invoke(T min, T max, T x) => T.Clamp(x, min, max);
+            public static T Invoke(T min, T max, T x) => T.Min(T.Max(x, min), max);
 
             public static Vector128<T> Invoke(Vector128<T> min, Vector128<T> max, Vector128<T> x) => Vector128.Clamp(x, min, max);
             public static Vector256<T> Invoke(Vector256<T> min, Vector256<T> max, Vector256<T> x) => Vector256.Clamp(x, min, max);
             public static Vector512<T> Invoke(Vector512<T> min, Vector512<T> max, Vector512<T> x) => Vector512.Clamp(x, min, max);
         }
 
-        /// <summary>T.Clamp(max, x, min)</summary>
+        /// <summary>Min(Max(x, min), max)</summary>
         internal readonly struct ClampOperatorMaxXMin<T> : ITernaryOperator<T>
             where T : INumber<T>
         {
             public static bool Vectorizable => true;
 
-            public static T Invoke(T max, T x, T min) => T.Clamp(x, min, max);
-
+            public static T Invoke(T max, T x, T min) => T.Min(T.Max(x, min), max);
 
             public static Vector128<T> Invoke(Vector128<T> max, Vector128<T> x, Vector128<T> min) => Vector128.Clamp(x, min, max);
             public static Vector256<T> Invoke(Vector256<T> max, Vector256<T> x, Vector256<T> min) => Vector256.Clamp(x, min, max);

--- a/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
@@ -261,12 +261,6 @@ namespace System
         }
 
         [DoesNotReturn]
-        internal static void ThrowArgument_MinGreaterThanMax()
-        {
-            throw new ArgumentException(SR.Argument_MinGreaterThanMax);
-        }
-
-        [DoesNotReturn]
         internal static void ThrowArithmetic_NaN()
         {
             throw new ArithmeticException(SR.Arithmetic_NaN);

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -2753,6 +2753,228 @@ namespace System.Numerics.Tensors.Tests
             Helpers.AssertEqualWithTolerance(expected, actual, tolerance);
         }
 
+        public static IEnumerable<object[]> Clamp_UnorderedBounds_Lengths()
+        {
+            // Small lengths (below the vector width) go through the scalar code path, while larger lengths
+            // (a whole multiple of every supported vector width) go through the vectorized path. Both must
+            // produce identical, non-throwing Min(Max(x, min), max) results even when min > max, matching
+            // the behavior of Vector128/256/512.Clamp (which follow HLSL and do not validate min <= max).
+            foreach (int length in new[] { 1, 2, 3, 8, 128 })
+            {
+                yield return new object[] { length };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Clamp_UnorderedBounds_Lengths))]
+        public void Clamp_UnorderedBoundsMatchScalarSemantics(int length)
+        {
+            static T Reference(T x, T min, T max) => T.Min(T.Max(x, min), max);
+
+            T zero = T.Zero;
+            T one = T.One;
+            T two = one + one;
+
+            T[] x = new T[length];
+            for (int i = 0; i < length; i++)
+            {
+                x[i] = T.CreateTruncating(i % 3);
+            }
+
+            T[] destination = new T[length];
+            T[] expected = new T[length];
+
+            foreach (int offendingIndex in new[] { 0, length - 1 })
+            {
+                // Span x, span min, span max
+                {
+                    T[] min = new T[length];
+                    T[] max = new T[length];
+                    Array.Fill(min, zero);
+                    Array.Fill(max, two);
+                    min[offendingIndex] = two;
+                    max[offendingIndex] = zero;
+
+                    TensorPrimitives.Clamp<T>(x, min, max, destination);
+                    for (int i = 0; i < length; i++)
+                    {
+                        expected[i] = Reference(x[i], min[i], max[i]);
+                    }
+                    AssertEqualsSequences(expected, destination);
+                }
+
+                // Span x, span min, scalar max
+                {
+                    T[] min = new T[length];
+                    Array.Fill(min, zero);
+                    min[offendingIndex] = two;
+
+                    TensorPrimitives.Clamp<T>(x, min, one, destination);
+                    for (int i = 0; i < length; i++)
+                    {
+                        expected[i] = Reference(x[i], min[i], one);
+                    }
+                    AssertEqualsSequences(expected, destination);
+                }
+
+                // Span x, scalar min, span max
+                {
+                    T[] max = new T[length];
+                    Array.Fill(max, two);
+                    max[offendingIndex] = zero;
+
+                    TensorPrimitives.Clamp<T>(x, one, max, destination);
+                    for (int i = 0; i < length; i++)
+                    {
+                        expected[i] = Reference(x[i], one, max[i]);
+                    }
+                    AssertEqualsSequences(expected, destination);
+                }
+
+                // Span x, scalar min, scalar max (min > max)
+                {
+                    TensorPrimitives.Clamp<T>(x, two, zero, destination);
+                    for (int i = 0; i < length; i++)
+                    {
+                        expected[i] = Reference(x[i], two, zero);
+                    }
+                    AssertEqualsSequences(expected, destination);
+                }
+
+                // Scalar x, span min, span max
+                {
+                    T[] min = new T[length];
+                    T[] max = new T[length];
+                    Array.Fill(min, zero);
+                    Array.Fill(max, two);
+                    min[offendingIndex] = two;
+                    max[offendingIndex] = zero;
+
+                    TensorPrimitives.Clamp<T>(one, min, max, destination);
+                    for (int i = 0; i < length; i++)
+                    {
+                        expected[i] = Reference(one, min[i], max[i]);
+                    }
+                    AssertEqualsSequences(expected, destination);
+                }
+
+                // Scalar x, span min, scalar max
+                {
+                    T[] min = new T[length];
+                    Array.Fill(min, zero);
+                    min[offendingIndex] = two;
+
+                    TensorPrimitives.Clamp<T>(one, min, one, destination);
+                    for (int i = 0; i < length; i++)
+                    {
+                        expected[i] = Reference(one, min[i], one);
+                    }
+                    AssertEqualsSequences(expected, destination);
+                }
+
+                // Scalar x, scalar min, span max
+                {
+                    T[] max = new T[length];
+                    Array.Fill(max, two);
+                    max[offendingIndex] = zero;
+
+                    TensorPrimitives.Clamp<T>(one, one, max, destination);
+                    for (int i = 0; i < length; i++)
+                    {
+                        expected[i] = Reference(one, one, max[i]);
+                    }
+                    AssertEqualsSequences(expected, destination);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Clamp_UnorderedBounds_Lengths))]
+        public void Clamp_SpecialValuesMatchScalarSemantics(int length)
+        {
+            // NaN and signed zeros are the exact class of values where a scalar-vs-vector mismatch would
+            // hide, so verify both code paths agree with the scalar Min(Max(x, min), max) formula for them.
+            if (!IsFloatingPoint)
+            {
+                return;
+            }
+
+            static T Reference(T x, T min, T max) => T.Min(T.Max(x, min), max);
+
+            static void AssertMatches(T[] expected, T[] actual)
+            {
+                Assert.Equal(expected.Length, actual.Length);
+                for (int i = 0; i < expected.Length; i++)
+                {
+                    // Assert.Equal treats NaN == NaN as equal but also treats +0.0 == -0.0 as equal, so the
+                    // sign of zero is pinned separately via IsNegative (skipped for NaN, whose sign bit may
+                    // legitimately differ between the paths).
+                    Assert.Equal(expected[i], actual[i]);
+                    if (!T.IsNaN(expected[i]))
+                    {
+                        Assert.Equal(T.IsNegative(expected[i]), T.IsNegative(actual[i]));
+                    }
+                }
+            }
+
+            T nan = T.CreateTruncating(float.NaN);
+            T negativeZero = NegativeZero;
+            T positiveZero = T.Zero;
+            T one = T.One;
+            T negativeOne = -one;
+            T two = one + one;
+
+            T[] pool = { nan, negativeZero, positiveZero, one, negativeOne, two };
+
+            T[] x = new T[length];
+            T[] min = new T[length];
+            T[] max = new T[length];
+            T[] destination = new T[length];
+            T[] expected = new T[length];
+
+            // Tile the pool across x/min/max at different phases so NaN, signed zeros, and unordered
+            // (min > max) bounds all appear in both the scalar and vectorized regions.
+            for (int i = 0; i < length; i++)
+            {
+                x[i] = pool[i % pool.Length];
+                min[i] = pool[(i + 2) % pool.Length];
+                max[i] = pool[(i + 4) % pool.Length];
+            }
+
+            // Span x, span min, span max
+            TensorPrimitives.Clamp<T>(x, min, max, destination);
+            for (int i = 0; i < length; i++)
+            {
+                expected[i] = Reference(x[i], min[i], max[i]);
+            }
+            AssertMatches(expected, destination);
+
+            // Span x, scalar min, scalar max (min > max, both special)
+            TensorPrimitives.Clamp<T>(x, positiveZero, negativeZero, destination);
+            for (int i = 0; i < length; i++)
+            {
+                expected[i] = Reference(x[i], positiveZero, negativeZero);
+            }
+            AssertMatches(expected, destination);
+
+            // Scalar x (NaN), span min, span max
+            TensorPrimitives.Clamp<T>(nan, min, max, destination);
+            for (int i = 0; i < length; i++)
+            {
+                expected[i] = Reference(nan, min[i], max[i]);
+            }
+            AssertMatches(expected, destination);
+        }
+
+        private static void AssertEqualsSequences(T[] expected, T[] actual)
+        {
+            Assert.Equal(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], actual[i]);
+            }
+        }
+
         protected override T Cosh(T x) => throw new NotSupportedException();
         protected override void Cosh(ReadOnlySpan<T> x, Span<T> destination) => throw new NotSupportedException();
         protected override T CosineSimilarity(ReadOnlySpan<T> x, ReadOnlySpan<T> y) => throw new NotSupportedException();

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -2949,7 +2949,7 @@ namespace System.Numerics.Tensors.Tests
             }
             AssertMatches(expected, destination);
 
-            // Span x, scalar min, scalar max (min > max, both special)
+            // Span x, scalar min, scalar max (signed-zero bounds; +0 and -0 compare equal, so this isn't an unordered-bounds case)
             TensorPrimitives.Clamp<T>(x, positiveZero, negativeZero, destination);
             for (int i = 0; i < length; i++)
             {

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 using Xunit;
@@ -2769,6 +2770,15 @@ namespace System.Numerics.Tensors.Tests
         [MemberData(nameof(Clamp_UnorderedBounds_Lengths))]
         public void Clamp_UnorderedBoundsMatchScalarSemantics(int length)
         {
+            // Only vector-accelerated types are guaranteed not to throw on unordered bounds: the scalar
+            // remainder must agree with the vectorized region. Types without vector acceleration run
+            // entirely through the scalar path and defer to T.Clamp (which throws when min > max); that
+            // behavior is covered by Clamp_UnorderedScalarBounds_ThrowsWhenNotVectorAccelerated.
+            if (!Vector128<T>.IsSupported)
+            {
+                return;
+            }
+
             static T Reference(T x, T min, T max) => T.Min(T.Max(x, min), max);
 
             T zero = T.Zero;
@@ -2894,7 +2904,10 @@ namespace System.Numerics.Tensors.Tests
         {
             // NaN and signed zeros are the exact class of values where a scalar-vs-vector mismatch would
             // hide, so verify both code paths agree with the scalar Min(Max(x, min), max) formula for them.
-            if (!IsFloatingPoint)
+            // This parity only applies to vector-accelerated floating-point types; the others (e.g. Half,
+            // NFloat) run entirely through the scalar path and defer to T.Clamp, which throws on the
+            // unordered bounds that this test's tiled pool intentionally produces.
+            if (!IsFloatingPoint || !Vector128<T>.IsSupported)
             {
                 return;
             }
@@ -2964,6 +2977,29 @@ namespace System.Numerics.Tensors.Tests
                 expected[i] = Reference(nan, min[i], max[i]);
             }
             AssertMatches(expected, destination);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Clamp_UnorderedScalarBounds_ThrowsWhenNotVectorAccelerated(int length)
+        {
+            // Types without vector acceleration flow entirely through the scalar path, which defers to
+            // T.Clamp and therefore throws when min > max. The lengths here stay below every vectorized
+            // threshold (including the Half-as-Int16 reinterpret path) so no element is silently clamped.
+            if (Vector128<T>.IsSupported)
+            {
+                return;
+            }
+
+            T zero = T.Zero;
+            T two = T.One + T.One;
+
+            T[] x = new T[length];
+            T[] destination = new T[length];
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Clamp<T>(x, two, zero, destination));
         }
 
         private static void AssertEqualsSequences(T[] expected, T[] actual)

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -2725,6 +2725,11 @@ namespace System.Numerics.Tensors.Tests
         protected override T ConvertFromSingle(float f) => T.CreateTruncating(f);
         protected override bool IsFloatingPoint => typeof(T) == typeof(Half) || base.IsFloatingPoint;
 
+        // TensorPrimitives vectorizes Clamp for every Vector128<T>-supported type, plus Half via its
+        // Half-as-Int16 path, so those types follow the non-throwing Min(Max(x, min), max) semantics while
+        // every other T defers to T.Clamp (which throws on unordered bounds).
+        private static bool IsClampVectorized => Vector128<T>.IsSupported || typeof(T) == typeof(Half);
+
         protected override T NextRandom()
         {
             T value = default;
@@ -2757,10 +2762,11 @@ namespace System.Numerics.Tensors.Tests
         public static IEnumerable<object[]> Clamp_UnorderedBounds_Lengths()
         {
             // These lengths intentionally span the scalar-only, scalar-remainder, and fully vectorized regions
-            // of the implementation. All of them must produce identical, non-throwing Min(Max(x, min), max)
-            // results even when min > max, matching the behavior of Vector128/256/512.Clamp (which follow HLSL
-            // and do not validate min <= max).
-            foreach (int length in new[] { 1, 2, 3, 8, 128 })
+            // of the implementation. 129 in particular forces a non-zero scalar remainder after the vectorized
+            // loop for every supported vector width. All of them must produce identical, non-throwing
+            // Min(Max(x, min), max) results even when min > max, matching the behavior of Vector128/256/512.Clamp
+            // (which follow HLSL and do not validate min <= max).
+            foreach (int length in new[] { 1, 2, 3, 8, 128, 129 })
             {
                 yield return new object[] { length };
             }
@@ -2770,11 +2776,11 @@ namespace System.Numerics.Tensors.Tests
         [MemberData(nameof(Clamp_UnorderedBounds_Lengths))]
         public void Clamp_UnorderedBoundsMatchScalarSemantics(int length)
         {
-            // Only vector-accelerated types are guaranteed not to throw on unordered bounds: the scalar
-            // remainder must agree with the vectorized region. Types without vector acceleration run
-            // entirely through the scalar path and defer to T.Clamp (which throws when min > max); that
-            // behavior is covered by Clamp_UnorderedScalarBounds_ThrowsWhenNotVectorAccelerated.
-            if (!Vector128<T>.IsSupported)
+            // Only vectorizable types are guaranteed not to throw on unordered bounds: the scalar remainder must
+            // agree with the vectorized region. Types that aren't vectorized run entirely through the scalar path
+            // and defer to T.Clamp (which throws when min > max); that behavior is covered by
+            // Clamp_UnorderedScalarBounds_ThrowsWhenNotVectorAccelerated.
+            if (!IsClampVectorized)
             {
                 return;
             }
@@ -2904,10 +2910,10 @@ namespace System.Numerics.Tensors.Tests
         {
             // NaN and signed zeros are the exact class of values where a scalar-vs-vector mismatch would
             // hide, so verify both code paths agree with the scalar Min(Max(x, min), max) formula for them.
-            // This parity only applies to vector-accelerated floating-point types; the rest are skipped
-            // because they defer to T.Clamp, which throws on the unordered bounds this test's tiled pool
+            // This parity only applies to vectorizable floating-point types; the rest are skipped because
+            // they defer to T.Clamp, which throws on the unordered bounds this test's tiled pool
             // intentionally produces.
-            if (!IsFloatingPoint || !Vector128<T>.IsSupported)
+            if (!IsFloatingPoint || !IsClampVectorized)
             {
                 return;
             }
@@ -2985,10 +2991,10 @@ namespace System.Numerics.Tensors.Tests
         [InlineData(3)]
         public void Clamp_UnorderedScalarBounds_ThrowsWhenNotVectorAccelerated(int length)
         {
-            // Types without vector acceleration flow entirely through the scalar path, which defers to
-            // T.Clamp and therefore throws when min > max. The lengths here stay below every vectorized
-            // threshold (including the Half-as-Int16 reinterpret path) so no element is silently clamped.
-            if (Vector128<T>.IsSupported)
+            // Types that aren't vectorized flow entirely through the scalar path, which defers to T.Clamp and
+            // therefore throws when min > max. Vectorizable types (including Half via its Half-as-Int16 path)
+            // never throw, so they're excluded here and covered by Clamp_UnorderedBoundsMatchScalarSemantics.
+            if (IsClampVectorized)
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -2756,10 +2756,10 @@ namespace System.Numerics.Tensors.Tests
 
         public static IEnumerable<object[]> Clamp_UnorderedBounds_Lengths()
         {
-            // Small lengths (below the vector width) go through the scalar code path, while larger lengths
-            // (a whole multiple of every supported vector width) go through the vectorized path. Both must
-            // produce identical, non-throwing Min(Max(x, min), max) results even when min > max, matching
-            // the behavior of Vector128/256/512.Clamp (which follow HLSL and do not validate min <= max).
+            // These lengths intentionally span the scalar-only, scalar-remainder, and fully vectorized regions
+            // of the implementation. All of them must produce identical, non-throwing Min(Max(x, min), max)
+            // results even when min > max, matching the behavior of Vector128/256/512.Clamp (which follow HLSL
+            // and do not validate min <= max).
             foreach (int length in new[] { 1, 2, 3, 8, 128 })
             {
                 yield return new object[] { length };
@@ -2904,9 +2904,9 @@ namespace System.Numerics.Tensors.Tests
         {
             // NaN and signed zeros are the exact class of values where a scalar-vs-vector mismatch would
             // hide, so verify both code paths agree with the scalar Min(Max(x, min), max) formula for them.
-            // This parity only applies to vector-accelerated floating-point types; the others (e.g. Half,
-            // NFloat) run entirely through the scalar path and defer to T.Clamp, which throws on the
-            // unordered bounds that this test's tiled pool intentionally produces.
+            // This parity only applies to vector-accelerated floating-point types; the rest are skipped
+            // because they defer to T.Clamp, which throws on the unordered bounds this test's tiled pool
+            // intentionally produces.
             if (!IsFloatingPoint || !Vector128<T>.IsSupported)
             {
                 return;


### PR DESCRIPTION
The span-based `TensorPrimitives.Clamp` overloads dispatch to the `ClampOperator*` structs whose scalar `Invoke` calls `T.Clamp`, which throws `ArgumentException` when `min > max`, while the `Vector128/256/512` `Invoke` paths call `Vector*.Clamp`, which follow HLSL and compute `Min(Max(x, min), max)` without validation.

This made behavior position-dependent for the span-min/span-max overloads: an unordered `min[i] > max[i]` pair threw when it landed in the scalar remainder but was silently clamped when it landed in the vectorized region. The `Clamp(ReadOnlySpan<T> x, T min, T max, ...)` overload additionally validated `min <= max` up front and threw before dispatch.

----------

Align the scalar path with the vector path by computing `Min(Max(x, min), max)` in the scalar `Invoke` and removing the up-front validation, so `Clamp` succeeds for unordered bounds regardless of element position, matching `Vector.Clamp`. `T.Min(T.Max(x, min), max)` is exactly `T.Clamp` minus the throw, and (via IEEE `Min`/`Max`) agrees with the vector path on `NaN` and signed zeros by construction.

Also removes the now-unused `ThrowArgument_MinGreaterThanMax` helper and its resource string, and updates the doc comments.

**Tests:** adds `Clamp_UnorderedBoundsMatchScalarSemantics` and `Clamp_SpecialValuesMatchScalarSemantics` to `GenericNumberTensorPrimitivesTests<T>`, exercising both the scalar (sub-vector lengths) and vectorized (length 128) paths across all affected overloads/operand orderings and types, including `NaN` and signed-zero parity between the two paths for the floating-point types.

----------

> [!NOTE]
> This is a documented-behavior change: the previously documented `ArgumentException` on `min > max` is removed, so it warrants breaking-change consideration.

> [!NOTE]
> This PR was authored with GitHub Copilot.
