### PR TITLE
Mark custom continuation resumptions as `StackTraceHidden`

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.ValueTaskSourceContinuation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.ValueTaskSourceContinuation.cs
@@ -86,6 +86,7 @@ namespace System.Runtime.CompilerServices
                     Resume = &ResumeValueTaskSourceContinuation,
                 };
 
+                [StackTraceHidden]
                 private static Continuation? ResumeValueTaskSourceContinuation(Continuation cont, ref byte result)
                 {
                     var vtsCont = (ValueTaskSourceContinuation)cont;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
@@ -149,6 +149,7 @@ namespace System.Runtime.CompilerServices
                 Resume = &ResumeTaskContinuation,
             };
 
+            [StackTraceHidden]
             private static Continuation? ResumeTaskContinuation(Continuation cont, ref byte result)
             {
                 var taskCont = (RuntimeAsyncTaskContinuation)cont;

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -14,6 +14,7 @@ using System.Text.RegularExpressions;
 using Microsoft.DotNet.RemoteExecutor;
 using System.Threading.Tasks;
 using Xunit;
+using System.Threading.Tasks.Sources;
 
 namespace System.Diagnostics
 {
@@ -229,6 +230,65 @@ namespace System.Diagnostics
         public static async Task EdiInner()
         {
             throw new InvalidOperationException("Exception from EdiInner");
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+#line 1 "ThrowsSoon.cs"
+        public static async Task ThrowsSoon()
+        {
+            Task t = ThrowsSoonInner();
+            Use(t); // Make sure ThrowsSoonInner does not become a real async call
+            await t;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Use(Task t)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+#line 1 "ThrowsSoonInner.cs"
+        public static async Task ThrowsSoonInner()
+        {
+            await Task.Delay(50);
+            throw new Exception("Exception from ThrowsSoonInner");
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+#line 1 "ThrowsSoonValueTaskSource.cs"
+        public static async Task ThrowsSoonValueTaskSource()
+        {
+            ValueTask vt = new ValueTask(new ThrowsSoonValueTaskSourceImpl(), 0);
+            await vt;
+        }
+
+        private class ThrowsSoonValueTaskSourceImpl : IValueTaskSource
+        {
+            private bool _isCompleted;
+
+            [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+            public void GetResult(short token)
+            {
+#line 1 "ThrowsSoonValueTaskSourceImpl.cs"
+                throw new Exception("Exception from ThrowsSoonValueTaskSourceImpl");
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return _isCompleted ? ValueTaskSourceStatus.Faulted : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                Task.Delay(50).ContinueWith(_ =>
+                {
+                    _isCompleted = true;
+                    continuation(state);
+                });
+            }
         }
     }
 }
@@ -664,6 +724,16 @@ namespace System.Diagnostics.Tests
                 @"V2Methods\.Baz\(\)" + FileInfoPattern(@".*Baz.*\.cs:line 4"),
                 @"V2Methods\.Bux\(\)" + FileInfoPattern(@".*Bux.*\.cs:line 6")
             }},
+            {"ThrowsSoon", new[] {
+                @"Exception from ThrowsSoonInner",
+                @"V2Methods\.ThrowsSoonInner\(\)" + FileInfoPattern(@".*ThrowsSoonInner.*\.cs:line 4"),
+                @"V2Methods\.ThrowsSoon\(\)" + FileInfoPattern(@".*ThrowsSoon.*\.cs:line [35]")
+            }},
+            {"ThrowsSoonValueTaskSource", new[] {
+                @"Exception from ThrowsSoonValueTaskSourceImpl",
+                @"V2Methods\.ThrowsSoonValueTaskSourceImpl.GetResult" + FileInfoPattern(@".*ThrowsSoonValueTaskSourceImpl.*\.cs:line 1"),
+                @"V2Methods\.ThrowsSoonValueTaskSource\(\)" + FileInfoPattern(@".*ThrowsSoonValueTaskSource.*\.cs:line 4")
+            }},
             { "EdiOuter", new[] {
                 @"Exception from EdiInner",
                 @"V2Methods\.EdiInner\(\)" + FileInfoPattern(@".*EdiInner.*\.cs:line 3"),
@@ -679,6 +749,8 @@ namespace System.Diagnostics.Tests
             yield return new object[] { () => V2Methods.Quux(), MethodExceptionStrings["Quux"] };
             yield return new object[] { () => V2Methods.Quuux(), MethodExceptionStrings["Quuux"] };
             yield return new object[] { () => V2Methods.Bux(), MethodExceptionStrings["Bux"] };
+            yield return new object[] { () => V2Methods.ThrowsSoon(), MethodExceptionStrings["ThrowsSoon"] };
+            yield return new object[] { () => V2Methods.ThrowsSoonValueTaskSource(), MethodExceptionStrings["ThrowsSoonValueTaskSource"] };
             yield return new object[] { () => V1Methods.EdiOuter(), MethodExceptionStrings["EdiOuter"] };
         }
 
@@ -714,6 +786,8 @@ namespace System.Diagnostics.Tests
             {
                 Assert.DoesNotContain("--- End of stack trace from previous location ---", exceptionText);
             }
+            Assert.DoesNotContain("ResumeTaskContinuation", exceptionText);
+            Assert.DoesNotContain("ResumeValueTaskSourceContinuation", exceptionText);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -281,7 +281,7 @@ namespace System.Diagnostics
                 return _isCompleted ? ValueTaskSourceStatus.Faulted : ValueTaskSourceStatus.Pending;
             }
 
-            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
             {
                 Task.Delay(50).ContinueWith(_ =>
                 {


### PR DESCRIPTION
E.g.
```csharp
public static async Task Main()
{
    Task t = ThrowsSoon();
    try
    {
        await t;
    }
    catch (Exception ex)
    {
        Console.WriteLine(ex);
    }
}

private static async Task ThrowsSoon()
{
    await Task.Delay(50);
    throw new Exception("Exception thrown");
}
```

```diff
 System.Exception: Exception thrown
    at Program.ThrowsSoon() in C:\dev\dotnet\playground\Program.cs:line 24
-   at System.Runtime.CompilerServices.RuntimeAsyncTaskContinuation.TaskContinuationResume.ResumeTaskContinuation(Continuation cont, Byte& result)
    at Program.Main() in C:\dev\dotnet\playground\Program.cs:line 13
```