### PR TITLE
Fix CRLF encoding in EightBitStream

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/EightBitStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/EightBitStream.cs
@@ -131,26 +131,23 @@ namespace System.Net.Mime
                     continue;
                 }
 
-                // Just regular seven bit data
+                // Regular data byte, pass it through unchanged.
                 WriteState.Append(buffer[i]);
             }
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Close()
         {
-            try
+            if (_lastWriteEndedWithCr)
             {
-                if (disposing && _lastWriteEndedWithCr)
-                {
-                    // write the delayed CR
-                    _lastWriteEndedWithCr = false;
-                    BaseStream.WriteByte((byte)'\r');
-                }
+                // Write the delayed CR before the underlying stream is closed.
+                // DelegatedStream.Close() closes the underlying stream, so this
+                // must happen before we delegate to the base implementation.
+                _lastWriteEndedWithCr = false;
+                BaseStream.WriteByte((byte)'\r');
             }
-            finally
-            {
-                base.Dispose(disposing);
-            }
+
+            base.Close();
         }
 
         public override async ValueTask DisposeAsync()

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/EightBitStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/EightBitStream.cs
@@ -158,6 +158,10 @@ namespace System.Net.Mime
                 _lastWriteEndedWithCr = false;
                 await BaseStream.WriteAsync(new byte[] { (byte)'\r' }, CancellationToken.None).ConfigureAwait(false);
             }
+
+            // DelegatedStream does not override DisposeAsync, so the base implementation
+            // falls back to synchronous Dispose(), which disposes the underlying stream.
+            await base.DisposeAsync().ConfigureAwait(false);
         }
 
         public int DecodeBytes(Span<byte> buffer) { throw new NotImplementedException(); }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/EightBitStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/EightBitStream.cs
@@ -30,6 +30,7 @@ namespace System.Net.Mime
         // We make this optional because this stream may be used recursively and
         // the encoding should only be done once.
         private readonly bool _shouldEncodeLeadingDots;
+        private bool _lastWriteEndedWithCr;
 
         private WriteStateInfoBase WriteState => field ??= new WriteStateInfoBase();
 
@@ -99,24 +100,66 @@ namespace System.Net.Mime
             {
                 // Note: for legacy reasons we are not enforcing buffer[i] <= 127.
 
-                // Detect CRLF line endings
-                if ((buffer[i] == '\r') && ((i + 1) < buffer.Length) && (buffer[i + 1] == '\n'))
+                if (_lastWriteEndedWithCr)
                 {
-                    WriteState.AppendCRLF(false); // Resets CurrentLineLength to 0
-                    i++; // Skip past the recorded CRLF
+                    _lastWriteEndedWithCr = false;
+
+                    // Detect CRLF line endings
+                    if (buffer[i] == '\n')
+                    {
+                        WriteState.AppendCRLF(false); // Resets CurrentLineLength to 0
+                        continue;
+                    }
+                    else
+                    {
+                        // Write the delayed CR since it wasn't part of a CRLF sequence
+                        WriteState.Append((byte)'\r');
+                    }
                 }
-                else if ((WriteState.CurrentLineLength == 0) && (buffer[i] == '.'))
+
+                if ((WriteState.CurrentLineLength == 0) && (buffer[i] == '.'))
                 {
                     // RFC 2821 Section 4.5.2: We must pad leading dots on a line with an extra dot
                     // This is the only 'encoding' change we make to the data in this method
                     WriteState.Append((byte)'.');
-                    WriteState.Append(buffer[i]);
                 }
-                else
+
+                if (buffer[i] == '\r')
                 {
-                    // Just regular seven bit data
-                    WriteState.Append(buffer[i]);
+                    // defer writing CR until we see if it's followed by LF
+                    _lastWriteEndedWithCr = true;
+                    continue;
                 }
+
+                // Just regular seven bit data
+                WriteState.Append(buffer[i]);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (disposing && _lastWriteEndedWithCr)
+                {
+                    // write the delayed CR
+                    _lastWriteEndedWithCr = false;
+                    BaseStream.WriteByte((byte)'\r');
+                }
+            }
+            finally
+            {
+                base.Dispose(disposing);
+            }
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (_lastWriteEndedWithCr)
+            {
+                // write the delayed CR
+                _lastWriteEndedWithCr = false;
+                await BaseStream.WriteAsync(new byte[] { (byte)'\r' }, CancellationToken.None).ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Net.Mail/tests/Unit/EightBitStreamTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/EightBitStreamTest.cs
@@ -89,6 +89,9 @@ namespace System.Net.Mime.Tests
 
             // Disposal flushes the deferred CR.
             Assert.Equal("Hello\r", Encoding.ASCII.GetString(outputStream.ToArray()));
+
+            // Disposal also disposes the underlying stream.
+            Assert.False(outputStream.CanWrite);
         }
     }
 }

--- a/src/libraries/System.Net.Mail/tests/Unit/EightBitStreamTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/EightBitStreamTest.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Net.Mime.Tests
@@ -40,6 +41,54 @@ namespace System.Net.Mime.Tests
             int bytesReadCount = outputStream.Read(bytesRead, 0, bytesRead.Length);
 
             Assert.Equal(expectedOutput, encoding.GetString(bytesRead, 0, bytesReadCount));
+        }
+
+        [Theory]
+        // A CRLF split across two writes is treated as a single line ending, so the
+        // leading dot on the following line is padded when padLeadingDots is enabled.
+        [InlineData(new[] { "Hello\r", "\n.World" }, true, "Hello\r\n..World")]
+        [InlineData(new[] { "Hello\r", "\n.World" }, false, "Hello\r\n.World")]
+        // A standalone CR (not followed by LF) is emitted verbatim before the next byte.
+        [InlineData(new[] { "Hello\r", "World" }, false, "Hello\rWorld")]
+        public static void TestEncodeStream_CrlfSplitAcrossWrites(string[] chunks, bool padLeadingDots, string expectedOutput)
+        {
+            var outputStream = new MemoryStream();
+            var testStream = new EightBitStream(outputStream, padLeadingDots);
+
+            foreach (string chunk in chunks)
+            {
+                byte[] bytesToWrite = Encoding.ASCII.GetBytes(chunk);
+                testStream.Write(bytesToWrite, 0, bytesToWrite.Length);
+            }
+
+            Assert.Equal(expectedOutput, Encoding.ASCII.GetString(outputStream.ToArray()));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static async Task TestEncodeStream_TrailingCarriageReturnEmittedOnDispose(bool useAsyncDispose)
+        {
+            var outputStream = new MemoryStream();
+            var testStream = new EightBitStream(outputStream, shouldEncodeLeadingDots: true);
+
+            byte[] bytesToWrite = Encoding.ASCII.GetBytes("Hello\r");
+            testStream.Write(bytesToWrite, 0, bytesToWrite.Length);
+
+            // The trailing CR is deferred until we know whether an LF follows it.
+            Assert.Equal("Hello", Encoding.ASCII.GetString(outputStream.ToArray()));
+
+            if (useAsyncDispose)
+            {
+                await testStream.DisposeAsync();
+            }
+            else
+            {
+                testStream.Dispose();
+            }
+
+            // Disposal flushes the deferred CR.
+            Assert.Equal("Hello\r", Encoding.ASCII.GetString(outputStream.ToArray()));
         }
     }
 }


### PR DESCRIPTION
Improve handling of CRLF line endings in the EightBitStream class. This change ensures that CR characters are correctly processed and written.