### PR TITLE
Add Android CoreCLR runtime tests

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -215,6 +215,16 @@
                                                    $(LibrariesNativeArtifactsPath)libbrotlidec.a;
                                                    $(LibrariesNativeArtifactsPath)libbrotlienc.a" />
 
+      <!-- Android CoreCLR also installs these native libs to its shared framework. -->
+      <ExcludeNativeLibrariesRuntimeFiles Condition="'$(TargetsAndroid)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(BuildNativeAOTRuntimePack)' != 'true'"
+                                          Include="$(LibrariesNativeArtifactsPath)libSystem.Globalization.Native.a;
+                                                   $(LibrariesNativeArtifactsPath)libSystem.IO.Compression.Native.a;
+                                                   $(LibrariesNativeArtifactsPath)libSystem.Native.a;
+                                                   $(LibrariesNativeArtifactsPath)libSystem.Security.Cryptography.Native.Android.a;
+                                                   $(LibrariesNativeArtifactsPath)libbrotlicommon.a;
+                                                   $(LibrariesNativeArtifactsPath)libbrotlidec.a;
+                                                   $(LibrariesNativeArtifactsPath)libbrotlienc.a" />
+
       <!-- Same situation on WASI with CoreCLR: System.IO.Compression.Native/CMakeLists.txt
            installs libSystem.IO.Compression.Native.a and libz.a directly into the
            CoreCLR sharedFramework directory for CLR_CMAKE_TARGET_WASI, where they are

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -204,10 +204,10 @@
       <ExcludeNativeLibrariesRuntimeFiles Condition="'$(RuntimeFlavor)' != 'Mono'"
                                           Include="$(LibrariesNativeArtifactsPath)System.Globalization.Native.dll;$(LibrariesNativeArtifactsPath)System.Globalization.Native.so;$(LibrariesNativeArtifactsPath)System.Globalization.Native.dylib" />
 
-      <!-- For Apple mobile with CoreCLR, these native libs are already installed to the CoreCLR shared framework.
+      <!-- For mobile CoreCLR, these native libs are already installed to the CoreCLR shared framework.
            Exclude them from LibrariesRuntimeFiles to avoid duplicate publish output files.
            This does not apply to NativeAOT because we do not reach back into CoreCLR sharedFramework artifacts. -->
-      <ExcludeNativeLibrariesRuntimeFiles Condition="'$(TargetsAppleMobile)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(BuildNativeAOTRuntimePack)' != 'true'"
+      <ExcludeNativeLibrariesRuntimeFiles Condition="('$(TargetsAppleMobile)' == 'true' or '$(TargetsAndroid)' == 'true') and '$(RuntimeFlavor)' == 'CoreCLR' and '$(BuildNativeAOTRuntimePack)' != 'true'"
                                           Include="$(LibrariesNativeArtifactsPath)libSystem.Globalization.Native.a;
                                                    $(LibrariesNativeArtifactsPath)libSystem.IO.Compression.Native.a;
                                                    $(LibrariesNativeArtifactsPath)libSystem.Native.a;
@@ -215,15 +215,8 @@
                                                    $(LibrariesNativeArtifactsPath)libbrotlidec.a;
                                                    $(LibrariesNativeArtifactsPath)libbrotlienc.a" />
 
-      <!-- Android CoreCLR also installs these native libs to its shared framework. -->
       <ExcludeNativeLibrariesRuntimeFiles Condition="'$(TargetsAndroid)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(BuildNativeAOTRuntimePack)' != 'true'"
-                                          Include="$(LibrariesNativeArtifactsPath)libSystem.Globalization.Native.a;
-                                                   $(LibrariesNativeArtifactsPath)libSystem.IO.Compression.Native.a;
-                                                   $(LibrariesNativeArtifactsPath)libSystem.Native.a;
-                                                   $(LibrariesNativeArtifactsPath)libSystem.Security.Cryptography.Native.Android.a;
-                                                   $(LibrariesNativeArtifactsPath)libbrotlicommon.a;
-                                                   $(LibrariesNativeArtifactsPath)libbrotlidec.a;
-                                                   $(LibrariesNativeArtifactsPath)libbrotlienc.a" />
+                                          Include="$(LibrariesNativeArtifactsPath)libSystem.Security.Cryptography.Native.Android.a" />
 
       <!-- Same situation on WASI with CoreCLR: System.IO.Compression.Native/CMakeLists.txt
            installs libSystem.IO.Compression.Native.a and libz.a directly into the

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -11,48 +11,6 @@ parameters:
 jobs:
 
 #
-# Build the whole product using Mono for Android and run runtime tests with Android devices
-#
-# Turn off the runtime testing for now, until https://github.com/dotnet/runtime/issues/60128 gets resolved
-# don't run tests on PRs until we can get significantly more devices
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/common/global-build-job.yml
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     buildConfig: Release
-#     runtimeFlavor: mono
-#     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-#     isAndroidOnlyBuild: ${{ parameters.isAndroidOnlyBuild }}
-#     platforms:
-#       - android_arm64
-#     variables:
-#       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-#         - name: _HelixSource
-#           value: pr/dotnet/runtime/$(Build.SourceBranch)
-#       - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-#         - name: _HelixSource
-#           value: ci/dotnet/runtime/$(Build.SourceBranch)
-#       - name: timeoutPerTestInMinutes
-#         value: 60
-#       - name: timeoutPerTestCollectionInMinutes
-#         value: 180
-#     jobParameters:
-#       testGroup: innerloop
-#       nameSuffix: AllSubsets_Mono_RuntimeTests
-#       runtimeVariant: minijit
-#       buildArgs: -s mono+libs -c $(_BuildConfig)
-#       timeoutInMinutes: 480
-#       ${{ if eq(variables['isRollingBuild'], true) }}:
-#         # extra steps, run tests
-#         postBuildSteps:
-#           - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-#             parameters:
-#               creator: dotnet-bot
-#               testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-#         extraVariablesTemplates:
-#           - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-
-#
 # Android devices
 # Build the whole product using CoreCLR and run libraries tests
 #

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -50,6 +50,45 @@ jobs:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
 #
+# Build the whole product using CoreCLR and run runtime tests
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    buildConfig: Release
+    runtimeFlavor: coreclr
+    isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+    isAndroidEmulatorOnlyBuild: ${{ parameters.isAndroidEmulatorOnlyBuild }}
+    platforms:
+      - android_x64
+    variables:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+        - name: _HelixSource
+          value: pr/dotnet/runtime/$(Build.SourceBranch)
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+        - name: _HelixSource
+          value: ci/dotnet/runtime/$(Build.SourceBranch)
+      - name: timeoutPerTestInMinutes
+        value: 60
+      - name: timeoutPerTestCollectionInMinutes
+        value: 180
+    jobParameters:
+      testGroup: innerloop
+      nameSuffix: AllSubsets_CoreCLR_RuntimeTests
+      buildArgs: -s clr+libs -c $(_BuildConfig)
+      timeoutInMinutes: 360
+      extraVariablesTemplates:
+        - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+          parameters:
+            testGroup: innerloop
+      postBuildSteps:
+        - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+          parameters:
+            creator: dotnet-bot
+            testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+
+#
 # Android emulators
 # Build the whole product using CoreCLR and run libraries tests
 #

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -58,8 +58,6 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     buildConfig: Release
     runtimeFlavor: coreclr
-    isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-    isAndroidEmulatorOnlyBuild: ${{ parameters.isAndroidEmulatorOnlyBuild }}
     platforms:
       - android_x64
     variables:


### PR DESCRIPTION
## Description

Add CoreCLR runtime innerloop coverage on the Android x64 emulator in `runtime-androidemulator`. The new job builds `clr+libs`, packages the Android runtime tests, and submits them to `Ubuntu.2204.Amd64.Android.29.Open`. Android CoreCLR live builds also exclude native archives already supplied by the CoreCLR shared framework, which avoids duplicate publish outputs while preserving the archives in NativeAOT runtime packs. The obsolete disabled Android ARM64 Mono runtime-test configuration is removed because .NET 11 mobile testing uses CoreCLR and NativeAOT.

Validation ran in https://dev.azure.com/dnceng-public/public/_build/results?buildId=1509777. The `android-x64 Release AllSubsets_CoreCLR_RuntimeTests` job passed with 75 completed Helix work items and zero failures.

Fixes #60128