### PR TITLE
Fix EC/DSA key generation cache under concurrency

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignatureFormatTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignatureFormatTests.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.Dsa.Tests
     [ConditionalClass(typeof(PlatformSupport), nameof(PlatformSupport.IsDSASupported))]
     public abstract class DSASignatureFormatTests : DsaFamilySignatureFormatTests
     {
-        private static readonly Dictionary<DSAProvider, KeyDescription[]> s_keyCache = new();
+        private static readonly Dictionary<(DSAProvider Provider, Type TestClass), KeyDescription[]> s_keyCache = new();
 
         protected abstract DSAProvider DSAFactory { get; }
 
@@ -24,10 +24,12 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             lock (s_keyCache)
             {
-                if (!s_keyCache.TryGetValue(DSAFactory, out KeyDescription[] keys))
+                (DSAProvider Provider, Type TestClass) cacheKey = (DSAFactory, GetType());
+
+                if (!s_keyCache.TryGetValue(cacheKey, out KeyDescription[] keys))
                 {
                     keys = LocalGenerateTestKeys().ToArray();
-                    s_keyCache.Add(DSAFactory, keys);
+                    s_keyCache.Add(cacheKey, keys);
                 }
 
                 return keys;

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaSignatureFormatTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaSignatureFormatTests.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
     [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public abstract class ECDsaSignatureFormatTests : DsaFamilySignatureFormatTests
     {
-        private static readonly Dictionary<ECDsaProvider, KeyDescription[]> s_keyCache = new();
+        private static readonly Dictionary<(ECDsaProvider Provider, Type TestClass), KeyDescription[]> s_keyCache = new();
 
         protected abstract ECDsaProvider ECDsaFactory { get; }
 
@@ -22,10 +22,12 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             lock (s_keyCache)
             {
-                if (!s_keyCache.TryGetValue(ECDsaFactory, out KeyDescription[] keys))
+                (ECDsaProvider Provider, Type TestClass) cacheKey = (ECDsaFactory, GetType());
+
+                if (!s_keyCache.TryGetValue(cacheKey, out KeyDescription[] keys))
                 {
                     keys = LocalGenerateTestKeys().ToArray();
-                    s_keyCache.Add(ECDsaFactory, keys);
+                    s_keyCache.Add(cacheKey, keys);
                 }
 
                 return keys;


### PR DESCRIPTION
In #129320 we introduced a regression where DSA keys could be hydrated concurrently. That is, the lazy key generation for `DSA` instances is not thread-safe, in the atomic sense.

This was previously reported in #34045 and fixed by #34199, but after consolidating our DSA tests we only cached the keys by the DSAProvider. We also need to cache by the derived types because `DsaArraySignatureFormatTests`, `DsaArrayOffsetSignatureFormatTests`, and `DsaSpanSignatureFormatTests` can all run concurrently for the same `DSAProvider`, which would result in shared `DSA` keys that are acted upon concurrently.

ECDsa has the same pattern, so it is fixed as well.

Fixes #130774
Fixes #130371 
Fixes #130048