### PR TITLE
[cDAC] Add base class instantiation lookup to RuntimeTypeSystem

### DIFF
--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -116,7 +116,10 @@ partial interface IRuntimeTypeSystem : IContract
     public virtual bool IsGenericTypeDefinition(TypeHandle typeHandle);
 
     public virtual bool IsCollectible(TypeHandle typeHandle);
-    public virtual bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor);
+    // Walks the class parent chain of derivedType, inclusive, to find the exact runtime
+    // instantiation whose module and TypeDef RID match baseType. Returns false and sets
+    // baseInstantiation to default when there is no match or the chain is detected as corrupt.
+    public virtual bool TryGetBaseClassInstantiation(TypeHandle derivedType, TypeHandle baseType, out TypeHandle baseInstantiation);
     public virtual bool ContainsGenericVariables(TypeHandle typeHandle);
     public virtual bool HasTypeParam(TypeHandle typeHandle);
 
@@ -980,27 +983,29 @@ Contracts used:
         return typeHandle.Flags.IsCollectible;
     }
 
-    private bool HasSameTypeDefinition(TypeHandle type, TypeHandle definingType)
+    private bool HasSameTypeDefinition(TypeHandle candidateType, TypeHandle baseType)
     {
-        if (type.Address == definingType.Address)
+        if (candidateType.Address == baseType.Address)
             return true;
 
-        uint typeRid = GetRowId(GetTypeDefToken(type));
-        uint definingTypeRid = GetRowId(GetTypeDefToken(definingType));
-        return typeRid != 0
-            && typeRid == definingTypeRid
-            && GetModule(type) == GetModule(definingType);
+        uint candidateTypeRid = GetRowId(GetTypeDefToken(candidateType));
+        uint baseTypeRid = GetRowId(GetTypeDefToken(baseType));
+        return candidateTypeRid != 0
+            && candidateTypeRid == baseTypeRid
+            && GetModule(candidateType) == GetModule(baseType);
     }
 
-    public bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor)
+    public bool TryGetBaseClassInstantiation(TypeHandle derivedType, TypeHandle baseType, out TypeHandle baseInstantiation)
     {
-        TypeHandle current = type;
+        const int MaxParentWalkIterations = 8096;
+
+        TypeHandle current = derivedType;
         TargetPointer previous = TargetPointer.Null;
-        for (int i = 0; i < 1000 && !current.IsNull; i++)
+        for (int i = 0; i < MaxParentWalkIterations && !current.IsNull; i++)
         {
-            if (HasSameTypeDefinition(current, definingType))
+            if (HasSameTypeDefinition(current, baseType))
             {
-                ancestor = current;
+                baseInstantiation = current;
                 return true;
             }
 
@@ -1012,7 +1017,7 @@ Contracts used:
             current = GetTypeHandle(next);
         }
 
-        ancestor = default;
+        baseInstantiation = default;
         return false;
     }
 

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -116,6 +116,7 @@ partial interface IRuntimeTypeSystem : IContract
     public virtual bool IsGenericTypeDefinition(TypeHandle typeHandle);
 
     public virtual bool IsCollectible(TypeHandle typeHandle);
+    public virtual bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor);
     public virtual bool ContainsGenericVariables(TypeHandle typeHandle);
     public virtual bool HasTypeParam(TypeHandle typeHandle);
 
@@ -977,6 +978,42 @@ Contracts used:
             return false;
         MethodTable typeHandle = _methodTables[typeHandle.Address];
         return typeHandle.Flags.IsCollectible;
+    }
+
+    private bool HasSameTypeDefinition(TypeHandle type, TypeHandle definingType)
+    {
+        if (type.Address == definingType.Address)
+            return true;
+
+        uint typeRid = GetRowId(GetTypeDefToken(type));
+        uint definingTypeRid = GetRowId(GetTypeDefToken(definingType));
+        return typeRid != 0
+            && typeRid == definingTypeRid
+            && GetModule(type) == GetModule(definingType);
+    }
+
+    public bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor)
+    {
+        TypeHandle current = type;
+        TargetPointer previous = TargetPointer.Null;
+        for (int i = 0; i < 1000 && !current.IsNull; i++)
+        {
+            if (HasSameTypeDefinition(current, definingType))
+            {
+                ancestor = current;
+                return true;
+            }
+
+            TargetPointer next = GetParentMethodTable(current);
+            if (next == TargetPointer.Null || next == previous || next == current.Address)
+                break;
+
+            previous = current.Address;
+            current = GetTypeHandle(next);
+        }
+
+        ancestor = default;
+        return false;
     }
 
     public bool ContainsGenericVariables(TypeHandle typeHandle)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -226,6 +226,7 @@ public interface IRuntimeTypeSystem : IContract
     bool IsGenericTypeDefinition(TypeHandle typeHandle) => throw new NotImplementedException();
     bool ContainsGenericVariables(TypeHandle typeHandle) => throw new NotImplementedException();
     bool IsCollectible(TypeHandle typeHandle) => throw new NotImplementedException();
+    bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor) => throw new NotImplementedException();
 
     bool HasTypeParam(TypeHandle typeHandle) => throw new NotImplementedException();
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -226,7 +226,18 @@ public interface IRuntimeTypeSystem : IContract
     bool IsGenericTypeDefinition(TypeHandle typeHandle) => throw new NotImplementedException();
     bool ContainsGenericVariables(TypeHandle typeHandle) => throw new NotImplementedException();
     bool IsCollectible(TypeHandle typeHandle) => throw new NotImplementedException();
-    bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor) => throw new NotImplementedException();
+    /// <summary>
+    /// Walks the class parent chain of <paramref name="derivedType"/> to find the exact runtime
+    /// instantiation whose module and TypeDef RID match <paramref name="baseType"/>.
+    /// </summary>
+    /// <param name="derivedType">The type at which to begin the inclusive parent-chain walk.</param>
+    /// <param name="baseType">The type whose module and TypeDef RID identify the base class to find.</param>
+    /// <param name="baseInstantiation">The matching runtime instantiation, or <see langword="default"/> on failure.</param>
+    /// <returns>
+    /// <see langword="true"/> if a matching instantiation is found; otherwise, <see langword="false"/>
+    /// when there is no match or the parent chain is detected as corrupt.
+    /// </returns>
+    bool TryGetBaseClassInstantiation(TypeHandle derivedType, TypeHandle baseType, out TypeHandle baseInstantiation) => throw new NotImplementedException();
 
     bool HasTypeParam(TypeHandle typeHandle) => throw new NotImplementedException();
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -1075,29 +1075,29 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
     public bool IsCollectible(TypeHandle typeHandle) => !typeHandle.IsMethodTable() ? false : _methodTables[typeHandle.Address].Flags.IsCollectible;
 
-    private bool HasSameTypeDefinition(TypeHandle type, TypeHandle definingType)
+    private bool HasSameTypeDefinition(TypeHandle candidateType, TypeHandle baseType)
     {
-        if (type.Address == definingType.Address)
+        if (candidateType.Address == baseType.Address)
             return true;
 
-        uint typeRid = EcmaMetadataUtils.GetRowId(GetTypeDefToken(type));
-        uint definingTypeRid = EcmaMetadataUtils.GetRowId(GetTypeDefToken(definingType));
-        return typeRid != 0
-            && typeRid == definingTypeRid
-            && GetModule(type) == GetModule(definingType);
+        uint candidateTypeRid = EcmaMetadataUtils.GetRowId(GetTypeDefToken(candidateType));
+        uint baseTypeRid = EcmaMetadataUtils.GetRowId(GetTypeDefToken(baseType));
+        return candidateTypeRid != 0
+            && candidateTypeRid == baseTypeRid
+            && GetModule(candidateType) == GetModule(baseType);
     }
 
-    public bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor)
+    public bool TryGetBaseClassInstantiation(TypeHandle derivedType, TypeHandle baseType, out TypeHandle baseInstantiation)
     {
         const int MaxParentWalkIterations = 8096;
 
-        TypeHandle current = type;
+        TypeHandle current = derivedType;
         TargetPointer previous = TargetPointer.Null;
         for (int i = 0; i < MaxParentWalkIterations && !current.IsNull; i++)
         {
-            if (HasSameTypeDefinition(current, definingType))
+            if (HasSameTypeDefinition(current, baseType))
             {
-                ancestor = current;
+                baseInstantiation = current;
                 return true;
             }
 
@@ -1109,7 +1109,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             current = GetTypeHandle(next);
         }
 
-        ancestor = default;
+        baseInstantiation = default;
         return false;
     }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -1089,9 +1089,11 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
     public bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor)
     {
+        const int MaxParentWalkIterations = 1000;
+
         TypeHandle current = type;
         TargetPointer previous = TargetPointer.Null;
-        for (int i = 0; i < 1000 && !current.IsNull; i++)
+        for (int i = 0; i < MaxParentWalkIterations && !current.IsNull; i++)
         {
             if (HasSameTypeDefinition(current, definingType))
             {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -1074,6 +1074,43 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
     }
 
     public bool IsCollectible(TypeHandle typeHandle) => !typeHandle.IsMethodTable() ? false : _methodTables[typeHandle.Address].Flags.IsCollectible;
+
+    private bool HasSameTypeDefinition(TypeHandle type, TypeHandle definingType)
+    {
+        if (type.Address == definingType.Address)
+            return true;
+
+        uint typeRid = EcmaMetadataUtils.GetRowId(GetTypeDefToken(type));
+        uint definingTypeRid = EcmaMetadataUtils.GetRowId(GetTypeDefToken(definingType));
+        return typeRid != 0
+            && typeRid == definingTypeRid
+            && GetModule(type) == GetModule(definingType);
+    }
+
+    public bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor)
+    {
+        TypeHandle current = type;
+        TargetPointer previous = TargetPointer.Null;
+        for (int i = 0; i < 1000 && !current.IsNull; i++)
+        {
+            if (HasSameTypeDefinition(current, definingType))
+            {
+                ancestor = current;
+                return true;
+            }
+
+            TargetPointer next = GetParentMethodTable(current);
+            if (next == TargetPointer.Null || next == previous || next == current.Address)
+                break;
+
+            previous = current.Address;
+            current = GetTypeHandle(next);
+        }
+
+        ancestor = default;
+        return false;
+    }
+
     public bool HasTypeParam(TypeHandle typeHandle)
     {
         if (typeHandle.IsMethodTable())

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -1089,7 +1089,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
     public bool TryFindAncestorWithSameTypeDefinition(TypeHandle type, TypeHandle definingType, out TypeHandle ancestor)
     {
-        const int MaxParentWalkIterations = 1000;
+        const int MaxParentWalkIterations = 8096;
 
         TypeHandle current = type;
         TargetPointer previous = TargetPointer.Null;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -3098,11 +3098,12 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                     else
                     {
                         // AcquiresInstMethodTableFromThis: token is some MethodTable*; it may be a
-                        // subclass, so walk the parent chain to find the exact declaring class.
+                        // subclass, so walk its class parent chain to find the exact runtime
+                        // instantiation of the declaring class.
                         TypeHandle thFromThis = rts.GetTypeHandle(new TargetPointer(genericsToken));
-                        if (rts.TryFindAncestorWithSameTypeDefinition(thFromThis, thRepMt, out TypeHandle thMatch))
+                        if (rts.TryGetBaseClassInstantiation(thFromThis, thRepMt, out TypeHandle thDeclaringTypeInstantiation))
                         {
-                            thSpecificClass = thMatch;
+                            thSpecificClass = thDeclaringTypeInstantiation;
                             isExact = true;
                         }
                     }
@@ -3122,8 +3123,8 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
 
             // Project the specific class onto the method's declaring class to get the class instantiation.
             TypeHandle thSpecMethodMt = rts.GetTypeHandle(rts.GetMethodTable(pSpecificMethod));
-            ReadOnlySpan<TypeHandle> classInst = rts.TryFindAncestorWithSameTypeDefinition(thSpecificClass, thSpecMethodMt, out TypeHandle thMatchingParent)
-                ? rts.GetInstantiation(thMatchingParent)
+            ReadOnlySpan<TypeHandle> classInst = rts.TryGetBaseClassInstantiation(thSpecificClass, thSpecMethodMt, out TypeHandle thBaseInstantiation)
+                ? rts.GetInstantiation(thBaseInstantiation)
                 : ReadOnlySpan<TypeHandle>.Empty;
             ReadOnlySpan<TypeHandle> methodInst = rts.GetGenericMethodInstantiation(pSpecificMethod);
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -3100,8 +3100,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                         // AcquiresInstMethodTableFromThis: token is some MethodTable*; it may be a
                         // subclass, so walk the parent chain to find the exact declaring class.
                         TypeHandle thFromThis = rts.GetTypeHandle(new TargetPointer(genericsToken));
-                        TypeHandle thMatch = GetMethodTableMatchingParentClass(rts, thFromThis, thRepMt);
-                        if (!thMatch.IsNull)
+                        if (rts.TryFindAncestorWithSameTypeDefinition(thFromThis, thRepMt, out TypeHandle thMatch))
                         {
                             thSpecificClass = thMatch;
                             isExact = true;
@@ -3122,12 +3121,10 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             }
 
             // Project the specific class onto the method's declaring class to get the class instantiation.
-            TargetPointer specMethodMtPtr = rts.GetMethodTable(pSpecificMethod);
-            TypeHandle thSpecMethodMt = rts.GetTypeHandle(specMethodMtPtr);
-            TypeHandle thMatchingParent = GetMethodTableMatchingParentClass(rts, thSpecificClass, thSpecMethodMt);
-            ReadOnlySpan<TypeHandle> classInst = thMatchingParent.IsNull
-                ? ReadOnlySpan<TypeHandle>.Empty
-                : rts.GetInstantiation(thMatchingParent);
+            TypeHandle thSpecMethodMt = rts.GetTypeHandle(rts.GetMethodTable(pSpecificMethod));
+            ReadOnlySpan<TypeHandle> classInst = rts.TryFindAncestorWithSameTypeDefinition(thSpecificClass, thSpecMethodMt, out TypeHandle thMatchingParent)
+                ? rts.GetInstantiation(thMatchingParent)
+                : ReadOnlySpan<TypeHandle>.Empty;
             ReadOnlySpan<TypeHandle> methodInst = rts.GetGenericMethodInstantiation(pSpecificMethod);
 
             cClassParams = (uint)classInst.Length;
@@ -5763,39 +5760,6 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         {
             TypeHandleToExpandedTypeInfoImpl(rts, AreValueTypesBoxed.NoValueTypeBoxing, thCanon, pTypeInfo);
         }
-    }
-
-    // True if `a` and `b` share the same non-zero TypeDef RID and Module.
-    // Mirrors native MethodTable::HasSameTypeDefAs.
-    private static bool HasSameTypeDefAs(IRuntimeTypeSystem rts, TypeHandle a, TypeHandle b)
-    {
-        if (a.Address == b.Address)
-            return true;
-        uint ridA = EcmaMetadataUtils.GetRowId(rts.GetTypeDefToken(a));
-        uint ridB = EcmaMetadataUtils.GetRowId(rts.GetTypeDefToken(b));
-        if (ridA == 0 || ridA != ridB)
-            return false;
-        return rts.GetModule(a) == rts.GetModule(b);
-    }
-
-    // Walks the parent chain of `start` and returns the first MethodTable whose TypeDef matches `parent`,
-    // or default if no match is found. The walk is bounded by a hard iteration cap to defend against
-    // cycles observed in corrupt dumps. Mirrors native MethodTable::GetMethodTableMatchingParentClass.
-    private static TypeHandle GetMethodTableMatchingParentClass(IRuntimeTypeSystem rts, TypeHandle start, TypeHandle parent)
-    {
-        TypeHandle current = start;
-        TargetPointer prev = TargetPointer.Null;
-        for (int i = 0; i < 1000 && !current.IsNull; i++)
-        {
-            if (HasSameTypeDefAs(rts, current, parent))
-                return current;
-            TargetPointer next = rts.GetParentMethodTable(current);
-            if (next == TargetPointer.Null || next == prev || next == current.Address)
-                break;
-            prev = current.Address;
-            current = rts.GetTypeHandle(next);
-        }
-        return default;
     }
 
     // Shared core implementation for TypeHandleToExpandedTypeInfo and GetObjectExpandedTypeInfo.

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/TypeNameBuilder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/TypeNameBuilder.cs
@@ -161,27 +161,10 @@ public struct TypeNameBuilder
     public static TypeHandle GetExactOwningType(IRuntimeTypeSystem runtimeTypeSystem, TypeHandle possiblyDerivedType, MethodDescHandle method)
     {
         TypeHandle approxOwner = runtimeTypeSystem.GetTypeHandle(runtimeTypeSystem.GetMethodTable(method));
+        if (runtimeTypeSystem.TryFindAncestorWithSameTypeDefinition(possiblyDerivedType, approxOwner, out TypeHandle exactOwner))
+            return exactOwner;
 
-        uint typeDefTokenOfOwner = runtimeTypeSystem.GetTypeDefToken(approxOwner);
-        TargetPointer moduleOfOwner = runtimeTypeSystem.GetModule(approxOwner);
-
-        do
-        {
-            uint typeDefTokenOfPossiblyDerivedType = runtimeTypeSystem.GetTypeDefToken(possiblyDerivedType);
-            TargetPointer moduleOfPossiblyDerivedType = runtimeTypeSystem.GetModule(possiblyDerivedType);
-
-            if ((typeDefTokenOfOwner == typeDefTokenOfPossiblyDerivedType) && (moduleOfOwner == moduleOfPossiblyDerivedType))
-            {
-                return possiblyDerivedType;
-            }
-
-            TargetPointer parentTypePointer = runtimeTypeSystem.GetParentMethodTable(possiblyDerivedType);
-            if (parentTypePointer.Value == 0)
-                throw new InvalidOperationException("Invalid parent type");
-
-            // TODO(cdac) - Consider adding infinite loop detection here
-            possiblyDerivedType = runtimeTypeSystem.GetTypeHandle(parentTypePointer);
-        } while (true);
+        throw new InvalidOperationException("Invalid parent type");
     }
 
     public static void AppendType(Target target, StringBuilder stringBuilder, Contracts.TypeHandle typeHandle, TypeNameFormat format)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/TypeNameBuilder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/TypeNameBuilder.cs
@@ -161,8 +161,8 @@ public struct TypeNameBuilder
     public static TypeHandle GetExactOwningType(IRuntimeTypeSystem runtimeTypeSystem, TypeHandle possiblyDerivedType, MethodDescHandle method)
     {
         TypeHandle approxOwner = runtimeTypeSystem.GetTypeHandle(runtimeTypeSystem.GetMethodTable(method));
-        if (runtimeTypeSystem.TryFindAncestorWithSameTypeDefinition(possiblyDerivedType, approxOwner, out TypeHandle exactOwner))
-            return exactOwner;
+        if (runtimeTypeSystem.TryGetBaseClassInstantiation(possiblyDerivedType, approxOwner, out TypeHandle baseInstantiation))
+            return baseInstantiation;
 
         throw new InvalidOperationException("Invalid parent type");
     }

--- a/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
@@ -185,6 +185,89 @@ public class MethodTableTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
+    public void TryFindAncestorWithSameTypeDefinition_MatchesDefinitionAndRejectsInvalidMatches(MockTarget.Architecture arch)
+    {
+        TargetPointer child = default;
+        TargetPointer matchingAncestor = default;
+        TargetPointer definingType = default;
+        TargetPointer unrelatedType = default;
+        TargetPointer differentModuleDefinition = default;
+        TargetPointer zeroRidChild = default;
+        TargetPointer zeroRidDefinition = default;
+        TargetPointer cycleType = default;
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            rtsBuilder =>
+            {
+                const ulong Module = 0x1234_0000;
+
+                MockMethodTable AddType(string name, uint rid, ulong parent = 0, ulong module = Module)
+                {
+                    MockEEClass eeClass = rtsBuilder.AddEEClass(name);
+                    MockMethodTable methodTable = rtsBuilder.AddMethodTable(name);
+                    methodTable.BaseSize = rtsBuilder.Builder.TargetTestHelpers.ObjectBaseSize;
+                    methodTable.Module = module;
+                    methodTable.MTFlags2 = rid << 8;
+                    methodTable.ParentMethodTable = parent;
+                    eeClass.MethodTable = methodTable.Address;
+                    methodTable.EEClassOrCanonMT = eeClass.Address;
+                    return methodTable;
+                }
+
+                definingType = AddType("Definition", 42).Address;
+                matchingAncestor = AddType("MatchingAncestor", 42, rtsBuilder.SystemObjectMethodTable.Address).Address;
+                child = AddType("Child", 43, matchingAncestor.Value).Address;
+                unrelatedType = AddType("Unrelated", 44).Address;
+                differentModuleDefinition = AddType("DifferentModuleDefinition", 42, module: Module + 1).Address;
+                TargetPointer zeroRidAncestor = AddType("ZeroRidAncestor", 0, rtsBuilder.SystemObjectMethodTable.Address).Address;
+                zeroRidChild = AddType("ZeroRidChild", 45, zeroRidAncestor.Value).Address;
+                zeroRidDefinition = AddType("ZeroRidDefinition", 0).Address;
+                MockMethodTable cycleFirst = AddType("CycleFirst", 46);
+                MockMethodTable cycleSecond = AddType("CycleSecond", 47, cycleFirst.Address);
+                cycleFirst.ParentMethodTable = cycleSecond.Address;
+                cycleType = cycleFirst.Address;
+            });
+
+        IRuntimeTypeSystem rts = target.Contracts.RuntimeTypeSystem;
+        Assert.True(rts.TryFindAncestorWithSameTypeDefinition(
+            rts.GetTypeHandle(child),
+            rts.GetTypeHandle(definingType),
+            out TypeHandle ancestor));
+        Assert.Equal(matchingAncestor, ancestor.Address);
+
+        Assert.True(rts.TryFindAncestorWithSameTypeDefinition(
+            rts.GetTypeHandle(zeroRidDefinition),
+            rts.GetTypeHandle(zeroRidDefinition),
+            out ancestor));
+        Assert.Equal(zeroRidDefinition, ancestor.Address);
+
+        Assert.False(rts.TryFindAncestorWithSameTypeDefinition(
+            rts.GetTypeHandle(child),
+            rts.GetTypeHandle(unrelatedType),
+            out ancestor));
+        Assert.True(ancestor.IsNull);
+
+        Assert.False(rts.TryFindAncestorWithSameTypeDefinition(
+            rts.GetTypeHandle(child),
+            rts.GetTypeHandle(differentModuleDefinition),
+            out ancestor));
+        Assert.True(ancestor.IsNull);
+
+        Assert.False(rts.TryFindAncestorWithSameTypeDefinition(
+            rts.GetTypeHandle(zeroRidChild),
+            rts.GetTypeHandle(zeroRidDefinition),
+            out ancestor));
+        Assert.True(ancestor.IsNull);
+
+        Assert.False(rts.TryFindAncestorWithSameTypeDefinition(
+            rts.GetTypeHandle(cycleType),
+            rts.GetTypeHandle(unrelatedType),
+            out ancestor));
+        Assert.True(ancestor.IsNull);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
     public void MethodTableEEClassInvalidThrows(MockTarget.Architecture arch)
     {
         TargetPointer badMethodTablePtr = default;

--- a/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
@@ -185,16 +185,16 @@ public class MethodTableTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void TryFindAncestorWithSameTypeDefinition_MatchesDefinitionAndRejectsInvalidMatches(MockTarget.Architecture arch)
+    public void TryGetBaseClassInstantiation_MatchesBaseDefinitionAndRejectsInvalidMatches(MockTarget.Architecture arch)
     {
-        TargetPointer child = default;
-        TargetPointer matchingAncestor = default;
-        TargetPointer definingType = default;
-        TargetPointer unrelatedType = default;
-        TargetPointer differentModuleDefinition = default;
-        TargetPointer zeroRidChild = default;
-        TargetPointer zeroRidDefinition = default;
-        TargetPointer cycleType = default;
+        TargetPointer derivedType = default;
+        TargetPointer matchingBaseInstantiation = default;
+        TargetPointer baseType = default;
+        TargetPointer unrelatedBaseType = default;
+        TargetPointer differentModuleBaseType = default;
+        TargetPointer zeroRidDerivedType = default;
+        TargetPointer zeroRidBaseType = default;
+        TargetPointer cycleDerivedType = default;
         TestPlaceholderTarget target = CreateTarget(
             arch,
             rtsBuilder =>
@@ -214,56 +214,56 @@ public class MethodTableTests
                     return methodTable;
                 }
 
-                definingType = AddType("Definition", 42).Address;
-                matchingAncestor = AddType("MatchingAncestor", 42, rtsBuilder.SystemObjectMethodTable.Address).Address;
-                child = AddType("Child", 43, matchingAncestor.Value).Address;
-                unrelatedType = AddType("Unrelated", 44).Address;
-                differentModuleDefinition = AddType("DifferentModuleDefinition", 42, module: Module + 1).Address;
-                TargetPointer zeroRidAncestor = AddType("ZeroRidAncestor", 0, rtsBuilder.SystemObjectMethodTable.Address).Address;
-                zeroRidChild = AddType("ZeroRidChild", 45, zeroRidAncestor.Value).Address;
-                zeroRidDefinition = AddType("ZeroRidDefinition", 0).Address;
+                baseType = AddType("BaseType", 42).Address;
+                matchingBaseInstantiation = AddType("MatchingBaseInstantiation", 42, rtsBuilder.SystemObjectMethodTable.Address).Address;
+                derivedType = AddType("DerivedType", 43, matchingBaseInstantiation.Value).Address;
+                unrelatedBaseType = AddType("UnrelatedBaseType", 44).Address;
+                differentModuleBaseType = AddType("DifferentModuleBaseType", 42, module: Module + 1).Address;
+                TargetPointer zeroRidBaseInstantiation = AddType("ZeroRidBaseInstantiation", 0, rtsBuilder.SystemObjectMethodTable.Address).Address;
+                zeroRidDerivedType = AddType("ZeroRidDerivedType", 45, zeroRidBaseInstantiation.Value).Address;
+                zeroRidBaseType = AddType("ZeroRidBaseType", 0).Address;
                 MockMethodTable cycleFirst = AddType("CycleFirst", 46);
                 MockMethodTable cycleSecond = AddType("CycleSecond", 47, cycleFirst.Address);
                 cycleFirst.ParentMethodTable = cycleSecond.Address;
-                cycleType = cycleFirst.Address;
+                cycleDerivedType = cycleFirst.Address;
             });
 
         IRuntimeTypeSystem rts = target.Contracts.RuntimeTypeSystem;
-        Assert.True(rts.TryFindAncestorWithSameTypeDefinition(
-            rts.GetTypeHandle(child),
-            rts.GetTypeHandle(definingType),
-            out TypeHandle ancestor));
-        Assert.Equal(matchingAncestor, ancestor.Address);
+        Assert.True(rts.TryGetBaseClassInstantiation(
+            rts.GetTypeHandle(derivedType),
+            rts.GetTypeHandle(baseType),
+            out TypeHandle baseInstantiation));
+        Assert.Equal(matchingBaseInstantiation, baseInstantiation.Address);
 
-        Assert.True(rts.TryFindAncestorWithSameTypeDefinition(
-            rts.GetTypeHandle(zeroRidDefinition),
-            rts.GetTypeHandle(zeroRidDefinition),
-            out ancestor));
-        Assert.Equal(zeroRidDefinition, ancestor.Address);
+        Assert.True(rts.TryGetBaseClassInstantiation(
+            rts.GetTypeHandle(zeroRidBaseType),
+            rts.GetTypeHandle(zeroRidBaseType),
+            out baseInstantiation));
+        Assert.Equal(zeroRidBaseType, baseInstantiation.Address);
 
-        Assert.False(rts.TryFindAncestorWithSameTypeDefinition(
-            rts.GetTypeHandle(child),
-            rts.GetTypeHandle(unrelatedType),
-            out ancestor));
-        Assert.True(ancestor.IsNull);
+        Assert.False(rts.TryGetBaseClassInstantiation(
+            rts.GetTypeHandle(derivedType),
+            rts.GetTypeHandle(unrelatedBaseType),
+            out baseInstantiation));
+        Assert.True(baseInstantiation.IsNull);
 
-        Assert.False(rts.TryFindAncestorWithSameTypeDefinition(
-            rts.GetTypeHandle(child),
-            rts.GetTypeHandle(differentModuleDefinition),
-            out ancestor));
-        Assert.True(ancestor.IsNull);
+        Assert.False(rts.TryGetBaseClassInstantiation(
+            rts.GetTypeHandle(derivedType),
+            rts.GetTypeHandle(differentModuleBaseType),
+            out baseInstantiation));
+        Assert.True(baseInstantiation.IsNull);
 
-        Assert.False(rts.TryFindAncestorWithSameTypeDefinition(
-            rts.GetTypeHandle(zeroRidChild),
-            rts.GetTypeHandle(zeroRidDefinition),
-            out ancestor));
-        Assert.True(ancestor.IsNull);
+        Assert.False(rts.TryGetBaseClassInstantiation(
+            rts.GetTypeHandle(zeroRidDerivedType),
+            rts.GetTypeHandle(zeroRidBaseType),
+            out baseInstantiation));
+        Assert.True(baseInstantiation.IsNull);
 
-        Assert.False(rts.TryFindAncestorWithSameTypeDefinition(
-            rts.GetTypeHandle(cycleType),
-            rts.GetTypeHandle(unrelatedType),
-            out ancestor));
-        Assert.True(ancestor.IsNull);
+        Assert.False(rts.TryGetBaseClassInstantiation(
+            rts.GetTypeHandle(cycleDerivedType),
+            rts.GetTypeHandle(unrelatedBaseType),
+            out baseInstantiation));
+        Assert.True(baseInstantiation.IsNull);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- Add `TryGetBaseClassInstantiation(TypeHandle derivedType, TypeHandle baseType, out TypeHandle baseInstantiation)` to `RuntimeTypeSystem`.
- Replace DacDbi's private ports of `MethodTable::HasSameTypeDefAs` and `GetMethodTableMatchingParentClass` with the shared contract operation.
- Walk the parent chain to recover the exact base-class instantiation needed by generic debugger scenarios, while preserving corruption and cycle guards.
- Use the operation from both DacDbi and TypeNameBuilder.

This keeps type-system interpretation and parent traversal behind the `RuntimeTypeSystem` contract instead of duplicating it in consumers.

## Validation

- Targeted tests: 4 passed
- Full cDAC tests: 2701 passed, 16 skipped
- Build completed cleanly

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
