### PR TITLE
Generalize IsBitwiseEquatable by introducing IEquatable<T>.IsBitwiseEquatable

### DIFF
--- a/src/coreclr/System.Private.CoreLib/CompatibilitySuppressions.xml
+++ b/src/coreclr/System.Private.CoreLib/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
@@ -24,6 +24,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.String.TrimStart(System.ReadOnlySpan{System.Char})</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.IEquatable`1.get_IsBitwiseEquatable</Target>
+    <Left>ref/net11.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net11.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.IEquatable`1.get_IsBitwiseIEquatable</Target>
+    <Left>ref/net11.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net11.0/System.Private.CoreLib.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0008</DiagnosticId>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -1,6 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Internal.Console</Target>
+  </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Internal.Metadata.NativeFormat.ArraySignature</Target>
@@ -52,14 +56,6 @@
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Internal.Metadata.NativeFormat.ConstantBooleanValueHandle</Target>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Internal.Metadata.NativeFormat.ConstantEnumValue</Target>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Internal.Metadata.NativeFormat.ConstantEnumValueHandle</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
@@ -116,6 +112,14 @@
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Internal.Metadata.NativeFormat.ConstantEnumArrayHandle</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Internal.Metadata.NativeFormat.ConstantEnumValue</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Internal.Metadata.NativeFormat.ConstantEnumValueHandle</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
@@ -655,6 +659,10 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Internal.NativeFormat.TypeHashingAlgorithms</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Internal.Reflection.Core.AssemblyBinder</Target>
   </Suppression>
   <Suppression>
@@ -727,6 +735,10 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Internal.TypeSystem.LockFreeReaderHashtableOfPointers`2</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:System.Diagnostics.DebugAnnotations</Target>
   </Suppression>
   <Suppression>
@@ -735,11 +747,11 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:System.MDArray</Target>
+    <Target>T:System.FieldHandleInfo</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:System.FieldHandleInfo</Target>
+    <Target>T:System.MDArray</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
@@ -807,10 +819,6 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Internal.TypeSystem.LockFreeReaderHashtableOfPointers`2</Target>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:System.Runtime.DispatchCell</Target>
   </Suppression>
   <Suppression>
@@ -819,7 +827,31 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:System.Resources.ResourceManager.BaseNameField</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:System.Resources.ResourceSet.Reader</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Diagnostics.DiagnosticMethodInfo.#ctor(System.String,System.String,System.String)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.Reflection.MethodBase.GetParametersAsSpan</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.String.Trim(System.ReadOnlySpan{System.Char})</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.String.TrimEnd(System.ReadOnlySpan{System.Char})</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.String.TrimStart(System.ReadOnlySpan{System.Char})</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
@@ -827,10 +859,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Diagnostics.DiagnosticMethodInfo.#ctor(System.String,System.String,System.String)</Target>
+    <Target>M:System.IEquatable`1.get_IsBitwiseEquatable</Target>
+    <Left>ref/net11.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net11.0/System.Private.CoreLib.dll</Right>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Internal.NativeFormat.TypeHashingAlgorithms</Target>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.IEquatable`1.get_IsBitwiseIEquatable</Target>
+    <Left>ref/net11.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net11.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:System.Collections.BitArray</Target>
   </Suppression>
 </Suppressions>

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
@@ -3,7 +3,6 @@
 
 using System;
 
-using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -32,50 +31,30 @@ namespace Internal.IL.Stubs
             bool result;
             if (method.Name == "IsBitwiseEquatable"u8)
             {
-                // Ideally we could detect automatically whether a type is trivially equatable
-                // (i.e., its operator == could be implemented via memcmp). But for now we'll
-                // do the simple thing and hardcode the list of types we know fulfill this contract.
-                // n.b. This doesn't imply that the type's CompareTo method can be memcmp-implemented,
-                // as a method like CompareTo may need to take a type's signedness into account.
-                switch (elementType.UnderlyingType.Category)
+                bool? equatable = ComparerIntrinsics.ImplementsIEquatable(elementType);
+                if (equatable == true)
                 {
-                    case TypeFlags.Boolean:
-                    case TypeFlags.Byte:
-                    case TypeFlags.SByte:
-                    case TypeFlags.Char:
-                    case TypeFlags.UInt16:
-                    case TypeFlags.Int16:
-                    case TypeFlags.UInt32:
-                    case TypeFlags.Int32:
-                    case TypeFlags.UInt64:
-                    case TypeFlags.Int64:
-                    case TypeFlags.IntPtr:
-                    case TypeFlags.UIntPtr:
-                        result = true;
-                        break;
-                    default:
-                        result = false;
-                        if (elementType is MetadataType mdType)
-                        {
-                            if (IsKnownBitwiseEquatableType(mdType))
-                            {
-                                result = true;
-                            }
-                            else if (mdType.IsValueType)
-                            {
-                                bool? equatable = ComparerIntrinsics.ImplementsIEquatable(mdType.GetTypeDefinition());
+                    TypeDesc iEquatable = elementType.Context.SystemModule
+                        .GetKnownType("System"u8, "IEquatable`1"u8)
+                        .MakeInstantiatedType(elementType);
+                    MethodDesc getIsBitwiseEquatable = iEquatable.GetKnownMethod("get_IsBitwiseEquatable"u8, null);
 
-                                if (equatable.HasValue && !equatable.Value)
-                                {
-                                    // Value type that can use memcmp and that doesn't override object.Equals or implement IEquatable<T>.Equals.
-                                    MethodDesc objectEquals = mdType.Context.GetWellKnownType(WellKnownType.Object).GetMethod("Equals"u8, null);
-                                    result =
-                                        mdType.FindVirtualFunctionTargetMethodOnObjectType(objectEquals).OwningType != mdType &&
-                                        ComparerIntrinsics.CanCompareValueTypeBits(mdType, objectEquals);
-                                }
-                            }
-                        }
-                        break;
+                    ILEmitter emitter = new ILEmitter();
+                    ILCodeStream codeStream = emitter.NewCodeStream();
+                    codeStream.Emit(ILOpcode.constrained, emitter.NewToken(elementType));
+                    codeStream.Emit(ILOpcode.call, emitter.NewToken(getIsBitwiseEquatable));
+                    codeStream.Emit(ILOpcode.ret);
+                    return emitter.Link(method);
+                }
+
+                result = elementType.IsEnum;
+                if (!result && equatable == false && elementType is MetadataType mdType && mdType.IsValueType)
+                {
+                    // Value type that can use memcmp and that doesn't override object.Equals or implement IEquatable<T>.Equals.
+                    MethodDesc objectEquals = mdType.Context.GetWellKnownType(WellKnownType.Object).GetMethod("Equals"u8, null);
+                    result =
+                        mdType.FindVirtualFunctionTargetMethodOnObjectType(objectEquals).OwningType != mdType &&
+                        ComparerIntrinsics.CanCompareValueTypeBits(mdType, objectEquals);
                 }
             }
             else
@@ -86,22 +65,6 @@ namespace Internal.IL.Stubs
             ILOpcode opcode = result ? ILOpcode.ldc_i4_1 : ILOpcode.ldc_i4_0;
 
             return new ILStubMethodIL(method, new byte[] { (byte)opcode, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), Array.Empty<object>());
-        }
-
-        private static bool IsKnownBitwiseEquatableType(MetadataType type)
-        {
-            if (type.Module != type.Context.SystemModule)
-            {
-                return false;
-            }
-
-            Utf8Span ns = type.Namespace;
-            if (ns == "System"u8)
-            {
-                Utf8Span name = type.Name;
-                return name == "Guid"u8 || name == "Int128"u8 || name == "UInt128"u8;
-            }
-            return ns == "System.Text"u8 && type.Name == "Rune"u8;
         }
     }
 }

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -1299,6 +1299,7 @@ DEFINE_CLASS(ICOMPARABLEGENERIC,    System,                 IComparable`1)
 DEFINE_METHOD(ICOMPARABLEGENERIC,   COMPARE_TO,             CompareTo,                  NoSig)
 
 DEFINE_CLASS(IEQUATABLEGENERIC,     System,                 IEquatable`1)
+DEFINE_METHOD(IEQUATABLEGENERIC,    GET_IS_BITWISE_EQUATABLE, get_IsBitwiseEquatable, NoSig)
 
 DEFINE_CLASS_U(Reflection,             LoaderAllocator,          LoaderAllocatorObject)
 DEFINE_FIELD_U(m_slots,                  LoaderAllocatorObject,      m_pSlots)

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -22,6 +22,7 @@
 #include "float.h"      // for isnan
 #include "dbginterface.h"
 #include "dllimport.h"
+#include "ilstubresolver.h"
 #include "callconvbuilder.hpp"
 #include "gcheaputilities.h"
 #include "comdelegate.h"
@@ -7330,31 +7331,37 @@ static bool getILIntrinsicImplementationForRuntimeHelpers(
         static const BYTE returnTrue[] = { CEE_LDC_I4_1, CEE_RET };
         static const BYTE returnFalse[] = { CEE_LDC_I4_0, CEE_RET };
 
-        // Ideally we could detect automatically whether a type is trivially equatable
-        // (i.e., its operator == could be implemented via memcmp). The best we can do
-        // for now is hardcode a list of known supported types and then also include anything
-        // that doesn't provide its own object.Equals override / IEquatable<T> implementation.
-        // n.b. This doesn't imply that the type's CompareTo method can be memcmp-implemented,
-        // as a method like CompareTo may need to take a type's signedness into account.
+        TypeHandle iEquatableType = TypeHandle(CoreLibBinder::GetClass(CLASS__IEQUATABLEGENERIC)).Instantiate(inst);
+        if (typeHandle.CanCastTo(iEquatableType))
+        {
+            MethodDesc* interfaceMethod = MethodDesc::FindOrCreateAssociatedMethodDesc(
+                CoreLibBinder::GetMethod(METHOD__IEQUATABLEGENERIC__GET_IS_BITWISE_EQUATABLE),
+                iEquatableType.AsMethodTable(),
+                FALSE,
+                Instantiation(),
+                FALSE,
+                TRUE);
 
-        if (methodTable == CoreLibBinder::GetClass(CLASS__BOOLEAN)
-            || methodTable == CoreLibBinder::GetClass(CLASS__BYTE)
-            || methodTable == CoreLibBinder::GetClass(CLASS__SBYTE)
-            || methodTable == CoreLibBinder::GetClass(CLASS__CHAR)
-            || methodTable == CoreLibBinder::GetClass(CLASS__INT16)
-            || methodTable == CoreLibBinder::GetClass(CLASS__UINT16)
-            || methodTable == CoreLibBinder::GetClass(CLASS__INT32)
-            || methodTable == CoreLibBinder::GetClass(CLASS__UINT32)
-            || methodTable == CoreLibBinder::GetClass(CLASS__INT64)
-            || methodTable == CoreLibBinder::GetClass(CLASS__UINT64)
-            || methodTable == CoreLibBinder::GetClass(CLASS__INT128)
-            || methodTable == CoreLibBinder::GetClass(CLASS__UINT128)
-            || methodTable == CoreLibBinder::GetClass(CLASS__INTPTR)
-            || methodTable == CoreLibBinder::GetClass(CLASS__UINTPTR)
-            || methodTable == CoreLibBinder::GetClass(CLASS__GUID)
-            || methodTable == CoreLibBinder::GetClass(CLASS__RUNE)
-            || methodTable->IsEnum()
-            || IsBitwiseEquatable(typeHandle, methodTable))
+            NewHolder<ILStubResolver> ilResolver = new ILStubResolver();
+            ilResolver->SetStubMethodDesc(ftn);
+
+            SigTypeContext genericContext;
+            SigTypeContext::InitTypeContext(ftn, &genericContext);
+
+            ILStubLinker sl(ftn->GetModule(), ftn->GetSignature(), &genericContext, ftn, ILSTUB_LINKER_FLAG_NONE);
+
+            ILCodeStream* code = sl.NewCodeStream(ILStubLinker::kDispatch);
+            code->EmitCONSTRAINED(code->GetToken(typeHandle));
+            code->EmitCALL(code->GetToken(interfaceMethod), 0, 1);
+            code->EmitRET();
+
+            cxt.Header = ilResolver->FinalizeILStub(&sl, CORJIT_FLAGS());
+            cxt.TransientResolver = ilResolver.Extract();
+            getMethodInfoILMethodHeaderHelper(cxt.Header, methInfo);
+            *localSig = SigPointer(cxt.Header->LocalVarSig, cxt.Header->cbLocalVarSig);
+            return true;
+        }
+        else if (methodTable->IsEnum() || IsBitwiseEquatable(typeHandle, methodTable))
         {
             methInfo->ILCode = const_cast<BYTE*>(returnTrue);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Boolean.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Boolean.cs
@@ -57,6 +57,8 @@ namespace System
         //
         public static readonly string FalseString = FalseLiteral;
 
+        static bool IEquatable<bool>.IsBitwiseEquatable => true;
+
         //
         // Overridden Instance Methods
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -46,6 +46,8 @@ namespace System
         /// <summary>Represents the number zero (0).</summary>
         private const byte Zero = 0;
 
+        static bool IEquatable<byte>.IsBitwiseEquatable => true;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -46,6 +46,8 @@ namespace System
         // The minimum character value.
         public const char MinValue = (char)0x00;
 
+        static bool IEquatable<char>.IsBitwiseEquatable => true;
+
         private const byte IsWhiteSpaceFlag = 0x80;
         private const byte IsUpperCaseLetterFlag = 0x40;
         private const byte IsLowerCaseLetterFlag = 0x20;

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -44,6 +44,8 @@ namespace System
         /// <remarks>This returns the value: FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF</remarks>
         public static Guid AllBitsSet => new Guid(uint.MaxValue, ushort.MaxValue, ushort.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue);
 
+        static bool IEquatable<Guid>.IsBitwiseEquatable => true;
+
         private readonly int _a;   // Do not rename (binary serialization)
         private readonly short _b; // Do not rename (binary serialization)
         private readonly short _c; // Do not rename (binary serialization)

--- a/src/libraries/System.Private.CoreLib/src/System/IEquatable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IEquatable.cs
@@ -9,5 +9,10 @@ namespace System
         /// <param name="other">An object to compare with this object.</param>
         /// <returns><c>true</c> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <c>false</c>.</returns>
         bool Equals(T? other);
+
+        /// <summary>
+        /// Indicates whether the current type is bitwise equatable.
+        /// </summary>
+        static virtual bool IsBitwiseEquatable => false;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -31,6 +31,8 @@ namespace System
         private readonly ulong _upper;
 #endif
 
+        static bool IEquatable<Int128>.IsBitwiseEquatable => true;
+
         /// <summary>Initializes a new instance of the <see cref="Int128" /> struct.</summary>
         /// <param name="upper">The upper 64-bits of the 128-bit value.</param>
         /// <param name="lower">The lower 64-bits of the 128-bit value.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -47,6 +47,8 @@ namespace System
         /// <summary>Represents the number negative one (-1).</summary>
         private const short NegativeOne = -1;
 
+        static bool IEquatable<short>.IsBitwiseEquatable => true;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -47,6 +47,8 @@ namespace System
         /// <summary>Represents the number negative one (-1).</summary>
         private const int NegativeOne = -1;
 
+        static bool IEquatable<int>.IsBitwiseEquatable => true;
+
         /// <summary>Produces the full product of two 32-bit numbers.</summary>
         /// <param name="left">The first number to multiply.</param>
         /// <param name="right">The second number to multiply.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -47,6 +47,8 @@ namespace System
         /// <summary>Represents the number negative one (-1).</summary>
         private const long NegativeOne = -1;
 
+        static bool IEquatable<long>.IsBitwiseEquatable => true;
+
         /// <summary>Produces the full product of two 64-bit numbers.</summary>
         /// <param name="left">The first number to multiply.</param>
         /// <param name="right">The second number to multiply.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -40,6 +40,8 @@ namespace System
         [Intrinsic]
         public static readonly nint Zero;
 
+        static bool IEquatable<nint>.IsBitwiseEquatable => true;
+
         [NonVersionable]
         public IntPtr(int value)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -50,6 +50,8 @@ namespace System
         /// <summary>Represents the number negative one (-1).</summary>
         private const sbyte NegativeOne = -1;
 
+        static bool IEquatable<sbyte>.IsBitwiseEquatable => true;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -68,6 +68,8 @@ namespace System.Text
 
         private readonly uint _value;
 
+        static bool IEquatable<Rune>.IsBitwiseEquatable => true;
+
         /// <summary>
         /// Creates a <see cref="Rune"/> from the provided UTF-16 code unit.
         /// </summary>

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -33,6 +33,8 @@ namespace System
         private readonly ulong _upper;
 #endif
 
+        static bool IEquatable<UInt128>.IsBitwiseEquatable => true;
+
         /// <summary>Initializes a new instance of the <see cref="UInt128" /> struct.</summary>
         /// <param name="upper">The upper 64-bits of the 128-bit value.</param>
         /// <param name="lower">The lower 64-bits of the 128-bit value.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -44,6 +44,8 @@ namespace System
         /// <summary>Represents the number zero (0).</summary>
         private const ushort Zero = 0;
 
+        static bool IEquatable<ushort>.IsBitwiseEquatable => true;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -44,6 +44,8 @@ namespace System
         /// <summary>Represents the number zero (0).</summary>
         private const uint Zero = 0;
 
+        static bool IEquatable<uint>.IsBitwiseEquatable => true;
+
         /// <summary>Produces the full product of two unsigned 32-bit numbers.</summary>
         /// <param name="left">The first number to multiply.</param>
         /// <param name="right">The second number to multiply.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -50,6 +50,8 @@ namespace System
         /// <returns>The number containing the product of the specified numbers.</returns>
         public static UInt128 BigMul(ulong left, ulong right) => Math.BigMul(left, right);
 
+        static bool IEquatable<ulong>.IsBitwiseEquatable => true;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -40,6 +40,8 @@ namespace System
         [Intrinsic]
         public static readonly nuint Zero;
 
+        static bool IEquatable<nuint>.IsBitwiseEquatable => true;
+
         [NonVersionable]
         public UIntPtr(uint value)
         {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -3551,6 +3551,7 @@ namespace System
     public partial interface IEquatable<T> where T : allows ref struct
     {
         bool Equals(T? other);
+        virtual static bool IsBitwiseIEquatable { get { throw null; } }
     }
     public partial interface IFormatProvider
     {


### PR DESCRIPTION
Alternate to #130723: Instead of hard-coding bitwise-equatable types or introducing a new marker interface or pattern matching by scanning IL, adding a virtual static property `bool IsBitwiseEquatable` to `IEquatable<T>` to allow types to opt-in explicitly.

```diff
namespace System;

interface IEquatable<T>
{
+   static virtual bool IsBitwiseEquatable => false;
}
```

Then `RuntimeHelpers.IsBitwiseEquatable<T>()` emits a constrained call to `IEquatable<T>.IsBitwiseEquatable` directly when 
`T` implements `IEquatable<T>`.

This approach also has several benefits over #130723 and #75642:

- Types need to opt-in explicitly: a type won't automatically become bitwise-equatable just because it happens to implement some interfaces that inherits from `IBitwiseEquatable<T>`
- Unlike attributes that can be applied to arbitrary types, a type can only opt-in this behavior if the type implemented `IEquatable<T>`
- No interface hierarchy change is needed, so users don't need to change their interface dependencies
- Using virtual static member in interface with defaults to `false` makes it a non-breaking change 

cc: @jkotas @stephentoub @tannergooding @EgorBo 

This PR introduced a new API which needs to go from API approval first, but I'm opening the PR here for your thoughts.