### PR TITLE
Disable r2r test on Release

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
@@ -102,8 +102,8 @@
     <RuntimeHostConfigurationOption Include="R2RTest.TargetOS">
       <Value>$(TargetOS)</Value>
     </RuntimeHostConfigurationOption>
-    <RuntimeHostConfigurationOption Include="R2RTest.Configuration">
-      <Value>$(Configuration)</Value>
+    <RuntimeHostConfigurationOption Include="R2RTest.CoreCLRConfiguration">
+      <Value>$(CoreCLRConfiguration)</Value>
     </RuntimeHostConfigurationOption>
   </ItemGroup>
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -166,7 +166,8 @@ public class R2RTestSuites
         }
     }
 
-    [Fact]
+    // JitStressProcedureSplitting is only available in Debug/Checked JIT builds
+    [ConditionalFact(typeof(TestPaths), nameof(TestPaths.IsNotRelease))]
     public void ArmThumbBitHotColdRuntimeFunctions()
     {
         var hotColdSplitting = new CompiledAssembly

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -166,8 +166,8 @@ public class R2RTestSuites
         }
     }
 
-    // JitStressProcedureSplitting is only available in Debug/Checked JIT builds
-    [ConditionalFact(typeof(TestPaths), nameof(TestPaths.IsNotRelease))]
+    // JitStressProcedureSplitting is only available in Debug/Checked JIT builds.
+    [ConditionalFact(typeof(TestPaths), nameof(TestPaths.IsNotReleaseCoreCLR))]
     public void ArmThumbBitHotColdRuntimeFunctions()
     {
         var hotColdSplitting = new CompiledAssembly

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/TestPaths.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/TestPaths.cs
@@ -150,6 +150,8 @@ internal sealed class TestPaths
     public static string TargetArchitecture => GetRequiredConfig("R2RTest.TargetArchitecture");
     public static string TargetOS => GetRequiredConfig("R2RTest.TargetOS");
     public static string Configuration => GetRequiredConfig("R2RTest.Configuration");
+    public static bool IsRelease => string.Equals(Configuration, "Release", StringComparison.OrdinalIgnoreCase);
+    public static bool IsNotRelease => !IsRelease;
 
     /// <summary>
     /// Path to the reference assembly pack (for Roslyn compilation).

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/TestPaths.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/TestPaths.cs
@@ -149,9 +149,9 @@ internal sealed class TestPaths
 
     public static string TargetArchitecture => GetRequiredConfig("R2RTest.TargetArchitecture");
     public static string TargetOS => GetRequiredConfig("R2RTest.TargetOS");
-    public static string Configuration => GetRequiredConfig("R2RTest.Configuration");
-    public static bool IsRelease => string.Equals(Configuration, "Release", StringComparison.OrdinalIgnoreCase);
-    public static bool IsNotRelease => !IsRelease;
+    public static string CoreCLRConfiguration => GetRequiredConfig("R2RTest.CoreCLRConfiguration");
+    public static bool IsReleaseCoreCLR => string.Equals(CoreCLRConfiguration, "Release", StringComparison.OrdinalIgnoreCase);
+    public static bool IsNotReleaseCoreCLR => !IsReleaseCoreCLR;
 
     /// <summary>
     /// Path to the reference assembly pack (for Roslyn compilation).


### PR DESCRIPTION
Disables recently added ILCompiler.ReadyToRun.Tests.TestCases.R2RTestSuites.ArmThumbBitHotColdRuntimeFunctions on Release, where it fails. This test passes `JitStressProcedureSplitting=1` to the JIT, option which is only valid on Debug/Checked builds.