### PR TITLE
[wasm] Fix reverse P/Invoke thunk key for nested [UnmanagedCallersOnly] types (CoreCLR + Mono)

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -182,10 +182,11 @@ namespace Wasm.Build.Tests
         public async Task UnmanagedCallersOnly_Nested(Configuration config, bool aot)
         {
             // Regression coverage for the wasm reverse-P/Invoke (native-to-interp) thunk key of a
-            // nested [UnmanagedCallersOnly] type on both runtimes. Reflection reports the enclosing
-            // namespace for a nested type while the runtime reads the (empty) metadata namespace; if
-            // PInvokeCollector emits the reflection namespace the key never matches, so the lookup
-            // returns null - CoreCLR asserts on the first cold ldftn and Mono traps as "null function".
+            // nested [UnmanagedCallersOnly] type. Reflection reports the enclosing namespace for a
+            // nested type while the runtime reads the (empty) metadata namespace; if PInvokeCollector
+            // emits the reflection namespace the key never matches, so the lookup returns null -
+            // CoreCLR asserts on the first cold ldftn and Mono traps as "null function". Executed on
+            // browser-wasm in CI for both the Mono and CoreCLR generators (the wasi leg is build-only).
             ProjectInfo info = CopyTestAsset(config, aot, TestAsset.WasmBasicTestApp, "cb_nested");
             string programRelativePath = Path.Combine("Common", "Program.cs");
             ReplaceFile(programRelativePath, Path.Combine(BuildEnvironment.TestAssetsPath, "EntryPoints", "PInvoke", "UnmanagedCallbackNested.cs"));

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -203,6 +203,31 @@ namespace Wasm.Build.Tests
 
         [Theory]
         [BuildAndRun()]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/130739")]
+        public async Task UnmanagedCallersOnly_NestedConflict(Configuration config, bool aot)
+        {
+            // The reverse-P/Invoke thunk key drops the enclosing-type chain, keying only on the
+            // simple type name plus the (empty) nested namespace. Two nested types that share a
+            // simple name under different enclosing types therefore collide and currently fail the
+            // build. This encodes the desired behavior (both callbacks resolve and run) and is
+            // skipped until #130739 removes the limitation.
+            ProjectInfo info = CopyTestAsset(config, aot, TestAsset.WasmBasicTestApp, "cb_nested_conflict");
+            string programRelativePath = Path.Combine("Common", "Program.cs");
+            ReplaceFile(programRelativePath, Path.Combine(BuildEnvironment.TestAssetsPath, "EntryPoints", "PInvoke", "UnmanagedCallbackNestedConflict.cs"));
+
+            PublishForVariadicFunctionTests(info, config, aot);
+
+            RunResult result = await RunForPublishWithWebServer(new BrowserRunOptions(
+                config,
+                TestScenario: "DotnetRun",
+                ExpectedExitCode: 42
+            ));
+            Assert.Contains("Conflicting.OuterA.Conflict.C", result.TestOutput);
+            Assert.Contains("Conflicting.OuterB.Conflict.C", result.TestOutput);
+        }
+
+        [Theory]
+        [BuildAndRun()]
         // The test fetches WasmAppBuilder.dll from the Microsoft.NET.Runtime.WebAssembly.Sdk
         // workload pack, which is not present in the NoWorkload (CoreCLR-Wasm) Helix payload.
         [TestCategory("mono")]

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -179,6 +179,30 @@ namespace Wasm.Build.Tests
 
         [Theory]
         [BuildAndRun()]
+        public async Task UnmanagedCallersOnly_Nested(Configuration config, bool aot)
+        {
+            // Regression coverage for the CoreCLR wasm reverse-P/Invoke thunk key of a nested
+            // [UnmanagedCallersOnly] type. Reflection reports the enclosing namespace for a nested
+            // type while the runtime reads the (empty) metadata namespace; if PInvokeCollector emits
+            // the reflection namespace the key never matches and the first cold ldftn asserts.
+            ProjectInfo info = CopyTestAsset(config, aot, TestAsset.WasmBasicTestApp, "cb_nested");
+            string programRelativePath = Path.Combine("Common", "Program.cs");
+            ReplaceFile(programRelativePath, Path.Combine(BuildEnvironment.TestAssetsPath, "EntryPoints", "PInvoke", "UnmanagedCallbackNested.cs"));
+
+            string output = PublishForVariadicFunctionTests(info, config, aot);
+            Assert.DoesNotMatch(".*(warning|error).*>[A-Z0-9]+__Foo", output);
+
+            RunResult result = await RunForPublishWithWebServer(new BrowserRunOptions(
+                config,
+                TestScenario: "DotnetRun",
+                ExpectedExitCode: 42
+            ));
+            Assert.Contains("Namespaced.Outer.Nested.C", result.TestOutput);
+            Assert.Contains("Namespaced.Outer.Nested.Deeper.D", result.TestOutput);
+        }
+
+        [Theory]
+        [BuildAndRun()]
         // The test fetches WasmAppBuilder.dll from the Microsoft.NET.Runtime.WebAssembly.Sdk
         // workload pack, which is not present in the NoWorkload (CoreCLR-Wasm) Helix payload.
         [TestCategory("mono")]

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -181,10 +181,11 @@ namespace Wasm.Build.Tests
         [BuildAndRun()]
         public async Task UnmanagedCallersOnly_Nested(Configuration config, bool aot)
         {
-            // Regression coverage for the CoreCLR wasm reverse-P/Invoke thunk key of a nested
-            // [UnmanagedCallersOnly] type. Reflection reports the enclosing namespace for a nested
-            // type while the runtime reads the (empty) metadata namespace; if PInvokeCollector emits
-            // the reflection namespace the key never matches and the first cold ldftn asserts.
+            // Regression coverage for the wasm reverse-P/Invoke (native-to-interp) thunk key of a
+            // nested [UnmanagedCallersOnly] type on both runtimes. Reflection reports the enclosing
+            // namespace for a nested type while the runtime reads the (empty) metadata namespace; if
+            // PInvokeCollector emits the reflection namespace the key never matches, so the lookup
+            // returns null - CoreCLR asserts on the first cold ldftn and Mono traps as "null function".
             ProjectInfo info = CopyTestAsset(config, aot, TestAsset.WasmBasicTestApp, "cb_nested");
             string programRelativePath = Path.Combine("Common", "Program.cs");
             ReplaceFile(programRelativePath, Path.Combine(BuildEnvironment.TestAssetsPath, "EntryPoints", "PInvoke", "UnmanagedCallbackNested.cs"));

--- a/src/mono/wasm/testassets/EntryPoints/PInvoke/UnmanagedCallbackNested.cs
+++ b/src/mono/wasm/testassets/EntryPoints/PInvoke/UnmanagedCallbackNested.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Runtime.InteropServices;
+
+public class Test
+{
+    public unsafe static int Main()
+    {
+        // Cold ldftn of a nested [UnmanagedCallersOnly] callback. The reverse-thunk key
+        // must use the metadata namespace (empty for nested types) to match the runtime,
+        // otherwise the lookup misses and the interpreter asserts at method-compile time.
+        ((delegate* unmanaged<void>)&Namespaced.Outer.Nested.C)();
+        ((delegate* unmanaged<void>)&Namespaced.Outer.Nested.Deeper.D)();
+        return 42;
+    }
+}
+
+namespace Namespaced
+{
+    public class Outer
+    {
+        public class Nested
+        {
+            [UnmanagedCallersOnly]
+            public static void C()
+            {
+                Console.WriteLine("TestOutput -> Namespaced.Outer.Nested.C");
+            }
+
+            public class Deeper
+            {
+                [UnmanagedCallersOnly]
+                public static void D()
+                {
+                    Console.WriteLine("TestOutput -> Namespaced.Outer.Nested.Deeper.D");
+                }
+            }
+        }
+    }
+}

--- a/src/mono/wasm/testassets/EntryPoints/PInvoke/UnmanagedCallbackNestedConflict.cs
+++ b/src/mono/wasm/testassets/EntryPoints/PInvoke/UnmanagedCallbackNestedConflict.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.InteropServices;
+
+public class Test
+{
+    public unsafe static int Main()
+    {
+        // Two nested types share the simple name "Conflict" under different enclosing types.
+        // The reverse-thunk key drops the enclosing-type chain (Method#argCount:Assembly::Type),
+        // so both callbacks currently map to the same key and the build fails (#130739).
+        ((delegate* unmanaged<void>)&Conflicting.OuterA.Conflict.C)();
+        ((delegate* unmanaged<void>)&Conflicting.OuterB.Conflict.C)();
+        return 42;
+    }
+}
+
+namespace Conflicting
+{
+    public class OuterA
+    {
+        public class Conflict
+        {
+            [UnmanagedCallersOnly]
+            public static void C()
+            {
+                Console.WriteLine("TestOutput -> Conflicting.OuterA.Conflict.C");
+            }
+        }
+    }
+
+    public class OuterB
+    {
+        public class Conflict
+        {
+            [UnmanagedCallersOnly]
+            public static void C()
+            {
+                Console.WriteLine("TestOutput -> Conflicting.OuterB.Conflict.C");
+            }
+        }
+    }
+}

--- a/src/tasks/WasmAppBuilder/coreclr/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/coreclr/PInvokeCollector.cs
@@ -336,7 +336,10 @@ internal sealed class PInvokeCallback
         TypeFullName = t.FullName!;
         AssemblyName = t.Module!.Assembly!.GetName()!.Name!;
         AssemblyFQName = t.Module!.Assembly!.GetName()!.FullName!;
-        Namespace = t.Namespace;
+        // Nested types: the runtime reverse-thunk key (vm/wasm/helpers.cpp GetHashCode ->
+        // GetFullyQualifiedNameInfo) reports an empty namespace for nested types, so match that
+        // here or the emitted g_ReverseThunks key won't be found at lookup time (#130129).
+        Namespace = t.IsNested ? string.Empty : t.Namespace;
         MethodName = method.Name!;
         ReturnType = method.ReturnType!;
         IsVoid = ReturnType.Name == "Void";

--- a/src/tasks/WasmAppBuilder/coreclr/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/coreclr/PInvokeCollector.cs
@@ -340,7 +340,8 @@ internal sealed class PInvokeCallback
         // GetFullyQualifiedNameInfo) reports an empty namespace for nested types, so match that
         // here or the emitted g_ReverseThunks key won't be found at lookup time (#130129).
         // This key drops the enclosing-type chain, so nested types with the same simple name in
-        // different namespaces collide; the duplicate-key check below turns that into a build error.
+        // different namespaces collide; the duplicate-key check in PInvokeTableGenerator
+        // (EmitNativeToInterp) turns that into a build error.
         // Tracked by https://github.com/dotnet/runtime/issues/130739.
         Namespace = t.IsNested ? string.Empty : t.Namespace;
         MethodName = method.Name!;

--- a/src/tasks/WasmAppBuilder/coreclr/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/coreclr/PInvokeCollector.cs
@@ -339,6 +339,9 @@ internal sealed class PInvokeCallback
         // Nested types: the runtime reverse-thunk key (vm/wasm/helpers.cpp GetHashCode ->
         // GetFullyQualifiedNameInfo) reports an empty namespace for nested types, so match that
         // here or the emitted g_ReverseThunks key won't be found at lookup time (#130129).
+        // This key drops the enclosing-type chain, so nested types with the same simple name in
+        // different namespaces collide; the duplicate-key check below turns that into a build error.
+        // Tracked by https://github.com/dotnet/runtime/issues/130739.
         Namespace = t.IsNested ? string.Empty : t.Namespace;
         MethodName = method.Name!;
         ReturnType = method.ReturnType!;

--- a/src/tasks/WasmAppBuilder/mono/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/mono/PInvokeCollector.cs
@@ -226,7 +226,12 @@ internal sealed class PInvokeCallback
         Method = method;
         TypeName = method.DeclaringType!.Name!;
         AssemblyName = method.DeclaringType!.Module!.Assembly!.GetName()!.Name!;
-        Namespace = method.DeclaringType!.Namespace;
+        // Nested types: the runtime native-to-interp key (browser/runtime/runtime.c get_native_to_interp
+        // via mono_class_get_namespace) reports an empty namespace for nested types, so match that here
+        // or the emitted wasm_native_to_interp_table key won't be found at lookup time. The token+name
+        // fallback in wasm_dl_get_native_to_interp cannot recover this because bsearch compares the key
+        // first, so a key mismatch defeats both lookups.
+        Namespace = method.DeclaringType!.IsNested ? string.Empty : method.DeclaringType!.Namespace;
         MethodName = method.Name!;
         ReturnType = method.ReturnType!;
         IsVoid = ReturnType.Name == "Void";


### PR DESCRIPTION
## Why

On wasm, the first cold `ldftn` of a nested `[UnmanagedCallersOnly]` callback failed to resolve its native-to-interp / reverse-thunk entry:

- **CoreCLR** asserted at `precode_portable.cpp:35`.
- **Mono** trapped as `MONO_WASM: null function`.

Both native-to-interp tables are keyed by `"{Method}#{argCount}:{Assembly}:{Namespace}:{Type}"`, and on both runtimes the two sides of that key disagreed for nested types:

- The generators (`PInvokeCollector`, one per runtime) used reflection's `Type.Namespace`, which for a nested type returns the **enclosing** namespace.
- The runtime lookups read the **metadata** namespace, which is **empty** for nested types:
  - CoreCLR: `helpers.cpp` `GetHashCode` -> `GetFullyQualifiedNameInfo`
  - Mono: `browser/runtime/runtime.c` `get_native_to_interp` -> `mono_class_get_namespace`

Because the keys never matched, the lookup returned null and the callback had no code.

Note the Mono token+name fallback in `wasm_dl_get_native_to_interp` does not recover this: `bsearch` compares the key first, so a key mismatch defeats both the (key, token) and key-only lookups. The token only disambiguates within a matching key (the trimmed case).

## Fix

Emit the metadata namespace (empty for nested types) in both generators so the generated key matches what each runtime computes at lookup time:

```csharp
Namespace = t.IsNested ? string.Empty : t.Namespace;
```

## Tests

- `UnmanagedCallersOnly_Nested` (new `Wasm.Build.Tests` case + `UnmanagedCallbackNested.cs` asset): cold-`ldftn`s and invokes `[UnmanagedCallersOnly]` callbacks on nested (and doubly-nested) types inside a namespace, asserting they run. It executes on **browser-wasm** for both the Mono and CoreCLR generators (the wasi WBT leg is build-only in CI). This test is what surfaced the Mono half of the bug (no prior test exercised nested UCO). The only pre-existing execution coverage was incidental and wasi/CoreCLR-only (a nested UCO helper in `TimeZoneInfoTests`, compiled out on browser).
- `UnmanagedCallersOnly_NestedConflict` (new, `[ActiveIssue(#130739)]`, skipped): documents the residual limitation where two nested types sharing a simple name under different enclosing types collide because the key drops the enclosing-type chain. It encodes the desired behavior so the attribute can be removed once #130739 is fixed.

## Notes

The key still drops the enclosing-type chain, so nested types sharing a simple name in different enclosing types collide. Tracked by https://github.com/dotnet/runtime/issues/130739 (which also records the proven Mono remedy: key+token lookup with a name-only fallback, per #107113). Related: https://github.com/dotnet/runtime/issues/130129.

## Files changed

- `src/tasks/WasmAppBuilder/coreclr/PInvokeCollector.cs` and `src/tasks/WasmAppBuilder/mono/PInvokeCollector.cs` (the fix, one per runtime)
- `src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs` and two `src/mono/wasm/testassets/EntryPoints/PInvoke/*.cs` assets (tests)

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.