### PR TITLE
Run InvalidFriendAssemblyName outside merged runner and disable in R2R

### DIFF
--- a/src/tests/Loader/classloader/regressions/InvalidFriendAssemblyName/InvalidFriendAssemblyName.csproj
+++ b/src/tests/Loader/classloader/regressions/InvalidFriendAssemblyName/InvalidFriendAssemblyName.csproj
@@ -1,4 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- This test relies on runtime compilation access checks to parse the invalid friend assembly name.
+         Crossgen2 does not implement these checks, and any checks would fail at build time, not run time. -->
+    <R2RIncompatible>true</R2RIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvalidFriendAssemblyName.cs" />
     <ProjectReference Include="$(TestLibraryProjectPath)" />


### PR DESCRIPTION
The test expects an exception to be thrown during runtime JIT compilation access/visibility checks. Crossgen2 does not implement checks and adding them would cause the failure to occur during compilation. Based on https://github.com/dotnet/runtime/issues/13392, the checks are not planned to be implemented anyway, as any validation would only catch invalid IL.

Instead, disable the test for R2R runs by moving it outside the merged test runner (RequiresProcessIsolation) and marking it as R2RIncompatible.

fixes https://github.com/dotnet/runtime/issues/130569