### PR TITLE
Ensure GenAPI can resolve implementation-only assemblies when regenerating ref source

### DIFF
--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -188,12 +188,18 @@
        affects GenAPI's resolution, not the compilation reference set. -->
   <Target Name="AddImplementationAssembliesToGenAPIResolutionPath"
           AfterTargets="ResolveAssemblyReferences"
-          Condition="'$(RuntimeFlavor)' != 'Mono' and '$(GenAPILibPath)' == '' and Exists('$(CoreCLRArtifactsPath)System.Private.CoreLib.dll')">
+          Condition="'$(RuntimeFlavor)' != 'Mono' and '$(GenAPILibPath)' == '' and (Exists('$(CoreCLRArtifactsPath)System.Private.CoreLib.dll') or Exists('$(CoreCLRArtifactsPath)IL/System.Private.CoreLib.dll'))">
+    <PropertyGroup>
+      <!-- CoreLib normally sits directly under CoreCLRArtifactsPath, but a crossgen'd build places the IL (metadata)
+           copy GenAPI needs under an 'IL' subdirectory, matching the fallback in liveBuilds.targets. -->
+      <_genAPICoreLibDir Condition="Exists('$(CoreCLRArtifactsPath)System.Private.CoreLib.dll')">$(CoreCLRArtifactsPath)</_genAPICoreLibDir>
+      <_genAPICoreLibDir Condition="'$(_genAPICoreLibDir)' == '' and Exists('$(CoreCLRArtifactsPath)IL/System.Private.CoreLib.dll')">$(CoreCLRArtifactsPath)IL/</_genAPICoreLibDir>
+    </PropertyGroup>
     <ItemGroup>
       <_genAPIReferencePathDirectory Include="@(ReferencePath->'%(RootDir)%(Directory)'->Distinct())" />
     </ItemGroup>
     <PropertyGroup>
-      <GenAPILibPath>@(_genAPIReferencePathDirectory);$(CoreCLRArtifactsPath);$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</GenAPILibPath>
+      <GenAPILibPath>@(_genAPIReferencePathDirectory);$(_genAPICoreLibDir);$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</GenAPILibPath>
     </PropertyGroup>
   </Target>
 

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -177,5 +177,25 @@
     </PropertyGroup>
   </Target>
 
+  <!-- Core types such as enums (e.g. System.AttributeTargets), the 'init' accessor marker (System.Runtime.CompilerServices.IsExternalInit),
+       the System.Enum generic constraint and System.Decimal are defined in the runtime implementation assemblies (System.Private.CoreLib
+       and the shared framework, e.g. System.Private.Uri) and merely type-forwarded by the reference facades. Those implementation
+       assemblies are never part of a reference pack, so they aren't on the assembly resolution path that GenAPI derives from ReferencePath.
+       Without them GenAPI can't resolve those types and silently degrades its output (emitting raw enum integers like
+       'EditorBrowsableAttribute(1)', turning 'init' accessors into 'set', dropping the 'System.Enum' constraint and rendering 'decimal' as
+       'System.Decimal'), which is the source of most of the manual fixups the reference sources have accumulated. Seed GenAPILibPath with
+       the ReferencePath directories plus the CoreLib and shared framework directories so the generated source is faithful. This only
+       affects GenAPI's resolution, not the compilation reference set. -->
+  <Target Name="AddImplementationAssembliesToGenAPIResolutionPath"
+          AfterTargets="ResolveAssemblyReferences"
+          Condition="'$(RuntimeFlavor)' != 'Mono' and '$(GenAPILibPath)' == '' and Exists('$(CoreCLRArtifactsPath)System.Private.CoreLib.dll')">
+    <ItemGroup>
+      <_genAPIReferencePathDirectory Include="@(ReferencePath->'%(RootDir)%(Directory)'->Distinct())" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenAPILibPath>@(_genAPIReferencePathDirectory);$(CoreCLRArtifactsPath);$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</GenAPILibPath>
+    </PropertyGroup>
+  </Target>
+
   <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
 </Project>


### PR DESCRIPTION
﻿When regenerating reference source via `GenerateReferenceAssemblySource`, GenAPI was unable to resolve the runtime implementation assemblies (`System.Private.CoreLib` and the shared framework, e.g. `System.Private.Uri`). These are implementation-only and never part of a reference pack, so they aren't on the assembly resolution path GenAPI derives from `ReferencePath`. Many core types -- enums (e.g. `System.AttributeTargets`), the `init` accessor marker (`IsExternalInit`), the `System.Enum` generic constraint, and `System.Decimal` -- are defined there and merely type-forwarded by the reference facades.

Without those assemblies GenAPI silently degrades its output:

- enums emitted as raw integers, e.g. `EditorBrowsableAttribute(1)`, `AttributeUsageAttribute(32)`, `DynamicallyAccessedMembersAttribute(1)`
- `init` accessors turned into `set`
- `where T : System.Enum` constraint dropped to `where T : struct`
- `decimal` rendered as `System.Decimal`

This is the source of most of the manual fixups the reference sources have accumulated, and it makes `GenerateReferenceAssemblySource` produce output that then has to be hand-corrected -- defeating the point of the tool.

This seeds `GenAPILibPath` (GenAPI's own resolution path, distinct from the compilation reference set) with the `ReferencePath` directories plus the CoreLib and shared framework directories, so the regenerated source is faithful. The target fires `AfterTargets="ResolveAssemblyReferences"` so `ReferencePath` is populated and it stays deterministic under parallel (`/m`) builds; it never runs on the cross-targeting outer build and doesn't touch the compile reference set.

Verified against `System.Text.Json` and `Microsoft.Extensions.Hosting.Abstractions`: enum-as-int, `init`->`set`, `DynamicallyAccessedMembers`-as-int and all "Unable to resolve assembly" warnings drop to `0`.

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot.
