### PR TITLE
Implement RFC 9659 compliance for "zstd" HttpContent compression

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/ZstandardCompressedContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/ZstandardCompressedContent.cs
@@ -39,6 +39,12 @@ namespace System.Net.Http
         /// </summary>
         /// <param name="content">The HTTP content to compress.</param>
         /// <param name="compressionLevel">One of the enumeration values that indicates whether to emphasize speed or compression efficiency.</param>
+        /// <remarks>
+        /// RFC 9659 requires that the "zstd" content coding be decodable with a window size of 8 MB (2^23) and
+        /// recommends that encoders not produce frames requiring a larger window. When setting <paramref name="compressionLevel"/>
+        /// to <see cref="CompressionLevel.SmallestSize"/>, this class applies RFC-compliant options to limit the window size
+        /// so that the produced content is accepted by servers that enforce this limit.
+        /// </remarks>
         public ZstandardCompressedContent(HttpContent content, CompressionLevel compressionLevel = CompressionLevel.Optimal)
         {
             ArgumentNullException.ThrowIfNull(content);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/ZstandardCompressedContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/ZstandardCompressedContent.cs
@@ -23,7 +23,7 @@ namespace System.Net.Http
         // Some compression levels (notably CompressionLevel.SmallestSize) would otherwise select a larger
         // window, producing payloads that a conformant server would reject. See RFC 9659, Section 3.
         private const int RfcMaxWindowLog2 = 23;
-        private static readonly ZstandardCompressionOptions s_SmallestSizeRfcOptions = new ZstandardCompressionOptions
+        private static readonly ZstandardCompressionOptions s_smallestSizeRfcOptions = new ZstandardCompressionOptions
         {
             Quality = ZstandardCompressionOptions.MaxQuality,
             WindowLog2 = RfcMaxWindowLog2
@@ -47,7 +47,7 @@ namespace System.Net.Http
             if (compressionLevel == CompressionLevel.SmallestSize)
             {
                 // use RFC-compliant options for SmallestSize to avoid producing frames that a conformant server would reject
-                _compressionOptions = s_SmallestSizeRfcOptions;
+                _compressionOptions = s_smallestSizeRfcOptions;
             }
             else
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/ZstandardCompressedContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/ZstandardCompressedContent.cs
@@ -18,6 +18,17 @@ namespace System.Net.Http
     {
         private const string Encoding = "zstd";
 
+        // RFC 9659 requires zstd decoders for the "zstd" content coding to support a window size of at
+        // least 8 MB (2^23) and recommends that encoders not produce frames requiring a larger window.
+        // Some compression levels (notably CompressionLevel.SmallestSize) would otherwise select a larger
+        // window, producing payloads that a conformant server would reject. See RFC 9659, Section 3.
+        private const int RfcMaxWindowLog2 = 23;
+        private static readonly ZstandardCompressionOptions s_SmallestSizeRfcOptions = new ZstandardCompressionOptions
+        {
+            Quality = ZstandardCompressionOptions.MaxQuality,
+            WindowLog2 = RfcMaxWindowLog2
+        };
+
         private readonly HttpContent _content;
         private readonly ZstandardCompressionOptions? _compressionOptions;
         private readonly CompressionLevel _compressionLevel;
@@ -33,7 +44,16 @@ namespace System.Net.Http
             ArgumentNullException.ThrowIfNull(content);
             CompressedContentCore.ValidateCompressionLevel(compressionLevel, nameof(compressionLevel));
 
-            _compressionLevel = compressionLevel;
+            if (compressionLevel == CompressionLevel.SmallestSize)
+            {
+                // use RFC-compliant options for SmallestSize to avoid producing frames that a conformant server would reject
+                _compressionOptions = s_SmallestSizeRfcOptions;
+            }
+            else
+            {
+                _compressionLevel = compressionLevel;
+            }
+
             _content = content;
             CompressedContentCore.InitializeHeaders(this, content, Encoding);
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/ZstandardCompressedContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/ZstandardCompressedContent.cs
@@ -64,6 +64,12 @@ namespace System.Net.Http
         /// </summary>
         /// <param name="content">The HTTP content to compress.</param>
         /// <param name="compressionOptions">The options used to fine-tune the compression.</param>
+        /// <remarks>
+        /// RFC 9659 requires that the "zstd" content coding be decodable with a window size of 8 MB (2^23) and
+        /// recommends that encoders not produce frames requiring a larger window. When supplying custom options,
+        /// consider limiting <see cref="ZstandardCompressionOptions.WindowLog2"/> to 23 or less so that the
+        /// produced content is accepted by servers that enforce this limit.
+        /// </remarks>
         public ZstandardCompressedContent(HttpContent content, ZstandardCompressionOptions compressionOptions)
         {
             ArgumentNullException.ThrowIfNull(content);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/CompressedContentTest.NonBrowser.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/CompressedContentTest.NonBrowser.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -105,14 +106,20 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData("br")]
-        [InlineData("zstd")]
-        public async Task BrotliZstd_SerializeToStream_WithCompressionLevel_RoundTrips(string encoding)
+        [InlineData("br", CompressionLevel.NoCompression)]
+        [InlineData("br", CompressionLevel.Fastest)]
+        [InlineData("br", CompressionLevel.Optimal)]
+        [InlineData("br", CompressionLevel.SmallestSize)]
+        [InlineData("zstd", CompressionLevel.NoCompression)]
+        [InlineData("zstd", CompressionLevel.Fastest)]
+        [InlineData("zstd", CompressionLevel.Optimal)]
+        [InlineData("zstd", CompressionLevel.SmallestSize)]
+        public async Task BrotliZstd_SerializeToStream_WithCompressionLevel_RoundTrips(string encoding, CompressionLevel compressionLevel)
         {
-            byte[] original = Encoding.UTF8.GetBytes(new string('a', 4096));
+            byte[] original = Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("The quick brown fox jumps over the lazy dog. ", 4096)));
             HttpContent content = encoding == "br"
-                ? new BrotliCompressedContent(new ByteArrayContent(original), CompressionLevel.SmallestSize)
-                : new ZstandardCompressedContent(new ByteArrayContent(original), CompressionLevel.SmallestSize);
+                ? new BrotliCompressedContent(new ByteArrayContent(original), compressionLevel)
+                : new ZstandardCompressedContent(new ByteArrayContent(original), compressionLevel);
 
             Assert.Equal(original, DecompressBrotliOrZstd(await SerializeAsync(content, async: true), encoding));
         }
@@ -145,7 +152,8 @@ namespace System.Net.Http.Functional.Tests
             using Stream decompressor = encoding switch
             {
                 "br" => new BrotliStream(source, CompressionMode.Decompress),
-                "zstd" => new ZstandardStream(source, CompressionMode.Decompress),
+                // RFC 9659 requires the "zstd" content coding to be decodable with an 8 MB (2^23) window.
+                "zstd" => new ZstandardStream(source, new ZstandardDecompressionOptions { MaxWindowLog2 = 23 }),
                 _ => throw new ArgumentOutOfRangeException(nameof(encoding))
             };
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/CompressedContentTest.NonBrowser.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/CompressedContentTest.NonBrowser.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Net.Http.Functional.Tests
 {
@@ -105,7 +106,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(original, DecompressBrotliOrZstd(await SerializeAsync(content, async: true), encoding));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("br", CompressionLevel.NoCompression)]
         [InlineData("br", CompressionLevel.Fastest)]
         [InlineData("br", CompressionLevel.Optimal)]
@@ -116,6 +117,14 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("zstd", CompressionLevel.SmallestSize)]
         public async Task BrotliZstd_SerializeToStream_WithCompressionLevel_RoundTrips(string encoding, CompressionLevel compressionLevel)
         {
+            if (PlatformDetection.Is32BitProcess && compressionLevel == CompressionLevel.SmallestSize && encoding == "zstd")
+            {
+                // Zstandard smallest size requires too much working memory
+                // (800+ MB) and causes intermittent allocation errors on 32-bit
+                // processes in CI.
+                throw new SkipTestException($"Skipping {encoding} with {compressionLevel} on 32-bit process due to excessive memory requirements.");
+            }
+
             byte[] original = Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("The quick brown fox jumps over the lazy dog. ", 4096)));
             HttpContent content = encoding == "br"
                 ? new BrotliCompressedContent(new ByteArrayContent(original), compressionLevel)


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/runtime/pull/130082 (I didn't get a notification about that one so I didn't comment in time).

cc @iremyux

Open Question: What do we for user-provided `ZstandardCompressionOptions`? should we prevent users from creating non-compliant content?

Opportunistically fixes https://github.com/dotnet/runtime/issues/130948