### PR TITLE
Fix IsSupported tests for ML-KEM

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemImplementationTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemImplementationTests.cs
@@ -29,7 +29,10 @@ namespace System.Security.Cryptography.Tests
         {
             return MLKem.ImportEncapsulationKey(algorithm, source);
         }
+    }
 
+    public static class MLKemImplementationSupportedTests
+    {
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static void IsSupported_InitializesCrypto()
         {
@@ -50,11 +53,17 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public static void IsSupported_AgreesWithPlatform()
         {
-            Assert.Equal(PlatformSupportsMLKem(), MLKem.IsSupported);
-        }
+            if (PlatformDetection.IsSymCryptOpenSsl && !PlatformDetection.IsAzureLinux4OrHigher)
+            {
+                // Azure Linux backported ML-KEM SymCrypt-OpenSSL in 1.10 so either true or false is acceptable
+                // currently. Azure Linux 4 and later have OpenSSL 3.5, so that should always be true and fall in to the
+                // IsOpenSsl3_5 check.
+                return;
+            }
 
-        private static bool PlatformSupportsMLKem() =>
-            PlatformDetection.IsOpenSsl3_5 ||
-            PlatformDetection.IsWindows10Version26100OrGreater;
+            Assert.Equal(
+                PlatformDetection.IsOpenSsl3_5 || PlatformDetection.IsWindows10Version26100OrGreater,
+                MLKem.IsSupported);
+        }
     }
 }


### PR DESCRIPTION
There are two things being fixed here.

1. The class that the `IsSupported` tests were in is marked `[ConditionalClass(typeof(MLKem), nameof(MLKem.IsSupported))]`. This means we only tested the `IsSupported` property when it was actually true. We never asserted that it should be true when it was actually false.
2. Azure Linux's SymCrypt-OpenSSL 1.10 package is going to light up ML-KEM. The tests keyed off the runtime `IsSupported` detection passed, it's just the platform comparison test that started failing.

    We don't know what version of SymCrypt-OpenSSL is installed on a given system and "asking" it requires using OpenSSL APIs we don't currently have in our shim. We can't ask the package manager because that will not work or vary in containers, and the shared object does not have an SOVERSION. So "either" answer is fine for Azure Linux, but in Azure Linux 4 we start expecting a hard yes.
    
    If we want we can revisit this test in a few months when it is likely SCOSSL 1.10 has been installed everywhere.