### PR TITLE
Remove unsafe code from System.Net.Mail decoders

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Base64Stream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Base64Stream.cs
@@ -84,14 +84,15 @@ namespace System.Net
 
             while (source < buffer.Length)
             {
+                byte current = buffer[source++];
+
                 //space and tab are ok because folding must include a whitespace char.
-                if (buffer[source] == '\r' || buffer[source] == '\n' || buffer[source] == '=' || buffer[source] == ' ' || buffer[source] == '\t')
+                if (current == '\r' || current == '\n' || current == '=' || current == ' ' || current == '\t')
                 {
-                    source++;
                     continue;
                 }
 
-                byte s = Base64DecodeMap[buffer[source]];
+                byte s = Base64DecodeMap[current];
 
                 if (s == InvalidBase64Value)
                 {
@@ -119,7 +120,6 @@ namespace System.Net
                         ReadState.Pos = 0;
                         break;
                 }
-                source++;
             }
 
             return destination;

--- a/src/libraries/System.Net.Mail/src/System/Net/Base64Stream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Base64Stream.cs
@@ -77,57 +77,52 @@ namespace System.Net
             base.Close();
         }
 
-        public unsafe int DecodeBytes(Span<byte> buffer)
+        public int DecodeBytes(Span<byte> buffer)
         {
-            fixed (byte* pBuffer = buffer)
+            int source = 0;
+            int destination = 0;
+
+            while (source < buffer.Length)
             {
-                byte* start = pBuffer;
-                byte* source = start;
-                byte* dest = start;
-                byte* end = start + buffer.Length;
-
-                while (source < end)
+                //space and tab are ok because folding must include a whitespace char.
+                if (buffer[source] == '\r' || buffer[source] == '\n' || buffer[source] == '=' || buffer[source] == ' ' || buffer[source] == '\t')
                 {
-                    //space and tab are ok because folding must include a whitespace char.
-                    if (*source == '\r' || *source == '\n' || *source == '=' || *source == ' ' || *source == '\t')
-                    {
-                        source++;
-                        continue;
-                    }
-
-                    byte s = Base64DecodeMap[*source];
-
-                    if (s == InvalidBase64Value)
-                    {
-                        throw new FormatException(SR.MailBase64InvalidCharacter);
-                    }
-
-                    switch (ReadState.Pos)
-                    {
-                        case 0:
-                            ReadState.Val = (byte)(s << 2);
-                            ReadState.Pos++;
-                            break;
-                        case 1:
-                            *dest++ = (byte)(ReadState.Val + (s >> 4));
-                            ReadState.Val = unchecked((byte)(s << 4));
-                            ReadState.Pos++;
-                            break;
-                        case 2:
-                            *dest++ = (byte)(ReadState.Val + (s >> 2));
-                            ReadState.Val = unchecked((byte)(s << 6));
-                            ReadState.Pos++;
-                            break;
-                        case 3:
-                            *dest++ = (byte)(ReadState.Val + s);
-                            ReadState.Pos = 0;
-                            break;
-                    }
                     source++;
+                    continue;
                 }
 
-                return (int)(dest - start);
+                byte s = Base64DecodeMap[buffer[source]];
+
+                if (s == InvalidBase64Value)
+                {
+                    throw new FormatException(SR.MailBase64InvalidCharacter);
+                }
+
+                switch (ReadState.Pos)
+                {
+                    case 0:
+                        ReadState.Val = (byte)(s << 2);
+                        ReadState.Pos++;
+                        break;
+                    case 1:
+                        buffer[destination++] = (byte)(ReadState.Val + (s >> 4));
+                        ReadState.Val = unchecked((byte)(s << 4));
+                        ReadState.Pos++;
+                        break;
+                    case 2:
+                        buffer[destination++] = (byte)(ReadState.Val + (s >> 2));
+                        ReadState.Val = unchecked((byte)(s << 6));
+                        ReadState.Pos++;
+                        break;
+                    case 3:
+                        buffer[destination++] = (byte)(ReadState.Val + s);
+                        ReadState.Pos = 0;
+                        break;
+                }
+                source++;
             }
+
+            return destination;
         }
 
         public int EncodeBytes(ReadOnlySpan<byte> buffer) =>

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/QEncodedStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/QEncodedStream.cs
@@ -94,9 +94,9 @@ namespace System.Net.Mime
                         byte b1 = HexDecodeMap[buffer[source]];
                         byte b2 = HexDecodeMap[buffer[source + 1]];
                         if (b1 == 255)
-                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source]));
                         if (b2 == 255)
-                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source + 1]));
 
                         buffer[destination++] = (byte)((b1 << 4) + b2);
                     }
@@ -111,9 +111,9 @@ namespace System.Net.Mime
                         byte b1 = HexDecodeMap[ReadState.Byte];
                         byte b2 = HexDecodeMap[buffer[source]];
                         if (b1 == 255)
-                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)ReadState.Byte));
                         if (b2 == 255)
-                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source]));
                         buffer[destination++] = (byte)((b1 << 4) + b2);
                     }
                     source++;
@@ -164,9 +164,9 @@ namespace System.Net.Mime
                                 byte b1 = HexDecodeMap[buffer[source + 1]];
                                 byte b2 = HexDecodeMap[buffer[source + 2]];
                                 if (b1 == 255)
-                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source + 1]));
                                 if (b2 == 255)
-                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source + 2]));
 
                                 buffer[destination++] = (byte)((b1 << 4) + b2);
                             }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/QEncodedStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/QEncodedStream.cs
@@ -61,122 +61,122 @@ namespace System.Net.Mime
             base.Close();
         }
 
-        public unsafe int DecodeBytes(Span<byte> buffer)
+        public int DecodeBytes(Span<byte> buffer)
         {
-            fixed (byte* pBuffer = buffer)
+            if (buffer.IsEmpty)
             {
-                byte* start = pBuffer;
-                byte* source = start;
-                byte* dest = start;
-                byte* end = start + buffer.Length;
+                return 0;
+            }
 
-                // if the last read ended in a partially decoded
-                // sequence, pick up where we left off.
-                if (ReadState.IsEscaped)
+            int source = 0;
+            int destination = 0;
+
+            // if the last read ended in a partially decoded
+            // sequence, pick up where we left off.
+            if (ReadState.IsEscaped)
+            {
+                // this will be -1 if the previous read ended
+                // with an escape character.
+                if (ReadState.Byte == -1)
                 {
-                    // this will be -1 if the previous read ended
-                    // with an escape character.
-                    if (ReadState.Byte == -1)
+                    // if we only read one byte from the underlying
+                    // stream, we'll need to save the byte and
+                    // ask for more.
+                    if (buffer.Length == 1)
                     {
-                        // if we only read one byte from the underlying
-                        // stream, we'll need to save the byte and
-                        // ask for more.
-                        if (buffer.Length == 1)
-                        {
-                            ReadState.Byte = *source;
-                            return 0;
-                        }
-
-                        // '=\r\n' means a soft (aka. invisible) CRLF sequence...
-                        if (source[0] != '\r' || source[1] != '\n')
-                        {
-                            byte b1 = HexDecodeMap[source[0]];
-                            byte b2 = HexDecodeMap[source[1]];
-                            if (b1 == 255)
-                                throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
-                            if (b2 == 255)
-                                throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
-
-                            *dest++ = (byte)((b1 << 4) + b2);
-                        }
-
-                        source += 2;
+                        ReadState.Byte = buffer[source];
+                        return 0;
                     }
-                    else
+
+                    // '=\r\n' means a soft (aka. invisible) CRLF sequence...
+                    if (buffer[source] != '\r' || buffer[source + 1] != '\n')
                     {
-                        // '=\r\n' means a soft (aka. invisible) CRLF sequence...
-                        if (ReadState.Byte != '\r' || *source != '\n')
-                        {
-                            byte b1 = HexDecodeMap[ReadState.Byte];
-                            byte b2 = HexDecodeMap[*source];
-                            if (b1 == 255)
-                                throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
-                            if (b2 == 255)
-                                throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
-                            *dest++ = (byte)((b1 << 4) + b2);
-                        }
+                        byte b1 = HexDecodeMap[buffer[source]];
+                        byte b2 = HexDecodeMap[buffer[source + 1]];
+                        if (b1 == 255)
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                        if (b2 == 255)
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+
+                        buffer[destination++] = (byte)((b1 << 4) + b2);
+                    }
+
+                    source += 2;
+                }
+                else
+                {
+                    // '=\r\n' means a soft (aka. invisible) CRLF sequence...
+                    if (ReadState.Byte != '\r' || buffer[source] != '\n')
+                    {
+                        byte b1 = HexDecodeMap[ReadState.Byte];
+                        byte b2 = HexDecodeMap[buffer[source]];
+                        if (b1 == 255)
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                        if (b2 == 255)
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+                        buffer[destination++] = (byte)((b1 << 4) + b2);
+                    }
+                    source++;
+                }
+                // reset state for next read.
+                ReadState.IsEscaped = false;
+                ReadState.Byte = -1;
+            }
+
+            // Here's where most of the decoding takes place.
+            // We'll loop around until we've inspected all the
+            // bytes read.
+            while (source < buffer.Length)
+            {
+                // if the source is not an escape character, then
+                // just copy as-is.
+                if (buffer[source] != '=')
+                {
+                    if (buffer[source] == '_')
+                    {
+                        buffer[destination++] = (byte)' ';
                         source++;
                     }
-                    // reset state for next read.
-                    ReadState.IsEscaped = false;
-                    ReadState.Byte = -1;
-                }
-
-                // Here's where most of the decoding takes place.
-                // We'll loop around until we've inspected all the
-                // bytes read.
-                while (source < end)
-                {
-                    // if the source is not an escape character, then
-                    // just copy as-is.
-                    if (*source != '=')
-                    {
-                        if (*source == '_')
-                        {
-                            *dest++ = (byte)' ';
-                            source++;
-                        }
-                        else
-                        {
-                            *dest++ = *source++;
-                        }
-                    }
                     else
                     {
-                        // determine where we are relative to the end
-                        // of the data.  If we don't have enough data to
-                        // decode the escape sequence, save off what we
-                        // have and continue the decoding in the next
-                        // read.  Otherwise, decode the data and copy
-                        // into dest.
-                        switch (end - source)
-                        {
-                            case 2:
-                                ReadState.Byte = source[1];
-                                goto case 1;
-                            case 1:
-                                ReadState.IsEscaped = true;
-                                goto EndWhile;
-                            default:
-                                if (source[1] != '\r' || source[2] != '\n')
-                                {
-                                    byte b1 = HexDecodeMap[source[1]];
-                                    byte b2 = HexDecodeMap[source[2]];
-                                    if (b1 == 255)
-                                        throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
-                                    if (b2 == 255)
-                                        throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
-
-                                    *dest++ = (byte)((b1 << 4) + b2);
-                                }
-                                source += 3;
-                                break;
-                        }
+                        buffer[destination++] = buffer[source++];
                     }
                 }
-            EndWhile:
-                return (int)(dest - start);
+                else
+                {
+                    // determine where we are relative to the end
+                    // of the data.  If we don't have enough data to
+                    // decode the escape sequence, save off what we
+                    // have and continue the decoding in the next
+                    // read.  Otherwise, decode the data and copy
+                    // into dest.
+                    switch (buffer.Length - source)
+                    {
+                        case 2:
+                            ReadState.Byte = buffer[source + 1];
+                            goto case 1;
+                        case 1:
+                            ReadState.IsEscaped = true;
+                            goto EndWhile;
+                        default:
+                            if (buffer[source + 1] != '\r' || buffer[source + 2] != '\n')
+                            {
+                                byte b1 = HexDecodeMap[buffer[source + 1]];
+                                byte b2 = HexDecodeMap[buffer[source + 2]];
+                                if (b1 == 255)
+                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                                if (b2 == 255)
+                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+
+                                buffer[destination++] = (byte)((b1 << 4) + b2);
+                            }
+                            source += 3;
+                            break;
+                    }
+                }
             }
+        EndWhile:
+            return destination;
         }
 
         public int EncodeBytes(ReadOnlySpan<byte> buffer) => _encoder.EncodeBytes(buffer, true, true);

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/QuotedPrintableStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/QuotedPrintableStream.cs
@@ -123,9 +123,9 @@ namespace System.Net.Mime
                         byte b1 = HexDecodeMap[buffer[source]];
                         byte b2 = HexDecodeMap[buffer[source + 1]];
                         if (b1 == 255)
-                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source]));
                         if (b2 == 255)
-                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source + 1]));
 
                         buffer[destination++] = (byte)((b1 << 4) + b2);
                     }
@@ -140,9 +140,9 @@ namespace System.Net.Mime
                         byte b1 = HexDecodeMap[ReadState.Byte];
                         byte b2 = HexDecodeMap[buffer[source]];
                         if (b1 == 255)
-                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)ReadState.Byte));
                         if (b2 == 255)
-                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source]));
                         buffer[destination++] = (byte)((b1 << 4) + b2);
                     }
                     source++;
@@ -185,9 +185,9 @@ namespace System.Net.Mime
                                 byte b1 = HexDecodeMap[buffer[source + 1]];
                                 byte b2 = HexDecodeMap[buffer[source + 2]];
                                 if (b1 == 255)
-                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source + 1]));
                                 if (b2 == 255)
-                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, (char)buffer[source + 2]));
 
                                 buffer[destination++] = (byte)((b1 << 4) + b2);
                             }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/QuotedPrintableStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/QuotedPrintableStream.cs
@@ -90,114 +90,114 @@ namespace System.Net.Mime
             base.Close();
         }
 
-        public unsafe int DecodeBytes(Span<byte> buffer)
+        public int DecodeBytes(Span<byte> buffer)
         {
-            fixed (byte* pBuffer = buffer)
+            if (buffer.IsEmpty)
             {
-                byte* start = pBuffer;
-                byte* source = start;
-                byte* dest = start;
-                byte* end = start + buffer.Length;
-
-                // if the last read ended in a partially decoded
-                // sequence, pick up where we left off.
-                if (ReadState.IsEscaped)
-                {
-                    // this will be -1 if the previous read ended
-                    // with an escape character.
-                    if (ReadState.Byte == -1)
-                    {
-                        // if we only read one byte from the underlying
-                        // stream, we'll need to save the byte and
-                        // ask for more.
-                        if (buffer.Length == 1)
-                        {
-                            ReadState.Byte = *source;
-                            return 0;
-                        }
-
-                        // '=\r\n' means a soft (aka. invisible) CRLF sequence...
-                        if (source[0] != '\r' || source[1] != '\n')
-                        {
-                            byte b1 = HexDecodeMap[source[0]];
-                            byte b2 = HexDecodeMap[source[1]];
-                            if (b1 == 255)
-                                throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
-                            if (b2 == 255)
-                                throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
-
-                            *dest++ = (byte)((b1 << 4) + b2);
-                        }
-
-                        source += 2;
-                    }
-                    else
-                    {
-                        // '=\r\n' means a soft (aka. invisible) CRLF sequence...
-                        if (ReadState.Byte != '\r' || *source != '\n')
-                        {
-                            byte b1 = HexDecodeMap[ReadState.Byte];
-                            byte b2 = HexDecodeMap[*source];
-                            if (b1 == 255)
-                                throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
-                            if (b2 == 255)
-                                throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
-                            *dest++ = (byte)((b1 << 4) + b2);
-                        }
-                        source++;
-                    }
-                    // reset state for next read.
-                    ReadState.IsEscaped = false;
-                    ReadState.Byte = -1;
-                }
-
-                // Here's where most of the decoding takes place.
-                // We'll loop around until we've inspected all the
-                // bytes read.
-                while (source < end)
-                {
-                    // if the source is not an escape character, then
-                    // just copy as-is.
-                    if (*source != '=')
-                    {
-                        *dest++ = *source++;
-                    }
-                    else
-                    {
-                        // determine where we are relative to the end
-                        // of the data.  If we don't have enough data to
-                        // decode the escape sequence, save off what we
-                        // have and continue the decoding in the next
-                        // read.  Otherwise, decode the data and copy
-                        // into dest.
-                        switch (end - source)
-                        {
-                            case 2:
-                                ReadState.Byte = source[1];
-                                goto case 1;
-                            case 1:
-                                ReadState.IsEscaped = true;
-                                goto EndWhile;
-                            default:
-                                if (source[1] != '\r' || source[2] != '\n')
-                                {
-                                    byte b1 = HexDecodeMap[source[1]];
-                                    byte b2 = HexDecodeMap[source[2]];
-                                    if (b1 == 255)
-                                        throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
-                                    if (b2 == 255)
-                                        throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
-
-                                    *dest++ = (byte)((b1 << 4) + b2);
-                                }
-                                source += 3;
-                                break;
-                        }
-                    }
-                }
-            EndWhile:
-                return (int)(dest - start);
+                return 0;
             }
+
+            int source = 0;
+            int destination = 0;
+
+            // if the last read ended in a partially decoded
+            // sequence, pick up where we left off.
+            if (ReadState.IsEscaped)
+            {
+                // this will be -1 if the previous read ended
+                // with an escape character.
+                if (ReadState.Byte == -1)
+                {
+                    // if we only read one byte from the underlying
+                    // stream, we'll need to save the byte and
+                    // ask for more.
+                    if (buffer.Length == 1)
+                    {
+                        ReadState.Byte = buffer[source];
+                        return 0;
+                    }
+
+                    // '=\r\n' means a soft (aka. invisible) CRLF sequence...
+                    if (buffer[source] != '\r' || buffer[source + 1] != '\n')
+                    {
+                        byte b1 = HexDecodeMap[buffer[source]];
+                        byte b2 = HexDecodeMap[buffer[source + 1]];
+                        if (b1 == 255)
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                        if (b2 == 255)
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+
+                        buffer[destination++] = (byte)((b1 << 4) + b2);
+                    }
+
+                    source += 2;
+                }
+                else
+                {
+                    // '=\r\n' means a soft (aka. invisible) CRLF sequence...
+                    if (ReadState.Byte != '\r' || buffer[source] != '\n')
+                    {
+                        byte b1 = HexDecodeMap[ReadState.Byte];
+                        byte b2 = HexDecodeMap[buffer[source]];
+                        if (b1 == 255)
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                        if (b2 == 255)
+                            throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+                        buffer[destination++] = (byte)((b1 << 4) + b2);
+                    }
+                    source++;
+                }
+                // reset state for next read.
+                ReadState.IsEscaped = false;
+                ReadState.Byte = -1;
+            }
+
+            // Here's where most of the decoding takes place.
+            // We'll loop around until we've inspected all the
+            // bytes read.
+            while (source < buffer.Length)
+            {
+                // if the source is not an escape character, then
+                // just copy as-is.
+                if (buffer[source] != '=')
+                {
+                    buffer[destination++] = buffer[source++];
+                }
+                else
+                {
+                    // determine where we are relative to the end
+                    // of the data.  If we don't have enough data to
+                    // decode the escape sequence, save off what we
+                    // have and continue the decoding in the next
+                    // read.  Otherwise, decode the data and copy
+                    // into dest.
+                    switch (buffer.Length - source)
+                    {
+                        case 2:
+                            ReadState.Byte = buffer[source + 1];
+                            goto case 1;
+                        case 1:
+                            ReadState.IsEscaped = true;
+                            goto EndWhile;
+                        default:
+                            if (buffer[source + 1] != '\r' || buffer[source + 2] != '\n')
+                            {
+                                byte b1 = HexDecodeMap[buffer[source + 1]];
+                                byte b2 = HexDecodeMap[buffer[source + 2]];
+                                if (b1 == 255)
+                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, b1));
+                                if (b2 == 255)
+                                    throw new FormatException(SR.Format(SR.InvalidHexDigit, b2));
+
+                                buffer[destination++] = (byte)((b1 << 4) + b2);
+                            }
+                            source += 3;
+                            break;
+                    }
+                }
+            }
+        EndWhile:
+            return destination;
         }
 
         public int EncodeBytes(ReadOnlySpan<byte> buffer)

--- a/src/libraries/System.Net.Mail/tests/Unit/QuotedPrintableStreamTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/QuotedPrintableStreamTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Xunit;
@@ -9,6 +10,32 @@ namespace System.Net.Mime.Tests
 {
     public class QuotedPrintableStreamTest
     {
+        public static IEnumerable<object[]> DecodeData()
+        {
+            yield return [new[] { "Hello=20World=21" }, "Hello World!"];
+            yield return [new[] { "Hello=", "20World=21" }, "Hello World!"];
+            yield return [new[] { "Hello=2", "0World=21" }, "Hello World!"];
+            yield return [new[] { "Hello=", "\r\nWorld" }, "HelloWorld"];
+            yield return [new[] { "Hello=\r", "\nWorld" }, "HelloWorld"];
+        }
+
+        [Theory]
+        [MemberData(nameof(DecodeData))]
+        public static void DecodeBytes_SplitInput_DecodesCorrectly(string[] chunks, string expected)
+        {
+            using var testStream = new QuotedPrintableStream(Stream.Null, EncodedStreamFactory.DefaultMaxLineLength);
+            var result = new StringBuilder();
+
+            foreach (string chunk in chunks)
+            {
+                byte[] buffer = Encoding.ASCII.GetBytes(chunk);
+                int bytesWritten = testStream.DecodeBytes(buffer);
+                result.Append(Encoding.ASCII.GetString(buffer, 0, bytesWritten));
+            }
+
+            Assert.Equal(expected, result.ToString());
+        }
+
         [Theory]
         [InlineData("Hello \r\n World", "Hello \r\n World", "ASCII", false)]
         [InlineData("Hello World  ", "Hello World =20", "ASCII", true)]


### PR DESCRIPTION
Remove unsafe code in System.Net.Mail. I'm assuming this code doesn't need every single bit of perf, so a couple of redundant bound checks won't hurt.

I recommend reviewing with whitespaces disabled.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.