### PR TITLE
[cDAC] Encapsulate loader heap block traversal

### DIFF
--- a/docs/design/datacontracts/Loader.md
+++ b/docs/design/datacontracts/Loader.md
@@ -54,12 +54,7 @@ record struct ModuleLookupTables(
     TargetPointer MethodDefToILCodeVersioningState,
     uint TableDataOffset);
 
-readonly struct LoaderHeapBlockData
-{
-    TargetPointer Address { get; init; }
-    TargetNUInt Size { get; init; }
-    TargetPointer NextBlock { get; init; }
-}
+readonly record struct LoaderHeapBlock(TargetPointer Address, TargetNUInt Size);
 
 enum LoaderAllocatorHeapType
 {
@@ -119,10 +114,7 @@ TargetPointer GetStubHeap(TargetPointer loaderAllocatorPointer);
 TargetPointer GetObjectHandle(TargetPointer loaderAllocatorPointer);
 TargetPointer GetILHeader(ModuleHandle handle, uint token);
 TargetPointer GetDynamicIL(ModuleHandle handle, uint token);
-// Returns the first block of the loader heap linked list, or TargetPointer.Null if the heap has no blocks.
-TargetPointer GetFirstLoaderHeapBlock(TargetPointer loaderHeap);
-// Returns the data for the given loader heap block (address, size, and next block pointer).
-LoaderHeapBlockData GetLoaderHeapBlockData(TargetPointer block);
+IEnumerable<LoaderHeapBlock> EnumerateLoaderHeapBlocks(TargetPointer loaderHeap);
 IReadOnlyDictionary<LoaderAllocatorHeapType, TargetPointer> GetLoaderAllocatorHeaps(TargetPointer loaderAllocatorPointer);
 
 DebuggerAssemblyControlFlags GetDebuggerInfoBits(ModuleHandle handle);
@@ -1003,21 +995,22 @@ class InstMethodHashTable
 }
 ```
 
-#### GetFirstLoaderHeapBlock, GetLoaderHeapBlockData
+#### EnumerateLoaderHeapBlocks
 
 ```csharp
-TargetPointer ILoader.GetFirstLoaderHeapBlock(TargetPointer loaderHeap)
+IEnumerable<LoaderHeapBlock> ILoader.EnumerateLoaderHeapBlocks(TargetPointer loaderHeap)
 {
-    return target.ReadPointer(loaderHeap + /* LoaderHeap::FirstBlock offset */);
-}
-
-LoaderHeapBlockData ILoader.GetLoaderHeapBlockData(TargetPointer block)
-{
-    return new LoaderHeapBlockData
+    TargetPointer block = target.ReadPointer(loaderHeap + /* LoaderHeap::FirstBlock offset */);
+    HashSet<TargetPointer> visited = [];
+    while (block != TargetPointer.Null)
     {
-        Address = target.ReadPointer(block + /* LoaderHeapBlock::VirtualAddress offset */),
-        Size = target.ReadNUInt(block + /* LoaderHeapBlock::VirtualSize offset */),
-        NextBlock = target.ReadPointer(block + /* LoaderHeapBlock::Next offset */),
-    };
+        if (!visited.Add(block))
+            throw new InvalidOperationException();
+
+        yield return new LoaderHeapBlock(
+            target.ReadPointer(block + /* LoaderHeapBlock::VirtualAddress offset */),
+            target.ReadNUInt(block + /* LoaderHeapBlock::VirtualSize offset */));
+        block = target.ReadPointer(block + /* LoaderHeapBlock::Next offset */);
+    }
 }
 ```

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -82,12 +82,7 @@ public record struct ModuleLookupTables(
     TargetPointer MethodDefToILCodeVersioningState,
     uint TableDataOffset);
 
-public readonly struct LoaderHeapBlockData
-{
-    public TargetPointer Address { get; init; }
-    public TargetNUInt Size { get; init; }
-    public TargetPointer NextBlock { get; init; }
-}
+public readonly record struct LoaderHeapBlock(TargetPointer Address, TargetNUInt Size);
 
 public interface ILoader : IContract
 {
@@ -136,10 +131,7 @@ public interface ILoader : IContract
     TargetPointer GetObjectHandle(TargetPointer loaderAllocatorPointer) => throw new NotImplementedException();
     TargetPointer GetDynamicIL(ModuleHandle handle, uint token) => throw new NotImplementedException();
 
-    // Returns the first block of the loader heap linked list, or TargetPointer.Null if the heap has no blocks.
-    TargetPointer GetFirstLoaderHeapBlock(TargetPointer loaderHeap) => throw new NotImplementedException();
-    // Returns the data for the given loader heap block (address, size, and next block pointer).
-    LoaderHeapBlockData GetLoaderHeapBlockData(TargetPointer block) => throw new NotImplementedException();
+    IEnumerable<LoaderHeapBlock> EnumerateLoaderHeapBlocks(TargetPointer loaderHeap) => throw new NotImplementedException();
     IReadOnlyDictionary<LoaderAllocatorHeapType, TargetPointer> GetLoaderAllocatorHeaps(TargetPointer loaderAllocatorPointer) => throw new NotImplementedException();
 
     DebuggerAssemblyControlFlags GetDebuggerInfoBits(ModuleHandle handle) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -714,20 +714,19 @@ internal readonly struct Loader_1 : ILoader
         return shashContract.LookupSHash(dynamicILBlobTable.HashTable, token).EntryIL;
     }
 
-    TargetPointer ILoader.GetFirstLoaderHeapBlock(TargetPointer loaderHeap)
+    IEnumerable<LoaderHeapBlock> ILoader.EnumerateLoaderHeapBlocks(TargetPointer loaderHeap)
     {
-        return _target.ProcessedData.GetOrAdd<Data.LoaderHeap>(loaderHeap).FirstBlock;
-    }
-
-    LoaderHeapBlockData ILoader.GetLoaderHeapBlockData(TargetPointer block)
-    {
-        Data.LoaderHeapBlock blockData = _target.ProcessedData.GetOrAdd<Data.LoaderHeapBlock>(block);
-        return new LoaderHeapBlockData
+        TargetPointer block = _target.ProcessedData.GetOrAdd<Data.LoaderHeap>(loaderHeap).FirstBlock;
+        HashSet<TargetPointer> visited = [];
+        while (block != TargetPointer.Null)
         {
-            Address = blockData.VirtualAddress,
-            Size = blockData.VirtualSize,
-            NextBlock = blockData.Next,
-        };
+            if (!visited.Add(block))
+                throw new InvalidOperationException("Cycle detected while enumerating loader heap blocks.");
+
+            Data.LoaderHeapBlock blockData = _target.ProcessedData.GetOrAdd<Data.LoaderHeapBlock>(block);
+            yield return new LoaderHeapBlock(blockData.VirtualAddress, blockData.VirtualSize);
+            block = blockData.Next;
+        }
     }
 
     IReadOnlyDictionary<LoaderAllocatorHeapType, TargetPointer> ILoader.GetLoaderAllocatorHeaps(TargetPointer loaderAllocatorPointer)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -4745,27 +4745,27 @@ public sealed unsafe partial class SOSDacImpl
             int iterationMax = 8192;
 
             Contracts.ILoader loader = _target.Contracts.Loader;
-            TargetPointer block = loader.GetFirstLoaderHeapBlock(loaderHeapAddr);
-            TargetPointer firstBlock = block;
+            using IEnumerator<Contracts.LoaderHeapBlock> blocks = loader.EnumerateLoaderHeapBlocks(loaderHeapAddr).GetEnumerator();
             int i = 0;
-            while (block != TargetPointer.Null && i++ < iterationMax)
+            try
             {
-                Contracts.LoaderHeapBlockData blockData;
-                try
+                while (i < iterationMax && blocks.MoveNext())
                 {
-                    blockData = loader.GetLoaderHeapBlockData(block);
-                }
-                catch (VirtualReadException)
-                {
-                    throw new NullReferenceException();
-                }
-                pCallback(blockData.Address.Value, (nuint)blockData.Size.Value, block == firstBlock ? Interop.BOOL.TRUE : Interop.BOOL.FALSE);
+                    i++;
+                    Contracts.LoaderHeapBlock block = blocks.Current;
+                    pCallback(block.Address.Value, (nuint)block.Size.Value, i == 1 ? Interop.BOOL.TRUE : Interop.BOOL.FALSE);
 #if DEBUG
-                DebugTraverseLoaderHeapBlocks.Add((blockData.Address.Value, (nuint)blockData.Size.Value));
+                    DebugTraverseLoaderHeapBlocks.Add((block.Address.Value, (nuint)block.Size.Value));
 #endif
-                block = blockData.NextBlock;
-                if (block == firstBlock)
-                    throw new NullReferenceException();
+                }
+            }
+            catch (VirtualReadException)
+            {
+                throw new NullReferenceException();
+            }
+            catch (InvalidOperationException)
+            {
+                throw new NullReferenceException();
             }
             if (i >= iterationMax)
                 hr = HResults.S_FALSE;

--- a/src/native/managed/cdac/tests/UnitTests/LoaderHeapTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/LoaderHeapTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
 using Xunit;
@@ -47,8 +48,7 @@ public class LoaderHeapTests
             heapAddr = new TargetPointer(heap.Address);
         });
 
-        TargetPointer firstBlock = loader.GetFirstLoaderHeapBlock(heapAddr);
-        Assert.Equal(TargetPointer.Null, firstBlock);
+        Assert.Empty(loader.EnumerateLoaderHeapBlocks(heapAddr));
     }
 
     [Theory]
@@ -66,13 +66,9 @@ public class LoaderHeapTests
             heapAddr = new TargetPointer(heap.Address);
         });
 
-        TargetPointer firstBlock = loader.GetFirstLoaderHeapBlock(heapAddr);
-        Assert.NotEqual(TargetPointer.Null, firstBlock);
-
-        LoaderHeapBlockData blockData = loader.GetLoaderHeapBlockData(firstBlock);
+        LoaderHeapBlock blockData = Assert.Single(loader.EnumerateLoaderHeapBlocks(heapAddr));
         Assert.Equal(virtualAddress, blockData.Address.Value);
         Assert.Equal(virtualSize, blockData.Size.Value);
-        Assert.Equal(TargetPointer.Null, blockData.NextBlock);
     }
 
     [Theory]
@@ -92,18 +88,30 @@ public class LoaderHeapTests
             heapAddr = new TargetPointer(heap.Address);
         });
 
-        List<(ulong Address, ulong Size)> blocks = [];
-        TargetPointer block = loader.GetFirstLoaderHeapBlock(heapAddr);
-        while (block != TargetPointer.Null)
-        {
-            LoaderHeapBlockData blockData = loader.GetLoaderHeapBlockData(block);
-            blocks.Add((blockData.Address.Value, blockData.Size.Value));
-            block = blockData.NextBlock;
-        }
+        List<(ulong Address, ulong Size)> blocks = loader.EnumerateLoaderHeapBlocks(heapAddr)
+            .Select(block => (block.Address.Value, block.Size.Value))
+            .ToList();
 
         Assert.Equal(2, blocks.Count);
         Assert.Equal((virtualAddresses[0], virtualSizes[0]), blocks[0]);
         Assert.Equal((virtualAddresses[1], virtualSizes[1]), blocks[1]);
     }
-}
 
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void CyclicLoaderHeapThrows(MockTarget.Architecture arch)
+    {
+        TargetPointer heapAddr = TargetPointer.Null;
+
+        ILoader loader = CreateLoaderContract(arch, loaderBuilder =>
+        {
+            MockLoaderHeapBlock block1 = loaderBuilder.AddLoaderHeapBlock(0x1000_0000, 0x8000);
+            MockLoaderHeapBlock block2 = loaderBuilder.AddLoaderHeapBlock(0x2000_0000, 0x10000, block1.Address);
+            block1.Next = block2.Address;
+            MockLoaderHeap heap = loaderBuilder.AddLoaderHeap(firstBlockAddress: block1.Address);
+            heapAddr = new TargetPointer(heap.Address);
+        });
+
+        Assert.Throws<InvalidOperationException>(() => loader.EnumerateLoaderHeapBlocks(heapAddr).ToList());
+    }
+}

--- a/src/native/managed/cdac/tests/UnitTests/LoaderTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/LoaderTests.cs
@@ -230,27 +230,20 @@ public unsafe class LoaderTests
         (ISOSDacInterface impl, Mock<ILoader> loader) = CreateSOSDacInterfaceForVirtCallHeapTests(arch);
 
         TargetPointer indcellHeap = new(0x8000);
-        TargetPointer firstBlock = new(0x8100);
         var heaps = new Dictionary<LoaderAllocatorHeapType, TargetPointer>
         {
             [LoaderAllocatorHeapType.IndcellHeap] = indcellHeap,
         };
         loader.Setup(l => l.GetLoaderAllocatorHeaps(new TargetPointer(0x100)))
             .Returns((IReadOnlyDictionary<LoaderAllocatorHeapType, TargetPointer>)heaps);
-        loader.Setup(l => l.GetFirstLoaderHeapBlock(indcellHeap)).Returns(firstBlock);
-        loader.Setup(l => l.GetLoaderHeapBlockData(firstBlock)).Returns(new LoaderHeapBlockData
-        {
-            Address = new TargetPointer(0x9000),
-            Size = new TargetNUInt(0x40),
-            NextBlock = TargetPointer.Null,
-        });
+        loader.Setup(l => l.EnumerateLoaderHeapBlocks(indcellHeap))
+            .Returns([new LoaderHeapBlock(new TargetPointer(0x9000), new TargetNUInt(0x40))]);
 
         delegate* unmanaged<ulong, nuint, Interop.BOOL, void> callback = &VisitHeapNoOp;
         int hr = impl.TraverseVirtCallStubHeap(new ClrDataAddress(0x1), VCSHeapTypeIndcell, callback);
 
         Assert.Equal(HResults.S_OK, hr);
-        loader.Verify(l => l.GetFirstLoaderHeapBlock(indcellHeap), Times.Once());
-        loader.Verify(l => l.GetLoaderHeapBlockData(firstBlock), Times.Once());
+        loader.Verify(l => l.EnumerateLoaderHeapBlocks(indcellHeap), Times.Once());
     }
 
     [Theory]
@@ -260,7 +253,6 @@ public unsafe class LoaderTests
         (ISOSDacInterface impl, Mock<ILoader> loader) = CreateSOSDacInterfaceForVirtCallHeapTests(arch);
 
         TargetPointer cacheEntryHeap = new(0x9000);
-        TargetPointer firstBlock = new(0x9100);
         var heaps = new Dictionary<LoaderAllocatorHeapType, TargetPointer>
         {
             [LoaderAllocatorHeapType.IndcellHeap] = new TargetPointer(0x8000),
@@ -268,20 +260,14 @@ public unsafe class LoaderTests
         };
         loader.Setup(l => l.GetLoaderAllocatorHeaps(new TargetPointer(0x100)))
             .Returns((IReadOnlyDictionary<LoaderAllocatorHeapType, TargetPointer>)heaps);
-        loader.Setup(l => l.GetFirstLoaderHeapBlock(cacheEntryHeap)).Returns(firstBlock);
-        loader.Setup(l => l.GetLoaderHeapBlockData(firstBlock)).Returns(new LoaderHeapBlockData
-        {
-            Address = new TargetPointer(0xA000),
-            Size = new TargetNUInt(0x40),
-            NextBlock = TargetPointer.Null,
-        });
+        loader.Setup(l => l.EnumerateLoaderHeapBlocks(cacheEntryHeap))
+            .Returns([new LoaderHeapBlock(new TargetPointer(0xA000), new TargetNUInt(0x40))]);
 
         delegate* unmanaged<ulong, nuint, Interop.BOOL, void> callback = &VisitHeapNoOp;
         int hr = impl.TraverseVirtCallStubHeap(new ClrDataAddress(0x1), VCSHeapTypeCacheEntry, callback);
 
         Assert.Equal(HResults.S_OK, hr);
-        loader.Verify(l => l.GetFirstLoaderHeapBlock(cacheEntryHeap), Times.Once());
-        loader.Verify(l => l.GetLoaderHeapBlockData(firstBlock), Times.Once());
+        loader.Verify(l => l.EnumerateLoaderHeapBlocks(cacheEntryHeap), Times.Once());
     }
 
     [Theory]
@@ -316,7 +302,7 @@ public unsafe class LoaderTests
         int hr = impl.TraverseVirtCallStubHeap(new ClrDataAddress(0x1), VCSHeapTypeCacheEntry, callback);
 
         Assert.Equal(HResults.S_OK, hr);
-        loader.Verify(l => l.GetFirstLoaderHeapBlock(It.IsAny<TargetPointer>()), Times.Never());
+        loader.Verify(l => l.EnumerateLoaderHeapBlocks(It.IsAny<TargetPointer>()), Times.Never());
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- Replace raw loader heap block pointer APIs with `EnumerateLoaderHeapBlocks` returning only address and size.
- Keep linked-list traversal and cycle detection inside the Loader contract.
- Preserve SOS callback ordering, first-block marking, the 8192-block limit, `S_FALSE` behavior, and invalid-memory error mapping.
- Update Loader documentation and contract/SOS unit tests.

This gives consumers the loader-heap data they need without exposing traversal pointers or requiring them to chase target-memory links.

## Validation

- `dotnet build src\native\managed\cdac\cdac.slnx -c Debug -p:UseSharedCompilation=false /nr:false`
- `dotnet test src\native\managed\cdac\tests\UnitTests\Microsoft.Diagnostics.DataContractReader.Tests.csproj -c Debug --no-build` (2701 passed, 16 skipped)
- Targeted `LoaderHeapTests` and `LoaderTests` run (224 passed)

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.