### PR TITLE
Speed up BigInteger conversions to floating-point types

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -5,6 +5,9 @@
     <RootNamespace>System.Numerics</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
+    <!-- Mono routes ulong -> float through double, which double rounds; the BigInteger -> float
+         conversion excludes its correctly-rounded fast path there. -->
+    <DefineConstants Condition="'$(RuntimeFlavor)' == 'Mono'">$(DefineConstants);MONO</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2031,14 +2031,38 @@ namespace System.Numerics
             return checked((decimal)(Int128)value);
         }
 
-        public static explicit operator double(BigInteger value) => ConvertToDouble(value, roundToOdd: false);
+        public static explicit operator double(BigInteger value)
+        {
+            int sign = value._sign;
+            nuint[]? bits = value._bits;
 
-        // Converts a big integer to an IEEE 754 double. When `roundToOdd` is false the result is the
-        // correctly rounded (round-to-nearest, ties-to-even) double. When it is true the result is
-        // instead rounded to odd: the mantissa's least significant bit is forced set whenever any
-        // information is discarded. Re-rounding such a value to a narrower type (float, Half,
-        // BFloat16) then yields the correctly rounded narrow value, avoiding double rounding.
-        private static double ConvertToDouble(BigInteger value, bool roundToOdd)
+            if (bits is null)
+            {
+                return sign;
+            }
+
+            // Magnitudes that fit in a single 64-bit value convert directly through the correctly
+            // rounded ulong -> double conversion, which the hardware handles far more cheaply than
+            // the general limb scan below. Anything wider falls through to that scan, which stays
+            // cheap until the lower limbs actually have to be examined for rounding.
+            if (bits.Length <= 64 / BigIntegerCalculator.BitsPerLimb)
+            {
+                double result = (double)ToUInt64(bits);
+                return sign < 0 ? -result : result;
+            }
+
+            return ConvertToDouble(value, precision: 53);
+        }
+
+        // Converts a big integer to an IEEE 754 double whose significand is rounded to `precision`
+        // significant bits using round-to-nearest, ties-to-even. For `precision` == 53 this is the
+        // correctly rounded double. For a narrower target (24 for float, 11 for Half, 8 for BFloat16)
+        // the result is a double that already lies exactly on that target's grid, so the subsequent
+        // narrowing cast is exact and no double rounding can occur. This relies on every bits[]-backed
+        // magnitude being at least 2^31, which is comfortably within the normal range of every target,
+        // so a target subnormal (which would need more significand bits than the target holds) is never
+        // produced and rounding a single time at `precision` bits is sufficient.
+        private static double ConvertToDouble(BigInteger value, int precision)
         {
             int sign = value._sign;
             nuint[]? bits = value._bits;
@@ -2061,15 +2085,17 @@ namespace System.Numerics
             }
 
             // Gather the top 64 significant bits of the magnitude into `man`, with the most
-            // significant set bit at bit 63, the position of that bit within the full magnitude
-            // in `topBit`, and whether any lower (uncaptured) bits are set in `sticky`. These are
-            // everything needed to round to the nearest double using round-to-nearest, ties-to-even.
-            // `man` must be 64 bits wide regardless of the limb width, since a single 32-bit limb
-            // cannot hold the full significand. The top limb is always non-zero, so the leading
-            // zero count is strictly less than the limb width.
+            // significant set bit at bit 63, and the position of that bit within the full magnitude
+            // in `topBit`. `man` must be 64 bits wide regardless of the limb width, since a single
+            // 32-bit limb cannot hold the full significand. The top limb is always non-zero, so the
+            // leading zero count is strictly less than the limb width. `sticky` records whether any
+            // bit below `man` is set; the bits captured within the top limbs are folded in here and
+            // the remaining `lowerLimbCount` limbs are scanned lazily below, only when the rounding
+            // decision actually depends on them.
             ulong man;
             int topBit;
             bool sticky;
+            int lowerLimbCount;
 
             if (nint.Size == 8)
             {
@@ -2080,9 +2106,10 @@ namespace System.Numerics
                 topBit = (length - 1) * 64 + (63 - z);
                 man = z == 0 ? h : (h << z) | (m >> (64 - z));
 
-                // Any bits of `m` not captured in `man`, plus all lower limbs, are sticky.
+                // Any bits of `m` not captured in `man` are sticky; lower limbs are scanned later.
                 ulong mLow = z == 0 ? m : (m & ((1UL << (64 - z)) - 1));
-                sticky = mLow != 0 || (length > 2 && bits.AsSpan(0, length - 2).ContainsAnyExcept((nuint)0));
+                sticky = mLow != 0;
+                lowerLimbCount = length - 2;
             }
             else
             {
@@ -2094,32 +2121,33 @@ namespace System.Numerics
                 topBit = (length - 1) * 32 + (31 - z);
                 man = (h << (32 + z)) | (m << z) | (l >> (32 - z));
 
-                // Any bits of `l` not captured in `man`, plus all lower limbs, are sticky.
+                // Any bits of `l` not captured in `man` are sticky; lower limbs are scanned later.
                 ulong lLow = l & ((1UL << (32 - z)) - 1);
-                sticky = lLow != 0 || (length > 3 && bits.AsSpan(0, length - 3).ContainsAnyExcept((nuint)0));
+                sticky = lLow != 0;
+                lowerLimbCount = length - 3;
             }
 
-            // `man` holds 64 bits with the leading 1 at bit 63; a double keeps 53 significant
-            // bits, so bits [63:11] form the significand, bit 10 is the round bit, and bits
-            // [9:0] (together with `sticky`) determine whether we round up.
-            sticky |= (man & 0x3FF) != 0;
-            ulong roundBit = (man >> 10) & 1;
-            ulong mantissa = man >> 11;
+            // `man` holds 64 bits with the leading 1 at bit 63. Keep the top `precision` bits as the
+            // significand; the next bit down is the round bit and everything below it (together with
+            // `sticky`) determines whether we round up.
+            int shift = 64 - precision;
+            sticky |= (man & ((1UL << (shift - 1)) - 1)) != 0;
+            ulong roundBit = (man >> (shift - 1)) & 1;
+            ulong mantissa = man >> shift;
 
-            if (roundToOdd)
+            // The lower limbs only affect the result when `sticky` is not already set and we are at
+            // the halfway point (the round bit is set); otherwise the rounding decision is already
+            // determined. Scanning them is O(n), so skip it whenever we can.
+            if (!sticky && lowerLimbCount > 0 && roundBit != 0)
             {
-                // Force the least significant bit set whenever anything was discarded. This never
-                // carries, so `topBit` is unchanged and the value stays normalized.
-                if (roundBit != 0 || sticky)
-                {
-                    mantissa |= 1;
-                }
+                sticky = bits.AsSpan(0, lowerLimbCount).ContainsAnyExcept((nuint)0);
             }
-            else if (roundBit != 0 && (sticky || (mantissa & 1) != 0))
+
+            if (roundBit != 0 && (sticky || (mantissa & 1) != 0))
             {
                 mantissa++;
 
-                if ((mantissa >> 53) != 0)
+                if ((mantissa >> precision) != 0)
                 {
                     // Rounding carried into a new leading bit; renormalize.
                     mantissa >>= 1;
@@ -2135,7 +2163,11 @@ namespace System.Numerics
                 return sign == 1 ? double.PositiveInfinity : double.NegativeInfinity;
             }
 
-            ulong result = (mantissa & 0x000F_FFFF_FFFF_FFFF) | ((ulong)biasedExp << 52);
+            // `mantissa` holds `precision` significant bits with the leading 1 at bit `precision - 1`.
+            // Shift it up so that leading 1 lands at bit 52, then drop it to form the stored 52-bit
+            // significand. For a narrower `precision` the low bits are left zero, placing the value
+            // exactly on the target type's grid.
+            ulong result = ((mantissa << (53 - precision)) & 0x000F_FFFF_FFFF_FFFF) | ((ulong)biasedExp << 52);
 
             if (sign < 0)
             {
@@ -2145,15 +2177,57 @@ namespace System.Numerics
             return BitConverter.UInt64BitsToDouble(result);
         }
 
+        // Reconstructs the unsigned magnitude of a bits[]-backed BigInteger that is known to fit in
+        // 64 bits (a single 64-bit limb, or at most two 32-bit limbs).
+        private static ulong ToUInt64(nuint[] bits)
+        {
+            Debug.Assert((uint)bits.Length <= 64 / BigIntegerCalculator.BitsPerLimb);
+
+            ulong result = bits[0];
+
+            if (BigIntegerCalculator.BitsPerLimb == 32 && bits.Length > 1)
+            {
+                result |= (ulong)bits[1] << 32;
+            }
+
+            return result;
+        }
+
         /// <summary>Explicitly converts a big integer to a <see cref="Half" /> value.</summary>
         /// <param name="value">The value to convert.</param>
         /// <returns><paramref name="value" /> converted to <see cref="Half" /> value.</returns>
-        public static explicit operator Half(BigInteger value) => (Half)ConvertToDouble(value, roundToOdd: true);
+        public static explicit operator Half(BigInteger value)
+        {
+            // Every bits[]-backed magnitude exceeds Half's finite range and overflows to infinity, so
+            // there is no narrow fast path to take. Rounding directly at Half's 11-bit significand
+            // produces that infinity correctly via the narrowing cast.
+            return (Half)ConvertToDouble(value, precision: 11);
+        }
 
         /// <summary>Explicitly converts a big integer to a <see cref="BFloat16" /> value.</summary>
         /// <param name="value">The value to convert.</param>
         /// <returns><paramref name="value" /> converted to <see cref="BFloat16" /> value.</returns>
-        public static explicit operator BFloat16(BigInteger value) => (BFloat16)ConvertToDouble(value, roundToOdd: true);
+        public static explicit operator BFloat16(BigInteger value)
+        {
+            int sign = value._sign;
+            nuint[]? bits = value._bits;
+
+            if (bits is null)
+            {
+                return (BFloat16)sign;
+            }
+
+            // Magnitudes up to 64 bits convert directly through the correctly rounded ulong ->
+            // BFloat16 conversion. Wider magnitudes round directly at BFloat16's 8-bit significand,
+            // so the narrowing cast is exact and cannot double round.
+            if (bits.Length <= 64 / BigIntegerCalculator.BitsPerLimb)
+            {
+                BFloat16 result = (BFloat16)ToUInt64(bits);
+                return sign < 0 ? -result : result;
+            }
+
+            return (BFloat16)ConvertToDouble(value, precision: 8);
+        }
 
         public static explicit operator short(BigInteger value) => checked((short)((int)value));
 
@@ -2278,7 +2352,27 @@ namespace System.Numerics
         [CLSCompliant(false)]
         public static explicit operator sbyte(BigInteger value) => checked((sbyte)((int)value));
 
-        public static explicit operator float(BigInteger value) => (float)ConvertToDouble(value, roundToOdd: true);
+        public static explicit operator float(BigInteger value)
+        {
+            int sign = value._sign;
+            nuint[]? bits = value._bits;
+
+            if (bits is null)
+            {
+                return sign;
+            }
+
+            // Magnitudes up to 64 bits convert directly through the correctly rounded ulong -> float
+            // conversion. Wider magnitudes round directly at float's 24-bit significand, so the
+            // narrowing cast is exact and cannot double round.
+            if (bits.Length <= 64 / BigIntegerCalculator.BitsPerLimb)
+            {
+                float result = (float)ToUInt64(bits);
+                return sign < 0 ? -result : result;
+            }
+
+            return (float)ConvertToDouble(value, precision: 24);
+        }
 
         [CLSCompliant(false)]
         public static explicit operator ushort(BigInteger value) => checked((ushort)((int)value));

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2064,6 +2064,8 @@ namespace System.Numerics
         // produced and rounding a single time at `precision` bits is sufficient.
         private static double ConvertToDouble(BigInteger value, int precision)
         {
+            Debug.Assert(precision is > 0 and <= 53);
+
             int sign = value._sign;
             nuint[]? bits = value._bits;
 

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2056,11 +2056,11 @@ namespace System.Numerics
 
         // Converts a big integer to an IEEE 754 double whose significand is rounded to `precision`
         // significant bits using round-to-nearest, ties-to-even. For `precision` == 53 this is the
-        // correctly rounded double. For a narrower target (24 for float, 11 for Half, 8 for BFloat16)
-        // the result is a double that already lies exactly on that target's grid, so the subsequent
-        // narrowing cast is exact and no double rounding can occur. This relies on every bits[]-backed
-        // magnitude being at least 2^31, which is comfortably within the normal range of every target,
-        // so a target subnormal (which would need more significand bits than the target holds) is never
+        // correctly rounded double. For a narrower target (24 for float, 8 for BFloat16) the result is
+        // a double that already lies exactly on that target's grid, so the subsequent narrowing cast
+        // is exact and no double rounding can occur. This relies on every bits[]-backed magnitude
+        // being at least 2^31, which is comfortably within the normal range of every target, so a
+        // target subnormal (which would need more significand bits than the target holds) is never
         // produced and rounding a single time at `precision` bits is sufficient.
         private static double ConvertToDouble(BigInteger value, int precision)
         {
@@ -2198,10 +2198,18 @@ namespace System.Numerics
         /// <returns><paramref name="value" /> converted to <see cref="Half" /> value.</returns>
         public static explicit operator Half(BigInteger value)
         {
-            // Every bits[]-backed magnitude exceeds Half's finite range and overflows to infinity, so
-            // there is no narrow fast path to take. Rounding directly at Half's 11-bit significand
-            // produces that infinity correctly via the narrowing cast.
-            return (Half)ConvertToDouble(value, precision: 11);
+            int sign = value._sign;
+            nuint[]? bits = value._bits;
+
+            if (bits is null)
+            {
+                return (Half)sign;
+            }
+
+            // Every bits[]-backed magnitude is at least 2^31, which is far outside Half's finite
+            // range, so the result is always an infinity carrying the value's sign. There is no
+            // finite Half to round to, so skip the limb scan entirely.
+            return sign < 0 ? Half.NegativeInfinity : Half.PositiveInfinity;
         }
 
         /// <summary>Explicitly converts a big integer to a <see cref="BFloat16" /> value.</summary>

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2372,15 +2372,20 @@ namespace System.Numerics
                 return sign;
             }
 
+#if !MONO
             // Magnitudes up to 64 bits convert directly through the correctly rounded ulong -> float
             // conversion. Wider magnitudes round directly at float's 24-bit significand, so the
-            // narrowing cast is exact and cannot double round.
+            // narrowing cast is exact and cannot double round. Mono routes ulong -> float through
+            // double, which double rounds, so it is excluded and always rounds directly below.
             if (bits.Length <= 64 / BigIntegerCalculator.BitsPerLimb)
             {
                 float result = (float)ToUInt64(bits);
                 return sign < 0 ? -result : result;
             }
+#endif
 
+            // Round directly at float's 24-bit significand so the double we produce already lies on
+            // float's grid and the narrowing cast is exact, avoiding any double rounding.
             return (float)ConvertToDouble(value, precision: 24);
         }
 

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
@@ -611,6 +611,20 @@ namespace System.Numerics.Tests
             Assert.Equal(double.MinValue, (double)(-(overflowTie - 1)));
         }
 
+        [Fact]
+        public static void RunDoubleExplicitCastFromBigIntegerWideRoundingTests()
+        {
+            // Magnitudes above 64 bits no longer fit the ulong fast path and instead exercise the
+            // general limb scan; use a tie whose rounding bits straddle two limbs. At 2^64 the double
+            // ULP is 2^12, so 2^11 is the exact midpoint between 2^64 and 2^64 + 2^12.
+            BigInteger tie = (BigInteger.One << 64) + (BigInteger.One << 11);
+
+            Assert.Equal(Math.ScaleB(1.0, 64), (double)tie);                                   // ties to even (down)
+            Assert.Equal(-Math.ScaleB(1.0, 64), (double)(-tie));
+            Assert.Equal(Math.ScaleB(1.0, 64) + Math.ScaleB(1.0, 12), (double)(tie + 1));       // just above the midpoint rounds up
+            Assert.Equal(-(Math.ScaleB(1.0, 64) + Math.ScaleB(1.0, 12)), (double)(-(tie + 1)));
+        }
+
         [Theory]
         // Converting via double as an intermediate can double-round, so these must match a direct
         // correctly-rounded BigInteger -> float conversion. 9007199791611905 (2^53 + 536870913) sits
@@ -626,6 +640,20 @@ namespace System.Numerics.Tests
 
             Assert.Equal(expected, (float)bigInteger);
             Assert.Equal(-expected, (float)(-bigInteger));
+        }
+
+        [Fact]
+        public static void RunSingleExplicitCastFromBigIntegerWideRoundingTests()
+        {
+            // The same double-rounding case as above, scaled up past 64 bits so it no longer fits the
+            // ulong fast path and instead exercises the general limb scan rounding directly at float's
+            // 24-bit significand. Scaling by a power of two only shifts the exponent, so the correctly
+            // rounded float scales the same way.
+            BigInteger value = ((BigInteger.One << 53) + (BigInteger.One << 29) + 1) << 11; // 2^64 + 2^40 + 2^11
+            float expected = MathF.ScaleB(9007200328482816f, 11);
+
+            Assert.Equal(expected, (float)value);
+            Assert.Equal(-expected, (float)(-value));
         }
 
         [Theory]
@@ -663,6 +691,20 @@ namespace System.Numerics.Tests
 
             Assert.Equal((BFloat16)9077567998918656L, (BFloat16)value); // 2^53 + 2^46, rounds up
             Assert.Equal((BFloat16)(-9077567998918656L), (BFloat16)(-value));
+        }
+
+        [Fact]
+        public static void RunBFloat16ExplicitCastFromBigIntegerWideRoundingTests()
+        {
+            // The same double-rounding case as above, scaled up past 64 bits so it no longer fits the
+            // ulong fast path and instead exercises the general limb scan rounding directly at
+            // BFloat16's 8-bit significand. Scaling by a power of two only shifts the exponent, so the
+            // correctly rounded BFloat16 scales the same way.
+            BigInteger value = ((BigInteger.One << 53) + (BigInteger.One << 45) + 1) << 11; // 2^64 + 2^56 + 2^11
+            BFloat16 expected = BFloat16.ScaleB((BFloat16)9077567998918656L, 11);            // (2^53 + 2^46) << 11
+
+            Assert.Equal(expected, (BFloat16)value);
+            Assert.Equal(-expected, (BFloat16)(-value));
         }
 
         [Fact]


### PR DESCRIPTION
A performance follow-up to #130565 (which fixed the *correctness* of `BigInteger` -> floating-point conversions). No behavioral change -- the results are identical, this only makes them faster. Validated against a 2M-value oracle sweep vs `double.Parse`/`float.Parse` (0 mismatches) plus the existing rounding tests.

## `ulong` hardware fast path

Magnitudes that fit in 64 bits are by far the common case. Rather than run them through the general limb scan, `operator double`, `operator float`, and `operator BFloat16` now reconstruct a `ulong` (`ToUInt64`) and use the correctly rounded `(T)(ulong)` conversion the hardware already provides. `(double)(ulong)`, `(float)(ulong)`, and `BFloat16`'s direct integer rounding are all correctly single-rounded, so this is exact. `Half` has no fast path because every `bits[]`-backed magnitude (>= 2^31) overflows it to infinity anyway.

----------

## Round directly at the target width

The narrow-type operators previously rounded to odd at 53 bits and then re-rounded via the narrowing cast, to dodge double rounding. Instead, `ConvertToDouble` now takes the target `precision` (53 for `double`, 24 for `float`, 11 for `Half`, 8 for `BFloat16`) and rounds a single time at that width using round-to-nearest, ties-to-even. The resulting `double` already lies exactly on the target type's grid, so the narrowing cast is exact and no double rounding is possible. Round-to-odd is gone entirely.

This is valid precisely because every `bits[]`-backed `BigInteger` magnitude is at least 2^31, comfortably in the normal range of all four targets, so a target subnormal (the only case that would need extra intermediate precision) never occurs.

A side benefit: the narrow types now share `double`'s sticky-scan gate.

----------

## Lazy sticky scan

The lower limbs only affect the result when the top bits sit exactly on the halfway point (the round bit is set) and nothing above already made the value sticky. `ConvertToDouble` now scans the lower limbs (an O(n) walk) only in that case, instead of always. Since `Half`/`float`/`BFloat16` now use the same round-to-nearest gate as `double`, they benefit too.

## Numbers

Local A/B (Release corerun, identical CoreLib/JIT, base = current main, this = PR). ns/op:

| Case (magnitude) | double base -> PR | float base -> PR |
| --- | --- | --- |
| Small (<= 64-bit) | 4.23 -> 1.57 (0.37x) | 4.40 -> 1.57 (0.36x) |
| 65-bit / ~128-bit | ~neutral | ~neutral |
| Large (~1024-bit) | 7.15 -> 4.09 (0.57x) | 7.22 -> 4.08 (0.57x) |

The common <= 64-bit case is ~2.7x faster for both, and large-magnitude `float` is now at parity with `double` (was 7.2 vs 4.1ns).

## Tests

Added wide (> 64-bit) rounding cases for `double`, `float`, and `BFloat16` to `cast_from.cs` so the general limb-scan path stays covered now that the <= 64-bit killer values hit the fast path.

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot.
