### PR TITLE
[Android] Support delayed client certificate selection in SslStream

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
@@ -60,9 +60,15 @@ internal static partial class Interop
         [LibraryImport(Interop.Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamCreateKeyManagersFromKeyStoreEntry")]
         internal static partial IntPtr SSLStreamCreateKeyManagersFromKeyStoreEntry(IntPtr privateKeyEntryHandle);
 
-        [LibraryImport(Interop.Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_RegisterRemoteCertificateValidationCallback")]
-        internal static unsafe partial void RegisterRemoteCertificateValidationCallback(
-            delegate* unmanaged<IntPtr, IntPtr, bool> verifyRemoteCertificate);
+        [LibraryImport(Interop.Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_SSLStreamCreateKeyManagersForSelection")]
+        private static partial IntPtr SSLStreamCreateKeyManagersForSelection(IntPtr sslStreamProxyHandle);
+        internal static IntPtr SSLStreamCreateKeyManagersForSelection(SslStream.JavaProxy sslStreamProxy)
+            => SSLStreamCreateKeyManagersForSelection(sslStreamProxy.Handle);
+
+        [LibraryImport(Interop.Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_RegisterSslStreamCallbacks")]
+        internal static unsafe partial void RegisterSslStreamCallbacks(
+            delegate* unmanaged<IntPtr, IntPtr, bool> verifyRemoteCertificate,
+            delegate* unmanaged<IntPtr, int, IntPtr*, IntPtr> selectLocalCertificate);
 
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_GetPlatformValidationError")]
         private static partial int GetPlatformValidationError(

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
@@ -6,6 +6,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
@@ -207,20 +208,29 @@ namespace System.Net.Http.Functional.Tests
         }
 
 #if TARGETS_ANDROID
-        [Fact]
-        public async Task Android_GetCertificateFromKeyStoreViaAlias()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Android_GetCertificateFromKeyStoreViaAlias(bool delayCertificateSelection)
         {
             var options = new LoopbackServer.Options { UseSsl = true };
+            if (delayCertificateSelection)
+            {
+                options.SslProtocols = SslProtocols.Tls12;
+            }
 
             (X509Store store, string alias) = AndroidKeyStoreHelper.AddCertificate(Configuration.Certificates.GetClientCertificate());
             try
             {
-                X509Certificate2 clientCertificate = AndroidKeyStoreHelper.GetCertificateViaAlias(store, alias);
+                using X509Certificate2 clientCertificate = AndroidKeyStoreHelper.GetCertificateViaAlias(store, alias);
                 Assert.True(clientCertificate.HasPrivateKey);
 
+                int callbackCount = 0;
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
-                    using HttpClient client = CreateHttpClientWithCert(clientCertificate);
+                    using HttpClient client = delayCertificateSelection
+                        ? CreateHttpClientWithDelayedCertificate(clientCertificate)
+                        : CreateHttpClientWithCert(clientCertificate);
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(
                         client.GetStringAsync(url),
@@ -228,15 +238,39 @@ namespace System.Net.Http.Functional.Tests
                         {
                             SslStream sslStream = Assert.IsType<SslStream>(connection.Stream);
 
+                            using X509Certificate2 receivedCertificate =
+                                X509CertificateLoader.LoadCertificate(sslStream.RemoteCertificate.Export(X509ContentType.Cert));
                             _output.WriteLine(
                                 "Client cert: {0}",
-                                X509CertificateLoader.LoadCertificate(sslStream.RemoteCertificate.Export(X509ContentType.Cert)).GetNameInfo(X509NameType.SimpleName, false));
+                                receivedCertificate.GetNameInfo(X509NameType.SimpleName, false));
 
                             Assert.Equal(clientCertificate.GetCertHashString(), sslStream.RemoteCertificate.GetCertHashString());
 
                             await connection.ReadRequestHeaderAndSendResponseAsync(additionalHeaders: "Connection: close\r\n");
                         }));
+
+                    if (delayCertificateSelection)
+                    {
+                        Assert.Equal(2, callbackCount);
+                    }
                 }, options);
+
+                HttpClient CreateHttpClientWithDelayedCertificate(X509Certificate2 certificate)
+                {
+                    var handler = new SocketsHttpHandler();
+                    handler.SslOptions = new SslClientAuthenticationOptions
+                    {
+                        EnabledSslProtocols = SslProtocols.Tls12,
+                        RemoteCertificateValidationCallback = delegate { return true; },
+                        LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) =>
+                        {
+                            callbackCount++;
+                            return remoteCertificate is null ? null : certificate;
+                        },
+                    };
+
+                    return CreateHttpClient(handler);
+                }
             }
             finally
             {

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -411,6 +411,7 @@
     <Compile Include="$(CommonPath)Interop\Android\System.Security.Cryptography.Native.Android\Interop.X509.cs"
              Link="Common\Interop\Android\System.Security.Cryptography.Native.Android\Interop.X509.cs" />
     <Compile Include="System\Net\CertificateValidationPal.Android.cs" />
+    <Compile Include="System\Net\Security\Pal.Android\AndroidKeyManager.cs" />
     <Compile Include="System\Net\Security\Pal.Android\SafeDeleteSslContext.cs" />
     <Compile Include="System\Net\Security\Pal.Managed\SslProtocolsValidation.cs" />
     <Compile Include="System\Net\Security\SslConnectionInfo.Android.cs" />

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/AndroidKeyManager.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/AndroidKeyManager.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+using PAL_KeyAlgorithm = Interop.AndroidCrypto.PAL_KeyAlgorithm;
+
+namespace System.Net
+{
+    internal static class AndroidKeyManager
+    {
+        internal static IntPtr Create(SslStreamCertificateContext context)
+        {
+            X509Certificate2 cert = context.TargetCertificate;
+            Debug.Assert(cert.HasPrivateKey);
+
+            IntPtr keyManagers;
+            if (Interop.AndroidCrypto.IsKeyStorePrivateKeyEntry(cert.Handle))
+            {
+                keyManagers = Interop.AndroidCrypto.SSLStreamCreateKeyManagersFromKeyStoreEntry(cert.Handle);
+            }
+            else
+            {
+                PAL_KeyAlgorithm algorithm;
+                byte[] keyBytes;
+                using (AsymmetricAlgorithm key = GetPrivateKeyAlgorithm(cert, out algorithm))
+                {
+                    keyBytes = key.ExportPkcs8PrivateKey();
+                }
+
+                try
+                {
+                    IntPtr[] ptrs = new IntPtr[context.IntermediateCertificates.Count + 1];
+                    ptrs[0] = cert.Handle;
+                    for (int i = 0; i < context.IntermediateCertificates.Count; i++)
+                    {
+                        ptrs[i + 1] = context.IntermediateCertificates[i].Handle;
+                    }
+
+                    keyManagers = Interop.AndroidCrypto.SSLStreamCreateKeyManagers(keyBytes, algorithm, ptrs);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(keyBytes);
+                }
+            }
+
+            if (keyManagers == IntPtr.Zero)
+            {
+                throw new Interop.AndroidCrypto.SslException();
+            }
+
+            return keyManagers;
+        }
+
+        private static AsymmetricAlgorithm GetPrivateKeyAlgorithm(X509Certificate2 cert, out PAL_KeyAlgorithm algorithm)
+        {
+            AsymmetricAlgorithm? key = cert.GetRSAPrivateKey();
+            if (key != null)
+            {
+                algorithm = PAL_KeyAlgorithm.RSA;
+                return key;
+            }
+
+            key = cert.GetECDsaPrivateKey();
+            if (key != null)
+            {
+                algorithm = PAL_KeyAlgorithm.EC;
+                return key;
+            }
+
+            key = cert.GetDSAPrivateKey();
+            if (key != null)
+            {
+                algorithm = PAL_KeyAlgorithm.DSA;
+                return key;
+            }
+
+            throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
+        }
+    }
+}

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -218,9 +218,19 @@ namespace System.Net
                     ? authOptions.TargetHost
                     : null;
 
-            IntPtr keyManagers = authOptions.CertificateContext is not null
-                ? CreateKeyManagers(authOptions.CertificateContext)
-                : IntPtr.Zero;
+            IntPtr keyManagers = IntPtr.Zero;
+            if (authOptions.CertificateContext is not null)
+            {
+                keyManagers = CreateKeyManagers(authOptions.CertificateContext);
+            }
+            else if (!authOptions.IsServer && authOptions.CertSelectionDelegate is not null)
+            {
+                keyManagers = Interop.AndroidCrypto.SSLStreamCreateKeyManagersForSelection(sslStreamProxy);
+                if (keyManagers == IntPtr.Zero)
+                {
+                    throw new Interop.AndroidCrypto.SslException();
+                }
+            }
 
             try
             {
@@ -242,50 +252,50 @@ namespace System.Net
                     Interop.JObjectLifetime.DeleteGlobalReference(keyManagers);
                 }
             }
+        }
 
-            static IntPtr CreateKeyManagers(SslStreamCertificateContext context)
+        internal static IntPtr CreateKeyManagers(SslStreamCertificateContext context)
+        {
+            X509Certificate2 cert = context.TargetCertificate;
+            Debug.Assert(cert.HasPrivateKey);
+
+            IntPtr keyManagers;
+            if (Interop.AndroidCrypto.IsKeyStorePrivateKeyEntry(cert.Handle))
             {
-                X509Certificate2 cert = context.TargetCertificate;
-                Debug.Assert(cert.HasPrivateKey);
-
-                IntPtr keyManagers;
-                if (Interop.AndroidCrypto.IsKeyStorePrivateKeyEntry(cert.Handle))
-                {
-                    keyManagers = Interop.AndroidCrypto.SSLStreamCreateKeyManagersFromKeyStoreEntry(cert.Handle);
-                }
-                else
-                {
-                    PAL_KeyAlgorithm algorithm;
-                    byte[] keyBytes;
-                    using (AsymmetricAlgorithm key = GetPrivateKeyAlgorithm(cert, out algorithm))
-                    {
-                        keyBytes = key.ExportPkcs8PrivateKey();
-                    }
-
-                    try
-                    {
-                        IntPtr[] ptrs = new IntPtr[context.IntermediateCertificates.Count + 1];
-                        ptrs[0] = cert.Handle;
-                        for (int i = 0; i < context.IntermediateCertificates.Count; i++)
-                        {
-                            ptrs[i + 1] = context.IntermediateCertificates[i].Handle;
-                        }
-
-                        keyManagers = Interop.AndroidCrypto.SSLStreamCreateKeyManagers(keyBytes, algorithm, ptrs);
-                    }
-                    finally
-                    {
-                        CryptographicOperations.ZeroMemory(keyBytes);
-                    }
-                }
-
-                if (keyManagers == IntPtr.Zero)
-                {
-                    throw new Interop.AndroidCrypto.SslException();
-                }
-
-                return keyManagers;
+                keyManagers = Interop.AndroidCrypto.SSLStreamCreateKeyManagersFromKeyStoreEntry(cert.Handle);
             }
+            else
+            {
+                PAL_KeyAlgorithm algorithm;
+                byte[] keyBytes;
+                using (AsymmetricAlgorithm key = GetPrivateKeyAlgorithm(cert, out algorithm))
+                {
+                    keyBytes = key.ExportPkcs8PrivateKey();
+                }
+
+                try
+                {
+                    IntPtr[] ptrs = new IntPtr[context.IntermediateCertificates.Count + 1];
+                    ptrs[0] = cert.Handle;
+                    for (int i = 0; i < context.IntermediateCertificates.Count; i++)
+                    {
+                        ptrs[i + 1] = context.IntermediateCertificates[i].Handle;
+                    }
+
+                    keyManagers = Interop.AndroidCrypto.SSLStreamCreateKeyManagers(keyBytes, algorithm, ptrs);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(keyBytes);
+                }
+            }
+
+            if (keyManagers == IntPtr.Zero)
+            {
+                throw new Interop.AndroidCrypto.SslException();
+            }
+
+            return keyManagers;
         }
 
         private static AsymmetricAlgorithm GetPrivateKeyAlgorithm(X509Certificate2 cert, out PAL_KeyAlgorithm algorithm)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -6,11 +6,8 @@ using System.Collections.Generic;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 
-using PAL_KeyAlgorithm = Interop.AndroidCrypto.PAL_KeyAlgorithm;
 using PAL_SSLStreamStatus = Interop.AndroidCrypto.PAL_SSLStreamStatus;
 
 namespace System.Net
@@ -221,7 +218,7 @@ namespace System.Net
             IntPtr keyManagers = IntPtr.Zero;
             if (authOptions.CertificateContext is not null)
             {
-                keyManagers = CreateKeyManagers(authOptions.CertificateContext);
+                keyManagers = AndroidKeyManager.Create(authOptions.CertificateContext);
             }
             else if (!authOptions.IsServer && authOptions.CertSelectionDelegate is not null)
             {
@@ -252,73 +249,6 @@ namespace System.Net
                     Interop.JObjectLifetime.DeleteGlobalReference(keyManagers);
                 }
             }
-        }
-
-        internal static IntPtr CreateKeyManagers(SslStreamCertificateContext context)
-        {
-            X509Certificate2 cert = context.TargetCertificate;
-            Debug.Assert(cert.HasPrivateKey);
-
-            IntPtr keyManagers;
-            if (Interop.AndroidCrypto.IsKeyStorePrivateKeyEntry(cert.Handle))
-            {
-                keyManagers = Interop.AndroidCrypto.SSLStreamCreateKeyManagersFromKeyStoreEntry(cert.Handle);
-            }
-            else
-            {
-                PAL_KeyAlgorithm algorithm;
-                byte[] keyBytes;
-                using (AsymmetricAlgorithm key = GetPrivateKeyAlgorithm(cert, out algorithm))
-                {
-                    keyBytes = key.ExportPkcs8PrivateKey();
-                }
-
-                try
-                {
-                    IntPtr[] ptrs = new IntPtr[context.IntermediateCertificates.Count + 1];
-                    ptrs[0] = cert.Handle;
-                    for (int i = 0; i < context.IntermediateCertificates.Count; i++)
-                    {
-                        ptrs[i + 1] = context.IntermediateCertificates[i].Handle;
-                    }
-
-                    keyManagers = Interop.AndroidCrypto.SSLStreamCreateKeyManagers(keyBytes, algorithm, ptrs);
-                }
-                finally
-                {
-                    CryptographicOperations.ZeroMemory(keyBytes);
-                }
-            }
-
-            if (keyManagers == IntPtr.Zero)
-            {
-                throw new Interop.AndroidCrypto.SslException();
-            }
-
-            return keyManagers;
-        }
-
-        private static AsymmetricAlgorithm GetPrivateKeyAlgorithm(X509Certificate2 cert, out PAL_KeyAlgorithm algorithm)
-        {
-            AsymmetricAlgorithm? key = cert.GetRSAPrivateKey();
-            if (key != null)
-            {
-                algorithm = PAL_KeyAlgorithm.RSA;
-                return key;
-            }
-            key = cert.GetECDsaPrivateKey();
-            if (key != null)
-            {
-                algorithm = PAL_KeyAlgorithm.EC;
-                return key;
-            }
-            key = cert.GetDSAPrivateKey();
-            if (key != null)
-            {
-                algorithm = PAL_KeyAlgorithm.DSA;
-                return key;
-            }
-            throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
         }
 
         private unsafe void InitializeSslContext(

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
@@ -67,7 +67,7 @@ namespace System.Net.Security
                 _sslAuthenticationOptions.SetCertificateContextFromCert(selectedCertificate);
             }
 
-            return SafeDeleteSslContext.CreateKeyManagers(_sslAuthenticationOptions.CertificateContext!);
+            return AndroidKeyManager.Create(_sslAuthenticationOptions.CertificateContext!);
         }
 
         private bool TryGetRemoteCertificateValidationResult(out SslPolicyErrors sslPolicyErrors, out X509ChainStatusFlags chainStatus, ref ProtocolToken alertToken, out bool isValid)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
@@ -85,11 +85,11 @@ namespace System.Net.Security
             private static bool s_initialized;
 
             private readonly SslStream _sslStream;
-            private GCHandle? _handle;
+            private GCHandle<JavaProxy> _handle;
 
             public IntPtr Handle
-                => _handle is GCHandle handle
-                    ? GCHandle.ToIntPtr(handle)
+                => _handle.IsAllocated
+                    ? GCHandle<JavaProxy>.ToIntPtr(_handle)
                     : throw new ObjectDisposedException(nameof(JavaProxy));
 
             public Exception? ValidationException { get; private set; }
@@ -101,13 +101,12 @@ namespace System.Net.Security
                 RegisterCallbacks();
 
                 _sslStream = sslStream;
-                _handle = GCHandle.Alloc(this);
+                _handle = new GCHandle<JavaProxy>(this);
             }
 
             public void Dispose()
             {
-                _handle?.Free();
-                _handle = null;
+                _handle.Dispose();
             }
 
             private static unsafe void RegisterCallbacks()
@@ -128,23 +127,14 @@ namespace System.Net.Security
 
                 try
                 {
-                    proxy = (JavaProxy?)GCHandle.FromIntPtr(sslStreamProxyHandle).Target;
-                    if (proxy is null)
-                    {
-                        return false;
-                    }
-
+                    proxy = GCHandle<JavaProxy>.FromIntPtr(sslStreamProxyHandle).Target;
                     Debug.Assert(proxy.ValidationResult is null);
                     proxy.ValidationResult = proxy._sslStream.VerifyRemoteCertificate(platformValidationError);
                     return proxy.ValidationResult.IsValid;
                 }
                 catch (Exception exception)
                 {
-                    if (proxy is not null)
-                    {
-                        proxy.ValidationException = exception;
-                    }
-
+                    proxy?.ValidationException = exception;
                     return false;
                 }
             }
@@ -159,12 +149,7 @@ namespace System.Net.Security
 
                 try
                 {
-                    proxy = (JavaProxy?)GCHandle.FromIntPtr(sslStreamProxyHandle).Target;
-                    if (proxy is null)
-                    {
-                        return IntPtr.Zero;
-                    }
-
+                    proxy = GCHandle<JavaProxy>.FromIntPtr(sslStreamProxyHandle).Target;
                     Debug.Assert(proxy.CertificateSelectionException is null);
                     string[] issuers = new string[acceptableIssuerCount];
                     for (int i = 0; i < issuers.Length; i++)
@@ -176,11 +161,7 @@ namespace System.Net.Security
                 }
                 catch (Exception exception)
                 {
-                    if (proxy is not null)
-                    {
-                        proxy.CertificateSelectionException = exception;
-                    }
-
+                    proxy?.CertificateSelectionException = exception;
                     return IntPtr.Zero;
                 }
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
@@ -54,6 +54,22 @@ namespace System.Net.Security
                 : _sslAuthenticationOptions.CertificateContext?.Trust is null;
         }
 
+        private IntPtr SelectClientCertificateForHandshake(string[] acceptableIssuers)
+        {
+            X509Certificate2? selectedCertificate = SelectClientCertificate(acceptableIssuers);
+            if (selectedCertificate is null)
+            {
+                return IntPtr.Zero;
+            }
+
+            if (_sslAuthenticationOptions.CertificateContext is null)
+            {
+                _sslAuthenticationOptions.SetCertificateContextFromCert(selectedCertificate);
+            }
+
+            return SafeDeleteSslContext.CreateKeyManagers(_sslAuthenticationOptions.CertificateContext!);
+        }
+
         private bool TryGetRemoteCertificateValidationResult(out SslPolicyErrors sslPolicyErrors, out X509ChainStatusFlags chainStatus, ref ProtocolToken alertToken, out bool isValid)
         {
             JavaProxy.RemoteCertificateValidationResult? validationResult = _securityContext?.SslStreamProxy.ValidationResult;
@@ -77,11 +93,12 @@ namespace System.Net.Security
                     : throw new ObjectDisposedException(nameof(JavaProxy));
 
             public Exception? ValidationException { get; private set; }
+            public Exception? CertificateSelectionException { get; private set; }
             public RemoteCertificateValidationResult? ValidationResult { get; private set; }
 
             public JavaProxy(SslStream sslStream)
             {
-                RegisterRemoteCertificateValidationCallback();
+                RegisterCallbacks();
 
                 _sslStream = sslStream;
                 _handle = GCHandle.Alloc(this);
@@ -93,11 +110,13 @@ namespace System.Net.Security
                 _handle = null;
             }
 
-            private static unsafe void RegisterRemoteCertificateValidationCallback()
+            private static unsafe void RegisterCallbacks()
             {
                 if (!s_initialized)
                 {
-                    Interop.AndroidCrypto.RegisterRemoteCertificateValidationCallback(&VerifyRemoteCertificate);
+                    Interop.AndroidCrypto.RegisterSslStreamCallbacks(
+                        &VerifyRemoteCertificate,
+                        &SelectClientCertificate);
                     s_initialized = true;
                 }
             }
@@ -105,19 +124,64 @@ namespace System.Net.Security
             [UnmanagedCallersOnly]
             private static bool VerifyRemoteCertificate(IntPtr sslStreamProxyHandle, IntPtr platformValidationError)
             {
-                var proxy = (JavaProxy?)GCHandle.FromIntPtr(sslStreamProxyHandle).Target;
-                Debug.Assert(proxy is not null);
-                Debug.Assert(proxy.ValidationResult is null);
+                JavaProxy? proxy = null;
 
                 try
                 {
+                    proxy = (JavaProxy?)GCHandle.FromIntPtr(sslStreamProxyHandle).Target;
+                    if (proxy is null)
+                    {
+                        return false;
+                    }
+
+                    Debug.Assert(proxy.ValidationResult is null);
                     proxy.ValidationResult = proxy._sslStream.VerifyRemoteCertificate(platformValidationError);
                     return proxy.ValidationResult.IsValid;
                 }
                 catch (Exception exception)
                 {
-                    proxy.ValidationException = exception;
+                    if (proxy is not null)
+                    {
+                        proxy.ValidationException = exception;
+                    }
+
                     return false;
+                }
+            }
+
+            [UnmanagedCallersOnly]
+            private static unsafe IntPtr SelectClientCertificate(
+                IntPtr sslStreamProxyHandle,
+                int acceptableIssuerCount,
+                IntPtr* acceptableIssuers)
+            {
+                JavaProxy? proxy = null;
+
+                try
+                {
+                    proxy = (JavaProxy?)GCHandle.FromIntPtr(sslStreamProxyHandle).Target;
+                    if (proxy is null)
+                    {
+                        return IntPtr.Zero;
+                    }
+
+                    Debug.Assert(proxy.CertificateSelectionException is null);
+                    string[] issuers = new string[acceptableIssuerCount];
+                    for (int i = 0; i < issuers.Length; i++)
+                    {
+                        issuers[i] = Marshal.PtrToStringUni(acceptableIssuers[i])!;
+                    }
+
+                    return proxy._sslStream.SelectClientCertificateForHandshake(issuers);
+                }
+                catch (Exception exception)
+                {
+                    if (proxy is not null)
+                    {
+                        proxy.CertificateSelectionException = exception;
+                    }
+
+                    return IntPtr.Zero;
                 }
             }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -286,7 +286,9 @@ namespace System.Net.Security
             return issuers;
         }
 
-        internal X509Certificate2? SelectClientCertificate()
+        internal X509Certificate2? SelectClientCertificate() => SelectClientCertificate(acceptableIssuers: null);
+
+        private X509Certificate2? SelectClientCertificate(string[]? acceptableIssuers)
         {
             X509Certificate? clientCertificate = null;        // candidate certificate that can come from the user callback or be guessed when targeting a session restart.
             X509Certificate2? selectedCert = null;            // final selected cert (ensured that it does have private key with it).
@@ -315,7 +317,7 @@ namespace System.Net.Security
                 X509Certificate2? remoteCert = null;
                 try
                 {
-                    issuers = GetRequestCertificateAuthorities();
+                    issuers = acceptableIssuers ?? GetRequestCertificateAuthorities();
                     remoteCert = CertificateValidationPal.GetRemoteCertificate(_securityContext);
                     _sslAuthenticationOptions.ClientCertificates ??= new X509CertificateCollection();
                     clientCertificate = _sslAuthenticationOptions.CertSelectionDelegate(this, _sslAuthenticationOptions.TargetHost, _sslAuthenticationOptions.ClientCertificates, remoteCert, issuers);
@@ -363,7 +365,7 @@ namespace System.Net.Security
                 //
                 // This should be a server request for the client cert sent over currently anonymous sessions.
                 //
-                issuers = GetRequestCertificateAuthorities();
+                issuers = acceptableIssuers ?? GetRequestCertificateAuthorities();
 
                 if (NetEventSource.Log.IsEnabled())
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
@@ -246,8 +246,15 @@ namespace System.Net.Security
                     _ => SecurityStatusPalErrorCode.InternalError
                 };
 
-                Exception? validationException = sslContext?.SslStreamProxy.ValidationException;
-                token.Status = new SecurityStatusPal(statusCode, validationException);
+                Exception? exception =
+                    sslContext?.SslStreamProxy.CertificateSelectionException ??
+                    sslContext?.SslStreamProxy.ValidationException;
+                if (exception is not null)
+                {
+                    statusCode = SecurityStatusPalErrorCode.InternalError;
+                }
+
+                token.Status = new SecurityStatusPal(statusCode, exception);
                 sslContext!.ReadPendingWrites(ref token);
                 return token;
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -45,11 +45,6 @@ namespace System.Net.Security.Tests
         [InlineData(false, false)]
         public async Task CertificateSelectionCallback_DelayedCertificate_OK(bool delayCertificate, bool sendClientCertificate)
         {
-            if (delayCertificate && OperatingSystem.IsAndroid())
-            {
-                throw new SkipTestException("Android does not support delayed certificate selection.");
-            }
-
             X509Certificate? remoteCertificate = null;
 
             (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
@@ -109,6 +104,102 @@ namespace System.Net.Security.Tests
                     // LocalCertificateSelectionCallback should be called with real remote certificate.
                     Assert.NotNull(remoteCertificate);
                 }
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid))]
+        public Task CertificateSelectionCallback_DelayedCertificate_ExceptionPropagates() =>
+            CertificateSelectionCallback_DelayedCertificate_ExceptionPropagates_Core(SslProtocols.Tls12);
+
+        [ConditionalFact(
+            typeof(PlatformDetection),
+            nameof(PlatformDetection.IsAndroid),
+            nameof(PlatformDetection.SupportsTls13))]
+        public Task CertificateSelectionCallback_DelayedCertificate_Tls13ExceptionPropagates() =>
+            CertificateSelectionCallback_DelayedCertificate_ExceptionPropagates_Core(SslProtocols.Tls13);
+
+        private async Task CertificateSelectionCallback_DelayedCertificate_ExceptionPropagates_Core(SslProtocols protocol)
+        {
+            const string ErrorMessage = "Certificate selection failed.";
+
+            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+            using (client)
+            using (server)
+            {
+                int callbackCount = 0;
+                var clientOptions = new SslClientAuthenticationOptions
+                {
+                    TargetHost = "localhost",
+                    EnabledSslProtocols = protocol,
+                    RemoteCertificateValidationCallback = delegate { return true; },
+                    LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, certificate, acceptableIssuers) =>
+                    {
+                        if (++callbackCount == 1)
+                        {
+                            return null;
+                        }
+
+                        throw new InvalidOperationException(ErrorMessage);
+                    },
+                };
+                var serverOptions = new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = _serverCertificate,
+                    ClientCertificateRequired = true,
+                    EnabledSslProtocols = protocol,
+                    RemoteCertificateValidationCallback = delegate { return true; },
+                };
+
+                Task clientAuthentication = client.AuthenticateAsClientAsync(clientOptions);
+                Task serverAuthentication = server.AuthenticateAsServerAsync(serverOptions);
+
+                await Assert.ThrowsAnyAsync<Exception>(() =>
+                    TestConfiguration.WhenAllOrAnyFailedWithTimeout(clientAuthentication, serverAuthentication));
+
+                Assert.True(clientAuthentication.IsFaulted);
+                AuthenticationException exception = Assert.IsType<AuthenticationException>(
+                    clientAuthentication.Exception!.GetBaseException());
+                InvalidOperationException innerException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+                Assert.Equal(ErrorMessage, innerException.Message);
+            }
+        }
+
+        [ConditionalTheory(
+            typeof(PlatformDetection),
+            nameof(PlatformDetection.IsAndroid),
+            nameof(PlatformDetection.SupportsTls13))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CertificateSelectionCallback_DelayedCertificate_Tls13_OK(bool sendClientCertificate)
+        {
+            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+            using (client)
+            using (server)
+            {
+                int callbackCount = 0;
+                var clientOptions = new SslClientAuthenticationOptions
+                {
+                    TargetHost = "localhost",
+                    EnabledSslProtocols = SslProtocols.Tls13,
+                    RemoteCertificateValidationCallback = delegate { return true; },
+                    LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, certificate, acceptableIssuers) =>
+                        ++callbackCount == 1 || !sendClientCertificate ? null : _clientCertificate,
+                };
+                var serverOptions = new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = _serverCertificate,
+                    ClientCertificateRequired = true,
+                    EnabledSslProtocols = SslProtocols.Tls13,
+                    RemoteCertificateValidationCallback = delegate { return true; },
+                };
+
+                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                    client.AuthenticateAsClientAsync(clientOptions),
+                    server.AuthenticateAsServerAsync(serverOptions));
+
+                Assert.Equal(2, callbackCount);
+                Assert.Equal(sendClientCertificate, client.IsMutuallyAuthenticated);
+                Assert.Equal(sendClientCertificate, server.IsMutuallyAuthenticated);
             }
         }
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
@@ -18,6 +18,7 @@ set(NATIVECRYPTO_SOURCES
     pal_hmac.c
     pal_jni.c
     pal_jni_onload.c
+    pal_key_manager.c
     pal_lifetime.c
     pal_memory.c
     pal_misc.c

--- a/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/DotnetX509KeyManager.java
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/DotnetX509KeyManager.java
@@ -129,7 +129,9 @@ public final class DotnetX509KeyManager extends X509ExtendedKeyManager {
     }
 
     private synchronized X509KeyManager selectClientKeyManager(Principal[] issuers) {
-        selectedKeyManager = null;
+        if (selectedKeyManager != null) {
+            return selectedKeyManager;
+        }
 
         KeyManager[] keyManagers = selectClientCertificate(sslStreamProxyHandle, getIssuerNames(issuers));
         if (keyManagers != null) {

--- a/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/DotnetX509KeyManager.java
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/DotnetX509KeyManager.java
@@ -11,19 +11,26 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
 
-public final class DotnetX509KeyManager implements X509KeyManager {
+public final class DotnetX509KeyManager extends X509ExtendedKeyManager {
     private static final String CLIENT_CERTIFICATE_ALIAS = "DOTNET_SSLStream_ClientCertificateContext";
 
+    private final long sslStreamProxyHandle;
     private final PrivateKey privateKey;
     private final X509Certificate[] certificateChain;
+    private volatile X509KeyManager selectedKeyManager;
+    private boolean selectionAttempted;
 
     public DotnetX509KeyManager(KeyStore.PrivateKeyEntry privateKeyEntry) {
         if (privateKeyEntry == null) {
             throw new IllegalArgumentException("PrivateKeyEntry must not be null");
         }
 
+        this.sslStreamProxyHandle = 0;
         this.privateKey = privateKeyEntry.getPrivateKey();
 
         Certificate[] certificates = privateKeyEntry.getCertificateChain();
@@ -41,13 +48,51 @@ public final class DotnetX509KeyManager implements X509KeyManager {
         this.certificateChain = x509Certificates.toArray(new X509Certificate[0]);
     }
 
+    public DotnetX509KeyManager(long sslStreamProxyHandle) {
+        if (sslStreamProxyHandle == 0) {
+            throw new IllegalArgumentException("SslStream proxy handle must not be zero");
+        }
+
+        this.sslStreamProxyHandle = sslStreamProxyHandle;
+        this.privateKey = null;
+        this.certificateChain = null;
+    }
+
     @Override
     public String[] getClientAliases(String keyType, Principal[] issuers) {
+        if (sslStreamProxyHandle != 0) {
+            // Delayed selection is triggered only when the TLS provider processes CertificateRequest.
+            return selectedKeyManager == null ? null : selectedKeyManager.getClientAliases(keyType, issuers);
+        }
+
         return new String[] { CLIENT_CERTIFICATE_ALIAS };
     }
 
     @Override
-    public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+    public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
+        if (sslStreamProxyHandle != 0) {
+            X509KeyManager keyManager = getSelectedKeyManager(issuers);
+            return keyManager == null ? null : keyManager.chooseClientAlias(keyTypes, issuers, socket);
+        }
+
+        return CLIENT_CERTIFICATE_ALIAS;
+    }
+
+    @Override
+    public String chooseEngineClientAlias(String[] keyTypes, Principal[] issuers, SSLEngine engine) {
+        if (sslStreamProxyHandle != 0) {
+            X509KeyManager keyManager = getSelectedKeyManager(issuers);
+            if (keyManager == null) {
+                return null;
+            }
+
+            if (keyManager instanceof X509ExtendedKeyManager) {
+                return ((X509ExtendedKeyManager) keyManager).chooseEngineClientAlias(keyTypes, issuers, engine);
+            }
+
+            return keyManager.chooseClientAlias(keyTypes, issuers, null);
+        }
+
         return CLIENT_CERTIFICATE_ALIAS;
     }
 
@@ -62,12 +107,62 @@ public final class DotnetX509KeyManager implements X509KeyManager {
     }
 
     @Override
+    public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
+        return null;
+    }
+
+    @Override
     public X509Certificate[] getCertificateChain(String alias) {
+        if (sslStreamProxyHandle != 0) {
+            return selectedKeyManager == null ? null : selectedKeyManager.getCertificateChain(alias);
+        }
+
         return certificateChain;
     }
 
     @Override
     public PrivateKey getPrivateKey(String alias) {
+        if (sslStreamProxyHandle != 0) {
+            return selectedKeyManager == null ? null : selectedKeyManager.getPrivateKey(alias);
+        }
+
         return privateKey;
     }
+
+    private synchronized X509KeyManager getSelectedKeyManager(Principal[] issuers) {
+        if (!selectionAttempted) {
+            // Conscrypt supplies all acceptable key types in one choose call. Invoke the managed
+            // callback only once for this key manager to avoid duplicate prompts for one request.
+            selectionAttempted = true;
+            KeyManager[] keyManagers = selectClientCertificate(sslStreamProxyHandle, getIssuerNames(issuers));
+            if (keyManagers != null) {
+                for (KeyManager keyManager : keyManagers) {
+                    if (keyManager instanceof X509KeyManager) {
+                        selectedKeyManager = (X509KeyManager) keyManager;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return selectedKeyManager;
+    }
+
+    private static String[] getIssuerNames(Principal[] issuers) {
+        if (issuers == null || issuers.length == 0) {
+            return new String[0];
+        }
+
+        String[] issuerNames = new String[issuers.length];
+        for (int i = 0; i < issuers.length; i++) {
+            // Principal.getName() uses the Android provider's RFC 2253 distinguished-name format.
+            issuerNames[i] = issuers[i].getName();
+        }
+
+        return issuerNames;
+    }
+
+    private static native KeyManager[] selectClientCertificate(
+            long sslStreamProxyHandle,
+            String[] acceptableIssuers);
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/DotnetX509KeyManager.java
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/DotnetX509KeyManager.java
@@ -23,7 +23,6 @@ public final class DotnetX509KeyManager extends X509ExtendedKeyManager {
     private final PrivateKey privateKey;
     private final X509Certificate[] certificateChain;
     private volatile X509KeyManager selectedKeyManager;
-    private boolean selectionAttempted;
 
     public DotnetX509KeyManager(KeyStore.PrivateKeyEntry privateKeyEntry) {
         if (privateKeyEntry == null) {
@@ -71,7 +70,7 @@ public final class DotnetX509KeyManager extends X509ExtendedKeyManager {
     @Override
     public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
         if (sslStreamProxyHandle != 0) {
-            X509KeyManager keyManager = getSelectedKeyManager(issuers);
+            X509KeyManager keyManager = selectClientKeyManager(issuers);
             return keyManager == null ? null : keyManager.chooseClientAlias(keyTypes, issuers, socket);
         }
 
@@ -81,7 +80,7 @@ public final class DotnetX509KeyManager extends X509ExtendedKeyManager {
     @Override
     public String chooseEngineClientAlias(String[] keyTypes, Principal[] issuers, SSLEngine engine) {
         if (sslStreamProxyHandle != 0) {
-            X509KeyManager keyManager = getSelectedKeyManager(issuers);
+            X509KeyManager keyManager = selectClientKeyManager(issuers);
             if (keyManager == null) {
                 return null;
             }
@@ -129,18 +128,15 @@ public final class DotnetX509KeyManager extends X509ExtendedKeyManager {
         return privateKey;
     }
 
-    private synchronized X509KeyManager getSelectedKeyManager(Principal[] issuers) {
-        if (!selectionAttempted) {
-            // Conscrypt supplies all acceptable key types in one choose call. Invoke the managed
-            // callback only once for this key manager to avoid duplicate prompts for one request.
-            selectionAttempted = true;
-            KeyManager[] keyManagers = selectClientCertificate(sslStreamProxyHandle, getIssuerNames(issuers));
-            if (keyManagers != null) {
-                for (KeyManager keyManager : keyManagers) {
-                    if (keyManager instanceof X509KeyManager) {
-                        selectedKeyManager = (X509KeyManager) keyManager;
-                        break;
-                    }
+    private synchronized X509KeyManager selectClientKeyManager(Principal[] issuers) {
+        selectedKeyManager = null;
+
+        KeyManager[] keyManagers = selectClientCertificate(sslStreamProxyHandle, getIssuerNames(issuers));
+        if (keyManagers != null) {
+            for (KeyManager keyManager : keyManagers) {
+                if (keyManager instanceof X509KeyManager) {
+                    selectedKeyManager = (X509KeyManager) keyManager;
+                    break;
                 }
             }
         }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "pal_jni.h"
+#include "pal_key_manager.h"
 #include "pal_trust_manager.h"
 #include <pthread.h>
 
@@ -498,7 +499,8 @@ jmethodID g_DotnetProxyTrustManagerCtor;
 
 // net/dot/android/crypto/DotnetX509KeyManager
 jclass    g_DotnetX509KeyManager;
-jmethodID g_DotnetX509KeyManagerCtor;
+jmethodID g_DotnetX509KeyManagerPrivateKeyEntryCtor;
+jmethodID g_DotnetX509KeyManagerProxyCtor;
 
 // net/dot/android/crypto/PalPbkdf2
 jclass    g_PalPbkdf2;
@@ -1105,8 +1107,15 @@ jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved)
     jint registerResult = (*env)->RegisterNatives(env, g_DotnetProxyTrustManager, trustManagerMethods, 1);
     abort_unless(registerResult == JNI_OK, "RegisterNatives for DotnetProxyTrustManager.verifyRemoteCertificate failed (error: %d)", registerResult);
 
-    g_DotnetX509KeyManager =     GetClassGRef(env, "net/dot/android/crypto/DotnetX509KeyManager");
-    g_DotnetX509KeyManagerCtor = GetMethod(env, false, g_DotnetX509KeyManager, "<init>", "(Ljava/security/KeyStore$PrivateKeyEntry;)V");
+    g_DotnetX509KeyManager =                    GetClassGRef(env, "net/dot/android/crypto/DotnetX509KeyManager");
+    g_DotnetX509KeyManagerPrivateKeyEntryCtor = GetMethod(env, false, g_DotnetX509KeyManager, "<init>", "(Ljava/security/KeyStore$PrivateKeyEntry;)V");
+    g_DotnetX509KeyManagerProxyCtor =           GetMethod(env, false, g_DotnetX509KeyManager, "<init>", "(J)V");
+
+    JNINativeMethod keyManagerMethods[] = {
+        { "selectClientCertificate", "(J[Ljava/lang/String;)[Ljavax/net/ssl/KeyManager;", (void*)Java_net_dot_android_crypto_DotnetX509KeyManager_selectClientCertificate },
+    };
+    registerResult = (*env)->RegisterNatives(env, g_DotnetX509KeyManager, keyManagerMethods, 1);
+    abort_unless(registerResult == JNI_OK, "RegisterNatives for DotnetX509KeyManager.selectClientCertificate failed (error: %d)", registerResult);
 
     g_PalPbkdf2              = GetClassGRef(env, "net/dot/android/crypto/PalPbkdf2");
     g_PalPbkdf2Pbkdf2OneShot = GetMethod(env, true, g_PalPbkdf2, "pbkdf2OneShot", "(Ljava/lang/String;[BLjava/nio/ByteBuffer;ILjava/nio/ByteBuffer;)I");

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -510,7 +510,8 @@ extern jmethodID g_DotnetProxyTrustManagerCtor;
 
 // net/dot/android/crypto/DotnetX509KeyManager
 extern jclass    g_DotnetX509KeyManager;
-extern jmethodID g_DotnetX509KeyManagerCtor;
+extern jmethodID g_DotnetX509KeyManagerPrivateKeyEntryCtor;
+extern jmethodID g_DotnetX509KeyManagerProxyCtor;
 
 // net/dot/android/crypto/PalPbkdf2
 extern jclass    g_PalPbkdf2;

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_key_manager.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_key_manager.c
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "pal_key_manager.h"
+#include <stdatomic.h>
+
+static _Atomic LocalCertificateSelectionCallback selectLocalCertificate;
+
+ARGS_NON_NULL_ALL void AndroidCryptoNative_RegisterSslStreamCallbacks(
+    RemoteCertificateValidationCallback remoteCertificateValidationCallback,
+    LocalCertificateSelectionCallback localCertificateSelectionCallback)
+{
+    SetRemoteCertificateValidationCallback(remoteCertificateValidationCallback);
+    atomic_store(&selectLocalCertificate, localCertificateSelectionCallback);
+}
+
+jobjectArray AndroidCryptoNative_SSLStreamCreateKeyManagersForSelection(intptr_t sslStreamProxyHandle)
+{
+    abort_unless(sslStreamProxyHandle != 0, "invalid pointer to the .NET SslStream proxy");
+
+    jobjectArray keyManagers = NULL;
+    JNIEnv* env = GetJNIEnv();
+
+    INIT_LOCALS(loc, dotnetX509KeyManager);
+
+    loc[dotnetX509KeyManager] = (*env)->NewObject(
+        env,
+        g_DotnetX509KeyManager,
+        g_DotnetX509KeyManagerProxyCtor,
+        (jlong)sslStreamProxyHandle);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+
+    keyManagers = make_java_object_array(env, 1, g_KeyManager, loc[dotnetX509KeyManager]);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+
+    keyManagers = ToGRef(env, keyManagers);
+
+cleanup:
+    RELEASE_LOCALS(loc, env);
+    return keyManagers;
+}
+
+JNIEXPORT jobjectArray JNICALL Java_net_dot_android_crypto_DotnetX509KeyManager_selectClientCertificate(
+    JNIEnv* env,
+    jclass thisClass,
+    jlong sslStreamProxyHandle,
+    jobjectArray acceptableIssuers)
+{
+    (void)thisClass;
+
+    jobjectArray keyManagers = NULL;
+    jobjectArray result = NULL;
+    uint16_t** issuerValues = NULL;
+
+    INIT_LOCALS(loc, issuerString, keyManagerArray);
+
+    jsize issuerCount = acceptableIssuers == NULL ? 0 : (*env)->GetArrayLength(env, acceptableIssuers);
+    if (CheckJNIExceptions(env))
+    {
+        goto cleanup;
+    }
+
+    if (issuerCount > 0)
+    {
+        issuerValues = xcalloc((size_t)issuerCount, sizeof(uint16_t*));
+
+        for (jsize i = 0; i < issuerCount; i++)
+        {
+            loc[issuerString] = (jstring)(*env)->GetObjectArrayElement(env, acceptableIssuers, i);
+            ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+            if (loc[issuerString] == NULL)
+            {
+                goto cleanup;
+            }
+
+            jsize length = (*env)->GetStringLength(env, loc[issuerString]);
+            ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+
+            issuerValues[i] = xmalloc(((size_t)length + 1) * sizeof(uint16_t));
+            (*env)->GetStringRegion(env, loc[issuerString], 0, length, (jchar*)issuerValues[i]);
+            ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+            issuerValues[i][length] = '\0';
+
+            ReleaseLRef(env, loc[issuerString]);
+            loc[issuerString] = NULL;
+        }
+    }
+
+    LocalCertificateSelectionCallback select = atomic_load(&selectLocalCertificate);
+    abort_unless(select, "selectLocalCertificate callback has not been registered");
+
+    intptr_t keyManagersHandle = select(
+        (intptr_t)sslStreamProxyHandle,
+        (int32_t)issuerCount,
+        issuerValues);
+    keyManagers = (jobjectArray)keyManagersHandle;
+
+    if (keyManagers == NULL)
+    {
+        goto cleanup;
+    }
+
+    loc[keyManagerArray] = (*env)->NewLocalRef(env, keyManagers);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    result = (jobjectArray)loc[keyManagerArray];
+    loc[keyManagerArray] = NULL;
+
+cleanup:
+    ReleaseGRef(env, keyManagers);
+    RELEASE_LOCALS(loc, env);
+
+    if (issuerValues != NULL)
+    {
+        for (jsize i = 0; i < issuerCount; i++)
+        {
+            if (issuerValues[i] != NULL)
+            {
+                free(issuerValues[i]);
+            }
+        }
+    }
+
+    free(issuerValues);
+    return result;
+}

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_key_manager.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_key_manager.h
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "pal_jni.h"
+#include "pal_trust_manager.h"
+#include <stdint.h>
+
+typedef intptr_t (*LocalCertificateSelectionCallback)(
+    intptr_t sslStreamProxyHandle,
+    int32_t acceptableIssuerCount,
+    uint16_t** acceptableIssuers);
+
+PALEXPORT void AndroidCryptoNative_RegisterSslStreamCallbacks(
+    RemoteCertificateValidationCallback remoteCertificateValidationCallback,
+    LocalCertificateSelectionCallback localCertificateSelectionCallback);
+
+PALEXPORT jobjectArray AndroidCryptoNative_SSLStreamCreateKeyManagersForSelection(
+    intptr_t sslStreamProxyHandle);
+
+JNIEXPORT jobjectArray JNICALL Java_net_dot_android_crypto_DotnetX509KeyManager_selectClientCertificate(
+    JNIEnv* env,
+    jclass thisClass,
+    jlong sslStreamProxyHandle,
+    jobjectArray acceptableIssuers);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -668,7 +668,11 @@ jobjectArray AndroidCryptoNative_SSLStreamCreateKeyManagersFromKeyStoreEntry(job
 
     INIT_LOCALS(loc, dotnetX509KeyManager);
 
-    loc[dotnetX509KeyManager] = (*env)->NewObject(env, g_DotnetX509KeyManager, g_DotnetX509KeyManagerCtor, privateKeyEntry);
+    loc[dotnetX509KeyManager] = (*env)->NewObject(
+        env,
+        g_DotnetX509KeyManager,
+        g_DotnetX509KeyManagerPrivateKeyEntryCtor,
+        privateKeyEntry);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     keyManagers = make_java_object_array(env, 1, g_KeyManager, loc[dotnetX509KeyManager]);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.c
@@ -9,7 +9,7 @@ static _Atomic RemoteCertificateValidationCallback verifyRemoteCertificate;
 // keystore from disk); caching avoids paying that cost on every TLS handshake.
 static _Atomic(jobject) g_cachedDefaultTrustManager = NULL;
 
-ARGS_NON_NULL_ALL void AndroidCryptoNative_RegisterRemoteCertificateValidationCallback(RemoteCertificateValidationCallback callback)
+ARGS_NON_NULL_ALL void SetRemoteCertificateValidationCallback(RemoteCertificateValidationCallback callback)
 {
     atomic_store(&verifyRemoteCertificate, callback);
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_trust_manager.h
@@ -6,7 +6,7 @@
 
 typedef bool (*RemoteCertificateValidationCallback)(intptr_t, jstring);
 
-PALEXPORT void AndroidCryptoNative_RegisterRemoteCertificateValidationCallback(RemoteCertificateValidationCallback callback);
+void SetRemoteCertificateValidationCallback(RemoteCertificateValidationCallback callback);
 
 PALEXPORT int32_t AndroidCryptoNative_GetPlatformValidationError(jstring platformValidationError, const uint16_t** out, int32_t* outLen) ARGS_NON_NULL(2, 3);
 PALEXPORT void AndroidCryptoNative_ReleasePlatformValidationError(jstring platformValidationError, const uint16_t* chars);


### PR DESCRIPTION
Fixes #109532

On Android, `LocalCertificateSelectionCallback` was invoked only before the TLS handshake. If it returned `null`, `SslStream` could not invoke it again when the server later sent `CertificateRequest`.

Install a proxy `X509ExtendedKeyManager` when a client selection callback is configured without an initial certificate. When JSSE processes `CertificateRequest`, the proxy calls into managed `SslStream` with the acceptable issuers and current handshake state. `SslStream` invokes `LocalCertificateSelectionCallback`, turns the selected certificate into a Java `KeyManager[]`, and returns it to JSSE to complete the handshake.

The bridge supports exportable private keys and Android KeyStore private-key entries. It uses a typed `GCHandle<JavaProxy>` for the native callback lifetime, caches a successful Java key-manager selection for the connection, and surfaces delayed-callback exceptions through the TLS handshake.

Tests cover:
- TLS 1.2 delayed selection, with and without a client certificate
- TLS 1.3 delayed selection, with and without a client certificate
- Delayed callback exception propagation for TLS 1.2 and TLS 1.3
- `SocketsHttpHandler` selection using an Android KeyStore certificate

> [!NOTE]
> This PR description was generated with GitHub Copilot assistance.