### PR TITLE
Remove dead/unreachable code in several JIT phases

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7805,15 +7805,12 @@ protected:
     CSEdsc* optCSEfindDsc(unsigned index);
     bool optUnmarkCSE(GenTree* tree);
 
-    // user defined callback data for the tree walk function optCSE_MaskHelper()
+    // Data for the tree walk that computes the mask of CSE definitions and uses
     struct optCSE_MaskData
     {
         EXPSET_TP CSE_defMask;
         EXPSET_TP CSE_useMask;
     };
-
-    // Treewalk helper for optCSE_DefMask and optCSE_UseMask
-    static fgWalkPreFn optCSE_MaskHelper;
 
     // This function walks all the node for an given tree
     // and return the mask of CSE definitions and uses for the tree

--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -688,16 +688,6 @@ GenTree* Compiler::impUtf16SpanComparison(StringComparisonKind kind, CORINFO_SIG
 
     if (unrolled != nullptr)
     {
-        // Wrap with the reference equality check for Equals.
-        // We believe it's less likely to be useful for StartsWith/EndsWith.
-        if (kind == StringComparisonKind::Equals)
-        {
-            GenTreeColon* refEqualityColon = gtNewColonNode(TYP_INT, gtNewTrue(), unrolled);
-            unrolled                       = gtNewQmarkNode(TYP_INT,
-                                                            gtNewOperNode(GT_EQ, TYP_INT, gtCloneExpr(spanReferenceFld), gtCloneExpr(cnsStr)),
-                                                            refEqualityColon);
-        }
-
         if (!spanObj->OperIs(GT_LCL_VAR))
         {
             impStoreToTemp(spanLclNum, spanObj, CHECK_SPILL_NONE);

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -2107,14 +2107,12 @@ private:
     //
     unsigned MorphStructFieldAddress(GenTree* node, ValueSize accessSize)
     {
-        unsigned offset       = 0;
-        bool     isSpanLength = false;
-        GenTree* addr         = node;
+        unsigned offset = 0;
+        GenTree* addr   = node;
         if (addr->OperIs(GT_FIELD_ADDR) && addr->AsFieldAddr()->IsInstance())
         {
-            offset       = addr->AsFieldAddr()->gtFldOffset;
-            isSpanLength = addr->AsFieldAddr()->IsSpanLength();
-            addr         = addr->AsFieldAddr()->GetFldObj();
+            offset = addr->AsFieldAddr()->gtFldOffset;
+            addr   = addr->AsFieldAddr()->GetFldObj();
         }
 
         if (addr->OperIs(GT_LCL_ADDR))
@@ -2130,16 +2128,6 @@ private:
                     // Access a promoted struct's field with an offset that doesn't correspond to any field.
                     // It can happen if the struct was cast to another struct with different offsets.
                     return BAD_VAR_NUM;
-                }
-
-                LclVarDsc* fieldVarDsc = m_compiler->lvaGetDesc(fieldLclNum);
-                ValueSize  fieldSize   = fieldVarDsc->lvValueSize();
-
-                // Span's Length is never negative unconditionally
-                if (isSpanLength && (accessSize.GetExact() == genTypeSize(TYP_INT)))
-                {
-                    unsigned exactSize      = accessSize.GetExact();
-                    unsigned exactFieldSize = fieldSize.GetExact();
                 }
 
                 if (!accessSize.IsNull() && m_compiler->IsWideAccess(fieldLclNum, 0, accessSize))

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -206,15 +206,6 @@ bool Compiler::optUnmarkCSE(GenTree* tree)
     }
 }
 
-Compiler::fgWalkResult Compiler::optCSE_MaskHelper(GenTree** pTree, fgWalkData* walkData)
-{
-    GenTree*         tree      = *pTree;
-    Compiler*        comp      = walkData->m_compiler;
-    optCSE_MaskData* pUserData = (optCSE_MaskData*)(walkData->pCallbackData);
-
-    return WALK_CONTINUE;
-}
-
 // This functions walks all the node for an given tree
 // and return the mask of CSE defs and uses for the tree
 //

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -901,25 +901,6 @@ void Rationalizer::RewriteHWIntrinsicToNonMask(GenTree** use, Compiler::GenTreeS
             break;
         }
 
-        case NI_AVX512_XnorMask:
-        {
-            var_types simdBaseType = node->GetSimdBaseType();
-            unsigned  simdSize     = node->GetSimdSize();
-            var_types simdType     = Compiler::getSIMDTypeForSize(simdSize);
-
-            GenTree* op1 =
-                m_compiler->gtNewSimdBinOpNode(GT_XOR, simdType, node->Op(1), node->Op(2), simdBaseType, simdSize);
-            BlockRange().InsertBefore(node, op1);
-            node->Op(1) = op1;
-
-            GenTree* op2 = m_compiler->gtNewAllBitsSetConNode(simdType);
-            BlockRange().InsertBefore(node, op2);
-            node->Op(2) = op2;
-
-            RewriteHWIntrinsicBitwiseOpToNonMask(use, parents, GT_XOR);
-            break;
-        }
-
         case NI_AVX512_CompareMask:
         case NI_AVX512_CompareEqualMask:
         case NI_AVX512_CompareGreaterThanMask:
@@ -1256,7 +1237,6 @@ bool Rationalizer::ShouldRewriteToNonMaskHWIntrinsic(GenTree* node)
         case NI_AVX512_AndNotMask:
         case NI_AVX512_OrMask:
         case NI_AVX512_XorMask:
-        case NI_AVX512_XnorMask:
         {
             // binary bitwise operations should be optimized if both inputs can
             assert(hwNode->GetOperandCount() == 2);


### PR DESCRIPTION
This removes four pieces of dead or unreachable code found while auditing the major JIT phases. Each is an isolated, no-diff-expected cleanup and is a separate commit.

----------

**Remove dead reference-equality fast path in span half-const `Equals`**

`impUtf16SpanComparison` wrapped the unrolled compare with `GT_EQ(spanReferenceFld, cnsStr)`. `spanReferenceFld` is the span's `_reference` (`TYP_BYREF`, pointing at the character data) where-as `cnsStr` is the string object handle (`TYP_REF`), so the comparison is always `false` and the fast path never fires. This was copy-pasted from the string variant in `impUtf16StringComparison`, where comparing two object references is correct.

Note the intent here was real (added by #117431); making it actually fire for spans requires comparing `span._reference` against the address of the frozen string literal's character data, which is a larger change. Removing the always-false path for now.

----------

**Remove unfinished `isSpanLength` block in `MorphStructFieldAddress`**

The block computed `exactSize`/`exactFieldSize` and then did nothing with them -- it was an unfinished attempt to preserve the "never negative" `Span.Length` property (from #81055) across struct promotion. The `IsSpanLength()` flag itself remains live and used; only the no-op block is removed.

----------

**Remove unused `optCSE_MaskHelper`**

Superseded leftover -- the mask-data collection it was meant to do is handled by the `MaskDataWalker` class in `optCSE_GetMaskData`. The helper was a no-op with no callers.

----------

**Remove unreachable `XnorMask` handling in rationalization**

`NI_AVX512_XnorMask` is only produced during lowering (`lowerxarch.cpp`), which runs after rationalization, so the `XnorMask` cases in `RewriteHWIntrinsicToNonMask` and `ShouldRewriteToNonMaskHWIntrinsic` were never reached. The rewrite was also malformed: it built a `TYP_SIMD` XOR from the still-`TYP_MASK` operands, which would trip `unreached()` if it ever ran.

----------

No behavioral change is expected from any of these; `jit-format` is clean.

> [!NOTE]
> This PR description and the underlying audit were drafted with the help of GitHub Copilot.