### PR TITLE
Derive from Stream in ReadOnlyMemoryStream and WritableMemoryStream

### DIFF
--- a/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
@@ -1094,8 +1094,9 @@ namespace System.IO.Tests
             if (SkipOnWasi(mode)) return;
 
             const int Length = 1024;
+            const int Copies = 3;
 
-            using Stream? stream = await CreateReadWriteStream();
+            using Stream? stream = await CreateReadWriteStream(new byte[Length * Copies]);
             if (stream is null)
             {
                 return;
@@ -1103,7 +1104,6 @@ namespace System.IO.Tests
 
             byte[] expected = GetRandomBytes(Length);
 
-            const int Copies = 3;
             for (int i = 0; i < Copies; i++)
             {
                 await WriteAsync(mode, stream, expected, 0, expected.Length);
@@ -1117,6 +1117,42 @@ namespace System.IO.Tests
                 int bytesRead = await ReadAllAsync(mode, stream, actual, 0, actual.Length);
                 AssertExtensions.SequenceEqual(expected, actual);
                 Array.Clear(actual, 0, actual.Length);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AllReadWriteModes))]
+        public virtual async Task Write_GrowsLength_Success(ReadWriteMode mode)
+        {
+            if (SkipOnWasi(mode)) return;
+
+            // Start from an empty stream. Streams that cannot produce an empty read-write instance
+            // (e.g. fixed-capacity streams that require initial data) return null and are skipped.
+            using Stream? stream = await CreateReadWriteStream();
+            if (stream is null)
+            {
+                return;
+            }
+
+            const int Length = 1024;
+            byte[] expected = GetRandomBytes(Length);
+
+            if (stream.CanSeek)
+            {
+                Assert.Equal(0, stream.Length);
+            }
+
+            await WriteAsync(mode, stream, expected, 0, expected.Length);
+
+            if (stream.CanSeek)
+            {
+                Assert.Equal(Length, stream.Position);
+                Assert.Equal(Length, stream.Length);
+
+                stream.Position = 0;
+                byte[] actual = new byte[Length];
+                Assert.Equal(Length, await ReadAllAsync(mode, stream, actual, 0, actual.Length));
+                AssertExtensions.SequenceEqual(expected, actual);
             }
         }
 

--- a/src/libraries/System.Memory/tests/ReadOnlyBuffer/NativeWritableMemoryStream.ConformanceTests.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlyBuffer/NativeWritableMemoryStream.ConformanceTests.cs
@@ -10,7 +10,6 @@ namespace System.Memory.Tests
     public class NativeWritableMemoryStreamConformanceTests : StandaloneStreamConformanceTests
     {
         protected override bool CanSeek => true;
-        protected override bool CanSetLength => false;
         protected override bool NopFlushCompletesSynchronously => true;
         protected override bool CanSetLengthGreaterThanCapacity => false;
 
@@ -20,17 +19,19 @@ namespace System.Memory.Tests
 
         protected override Task<Stream?> CreateReadWriteStreamCore(byte[]? initialData)
         {
-            int dataLength = initialData?.Length ?? 0;
-            int length = dataLength == 0 ? 64 * 1024 : dataLength;
-            var manager = new System.Buffers.NativeMemoryManager(length);
+            // See WritableMemoryStreamConformanceTests: WritableMemoryStream is fixed-capacity, so the
+            // empty case returns null and the grow-from-empty conformance tests are skipped.
+            if (initialData is null or { Length: 0 })
+            {
+                return Task.FromResult<Stream?>(null);
+            }
+
+            var manager = new System.Buffers.NativeMemoryManager(initialData.Length);
             manager.GetSpan().Clear();
 
             var inner = new WritableMemoryStream(manager.Memory);
-            if (dataLength != 0)
-            {
-                inner.Write(initialData!, 0, dataLength);
-                inner.Position = 0;
-            }
+            inner.Write(initialData, 0, initialData.Length);
+            inner.Position = 0;
 
             return Task.FromResult<Stream?>(new NativeMemoryOwningStream(inner, manager));
         }

--- a/src/libraries/System.Memory/tests/ReadOnlyBuffer/NativeWritableMemoryStream.ConformanceTests.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlyBuffer/NativeWritableMemoryStream.ConformanceTests.cs
@@ -20,8 +20,8 @@ namespace System.Memory.Tests
         protected override Task<Stream?> CreateReadWriteStreamCore(byte[]? initialData)
         {
             // See WritableMemoryStreamConformanceTests: WritableMemoryStream is fixed-capacity, so the
-            // empty case returns null and the grow-from-empty conformance tests are skipped.
-            if (initialData is null or { Length: 0 })
+            // null case returns null and the grow-from-empty conformance tests are skipped.
+            if (initialData is null)
             {
                 return Task.FromResult<Stream?>(null);
             }

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1952,6 +1952,9 @@
   <data name="ArgumentOutOfRange_StreamLength" xml:space="preserve">
     <value>Stream length must be non-negative and less than the maximum array length {0} - origin.</value>
   </data>
+  <data name="ArgumentOutOfRange_StreamPosition" xml:space="preserve">
+    <value>Stream position must be non-negative and less than or equal to {0}.</value>
+  </data>
   <data name="ArgumentOutOfRange_UIntPtrMax" xml:space="preserve">
     <value>The length of the buffer must be less than the maximum UIntPtr value for your platform.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -20,17 +20,17 @@ namespace System.IO
     // a stream "view" of the data.
     public class MemoryStream : Stream
     {
-        private byte[] _buffer;    // Either allocated internally or externally.
-        private readonly int _origin;       // For user-provided arrays, start at this origin
-        private int _position;     // read/write head.
-        private int _length;       // Number of bytes within the memory stream
-        private int _capacity;     // length of usable portion of buffer for stream
+        private byte[] _buffer;            // Either allocated internally or externally.
+        private readonly int _origin;      // For user-provided arrays, start at this origin
+        private int _position;             // read/write head.
+        private int _length;               // Number of bytes within the memory stream
+        private int _capacity;             // length of usable portion of buffer for stream
         // Note that _capacity == _buffer.Length for non-user-provided byte[]'s
 
-        private bool _expandable;  // User-provided buffers aren't expandable.
-        private bool _writable;    // Can user write to this stream?
-        private readonly bool _exposable;   // Whether the array can be returned to the user.
-        private bool _isOpen;      // Is this stream open or closed?
+        private bool _expandable;          // User-provided buffers aren't expandable.
+        private bool _writable;            // Can user write to this stream?
+        private readonly bool _exposable;  // Whether the array can be returned to the user.
+        private bool _isOpen;              // Is this stream open or closed?
 
         private CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -20,19 +20,19 @@ namespace System.IO
     // a stream "view" of the data.
     public class MemoryStream : Stream
     {
-        private byte[] _buffer;             // Either allocated internally or externally.
+        private byte[] _buffer;    // Either allocated internally or externally.
         private readonly int _origin;       // For user-provided arrays, start at this origin
-        private protected int _position;    // read/write head.
-        private protected int _length;      // Number of bytes within the memory stream
-        private int _capacity;              // length of usable portion of buffer for stream
+        private int _position;     // read/write head.
+        private int _length;       // Number of bytes within the memory stream
+        private int _capacity;     // length of usable portion of buffer for stream
         // Note that _capacity == _buffer.Length for non-user-provided byte[]'s
 
-        private bool _expandable;           // User-provided buffers aren't expandable.
-        private protected bool _writable;   // Can user write to this stream?
+        private bool _expandable;  // User-provided buffers aren't expandable.
+        private bool _writable;    // Can user write to this stream?
         private readonly bool _exposable;   // Whether the array can be returned to the user.
-        private protected bool _isOpen;     // Is this stream open or closed?
+        private bool _isOpen;      // Is this stream open or closed?
 
-        private protected CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
+        private CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
 
         public MemoryStream()
             : this(0)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
@@ -7,48 +7,77 @@ using System.Threading.Tasks;
 namespace System.IO
 {
     /// <summary>
-    /// Provides a seekable, read-only <see cref="MemoryStream"/> over a <see cref="ReadOnlyMemory{Byte}"/>.
+    /// Provides a seekable, read-only <see cref="Stream"/> over a <see cref="ReadOnlyMemory{Byte}"/>.
     /// </summary>
     /// <remarks>
-    /// <para>The stream cannot be written to. <see cref="MemoryStream.CanWrite"/> always returns <see langword="false"/>.</para>
-    /// <para><see cref="MemoryStream.GetBuffer"/> throws and <see cref="MemoryStream.TryGetBuffer"/> returns <see langword="false"/>.</para>
+    /// <para>The stream cannot be written to. <see cref="CanWrite"/> always returns <see langword="false"/>.</para>
     /// </remarks>
-    public sealed class ReadOnlyMemoryStream : MemoryStream
+    public sealed class ReadOnlyMemoryStream : Stream
     {
         private ReadOnlyMemory<byte> _memory;
+        private int _position;
+        private bool _isOpen;
+        private CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyMemoryStream"/> class over the specified <see cref="ReadOnlyMemory{Byte}"/>.
         /// </summary>
         /// <param name="source">The <see cref="ReadOnlyMemory{Byte}"/> to wrap.</param>
-        public ReadOnlyMemoryStream(ReadOnlyMemory<byte> source) : base()
+        public ReadOnlyMemoryStream(ReadOnlyMemory<byte> source)
         {
-            _writable = false;
             _memory = source;
-            _length = source.Length;
+            _isOpen = true;
         }
 
         /// <inheritdoc/>
-        public override int Capacity
+        public override bool CanRead => _isOpen;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => _isOpen;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => false;
+
+        /// <inheritdoc/>
+        public override long Length
         {
             get
             {
                 EnsureNotClosed();
                 return _memory.Length;
             }
-            set => throw new NotSupportedException(SR.NotSupported_MemStreamNotExpandable);
         }
 
         /// <inheritdoc/>
-        public override byte[] GetBuffer() =>
-            throw new UnauthorizedAccessException(SR.UnauthorizedAccess_MemStreamBuffer);
-
-        /// <inheritdoc/>
-        public override bool TryGetBuffer(out ArraySegment<byte> buffer)
+        public override long Position
         {
-            buffer = default;
-            return false;
+            get
+            {
+                EnsureNotClosed();
+                return _position;
+            }
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                EnsureNotClosed();
+
+                if (value > int.MaxValue)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.ArgumentOutOfRange_StreamPosition, int.MaxValue));
+                }
+
+                _position = (int)value;
+            }
         }
+
+        /// <inheritdoc/>
+        public override void Flush()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override Task FlushAsync(CancellationToken cancellationToken) =>
+            cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) : Task.CompletedTask;
 
         /// <inheritdoc/>
         public override int ReadByte()
@@ -122,6 +151,34 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            EnsureNotClosed();
+
+            int loc = origin switch
+            {
+                SeekOrigin.Begin => 0,
+                SeekOrigin.Current => _position,
+                SeekOrigin.End => _memory.Length,
+                _ => throw new ArgumentException(SR.Argument_InvalidSeekOrigin)
+            };
+
+            if (offset > int.MaxValue - loc)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.Format(SR.ArgumentOutOfRange_StreamPosition, int.MaxValue));
+            }
+
+            int tempPosition = unchecked(loc + (int)offset);
+            if (unchecked(loc + offset) < 0 || tempPosition < 0)
+            {
+                throw new IOException(SR.IO_SeekBeforeBegin);
+            }
+
+            _position = tempPosition;
+            return _position;
+        }
+
+        /// <inheritdoc/>
         public override void CopyTo(Stream destination, int bufferSize)
         {
             ValidateCopyToArguments(destination, bufferSize);
@@ -157,32 +214,17 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
-        public override byte[] ToArray()
-        {
-            EnsureNotClosed();
-            if (_memory.Length == 0)
-            {
-                return Array.Empty<byte>();
-            }
-
-            byte[] copy = GC.AllocateUninitializedArray<byte>(_memory.Length);
-            _memory.Span.CopyTo(copy);
-            return copy;
-        }
+        public override void SetLength(long value) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
-        public override void WriteTo(Stream stream)
-        {
-            ArgumentNullException.ThrowIfNull(stream);
-            EnsureNotClosed();
-
-            stream.Write(_memory.Span);
-        }
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
+            _isOpen = false;
             _memory = default;
+            _lastReadTask = default;
             base.Dispose(disposing);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
@@ -220,6 +220,18 @@ namespace System.IO
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+
+        /// <inheritdoc/>
+        public override void WriteByte(byte value) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+
+        /// <inheritdoc/>
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+
+        /// <inheritdoc/>
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+
+        /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
             _isOpen = false;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/WritableMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/WritableMemoryStream.cs
@@ -7,46 +7,76 @@ using System.Threading.Tasks;
 namespace System.IO
 {
     /// <summary>
-    /// Provides a seekable, writable <see cref="MemoryStream"/> over a <see cref="Memory{Byte}"/> with fixed capacity.
+    /// Provides a seekable, writable <see cref="Stream"/> over a <see cref="Memory{Byte}"/>.
     /// </summary>
-    /// <remarks>
-    /// <para>The stream cannot expand beyond the initial memory capacity.</para>
-    /// <para><see cref="MemoryStream.GetBuffer"/> throws and <see cref="MemoryStream.TryGetBuffer"/> returns <see langword="false"/>.</para>
-    /// </remarks>
-    public sealed class WritableMemoryStream : MemoryStream
+    public sealed class WritableMemoryStream : Stream
     {
         private Memory<byte> _memory;
+        private int _position;
+        private int _length;
+        private bool _isOpen;
+        private CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WritableMemoryStream"/> class over the specified <see cref="Memory{Byte}"/>.
         /// </summary>
         /// <param name="buffer">The <see cref="Memory{Byte}"/> to wrap.</param>
-        public WritableMemoryStream(Memory<byte> buffer) : base()
+        public WritableMemoryStream(Memory<byte> buffer)
         {
             _memory = buffer;
+            _length = buffer.Length;
+            _isOpen = true;
         }
 
         /// <inheritdoc/>
-        public override int Capacity
+        public override bool CanRead => _isOpen;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => _isOpen;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => _isOpen;
+
+        /// <inheritdoc/>
+        public override long Length
         {
             get
             {
                 EnsureNotClosed();
-                return _memory.Length;
+                return _length;
             }
-            set => throw new NotSupportedException(SR.NotSupported_MemStreamNotExpandable);
         }
 
         /// <inheritdoc/>
-        public override byte[] GetBuffer() =>
-            throw new UnauthorizedAccessException(SR.UnauthorizedAccess_MemStreamBuffer);
-
-        /// <inheritdoc/>
-        public override bool TryGetBuffer(out ArraySegment<byte> buffer)
+        public override long Position
         {
-            buffer = default;
-            return false;
+            get
+            {
+                EnsureNotClosed();
+                return _position;
+            }
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                EnsureNotClosed();
+
+                if (value > int.MaxValue)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.ArgumentOutOfRange_StreamPosition, int.MaxValue));
+                }
+
+                _position = (int)value;
+            }
         }
+
+        /// <inheritdoc/>
+        public override void Flush()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override Task FlushAsync(CancellationToken cancellationToken) =>
+            cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) : Task.CompletedTask;
 
         /// <inheritdoc/>
         public override int ReadByte()
@@ -117,6 +147,34 @@ namespace System.IO
             }
 
             return new ValueTask<int>(Read(buffer.Span));
+        }
+
+        /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            EnsureNotClosed();
+
+            int loc = origin switch
+            {
+                SeekOrigin.Begin => 0,
+                SeekOrigin.Current => _position,
+                SeekOrigin.End => _length,
+                _ => throw new ArgumentException(SR.Argument_InvalidSeekOrigin)
+            };
+
+            if (offset > int.MaxValue - loc)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.Format(SR.ArgumentOutOfRange_StreamPosition, int.MaxValue));
+            }
+
+            int tempPosition = unchecked(loc + (int)offset);
+            if (unchecked(loc + offset) < 0 || tempPosition < 0)
+            {
+                throw new IOException(SR.IO_SeekBeforeBegin);
+            }
+
+            _position = tempPosition;
+            return _position;
         }
 
         /// <inheritdoc/>
@@ -236,35 +294,36 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
-        public override void SetLength(long value) => throw new NotSupportedException(SR.NotSupported_MemStreamNotExpandable);
-
-        /// <inheritdoc/>
-        public override byte[] ToArray()
+        public override void SetLength(long value)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
             EnsureNotClosed();
-            if (_length == 0)
+
+            if (value > _memory.Length)
             {
-                return Array.Empty<byte>();
+                throw new NotSupportedException(SR.IO_FixedCapacity);
             }
 
-            byte[] copy = GC.AllocateUninitializedArray<byte>(_length);
-            _memory.Span.Slice(0, _length).CopyTo(copy);
-            return copy;
-        }
+            int newLength = (int)value;
+            if (newLength > _length)
+            {
+                // Zero out the newly exposed region so it reads back as zeros.
+                _memory.Span.Slice(_length, newLength - _length).Clear();
+            }
 
-        /// <inheritdoc/>
-        public override void WriteTo(Stream stream)
-        {
-            ArgumentNullException.ThrowIfNull(stream);
-            EnsureNotClosed();
-
-            stream.Write(_memory.Span.Slice(0, _length));
+            _length = newLength;
+            if (_position > newLength)
+            {
+                _position = newLength;
+            }
         }
 
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
+            _isOpen = false;
             _memory = default;
+            _lastReadTask = default;
             base.Dispose(disposing);
         }
 
@@ -278,7 +337,7 @@ namespace System.IO
         {
             if (count != 0 && _position > _memory.Length - count)
             {
-                throw new NotSupportedException(SR.NotSupported_MemStreamNotExpandable);
+                throw new NotSupportedException(SR.IO_FixedCapacity);
             }
         }
     }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -11109,45 +11109,53 @@ namespace System.IO
         public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public sealed partial class ReadOnlyMemoryStream : System.IO.MemoryStream
+    public sealed partial class ReadOnlyMemoryStream : System.IO.Stream
     {
         public ReadOnlyMemoryStream(System.ReadOnlyMemory<byte> source) { }
-        public override int Capacity { get { throw null; } set { } }
+        public override bool CanRead { get { throw null; } }
+        public override bool CanSeek { get { throw null; } }
+        public override bool CanWrite { get { throw null; } }
+        public override long Length { get { throw null; } }
+        public override long Position { get { throw null; } set { } }
         public override void CopyTo(System.IO.Stream destination, int bufferSize) { }
         public override System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override void Dispose(bool disposing) { }
-        public override byte[] GetBuffer() { throw null; }
+        public override void Flush() { }
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int Read(System.Span<byte> buffer) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override int ReadByte() { throw null; }
-        public override byte[] ToArray() { throw null; }
-        public override bool TryGetBuffer(out System.ArraySegment<byte> buffer) { throw null; }
-        public override void WriteTo(System.IO.Stream stream) { }
+        public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
+        public override void SetLength(long value) { }
+        public override void Write(byte[] buffer, int offset, int count) { }
     }
-    public sealed partial class WritableMemoryStream : System.IO.MemoryStream
+    public sealed partial class WritableMemoryStream : System.IO.Stream
     {
         public WritableMemoryStream(System.Memory<byte> buffer) { }
-        public override int Capacity { get { throw null; } set { } }
+        public override bool CanRead { get { throw null; } }
+        public override bool CanSeek { get { throw null; } }
+        public override bool CanWrite { get { throw null; } }
+        public override long Length { get { throw null; } }
+        public override long Position { get { throw null; } set { } }
         public override void CopyTo(System.IO.Stream destination, int bufferSize) { }
         public override System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override void Dispose(bool disposing) { }
-        public override byte[] GetBuffer() { throw null; }
+        public override void Flush() { }
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int Read(System.Span<byte> buffer) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override int ReadByte() { throw null; }
+        public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
-        public override byte[] ToArray() { throw null; }
-        public override bool TryGetBuffer(out System.ArraySegment<byte> buffer) { throw null; }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }
         public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override void WriteByte(byte value) { }
-        public override void WriteTo(System.IO.Stream stream) { }
     }
     public partial class StringWriter : System.IO.TextWriter
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -11130,6 +11130,10 @@ namespace System.IO
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
         public override void Write(byte[] buffer, int offset, int count) { }
+        public override void Write(System.ReadOnlySpan<byte> buffer) { }
+        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override void WriteByte(byte value) { }
     }
     public sealed partial class WritableMemoryStream : System.IO.Stream
     {

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
@@ -166,6 +166,68 @@ namespace System.IO.Tests
             }
         }
 
+        [Fact]
+        public void UserBuffer_WriteBeyondCapacityThrows()
+        {
+            byte[] buffer = new byte[10];
+            using MemoryStream stream = new MemoryStream(buffer);
+
+            byte[] data = new byte[15];
+            Assert.Throws<NotSupportedException>(() => stream.Write(data, 0, data.Length));
+        }
+
+        [Fact]
+        public void UserBuffer_WriteUpToExactCapacitySucceeds()
+        {
+            byte[] buffer = new byte[10];
+            using MemoryStream stream = new MemoryStream(buffer);
+
+            byte[] data = new byte[10];
+            for (int i = 0; i < data.Length; i++) data[i] = (byte)i;
+
+            stream.Write(data, 0, data.Length);
+
+            Assert.Equal(10, stream.Position);
+            Assert.Equal(10, stream.Length);
+
+            stream.Position = 0;
+            byte[] readBack = new byte[10];
+            int bytesRead = stream.Read(readBack, 0, 10);
+            Assert.Equal(10, bytesRead);
+            Assert.Equal(data, readBack);
+        }
+
+        [Fact]
+        public void UserBuffer_SetLengthBeyondCapacityThrows()
+        {
+            byte[] buffer = new byte[8];
+            using MemoryStream stream = new MemoryStream(buffer);
+
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(9));
+            Assert.Equal(8, stream.Length);
+        }
+
+        [Fact]
+        public void UserBuffer_WritePastShrunkenLengthExtendsAndZeroesGap()
+        {
+            byte[] buffer = { 1, 2, 3, 4, 5, 6, 7, 8 };
+            using MemoryStream stream = new MemoryStream(buffer);
+
+            stream.SetLength(2);
+            Assert.Equal(2, stream.Length);
+
+            stream.Position = 5;
+            stream.WriteByte(42);
+
+            Assert.Equal(6, stream.Length);
+            Assert.Equal(6, stream.Position);
+
+            stream.Position = 0;
+            byte[] readBack = new byte[6];
+            Assert.Equal(6, stream.Read(readBack, 0, readBack.Length));
+            Assert.Equal(new byte[] { 1, 2, 0, 0, 0, 42 }, readBack);
+        }
+
         private class ReadWriteOverridingMemoryStream : MemoryStream
         {
             public bool ReadArrayInvoked, WriteArrayInvoked;

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/ReadOnlyMemoryStream/ReadOnlyMemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/ReadOnlyMemoryStream/ReadOnlyMemoryStreamTests.cs
@@ -35,15 +35,12 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void GetBuffer_Throws_TryGetBuffer_ReturnsFalse()
+        public void WriteThrowsNotSupported()
         {
             var stream = new ReadOnlyMemoryStream(new byte[] { 1, 2, 3 });
 
-            Assert.Throws<UnauthorizedAccessException>(() => stream.GetBuffer());
-            Assert.False(stream.TryGetBuffer(out ArraySegment<byte> segment));
-            Assert.Null(segment.Array);
-            Assert.Equal(0, segment.Offset);
-            Assert.Equal(0, segment.Count);
+            Assert.Throws<NotSupportedException>(() => stream.Write(new byte[1], 0, 1));
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(1));
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/ReadOnlyMemoryStream/ReadOnlyMemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/ReadOnlyMemoryStream/ReadOnlyMemoryStreamTests.cs
@@ -40,6 +40,10 @@ namespace System.IO.Tests
             var stream = new ReadOnlyMemoryStream(new byte[] { 1, 2, 3 });
 
             Assert.Throws<NotSupportedException>(() => stream.Write(new byte[1], 0, 1));
+            Assert.Throws<NotSupportedException>(() => stream.Write(new byte[1].AsSpan()));
+            Assert.Throws<NotSupportedException>(() => stream.WriteByte(1));
+            Assert.Throws<NotSupportedException>(() => { _ = stream.WriteAsync(new byte[1], 0, 1); });
+            Assert.Throws<NotSupportedException>(() => { _ = stream.WriteAsync(new byte[1].AsMemory()); });
             Assert.Throws<NotSupportedException>(() => stream.SetLength(1));
         }
     }

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/WritableMemoryStream/WritableMemoryStreamConformanceTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/WritableMemoryStream/WritableMemoryStreamConformanceTests.cs
@@ -9,7 +9,6 @@ namespace System.IO.Tests
     public class WritableMemoryStreamConformanceTests : StandaloneStreamConformanceTests
     {
         protected override bool CanSeek => true;
-        protected override bool CanSetLength => false;
         protected override bool NopFlushCompletesSynchronously => true;
         protected override bool CanSetLengthGreaterThanCapacity => false;
 
@@ -19,16 +18,19 @@ namespace System.IO.Tests
 
         protected override Task<Stream?> CreateReadWriteStreamCore(byte[]? initialData)
         {
-            int length = initialData?.Length ?? 0;
-            if (length == 0)
+            // WritableMemoryStream wraps a fixed-capacity buffer and cannot be created empty and then
+            // grown, so - like the other fixed-capacity streams (UnmanagedMemoryStream,
+            // MemoryMappedViewStream) - the empty case returns null and the grow-from-empty conformance
+            // tests are skipped. Growing the length within the fixed capacity is covered by the unit
+            // tests in WritableMemoryStreamTests.
+            if (initialData is null or { Length: 0 })
             {
-                return Task.FromResult<Stream?>(
-                    new WritableMemoryStream(new Memory<byte>(new byte[64 * 1024])));
+                return Task.FromResult<Stream?>(null);
             }
 
-            var memory = new Memory<byte>(new byte[length]);
+            var memory = new Memory<byte>(new byte[initialData.Length]);
             var stream = new WritableMemoryStream(memory);
-            stream.Write(initialData!, 0, length);
+            stream.Write(initialData, 0, initialData.Length);
             stream.Position = 0;
             return Task.FromResult<Stream?>(stream);
         }

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/WritableMemoryStream/WritableMemoryStreamConformanceTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/WritableMemoryStream/WritableMemoryStreamConformanceTests.cs
@@ -20,10 +20,10 @@ namespace System.IO.Tests
         {
             // WritableMemoryStream wraps a fixed-capacity buffer and cannot be created empty and then
             // grown, so - like the other fixed-capacity streams (UnmanagedMemoryStream,
-            // MemoryMappedViewStream) - the empty case returns null and the grow-from-empty conformance
+            // MemoryMappedViewStream) - the null case returns null and the grow-from-empty conformance
             // tests are skipped. Growing the length within the fixed capacity is covered by the unit
             // tests in WritableMemoryStreamTests.
-            if (initialData is null or { Length: 0 })
+            if (initialData is null)
             {
                 return Task.FromResult<Stream?>(null);
             }

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/WritableMemoryStream/WritableMemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/WritableMemoryStream/WritableMemoryStreamTests.cs
@@ -80,34 +80,34 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void WriteOverExistingDataReplacesData()
+        public void SetLengthBeyondCapacityThrows()
         {
-            byte[] initialData = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-            byte[] backing = new byte[10];
-            Stream stream = new WritableMemoryStream(new Memory<byte>(backing));
-            stream.Write(initialData, 0, initialData.Length);
+            byte[] buffer = new byte[8];
+            Stream stream = new WritableMemoryStream(new Memory<byte>(buffer));
 
-            stream.Position = 3;
-            stream.Write(new byte[] { 100, 101, 102 }, 0, 3);
-
-            stream.Position = 0;
-            byte[] result = new byte[10];
-            int bytesRead = stream.Read(result, 0, 10);
-
-            Assert.Equal(10, bytesRead);
-            Assert.Equal(new byte[] { 1, 2, 3, 100, 101, 102, 7, 8, 9, 10 }, result);
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(9));
+            Assert.Equal(8, stream.Length);
         }
 
         [Fact]
-        public void GetBuffer_Throws_TryGetBuffer_ReturnsFalse()
+        public void WritePastShrunkenLengthExtendsAndZeroesGap()
         {
-            using var stream = new WritableMemoryStream(new byte[8]);
+            byte[] buffer = { 1, 2, 3, 4, 5, 6, 7, 8 };
+            Stream stream = new WritableMemoryStream(new Memory<byte>(buffer));
 
-            Assert.Throws<UnauthorizedAccessException>(() => stream.GetBuffer());
-            Assert.False(stream.TryGetBuffer(out ArraySegment<byte> segment));
-            Assert.Null(segment.Array);
-            Assert.Equal(0, segment.Offset);
-            Assert.Equal(0, segment.Count);
+            stream.SetLength(2);
+            Assert.Equal(2, stream.Length);
+
+            stream.Position = 5;
+            stream.WriteByte(42);
+
+            Assert.Equal(6, stream.Length);
+            Assert.Equal(6, stream.Position);
+
+            stream.Position = 0;
+            byte[] readBack = new byte[6];
+            Assert.Equal(6, stream.Read(readBack, 0, readBack.Length));
+            Assert.Equal(new byte[] { 1, 2, 0, 0, 0, 42 }, readBack);
         }
     }
 }


### PR DESCRIPTION
Instead of deriving from MemoryStream.
Also support `WritableMemoryStream.SetLength(long)` since 1) is writable and seekable and 2) to properly align with `MemoryStream` user-buffer mode.

Fixes https://github.com/dotnet/runtime/issues/130330.