### PR TITLE
[cDAC] Remove vestigial IsPegged from HandleData

### DIFF
--- a/docs/design/datacontracts/GC.md
+++ b/docs/design/datacontracts/GC.md
@@ -839,7 +839,6 @@ private HandleData CreateHandleData(TargetPointer handleAddress, byte uBlock, ui
     HandleData handleData = default;
     handleData.Handle = handleAddress;
     handleData.Type = GetInternalHandleType(type);
-    handleData.IsPegged = false;
     handleData.StrongReference = IsStrongReference(type);
     if (HasSecondary(type))
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IGC.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IGC.cs
@@ -36,8 +36,7 @@ public record struct HandleData(
     TargetPointer Secondary,
     uint Type,
     bool StrongReference,
-    uint RefCount,
-    bool IsPegged);
+    uint RefCount);
 
 public readonly struct GCHeapData
 {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GC_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GC_1.cs
@@ -644,7 +644,6 @@ internal struct GC_1 : IGC
         HandleData handleData = default;
         handleData.Handle = handleAddress;
         handleData.Type = GetInternalHandleType(type);
-        handleData.IsPegged = false;
         handleData.StrongReference = IsStrongReference(type);
         if (HasSecondary(type))
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1687,8 +1687,7 @@ public sealed unsafe partial class SOSDacImpl
                         Debug.Assert(handles[i].StrongReference == handlesLocal[i].StrongReference, $"cDAC: {handles[i].StrongReference}, DAC: {handlesLocal[i].StrongReference}");
                         Debug.Assert(handles[i].RefCount == handlesLocal[i].RefCount, $"cDAC: {handles[i].RefCount}, DAC: {handlesLocal[i].RefCount}");
                         Debug.Assert(handles[i].JupiterRefCount == handlesLocal[i].JupiterRefCount, $"cDAC: {handles[i].JupiterRefCount}, DAC: {handlesLocal[i].JupiterRefCount}");
-                        Debug.Assert(handles[i].IsPegged == 0, $"cDAC IsPegged must be 0, actual: {handles[i].IsPegged}");
-                        Debug.Assert(handlesLocal[i].IsPegged == 0, $"DAC IsPegged must be 0, actual: {handlesLocal[i].IsPegged}");
+                        Debug.Assert(handles[i].IsPegged == handlesLocal[i].IsPegged, $"cDAC: {handles[i].IsPegged}, DAC: {handlesLocal[i].IsPegged}");
                     }
                 }
             }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1642,7 +1642,7 @@ public sealed unsafe partial class SOSDacImpl
                     StrongReference = h.StrongReference ? 1 : 0,
                     RefCount = h.RefCount,
                     JupiterRefCount = 0,
-                    IsPegged = h.IsPegged ? 1 : 0,
+                    IsPegged = 0,
                 };
             }
 
@@ -1687,7 +1687,8 @@ public sealed unsafe partial class SOSDacImpl
                         Debug.Assert(handles[i].StrongReference == handlesLocal[i].StrongReference, $"cDAC: {handles[i].StrongReference}, DAC: {handlesLocal[i].StrongReference}");
                         Debug.Assert(handles[i].RefCount == handlesLocal[i].RefCount, $"cDAC: {handles[i].RefCount}, DAC: {handlesLocal[i].RefCount}");
                         Debug.Assert(handles[i].JupiterRefCount == handlesLocal[i].JupiterRefCount, $"cDAC: {handles[i].JupiterRefCount}, DAC: {handlesLocal[i].JupiterRefCount}");
-                        Debug.Assert(handles[i].IsPegged == handlesLocal[i].IsPegged, $"cDAC: {handles[i].IsPegged}, DAC: {handlesLocal[i].IsPegged}");
+                        Debug.Assert(handles[i].IsPegged == 0, $"cDAC IsPegged must be 0, actual: {handles[i].IsPegged}");
+                        Debug.Assert(handlesLocal[i].IsPegged == 0, $"DAC IsPegged must be 0, actual: {handlesLocal[i].IsPegged}");
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Remove the vestigial `IsPegged` value from the consumer-facing `HandleData` shape.
- Keep the frozen `SOSHandleData.IsPegged` field and populate it with zero directly.
- Preserve DEBUG parity checks by asserting that both cDAC and legacy DAC outputs remain zero.

This keeps the GC contract focused on values consumers can observe while preserving SOS output behavior.

## Validation

- `dotnet build src\native\managed\cdac\cdac.slnx -c Debug -p:UseSharedCompilation=false /nr:false`
- `dotnet test src\native\managed\cdac\tests\UnitTests\Microsoft.Diagnostics.DataContractReader.Tests.csproj -c Debug --no-build` (2697 passed, 16 skipped)
- Targeted `FullyQualifiedName~GCTests` run (24 passed)

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.