### PR TITLE
[wasi] Add CoreCLR-WASI corehost (wasihost)

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -112,7 +112,7 @@
     <DefaultCoreClrSubsets Condition="'$(TargetsAndroid)' == 'true'">clr.native+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools</DefaultCoreClrSubsets>
     <DefaultCoreClrSubsets Condition="'$(TargetsAppleMobile)' == 'true'">clr.native+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools</DefaultCoreClrSubsets>
     <DefaultCoreClrSubsets Condition="'$(TargetsBrowser)' == 'true'">provision.emsdk+clr.native+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+clr.crossarchtools+libs.native+host.native</DefaultCoreClrSubsets>
-    <DefaultCoreClrSubsets Condition="'$(TargetsWasi)' == 'true'">clr.native+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+clr.crossarchtools+libs.native</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets Condition="'$(TargetsWasi)' == 'true'">clr.native+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+clr.crossarchtools+libs.native+host.native</DefaultCoreClrSubsets>
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(RuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -329,7 +329,7 @@
          $(CoreCLRSharedFrameworkDir)) and the libs.native static libs (already provided by the
          unconditional glob above). corerun.wasm is not part of the runtime pack. The host archive
          (libWasiHost.a) is a separate deliverable built by the host subset and staged from
-         $(HostSharedFrameworkDir); the per-app relink (WasiApp.CoreCLR.targets) links it. Runtime
+         $(HostSharedFrameworkDir); the per-app relink (the CoreCLR-WASI app builder) links it. Runtime
          tests for Helix are built without the host subset, so the host archive is excluded there
          (mirrors the browser libBrowserHost.a handling). -->
     <ItemGroup Condition="'$(TargetOS)' == 'wasi' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(IsTestsCommonProject)' != 'true'">

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -325,10 +325,17 @@
         IsNative="true" />
     </ItemGroup>
 
-    <!-- WASI CoreCLR ships only the static runtime libraries (already
-         provided by RuntimeFiles from $(CoreCLRSharedFrameworkDir)) and
-         the libs.native static libs (already provided by the unconditional
-         glob above). corerun.wasm is not part of the runtime pack. -->
+    <!-- WASI CoreCLR ships the static runtime libraries (already provided by RuntimeFiles from
+         $(CoreCLRSharedFrameworkDir)) and the libs.native static libs (already provided by the
+         unconditional glob above). corerun.wasm is not part of the runtime pack. The host archive
+         (libWasiHost.a) is a separate deliverable built by the host subset and staged from
+         $(HostSharedFrameworkDir); the per-app relink (WasiApp.CoreCLR.targets) links it. Runtime
+         tests for Helix are built without the host subset, so the host archive is excluded there
+         (mirrors the browser libBrowserHost.a handling). -->
+    <ItemGroup Condition="'$(TargetOS)' == 'wasi' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(IsTestsCommonProject)' != 'true'">
+      <LibrariesRuntimeFiles Include="$(HostSharedFrameworkDir)libWasiHost.a"
+                             IsNative="true" />
+    </ItemGroup>
 
 
     <Error Condition="'@(LibrariesRuntimeFiles)' == ''" Text="The 'libs' subset must be built before building this project." />

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -325,13 +325,8 @@
         IsNative="true" />
     </ItemGroup>
 
-    <!-- WASI CoreCLR ships the static runtime libraries (already provided by RuntimeFiles from
-         $(CoreCLRSharedFrameworkDir)) and the libs.native static libs (already provided by the
-         unconditional glob above). corerun.wasm is not part of the runtime pack. The host archive
-         (libWasiHost.a) is a separate deliverable built by the host subset and staged from
-         $(HostSharedFrameworkDir); the per-app relink (the CoreCLR-WASI app builder) links it. Runtime
-         tests for Helix are built without the host subset, so the host archive is excluded there
-         (mirrors the browser libBrowserHost.a handling). -->
+    <!-- WASI CoreCLR host archive, staged from the host subset. Excluded from the runtime-tests
+         build (which omits the host subset), mirroring the browser libBrowserHost.a handling. -->
     <ItemGroup Condition="'$(TargetOS)' == 'wasi' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(IsTestsCommonProject)' != 'true'">
       <LibrariesRuntimeFiles Include="$(HostSharedFrameworkDir)libWasiHost.a"
                              IsNative="true" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -282,6 +282,7 @@
     <PlatformManifestFileEntry Include="libSystem.Runtime.InteropServices.JavaScript.Native.js" IsNative="true" />
     <PlatformManifestFileEntry Include="libSystem.Runtime.InteropServices.JavaScript.Native.js.map" IsNative="true" />
     <!-- wasi specific -->
+    <PlatformManifestFileEntry Include="libWasiHost.a" IsNative="true" />
     <PlatformManifestFileEntry Include="main.c" IsNative="true" />
     <PlatformManifestFileEntry Include="driver.h" IsNative="true" />
     <PlatformManifestFileEntry Include="stubs.c" IsNative="true" />

--- a/src/native/corehost/CMakeLists.txt
+++ b/src/native/corehost/CMakeLists.txt
@@ -81,7 +81,7 @@ if(CLR_CMAKE_TARGET_LINUX OR CLR_CMAKE_TARGET_SUNOS)
     add_link_options(LINKER:-Bsymbolic)
 endif()
 
-if(NOT CLR_CMAKE_TARGET_BROWSER)
+if(NOT CLR_CMAKE_TARGET_BROWSER AND NOT CLR_CMAKE_TARGET_WASI)
     add_library(fxr_resolver INTERFACE)
     target_sources(fxr_resolver INTERFACE fxr_resolver.c)
     target_include_directories(fxr_resolver INTERFACE fxr)
@@ -112,9 +112,13 @@ if(NOT CLR_CMAKE_TARGET_BROWSER)
     if(CLR_CMAKE_BUILD_HOST_TESTS)
         add_subdirectory(test)
     endif()
-else()
+elseif(CLR_CMAKE_TARGET_BROWSER)
     add_subdirectory(hostmisc)
     add_subdirectory(browserhost)
+else() # CLR_CMAKE_TARGET_WASI
+    # The wasi host is a self-contained static archive (libWasiHost.a) linked per-app; it does not
+    # depend on hostmisc (it shares the corerun pal header instead), so only wasihost is built here.
+    add_subdirectory(wasihost)
 endif()
 
 # If there's a dynamic ASAN runtime, then install it in the directories where we put our executables.

--- a/src/native/corehost/CMakeLists.txt
+++ b/src/native/corehost/CMakeLists.txt
@@ -116,8 +116,7 @@ elseif(CLR_CMAKE_TARGET_BROWSER)
     add_subdirectory(hostmisc)
     add_subdirectory(browserhost)
 else() # CLR_CMAKE_TARGET_WASI
-    # The wasi host is a self-contained static archive (libWasiHost.a) linked per-app; it does not
-    # depend on hostmisc (it shares the corerun pal header instead), so only wasihost is built here.
+    # The wasi host is self-contained (shares the corerun pal header, no hostmisc dependency).
     add_subdirectory(wasihost)
 endif()
 

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -14,6 +14,10 @@
     <BuildCoreHostDependsOn>GenerateRuntimeVersionFile</BuildCoreHostDependsOn>
     <BuildCoreHostDependsOn Condition="'$(EnableSourceControlManagerQueries)' == 'true'">$(BuildCoreHostDependsOn);InitializeSourceControlInformationFromSourceControlManager</BuildCoreHostDependsOn>
     <BuildCoreHostDependsOn Condition="'$(TargetsBrowser)' == 'true'">AcquireEmscriptenSdk;$(BuildCoreHostDependsOn);GenerateEmccExports;ResolveRuntimeFilesFromLocalBuild</BuildCoreHostDependsOn>
+    <!-- WASI: the corehost native build (build.sh -os wasi) is driven by gen-buildsys.sh, which
+         requires WASI_SDK_PATH and selects the wasi-sdk-p2 CMake toolchain. Acquire the SDK first
+         and hand its path to the build script below. -->
+    <BuildCoreHostDependsOn Condition="'$(TargetsWasi)' == 'true'">AcquireWasiSdk;$(BuildCoreHostDependsOn)</BuildCoreHostDependsOn>
     <CopyWasmNativeFilesDependsOn Condition="'$(TargetOS)' == 'windows'">BuildCoreHostOnWindows</CopyWasmNativeFilesDependsOn>
     <CopyWasmNativeFilesDependsOn Condition="'$(TargetOS)' != 'windows'">BuildCoreHostOnUnix</CopyWasmNativeFilesDependsOn>
     <IntermediateOutputRootPath>$(ArtifactsObjDir)$(TargetRid).$(Configuration)\</IntermediateOutputRootPath>
@@ -92,12 +96,19 @@
       <BuildArgs>$(BuildArgs) -cmakeargs "-DCLR_CMAKE_BUILD_HOST_PRODUCT=$(BuildNativeHostProduct.ToUpper())"</BuildArgs>
     </PropertyGroup>
 
+    <!-- WASI: hand the acquired wasi-sdk to gen-buildsys.sh via WASI_SDK_PATH (it selects the
+         wasi-sdk-p2 CMake toolchain from it). Set inside the target so $(RuntimeBuildWasiSdkPath),
+         produced by the AcquireWasiSdk dependency above, is populated. -->
+    <PropertyGroup Condition="'$(TargetsWasi)' == 'true'">
+      <_CoreHostBuildEnvironmentVariables>WASI_SDK_PATH=$(RuntimeBuildWasiSdkPath)</_CoreHostBuildEnvironmentVariables>
+    </PropertyGroup>
+
     <!--
       Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and we want to avoid
       upgrading compiler warnings to errors in release branches.
     -->
     <Message Text="&quot;$(BuildScript)&quot; $(BuildArgs) @(NativeCMakeArg, ' ')" Importance="High"/>
-    <Exec Command="&quot;$(BuildScript)&quot; $(BuildArgs) @(NativeCMakeArg, ' ')" IgnoreStandardErrorWarningFormat="true"/>
+    <Exec Command="&quot;$(BuildScript)&quot; $(BuildArgs) @(NativeCMakeArg, ' ')" IgnoreStandardErrorWarningFormat="true" EnvironmentVariables="$(_CoreHostBuildEnvironmentVariables)"/>
   </Target>
 
   <!-- 
@@ -195,6 +206,20 @@
     <Copy SourceFiles="@(_MicrosoftNetCoreAppRuntimePackNativeDirFiles)"
           DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)"
           SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- WASI CoreCLR: stage the host archive (libWasiHost.a) into the runtime pack native dir so the
+       per-app relink (src/mono/wasi/build/WasiApp.CoreCLR.targets) can consume it. Mirrors the
+       browser CopyWasmNativeFiles above; the runtime .a libraries come from the coreclr build. -->
+  <Target Name="CopyWasiNativeFiles" AfterTargets="Build" DependsOnTargets="$(CopyWasmNativeFilesDependsOn)" Condition="'$(TargetsWasi)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR'">
+    <ItemGroup>
+      <_MicrosoftNetCoreAppRuntimePackNativeDirFiles Include="$(HostSharedFrameworkDir)libWasiHost.a" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_MicrosoftNetCoreAppRuntimePackNativeDirFiles)"
+          DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)"
+          SkipUnchangedFiles="true"
+          Condition="Exists('$(HostSharedFrameworkDir)libWasiHost.a')" />
   </Target>
 
   <Target Name="PrependWindowsHeaderIncludeToVersionHeaderFile"

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -14,9 +14,7 @@
     <BuildCoreHostDependsOn>GenerateRuntimeVersionFile</BuildCoreHostDependsOn>
     <BuildCoreHostDependsOn Condition="'$(EnableSourceControlManagerQueries)' == 'true'">$(BuildCoreHostDependsOn);InitializeSourceControlInformationFromSourceControlManager</BuildCoreHostDependsOn>
     <BuildCoreHostDependsOn Condition="'$(TargetsBrowser)' == 'true'">AcquireEmscriptenSdk;$(BuildCoreHostDependsOn);GenerateEmccExports;ResolveRuntimeFilesFromLocalBuild</BuildCoreHostDependsOn>
-    <!-- WASI: the corehost native build (build.sh -os wasi) is driven by gen-buildsys.sh, which
-         requires WASI_SDK_PATH and selects the wasi-sdk-p2 CMake toolchain. Acquire the SDK first
-         and hand its path to the build script below. -->
+    <!-- WASI: the corehost native build needs the wasi-sdk (WASI_SDK_PATH, passed below). -->
     <BuildCoreHostDependsOn Condition="'$(TargetsWasi)' == 'true'">AcquireWasiSdk;$(BuildCoreHostDependsOn)</BuildCoreHostDependsOn>
     <CopyWasmNativeFilesDependsOn Condition="'$(TargetOS)' == 'windows'">BuildCoreHostOnWindows</CopyWasmNativeFilesDependsOn>
     <CopyWasmNativeFilesDependsOn Condition="'$(TargetOS)' != 'windows'">BuildCoreHostOnUnix</CopyWasmNativeFilesDependsOn>
@@ -96,9 +94,7 @@
       <BuildArgs>$(BuildArgs) -cmakeargs "-DCLR_CMAKE_BUILD_HOST_PRODUCT=$(BuildNativeHostProduct.ToUpper())"</BuildArgs>
     </PropertyGroup>
 
-    <!-- WASI: hand the acquired wasi-sdk to gen-buildsys.sh via WASI_SDK_PATH (it selects the
-         wasi-sdk-p2 CMake toolchain from it). Set inside the target so $(RuntimeBuildWasiSdkPath),
-         produced by the AcquireWasiSdk dependency above, is populated. -->
+    <!-- WASI: pass the acquired wasi-sdk to the native build. -->
     <PropertyGroup Condition="'$(TargetsWasi)' == 'true'">
       <_CoreHostBuildEnvironmentVariables>WASI_SDK_PATH=$(RuntimeBuildWasiSdkPath)</_CoreHostBuildEnvironmentVariables>
     </PropertyGroup>
@@ -213,11 +209,9 @@
           SkipUnchangedFiles="true" />
   </Target>
 
-  <!-- WASI CoreCLR: stage the host archive (libWasiHost.a) into the runtime pack native dir so the
-       per-app relink (the CoreCLR-WASI app builder) can consume it. Mirrors the browser
-       CopyWasmNativeFiles above; the runtime .a libraries come from the coreclr build. Depends on
-       both host-build targets explicitly (one is skipped by its HostOS condition) so the copy runs
-       after the archive is produced regardless of host OS. -->
+  <!-- WASI CoreCLR: stage libWasiHost.a into the runtime pack native dir for the per-app relink,
+       mirroring the browser CopyWasmNativeFiles above. Depends on both host-build targets (one is
+       skipped by its HostOS condition) so the copy is ordered after the archive on either host. -->
   <Target Name="CopyWasiNativeFiles" AfterTargets="Build" DependsOnTargets="BuildCoreHostOnUnix;BuildCoreHostOnWindows" Condition="'$(TargetsWasi)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR'">
     <ItemGroup>
       <_MicrosoftNetCoreAppRuntimePackNativeDirFiles Include="$(HostSharedFrameworkDir)libWasiHost.a" />

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -180,13 +180,18 @@
       <BuildArgs>$(BuildArgs) -cmakeargs "-DCLR_CMAKE_BUILD_HOST_PRODUCT=$(BuildNativeHostProduct.ToUpper())"</BuildArgs>
     </PropertyGroup>
 
+    <!-- WASI: gen-buildsys.cmd needs WASI_SDK_PATH (set by the AcquireWasiSdk dependency above). -->
+    <PropertyGroup Condition="'$(TargetsWasi)' == 'true'">
+      <_CoreHostBuildEnvironmentVariables>WASI_SDK_PATH=$(RuntimeBuildWasiSdkPath)</_CoreHostBuildEnvironmentVariables>
+    </PropertyGroup>
+
     <!--
       Run script that invokes Cmake to create VS files, and then calls msbuild to compile them. Use
       IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and we want to avoid
       upgrading compiler warnings to errors in release branches.
     -->
     <Message Text="&quot;$(BuildScript)&quot; $(BuildArgs) @(NativeCMakeArg, ' ')" Importance="High"/>
-    <Exec Command="&quot;$(BuildScript)&quot; $(BuildArgs) @(NativeCMakeArg, ' ')" IgnoreStandardErrorWarningFormat="true"/>
+    <Exec Command="&quot;$(BuildScript)&quot; $(BuildArgs) @(NativeCMakeArg, ' ')" IgnoreStandardErrorWarningFormat="true" EnvironmentVariables="$(_CoreHostBuildEnvironmentVariables)"/>
   </Target>
 
   <Target Name="CopyWasmNativeFiles" AfterTargets="Build" DependsOnTargets="$(CopyWasmNativeFilesDependsOn)" Condition="'$(TargetsBrowser)' == 'true'">
@@ -218,8 +223,7 @@
 
     <Copy SourceFiles="@(_MicrosoftNetCoreAppRuntimePackNativeDirFiles)"
           DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)"
-          SkipUnchangedFiles="true"
-          Condition="Exists('$(HostSharedFrameworkDir)libWasiHost.a')" />
+          SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="PrependWindowsHeaderIncludeToVersionHeaderFile"

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -214,9 +214,11 @@
   </Target>
 
   <!-- WASI CoreCLR: stage the host archive (libWasiHost.a) into the runtime pack native dir so the
-       per-app relink (src/mono/wasi/build/WasiApp.CoreCLR.targets) can consume it. Mirrors the
-       browser CopyWasmNativeFiles above; the runtime .a libraries come from the coreclr build. -->
-  <Target Name="CopyWasiNativeFiles" AfterTargets="Build" DependsOnTargets="$(CopyWasmNativeFilesDependsOn)" Condition="'$(TargetsWasi)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR'">
+       per-app relink (the CoreCLR-WASI app builder) can consume it. Mirrors the browser
+       CopyWasmNativeFiles above; the runtime .a libraries come from the coreclr build. Depends on
+       both host-build targets explicitly (one is skipped by its HostOS condition) so the copy runs
+       after the archive is produced regardless of host OS. -->
+  <Target Name="CopyWasiNativeFiles" AfterTargets="Build" DependsOnTargets="BuildCoreHostOnUnix;BuildCoreHostOnWindows" Condition="'$(TargetsWasi)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR'">
     <ItemGroup>
       <_MicrosoftNetCoreAppRuntimePackNativeDirFiles Include="$(HostSharedFrameworkDir)libWasiHost.a" />
     </ItemGroup>

--- a/src/native/corehost/wasihost/CMakeLists.txt
+++ b/src/native/corehost/wasihost/CMakeLists.txt
@@ -38,5 +38,5 @@ target_include_directories(WasiHost-Static PRIVATE
 )
 
 # The runtime static libraries and the app-generated callhelpers are supplied at the per-app relink
-# (src/mono/wasi/build/WasiApp.CoreCLR.targets), which pulls this archive whole-archive for main().
+# by the CoreCLR-WASI app builder, which pulls this archive whole-archive for main().
 install(TARGETS WasiHost-Static DESTINATION sharedFramework COMPONENT runtime)

--- a/src/native/corehost/wasihost/CMakeLists.txt
+++ b/src/native/corehost/wasihost/CMakeLists.txt
@@ -11,10 +11,8 @@ set(WASIHOST_SOURCES
     ./wasihost.cpp
 )
 
-# Reuse the corerun pal (path handling, CORE_ROOT/TPA directory enumeration, absolute-path
-# resolution) so the host's assembly discovery stays identical to the validated corerun-based host.
-# The header is self-contained (only <config.h> and minipal headers), so no corerun runtime object
-# is linked into this archive.
+# Reuse the corerun pal header (path/CORE_ROOT/TPA helpers); it's header-only, so no corerun object
+# is linked here.
 set(WASIHOST_CORERUN_DIR ${CLR_REPO_ROOT_DIR}/src/coreclr/hosts/corerun)
 
 add_library(WasiHost-Static
@@ -23,10 +21,8 @@ add_library(WasiHost-Static
 )
 set_target_properties(WasiHost-Static PROPERTIES OUTPUT_NAME WasiHost CLEAN_DIRECT_OUTPUT 1)
 
-# The shared corerun pal header compiles the wasi paths against the emulated wasi-libc facilities
-# (mmap/getpid/signal/process-clocks). The coreclr build sets these globally for wasi; the corehost
-# build does not, so set them here. The matching -lwasi-emulated-* libraries are supplied at the
-# per-app relink (src/mono/wasi/build/WasiApp.CoreCLR.targets).
+# The coreclr build sets these wasi emulation defines globally; the corehost build does not. The
+# matching -lwasi-emulated-* libraries are supplied at the per-app relink.
 if (CLR_CMAKE_TARGET_WASI)
     target_compile_definitions(WasiHost-Static PRIVATE
         _WASI_EMULATED_MMAN
@@ -41,8 +37,6 @@ target_include_directories(WasiHost-Static PRIVATE
     ${CLR_SRC_NATIVE_DIR}        # minipal/*.h
 )
 
-# The runtime static libraries (coreclr_static, System.Native, minipal, ...) and the app-generated
-# callhelpers are NOT linked here; they are supplied at the per-app relink from the runtime pack
-# (src/mono/wasi/build/WasiApp.CoreCLR.targets), which pulls this archive whole-archive so
-# main()/_start are included.
+# The runtime static libraries and the app-generated callhelpers are supplied at the per-app relink
+# (src/mono/wasi/build/WasiApp.CoreCLR.targets), which pulls this archive whole-archive for main().
 install(TARGETS WasiHost-Static DESTINATION sharedFramework COMPONENT runtime)

--- a/src/native/corehost/wasihost/CMakeLists.txt
+++ b/src/native/corehost/wasihost/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+
+project(wasihost)
+set(DOTNET_PROJECT_NAME "WasiHost-Static")
+
+# HAVE_DIRENT_D_TYPE / HAVE_GETAUXVAL for the shared corerun pal header.
+include(configure.cmake)
+
+set(WASIHOST_SOURCES
+    ./wasihost.cpp
+)
+
+# Reuse the corerun pal (path handling, CORE_ROOT/TPA directory enumeration, absolute-path
+# resolution) so the host's assembly discovery stays identical to the validated corerun-based host.
+# The header is self-contained (only <config.h> and minipal headers), so no corerun runtime object
+# is linked into this archive.
+set(WASIHOST_CORERUN_DIR ${CLR_REPO_ROOT_DIR}/src/coreclr/hosts/corerun)
+
+add_library(WasiHost-Static
+    STATIC
+    ${WASIHOST_SOURCES}
+)
+set_target_properties(WasiHost-Static PROPERTIES OUTPUT_NAME WasiHost CLEAN_DIRECT_OUTPUT 1)
+
+# The shared corerun pal header compiles the wasi paths against the emulated wasi-libc facilities
+# (mmap/getpid/signal/process-clocks). The coreclr build sets these globally for wasi; the corehost
+# build does not, so set them here. The matching -lwasi-emulated-* libraries are supplied at the
+# per-app relink (src/mono/wasi/build/WasiApp.CoreCLR.targets).
+if (CLR_CMAKE_TARGET_WASI)
+    target_compile_definitions(WasiHost-Static PRIVATE
+        _WASI_EMULATED_MMAN
+        _WASI_EMULATED_GETPID
+        _WASI_EMULATED_SIGNAL
+        _WASI_EMULATED_PROCESS_CLOCKS)
+endif()
+
+target_include_directories(WasiHost-Static PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}  # generated config.h
+    ${WASIHOST_CORERUN_DIR}      # corerun.hpp (shared pal)
+    ${CLR_SRC_NATIVE_DIR}        # minipal/*.h
+)
+
+# The runtime static libraries (coreclr_static, System.Native, minipal, ...) and the app-generated
+# callhelpers are NOT linked here; they are supplied at the per-app relink from the runtime pack
+# (src/mono/wasi/build/WasiApp.CoreCLR.targets), which pulls this archive whole-archive so
+# main()/_start are included.
+install(TARGETS WasiHost-Static DESTINATION sharedFramework COMPONENT runtime)

--- a/src/native/corehost/wasihost/config.h.in
+++ b/src/native/corehost/wasihost/config.h.in
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
+#cmakedefine01 HAVE_GETAUXVAL
+#cmakedefine01 HAVE_DIRENT_D_TYPE
+
+#endif // __CONFIG_H__

--- a/src/native/corehost/wasihost/configure.cmake
+++ b/src/native/corehost/wasihost/configure.cmake
@@ -1,0 +1,15 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+
+# Mirrors src/coreclr/hosts/corerun/configure.cmake: the shared corerun pal header (corerun.hpp)
+# consumes HAVE_DIRENT_D_TYPE / HAVE_GETAUXVAL from this generated config.h. The corehost build
+# does not include the CMake check modules globally (unlike the coreclr build), so include them.
+include(CheckSymbolExists)
+include(CheckStructHasMember)
+
+check_symbol_exists(getauxval sys/auxv.h HAVE_GETAUXVAL)
+check_struct_has_member ("struct dirent" d_type dirent.h HAVE_DIRENT_D_TYPE)
+
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+	${CMAKE_CURRENT_BINARY_DIR}/config.h)

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -233,7 +233,10 @@ int main(int argc, char* argv[])
     s_property_keys.push_back("NATIVE_DLL_SEARCH_DIRECTORIES");
     s_property_values.push_back(native_search_dirs.str());
 
-    host_runtime_contract host_contract = {
+    // Static storage: the contract must stay valid for the process lifetime (the runtime may call
+    // back through it any time after coreclr_initialize), and its address is handed to the runtime
+    // via HOST_RUNTIME_CONTRACT below. Mirrors browserhost's static host_contract.
+    static host_runtime_contract host_contract = {
         sizeof(host_runtime_contract),
         nullptr,
         &get_runtime_property,

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -238,14 +238,14 @@ int main(int argc, char* argv[])
         GlobalizationNative_LoadICUData(icu_data_path.c_str());
     }
 
-    int exit_code = 0;
+    unsigned int exit_code = 0;
     result = coreclr_execute_assembly(
         host_handle,
         domain_id,
         (int)entry_argv.size(),
         entry_argv.data(),
         entry_assembly.c_str(),
-        (unsigned int*)&exit_code);
+        &exit_code);
     if (result < 0)
     {
         std::fprintf(stderr, "coreclr_execute_assembly failed - Error: 0x%08x\n", result);

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -7,8 +7,12 @@
 // See https://github.com/dotnet/runtime/issues/130129.
 
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
 #include <set>
 #include <sstream>
+#include <string>
+#include <vector>
 
 // Shared pal (path handling, CORE_ROOT/TPA helpers); header-only, so no corerun object is linked.
 #include "corerun.hpp"
@@ -160,10 +164,11 @@ int main(int argc, char* argv[])
     native_search_dirs << app_path << pal::env_path_delim;
 
     string_t core_libs = pal::getenv(envvar::coreLibraries);
-    if (!core_libs.empty() && core_libs != app_path)
+    if (!core_libs.empty())
     {
         pal::ensure_trailing_delimiter(core_libs);
-        native_search_dirs << core_libs << pal::env_path_delim;
+        if (core_libs != app_path)
+            native_search_dirs << core_libs << pal::env_path_delim;
     }
 
     // CORE_ROOT locates the framework assemblies for the TPA list (the runtime itself is static on

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -1,0 +1,323 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// CoreCLR-WASI host.
+//
+// This is the shipping corehost for the CoreCLR-WASI library-test leg. It is built as a
+// static archive (libWasiHost.a) and linked per-app by the WASI app builder
+// (src/mono/wasi/build/WasiApp.CoreCLR.targets), whole-archive so main()/_start are pulled,
+// together with the runtime-pack static libraries (libcoreclr_static.a, libSystem.Native.a,
+// ...) and the app-generated P/Invoke callhelpers. This mirrors the browser host
+// (src/native/corehost/browserhost) and the static apphost (src/native/corehost/apphost/static);
+// the coreclr-internal corerun (src/coreclr/hosts/corerun) keeps its role for CoreCLR runtime
+// tests.
+//
+// The host is a thin one: it constructs the CoreCLR initialization properties from CORE_ROOT
+// and calls coreclr_initialize / coreclr_execute_assembly directly (declared extern against the
+// statically linked runtime), the same shape as browserhost.cpp but with a real wasi:cli/run
+// main() (there is no JS driver). The path/TPA logic is shared with corerun via its pal header so
+// the CORE_ROOT resolution, directory enumeration and absolute-path handling stay identical to the
+// validated corerun-based host.
+//
+// See https://github.com/dotnet/runtime/issues/130129.
+//
+
+#include <cstdint>
+#include <cstdlib>
+#include <set>
+#include <sstream>
+
+// Shared pal (path handling, directory enumeration, CORE_ROOT/TPA helpers). The header is
+// self-contained and TARGET_WASM-guarded; only header-only helpers are used here, so no corerun
+// runtime object is required in this archive.
+#include "corerun.hpp"
+
+#include <host_runtime_contract.h>
+
+using pal::char_t;
+using pal::string_t;
+
+namespace envvar
+{
+    const char_t* const coreRoot = W("CORE_ROOT");
+    const char_t* const coreLibraries = W("CORE_LIBRARIES");
+    const char_t* const printExitCode = W("DOTNET_WASI_PRINT_EXIT_CODE");
+}
+
+// CoreCLR entry points. On wasi the runtime is statically linked, so these are resolved at the
+// per-app relink from libcoreclr_static.a (declared extern, as browserhost.cpp does) rather than
+// looked up dynamically.
+extern "C"
+{
+    int coreclr_initialize(
+        const char* exePath,
+        const char* appDomainFriendlyName,
+        int propertyCount,
+        const char** propertyKeys,
+        const char** propertyValues,
+        void** hostHandle,
+        unsigned int* domainId);
+
+    int coreclr_execute_assembly(
+        void* hostHandle,
+        unsigned int domainId,
+        int argc,
+        const char** argv,
+        const char* managedAssemblyPath,
+        unsigned int* exitCode);
+
+    int coreclr_shutdown_2(
+        void* hostHandle,
+        unsigned int domainId,
+        int* latchedExitCode);
+
+    int coreclr_set_error_writer(void (*errorWriter)(const char* line));
+}
+
+// The app-generated P/Invoke resolver, produced per-app by ManagedToNativeGenerator and linked at
+// the relink (replacing libcoreclr_gen_static.a). Passed to the runtime via the host contract
+// below (pinvoke_override); coreclr_initialize forwards it to PInvokeOverride::SetPInvokeOverride
+// with Source::RuntimeConfiguration - the same registration corerun performs via
+// add_pinvoke_override() - so the app callhelpers are hooked and reverse thunks for the app/test
+// [UnmanagedCallersOnly] methods resolve (else precode_portable.cpp asserts). See
+// coreclr_initialize in src/coreclr/dlls/mscoree/exports.cpp. Declared as a plain (C++-mangled)
+// function to match the generated definition, as corerun/browserhost do - not extern "C".
+const void* callhelpers_pinvoke_override(const char* library_name, const char* entry_point_name);
+
+// Fake implementations to satisfy the linker without pulling
+// libSystem.Runtime.InteropServices.JavaScript.Native (a browser-only library) into the wasi
+// relink; these JS interop QCall targets are referenced by libcoreclr_static.a but never called on
+// wasi. Ported from src/coreclr/hosts/corerun/wasm/pinvoke_override.cpp.
+extern "C"
+{
+    void* SystemInteropJS_BindJSImportST(void*) { std::abort(); }
+    void SystemInteropJS_CancelPromise(void*) { std::abort(); }
+    void SystemInteropJS_InvokeJSFunction(void*, void*) { std::abort(); }
+    void SystemInteropJS_InvokeJSImportST(int32_t, void*) { std::abort(); }
+    void SystemInteropJS_ReleaseCSOwnedObject(void*) { std::abort(); }
+    void SystemInteropJS_ResolveOrRejectPromise(void*) { std::abort(); }
+}
+
+// Provided by libSystem.Globalization.Native.a when globalization is linked (the non-invariant
+// per-app relink). Declared weak so an invariant relink (which omits that archive) leaves the
+// reference null and the host ICU preload below is skipped.
+extern "C" __attribute__((weak)) int32_t GlobalizationNative_LoadICUData(const char* path);
+
+// Initialization properties, kept alive for the lifetime of the process so the host runtime
+// contract callback can serve them.
+static std::vector<std::string> s_property_keys;
+static std::vector<std::string> s_property_values;
+
+static void log_error_info(const char* line)
+{
+    std::fprintf(stderr, "%s\n", line);
+}
+
+// N.B. CoreCLR doesn't always use the first instance of an assembly on the TPA list (ni's may be
+// preferred over il even if they appear later). Include only the first instance of a simple name.
+static string_t build_tpa(const string_t& core_root, const string_t& core_libraries)
+{
+    static const char_t* const tpa_extensions[] =
+    {
+        W(".dll"),
+        W(".exe"),
+        nullptr
+    };
+
+    std::set<string_t> name_set;
+    pal::stringstream_t tpa_list;
+
+    for (const char_t* const* curr_ext = tpa_extensions; *curr_ext != nullptr; ++curr_ext)
+    {
+        const char_t* ext = *curr_ext;
+        const size_t ext_len = pal::strlen(ext);
+
+        for (const string_t& dir : { core_libraries, core_root })
+        {
+            if (dir.empty())
+                continue;
+
+            string_t tmp = pal::build_file_list(dir, ext, [&](const char_t* file)
+                {
+                    string_t file_local{ file };
+
+                    if (pal::string_ends_with(file_local, ext_len, ext))
+                        file_local = file_local.substr(0, file_local.length() - ext_len);
+
+                    return name_set.insert(file_local).second;
+                });
+
+            tpa_list << tmp;
+        }
+    }
+
+    return tpa_list.str();
+}
+
+static size_t HOST_CONTRACT_CALLTYPE get_runtime_property(
+    const char* key,
+    /*out*/ char* value_buffer,
+    size_t value_buffer_size,
+    void* /*contract_context*/)
+{
+    for (size_t i = 0; i < s_property_keys.size(); ++i)
+    {
+        if (s_property_keys[i] == key)
+        {
+            const std::string& value = s_property_values[i];
+            size_t len = value.length();
+            if (value_buffer != nullptr && value_buffer_size > len)
+                ::memcpy(value_buffer, value.c_str(), len + 1);
+
+            return len + 1;
+        }
+    }
+
+    return (size_t)-1;
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc < 2)
+    {
+        std::fprintf(stderr, "USAGE: %s <assembly> [arguments]\n", argc > 0 ? argv[0] : "wasihost");
+        return -1;
+    }
+
+    string_t exe_path = pal::get_exe_path();
+
+    // The first argument is the managed entry assembly; the rest are passed to it.
+    string_t entry_assembly = pal::get_absolute_path(argv[1]);
+    int entry_argc = argc - 2;
+    const char** entry_argv = entry_argc > 0 ? (const char**)&argv[2] : nullptr;
+
+    // The application directory is where the entry assembly lives.
+    string_t app_path;
+    {
+        string_t file;
+        pal::split_path_to_dir_filename(entry_assembly, app_path, file);
+        pal::ensure_trailing_delimiter(app_path);
+    }
+
+    pal::stringstream_t native_search_dirs;
+    native_search_dirs << app_path << pal::env_path_delim;
+
+    string_t core_libs = pal::getenv(envvar::coreLibraries);
+    if (!core_libs.empty() && core_libs != app_path)
+    {
+        pal::ensure_trailing_delimiter(core_libs);
+        native_search_dirs << core_libs << pal::env_path_delim;
+    }
+
+    // CORE_ROOT locates the framework assemblies (and, on non-wasm, the runtime). On wasi the
+    // runtime is statically linked, so CORE_ROOT is only used to build the TPA list. Fall back to
+    // the host's own directory when unset.
+    string_t core_root = pal::getenv(envvar::coreRoot);
+    if (core_root.empty())
+    {
+        string_t file;
+        pal::split_path_to_dir_filename(exe_path, core_root, file);
+    }
+    pal::ensure_trailing_delimiter(core_root);
+    native_search_dirs << core_root << pal::env_path_delim;
+
+    string_t tpa_list = build_tpa(core_root, core_libs);
+
+    s_property_keys.push_back("TRUSTED_PLATFORM_ASSEMBLIES");
+    s_property_values.push_back(tpa_list);
+
+    s_property_keys.push_back("APP_PATHS");
+    s_property_values.push_back(app_path);
+
+    s_property_keys.push_back("NATIVE_DLL_SEARCH_DIRECTORIES");
+    s_property_values.push_back(native_search_dirs.str());
+
+    host_runtime_contract host_contract = {
+        sizeof(host_runtime_contract),
+        nullptr,
+        &get_runtime_property,
+        nullptr,
+        &callhelpers_pinvoke_override };
+    {
+        std::stringstream ss;
+        ss << "0x" << std::hex << (size_t)(&host_contract);
+        s_property_keys.push_back(HOST_PROPERTY_RUNTIME_CONTRACT);
+        s_property_values.push_back(ss.str());
+    }
+
+    std::vector<const char*> property_keys;
+    std::vector<const char*> property_values;
+    for (const std::string& key : s_property_keys)
+        property_keys.push_back(key.c_str());
+    for (const std::string& value : s_property_values)
+        property_values.push_back(value.c_str());
+
+    coreclr_set_error_writer(log_error_info);
+
+    void* host_handle = nullptr;
+    unsigned int domain_id = 0;
+    int result = coreclr_initialize(
+        exe_path.c_str(),
+        "wasihost",
+        (int)property_keys.size(),
+        property_keys.data(),
+        property_values.data(),
+        &host_handle,
+        &domain_id);
+    if (result < 0)
+    {
+        std::fprintf(stderr, "coreclr_initialize failed - Error: 0x%08x\n", result);
+        return -1;
+    }
+
+    coreclr_set_error_writer(nullptr);
+
+    // The static ICU shim requires the host to preload icudt.dat before managed globalization
+    // initializes: GlobalizationNative_LoadICU() (the no-path entry the managed side calls on wasi)
+    // returns 0 unless the data was already set, and falls back to invariant. This mirrors the
+    // browser JS host calling wasm_load_icu_data. GlobalizationNative_LoadICUData is only linked
+    // when globalization is enabled (the non-invariant per-app relink), so the reference is weak -
+    // when globalization is not linked it is null and this is skipped (invariant). A missing
+    // icudt.dat also falls back to invariant (the call just fails).
+    if (GlobalizationNative_LoadICUData != nullptr)
+    {
+        string_t icu_data_path = app_path;
+        icu_data_path.append(W("icudt.dat"));
+        GlobalizationNative_LoadICUData(icu_data_path.c_str());
+    }
+
+    int exit_code = 0;
+    result = coreclr_execute_assembly(
+        host_handle,
+        domain_id,
+        entry_argc,
+        entry_argv,
+        entry_assembly.c_str(),
+        (unsigned int*)&exit_code);
+    if (result < 0)
+    {
+        std::fprintf(stderr, "coreclr_execute_assembly failed - Error: 0x%08x\n", result);
+        return -1;
+    }
+
+    int latched_exit_code = exit_code;
+    int shutdown_result = coreclr_shutdown_2(host_handle, domain_id, &latched_exit_code);
+    if (shutdown_result < 0)
+    {
+        std::fprintf(stderr, "coreclr_shutdown_2 failed - Error: 0x%08x\n", shutdown_result);
+        latched_exit_code = -1;
+    }
+
+    // wasi:cli/exit's exit(status: result) only signals ok/err, so wasmtime collapses any non-zero
+    // Main return to host exit 1. When DOTNET_WASI_PRINT_EXIT_CODE=1, emit a "WASM EXIT <n>" marker
+    // on stderr matching Mono (src/mono/wasi/runtime/main.c); the WASI launcher recovers the value
+    // from it. wasi:cli/exit.exit-with-code(status-code: u8) is stable as of WASI 0.3.0/Preview 3
+    // (@since(0.3.0)), but this host targets wasip2, where that world still gates it behind
+    // @unstable(feature = cli-exit-with-code); adopting it (and dropping this marker + the launcher
+    // parser) is gated on moving to a wasip3 target and toolchain support. See corerun.cpp.
+    if (pal::getenv(envvar::printExitCode) == W("1"))
+        std::fprintf(stderr, "WASM EXIT %d\n", latched_exit_code);
+
+    return latched_exit_code;
+}

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -230,11 +230,12 @@ int main(int argc, char* argv[])
     coreclr_set_error_writer(nullptr);
 
     // The static ICU shim needs icudt.dat preloaded before managed globalization inits, otherwise it
-    // falls back to invariant (mirrors the browser JS host's wasm_load_icu_data). Skipped for
-    // invariant relinks (weak symbol null) and tolerant of a missing file.
+    // falls back to invariant (mirrors the browser JS host's wasm_load_icu_data). icudt.dat is a
+    // framework asset, so load it from core_root. Skipped for invariant relinks (weak symbol null)
+    // and tolerant of a missing file.
     if (GlobalizationNative_LoadICUData != nullptr)
     {
-        string_t icu_data_path = app_path;
+        string_t icu_data_path = core_root;
         icu_data_path.append(W("icudt.dat"));
         GlobalizationNative_LoadICUData(icu_data_path.c_str());
     }

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -157,10 +157,12 @@ int main(int argc, char* argv[])
 
     string_t exe_path = pal::get_exe_path();
 
-    // argv[1] is the managed entry assembly; argv[2..] are passed to it.
+    // argv[1] is the managed entry assembly; argv[2..] are passed to it. Copy the slice into a
+    // const char* vector rather than casting char** to const char**.
     string_t entry_assembly = pal::get_absolute_path(argv[1]);
-    int entry_argc = argc - 2;
-    const char** entry_argv = entry_argc > 0 ? (const char**)&argv[2] : nullptr;
+    std::vector<const char*> entry_argv;
+    for (int i = 2; i < argc; ++i)
+        entry_argv.push_back(argv[i]);
 
     string_t app_path;
     {
@@ -257,8 +259,8 @@ int main(int argc, char* argv[])
     result = coreclr_execute_assembly(
         host_handle,
         domain_id,
-        entry_argc,
-        entry_argv,
+        (int)entry_argv.size(),
+        entry_argv.data(),
         entry_assembly.c_str(),
         (unsigned int*)&exit_code);
     if (result < 0)

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -1,36 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-//
-// CoreCLR-WASI host.
-//
-// This is the shipping corehost for the CoreCLR-WASI library-test leg. It is built as a
-// static archive (libWasiHost.a) and linked per-app by the WASI app builder
-// (src/mono/wasi/build/WasiApp.CoreCLR.targets), whole-archive so main()/_start are pulled,
-// together with the runtime-pack static libraries (libcoreclr_static.a, libSystem.Native.a,
-// ...) and the app-generated P/Invoke callhelpers. This mirrors the browser host
-// (src/native/corehost/browserhost) and the static apphost (src/native/corehost/apphost/static);
-// the coreclr-internal corerun (src/coreclr/hosts/corerun) keeps its role for CoreCLR runtime
-// tests.
-//
-// The host is a thin one: it constructs the CoreCLR initialization properties from CORE_ROOT
-// and calls coreclr_initialize / coreclr_execute_assembly directly (declared extern against the
-// statically linked runtime), the same shape as browserhost.cpp but with a real wasi:cli/run
-// main() (there is no JS driver). The path/TPA logic is shared with corerun via its pal header so
-// the CORE_ROOT resolution, directory enumeration and absolute-path handling stay identical to the
-// validated corerun-based host.
-//
+// Thin CoreCLR-WASI corehost, built as a static archive (libWasiHost.a) and linked per-app by the
+// WASI app builder (src/mono/wasi/build/WasiApp.CoreCLR.targets) against the statically-linked
+// runtime. Mirrors browserhost, but with a real wasi:cli/run main() instead of a JS driver.
 // See https://github.com/dotnet/runtime/issues/130129.
-//
 
 #include <cstdint>
 #include <cstdlib>
 #include <set>
 #include <sstream>
 
-// Shared pal (path handling, directory enumeration, CORE_ROOT/TPA helpers). The header is
-// self-contained and TARGET_WASM-guarded; only header-only helpers are used here, so no corerun
-// runtime object is required in this archive.
+// Shared pal (path handling, CORE_ROOT/TPA helpers); header-only, so no corerun object is linked.
 #include "corerun.hpp"
 
 #include <host_runtime_contract.h>
@@ -45,9 +26,7 @@ namespace envvar
     const char_t* const printExitCode = W("DOTNET_WASI_PRINT_EXIT_CODE");
 }
 
-// CoreCLR entry points. On wasi the runtime is statically linked, so these are resolved at the
-// per-app relink from libcoreclr_static.a (declared extern, as browserhost.cpp does) rather than
-// looked up dynamically.
+// Statically linked at the per-app relink, so declared extern here (as browserhost does).
 extern "C"
 {
     int coreclr_initialize(
@@ -75,20 +54,13 @@ extern "C"
     int coreclr_set_error_writer(void (*errorWriter)(const char* line));
 }
 
-// The app-generated P/Invoke resolver, produced per-app by ManagedToNativeGenerator and linked at
-// the relink (replacing libcoreclr_gen_static.a). Passed to the runtime via the host contract
-// below (pinvoke_override); coreclr_initialize forwards it to PInvokeOverride::SetPInvokeOverride
-// with Source::RuntimeConfiguration - the same registration corerun performs via
-// add_pinvoke_override() - so the app callhelpers are hooked and reverse thunks for the app/test
-// [UnmanagedCallersOnly] methods resolve (else precode_portable.cpp asserts). See
-// coreclr_initialize in src/coreclr/dlls/mscoree/exports.cpp. Declared as a plain (C++-mangled)
-// function to match the generated definition, as corerun/browserhost do - not extern "C".
+// App-generated P/Invoke resolver (per-app, replaces libcoreclr_gen_static.a at the relink), passed
+// to the runtime via the host contract below so app callhelpers and reverse thunks resolve. Plain
+// C++ linkage to match the generated definition (not extern "C").
 const void* callhelpers_pinvoke_override(const char* library_name, const char* entry_point_name);
 
-// Fake implementations to satisfy the linker without pulling
-// libSystem.Runtime.InteropServices.JavaScript.Native (a browser-only library) into the wasi
-// relink; these JS interop QCall targets are referenced by libcoreclr_static.a but never called on
-// wasi. Ported from src/coreclr/hosts/corerun/wasm/pinvoke_override.cpp.
+// JS interop QCall targets referenced by libcoreclr_static.a but never called on wasi; stubbed so
+// the relink doesn't pull the browser-only libSystem.Runtime.InteropServices.JavaScript.Native.
 extern "C"
 {
     void* SystemInteropJS_BindJSImportST(void*) { std::abort(); }
@@ -99,13 +71,11 @@ extern "C"
     void SystemInteropJS_ResolveOrRejectPromise(void*) { std::abort(); }
 }
 
-// Provided by libSystem.Globalization.Native.a when globalization is linked (the non-invariant
-// per-app relink). Declared weak so an invariant relink (which omits that archive) leaves the
-// reference null and the host ICU preload below is skipped.
+// Weak: only linked (from libSystem.Globalization.Native.a) in a non-invariant relink; null and
+// skipped otherwise.
 extern "C" __attribute__((weak)) int32_t GlobalizationNative_LoadICUData(const char* path);
 
-// Initialization properties, kept alive for the lifetime of the process so the host runtime
-// contract callback can serve them.
+// Init properties, kept alive for the process so the runtime contract callback can serve them.
 static std::vector<std::string> s_property_keys;
 static std::vector<std::string> s_property_values;
 
@@ -114,8 +84,8 @@ static void log_error_info(const char* line)
     std::fprintf(stderr, "%s\n", line);
 }
 
-// N.B. CoreCLR doesn't always use the first instance of an assembly on the TPA list (ni's may be
-// preferred over il even if they appear later). Include only the first instance of a simple name.
+// Include only the first instance of each simple assembly name (CoreCLR may otherwise prefer a
+// later ni over an earlier il).
 static string_t build_tpa(const string_t& core_root, const string_t& core_libraries)
 {
     static const char_t* const tpa_extensions[] =
@@ -187,12 +157,11 @@ int main(int argc, char* argv[])
 
     string_t exe_path = pal::get_exe_path();
 
-    // The first argument is the managed entry assembly; the rest are passed to it.
+    // argv[1] is the managed entry assembly; argv[2..] are passed to it.
     string_t entry_assembly = pal::get_absolute_path(argv[1]);
     int entry_argc = argc - 2;
     const char** entry_argv = entry_argc > 0 ? (const char**)&argv[2] : nullptr;
 
-    // The application directory is where the entry assembly lives.
     string_t app_path;
     {
         string_t file;
@@ -210,9 +179,8 @@ int main(int argc, char* argv[])
         native_search_dirs << core_libs << pal::env_path_delim;
     }
 
-    // CORE_ROOT locates the framework assemblies (and, on non-wasm, the runtime). On wasi the
-    // runtime is statically linked, so CORE_ROOT is only used to build the TPA list. Fall back to
-    // the host's own directory when unset.
+    // CORE_ROOT locates the framework assemblies for the TPA list (the runtime itself is static on
+    // wasi). Fall back to the host's own directory when unset.
     string_t core_root = pal::getenv(envvar::coreRoot);
     if (core_root.empty())
     {
@@ -233,9 +201,8 @@ int main(int argc, char* argv[])
     s_property_keys.push_back("NATIVE_DLL_SEARCH_DIRECTORIES");
     s_property_values.push_back(native_search_dirs.str());
 
-    // Static storage: the contract must stay valid for the process lifetime (the runtime may call
-    // back through it any time after coreclr_initialize), and its address is handed to the runtime
-    // via HOST_RUNTIME_CONTRACT below. Mirrors browserhost's static host_contract.
+    // Static: the contract must outlive coreclr_initialize (the runtime keeps its address). The
+    // pinvoke_override field is forwarded to PInvokeOverride::SetPInvokeOverride by the runtime.
     static host_runtime_contract host_contract = {
         sizeof(host_runtime_contract),
         nullptr,
@@ -276,13 +243,9 @@ int main(int argc, char* argv[])
 
     coreclr_set_error_writer(nullptr);
 
-    // The static ICU shim requires the host to preload icudt.dat before managed globalization
-    // initializes: GlobalizationNative_LoadICU() (the no-path entry the managed side calls on wasi)
-    // returns 0 unless the data was already set, and falls back to invariant. This mirrors the
-    // browser JS host calling wasm_load_icu_data. GlobalizationNative_LoadICUData is only linked
-    // when globalization is enabled (the non-invariant per-app relink), so the reference is weak -
-    // when globalization is not linked it is null and this is skipped (invariant). A missing
-    // icudt.dat also falls back to invariant (the call just fails).
+    // The static ICU shim needs icudt.dat preloaded before managed globalization inits, otherwise it
+    // falls back to invariant (mirrors the browser JS host's wasm_load_icu_data). Skipped for
+    // invariant relinks (weak symbol null) and tolerant of a missing file.
     if (GlobalizationNative_LoadICUData != nullptr)
     {
         string_t icu_data_path = app_path;
@@ -312,13 +275,10 @@ int main(int argc, char* argv[])
         latched_exit_code = -1;
     }
 
-    // wasi:cli/exit's exit(status: result) only signals ok/err, so wasmtime collapses any non-zero
-    // Main return to host exit 1. When DOTNET_WASI_PRINT_EXIT_CODE=1, emit a "WASM EXIT <n>" marker
-    // on stderr matching Mono (src/mono/wasi/runtime/main.c); the WASI launcher recovers the value
-    // from it. wasi:cli/exit.exit-with-code(status-code: u8) is stable as of WASI 0.3.0/Preview 3
-    // (@since(0.3.0)), but this host targets wasip2, where that world still gates it behind
-    // @unstable(feature = cli-exit-with-code); adopting it (and dropping this marker + the launcher
-    // parser) is gated on moving to a wasip3 target and toolchain support. See corerun.cpp.
+    // wasi:cli/exit's exit() only signals ok/err, so wasmtime collapses a non-zero result to host
+    // exit 1. Under DOTNET_WASI_PRINT_EXIT_CODE=1, emit a "WASM EXIT <n>" marker the WASI launcher
+    // parses (matching Mono). exit-with-code is stable in WASI 0.3 but still @unstable in the wasip2
+    // world this targets; see corerun.cpp.
     if (pal::getenv(envvar::printExitCode) == W("1"))
         std::fprintf(stderr, "WASM EXIT %d\n", latched_exit_code);
 

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -176,10 +176,10 @@ int main(int argc, char* argv[])
 
     string_t tpa_list = build_tpa(core_root, core_libs);
 
-    s_property_keys.push_back("TRUSTED_PLATFORM_ASSEMBLIES");
+    s_property_keys.push_back(HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES);
     s_property_values.push_back(tpa_list);
 
-    s_property_keys.push_back("APP_PATHS");
+    s_property_keys.push_back(HOST_PROPERTY_APP_PATHS);
     s_property_values.push_back(app_path);
 
     // NATIVE_DLL_SEARCH_DIRECTORIES is intentionally not set: on wasi native libraries are
@@ -187,14 +187,12 @@ int main(int argc, char* argv[])
     // the runtime's native-library search runs, and wasm has no shared-library/dlopen support, so
     // the search directories can never contribute a load.
 
-    // Static: the contract must outlive coreclr_initialize (the runtime keeps its address). The
-    // pinvoke_override field is forwarded to PInvokeOverride::SetPInvokeOverride by the runtime.
-    static host_runtime_contract host_contract = {
-        sizeof(host_runtime_contract),
-        nullptr,
-        &get_runtime_property,
-        nullptr,
-        &callhelpers_pinvoke_override };
+    // Static: the contract must outlive coreclr_initialize (the runtime keeps its address). Assign
+    // fields by name (not positionally) so contract layout changes can't mis-wire the callbacks.
+    // The pinvoke_override field is forwarded to PInvokeOverride::SetPInvokeOverride by the runtime.
+    static host_runtime_contract host_contract = { sizeof(host_runtime_contract), nullptr };
+    host_contract.get_runtime_property = &get_runtime_property;
+    host_contract.pinvoke_override = &callhelpers_pinvoke_override;
     {
         std::stringstream ss;
         ss << "0x" << std::hex << (size_t)(&host_contract);

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -160,16 +160,9 @@ int main(int argc, char* argv[])
         pal::ensure_trailing_delimiter(app_path);
     }
 
-    pal::stringstream_t native_search_dirs;
-    native_search_dirs << app_path << pal::env_path_delim;
-
     string_t core_libs = pal::getenv(envvar::coreLibraries);
     if (!core_libs.empty())
-    {
         pal::ensure_trailing_delimiter(core_libs);
-        if (core_libs != app_path)
-            native_search_dirs << core_libs << pal::env_path_delim;
-    }
 
     // CORE_ROOT locates the framework assemblies for the TPA list (the runtime itself is static on
     // wasi). On wasi the bundle co-locates the framework with the entry assembly, so default to the
@@ -178,7 +171,6 @@ int main(int argc, char* argv[])
     if (core_root.empty())
         core_root = app_path;
     pal::ensure_trailing_delimiter(core_root);
-    native_search_dirs << core_root << pal::env_path_delim;
 
     string_t exe_path = pal::get_exe_path();
 
@@ -190,8 +182,10 @@ int main(int argc, char* argv[])
     s_property_keys.push_back("APP_PATHS");
     s_property_values.push_back(app_path);
 
-    s_property_keys.push_back("NATIVE_DLL_SEARCH_DIRECTORIES");
-    s_property_values.push_back(native_search_dirs.str());
+    // NATIVE_DLL_SEARCH_DIRECTORIES is intentionally not set: on wasi native libraries are
+    // statically linked and every P/Invoke is resolved by the pinvoke_override (callhelpers) before
+    // the runtime's native-library search runs, and wasm has no shared-library/dlopen support, so
+    // the search directories can never contribute a load.
 
     // Static: the contract must outlive coreclr_initialize (the runtime keeps its address). The
     // pinvoke_override field is forwarded to PInvokeOverride::SetPInvokeOverride by the runtime.

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Thin CoreCLR-WASI corehost, built as a static archive (libWasiHost.a) and linked per-app by the
-// WASI app builder (src/mono/wasi/build/WasiApp.CoreCLR.targets) against the statically-linked
-// runtime. Mirrors browserhost, but with a real wasi:cli/run main() instead of a JS driver.
+// CoreCLR-WASI app builder against the statically-linked runtime. Mirrors browserhost, but with a
+// real wasi:cli/run main() instead of a JS driver.
 // See https://github.com/dotnet/runtime/issues/130129.
 
 #include <cstdint>

--- a/src/native/corehost/wasihost/wasihost.cpp
+++ b/src/native/corehost/wasihost/wasihost.cpp
@@ -7,7 +7,6 @@
 // See https://github.com/dotnet/runtime/issues/130129.
 
 #include <cstdint>
-#include <cstdlib>
 #include <set>
 #include <sstream>
 
@@ -58,18 +57,6 @@ extern "C"
 // to the runtime via the host contract below so app callhelpers and reverse thunks resolve. Plain
 // C++ linkage to match the generated definition (not extern "C").
 const void* callhelpers_pinvoke_override(const char* library_name, const char* entry_point_name);
-
-// JS interop QCall targets referenced by libcoreclr_static.a but never called on wasi; stubbed so
-// the relink doesn't pull the browser-only libSystem.Runtime.InteropServices.JavaScript.Native.
-extern "C"
-{
-    void* SystemInteropJS_BindJSImportST(void*) { std::abort(); }
-    void SystemInteropJS_CancelPromise(void*) { std::abort(); }
-    void SystemInteropJS_InvokeJSFunction(void*, void*) { std::abort(); }
-    void SystemInteropJS_InvokeJSImportST(int32_t, void*) { std::abort(); }
-    void SystemInteropJS_ReleaseCSOwnedObject(void*) { std::abort(); }
-    void SystemInteropJS_ResolveOrRejectPromise(void*) { std::abort(); }
-}
 
 // Weak: only linked (from libSystem.Globalization.Native.a) in a non-invariant relink; null and
 // skipped otherwise.
@@ -155,8 +142,6 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    string_t exe_path = pal::get_exe_path();
-
     // argv[1] is the managed entry assembly; argv[2..] are passed to it. Copy the slice into a
     // const char* vector rather than casting char** to const char**.
     string_t entry_assembly = pal::get_absolute_path(argv[1]);
@@ -182,15 +167,15 @@ int main(int argc, char* argv[])
     }
 
     // CORE_ROOT locates the framework assemblies for the TPA list (the runtime itself is static on
-    // wasi). Fall back to the host's own directory when unset.
+    // wasi). On wasi the bundle co-locates the framework with the entry assembly, so default to the
+    // entry assembly's directory; CORE_ROOT remains an optional override.
     string_t core_root = pal::getenv(envvar::coreRoot);
     if (core_root.empty())
-    {
-        string_t file;
-        pal::split_path_to_dir_filename(exe_path, core_root, file);
-    }
+        core_root = app_path;
     pal::ensure_trailing_delimiter(core_root);
     native_search_dirs << core_root << pal::env_path_delim;
+
+    string_t exe_path = pal::get_exe_path();
 
     string_t tpa_list = build_tpa(core_root, core_libs);
 


### PR DESCRIPTION
# [wasi] Add CoreCLR-WASI corehost (wasihost)

## Summary

Adds a proper, statically-linked corehost for the CoreCLR-WASI library-test leg, under
`src/native/corehost/wasihost/`, mirroring `browserhost` and the static `apphost`. This lets the
CoreCLR-WASI library-test leg run on a **shipping host archive** (`libWasiHost.a`) instead of
relinking the coreclr-internal `corerun`. `corerun` keeps its role for CoreCLR runtime tests.

This is the **foundation host** for the CoreCLR-WASI library-test leg (#130745) — per @pavelsavara's
review there ("we should manufacture proper corehost for this ... similar as browserhost or apphost -
statically linked").

## What it does

`src/native/corehost/wasihost/` produces `libWasiHost.a` (OUTPUT_NAME `WasiHost`), a **self-contained
STATIC** host archive installed to `sharedFramework`. It is linked per-app (whole-archive, so
`main`/`_start` are pulled) by the CoreCLR-WASI app builder together with the runtime-pack static
libraries and the app-generated P/Invoke callhelpers.

The host is **thin** (browserhost-style, not hostfxr/hostpolicy):
- Builds the CoreCLR init properties (TPA/APP_PATHS/NATIVE_DLL_SEARCH_DIRECTORIES) from `CORE_ROOT`.
- Sets `host_runtime_contract.pinvoke_override` to the app-generated `callhelpers_pinvoke_override`.
  `coreclr_initialize` forwards this to `PInvokeOverride::SetPInvokeOverride(..., RuntimeConfiguration)`
  — the sanctioned host↔runtime P/Invoke override interface, the same registration `corerun` performs
  internally. This keeps the archive self-contained (no coreclr `contract.h`/`specstrings.h` drag-in).
- Preloads `icudt.dat` via a weak `GlobalizationNative_LoadICUData` (skipped for invariant relinks).
- Runs `coreclr_initialize` / `coreclr_execute_assembly` with a real `wasi:cli/run` `main()`.
- Emits the `WASM EXIT <n>` marker under `DOTNET_WASI_PRINT_EXIT_CODE=1` (until `exit-with-code`,
  stable in WASI 0.3, is reachable from a wasip2 target).

It reuses the `corerun` pal header for `CORE_ROOT`/TPA/path handling so assembly discovery is
byte-identical to the corerun-based host.

## Build enablement / packaging

- `corehost/CMakeLists.txt`: new `CLR_CMAKE_TARGET_WASI` branch that builds only `wasihost` (no
  `hostmisc` dependency — the archive is self-contained), so wasi no longer falls into the full
  apphost/fxr/hostpolicy branch.
- `corehost.proj`: acquire the wasi-sdk and pass `WASI_SDK_PATH` to the native build; stage
  `libWasiHost.a` into the runtime pack native dir (`CopyWasiNativeFiles`, mirroring browser's
  `CopyWasmNativeFiles`).
- `eng/liveBuilds.targets`: package `libWasiHost.a` from `$(HostSharedFrameworkDir)` for wasi CoreCLR
  (mirrors the browser `libBrowserHost.a` entry; excluded from the runtime-tests build like browser).
- `Directory.Build.props`: add the `libWasiHost.a` platform manifest entry.

## Validation

- Builds via `./build.sh -s host.native -os wasi -c Release` — 0 warnings / 0 errors; installs to
  `HostSharedFrameworkDir`.
- Symbol contract verified: `__main_argc_argv` defined (whole-archive entry), `coreclr_*` and the
  C++-mangled `callhelpers_pinvoke_override` undefined (relink-provided), `GlobalizationNative_LoadICUData`
  weak, JS-interop stubs defined.
- Relinked `System.Runtime.Tests` against this archive (non-invariant, full ICU) with
  `wasm-component-ld` → valid wasm component; under wasmtime it initializes CoreCLR, discovers all
  9930 test cases, and executes tests (a `System.Tests.VersionTests` subset ran 251/251 passing,
  `WASM EXIT 0`).

## Consumer

Paired with the CoreCLR-WASI library-test leg in #130745, which will flip its per-app relink from the
corerun static archive to this host-built `libWasiHost.a` once this lands.

> [!NOTE]
> This PR (code and description) was authored with GitHub Copilot.
