### PR TITLE
Enable additional library tests in ReadyToRun pipeline

### DIFF
--- a/src/libraries/System.Reflection.TypeExtensions/tests/ModuleTests.cs
+++ b/src/libraries/System.Reflection.TypeExtensions/tests/ModuleTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using Xunit;
 
 namespace System.Reflection.Tests
@@ -22,11 +23,10 @@ namespace System.Reflection.Tests
             }
         }
 
-        // This calls Assembly.Load, but xUnit turn is into a LoadFrom because TinyAssembly is just a Content item in the project.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsAssemblyLoadingSupported))]
         public void GetModuleVersionId_KnownAssembly_ReturnsExpected()
         {
-            Module module = Assembly.Load(new AssemblyName("TinyAssembly")).ManifestModule;
+            Module module = Assembly.LoadFrom(Path.Combine(AppContext.BaseDirectory, "TinyAssembly.dll")).ManifestModule;
             Assert.True(module.HasModuleVersionId());
             if (!(PlatformDetection.IsMonoRuntime && PlatformDetection.IsAppleMobile && PlatformDetection.IsBuiltWithAggressiveTrimming))
             {

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -129,4 +129,13 @@
     <Delete Files="$(OutDir)System.Runtime.Loader.Test.BindFailure.Locked.dll" />
     <Delete Files="$(OutDir)System.Runtime.Loader.Test.BindFailure.Corrupt.dll" />
   </Target>
+
+  <Target Name="RemoveBindFailureTestAssembliesFromReadyToRunPublish"
+          Condition="'$(TestReadyToRun)' == 'true'"
+          AfterTargets="Publish"
+          BeforeTargets="ZipTestArchive">
+    <Delete Files="$(BundleDir)System.Runtime.Loader.Test.BindFailure.Missing.dll" />
+    <Delete Files="$(BundleDir)System.Runtime.Loader.Test.BindFailure.Locked.dll" />
+    <Delete Files="$(BundleDir)System.Runtime.Loader.Test.BindFailure.Corrupt.dll" />
+  </Target>
 </Project>

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/AssemblyTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/AssemblyTests.cs
@@ -154,7 +154,7 @@ namespace System.Reflection.Tests
             string assembly = Assembly.GetEntryAssembly().ToString();
 
             bool correct;
-            if (PlatformDetection.IsNativeAot)
+            if (PlatformDetection.IsNativeAot || PlatformDetection.IsReadyToRunCompiled)
             {
                 // The single file test runner is not 'xunit.console'.
                 correct = assembly.IndexOf("System.Reflection.Tests", StringComparison.OrdinalIgnoreCase) != -1;

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -666,7 +666,6 @@
   <ItemGroup Condition="'$(TestReadyToRun)' == 'true'">
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime/tests/System.Reflection.Tests/System.Reflection.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.TypeExtensions/tests/System.Reflection.TypeExtensions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader/tests/DefaultContext/System.Runtime.Loader.DefaultContext.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj" />
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -664,7 +664,6 @@
       Tracking Issue for this work item: https://github.com/dotnet/runtime/issues/95928
   -->
   <ItemGroup Condition="'$(TestReadyToRun)' == 'true'">
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.TypeExtensions/tests/System.Reflection.TypeExtensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj" />
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -664,7 +664,6 @@
       Tracking Issue for this work item: https://github.com/dotnet/runtime/issues/95928
   -->
   <ItemGroup Condition="'$(TestReadyToRun)' == 'true'">
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime/tests/System.Reflection.Tests/System.Reflection.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.TypeExtensions/tests/System.Reflection.TypeExtensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -655,16 +655,8 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Numerics.Tensors\tests\System.Numerics.Tensors.Tests.csproj" Condition="'$(TargetArchitecture)' == 'x64'" />
   </ItemGroup>
 
-  <!--
-      There is a decent number of hidden tests that fail with TestReadyToRun, and
-      it's proven to be a neverending task to flush all of them at once. So, we will
-      start by only enabling the tests we have confirmed work correctly, and we will
-      gradually enable the rest in subsequent PR's.
-
-      Tracking Issue for this work item: https://github.com/dotnet/runtime/issues/95928
-  -->
   <ItemGroup Condition="'$(TestReadyToRun)' == 'true'">
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj" />
+    <!-- https://github.com/dotnet/runtime/issues/95928 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/129832 -->


### PR DESCRIPTION
## Summary

- Enable ReadyToRun coverage for `System.Runtime.Loader.DefaultContext.Tests`, `System.Reflection.Tests`, `System.Reflection.TypeExtensions.Tests`, and `System.Runtime.Loader.Tests`.
- Account for the ReadyToRun test runner being the entry assembly in Reflection tests.
- Load the TypeExtensions fixture explicitly from the published test directory.
- Remove bind-failure fixtures from the ReadyToRun publish directory before Helix archives it, while retaining their `deps.json` entries.
- Keep `System.Text.RegularExpressions.Tests` excluded for follow-up work.

Part of #95928.
