### PR TITLE
Run Wasm.Build.Tests Helix jobs in parallel

### DIFF
--- a/eng/pipelines/common/templates/browser-wasm-build-tests.yml
+++ b/eng/pipelines/common/templates/browser-wasm-build-tests.yml
@@ -125,6 +125,11 @@ jobs:
             parameters:
               creator: dotnet-bot
               testRunNamePrefixSuffix: Mono_$(_BuildConfig)_$(_hostedOs)
-              extraHelixArguments: /p:BrowserHost=$(_hostedOs)
+              # WBT (buildwasmapps) fans out into several sendtohelixhelp.proj invocations
+              # (Workloads/Webcil/Fingerprinting/Bundler combos). sendtohelix.proj already builds
+              # them with BuildInParallel=true, but that only parallelizes when the msbuild running
+              # it has multiple nodes. /maxcpucount lets the Helix jobs be sent (and waited on)
+              # concurrently instead of one-send-then-wait-for-completion serially (see issue #118938).
+              extraHelixArguments: /p:BrowserHost=$(_hostedOs) /maxcpucount:8
               scenarios:
               - buildwasmapps

--- a/eng/pipelines/common/templates/browser-wasm-coreclr-build-tests.yml
+++ b/eng/pipelines/common/templates/browser-wasm-coreclr-build-tests.yml
@@ -138,6 +138,11 @@ jobs:
             parameters:
               creator: dotnet-bot
               testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)_$(_hostedOs)
-              extraHelixArguments: /p:BrowserHost=$(_hostedOs)
+              # WBT (buildwasmapps) fans out into several sendtohelixhelp.proj invocations
+              # (Workloads/Webcil/Fingerprinting/Bundler combos). sendtohelix.proj already builds
+              # them with BuildInParallel=true, but that only parallelizes when the msbuild running
+              # it has multiple nodes. /maxcpucount lets the Helix jobs be sent (and waited on)
+              # concurrently instead of one-send-then-wait-for-completion serially (see issue #118938).
+              extraHelixArguments: /p:BrowserHost=$(_hostedOs) /maxcpucount:8
               scenarios:
               - buildwasmapps

--- a/eng/pipelines/common/templates/simple-wasm-build-tests.yml
+++ b/eng/pipelines/common/templates/simple-wasm-build-tests.yml
@@ -47,7 +47,12 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_$(_BuildConfig)_$(_hostedOs)
-            extraHelixArguments: /p:BrowserHost=$(_hostedOs)
+            # WBT (buildwasmapps) fans out into several sendtohelixhelp.proj invocations
+            # (Workloads/Webcil/Fingerprinting/Bundler combos). sendtohelix.proj already builds
+            # them with BuildInParallel=true, but that only parallelizes when the msbuild running
+            # it has multiple nodes. /maxcpucount lets the Helix jobs be sent (and waited on)
+            # concurrently instead of one-send-then-wait-for-completion serially (see issue #118938).
+            extraHelixArguments: /p:BrowserHost=$(_hostedOs) /maxcpucount:8
             scenarios:
             - buildwasmapps
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/118938

## Problem

Wasm.Build.Tests (WBT, the `buildwasmapps` scenario) sends its Helix jobs **sequentially** — each job is sent, then the build blocks on `Waiting for completion` before the next `Sent Helix Job` is issued. This serializes the whole WBT run behind the sum of every Helix job's duration.

## Root cause

WBT `postBuildSteps` call [`eng/pipelines/libraries/helix.yml`](https://github.com/dotnet/runtime/blob/main/eng/pipelines/libraries/helix.yml), which runs `src/libraries/sendtohelix.proj`. For `buildwasmapps`, that project fans out into a **cartesian product** of sub-projects (`TestUsingWorkloads` × `WasmEnableWebcil` × `WasmFingerprintAssets` × bundler-friendly), and invokes them with:

```xml
<MSBuild Projects="@(_ProjectsToBuild)" Targets="Test" BuildInParallel="$(_BuildInParallel)" StopOnFirstFailure="false" />
```

`_BuildInParallel` is already `true` when there is more than one sub-project. But `BuildInParallel` only actually runs builds concurrently when the **msbuild process driving it has multiple nodes** (`/maxcpucount`). The `Send to Helix` step passed no `/maxcpucount`, so it ran on a single node — each sub-project's `Test` target (which sends a Helix job **and** waits for its completion) ran to completion before the next started. That is exactly the sequential `Sent Helix Job` → `Waiting for completion` pattern in #118938.

## Fix

Pass `/maxcpucount:8` to the WBT Helix send (via the existing `extraHelixArguments`), so the already-present `BuildInParallel=true` sends and awaits the per-combo Helix jobs **concurrently**. This is the same mechanism [`eng/pipelines/coreclr/libraries-jitstress.yml`](https://github.com/dotnet/runtime/blob/main/eng/pipelines/coreclr/libraries-jitstress.yml) already uses (`extraHelixArguments: /maxcpucount:10`) to parallelize its multi-scenario sends.

Applied to all three WBT senders:
- `eng/pipelines/common/templates/browser-wasm-build-tests.yml` (browser Mono)
- `eng/pipelines/common/templates/browser-wasm-coreclr-build-tests.yml` (browser CoreCLR)
- `eng/pipelines/common/templates/simple-wasm-build-tests.yml` (Mono single-threaded; used by the extra-platforms wasm pipelines)

## Notes

- The WBT jobs stay in the existing `Build` stage — no new stage, no dependency on the whole `Build` stage completing, and no Helix Job Monitor. This is an intentional **alternative** to #130773 (which moves WBT into a dedicated `WasmBuildTests` stage); that approach fixes stage organization but delays WBT start until the entire `Build` stage finishes and does not by itself change the sequential send behavior.
- `StopOnFirstFailure="false"` is already set, so parallel sends still aggregate all failures; per-Helix-job timeouts are unchanged.
- Full effect can only be confirmed by running the pipelines on Azure DevOps; local validation covered YAML parsing and template structure.

> [!NOTE]
> This pull request was authored by GitHub Copilot.