### PR TITLE
[cDAC] Avoid exception-based GetTypeParam probing

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1089,20 +1089,14 @@ public sealed unsafe partial class SOSDacImpl
                 // array MTs
                 else if (rtsContract.IsArray(foundTypeHandle, out _))
                     data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
-                else
+                else if (rtsContract.HasTypeParam(foundTypeHandle))
                 {
-                    try
-                    {
-                        // value typedescs
-                        TypeHandle paramTypeHandle = rtsContract.GetTypeParam(foundTypeHandle);
-                        data->MTOfType = paramTypeHandle.Address.ToClrDataAddress(_target);
-                    }
-                    catch (ArgumentException)
-                    {
-                        // non-array MTs
-                        data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
-                    }
+                    // value typedescs
+                    TypeHandle paramTypeHandle = rtsContract.GetTypeParam(foundTypeHandle);
+                    data->MTOfType = paramTypeHandle.Address.ToClrDataAddress(_target);
                 }
+                else
+                    data->MTOfType = foundTypeHandle.Address.ToClrDataAddress(_target);
             }
             catch (VirtualReadException)
             {


### PR DESCRIPTION
## Summary

- Use the existing `HasTypeParam` predicate before calling `GetTypeParam` in SOS field descriptor projection.
- Keep the same value-type descriptor and MethodTable output behavior without using `ArgumentException` as normal control flow.

## Validation

- `dotnet build src\native\managed\cdac\cdac.slnx -c Debug -p:UseSharedCompilation=false /nr:false` (final run: 0 warnings, 0 errors)
- `dotnet test src\native\managed\cdac\tests\UnitTests\Microsoft.Diagnostics.DataContractReader.Tests.csproj -c Debug --no-build` (2697 passed, 16 skipped)
- Targeted `TypeDescTests` run (16 passed)

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.