### PR TITLE
[AsyncProfiler] Add TraceID Event Enrichment

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -51,20 +51,29 @@ namespace System.Runtime.CompilerServices
                 SyncPoint.Check(context);
 
                 EventKeywords eventKeywords = context.ActiveEventKeywords;
-                if (IsEnabled.AnyAsyncEvents(eventKeywords))
+                if (IsEnabled.AnyBufferedEvents(eventKeywords))
                 {
-                    ulong parentDispatcherId = DispatcherIds.CaptureParentDispatcherId();
-                    ulong dispatcherId = DispatcherIds.GetDispatcherId(dispatcher);
                     long currentTimestamp = Stopwatch.GetTimestamp();
 
-                    if (IsEnabled.CreateRuntimeAsyncContextEvent(eventKeywords))
+                    if (IsEnabled.TraceIdChangedEvent(eventKeywords))
                     {
-                        EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.CreateRuntimeAsyncContext);
+                        ResumeAsyncContext.EmitTraceIdIfChanged(context, currentTimestamp);
                     }
 
-                    if (IsEnabled.CreateRuntimeAsyncCallstackEvent(eventKeywords) && nextContinuation != null)
+                    if (IsEnabled.AnyAsyncEvents(eventKeywords))
                     {
-                        AsyncCallstack.EmitCreateEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, nextContinuation);
+                        ulong parentDispatcherId = DispatcherIds.CaptureParentDispatcherId();
+                        ulong dispatcherId = DispatcherIds.GetDispatcherId(dispatcher);
+
+                        if (IsEnabled.CreateRuntimeAsyncContextEvent(eventKeywords))
+                        {
+                            EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.CreateRuntimeAsyncContext);
+                        }
+
+                        if (IsEnabled.CreateRuntimeAsyncCallstackEvent(eventKeywords) && nextContinuation != null)
+                        {
+                            AsyncCallstack.EmitCreateEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, nextContinuation);
+                        }
                     }
                 }
 
@@ -124,9 +133,14 @@ namespace System.Runtime.CompilerServices
                 SyncPoint.Check(context);
 
                 EventKeywords activeEventKeywords = context.ActiveEventKeywords;
-                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
+                if (IsEnabled.AnyBufferedEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
+
+                    if (IsEnabled.TraceIdChangedEvent(activeEventKeywords))
+                    {
+                        ResumeAsyncContext.EmitTraceIdIfChanged(context, currentTimestamp);
+                    }
 
                     if (IsEnabled.SuspendRuntimeAsyncCallstackEvent(activeEventKeywords) && nextContinuation != null)
                     {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -4,5 +4,9 @@
       <!-- Used by System.Private.CoreLib via reflection to init the EventSource -->
       <method name="GetInstance" />
     </type>
+    <type fullname="System.Diagnostics.Activity">
+      <!-- Read by System.Private.CoreLib's EventSource write path via UnsafeAccessor to enrich events with the current trace id -->
+      <method name="TryGetCurrentTraceId" />
+    </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -104,6 +104,7 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <Compile Include="System\Diagnostics\Activity.AsyncProfiler.netcoreapp.cs" />
     <Compile Include="System\Diagnostics\Activity.GenerateRootId.netcoreapp.cs" />
     <Compile Include="System\Diagnostics\ActivityContext.netcoreapp.cs" />
     <Compile Include="System\Diagnostics\ActivityLink.netcoreapp.cs" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.AsyncProfiler.netcoreapp.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.AsyncProfiler.netcoreapp.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System.Diagnostics
+{
+    partial class Activity
+    {
+        static Activity()
+        {
+            // Register the synchronous trace-id bridge on first use of Activity. Registration only stores a
+            // keyword-toggle callback in a lightweight CoreLib holder; it does not construct the
+            // AsyncProfilerEventSource, which is built only when a diagnostics session enables it.
+            AsyncProfilerTraceIdBridge.Initialize();
+        }
+
+        // Copies the current Activity's 16-byte trace id into <paramref name="traceId"/>. The trace id is a
+        // W3C concept, so this returns false (leaving the span untouched) when there is no current Activity or
+        // it is not in the W3C id format. Called from System.Private.CoreLib via UnsafeAccessor; CoreLib cannot
+        // reference this assembly directly (it is the one referencing CoreLib), so the reader lives here.
+        internal static bool TryGetCurrentTraceId(Span<byte> traceId)
+        {
+            Activity? activity = Current;
+            if (activity is null || activity.IdFormat != ActivityIdFormat.W3C)
+            {
+                return false;
+            }
+
+            activity.TraceId.CopyTo(traceId);
+            return true;
+        }
+    }
+
+    // Bridges the synchronous Activity.Current timeline into System.Private.CoreLib's
+    // AsyncProfilerEventSource. Initialized from Activity's static ctor (first use of Activity). CoreLib pushes
+    // keyword on/off transitions, and this type (un)subscribes Activity.CurrentChanged accordingly. On each
+    // change it forwards the new Activity's trace id (or a zero "cleared" marker) to CoreLib, which adds the OS
+    // thread id and routes it to the per-thread buffer.
+    //
+    // NET-only: relies on UnsafeAccessor/UnsafeAccessorType, absent on the netstandard2.0 and net462 targets
+    // this assembly also builds. Compiled only for .NETCoreApp via the csproj (see Activity.AsyncProfiler.netcoreapp.cs).
+    internal static class AsyncProfilerTraceIdBridge
+    {
+        private static int s_subscribed;
+
+        internal static void Initialize()
+        {
+            Register(null, OnKeywordToggled);
+
+            [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "Register")]
+            static extern void Register(
+                [UnsafeAccessorType("System.Runtime.CompilerServices.AsyncProfilerTraceIdKeyword, System.Private.CoreLib")] object? keywordType,
+                Action<bool> callback);
+        }
+
+        private static void OnKeywordToggled(bool enabled)
+        {
+            if (enabled)
+            {
+                if (Interlocked.Exchange(ref s_subscribed, 1) == 0)
+                {
+                    Activity.CurrentChanged += OnCurrentChanged;
+                }
+            }
+            else
+            {
+                if (Interlocked.Exchange(ref s_subscribed, 0) == 1)
+                {
+                    Activity.CurrentChanged -= OnCurrentChanged;
+                }
+            }
+        }
+
+        private static void OnCurrentChanged(object? sender, ActivityChangedEventArgs e)
+        {
+            Span<byte> traceId = stackalloc byte[16];
+            Activity? current = e.Current;
+            if (current is not null && current.IdFormat == ActivityIdFormat.W3C)
+            {
+                current.TraceId.CopyTo(traceId);
+            }
+            else
+            {
+                traceId.Clear(); // all-zero "cleared" marker: no active W3C trace on this thread
+            }
+
+            // Dedup and baseline-after-reenable are owned by the per-thread context in CoreLib (one last-seen
+            // shared with the async change-points), so this bridge forwards every transition and lets CoreLib
+            // decide whether it is a real change.
+            EmitCurrentTraceIdChanged(null, traceId);
+
+            [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "EmitCurrentTraceIdChanged")]
+            static extern void EmitCurrentTraceIdChanged(
+                [UnsafeAccessorType("System.Runtime.CompilerServices.AsyncProfilerEventSource, System.Private.CoreLib")] object? asyncProfilerType,
+                ReadOnlySpan<byte> traceId);
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -939,22 +939,6 @@ namespace System.Diagnostics
             }
         }
 
-        // Copies the current Activity's 16-byte trace id into <paramref name="traceId"/>. The trace id is a
-        // W3C concept, so this returns false (leaving the span untouched) when there is no current Activity or
-        // it is not in the W3C id format. Called from System.Private.CoreLib via UnsafeAccessor; CoreLib cannot
-        // reference this assembly directly (it is the one referencing CoreLib), so the reader lives here.
-        internal static bool TryGetCurrentTraceId(Span<byte> traceId)
-        {
-            Activity? activity = Current;
-            if (activity is null || activity.IdFormat != ActivityIdFormat.W3C)
-            {
-                return false;
-            }
-
-            activity.TraceId.CopyTo(traceId);
-            return true;
-        }
-
         /// <summary>
         /// True if the <see cref="ActivityTraceFlags.RandomTraceId"/> flag is set.
         /// </summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -939,6 +939,22 @@ namespace System.Diagnostics
             }
         }
 
+        // Copies the current Activity's 16-byte trace id into <paramref name="traceId"/>. The trace id is a
+        // W3C concept, so this returns false (leaving the span untouched) when there is no current Activity or
+        // it is not in the W3C id format. Called from System.Private.CoreLib via UnsafeAccessor; CoreLib cannot
+        // reference this assembly directly (it is the one referencing CoreLib), so the reader lives here.
+        internal static bool TryGetCurrentTraceId(Span<byte> traceId)
+        {
+            Activity? activity = Current;
+            if (activity is null || activity.IdFormat != ActivityIdFormat.W3C)
+            {
+                return false;
+            }
+
+            activity.TraceId.CopyTo(traceId);
+            return true;
+        }
+
         /// <summary>
         /// True if the <see cref="ActivityTraceFlags.RandomTraceId"/> flag is set.
         /// </summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/AsyncProfilerTraceIdTests.Parsing.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/AsyncProfilerTraceIdTests.Parsing.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
@@ -147,9 +148,9 @@ namespace System.Diagnostics.Tests
                 return;
             }
 
-            ulong osThreadId = BitConverter.ToUInt64(block, OsThreadIdOffset);
-            uint eventCount = BitConverter.ToUInt32(block, EventCountOffset);
-            ulong timestamp = BitConverter.ToUInt64(block, StartTimestampOffset);
+            ulong osThreadId = BinaryPrimitives.ReadUInt64LittleEndian(block.AsSpan(OsThreadIdOffset));
+            uint eventCount = BinaryPrimitives.ReadUInt32LittleEndian(block.AsSpan(EventCountOffset));
+            ulong timestamp = BinaryPrimitives.ReadUInt64LittleEndian(block.AsSpan(StartTimestampOffset));
 
             int pos = HeaderSize;
             for (uint i = 0; i < eventCount && pos < block.Length; i++)
@@ -166,7 +167,7 @@ namespace System.Diagnostics.Tests
                 int payloadLength = prefix switch
                 {
                     PayloadPrefix.Byte => block[pos],
-                    PayloadPrefix.UShort => BitConverter.ToUInt16(block, pos),
+                    PayloadPrefix.UShort => BinaryPrimitives.ReadUInt16LittleEndian(block.AsSpan(pos)),
                     _ => 0,
                 };
                 pos += (int)prefix;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/AsyncProfilerTraceIdTests.Parsing.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/AsyncProfilerTraceIdTests.Parsing.cs
@@ -1,0 +1,235 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+
+namespace System.Diagnostics.Tests
+{
+    // Decoding half of the trace-id tests: the listener that collects the AsyncProfilerEventSource stream, the
+    // per-thread buffer parser and its event manifest, and the timeline helpers that reconstruct the sparse
+    // (osThreadId, timestamp, traceId) step function the scenarios in AsyncProfilerTraceIdTests.cs assert on.
+    public partial class AsyncProfilerTraceIdTests
+    {
+        private const int AsyncEventsEventId = 1;         // AsyncProfilerEventSource.ASYNC_EVENTS_ID
+
+        // Async event ids as emitted into the per-thread buffer. Mirrors AsyncProfiler.AsyncEventID in the
+        // runtime (internal, inaccessible from tests); TraceIdChanged (24) is the record this test decodes.
+        private enum AsyncEventId : byte
+        {
+            CreateRuntimeAsyncContext = 1,
+            ResumeRuntimeAsyncContext = 2,
+            SuspendRuntimeAsyncContext = 3,
+            CompleteRuntimeAsyncContext = 4,
+            UnwindRuntimeAsyncException = 5,
+            CreateRuntimeAsyncCallstack = 6,
+            ResumeRuntimeAsyncCallstack = 7,
+            SuspendRuntimeAsyncCallstack = 8,
+            ResumeRuntimeAsyncMethod = 9,
+            CompleteRuntimeAsyncMethod = 10,
+            CreateStateMachineAsyncContext = 11,
+            ResumeStateMachineAsyncContext = 12,
+            SuspendStateMachineAsyncContext = 13,
+            CompleteStateMachineAsyncContext = 14,
+            UnwindStateMachineAsyncException = 15,
+            ResumeStateMachineAsyncCallstack = 16,
+            ResumeStateMachineAsyncMethod = 17,
+            CompleteStateMachineAsyncMethod = 18,
+            AppendStateMachineAsyncCallstack = 19,
+            ResetAsyncThreadContext = 20,
+            ResetAsyncContinuationWrapperIndex = 21,
+            AsyncProfilerMetadata = 22,
+            AsyncProfilerSyncClock = 23,
+            TraceIdChanged = 24,
+        }
+
+        // Number of bytes of little-endian length prefix that precede an event's payload. The numeric value is
+        // also the size in bytes of that prefix, so it doubles as the amount to advance past it.
+        private enum PayloadPrefix : byte
+        {
+            None = 0,
+            Byte = 1,
+            UShort = 2,
+        }
+
+        private sealed record ChangePoint(ulong OsThreadId, ulong Timestamp, byte[] TraceId)
+        {
+            public bool IsCleared => TraceId.All(static b => b == 0);
+            public string TraceIdHex => Convert.ToHexStringLower(TraceId);
+        }
+
+        // Captures the buffered TraceId records (TraceIdChanged, inside the AsyncEvents blob) into one ordered
+        // set of change-points, the timeline a consumer reconstructs.
+        private sealed class ChangePointListener : EventListener
+        {
+            public readonly ConcurrentQueue<ChangePoint> Points = new();
+            public volatile EventSource? Source;
+
+            // EventListener's base constructor invokes OnEventSourceCreated for already-created sources before
+            // any derived field initializer runs, so it only captures the source; the test enables it later.
+            protected override void OnEventSourceCreated(EventSource source)
+            {
+                if (source.Name == AsyncProfilerSourceName)
+                {
+                    Source = source;
+                }
+            }
+
+            public void Enable(EventKeywords keywords) =>
+                EnableEvents(Source!, EventLevel.Informational, keywords);
+
+            public void Disable() => DisableEvents(Source!);
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                if (eventData.EventId == AsyncEventsEventId && eventData.Payload is { Count: > 0 }
+                    && eventData.Payload[0] is byte[] block)
+                {
+                    ParseBlock(block, Points);
+                }
+            }
+        }
+
+        // Groups change-points by OS thread id, orders by timestamp, and collapses consecutive equal trace ids
+        // into the sparse step function the timeline reconstructs.
+        private static Dictionary<ulong, List<ChangePoint>> BuildPerThreadTimelines(List<ChangePoint> points)
+        {
+            Dictionary<ulong, List<ChangePoint>> byThread = new();
+            foreach (IGrouping<ulong, ChangePoint> group in points.GroupBy(p => p.OsThreadId))
+            {
+                List<ChangePoint> stepFunction = new();
+                foreach (ChangePoint p in group.OrderBy(p => p.Timestamp))
+                {
+                    if (stepFunction.Count == 0 || stepFunction[^1].TraceIdHex != p.TraceIdHex)
+                    {
+                        stepFunction.Add(p);
+                    }
+                }
+                byThread[group.Key] = stepFunction;
+            }
+            return byThread;
+        }
+
+        // The active trace id at 'timestamp' is the last change-point at or before it (null before the first).
+        private static string? Resolve(List<ChangePoint> timeline, ulong timestamp)
+        {
+            string? active = null;
+            foreach (ChangePoint p in timeline)
+            {
+                if (p.Timestamp > timestamp)
+                {
+                    break;
+                }
+                active = p.IsCleared ? null : p.TraceIdHex;
+            }
+            return active;
+        }
+
+        private static string Describe(IEnumerable<ChangePoint> points) =>
+            $"[{string.Join(",", points.Select(p => $"{(p.IsCleared ? "0" : p.TraceIdHex.Substring(0, 4))}@{p.Timestamp}"))}]";
+
+        // Parses the per-thread block written by AsyncProfiler.EventBuffer.Serializer and pulls out the
+        // TraceIdChanged records:
+        //   Block header (37 bytes): version(1) size(u32) asyncThreadContextId(u32) osThreadId(u64)
+        //                            eventCount(u32) startTimestamp(u64) endTimestamp(u64)
+        //   Per event: eventId(1) deltaTicks(varint) [lengthPrefix(PayloadPrefix bytes)] [payload]
+        private const int HeaderSize = 37;
+        private const int OsThreadIdOffset = 9;
+        private const int EventCountOffset = 17;
+        private const int StartTimestampOffset = 21;
+
+        private static void ParseBlock(byte[] block, ConcurrentQueue<ChangePoint> sink)
+        {
+            if (block.Length < HeaderSize)
+            {
+                return;
+            }
+
+            ulong osThreadId = BitConverter.ToUInt64(block, OsThreadIdOffset);
+            uint eventCount = BitConverter.ToUInt32(block, EventCountOffset);
+            ulong timestamp = BitConverter.ToUInt64(block, StartTimestampOffset);
+
+            int pos = HeaderSize;
+            for (uint i = 0; i < eventCount && pos < block.Length; i++)
+            {
+                byte eventId = block[pos++];
+                timestamp += ReadVarint(block, ref pos);
+
+                if (eventId >= s_payloadPrefixByEventId.Length)
+                {
+                    return; // unknown id: cannot know its framing, bail on this block
+                }
+
+                PayloadPrefix prefix = s_payloadPrefixByEventId[eventId];
+                int payloadLength = prefix switch
+                {
+                    PayloadPrefix.Byte => block[pos],
+                    PayloadPrefix.UShort => BitConverter.ToUInt16(block, pos),
+                    _ => 0,
+                };
+                pos += (int)prefix;
+
+                if ((AsyncEventId)eventId == AsyncEventId.TraceIdChanged)
+                {
+                    byte[] traceId = block.AsSpan(pos, payloadLength).ToArray();
+                    sink.Enqueue(new ChangePoint(osThreadId, timestamp, traceId));
+                }
+
+                pos += payloadLength;
+            }
+        }
+
+        private static ulong ReadVarint(byte[] buffer, ref int pos)
+        {
+            ulong result = 0;
+            int shift = 0;
+            while (true)
+            {
+                byte b = buffer[pos++];
+                result |= (ulong)(b & 0x7F) << shift;
+                if ((b & 0x80) == 0)
+                {
+                    break;
+                }
+                shift += 7;
+            }
+            return result;
+        }
+
+        // Payload framing per async event id, mirroring AsyncProfiler's emit so the parser can skip events it
+        // does not care about and locate the TraceIdChanged payload. Indexed by (byte)AsyncEventId.
+        private static readonly PayloadPrefix[] s_payloadPrefixByEventId = BuildPayloadPrefixTable();
+
+        private static PayloadPrefix[] BuildPayloadPrefixTable()
+        {
+            PayloadPrefix[] table = new PayloadPrefix[(int)AsyncEventId.TraceIdChanged + 1];
+            table[(int)AsyncEventId.CreateRuntimeAsyncContext] = PayloadPrefix.Byte;
+            table[(int)AsyncEventId.ResumeRuntimeAsyncContext] = PayloadPrefix.Byte;
+            table[(int)AsyncEventId.SuspendRuntimeAsyncContext] = PayloadPrefix.None;
+            table[(int)AsyncEventId.CompleteRuntimeAsyncContext] = PayloadPrefix.None;
+            table[(int)AsyncEventId.UnwindRuntimeAsyncException] = PayloadPrefix.Byte;
+            table[(int)AsyncEventId.CreateRuntimeAsyncCallstack] = PayloadPrefix.UShort;
+            table[(int)AsyncEventId.ResumeRuntimeAsyncCallstack] = PayloadPrefix.UShort;
+            table[(int)AsyncEventId.SuspendRuntimeAsyncCallstack] = PayloadPrefix.UShort;
+            table[(int)AsyncEventId.ResumeRuntimeAsyncMethod] = PayloadPrefix.None;
+            table[(int)AsyncEventId.CompleteRuntimeAsyncMethod] = PayloadPrefix.None;
+            table[(int)AsyncEventId.CreateStateMachineAsyncContext] = PayloadPrefix.Byte;
+            table[(int)AsyncEventId.ResumeStateMachineAsyncContext] = PayloadPrefix.Byte;
+            table[(int)AsyncEventId.SuspendStateMachineAsyncContext] = PayloadPrefix.None;
+            table[(int)AsyncEventId.CompleteStateMachineAsyncContext] = PayloadPrefix.None;
+            table[(int)AsyncEventId.UnwindStateMachineAsyncException] = PayloadPrefix.Byte;
+            table[(int)AsyncEventId.ResumeStateMachineAsyncCallstack] = PayloadPrefix.UShort;
+            table[(int)AsyncEventId.ResumeStateMachineAsyncMethod] = PayloadPrefix.None;
+            table[(int)AsyncEventId.CompleteStateMachineAsyncMethod] = PayloadPrefix.None;
+            table[(int)AsyncEventId.AppendStateMachineAsyncCallstack] = PayloadPrefix.UShort;
+            table[(int)AsyncEventId.ResetAsyncThreadContext] = PayloadPrefix.None;
+            table[(int)AsyncEventId.ResetAsyncContinuationWrapperIndex] = PayloadPrefix.None;
+            table[(int)AsyncEventId.AsyncProfilerMetadata] = PayloadPrefix.UShort;
+            table[(int)AsyncEventId.AsyncProfilerSyncClock] = PayloadPrefix.Byte;
+            table[(int)AsyncEventId.TraceIdChanged] = PayloadPrefix.Byte;   // 16-byte trace id, byte length prefix
+            return table;
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/AsyncProfilerTraceIdTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/AsyncProfilerTraceIdTests.cs
@@ -1,0 +1,338 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    // Verifies the W3C TraceId timeline that AsyncProfilerEventSource surfaces: as Activity.Current changes on
+    // a thread, a change-point carrying (osThreadId, timestamp, 16-byte traceId) is emitted so a consumer can
+    // resolve the active trace for any (osThreadId, timestamp).
+    //
+    // Two producers feed one per-thread timeline under a single dedup:
+    //   * asynchronous change-points captured at the async create/suspend hooks, written into the per-thread
+    //     byte buffer as AsyncEventID.TraceIdChanged (24) and delivered inside the AsyncEvents blob (id 1);
+    //   * synchronous change-points raised from Activity.CurrentChanged, routed into the same buffer.
+    // Both feed one Stopwatch (QPC) stamped stream, so tests assert on the merged per-thread timeline.
+    // This file holds the scenarios and the workloads that drive them. The listener, buffer parser, event
+    // manifest, and timeline helpers that decode what the scenarios produce live in the .Parsing.cs partial.
+    public partial class AsyncProfilerTraceIdTests
+    {
+        private const string AsyncProfilerSourceName = "System.Runtime.CompilerServices.AsyncProfilerEventSource";
+        private const int FlushCommand = 1;               // AsyncProfilerEventSource.FlushCommand
+
+        // The TraceId keyword is decoupled from the async keywords: enabling it alone must still deliver
+        // change-points, and enabling the async keywords without it must deliver none.
+        private const EventKeywords TraceIdChangedKeyword = (EventKeywords)0x40000;
+
+        // Async create/suspend/resume for both RuntimeAsync (V2) and StateMachineAsync (V1), so the workload
+        // produces async change-points regardless of how it is lowered.
+        private const EventKeywords AsyncContextKeywords = (EventKeywords)(
+            0x1 | 0x2 | 0x4 |          // Create/Resume/Suspend RuntimeAsyncContext
+            0x400 | 0x800 | 0x1000);   // Create/Resume/Suspend StateMachineAsyncContext
+
+        private const EventKeywords AsyncAndTraceIdKeywords = AsyncContextKeywords | TraceIdChangedKeyword;
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public void AsyncChangePoint_EmitsTraceIdIntoTimeline()
+        {
+            _ = Activity.Current; // materialize the source before the listener attaches
+
+            using var listener = new ChangePointListener();
+            Assert.NotNull(listener.Source);
+            listener.Enable(AsyncAndTraceIdKeywords);
+
+            Activity activity = new Activity("async-op");
+            activity.SetIdFormat(ActivityIdFormat.W3C);
+            activity.Start();
+            string expectedTraceId = activity.TraceId.ToHexString();
+
+            RunScenarioAndFlush(RunAsyncWorkload);
+
+            activity.Stop();
+            listener.Disable();
+
+            List<ChangePoint> points = listener.Points.ToList();
+            ChangePoint? matched = points.FirstOrDefault(p => p.TraceIdHex == expectedTraceId);
+            Assert.True(matched is not null,
+                $"No change-point carried the async trace id {expectedTraceId}. points={Describe(points)}");
+            Assert.NotEqual(0UL, matched!.OsThreadId);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public void AsyncChangePoint_EmitsClearedMarkerWhenActivityCleared()
+        {
+            // Once an async flow leaves the W3C activity (Activity.Current becomes null), an all-zero
+            // change-point is emitted so a consumer knows the trace is no longer active on that thread and a
+            // recycled thread cannot inherit a stale trace id.
+            _ = Activity.Current;
+
+            using var listener = new ChangePointListener();
+            Assert.NotNull(listener.Source);
+            listener.Enable(AsyncAndTraceIdKeywords);
+
+            Activity activity = new Activity("async-op");
+            activity.SetIdFormat(ActivityIdFormat.W3C);
+            activity.Start();
+            string expectedTraceId = activity.TraceId.ToHexString();
+
+            RunScenarioAndFlush(RunAsyncWorkloadThenClearActivity);
+
+            activity.Stop();
+            listener.Disable();
+
+            List<ChangePoint> points = listener.Points.ToList();
+            Assert.True(points.Any(p => p.TraceIdHex == expectedTraceId),
+                $"No change-point carried the async trace id {expectedTraceId}. points={Describe(points)}");
+            Assert.True(points.Any(p => p.IsCleared),
+                $"No cleared (all-zero) change-point was emitted after the activity was cleared. points={Describe(points)}");
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public void SyncChangePoint_EmitsTraceIdIntoTimeline()
+        {
+            // A purely synchronous span on a dedicated (non-async) thread must still produce a change-point,
+            // proving the synchronous producer feeds the same timeline as the asynchronous one.
+            _ = Activity.Current;
+
+            using var listener = new ChangePointListener();
+            Assert.NotNull(listener.Source);
+            listener.Enable(AsyncAndTraceIdKeywords);
+
+            string traceId = RunSynchronousSpanOnDedicatedThread();
+            SendFlushCommand();
+
+            listener.Disable();
+
+            List<ChangePoint> points = listener.Points.ToList();
+            ChangePoint? matched = points.FirstOrDefault(p => p.TraceIdHex == traceId);
+            Assert.True(matched is not null,
+                $"No change-point carried the synchronous trace id {traceId}. points={Describe(points)}");
+            Assert.NotEqual(0UL, matched!.OsThreadId);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public void TraceIdKeywordAlone_DeliversChangePoints()
+        {
+            // The TraceId keyword is decoupled from the async keywords: enabling only it (no async
+            // instrumentation) must still deliver the synchronous change-points, which requires the buffer
+            // carrier to be enabled under the TraceId keyword.
+            _ = Activity.Current;
+
+            using var listener = new ChangePointListener();
+            Assert.NotNull(listener.Source);
+            listener.Enable(TraceIdChangedKeyword);
+
+            string traceId = RunSynchronousSpanOnDedicatedThread();
+            SendFlushCommand();
+
+            listener.Disable();
+
+            List<ChangePoint> points = listener.Points.ToList();
+            Assert.True(points.Any(p => p.TraceIdHex == traceId),
+                $"TraceId keyword alone did not deliver the synchronous trace id {traceId}. points={Describe(points)}");
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public void NoChangePoints_WhenTraceIdKeywordOff()
+        {
+            // Enabling the async keywords without the TraceId keyword must not emit any TraceId change-point,
+            // and the Activity.CurrentChanged bridge must not subscribe.
+            _ = Activity.Current;
+
+            using var listener = new ChangePointListener();
+            Assert.NotNull(listener.Source);
+            listener.Enable(AsyncContextKeywords);
+
+            string traceId = RunSynchronousSpanOnDedicatedThread();
+            SendFlushCommand();
+
+            listener.Disable();
+
+            List<ChangePoint> points = listener.Points.ToList();
+            Assert.False(points.Any(p => p.TraceIdHex == traceId),
+                $"Unexpected TraceId change-point for {traceId} while the TraceId keyword was off. points={Describe(points)}");
+        }
+
+        // Windows-only: the probe needs the current OS thread id to key into the merged timeline, and
+        // GetCurrentThreadId matches the osThreadId the buffer stamps (Thread.CurrentOSThreadId) on Windows.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        public void SyncAndAsyncChangePoints_ResolveOnMergedPerThreadTimeline()
+        {
+            // A synchronous span nested inside an async flow shares the async flow's thread. Because both
+            // producers stamp the same Stopwatch clock and key on the OS thread id, a merged per-thread
+            // timeline resolves the nested synchronous trace id at the moment it was active -- which is only
+            // possible if the two producers fold into one ordered stream.
+            _ = Activity.Current;
+
+            using var listener = new ChangePointListener();
+            Assert.NotNull(listener.Source);
+            listener.Enable(AsyncAndTraceIdKeywords);
+
+            ulong runStart = (ulong)Stopwatch.GetTimestamp();
+
+            Activity asyncActivity = new Activity("async-op");
+            asyncActivity.SetIdFormat(ActivityIdFormat.W3C);
+            asyncActivity.Start();
+            string asyncTraceId = asyncActivity.TraceId.ToHexString();
+
+            Probe probe = new();
+            RunScenarioAndFlush(() => RunAsyncWorkloadWithNestedSyncSpan(probe));
+
+            asyncActivity.Stop();
+            ulong runEnd = (ulong)Stopwatch.GetTimestamp();
+
+            listener.Disable();
+
+            List<ChangePoint> points = listener.Points.ToList();
+            string diag = Describe(points);
+
+            Assert.True(points.Any(p => p.TraceIdHex == asyncTraceId),
+                $"async trace id {asyncTraceId} was never emitted. {diag}");
+
+            // Shared clock: every change-point falls within the QPC window of the run, which is only possible
+            // if both producers stamp the same Stopwatch clock.
+            Assert.All(points, p =>
+                Assert.True(p.Timestamp >= runStart && p.Timestamp <= runEnd,
+                    $"change-point timestamp {p.Timestamp} outside run window [{runStart},{runEnd}]. {diag}"));
+
+            Assert.NotEqual("", probe.TraceIdHex);
+            Assert.NotEqual(asyncTraceId, probe.TraceIdHex); // nested span is a fresh root, distinct trace
+
+            Dictionary<ulong, List<ChangePoint>> byThread = BuildPerThreadTimelines(points);
+            Assert.True(byThread.TryGetValue(probe.OsThreadId, out List<ChangePoint>? timeline),
+                $"probe thread {probe.OsThreadId} has no timeline. {diag}");
+
+            string? resolved = Resolve(timeline!, probe.Timestamp);
+            Assert.True(resolved == probe.TraceIdHex,
+                $"merged timeline resolved ({probe.OsThreadId},{probe.Timestamp}) to '{resolved}', expected '{probe.TraceIdHex}'. " +
+                $"timeline={Describe(timeline!)}");
+        }
+
+        // Captured inside the workload at a point where the current trace id is known synchronously.
+        private sealed class Probe
+        {
+            public ulong OsThreadId;
+            public ulong Timestamp;
+            public string TraceIdHex = "";
+        }
+
+        [DllImport("kernel32.dll")]
+        private static extern uint GetCurrentThreadId();
+
+        private static async Task RunAsyncWorkload()
+        {
+            // Force real continuation dispatches on thread-pool threads. Activity.Current flows via
+            // ExecutionContext, so each suspend/create hook observes the started activity's trace id.
+            for (int i = 0; i < 50; i++)
+            {
+                await Task.Yield();
+                await Task.Delay(1).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task RunAsyncWorkloadThenClearActivity()
+        {
+            for (int i = 0; i < 25; i++)
+            {
+                await Task.Yield();
+                await Task.Delay(1).ConfigureAwait(false);
+            }
+
+            Activity.Current = null;
+
+            for (int i = 0; i < 25; i++)
+            {
+                await Task.Yield();
+                await Task.Delay(1).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task RunAsyncWorkloadWithNestedSyncSpan(Probe probe)
+        {
+            // Runs under the caller's async activity (flows in via ExecutionContext). Partway through, drop out
+            // of it and run a nested synchronous root span so the synchronous producer fires (a fresh trace id)
+            // on the same thread the asynchronous producer is capturing on.
+            for (int i = 0; i < 40; i++)
+            {
+                await Task.Yield();
+                await Task.Delay(1).ConfigureAwait(false);
+
+                if (i == 20)
+                {
+                    Activity? saved = Activity.Current;
+                    Activity.Current = null;
+
+                    Activity nested = new Activity("nested-sync-root");
+                    nested.SetIdFormat(ActivityIdFormat.W3C);
+                    nested.Start();
+
+                    probe.OsThreadId = GetCurrentThreadId();
+                    probe.TraceIdHex = nested.TraceId.ToHexString();
+                    Thread.SpinWait(50_000);
+                    probe.Timestamp = (ulong)Stopwatch.GetTimestamp();
+                    Thread.SpinWait(50_000);
+
+                    nested.Stop();
+                    Activity.Current = saved;
+                }
+            }
+        }
+
+        private static string RunSynchronousSpanOnDedicatedThread()
+        {
+            string traceId = "";
+            Thread t = new Thread(() =>
+            {
+                Activity a = new Activity("sync-only-op");
+                a.SetIdFormat(ActivityIdFormat.W3C);
+                a.Start();
+                traceId = a.TraceId.ToHexString();
+                Thread.SpinWait(100_000); // synchronous CPU work under the span
+                a.Stop();
+            });
+            t.Start();
+            t.Join();
+            return traceId;
+        }
+
+        // Isolate the state-machine chain on a thread-pool thread (clearing the xunit SynchronizationContext so
+        // continuations inline instead of re-queuing), then force a synchronous flush of every per-thread buffer.
+        private static void RunScenarioAndFlush(Func<Task> scenario)
+        {
+            SynchronizationContext? prevCtx = SynchronizationContext.Current;
+            int originalThreadId = Environment.CurrentManagedThreadId;
+            SynchronizationContext.SetSynchronizationContext(null);
+            try
+            {
+                Task.Run(scenario).GetAwaiter().GetResult();
+            }
+            finally
+            {
+                Thread.Sleep(50);
+                if (Environment.CurrentManagedThreadId == originalThreadId)
+                {
+                    SynchronizationContext.SetSynchronizationContext(prevCtx);
+                }
+                SendFlushCommand();
+            }
+        }
+
+        private static void SendFlushCommand()
+        {
+            foreach (EventSource source in EventSource.GetSources())
+            {
+                if (source.Name == AsyncProfilerSourceName)
+                {
+                    EventSource.SendCommand(source, (EventCommand)FlushCommand, null);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/AsyncProfilerTraceIdTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/AsyncProfilerTraceIdTests.cs
@@ -39,10 +39,24 @@ namespace System.Diagnostics.Tests
 
         private const EventKeywords AsyncAndTraceIdKeywords = AsyncContextKeywords | TraceIdChangedKeyword;
 
+        // Ensures AsyncProfilerEventSource exists before a listener attaches. Reading Activity.Current runs
+        // Activity's static init (registering the synchronous trace-id bridge) but does not construct the event
+        // source; the source is built the first time the async instrumentation synchronizes its flags
+        // (AsyncInstrumentation.SynchronizeFlags touches AsyncProfilerEventSource.Log), which happens at the
+        // first real await in the process. Forcing one here keeps each test self-contained: the listener
+        // created next captures the source in OnEventSourceCreated regardless of incidental prior async usage.
+        private static void EnsureAsyncProfilerSourceConstructed()
+        {
+            _ = Activity.Current;
+            ForceAwait().GetAwaiter().GetResult();
+
+            static async Task ForceAwait() => await Task.Yield();
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
         public void AsyncChangePoint_EmitsTraceIdIntoTimeline()
         {
-            _ = Activity.Current; // materialize the source before the listener attaches
+            EnsureAsyncProfilerSourceConstructed();
 
             using var listener = new ChangePointListener();
             Assert.NotNull(listener.Source);
@@ -71,7 +85,7 @@ namespace System.Diagnostics.Tests
             // Once an async flow leaves the W3C activity (Activity.Current becomes null), an all-zero
             // change-point is emitted so a consumer knows the trace is no longer active on that thread and a
             // recycled thread cannot inherit a stale trace id.
-            _ = Activity.Current;
+            EnsureAsyncProfilerSourceConstructed();
 
             using var listener = new ChangePointListener();
             Assert.NotNull(listener.Source);
@@ -99,7 +113,7 @@ namespace System.Diagnostics.Tests
         {
             // A purely synchronous span on a dedicated (non-async) thread must still produce a change-point,
             // proving the synchronous producer feeds the same timeline as the asynchronous one.
-            _ = Activity.Current;
+            EnsureAsyncProfilerSourceConstructed();
 
             using var listener = new ChangePointListener();
             Assert.NotNull(listener.Source);
@@ -123,7 +137,7 @@ namespace System.Diagnostics.Tests
             // The TraceId keyword is decoupled from the async keywords: enabling only it (no async
             // instrumentation) must still deliver the synchronous change-points, which requires the buffer
             // carrier to be enabled under the TraceId keyword.
-            _ = Activity.Current;
+            EnsureAsyncProfilerSourceConstructed();
 
             using var listener = new ChangePointListener();
             Assert.NotNull(listener.Source);
@@ -144,7 +158,7 @@ namespace System.Diagnostics.Tests
         {
             // Enabling the async keywords without the TraceId keyword must not emit any TraceId change-point,
             // and the Activity.CurrentChanged bridge must not subscribe.
-            _ = Activity.Current;
+            EnsureAsyncProfilerSourceConstructed();
 
             using var listener = new ChangePointListener();
             Assert.NotNull(listener.Source);
@@ -169,7 +183,7 @@ namespace System.Diagnostics.Tests
             // producers stamp the same Stopwatch clock and key on the OS thread id, a merged per-thread
             // timeline resolves the nested synchronous trace id at the moment it was active -- which is only
             // possible if the two producers fold into one ordered stream.
-            _ = Activity.Current;
+            EnsureAsyncProfilerSourceConstructed();
 
             using var listener = new ChangePointListener();
             Assert.NotNull(listener.Source);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -61,6 +61,8 @@
     <Compile Include="DiagnosticSourceEventSourceBridgeTests.cs" />
     <Compile Include="RuntimeMetricsTests.cs" />
     <Compile Include="TestNotSupported.cs" />
+    <Compile Include="AsyncProfilerTraceIdTests.cs" />
+    <Compile Include="AsyncProfilerTraceIdTests.Parsing.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -39,5 +39,9 @@
       <method name="LoadAssemblyAndGetFunctionPointer" />
       <method name="GetFunctionPointer" />
     </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncProfilerTraceIdKeyword">
+      <!-- Called by System.Diagnostics.DiagnosticSource (Activity) via UnsafeAccessor -->
+      <method name="Register" />
+    </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -43,5 +43,9 @@
       <!-- Called by System.Diagnostics.DiagnosticSource (Activity) via UnsafeAccessor -->
       <method name="Register" />
     </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncProfilerEventSource">
+      <!-- Called by System.Diagnostics.DiagnosticSource (Activity) via UnsafeAccessor -->
+      <method name="EmitCurrentTraceIdChanged" />
+    </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3933,6 +3933,24 @@ namespace System.Diagnostics.Tracing
 #endregion
     }
 
+    // Reads the current Activity's trace id for the EventSource write path without a hard reference to
+    // System.Diagnostics.DiagnosticSource (CoreLib cannot reference that assembly). The bind is resolved at
+    // runtime through UnsafeAccessor; an ILLink descriptor in DiagnosticSource preserves the target method.
+    internal static class EventTraceContext
+    {
+        // Copies the current W3C Activity's 16-byte trace id into the provided span.
+        // Returns false when there is no current W3C-format Activity.
+        public static bool TryGetCurrentTraceId(Span<byte> traceId)
+        {
+            return TryGetCurrentTraceId(null, traceId);
+
+            [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "TryGetCurrentTraceId")]
+            static extern bool TryGetCurrentTraceId(
+                [UnsafeAccessorType("System.Diagnostics.Activity, System.Diagnostics.DiagnosticSource")] object? activityType,
+                Span<byte> traceId);
+        }
+    }
+
     // This type is logically just more static EventSource functionality but it needs to be a separate class
     // to ensure that the IL linker can remove unused methods in it. Methods defined within the EventSource type
     // are never removed because EventSource has the potential to reflect over its own members.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -48,7 +48,16 @@ namespace System.Runtime.CompilerServices
             ResetAsyncContinuationWrapperIndex = 21,
             AsyncProfilerMetadata = 22,
             AsyncProfilerSyncClock = 23,
+
+            // Per-thread trace-id change-point (16-byte payload). Emitted on-change at the async hooks and at
+            // synchronous Activity.Current transitions, so a parser can resolve the active trace at any
+            // (osThreadId, timestamp).
+            TraceIdChanged = 24,
         }
+
+        // W3C trace id is 16 bytes: the TraceIdChanged payload, the async-path scratch buffer, and the
+        // per-context last-seen id all share this width.
+        private const int TraceIdLength = 16;
 
         // Per-event manifest entry: schema version + payload length-prefix size.
         // The runtime emits this table in the AsyncProfilerMetadata event so parsers can
@@ -98,6 +107,8 @@ namespace System.Runtime.CompilerServices
             public const EventManifestEntry.PayloadLengthFieldSize AsyncProfilerMetadataPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.UShort;
             public const EventManifestEntry.PayloadLengthFieldSize AsyncProfilerSyncClockPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.Byte;
 
+            public const EventManifestEntry.PayloadLengthFieldSize TraceIdChangedPayloadLengthFieldSize = EventManifestEntry.PayloadLengthFieldSize.Byte;
+
             public static readonly EventManifestEntry[] Entries = BuildEntries();
 
             public static EventManifestEntry.PayloadLengthFieldSize GetPayloadLengthFieldSize(AsyncEventID eventID)
@@ -138,6 +149,8 @@ namespace System.Runtime.CompilerServices
                     new EventManifestEntry(AsyncEventID.ResetAsyncContinuationWrapperIndex, 1, ResetAsyncContinuationWrapperIndexPayloadLengthFieldSize),
                     new EventManifestEntry(AsyncEventID.AsyncProfilerMetadata, 1, AsyncProfilerMetadataPayloadLengthFieldSize),
                     new EventManifestEntry(AsyncEventID.AsyncProfilerSyncClock, 1, AsyncProfilerSyncClockPayloadLengthFieldSize),
+
+                    new EventManifestEntry(AsyncEventID.TraceIdChanged, 1, TraceIdChangedPayloadLengthFieldSize),
                 ];
 
 #if DEBUG
@@ -193,7 +206,7 @@ namespace System.Runtime.CompilerServices
                         EventBufferSize = Math.Min(eventBufferSize, 64 * 1024 - 256);
                     }
 
-                    if (IsEnabled.AnyAsyncEvents(ActiveEventKeywords))
+                    if (IsEnabled.AnyBufferedEvents(ActiveEventKeywords))
                     {
                         AsyncThreadContextCache.EnableFlushTimer();
                         AsyncThreadContextCache.DisableCleanupTimer();
@@ -291,7 +304,7 @@ namespace System.Runtime.CompilerServices
 
                 s_lastSyncClockEventTimestamp = currentTimestamp;
 
-                if (IsEnabled.AnyAsyncEvents(ActiveEventKeywords))
+                if (IsEnabled.AnyBufferedEvents(ActiveEventKeywords))
                 {
                     AsyncThreadContext transientContext = AsyncThreadContext.AcquireTransient();
 
@@ -371,6 +384,8 @@ namespace System.Runtime.CompilerServices
                 flags |= IsEnabled.ResumeStateMachineAsyncCallstackEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncContext : AsyncInstrumentation.Flags.Disabled;
                 flags |= IsEnabled.ResumeStateMachineAsyncMethodEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.ResumeAsyncMethod : AsyncInstrumentation.Flags.Disabled;
                 flags |= IsEnabled.CompleteStateMachineAsyncMethodEvent(ActiveEventKeywords) ? AsyncInstrumentation.Flags.CompleteAsyncMethod : AsyncInstrumentation.Flags.Disabled;
+
+                flags |= IsEnabled.TraceIdChangedEvent(ActiveEventKeywords) ? (AsyncInstrumentation.Flags.CreateAsyncContext | AsyncInstrumentation.Flags.SuspendAsyncContext) : AsyncInstrumentation.Flags.Disabled;
 
                 AsyncInstrumentation.UpdateAsyncProfilerFlags(flags);
             }
@@ -700,6 +715,26 @@ namespace System.Runtime.CompilerServices
 
             public volatile bool BlockContext;
 
+            // Last trace id buffered as a change-point on this context (emit-on-change dedup). Reset on context
+            // reset / return-to-pool so a recycled thread re-declares its id rather than inheriting a stale one.
+            private readonly byte[] _lastTraceId = new byte[TraceIdLength];
+            private bool _hasLastTraceId;
+
+            public bool TraceIdChanged(ReadOnlySpan<byte> traceId)
+            {
+                Debug.Assert(traceId.Length == TraceIdLength);
+                return !_hasLastTraceId || !traceId.SequenceEqual(_lastTraceId);
+            }
+
+            public void SetLastTraceId(ReadOnlySpan<byte> traceId)
+            {
+                Debug.Assert(traceId.Length == TraceIdLength);
+                traceId.CopyTo(_lastTraceId);
+                _hasLastTraceId = true;
+            }
+
+            public void ResetLastTraceId() => _hasLastTraceId = false;
+
             public ref EventBuffer EventBuffer
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -929,9 +964,15 @@ namespace System.Runtime.CompilerServices
                 SyncPoint.Check(context);
 
                 EventKeywords activeEventKeywords = context.ActiveEventKeywords;
-                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
+                if (IsEnabled.AnyBufferedEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
+
+                    if (IsEnabled.TraceIdChangedEvent(activeEventKeywords))
+                    {
+                        ResumeAsyncContext.EmitTraceIdIfChanged(context, currentTimestamp);
+                    }
+
                     if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                     {
                         ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
@@ -1013,6 +1054,54 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
+            // Samples the current trace id at an async hook and buffers it if it changed.
+            //
+            // Called at create and suspend where the user's ExecutionContext (and thus Activity.Current) is live,
+            // and not called at resume where the hook runs before the continuation's ExecutionContext is restored,
+            // so Activity.Current (an AsyncLocal) would read its ambient null value.
+            //
+            // There is no cheaper edge-trigger for async: an ExecutionContext restore does not raise Activity.CurrentChanged,
+            // so the async trace context is invisible to that event and must be sampled here.
+            // A cleared/non-W3C Activity reads as the all-zero id, so clearing the trace is just another change-point.
+            public static void EmitTraceIdIfChanged(AsyncThreadContext context, long currentTimestamp)
+            {
+                Span<byte> traceId = stackalloc byte[TraceIdLength];
+                if (!EventTraceContext.TryGetCurrentTraceId(traceId))
+                {
+                    traceId.Clear();
+                }
+
+                WriteTraceIdChanged(context, currentTimestamp, traceId);
+            }
+
+            // Buffers a 16-byte trace-id change-point, deduped against this context's last-seen id. Shared by the
+            // async change-points (which sample the live Activity.Current) and the synchronous change-point
+            // (which supplies the new activity's id directly), so both funnel through one buffer and one
+            // last-seen. Last-seen advances only after a successful write, so a record dropped by a full buffer
+            // is re-attempted next time.
+            public static void WriteTraceIdChanged(AsyncThreadContext context, long currentTimestamp, ReadOnlySpan<byte> traceId)
+            {
+                Debug.Assert(traceId.Length == TraceIdLength);
+
+                if (!context.TraceIdChanged(traceId))
+                {
+                    return;
+                }
+
+                const int MaxPayloadLength = TraceIdLength;
+
+                ref EventBuffer eventBuffer = ref context.EventBuffer;
+                if (Serializer.AsyncEventHeader(context, ref eventBuffer, currentTimestamp, AsyncEventID.TraceIdChanged, EventManifest.TraceIdChangedPayloadLengthFieldSize, MaxPayloadLength, out int payloadLengthFieldOffset))
+                {
+                    Span<byte> payload = eventBuffer.Data.AsSpan(eventBuffer.Index, MaxPayloadLength);
+                    traceId.CopyTo(payload);
+                    eventBuffer.Index += MaxPayloadLength;
+                    Serializer.WriteAsyncEventPayloadLength(ref eventBuffer, AsyncEventID.TraceIdChanged, EventManifest.TraceIdChangedPayloadLengthFieldSize, payloadLengthFieldOffset);
+
+                    context.SetLastTraceId(traceId);
+                }
+            }
+
             public static void Append(AsyncStateMachineDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp)
             {
                 if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
@@ -1059,9 +1148,15 @@ namespace System.Runtime.CompilerServices
                 SyncPoint.Check(context);
 
                 EventKeywords activeEventKeywords = context.ActiveEventKeywords;
-                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
+                if (IsEnabled.AnyBufferedEvents(activeEventKeywords))
                 {
                     long currentTimestamp = Stopwatch.GetTimestamp();
+
+                    if (IsEnabled.TraceIdChangedEvent(activeEventKeywords))
+                    {
+                        ResumeAsyncContext.EmitTraceIdIfChanged(context, currentTimestamp);
+                    }
+
                     if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                     {
                         ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
@@ -1307,9 +1402,20 @@ namespace System.Runtime.CompilerServices
                 context.ConfigRevision = Config.Revision;
                 context.ActiveEventKeywords = Config.ActiveEventKeywords;
 
-                if (IsEnabled.AnyAsyncEvents(context.ActiveEventKeywords))
+                // Reset the last-seen so the next change-point re-declares the id: a reset means a late-joining
+                // session or a recycled thread, and the parser must not trust a value from before the reset.
+                context.ResetLastTraceId();
+
+                // Metadata (clock sync + manifest) is required to decode any buffered event, including a lone
+                // trace-id change-point, so emit it whenever the buffer path is active.
+                if (IsEnabled.AnyBufferedEvents(context.ActiveEventKeywords))
                 {
                     Config.EmitAsyncProfilerMetadataIfNeeded(context);
+                }
+
+                // The continuation-wrapper index only matters to async callstack events; skip it in TraceId-only mode.
+                if (IsEnabled.AnyAsyncEvents(context.ActiveEventKeywords))
+                {
                     EmitEvent(context);
                 }
 
@@ -1369,6 +1475,10 @@ namespace System.Runtime.CompilerServices
             public static bool ResumeStateMachineAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.ResumeStateMachineAsyncMethod) != 0;
             public static bool CompleteStateMachineAsyncMethodEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.CompleteStateMachineAsyncMethod) != 0;
             public static bool AnyAsyncEvents(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.AsyncEventKeywords) != 0;
+
+            public static bool TraceIdChangedEvent(EventKeywords eventKeywords) => (eventKeywords & AsyncProfilerEventSource.Keywords.TraceIdChanged) != 0;
+
+            public static bool AnyBufferedEvents(EventKeywords eventKeywords) => AnyAsyncEvents(eventKeywords) || TraceIdChangedEvent(eventKeywords);
         }
 
         private static class AsyncThreadContextCache
@@ -1450,7 +1560,7 @@ namespace System.Runtime.CompilerServices
                 {
                     FlushCore(false);
 
-                    if (IsEnabled.AnyAsyncEvents(Config.ActiveEventKeywords))
+                    if (IsEnabled.AnyBufferedEvents(Config.ActiveEventKeywords))
                     {
                         // Restart flush timer.
                         s_flushTimer?.Change(AsyncThreadContextCacheFlushTimerIntervalMs, Timeout.Infinite);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -994,9 +994,20 @@ namespace System.Runtime.CompilerServices
 
                 SyncPoint.Check(context);
 
-                if (IsEnabled.CreateStateMachineAsyncContextEvent(context.ActiveEventKeywords))
+                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
+                if (IsEnabled.AnyBufferedEvents(activeEventKeywords))
                 {
-                    EmitEvent(context, Stopwatch.GetTimestamp(), parentDispatcherId, dispatcherId, AsyncEventID.CreateStateMachineAsyncContext);
+                    long currentTimestamp = Stopwatch.GetTimestamp();
+
+                    if (IsEnabled.TraceIdChangedEvent(activeEventKeywords))
+                    {
+                        ResumeAsyncContext.EmitTraceIdIfChanged(context, currentTimestamp);
+                    }
+
+                    if (IsEnabled.CreateStateMachineAsyncContextEvent(activeEventKeywords))
+                    {
+                        EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.CreateStateMachineAsyncContext);
+                    }
                 }
 
                 AsyncThreadContext.Release(context);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -1139,6 +1139,34 @@ namespace System.Runtime.CompilerServices
             }
         }
 
+        // Routes the synchronous Activity.Current change-point (raised on the mutating thread from
+        // Activity.CurrentChanged) into the same per-thread buffer the async change-points use, so both share
+        // one ordered, delta-timestamped stream and one dedup (context.TraceIdChanged).
+        //
+        // Gated purely on the buffer's own config, exactly like the async change-points: if the trace-id keyword
+        // is not active in this context's config, the change-point is dropped rather than routed through a
+        // second, standalone transport.
+        internal static void EmitSyncTraceIdChanged(ReadOnlySpan<byte> traceId)
+        {
+            AsyncThreadContext context = AsyncThreadContext.Get();
+
+            // CurrentChanged is raised only from Activity.Start/Stop/set_Current, none of which run inside an
+            // async-profiler emit window, so this entry is non-reentrant like the async hooks; Acquire asserts it.
+            AsyncThreadContext.Acquire(context);
+
+            // Run the same config (metadata, manifest, baseline reset) the async hooks do, so a lone synchronous
+            // change-point is self-describing and the shared last-seen is reset on (re)enable.
+            SyncPoint.Check(context);
+
+            if (IsEnabled.TraceIdChangedEvent(context.ActiveEventKeywords))
+            {
+                long currentTimestamp = Stopwatch.GetTimestamp();
+                ResumeAsyncContext.WriteTraceIdChanged(context, currentTimestamp, traceId);
+            }
+
+            AsyncThreadContext.Release(context);
+        }
+
         internal static partial class SuspendAsyncContext
         {
             public static void Suspend(AsyncStateMachineDispatcher dispatcher, ref Info info)
@@ -1404,6 +1432,14 @@ namespace System.Runtime.CompilerServices
 
                 // Reset the last-seen so the next change-point re-declares the id: a reset means a late-joining
                 // session or a recycled thread, and the parser must not trust a value from before the reset.
+                //
+                // Late attach is forward-only for both producers: a session that enables while activities are
+                // already in flight learns a thread's current trace only at that thread's next sampling point
+                // (an async create/suspend hook, or an Activity.CurrentChanged edge) - the reset forces that next
+                // observation to emit even when the id is unchanged. There is no rundown that replays already-open
+                // traces at enable time, because Activity.Current is a per-thread AsyncLocal that cannot be
+                // snapshot cross-thread; a thread that neither runs async work nor changes Activity.Current after
+                // enable stays undeclared until its next transition.
                 context.ResetLastTraceId();
 
                 // Metadata (clock sync + manifest) is required to decode any buffered event, including a lone

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
@@ -160,26 +160,26 @@ namespace System.Runtime.CompilerServices
     // Activity does not construct the event source; the source is built only when a session enables it.
     internal static class AsyncProfilerTraceIdKeyword
     {
-        private static bool s_enabled;
+        private static int s_enabled;
         private static Action<bool>? s_subscriber;
 
         // True while any session has the trace-id keyword enabled. Read on the synchronous emit path as a
         // cheap guard against a keyword-off race between a CurrentChanged transition and its emit.
-        internal static bool Enabled => Volatile.Read(ref s_enabled);
+        internal static bool Enabled => Volatile.Read(ref s_enabled) != 0;
 
         // Installs the CurrentChanged (un)subscribe callback on first use of Activity, then syncs it to the
         // current state so a keyword enabled before Activity was first used still subscribes.
         internal static void Register(Action<bool> callback)
         {
-            s_subscriber = callback;
-            callback(Volatile.Read(ref s_enabled));
+            Interlocked.Exchange(ref s_subscriber, callback);
+            callback(Volatile.Read(ref s_enabled) != 0);
         }
 
         // Drives the subscription from OnEventCommand so change-points flow only while the keyword is enabled.
         internal static void Set(bool enabled)
         {
-            Volatile.Write(ref s_enabled, enabled);
-            s_subscriber?.Invoke(enabled);
+            Interlocked.Exchange(ref s_enabled, enabled ? 1 : 0);
+            Volatile.Read(ref s_subscriber)?.Invoke(enabled);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
@@ -143,7 +143,7 @@ namespace System.Runtime.CompilerServices
             // while the source is being disabled.
             if (keywords == 0 && IsEnabled())
             {
-                keywords = AsyncEventKeywords;
+                keywords = AsyncEventKeywords | Keywords.TraceIdChanged;
             }
 
             AsyncProfiler.Config.Update(m_level, keywords);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
+using System.Threading;
 
 namespace System.Runtime.CompilerServices
 {
@@ -34,6 +35,7 @@ namespace System.Runtime.CompilerServices
             public const EventKeywords ResumeStateMachineAsyncCallstack = (EventKeywords)0x8000;
             public const EventKeywords ResumeStateMachineAsyncMethod = (EventKeywords)0x10000;
             public const EventKeywords CompleteStateMachineAsyncMethod = (EventKeywords)0x20000;
+            public const EventKeywords TraceIdChanged = (EventKeywords)0x40000;
         }
 
         public const EventKeywords AsyncEventKeywords =
@@ -56,7 +58,6 @@ namespace System.Runtime.CompilerServices
             Keywords.ResumeStateMachineAsyncMethod |
             Keywords.CompleteStateMachineAsyncMethod;
 
-
         public const int FlushCommand = 1;
 
         //----------------------- Event IDs (must be unique) -----------------------
@@ -71,7 +72,10 @@ namespace System.Runtime.CompilerServices
             Version = 1,
             Opcode = EventOpcode.Info,
             Level = EventLevel.Informational,
-            Keywords = AsyncEventKeywords,
+            // This blob carries every buffered payload, including trace-id records under the decoupled
+            // transport, so its keyword must include TraceIdChanged; otherwise a trace-id-only session buffers
+            // records that are then dropped here because the carrier's keyword is inactive.
+            Keywords = AsyncEventKeywords | Keywords.TraceIdChanged,
             Message = "")]
         public void AsyncEvents(byte[] buffer)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfilerEventSource.cs
@@ -103,6 +103,27 @@ namespace System.Runtime.CompilerServices
             }
         }
 
+        // --------------------------------------------------------------------------------------------
+        // Synchronous trace-id timeline
+        //
+        // The synchronous change-points (Activity.Current transitions) are produced in
+        // System.Diagnostics.DiagnosticSource and reach CoreLib through UnsafeAccessor:
+        //   * AsyncProfilerTraceIdKeyword.Register - installs the CurrentChanged (un)subscribe callback.
+        //   * EmitCurrentTraceIdChanged - called from the CurrentChanged handler; routes the change-point to
+        //     the per-thread buffer, the same transport the async change-points use.
+        // --------------------------------------------------------------------------------------------
+
+        [NonEvent]
+        internal static void EmitCurrentTraceIdChanged(ReadOnlySpan<byte> traceId)
+        {
+            if (!AsyncProfilerTraceIdKeyword.Enabled)
+            {
+                return;
+            }
+
+            AsyncProfiler.EmitSyncTraceIdChanged(traceId);
+        }
+
         /// <summary>
         /// Get callbacks when the ETW sends us commands
         /// </summary>
@@ -126,6 +147,39 @@ namespace System.Runtime.CompilerServices
             }
 
             AsyncProfiler.Config.Update(m_level, keywords);
+
+            // Publish the trace-id keyword transition so DiagnosticSource can (un)subscribe
+            // Activity.CurrentChanged. Use IsEnabled (the aggregate across all sessions), not this one
+            // command's mask, so an unrelated enable/disable does not spuriously toggle the subscription.
+            AsyncProfilerTraceIdKeyword.Set(IsEnabled(EventLevel.Informational, Keywords.TraceIdChanged));
+        }
+    }
+
+    // Carries the trace-id keyword's on/off state and the DiagnosticSource-side CurrentChanged subscription
+    // toggle. Kept separate from AsyncProfilerEventSource so that registering the bridge on first use of
+    // Activity does not construct the event source; the source is built only when a session enables it.
+    internal static class AsyncProfilerTraceIdKeyword
+    {
+        private static bool s_enabled;
+        private static Action<bool>? s_subscriber;
+
+        // True while any session has the trace-id keyword enabled. Read on the synchronous emit path as a
+        // cheap guard against a keyword-off race between a CurrentChanged transition and its emit.
+        internal static bool Enabled => Volatile.Read(ref s_enabled);
+
+        // Installs the CurrentChanged (un)subscribe callback on first use of Activity, then syncs it to the
+        // current state so a keyword enabled before Activity was first used still subscribes.
+        internal static void Register(Action<bool> callback)
+        {
+            s_subscriber = callback;
+            callback(Volatile.Read(ref s_enabled));
+        }
+
+        // Drives the subscription from OnEventCommand so change-points flow only while the keyword is enabled.
+        internal static void Set(bool enabled)
+        {
+            Volatile.Write(ref s_enabled, enabled);
+            s_subscriber?.Invoke(enabled);
         }
     }
 }


### PR DESCRIPTION
The async-profiler `EventSource` stream lets a tool reconstruct **logical async causality** - who awaited whom, on which OS thread, at which time - that the physical thread stack loses across `await` boundaries. What it cannot say today is **which request** any of that work belonged to: the async call graph is structural, not tied to a distributed trace.

This PR records the W3C distributed-tracing **TraceId** (carried by the ambient `Activity.Current`) into that same stream, so a trace-analysis tool can answer **which request was active on which thread at which time**. It is written not by stamping a TraceId onto individual events, but as a separate, sparse **per-thread timeline**: a few small records per thread, each marking a moment the active TraceId changed, from which a parser reconstructs the TraceId in effect at any instant.

Recording it as a separate timeline, rather than per-event, is what gives the feature its reach. A performance trace is dominated by events the runtime never authored - kernel CPU samples, ETW / `user_events` (**foreign events**). The collection tool already captures those, each tagged with a `(thread, timestamp)`, but it cannot know which request each one served, and the runtime cannot restamp them - they carry a thread and a timestamp but no managed trace context. Given the timeline, the tool looks up `(thread, timestamp)` and attributes the event to a TraceId after the fact, without changing - or even parsing - the event's own format. The motivating case is CPU attribution: for each `(thread, timestamp)` CPU sample, resolve the active TraceId and aggregate ("trace `abc123` consumed 45 ms of CPU across threads X and Z") - request-level resource attribution over samples the runtime never touched.

That reach forces coverage of **both asynchronous and synchronous** work. CPU samples land on whatever thread was running: a pooled thread resuming an `await` continuation, *and* a dedicated thread (`new Thread`, a long-running task, a `BackgroundService` loop) running synchronous CPU-bound work under an `Activity` it started itself. To attribute either, the timeline must record the active trace id on that thread regardless of whether an async operation was ever involved - which is what forces the detection mechanism to reach beyond the async profiler's own instrumentation points (see the synchronous producer below).

## Sparse emission, full resolution

Viewed on one thread over time, the active TraceId is a **step function**: none, then request A, then none, then request B - it holds a value, then jumps at a discrete moment. So the whole function is captured by recording only the **jumps**. Emitting a `(osThreadId, timestamp, 16-byte traceId)` record only when the value changes, deduplicated per thread, reconstructs the trace id at *any* instant as the last change-point at or before it (an all-zero id marks "no active W3C trace").

Sparse emission is also the only affordable option: the carrier is byte-starved. Each logical async event is a 1-byte kind plus a varint timestamp delta and a tiny payload, emitted in bulk on hot async paths; stamping a 16-byte TraceId onto every event would multiply the stream. A "trace id changed here" record slots in as just another small logical event, added only on change - which is exactly what the stream already does for other per-thread state transitions (e.g. `ResetAsyncThreadContext`).

## Sampling the trace id where the async context is live

The asynchronous producer samples at the async **create** and **suspend** hooks, the points where the user's `ExecutionContext` - and therefore `Activity.Current` - is the live one. CoreLib reads the current 16-byte trace id there via `EventTraceContext.TryGetCurrentTraceId`, and when it differs from the last id emitted on this thread context, writes it into the per-thread byte buffer as `AsyncEventID.TraceIdChanged` (24), inside the same `AsyncEvents` blob the async events travel in.

Two subtleties dictate *where* the sample happens. First, sampling must be driven at the hooks, not off an event: an `ExecutionContext` restore - the thing that makes the right trace current on a resumed continuation - does **not** raise `Activity.CurrentChanged`, so the async trace context is invisible to that event and has to be read directly. Second, create/suspend rather than resume: the resume hook runs *before* the continuation's `ExecutionContext` is restored, so `Activity.Current` there still reads its ambient (usually null) value; sampling at suspend/create observes the trace that was actually running. A cleared or non-W3C `Activity` reads as the all-zero id, so leaving a trace is itself a change-point.

## Extending the timeline to synchronous work

Async hooks only fire for async work, so a purely synchronous span - an `Activity` started and stopped on one thread with no `await` - would never appear. The synchronous producer closes that gap by observing `Activity.CurrentChanged` directly: on each transition it reads the current trace id (all-zero when `Activity.Current` is cleared or non-W3C) and forwards it to CoreLib's `AsyncProfiler.EmitSyncTraceIdChanged`, which routes the change-point into the **same** per-thread buffer as the async producer.

Because both producers share the per-thread last-seen id and the emit-on-change dedup, a synchronous change-point is byte-for-byte the same record as an asynchronous one (`AsyncEventID.TraceIdChanged`, 24) and the two interleave into one ordered per-thread timeline. If the buffer cannot take the record - the trace-id keyword is not active in that buffer's own config - the change-point is skipped rather than emitted through a side channel; the shared dedup re-declares it at the next observation, so the timeline stays consistent without a second event shape for a parser to handle.

## Paying only when the feature is on

The subscription is wired so a session that never asks for trace ids pays nothing. CoreLib exposes a trace-id keyword-toggle hook (`AsyncProfilerTraceIdKeyword.Register`); the DiagnosticSource bridge registers a callback and attaches its `Activity.CurrentChanged` handler **only while the trace-id keyword is enabled**, detaching it when the keyword is turned off. Registration only stores a callback in a lightweight CoreLib holder - it does **not** construct the `AsyncProfilerEventSource` - so an app that loads DiagnosticSource but never enables the keyword never builds the event source and never subscribes to `CurrentChanged`.

The trace-id keyword (`0x40000`) is also deliberately **decoupled** from the async keywords: it is excluded from `AsyncEventKeywords`, so neither set forces the other, and the buffer carrier and shared buffer infrastructure (flush timer, metadata, sync-clock) are gated by `AnyBufferedEvents` rather than the async keywords. A **trace-id-only** session therefore still delivers its buffered change-points, without pulling in the async instrumentation.

## Cross-assembly wiring without a hard reference

CoreLib cannot reference `System.Diagnostics.DiagnosticSource` - the dependency runs the other way - so the trace id is read across the boundary via `UnsafeAccessor`. `EventTraceContext` (in CoreLib) binds `Activity.TryGetCurrentTraceId` by name at runtime, and the DiagnosticSource bridge binds CoreLib's `AsyncProfilerTraceIdKeyword.Register` / `AsyncProfilerEventSource.EmitCurrentTraceIdChanged` the same way. Two consequences follow. The bridge is **NET-only** - it relies on `UnsafeAccessor`/`UnsafeAccessorType`, which do not exist on this assembly's `netstandard2.0` and `net462` targets - so it lives in `Activity.AsyncProfiler.netcoreapp.cs`, compiled only for `.NETCoreApp`, rather than under an inline `#if NET`. And because `AsyncProfilerTraceIdKeyword.Register` is reachable *only* through the cross-assembly `UnsafeAccessor` bind, it is invisible to the CoreLib IL linker, so an `ILLink.Descriptors` entry preserves it from trimming.

## Late attach is forward-only

Both producers are forward-only. On (re)enable the per-thread last-seen id is reset on the config revision, so the next sampling point re-declares the current trace even if it has not changed, and a listener that attaches mid-run picks the timeline up from its next change-point. There is no cross-thread rundown: `Activity.Current` is a per-thread `AsyncLocal`, so a session cannot snapshot every thread's current trace at enable time. A consumer's timeline is therefore valid from the first per-thread change-point after the session is enabled.

## Testing

Six tests in `System.Diagnostics.DiagnosticSource.Tests` (`AsyncProfilerTraceIdTests`), all passing; DiagnosticSource src + tests build clean across `net11.0`, `net11.0-browser`, and `net462`/`net481` (0 warnings, 0 errors). The tests decode the raw per-thread buffer and assert on the reconstructed timeline:

| Test | What it proves |
|---|---|
| `AsyncChangePoint_EmitsTraceIdIntoTimeline` | An async workload emits a change-point carrying the started activity's trace id, keyed to a real OS thread. |
| `AsyncChangePoint_EmitsClearedMarkerWhenActivityCleared` | Clearing `Activity.Current` mid-async emits an all-zero cleared marker after the trace id. |
| `SyncChangePoint_EmitsTraceIdIntoTimeline` | A purely synchronous span on a dedicated thread still produces a change-point - the sync producer feeds the same timeline. |
| `TraceIdKeywordAlone_DeliversChangePoints` | Enabling only the trace-id keyword (no async keywords) still delivers change-points - the buffer carrier is gated by `AnyBufferedEvents`, not the async keywords. |
| `NoChangePoints_WhenTraceIdKeywordOff` | Enabling the async keywords *without* the trace-id keyword emits no trace-id change-point, and the `CurrentChanged` bridge does not subscribe. |
| `SyncAndAsyncChangePoints_ResolveOnMergedPerThreadTimeline` (Windows) | A synchronous span nested inside an async flow, on the same thread, resolves correctly at the moment it was active on the merged timeline - proving both producers stamp one shared QPC clock and fold into one ordered stream. |