### PR TITLE
Skip null elements in [ValidateEnumeratedItems] validation

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.Async.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.Async.cs
@@ -139,11 +139,16 @@ namespace Microsoft.Extensions.Options
                     visited.Add(options);
 
                     int index = 0;
-                    foreach (object item in enumerable)
+                    foreach (object? item in enumerable)
                     {
-                        bool innerRes;
-                        (innerRes, errors) = await TryValidateOptionsAsync(item, $"{qualifiedName}.{propertyInfo.Name}[{index++}]", results, errors, visited, cancellationToken).ConfigureAwait(false);
-                        res = innerRes && res;
+                        if (item is not null)
+                        {
+                            bool innerRes;
+                            (innerRes, errors) = await TryValidateOptionsAsync(item, $"{qualifiedName}.{propertyInfo.Name}[{index}]", results, errors, visited, cancellationToken).ConfigureAwait(false);
+                            res = innerRes && res;
+                        }
+
+                        index++;
                     }
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.cs
@@ -131,9 +131,14 @@ namespace Microsoft.Extensions.Options
                     results ??= new List<ValidationResult>();
 
                     int index = 0;
-                    foreach (object item in enumerable)
+                    foreach (object? item in enumerable)
                     {
-                        res = TryValidateOptions(item, $"{qualifiedName}.{propertyInfo.Name}[{index++}]", results, ref errors, ref visited) && res;
+                        if (item is not null)
+                        {
+                            res = TryValidateOptions(item, $"{qualifiedName}.{propertyInfo.Name}[{index}]", results, ref errors, ref visited) && res;
+                        }
+
+                        index++;
                     }
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
@@ -1203,6 +1203,26 @@ namespace Microsoft.Extensions.Options.Tests
             ValidateOptionsResult result = await validator.ValidateAsync(Options.DefaultName, options);
             Assert.True(result.Succeeded);
         }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_ReportsInvalidItemAfterNullElement()
+        {
+            var options = new ParentWithEnumeratedItems
+            {
+                Items = new List<EnumeratedChildOptions?>
+                {
+                    new() { Name = "first" },
+                    null,
+                    new() { Name = null },
+                }
+            };
+
+            var validator = new DataAnnotationValidateOptions<ParentWithEnumeratedItems>(Options.DefaultName);
+            ValidateOptionsResult result = await validator.ValidateAsync(Options.DefaultName, options);
+            Assert.True(result.Failed);
+            Assert.Contains("ParentWithEnumeratedItems.Items[2]", result.FailureMessage);
+            Assert.DoesNotContain("[1]", result.FailureMessage);
+        }
 #endif // NET11_0_OR_GREATER
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
@@ -904,6 +904,56 @@ namespace Microsoft.Extensions.Options.Tests
             Assert.NotNull(unvalidated);
         }
 
+        private class EnumeratedChildOptions
+        {
+            [Required]
+            public string? Name { get; set; }
+        }
+
+        private class ParentWithEnumeratedItems
+        {
+            [ValidateEnumeratedItems]
+            public IReadOnlyList<EnumeratedChildOptions?>? Items { get; set; }
+        }
+
+        [Fact]
+        public void DataAnnotationValidateOptions_Validate_SkipsNullEnumeratedItems()
+        {
+            var options = new ParentWithEnumeratedItems
+            {
+                Items = new List<EnumeratedChildOptions?>
+                {
+                    new() { Name = "first" },
+                    null,
+                    new() { Name = "third" },
+                }
+            };
+
+            var validator = new DataAnnotationValidateOptions<ParentWithEnumeratedItems>(Options.DefaultName);
+            ValidateOptionsResult result = validator.Validate(Options.DefaultName, options);
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public void DataAnnotationValidateOptions_Validate_ReportsInvalidItemAfterNullElement()
+        {
+            var options = new ParentWithEnumeratedItems
+            {
+                Items = new List<EnumeratedChildOptions?>
+                {
+                    new() { Name = "first" },
+                    null,
+                    new() { Name = null },
+                }
+            };
+
+            var validator = new DataAnnotationValidateOptions<ParentWithEnumeratedItems>(Options.DefaultName);
+            ValidateOptionsResult result = validator.Validate(Options.DefaultName, options);
+            Assert.True(result.Failed);
+            Assert.Contains("ParentWithEnumeratedItems.Items[2]", result.FailureMessage);
+            Assert.DoesNotContain("[1]", result.FailureMessage);
+        }
+
 #if NET11_0_OR_GREATER
         private sealed class AsyncOnlyFailAttribute : AsyncValidationAttribute
         {
@@ -1134,6 +1184,24 @@ namespace Microsoft.Extensions.Options.Tests
             Assert.Contains("[0]", asyncResult.FailureMessage);
             Assert.Contains("[1]", asyncResult.FailureMessage);
             Assert.Contains("Async-only failure", asyncResult.FailureMessage);
+        }
+
+        [Fact]
+        public async Task DataAnnotationValidateOptions_ValidateAsync_SkipsNullEnumeratedItems()
+        {
+            var options = new ParentWithEnumeratedItems
+            {
+                Items = new List<EnumeratedChildOptions?>
+                {
+                    new() { Name = "first" },
+                    null,
+                    new() { Name = "third" },
+                }
+            };
+
+            var validator = new DataAnnotationValidateOptions<ParentWithEnumeratedItems>(Options.DefaultName);
+            ValidateOptionsResult result = await validator.ValidateAsync(Options.DefaultName, options);
+            Assert.True(result.Succeeded);
         }
 #endif // NET11_0_OR_GREATER
     }


### PR DESCRIPTION
## Summary

`DataAnnotationValidateOptions<TOptions>` threw `ArgumentNullException` when a property annotated with `[ValidateEnumeratedItems]` contained a null element. The null item was passed straight into the recursive validation helper, which reaches `Validator.TryValidateObject` / `new ValidationContext(...)` and rejects a null instance, aborting the entire validation before any result is returned.

This skips null elements in the enumerated-items loop, while still advancing the index so the remaining items keep their real positions in reported error paths (for example `Parent.Children[2]`). The change is applied to both the synchronous `Validate` path and the asynchronous `ValidateAsync` path (the latter had the same unguarded loop).

## Why skip rather than report

- It is consistent with what the validator already does one level up: a null property value is skipped today via `if (value is null) continue;`, so skipping a null element is the natural extension.
- Every error this validator produces describes a failing member inside an item (for example `... members: 'Name' with the error: 'The Name field is required.'`). A null element has no member and no `ValidationResult`, so reporting it would require inventing a synthetic message with empty member names that does not match any other output. There is also no per-item `[Required]` semantic that would make a null element invalid on its own.

Enforcing item non-nullability would be a separate, deliberate validation rule rather than part of this fix.

## Testing

- Added sync tests that a null element among valid items is skipped, and that an invalid item after a null element is still reported with its true index (and the null index is not reported).
- Added an async test for the null-skip behavior.
- Verified the new tests fail without the fix (`ArgumentNullException`) and pass with it.
- Full `Microsoft.Extensions.Options.Tests` suite passes: 141 tests on net (NetCoreAppCurrent) and 127 on net481, 0 failures.

Fixes #130682
