### PR TITLE
Fix Duplicate ownership state machine under concurrency for NCrypt handles

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/Microsoft/Win32/SafeHandles/NCryptSafeHandles.cs
+++ b/src/libraries/System.Security.Cryptography/src/Microsoft/Win32/SafeHandles/NCryptSafeHandles.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Threading;
 
 using ErrorCode = Interop.NCrypt.ErrorCode;
 
@@ -57,7 +58,8 @@ namespace Microsoft.Win32.SafeHandles
             Holder
         }
 
-        private OwnershipState _ownershipState;
+        private volatile OwnershipState _ownershipState;
+        private Lock? _ownershipLock;
 
         /// <summary>
         ///     If the handle is a Duplicate, this points at the safe handle which actually owns the native handle.
@@ -208,21 +210,30 @@ namespace Microsoft.Win32.SafeHandles
         /// </remarks>
         internal T Duplicate<T>() where T : SafeNCryptHandle, new()
         {
-#if DEBUG
-            Debug.Assert(IsValidOpenState);
-#endif
-            Debug.Assert(_ownershipState != OwnershipState.Holder);
             Debug.Assert(typeof(T) == this.GetType());
 
             if (_ownershipState == OwnershipState.Owner)
             {
-                return DuplicateOwnerHandle<T>();
+                // Only the first duplication mutates the source handle. Publish that transition once so
+                // concurrent callers cannot create independent holders for the same native handle.
+                lock (LazyInitializer.EnsureInitialized(ref _ownershipLock))
+                {
+#if DEBUG
+                    Debug.Assert(IsValidOpenState);
+#endif
+                    if (_ownershipState == OwnershipState.Owner)
+                    {
+                        return DuplicateOwnerHandle<T>();
+                    }
+                }
             }
-            else
-            {
-                // If we're not an owner handle, and we're being duplicated then we must be a duplicate handle.
-                return DuplicateDuplicatedHandle<T>();
-            }
+
+#if DEBUG
+            Debug.Assert(IsValidOpenState);
+#endif
+            Debug.Assert(_ownershipState == OwnershipState.Duplicate);
+
+            return DuplicateDuplicatedHandle<T>();
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/tests/CngKeyTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/CngKeyTests.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
 using Test.Cryptography;
 using Xunit;
 
@@ -56,6 +58,62 @@ namespace System.Security.Cryptography.Tests
                     CngAlgorithm.ECDsaP256,
                     creationOption: creationOption,
                     keySuffix: creationOption.ToString()));
+        }
+
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [Fact]
+        public void Handle_ConcurrentFirstAccess()
+        {
+            const int IterationCount = 10;
+            const int ThreadCount = 8;
+
+            for (int iteration = 0; iteration < IterationCount; iteration++)
+            {
+                using CngKey key = CngKey.Create(CngAlgorithm.ECDsaP256);
+                using Barrier barrier = new Barrier(ThreadCount);
+                var handles = new SafeNCryptKeyHandle?[ThreadCount];
+                var exceptions = new Exception?[ThreadCount];
+                var threads = new Thread[ThreadCount];
+
+                for (int i = 0; i < threads.Length; i++)
+                {
+                    int index = i;
+                    threads[i] = new Thread(() =>
+                    {
+                        try
+                        {
+                            barrier.SignalAndWait();
+                            handles[index] = key.Handle;
+                        }
+                        catch (Exception e)
+                        {
+                            exceptions[index] = e;
+                        }
+                    });
+                    threads[i].Start();
+                }
+
+                foreach (Thread thread in threads)
+                {
+                    thread.Join();
+                }
+
+                Assert.All(exceptions, Assert.Null);
+                Assert.All(handles, Assert.NotNull);
+
+                key.Dispose();
+
+                for (int i = 0; i < handles.Length - 1; i++)
+                {
+                    handles[i]!.Dispose();
+                }
+
+                using SafeNCryptKeyHandle remainingHandle = handles[^1]!;
+                using CngKey remainingKey = CngKey.Open(
+                    remainingHandle,
+                    CngKeyHandleOpenOptions.EphemeralKey);
+                Assert.Equal(CngAlgorithm.ECDsaP256, remainingKey.Algorithm);
+            }
         }
 
         private static void SignAndVerifyECDsa(CngKey key)

--- a/src/libraries/System.Security.Cryptography/tests/CngKeyTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/CngKeyTests.cs
@@ -66,6 +66,7 @@ namespace System.Security.Cryptography.Tests
         {
             const int IterationCount = 10;
             const int ThreadCount = 8;
+            TimeSpan timeout = TimeSpan.FromSeconds(30);
 
             for (int iteration = 0; iteration < IterationCount; iteration++)
             {
@@ -82,7 +83,7 @@ namespace System.Security.Cryptography.Tests
                     {
                         try
                         {
-                            barrier.SignalAndWait();
+                            Assert.True(barrier.SignalAndWait(timeout), "Timed out waiting for concurrent handle access.");
                             handles[index] = key.Handle;
                         }
                         catch (Exception e)
@@ -90,12 +91,13 @@ namespace System.Security.Cryptography.Tests
                             exceptions[index] = e;
                         }
                     });
+                    threads[i].IsBackground = true;
                     threads[i].Start();
                 }
 
                 foreach (Thread thread in threads)
                 {
-                    thread.Join();
+                    Assert.True(thread.Join(timeout), "Timed out waiting for handle access thread.");
                 }
 
                 Assert.All(exceptions, Assert.Null);


### PR DESCRIPTION
Duplicating NCrypt safe handles is not currently thread safe. This is observable through `CngKey.Handle` which calls `Duplicate` on a `SafeNCryptKeyHandle`. The crux of the issue is that two threads can both observe `_ownershipState == Owner` and enter `DuplicateOwnerHandle()`. Each creates a different holder for the same native handle. The first transitions the original handle to `Duplicate`, the second then hits the assertion when it attempts the same transition.

This assert was observed in https://github.com/dotnet/runtime/issues/130760.

In a release build, this can result in an invalid `NCryptKeyHandle` getting passed to native functions.

1. Both threads create separate holders for the same raw NCrypt handle.
2. The later thread overwrites the original handle's  _holder .
3. Managed reference counts no longer represent the native handle's actual users.
4. The winning holder can call `NCryptFreeObject` while duplicates associated with an overwritten holder remain open.

This simplest solution is to take a lock, which will unfortunately ding performance a little bit when accessing `Handle`.

A unit test was added to attempt racing the handles. Before the fix, this test would fail quickly with

```
Error Message:
Assert.All() Failure: 7 out of 8 items in the collection did not pass.
[0]: Item:  Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException: Method Debug.Fail failed with '_ownershipState == OwnershipState.Owner
', and was translated to Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException to avoid terminating the process hosting the test.
    at Microsoft.Win32.SafeHandles.SafeNCryptHandle.DuplicateOwnerHandle[T]() in E:\code\runtime\src\libraries\System.Security.Cryptography\src\Microsoft\Win32\SafeHandles\NCryptSafeHandles.cs:line 263
    at Microsoft.Win32.SafeHandles.SafeNCryptHandle.Duplicate[T]() in E:\code\runtime\src\libraries\System.Security.Cryptography\src\Microsoft\Win32\SafeHandles\NCryptSafeHandles.cs:line 219
    at Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle.Duplicate() in E:\code\runtime\src\libraries\System.Security.Cryptography\src\Microsoft\Win32\SafeHandles\NCryptSafeHandles.cs:line 364
    at System.Security.Cryptography.CngKey.get_Handle() in E:\code\runtime\src\libraries\System.Security.Cryptography\src\System\Security\Cryptography\CngKey.StandardProperties.cs:line 93
    at System.Security.Cryptography.Tests.CngKeyTests.<>c__DisplayClass3_1.<Handle_ConcurrentFirstAccess>b__0() in E:\code\runtime\src\libraries\System.Security.Cryptography\tests\CngKeyTests.cs:line 86
    at System.Threading.Thread.StartCallback(Thread* pThread) in E:\code\runtime\src\coreclr\System.Private.CoreLib\src\System\Threading\Thread.CoreCLR.cs:line 117
```

After the lock the test consistently passes.

Doing this lock-free is non-trivial. There are multiple fields we need to ensure get published atomically, namely `_ownershipState`, `_holder`, and `_parentHandle`. However we avoid the lock entirely unless the current state is `OwnershipState.Owner`.

Fixes #130760