### PR TITLE
Remove dead switch-table disassembly code from the xarch emitter

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -7389,42 +7389,6 @@ void emitter::emitIns_I(instruction ins, emitAttr attr, cnsval_ssize_t val)
 
 /*****************************************************************************
  *
- *  Add a "jump through a table" instruction.
- */
-
-void emitter::emitIns_IJ(emitAttr attr, regNumber reg, unsigned base)
-{
-    assert(EA_SIZE(attr) == EA_4BYTE);
-
-    UNATIVE_OFFSET    sz  = 3 + 4;
-    const instruction ins = INS_i_jmp;
-
-    if (IsExtendedReg(reg, attr))
-    {
-        sz += emitGetRexPrefixSize(ins);
-    }
-
-    instrDesc* id = emitNewInstrAmd(attr, base);
-
-    id->idIns(ins);
-    id->idInsFmt(emitInsModeFormat(ins, IF_ARD));
-    id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-    id->idAddr()->iiaAddrMode.amIndxReg = reg;
-    id->idAddr()->iiaAddrMode.amScale   = emitter::OPSZP;
-
-    if (m_debugInfoSize > 0)
-    {
-        id->idDebugOnlyInfo()->idMemCookie = base;
-    }
-
-    id->idCodeSize(sz);
-
-    dispIns(id);
-    emitCurIGsize += sz;
-}
-
-/*****************************************************************************
- *
  *  Add an instruction with a static data member operand. If 'size' is 0, the
  *  instruction operates on the address of the static member instead of its
  *  value (e.g. "push offset clsvar", rather than "push dword ptr [clsvar]").
@@ -12355,59 +12319,14 @@ void emitter::emitDispReloc(ssize_t value) const
  *  Display an address mode.
  */
 
-void emitter::emitDispAddrMode(instrDesc* id, bool noDetail) const
+void emitter::emitDispAddrMode(instrDesc* id) const
 {
     bool    nsep = false;
     ssize_t disp;
 
-    unsigned     jtno = 0;
-    dataSection* jdsc = nullptr;
-
     /* The displacement field is in an unusual place for calls */
 
     disp = (id->idIns() == INS_call) || (id->idIns() == INS_tail_i_jmp) ? emitGetInsCIdisp(id) : emitGetInsAmdAny(id);
-
-    /* Display a jump table label if this is a switch table jump */
-
-    if (id->idIns() == INS_i_jmp)
-    {
-        UNATIVE_OFFSET offs = 0;
-
-        /* Find the appropriate entry in the data section list */
-
-        for (jdsc = emitConsDsc.dsdList, jtno = 0; jdsc; jdsc = jdsc->dsNext)
-        {
-            UNATIVE_OFFSET size = jdsc->dsSize;
-
-            /* Is this a label table? */
-
-            if (size & 1)
-            {
-                size--;
-                jtno++;
-
-                if (offs == id->idDebugOnlyInfo()->idMemCookie)
-                {
-                    break;
-                }
-            }
-
-            offs += size;
-        }
-
-        /* If we've found a matching entry then is a table jump */
-
-        if (jdsc)
-        {
-            if (id->idIsDspReloc())
-            {
-                printf("reloc ");
-            }
-            printf("J_M%03u_DS%02u", m_compiler->compMethodID, (unsigned)id->idDebugOnlyInfo()->idMemCookie);
-
-            disp -= id->idDebugOnlyInfo()->idMemCookie;
-        }
-    }
 
     bool frameRef = false;
 
@@ -12520,33 +12439,6 @@ void emitter::emitDispAddrMode(instrDesc* id, bool noDetail) const
     }
 
     printf("]");
-
-    if (jdsc && !noDetail)
-    {
-        unsigned     cnt = (jdsc->dsSize - 1) / TARGET_POINTER_SIZE;
-        BasicBlock** bbp = jdsc->Blocks();
-
-#ifdef TARGET_AMD64
-#define SIZE_LETTER "Q"
-#else
-#define SIZE_LETTER "D"
-#endif
-        printf("\n\n    J_M%03u_DS%02u LABEL   " SIZE_LETTER "WORD", m_compiler->compMethodID, jtno);
-
-        /* Display the label table (it's stored as "BasicBlock*" values) */
-
-        do
-        {
-            insGroup* lab;
-
-            /* Convert the BasicBlock* value to an IG address */
-
-            lab = (insGroup*)emitCodeGetCookie(*bbp++);
-            assert(lab);
-
-            printf("\n            D" SIZE_LETTER "      %s", emitLabelString(lab));
-        } while (--cnt);
-    }
 }
 
 /*****************************************************************************
@@ -12987,7 +12879,7 @@ void emitter::emitDispIns(
                     printf("%s", sstr);
                 }
 
-                emitDispAddrMode(id, isNew);
+                emitDispAddrMode(id);
                 emitDispShift(ins);
             }
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -811,7 +811,7 @@ bool isPrefetch(instruction ins)
 
 void emitDispMask(const instrDesc* id, regNumber reg) const;
 void emitDispReloc(ssize_t value) const;
-void emitDispAddrMode(instrDesc* id, bool noDetail = false) const;
+void emitDispAddrMode(instrDesc* id) const;
 void emitDispShift(instruction ins, int cnt = 0) const;
 
 const char* emitXMMregName(unsigned reg) const;
@@ -1114,8 +1114,6 @@ void emitIns_C_I(instruction          ins,
                  int                  offs,
                  int                  val,
                  insOpts              instOptions = INS_OPTS_NONE);
-
-void emitIns_IJ(emitAttr attr, regNumber reg, unsigned base);
 
 void emitIns_J_S(instruction ins, emitAttr attr, BasicBlock* dst, int varx, int offs);
 


### PR DESCRIPTION
Removes dead switch-table disassembly code from the xarch emitter.

The `INS_i_jmp` block in `emitter::emitDispAddrMode` identified a jump-table data section by testing `jdsc->dsSize & 1` (an odd-size marker), then printed a `J_M%03u_DS%02u` label and adjusted the displacement, and a trailing block dumped the table's `BasicBlock*` targets.

No data section ever has an odd `dsSize` today: `emitDataGenBeg` asserts `(size % dataSection::MIN_DATA_ALIGN) == 0` and `emitBBTableDataGenBeg` stores even `numEntries * elemSize`. Jump-table sections are now discriminated by `dsType` (`blockRelative32` / `blockAbsoluteAddr`), so the odd-size marker is a pre-`dsType` fossil — `jdsc` is always `null` and both display blocks are unreachable. Their sole producer, `emitIns_IJ` (the only function that emitted an address-mode `INS_i_jmp` with a jump-table `idMemCookie`), has no callers; modern switch codegen (`genTableBasedSwitch`) emits `jmp reg`. `git log -S` on both the marker and `emitIns_IJ` surfaces only the 2020 directory-move (#44973), so this has been dead for a long time.

This removes:
- the `jtno` / `jdsc` locals, the `INS_i_jmp` label-finder loop + `if (jdsc)` printf, and the `if (jdsc && !noDetail)` table dump in `emitDispAddrMode`
- the now-vestigial `noDetail` parameter (its only non-default caller passed `isNew` purely to gate the dead dump)
- the dead `emitIns_IJ`

----------

This is `DEBUG`-only display code with no behavior change on any live path -- the only reachable address-mode `INS_i_jmp` is `genNonLocalJmp`'s `jmp [mem]`, which never carried a jump-table cookie, so `jdsc` stayed `null` there and `disp` was never adjusted.

The disassembly is unaffected because the same information is already produced by the live paths:
- the instruction that references the table (`lea reg, [@RWD00]` from `genJumpTable` via `emitIns_R_C`) is labeled by `emitDispClsVar` as `@RWD%02u`
- the table entries are dumped by `emitter::emitDispDataSec`, called from `emitOutputDataSec` under `opts.disAsm`, keyed off `dsType == blockRelative32 / blockAbsoluteAddr`, as `dd/dq <blockLabel> ; case <blockLabel>`
- `genEmitJumpTable` emits the verbose `J_M%03u_DS%02u LABEL DWORD` header + entries during codegen

Other architectures are unaffected: the odd-`dsSize` marker was xarch-only, `arm` already identifies the table correctly via `dsType == blockAbsoluteAddr` (reachable through its `movw`/`movt`), and `arm64` / `riscv64` / `loongarch64` have no arch-specific jump-table display walk at all (they rely on the shared `emitDispDataSec` + `@RWD` labels).

Built `clr.jit -c checked -a x64` (0 warnings / 0 errors) and ran `jitformat.py` (no changes).

> [!NOTE]
> This PR description was drafted by GitHub Copilot on behalf of the author.
