### PR TITLE
Compact NativeAOT dispatch cell info encoding

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
@@ -47,6 +47,11 @@ namespace Internal.Runtime.TypeLoader
             return Initialize(module, ReflectionMapBlob.CommonFixupsTable);
         }
 
+        public bool InitializeNativeReferences(TypeManagerHandle module)
+        {
+            return Initialize(module, ReflectionMapBlob.NativeReferences);
+        }
+
         public unsafe IntPtr GetIntPtrFromIndex(uint index)
         {
             return GetAddressFromIndex(index);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 using Internal.Metadata.NativeFormat;
 using Internal.Runtime.Augments;
@@ -23,13 +22,13 @@ namespace Internal.Runtime
                 var pDispatchCellRegion = (DispatchCell*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.InterfaceDispatchCellRegion, out int length);
                 if ((byte*)pCell >= (byte*)pDispatchCellRegion && (byte*)pCell < (byte*)pDispatchCellRegion + length)
                 {
-                    return ResolveStaticInterfaceDispatch(typeManager, pObject, (nint)(pCell - pDispatchCellRegion));
+                    return ResolveStaticInterfaceDispatch(typeManager, pObject, (nuint)(pCell - pDispatchCellRegion), (uint)(length / sizeof(DispatchCell)));
                 }
 
                 pDispatchCellRegion = (DispatchCell*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.GvmDispatchCellRegion, out length);
                 if ((byte*)pCell >= (byte*)pDispatchCellRegion && (byte*)pCell < (byte*)pDispatchCellRegion + length)
                 {
-                    return ResolveGvmDispatch(typeManager, pObject, (nint)(pCell - pDispatchCellRegion));
+                    return ResolveGvmDispatch(typeManager, pObject, (nuint)(pCell - pDispatchCellRegion), (uint)(length / sizeof(DispatchCell)));
                 }
             }
 
@@ -51,85 +50,144 @@ namespace Internal.Runtime
             return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, (MethodTable*)pDynamicInterfaceCell->InterfaceType, (ushort)pDynamicInterfaceCell->Slot);
         }
 
-        private static unsafe IntPtr ResolveStaticInterfaceDispatch(TypeManagerHandle typeManager, object pObject, nint cellIndex)
+        private static unsafe IntPtr ResolveStaticInterfaceDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex, uint cellCount)
         {
-            IntPtr pDispatchCellInfoRegion = RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.InterfaceDispatchCellInfoRegion, out _);
-            if (MethodTable.SupportsRelativePointers)
+            if (cellIndex >= cellCount)
+                throw new BadImageFormatException();
+
+            byte* pInfo = (byte*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.InterfaceDispatchCellInfoRegion, out int length);
+            int pointerSize = MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint);
+            int descriptorSize = pointerSize + sizeof(ushort);
+            byte* pointerTable;
+            byte* slotTable;
+            uint descriptorIndex;
+
+            if ((ulong)length == (ulong)cellCount * (uint)descriptorSize)
             {
-                var dispatchCellInfo = &((RelativeInterfaceDispatchInfo*)pDispatchCellInfoRegion)[cellIndex];
-                return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, dispatchCellInfo->InterfaceType, (ushort)dispatchCellInfo->Slot);
+                pointerTable = pInfo;
+                slotTable = pInfo + (nuint)cellCount * (uint)pointerSize;
+                descriptorIndex = checked((uint)cellIndex);
             }
             else
             {
-                var dispatchCellInfo = &((InterfaceDispatchInfo*)pDispatchCellInfoRegion)[cellIndex];
-                return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, dispatchCellInfo->InterfaceType, (ushort)dispatchCellInfo->Slot);
+                GetDictionaryTables(pInfo, length, cellCount, pointerSize, descriptorSize, cellIndex,
+                    out descriptorIndex, out uint descriptorCount, out pointerTable);
+                slotTable = pointerTable + (nuint)descriptorCount * (uint)pointerSize;
             }
+
+            MethodTable* interfaceType = ReadMethodTable(pointerTable + (nuint)descriptorIndex * (uint)pointerSize);
+            ushort slot = *(ushort*)(slotTable + (nuint)descriptorIndex * sizeof(ushort));
+            return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, interfaceType, slot);
         }
 
-        private static unsafe IntPtr ResolveGvmDispatch(TypeManagerHandle typeManager, object pObject, nint cellIndex)
+        private static unsafe IntPtr ResolveGvmDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex, uint cellCount)
         {
-            IntPtr pDispatchCellInfoRegion = RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.GvmDispatchCellInfoRegion, out _);
-            if (MethodTable.SupportsRelativePointers)
+            if (cellIndex >= cellCount)
+                throw new BadImageFormatException();
+
+            byte* pInfo = (byte*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.GvmDispatchCellInfoRegion, out int length);
+            int pointerSize = MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint);
+            int descriptorSize = 2 * pointerSize + sizeof(int);
+            byte* owningTypeTable;
+            byte* instantiationTable;
+            byte* flagsAndTokenTable;
+            uint descriptorIndex;
+
+            if ((ulong)length == (ulong)cellCount * (uint)descriptorSize)
             {
-                var dispatchCellInfo = &((RelativeGvmDispatchInfo*)pDispatchCellInfoRegion)[cellIndex];
-                return RuntimeAugments.TypeLoaderCallbacks.ResolveGenericVirtualMethodTarget(
-                    new RuntimeTypeHandle(pObject.GetMethodTable()), new RuntimeTypeHandle(dispatchCellInfo->OwningType), dispatchCellInfo->Handle, dispatchCellInfo->IsAsyncVariant, dispatchCellInfo->Instantiation, isMethodInstantiationDataRelative: true);
+                owningTypeTable = pInfo;
+                instantiationTable = pInfo + (nuint)cellCount * (uint)pointerSize;
+                flagsAndTokenTable = instantiationTable + (nuint)cellCount * (uint)pointerSize;
+                descriptorIndex = checked((uint)cellIndex);
             }
             else
             {
-                var dispatchCellInfo = &((GvmDispatchInfo*)pDispatchCellInfoRegion)[cellIndex];
-                return RuntimeAugments.TypeLoaderCallbacks.ResolveGenericVirtualMethodTarget(
-                    new RuntimeTypeHandle(pObject.GetMethodTable()), new RuntimeTypeHandle(dispatchCellInfo->OwningType), dispatchCellInfo->Handle, dispatchCellInfo->IsAsyncVariant, dispatchCellInfo->Instantiation, isMethodInstantiationDataRelative: false);
+                GetDictionaryTables(pInfo, length, cellCount, pointerSize, descriptorSize, cellIndex,
+                    out descriptorIndex, out uint descriptorCount, out owningTypeTable);
+                instantiationTable = owningTypeTable + (nuint)descriptorCount * (uint)pointerSize;
+                flagsAndTokenTable = instantiationTable + (nuint)descriptorCount * (uint)pointerSize;
             }
+
+            MethodTable* owningType = ReadMethodTable(owningTypeTable + (nuint)descriptorIndex * (uint)pointerSize);
+            void* instantiation = ReadPointer(instantiationTable + (nuint)descriptorIndex * (uint)pointerSize);
+            int flagsAndToken = *(int*)(flagsAndTokenTable + (nuint)descriptorIndex * sizeof(int));
+
+            return RuntimeAugments.TypeLoaderCallbacks.ResolveGenericVirtualMethodTarget(
+                new RuntimeTypeHandle(pObject.GetMethodTable()),
+                new RuntimeTypeHandle(owningType),
+                new MethodHandle(flagsAndToken & ~GvmDispatchCellFlags.IsAsyncVariant),
+                (flagsAndToken & GvmDispatchCellFlags.IsAsyncVariant) != 0,
+                instantiation,
+                isMethodInstantiationDataRelative: MethodTable.SupportsRelativePointers);
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct RelativeInterfaceDispatchInfo
+        private static unsafe void GetDictionaryTables(
+            byte* pInfo,
+            int length,
+            uint cellCount,
+            int pointerSize,
+            int descriptorSize,
+            nuint cellIndex,
+            out uint descriptorIndex,
+            out uint descriptorCount,
+            out byte* pointerTable)
         {
-            private int _interfaceTypeRelPtr;
-            public int Slot;
+            // Dictionary format:
+            // uint descriptorCount; index[cellCount]; padding; descriptor field arrays.
+            if (length < sizeof(uint))
+                throw new BadImageFormatException();
 
-            public unsafe MethodTable* InterfaceType
-                => (MethodTable*)((byte*)Unsafe.AsPointer(ref _interfaceTypeRelPtr) + _interfaceTypeRelPtr);
+            descriptorCount = *(uint*)pInfo;
+            if (descriptorCount == 0)
+                throw new BadImageFormatException();
+
+            int indexSize = GetIndexSize(descriptorCount);
+            ulong pointerTableOffset = AlignUp(sizeof(uint) + (ulong)cellCount * (uint)indexSize, (uint)pointerSize);
+            ulong expectedLength = pointerTableOffset + (ulong)descriptorCount * (uint)descriptorSize;
+            if ((ulong)length != expectedLength || cellIndex >= cellCount)
+                throw new BadImageFormatException();
+
+            byte* pIndex = pInfo + sizeof(uint) + cellIndex * (uint)indexSize;
+            descriptorIndex = indexSize switch
+            {
+                sizeof(byte) => *pIndex,
+                sizeof(ushort) => *(ushort*)pIndex,
+                _ => *(uint*)pIndex,
+            };
+
+            if (descriptorIndex >= descriptorCount)
+                throw new BadImageFormatException();
+
+            pointerTable = pInfo + pointerTableOffset;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct InterfaceDispatchInfo
+        private static int GetIndexSize(uint descriptorCount)
         {
-            public unsafe MethodTable* InterfaceType;
-            private nint _slot;
+            if (descriptorCount <= 1 << 8)
+                return sizeof(byte);
 
-            public int Slot => (int)_slot;
+            if (descriptorCount <= 1 << 16)
+                return sizeof(ushort);
+
+            return sizeof(uint);
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct RelativeGvmDispatchInfo
+        private static ulong AlignUp(ulong value, uint alignment)
         {
-            private int _owningTypeRelPtr;
-            private int _compositionRelPtr;
-            private int _flagsAndToken;
-
-            public unsafe MethodTable* OwningType
-                => (MethodTable*)((byte*)Unsafe.AsPointer(ref _owningTypeRelPtr) + _owningTypeRelPtr);
-
-            public unsafe void* Instantiation
-                => (byte*)Unsafe.AsPointer(ref _compositionRelPtr) + _compositionRelPtr;
-
-            public MethodHandle Handle => new MethodHandle(_flagsAndToken & ~GvmDispatchCellFlags.IsAsyncVariant);
-
-            public bool IsAsyncVariant => (_flagsAndToken & GvmDispatchCellFlags.IsAsyncVariant) != 0;
+            return (value + alignment - 1) & ~(alignment - 1);
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct GvmDispatchInfo
+        private static unsafe MethodTable* ReadMethodTable(byte* address)
         {
-            public unsafe MethodTable* OwningType;
-            public unsafe void* Instantiation;
-            private nint _flagsAndToken;
+            return (MethodTable*)ReadPointer(address);
+        }
 
-            public MethodHandle Handle => new MethodHandle((int)_flagsAndToken & ~GvmDispatchCellFlags.IsAsyncVariant);
+        private static unsafe void* ReadPointer(byte* address)
+        {
+            if (MethodTable.SupportsRelativePointers)
+                return address + *(int*)address;
 
-            public bool IsAsyncVariant => ((int)_flagsAndToken & GvmDispatchCellFlags.IsAsyncVariant) != 0;
+            return *(void**)address;
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
@@ -61,7 +61,6 @@ namespace Internal.Runtime
                 typeManager,
                 ReadyToRunSectionType.InterfaceDispatchCellInfoRegion,
                 checked((uint)cellIndex),
-                cellCount,
                 out ExternalReferencesTable externalReferences);
 
             uint interfaceTypeIndex = parser.GetUnsigned();
@@ -79,7 +78,6 @@ namespace Internal.Runtime
                 typeManager,
                 ReadyToRunSectionType.GvmDispatchCellInfoRegion,
                 checked((uint)cellIndex),
-                cellCount,
                 out ExternalReferencesTable externalReferences);
 
             uint owningTypeIndex = parser.GetUnsigned();
@@ -103,7 +101,6 @@ namespace Internal.Runtime
             TypeManagerHandle typeManager,
             ReadyToRunSectionType section,
             uint cellIndex,
-            uint cellCount,
             out ExternalReferencesTable externalReferences)
         {
             byte* pInfo = (byte*)RuntimeImports.RhGetModuleSection(typeManager, section, out int length);
@@ -113,30 +110,15 @@ namespace Internal.Runtime
 
             NativeReader reader = new NativeReader(pInfo, checked((uint)length));
             NativeArray entries = new NativeArray(new NativeParser(reader, 0));
-            uint entryCount = entries.GetCount();
 
-            uint low = 0;
-            uint high = entryCount;
-            while (low < high)
+            NativeParser parser;
+            while (!entries.TryGetAt(cellIndex, out parser))
             {
-                uint middle = low + ((high - low) >> 1);
-                bool found = entries.TryGetAt(middle, out NativeParser parser);
-                Debug.Assert(found);
-
-                if (parser.GetUnsigned() <= cellIndex)
-                    low = middle + 1;
-                else
-                    high = middle;
+                Debug.Assert(cellIndex > 0);
+                cellIndex--;
             }
 
-            Debug.Assert(low < entryCount);
-            bool resultFound = entries.TryGetAt(low, out NativeParser result);
-            Debug.Assert(resultFound);
-
-            uint endCellIndex = result.GetUnsigned();
-            Debug.Assert(endCellIndex > cellIndex && endCellIndex <= cellCount);
-
-            return result;
+            return parser;
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
@@ -6,8 +6,10 @@ using System.Runtime;
 using System.Runtime.CompilerServices;
 
 using Internal.Metadata.NativeFormat;
+using Internal.NativeFormat;
 using Internal.Runtime.Augments;
 using Internal.Runtime.CompilerHelpers;
+using Internal.Runtime.TypeLoader;
 
 namespace Internal.Runtime
 {
@@ -55,29 +57,35 @@ namespace Internal.Runtime
             if (cellIndex >= cellCount)
                 throw new BadImageFormatException();
 
-            byte* pInfo = (byte*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.InterfaceDispatchCellInfoRegion, out int length);
-            int pointerSize = MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint);
-            int descriptorSize = pointerSize + sizeof(ushort);
-            byte* pointerTable;
-            byte* slotTable;
-            uint descriptorIndex;
+            NativeParser parser = GetDispatchCellInfoParser(
+                typeManager,
+                ReadyToRunSectionType.InterfaceDispatchCellInfoRegion,
+                out ExternalReferencesTable externalReferences);
 
-            if ((ulong)length == (ulong)cellCount * (uint)descriptorSize)
+            uint remainingCellIndex = checked((uint)cellIndex);
+            uint entryCount = parser.GetSequenceCount();
+            for (uint i = 0; i < entryCount; i++)
             {
-                pointerTable = pInfo;
-                slotTable = pInfo + (nuint)cellCount * (uint)pointerSize;
-                descriptorIndex = checked((uint)cellIndex);
-            }
-            else
-            {
-                GetDictionaryTables(pInfo, length, cellCount, pointerSize, descriptorSize, cellIndex,
-                    out descriptorIndex, out uint descriptorCount, out pointerTable);
-                slotTable = pointerTable + (nuint)descriptorCount * (uint)pointerSize;
+                uint runLength = parser.GetUnsigned();
+                uint interfaceTypeIndex = parser.GetUnsigned();
+                uint slot = parser.GetUnsigned();
+
+                if (runLength == 0)
+                    throw new BadImageFormatException();
+
+                if (remainingCellIndex < runLength)
+                {
+                    if (slot > ushort.MaxValue)
+                        throw new BadImageFormatException();
+
+                    MethodTable* interfaceType = (MethodTable*)externalReferences.GetIntPtrFromIndex(interfaceTypeIndex);
+                    return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, interfaceType, (ushort)slot);
+                }
+
+                remainingCellIndex -= runLength;
             }
 
-            MethodTable* interfaceType = ReadMethodTable(pointerTable + (nuint)descriptorIndex * (uint)pointerSize);
-            ushort slot = *(ushort*)(slotTable + (nuint)descriptorIndex * sizeof(ushort));
-            return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, interfaceType, slot);
+            throw new BadImageFormatException();
         }
 
         private static unsafe IntPtr ResolveGvmDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex, uint cellCount)
@@ -85,109 +93,58 @@ namespace Internal.Runtime
             if (cellIndex >= cellCount)
                 throw new BadImageFormatException();
 
-            byte* pInfo = (byte*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.GvmDispatchCellInfoRegion, out int length);
-            int pointerSize = MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint);
-            int descriptorSize = 2 * pointerSize + sizeof(int);
-            byte* owningTypeTable;
-            byte* instantiationTable;
-            byte* flagsAndTokenTable;
-            uint descriptorIndex;
+            NativeParser parser = GetDispatchCellInfoParser(
+                typeManager,
+                ReadyToRunSectionType.GvmDispatchCellInfoRegion,
+                out ExternalReferencesTable externalReferences);
 
-            if ((ulong)length == (ulong)cellCount * (uint)descriptorSize)
+            uint remainingCellIndex = checked((uint)cellIndex);
+            uint entryCount = parser.GetSequenceCount();
+            for (uint i = 0; i < entryCount; i++)
             {
-                owningTypeTable = pInfo;
-                instantiationTable = pInfo + (nuint)cellCount * (uint)pointerSize;
-                flagsAndTokenTable = instantiationTable + (nuint)cellCount * (uint)pointerSize;
-                descriptorIndex = checked((uint)cellIndex);
+                uint runLength = parser.GetUnsigned();
+                uint owningTypeIndex = parser.GetUnsigned();
+                uint instantiationIndex = parser.GetUnsigned();
+                uint token = parser.GetUnsigned();
+                uint isAsyncVariant = parser.GetUnsigned();
+
+                if (runLength == 0 || token > int.MaxValue || isAsyncVariant > 1)
+                    throw new BadImageFormatException();
+
+                if (remainingCellIndex < runLength)
+                {
+                    MethodTable* owningType = (MethodTable*)externalReferences.GetIntPtrFromIndex(owningTypeIndex);
+                    void* instantiation = (void*)externalReferences.GetIntPtrFromIndex(instantiationIndex);
+
+                    return RuntimeAugments.TypeLoaderCallbacks.ResolveGenericVirtualMethodTarget(
+                        new RuntimeTypeHandle(pObject.GetMethodTable()),
+                        new RuntimeTypeHandle(owningType),
+                        new MethodHandle((int)token),
+                        isAsyncVariant != 0,
+                        instantiation,
+                        isMethodInstantiationDataRelative: MethodTable.SupportsRelativePointers);
+                }
+
+                remainingCellIndex -= runLength;
             }
-            else
-            {
-                GetDictionaryTables(pInfo, length, cellCount, pointerSize, descriptorSize, cellIndex,
-                    out descriptorIndex, out uint descriptorCount, out owningTypeTable);
-                instantiationTable = owningTypeTable + (nuint)descriptorCount * (uint)pointerSize;
-                flagsAndTokenTable = instantiationTable + (nuint)descriptorCount * (uint)pointerSize;
-            }
 
-            MethodTable* owningType = ReadMethodTable(owningTypeTable + (nuint)descriptorIndex * (uint)pointerSize);
-            void* instantiation = ReadPointer(instantiationTable + (nuint)descriptorIndex * (uint)pointerSize);
-            int flagsAndToken = *(int*)(flagsAndTokenTable + (nuint)descriptorIndex * sizeof(int));
-
-            return RuntimeAugments.TypeLoaderCallbacks.ResolveGenericVirtualMethodTarget(
-                new RuntimeTypeHandle(pObject.GetMethodTable()),
-                new RuntimeTypeHandle(owningType),
-                new MethodHandle(flagsAndToken & ~GvmDispatchCellFlags.IsAsyncVariant),
-                (flagsAndToken & GvmDispatchCellFlags.IsAsyncVariant) != 0,
-                instantiation,
-                isMethodInstantiationDataRelative: MethodTable.SupportsRelativePointers);
+            throw new BadImageFormatException();
         }
 
-        private static unsafe void GetDictionaryTables(
-            byte* pInfo,
-            int length,
-            uint cellCount,
-            int pointerSize,
-            int descriptorSize,
-            nuint cellIndex,
-            out uint descriptorIndex,
-            out uint descriptorCount,
-            out byte* pointerTable)
+        private static unsafe NativeParser GetDispatchCellInfoParser(
+            TypeManagerHandle typeManager,
+            ReadyToRunSectionType section,
+            out ExternalReferencesTable externalReferences)
         {
-            // Dictionary format:
-            // uint descriptorCount; index[cellCount]; padding; descriptor field arrays.
-            if (length < sizeof(uint))
+            byte* pInfo = (byte*)RuntimeImports.RhGetModuleSection(typeManager, section, out int length);
+            if (length <= 0)
                 throw new BadImageFormatException();
 
-            descriptorCount = *(uint*)pInfo;
-            if (descriptorCount == 0)
+            externalReferences = default;
+            if (!externalReferences.InitializeNativeReferences(typeManager))
                 throw new BadImageFormatException();
 
-            int indexSize = GetIndexSize(descriptorCount);
-            ulong pointerTableOffset = AlignUp(sizeof(uint) + (ulong)cellCount * (uint)indexSize, (uint)pointerSize);
-            ulong expectedLength = pointerTableOffset + (ulong)descriptorCount * (uint)descriptorSize;
-            if ((ulong)length != expectedLength || cellIndex >= cellCount)
-                throw new BadImageFormatException();
-
-            byte* pIndex = pInfo + sizeof(uint) + cellIndex * (uint)indexSize;
-            descriptorIndex = indexSize switch
-            {
-                sizeof(byte) => *pIndex,
-                sizeof(ushort) => *(ushort*)pIndex,
-                _ => *(uint*)pIndex,
-            };
-
-            if (descriptorIndex >= descriptorCount)
-                throw new BadImageFormatException();
-
-            pointerTable = pInfo + pointerTableOffset;
-        }
-
-        private static int GetIndexSize(uint descriptorCount)
-        {
-            if (descriptorCount <= 1 << 8)
-                return sizeof(byte);
-
-            if (descriptorCount <= 1 << 16)
-                return sizeof(ushort);
-
-            return sizeof(uint);
-        }
-
-        private static ulong AlignUp(ulong value, uint alignment)
-        {
-            return (value + alignment - 1) & ~(alignment - 1);
-        }
-
-        private static unsafe MethodTable* ReadMethodTable(byte* address)
-        {
-            return (MethodTable*)ReadPointer(address);
-        }
-
-        private static unsafe void* ReadPointer(byte* address)
-        {
-            if (MethodTable.SupportsRelativePointers)
-                return address + *(int*)address;
-
-            return *(void**)address;
+            return new NativeParser(new NativeReader(pInfo, checked((uint)length)), 0);
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
@@ -25,13 +25,13 @@ namespace Internal.Runtime
                 var pDispatchCellRegion = (DispatchCell*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.InterfaceDispatchCellRegion, out int length);
                 if ((byte*)pCell >= (byte*)pDispatchCellRegion && (byte*)pCell < (byte*)pDispatchCellRegion + length)
                 {
-                    return ResolveStaticInterfaceDispatch(typeManager, pObject, (nuint)(pCell - pDispatchCellRegion), (uint)(length / sizeof(DispatchCell)));
+                    return ResolveStaticInterfaceDispatch(typeManager, pObject, (nuint)(pCell - pDispatchCellRegion));
                 }
 
                 pDispatchCellRegion = (DispatchCell*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.GvmDispatchCellRegion, out length);
                 if ((byte*)pCell >= (byte*)pDispatchCellRegion && (byte*)pCell < (byte*)pDispatchCellRegion + length)
                 {
-                    return ResolveGvmDispatch(typeManager, pObject, (nuint)(pCell - pDispatchCellRegion), (uint)(length / sizeof(DispatchCell)));
+                    return ResolveGvmDispatch(typeManager, pObject, (nuint)(pCell - pDispatchCellRegion));
                 }
             }
 
@@ -53,10 +53,8 @@ namespace Internal.Runtime
             return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, (MethodTable*)pDynamicInterfaceCell->InterfaceType, (ushort)pDynamicInterfaceCell->Slot);
         }
 
-        private static unsafe IntPtr ResolveStaticInterfaceDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex, uint cellCount)
+        private static unsafe IntPtr ResolveStaticInterfaceDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex)
         {
-            Debug.Assert(cellIndex < cellCount);
-
             NativeParser parser = GetDispatchCellInfo(
                 typeManager,
                 ReadyToRunSectionType.InterfaceDispatchCellInfoRegion,
@@ -70,10 +68,8 @@ namespace Internal.Runtime
             return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, interfaceType, checked((ushort)slot));
         }
 
-        private static unsafe IntPtr ResolveGvmDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex, uint cellCount)
+        private static unsafe IntPtr ResolveGvmDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex)
         {
-            Debug.Assert(cellIndex < cellCount);
-
             NativeParser parser = GetDispatchCellInfo(
                 typeManager,
                 ReadyToRunSectionType.GvmDispatchCellInfoRegion,

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
@@ -55,8 +55,7 @@ namespace Internal.Runtime
 
         private static unsafe IntPtr ResolveStaticInterfaceDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex, uint cellCount)
         {
-            if (cellIndex >= cellCount)
-                throw new BadImageFormatException();
+            Debug.Assert(cellIndex < cellCount);
 
             NativeParser parser = GetDispatchCellInfo(
                 typeManager,
@@ -68,17 +67,13 @@ namespace Internal.Runtime
             uint interfaceTypeIndex = parser.GetUnsigned();
             uint slot = parser.GetUnsigned();
 
-            if (slot > ushort.MaxValue)
-                throw new BadImageFormatException();
-
             MethodTable* interfaceType = (MethodTable*)externalReferences.GetIntPtrFromIndex(interfaceTypeIndex);
-            return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, interfaceType, (ushort)slot);
+            return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, interfaceType, checked((ushort)slot));
         }
 
         private static unsafe IntPtr ResolveGvmDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex, uint cellCount)
         {
-            if (cellIndex >= cellCount)
-                throw new BadImageFormatException();
+            Debug.Assert(cellIndex < cellCount);
 
             NativeParser parser = GetDispatchCellInfo(
                 typeManager,
@@ -91,9 +86,6 @@ namespace Internal.Runtime
             uint instantiationIndex = parser.GetUnsigned();
             uint token = parser.GetUnsigned();
             uint isAsyncVariant = parser.GetUnsigned();
-
-            if (token > int.MaxValue || isAsyncVariant > 1)
-                throw new BadImageFormatException();
 
             MethodTable* owningType = (MethodTable*)externalReferences.GetIntPtrFromIndex(owningTypeIndex);
             void* instantiation = (void*)externalReferences.GetIntPtrFromIndex(instantiationIndex);
@@ -115,12 +107,9 @@ namespace Internal.Runtime
             out ExternalReferencesTable externalReferences)
         {
             byte* pInfo = (byte*)RuntimeImports.RhGetModuleSection(typeManager, section, out int length);
-            if (length <= 0)
-                throw new BadImageFormatException();
 
             externalReferences = default;
-            if (!externalReferences.InitializeNativeReferences(typeManager))
-                throw new BadImageFormatException();
+            externalReferences.InitializeNativeReferences(typeManager);
 
             NativeReader reader = new NativeReader(pInfo, checked((uint)length));
             NativeArray entries = new NativeArray(new NativeParser(reader, 0));

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Dispatch.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 
@@ -57,35 +58,21 @@ namespace Internal.Runtime
             if (cellIndex >= cellCount)
                 throw new BadImageFormatException();
 
-            NativeParser parser = GetDispatchCellInfoParser(
+            NativeParser parser = GetDispatchCellInfo(
                 typeManager,
                 ReadyToRunSectionType.InterfaceDispatchCellInfoRegion,
+                checked((uint)cellIndex),
+                cellCount,
                 out ExternalReferencesTable externalReferences);
 
-            uint remainingCellIndex = checked((uint)cellIndex);
-            uint entryCount = parser.GetSequenceCount();
-            for (uint i = 0; i < entryCount; i++)
-            {
-                uint runLength = parser.GetUnsigned();
-                uint interfaceTypeIndex = parser.GetUnsigned();
-                uint slot = parser.GetUnsigned();
+            uint interfaceTypeIndex = parser.GetUnsigned();
+            uint slot = parser.GetUnsigned();
 
-                if (runLength == 0)
-                    throw new BadImageFormatException();
+            if (slot > ushort.MaxValue)
+                throw new BadImageFormatException();
 
-                if (remainingCellIndex < runLength)
-                {
-                    if (slot > ushort.MaxValue)
-                        throw new BadImageFormatException();
-
-                    MethodTable* interfaceType = (MethodTable*)externalReferences.GetIntPtrFromIndex(interfaceTypeIndex);
-                    return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, interfaceType, (ushort)slot);
-                }
-
-                remainingCellIndex -= runLength;
-            }
-
-            throw new BadImageFormatException();
+            MethodTable* interfaceType = (MethodTable*)externalReferences.GetIntPtrFromIndex(interfaceTypeIndex);
+            return CachedInterfaceDispatch.RhResolveDispatchWorker(pObject, interfaceType, (ushort)slot);
         }
 
         private static unsafe IntPtr ResolveGvmDispatch(TypeManagerHandle typeManager, object pObject, nuint cellIndex, uint cellCount)
@@ -93,47 +80,38 @@ namespace Internal.Runtime
             if (cellIndex >= cellCount)
                 throw new BadImageFormatException();
 
-            NativeParser parser = GetDispatchCellInfoParser(
+            NativeParser parser = GetDispatchCellInfo(
                 typeManager,
                 ReadyToRunSectionType.GvmDispatchCellInfoRegion,
+                checked((uint)cellIndex),
+                cellCount,
                 out ExternalReferencesTable externalReferences);
 
-            uint remainingCellIndex = checked((uint)cellIndex);
-            uint entryCount = parser.GetSequenceCount();
-            for (uint i = 0; i < entryCount; i++)
-            {
-                uint runLength = parser.GetUnsigned();
-                uint owningTypeIndex = parser.GetUnsigned();
-                uint instantiationIndex = parser.GetUnsigned();
-                uint token = parser.GetUnsigned();
-                uint isAsyncVariant = parser.GetUnsigned();
+            uint owningTypeIndex = parser.GetUnsigned();
+            uint instantiationIndex = parser.GetUnsigned();
+            uint token = parser.GetUnsigned();
+            uint isAsyncVariant = parser.GetUnsigned();
 
-                if (runLength == 0 || token > int.MaxValue || isAsyncVariant > 1)
-                    throw new BadImageFormatException();
+            if (token > int.MaxValue || isAsyncVariant > 1)
+                throw new BadImageFormatException();
 
-                if (remainingCellIndex < runLength)
-                {
-                    MethodTable* owningType = (MethodTable*)externalReferences.GetIntPtrFromIndex(owningTypeIndex);
-                    void* instantiation = (void*)externalReferences.GetIntPtrFromIndex(instantiationIndex);
+            MethodTable* owningType = (MethodTable*)externalReferences.GetIntPtrFromIndex(owningTypeIndex);
+            void* instantiation = (void*)externalReferences.GetIntPtrFromIndex(instantiationIndex);
 
-                    return RuntimeAugments.TypeLoaderCallbacks.ResolveGenericVirtualMethodTarget(
-                        new RuntimeTypeHandle(pObject.GetMethodTable()),
-                        new RuntimeTypeHandle(owningType),
-                        new MethodHandle((int)token),
-                        isAsyncVariant != 0,
-                        instantiation,
-                        isMethodInstantiationDataRelative: MethodTable.SupportsRelativePointers);
-                }
-
-                remainingCellIndex -= runLength;
-            }
-
-            throw new BadImageFormatException();
+            return RuntimeAugments.TypeLoaderCallbacks.ResolveGenericVirtualMethodTarget(
+                new RuntimeTypeHandle(pObject.GetMethodTable()),
+                new RuntimeTypeHandle(owningType),
+                new MethodHandle((int)token),
+                isAsyncVariant != 0,
+                instantiation,
+                isMethodInstantiationDataRelative: MethodTable.SupportsRelativePointers);
         }
 
-        private static unsafe NativeParser GetDispatchCellInfoParser(
+        private static unsafe NativeParser GetDispatchCellInfo(
             TypeManagerHandle typeManager,
             ReadyToRunSectionType section,
+            uint cellIndex,
+            uint cellCount,
             out ExternalReferencesTable externalReferences)
         {
             byte* pInfo = (byte*)RuntimeImports.RhGetModuleSection(typeManager, section, out int length);
@@ -144,7 +122,32 @@ namespace Internal.Runtime
             if (!externalReferences.InitializeNativeReferences(typeManager))
                 throw new BadImageFormatException();
 
-            return new NativeParser(new NativeReader(pInfo, checked((uint)length)), 0);
+            NativeReader reader = new NativeReader(pInfo, checked((uint)length));
+            NativeArray entries = new NativeArray(new NativeParser(reader, 0));
+            uint entryCount = entries.GetCount();
+
+            uint low = 0;
+            uint high = entryCount;
+            while (low < high)
+            {
+                uint middle = low + ((high - low) >> 1);
+                bool found = entries.TryGetAt(middle, out NativeParser parser);
+                Debug.Assert(found);
+
+                if (parser.GetUnsigned() <= cellIndex)
+                    low = middle + 1;
+                else
+                    high = middle;
+            }
+
+            Debug.Assert(low < entryCount);
+            bool resultFound = entries.TryGetAt(low, out NativeParser result);
+            Debug.Assert(resultFound);
+
+            uint endCellIndex = result.GetUnsigned();
+            Debug.Assert(endCellIndex > cellIndex && endCellIndex <= cellCount);
+
+            return result;
         }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
@@ -101,7 +101,6 @@ namespace ILCompiler.DependencyAnalysis
             ProxyTypeMapObjectNode,
             StackTraceLineNumbersNode,
             StackTraceDocumentsNode,
-            ExternalReferencesTableNode,
             StackTraceEmbeddedMetadataNode,
             StackTraceMethodMappingNode,
             ArrayOfEmbeddedDataNode,
@@ -109,6 +108,7 @@ namespace ILCompiler.DependencyAnalysis
             InterfaceDispatchCellSection,
             GvmDispatchCellInfoSection,
             GvmDispatchCellSection,
+            ExternalReferencesTableNode,
 
             //
             // Wasm type signatures (need to be emitted some time before the unordered phase)

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.cs
@@ -453,6 +453,88 @@ namespace Internal.NativeFormat
         }
     }
 
+    internal struct NativeArray
+    {
+        private const uint BlockSize = 16;
+
+        private NativeReader _reader;
+        private uint _baseOffset;
+        private uint _nElements;
+        private byte _entryIndexSize;
+
+        public NativeArray(NativeParser parser)
+        {
+            _reader = parser.Reader;
+            _baseOffset = _reader.DecodeUnsigned(parser.Offset, out uint val);
+            _nElements = val >> 2;
+
+            byte entryIndexSize = (byte)(val & 3);
+            if (entryIndexSize > 2)
+                NativeReader.ThrowBadImageFormatException();
+            _entryIndexSize = entryIndexSize;
+        }
+
+        public uint GetCount()
+        {
+            return _nElements;
+        }
+
+        public bool TryGetAt(uint index, out NativeParser parser)
+        {
+            parser = default;
+
+            if (index >= _nElements)
+                return false;
+
+            uint offset;
+            if (_entryIndexSize == 0)
+            {
+                offset = _reader.ReadUInt8(_baseOffset + (index / BlockSize));
+            }
+            else if (_entryIndexSize == 1)
+            {
+                offset = _reader.ReadUInt16(_baseOffset + 2 * (index / BlockSize));
+            }
+            else
+            {
+                offset = _reader.ReadUInt32(_baseOffset + 4 * (index / BlockSize));
+            }
+            offset += _baseOffset;
+
+            for (uint bit = BlockSize >> 1; bit > 0; bit >>= 1)
+            {
+                uint offset2 = _reader.DecodeUnsigned(offset, out uint val);
+                if ((index & bit) != 0)
+                {
+                    if ((val & 2) != 0)
+                    {
+                        offset += val >> 2;
+                        continue;
+                    }
+                }
+                else
+                {
+                    if ((val & 1) != 0)
+                    {
+                        offset = offset2;
+                        continue;
+                    }
+                }
+
+                if ((val & 3) == 0 && (val >> 2) == (index & (BlockSize - 1)))
+                {
+                    offset = offset2;
+                    break;
+                }
+
+                return false;
+            }
+
+            parser = new NativeParser(_reader, offset);
+            return true;
+        }
+    }
+
     internal struct NativeHashtable
     {
         private NativeReader _reader;

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
@@ -1705,7 +1705,8 @@ namespace Internal.NativeFormat
                 if (place)
                     _section.Place(tree);
 
-                _section.Place(second);
+                second = _section.Place(second);
+                tree.Update(first, second);
 
                 isLeaf = false;
                 return tree;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DispatchCellNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DispatchCellNode.cs
@@ -14,6 +14,7 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class DispatchCellNode : SortableDependencyNode, ISymbolDefinitionNode
     {
         private const int InvalidOffset = -1;
+        internal const int MaxCellInfoLookupDistance = 100;
 
         private readonly MethodDesc _targetMethod;
         private readonly ISortableSymbolNode _callSiteIdentifier;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DispatchCellNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DispatchCellNode.cs
@@ -108,44 +108,14 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
     }
 
-    internal static class DispatchCellInfoEncoding
+    internal sealed class DispatchCellInfoComparer : IComparer<DispatchCellNode>
     {
-        // The direct format stores descriptor fields in parallel arrays. If enough cells share a
-        // descriptor, the dictionary format prefixes the unique descriptor arrays with a compact
-        // per-cell index. The section size tells the runtime which format was selected.
-        public static int GetIndexSize(int descriptorCount)
+        private readonly CompilerComparer _comparer = CompilerComparer.Instance;
+
+        public int Compare(DispatchCellNode x, DispatchCellNode y)
         {
-            if (descriptorCount <= 1 << 8)
-                return sizeof(byte);
-
-            if (descriptorCount <= 1 << 16)
-                return sizeof(ushort);
-
-            return sizeof(uint);
-        }
-
-        public static int GetDictionarySize(int cellCount, int descriptorCount, int pointerSize, int descriptorSize)
-        {
-            int indexSize = GetIndexSize(descriptorCount);
-            int pointerTableOffset = AlignmentHelper.AlignUp(checked(sizeof(uint) + checked(cellCount * indexSize)), pointerSize);
-            return checked(pointerTableOffset + checked(descriptorCount * descriptorSize));
-        }
-
-        public static void EmitIndex(ref ObjectDataBuilder builder, int index, int indexSize)
-        {
-            switch (indexSize)
-            {
-                case sizeof(byte):
-                    builder.EmitByte(checked((byte)index));
-                    break;
-                case sizeof(ushort):
-                    builder.EmitUShort(checked((ushort)index));
-                    break;
-                default:
-                    Debug.Assert(indexSize == sizeof(uint));
-                    builder.EmitUInt(checked((uint)index));
-                    break;
-            }
+            int result = _comparer.Compare(x.TargetMethod, y.TargetMethod);
+            return result != 0 ? result : _comparer.Compare(x.CallSiteIdentifier, y.CallSiteIdentifier);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DispatchCellNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DispatchCellNode.cs
@@ -107,4 +107,45 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
     }
+
+    internal static class DispatchCellInfoEncoding
+    {
+        // The direct format stores descriptor fields in parallel arrays. If enough cells share a
+        // descriptor, the dictionary format prefixes the unique descriptor arrays with a compact
+        // per-cell index. The section size tells the runtime which format was selected.
+        public static int GetIndexSize(int descriptorCount)
+        {
+            if (descriptorCount <= 1 << 8)
+                return sizeof(byte);
+
+            if (descriptorCount <= 1 << 16)
+                return sizeof(ushort);
+
+            return sizeof(uint);
+        }
+
+        public static int GetDictionarySize(int cellCount, int descriptorCount, int pointerSize, int descriptorSize)
+        {
+            int indexSize = GetIndexSize(descriptorCount);
+            int pointerTableOffset = AlignmentHelper.AlignUp(checked(sizeof(uint) + checked(cellCount * indexSize)), pointerSize);
+            return checked(pointerTableOffset + checked(descriptorCount * descriptorSize));
+        }
+
+        public static void EmitIndex(ref ObjectDataBuilder builder, int index, int indexSize)
+        {
+            switch (indexSize)
+            {
+                case sizeof(byte):
+                    builder.EmitByte(checked((byte)index));
+                    break;
+                case sizeof(ushort):
+                    builder.EmitUShort(checked((ushort)index));
+                    break;
+                default:
+                    Debug.Assert(indexSize == sizeof(uint));
+                    builder.EmitUInt(checked((uint)index));
+                    break;
+            }
+        }
+    }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GvmDispatchCellInfoSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GvmDispatchCellInfoSectionNode.cs
@@ -50,7 +50,6 @@ namespace ILCompiler.DependencyAnalysis
             var entries = new VertexArray(section);
             section.Place(entries);
 
-            int entryIndex = 0;
             for (int firstCell = 0; firstCell < cells.Count;)
             {
                 MethodDesc targetMethod = cells[firstCell].TargetMethod;
@@ -63,14 +62,16 @@ namespace ILCompiler.DependencyAnalysis
 
                 int token = factory.MetadataManager.GetMetadataHandleForMethod(factory, GetMethodForMetadata(targetMethod, out bool isAsyncVariant));
 
-                entries.Set(entryIndex++, writer.GetTuple(
-                    writer.GetUnsignedConstant(checked((uint)nextCell)),
+                Vertex entry = writer.GetTuple(
                     writer.GetUnsignedConstant(owningTypeIndex),
                     writer.GetTuple(
                         writer.GetUnsignedConstant(instantiationIndex),
                         writer.GetTuple(
                             writer.GetUnsignedConstant(checked((uint)(token & MetadataManager.MetadataOffsetMask))),
-                            writer.GetUnsignedConstant(isAsyncVariant ? 1u : 0u)))));
+                            writer.GetUnsignedConstant(isAsyncVariant ? 1u : 0u))));
+
+                for (int cell = firstCell; cell < nextCell; cell += DispatchCellNode.MaxCellInfoLookupDistance)
+                    entries.Set(cell, entry);
 
                 firstCell = nextCell;
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GvmDispatchCellInfoSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GvmDispatchCellInfoSectionNode.cs
@@ -47,10 +47,10 @@ namespace ILCompiler.DependencyAnalysis
 
             var writer = new NativeWriter();
             Section section = writer.NewSection();
-            var entries = new VertexSequence();
+            var entries = new VertexArray(section);
             section.Place(entries);
 
-            // Cells are ordered by descriptor, so each entry describes one contiguous run.
+            int entryIndex = 0;
             for (int firstCell = 0; firstCell < cells.Count;)
             {
                 MethodDesc targetMethod = cells[firstCell].TargetMethod;
@@ -63,8 +63,8 @@ namespace ILCompiler.DependencyAnalysis
 
                 int token = factory.MetadataManager.GetMetadataHandleForMethod(factory, GetMethodForMetadata(targetMethod, out bool isAsyncVariant));
 
-                entries.Append(writer.GetTuple(
-                    writer.GetUnsignedConstant(checked((uint)(nextCell - firstCell))),
+                entries.Set(entryIndex++, writer.GetTuple(
+                    writer.GetUnsignedConstant(checked((uint)nextCell)),
                     writer.GetUnsignedConstant(owningTypeIndex),
                     writer.GetTuple(
                         writer.GetUnsignedConstant(instantiationIndex),
@@ -74,6 +74,8 @@ namespace ILCompiler.DependencyAnalysis
 
                 firstCell = nextCell;
             }
+
+            entries.ExpandLayout();
 
             return new ObjectData(writer.Save(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GvmDispatchCellInfoSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GvmDispatchCellInfoSectionNode.cs
@@ -24,41 +24,100 @@ namespace ILCompiler.DependencyAnalysis
             if (relocsOnly)
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
 
+            var cells = new List<DispatchCellNode>();
+            foreach (DispatchCellNode node in new SortedSet<DispatchCellNode>(factory.MetadataManager.GetDispatchCells(), new DispatchCellComparer()))
+            {
+                if (!node.TargetMethod.HasInstantiation)
+                    continue;
+
+                node.InitializeOffset(checked(cells.Count * node.Size));
+                cells.Add(node);
+            }
+
+            var descriptorIndices = new Dictionary<MethodDesc, int>();
+            var descriptors = new List<MethodDesc>();
+            var cellDescriptorIndices = new int[cells.Count];
+
+            for (int i = 0; i < cells.Count; i++)
+            {
+                MethodDesc targetMethod = cells[i].TargetMethod;
+                if (!descriptorIndices.TryGetValue(targetMethod, out int descriptorIndex))
+                {
+                    descriptorIndex = descriptors.Count;
+                    descriptorIndices.Add(targetMethod, descriptorIndex);
+                    descriptors.Add(targetMethod);
+                }
+
+                cellDescriptorIndices[i] = descriptorIndex;
+            }
+
             var builder = new ObjectDataBuilder(factory, relocsOnly);
             builder.AddSymbol(this);
 
             builder.RequireInitialAlignment(factory.Target.PointerSize);
 
-            int currentDispatchCellOffset = 0;
-            foreach (DispatchCellNode node in new SortedSet<DispatchCellNode>(factory.MetadataManager.GetDispatchCells(), new DispatchCellComparer()))
+            int pointerSize = factory.Target.SupportsRelativePointers ? sizeof(int) : factory.Target.PointerSize;
+            int descriptorSize = checked(2 * pointerSize + sizeof(int));
+            int directSize = checked(cells.Count * descriptorSize);
+            int dictionarySize = DispatchCellInfoEncoding.GetDictionarySize(cells.Count, descriptors.Count, pointerSize, descriptorSize);
+
+            if (dictionarySize < directSize)
             {
-                MethodDesc targetMethod = node.TargetMethod;
-                if (!targetMethod.HasInstantiation)
-                    continue;
+                builder.EmitUInt(checked((uint)descriptors.Count));
 
-                node.InitializeOffset(currentDispatchCellOffset);
+                int indexSize = DispatchCellInfoEncoding.GetIndexSize(descriptors.Count);
+                foreach (int descriptorIndex in cellDescriptorIndices)
+                    DispatchCellInfoEncoding.EmitIndex(ref builder, descriptorIndex, indexSize);
 
-                int token = factory.MetadataManager.GetMetadataHandleForMethod(factory, GetMethodForMetadata(targetMethod, out bool isAsyncVariant));
-                int flags = isAsyncVariant ? GvmDispatchCellFlags.IsAsyncVariant : 0;
-                int flagsAndToken = (token & MetadataManager.MetadataOffsetMask) | flags;
+                builder.PadAlignment(pointerSize);
 
-                if (factory.Target.SupportsRelativePointers)
-                {
-                    builder.EmitReloc(factory.MaximallyConstructableType(targetMethod.OwningType), RelocType.IMAGE_REL_BASED_RELPTR32);
-                    builder.EmitReloc(factory.ConstructedGenericComposition(targetMethod.Instantiation), RelocType.IMAGE_REL_BASED_RELPTR32);
-                    builder.EmitInt(flagsAndToken);
-                }
-                else
-                {
-                    builder.EmitPointerReloc(factory.MaximallyConstructableType(targetMethod.OwningType));
-                    builder.EmitPointerReloc(factory.ConstructedGenericComposition(targetMethod.Instantiation));
-                    builder.EmitNaturalInt(flagsAndToken);
-                }
+                foreach (MethodDesc targetMethod in descriptors)
+                    EmitOwningType(ref builder, factory, targetMethod);
 
-                currentDispatchCellOffset += node.Size;
+                foreach (MethodDesc targetMethod in descriptors)
+                    EmitInstantiation(ref builder, factory, targetMethod);
+
+                foreach (MethodDesc targetMethod in descriptors)
+                    EmitFlagsAndToken(ref builder, factory, targetMethod);
+            }
+            else
+            {
+                foreach (DispatchCellNode cell in cells)
+                    EmitOwningType(ref builder, factory, cell.TargetMethod);
+
+                foreach (DispatchCellNode cell in cells)
+                    EmitInstantiation(ref builder, factory, cell.TargetMethod);
+
+                foreach (DispatchCellNode cell in cells)
+                    EmitFlagsAndToken(ref builder, factory, cell.TargetMethod);
             }
 
             return builder.ToObjectData();
+        }
+
+        private static void EmitOwningType(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
+        {
+            IEETypeNode owningType = factory.MaximallyConstructableType(targetMethod.OwningType);
+            if (factory.Target.SupportsRelativePointers)
+                builder.EmitReloc(owningType, RelocType.IMAGE_REL_BASED_RELPTR32);
+            else
+                builder.EmitPointerReloc(owningType);
+        }
+
+        private static void EmitInstantiation(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
+        {
+            ISymbolNode instantiation = factory.ConstructedGenericComposition(targetMethod.Instantiation);
+            if (factory.Target.SupportsRelativePointers)
+                builder.EmitReloc(instantiation, RelocType.IMAGE_REL_BASED_RELPTR32);
+            else
+                builder.EmitPointerReloc(instantiation);
+        }
+
+        private static void EmitFlagsAndToken(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
+        {
+            int token = factory.MetadataManager.GetMetadataHandleForMethod(factory, GetMethodForMetadata(targetMethod, out bool isAsyncVariant));
+            int flags = isAsyncVariant ? GvmDispatchCellFlags.IsAsyncVariant : 0;
+            builder.EmitInt((token & MetadataManager.MetadataOffsetMask) | flags);
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GvmDispatchCellInfoSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GvmDispatchCellInfoSectionNode.cs
@@ -3,11 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+
+using Internal.NativeFormat;
 using Internal.Runtime;
 using Internal.Text;
 using Internal.TypeSystem;
 
-using Debug = System.Diagnostics.Debug;
 using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
 using DependencyListEntry = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyListEntry;
 
@@ -19,13 +20,20 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     public class GvmDispatchCellInfoSectionNode : ObjectNode, ISymbolDefinitionNode
     {
+        private readonly ExternalReferencesTableNode _externalReferences;
+
+        public GvmDispatchCellInfoSectionNode(ExternalReferencesTableNode externalReferences)
+        {
+            _externalReferences = externalReferences;
+        }
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             if (relocsOnly)
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
 
             var cells = new List<DispatchCellNode>();
-            foreach (DispatchCellNode node in new SortedSet<DispatchCellNode>(factory.MetadataManager.GetDispatchCells(), new DispatchCellComparer()))
+            foreach (DispatchCellNode node in new SortedSet<DispatchCellNode>(factory.MetadataManager.GetDispatchCells(), new DispatchCellInfoComparer()))
             {
                 if (!node.TargetMethod.HasInstantiation)
                     continue;
@@ -34,90 +42,40 @@ namespace ILCompiler.DependencyAnalysis
                 cells.Add(node);
             }
 
-            var descriptorIndices = new Dictionary<MethodDesc, int>();
-            var descriptors = new List<MethodDesc>();
-            var cellDescriptorIndices = new int[cells.Count];
+            if (cells.Count == 0)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
 
-            for (int i = 0; i < cells.Count; i++)
+            var writer = new NativeWriter();
+            Section section = writer.NewSection();
+            var entries = new VertexSequence();
+            section.Place(entries);
+
+            // Cells are ordered by descriptor, so each entry describes one contiguous run.
+            for (int firstCell = 0; firstCell < cells.Count;)
             {
-                MethodDesc targetMethod = cells[i].TargetMethod;
-                if (!descriptorIndices.TryGetValue(targetMethod, out int descriptorIndex))
-                {
-                    descriptorIndex = descriptors.Count;
-                    descriptorIndices.Add(targetMethod, descriptorIndex);
-                    descriptors.Add(targetMethod);
-                }
+                MethodDesc targetMethod = cells[firstCell].TargetMethod;
+                int nextCell = firstCell + 1;
+                while (nextCell < cells.Count && cells[nextCell].TargetMethod == targetMethod)
+                    nextCell++;
 
-                cellDescriptorIndices[i] = descriptorIndex;
+                uint owningTypeIndex = _externalReferences.GetIndex(factory.MaximallyConstructableType(targetMethod.OwningType));
+                uint instantiationIndex = _externalReferences.GetIndex(factory.ConstructedGenericComposition(targetMethod.Instantiation));
+
+                int token = factory.MetadataManager.GetMetadataHandleForMethod(factory, GetMethodForMetadata(targetMethod, out bool isAsyncVariant));
+
+                entries.Append(writer.GetTuple(
+                    writer.GetUnsignedConstant(checked((uint)(nextCell - firstCell))),
+                    writer.GetUnsignedConstant(owningTypeIndex),
+                    writer.GetTuple(
+                        writer.GetUnsignedConstant(instantiationIndex),
+                        writer.GetTuple(
+                            writer.GetUnsignedConstant(checked((uint)(token & MetadataManager.MetadataOffsetMask))),
+                            writer.GetUnsignedConstant(isAsyncVariant ? 1u : 0u)))));
+
+                firstCell = nextCell;
             }
 
-            var builder = new ObjectDataBuilder(factory, relocsOnly);
-            builder.AddSymbol(this);
-
-            builder.RequireInitialAlignment(factory.Target.PointerSize);
-
-            int pointerSize = factory.Target.SupportsRelativePointers ? sizeof(int) : factory.Target.PointerSize;
-            int descriptorSize = checked(2 * pointerSize + sizeof(int));
-            int directSize = checked(cells.Count * descriptorSize);
-            int dictionarySize = DispatchCellInfoEncoding.GetDictionarySize(cells.Count, descriptors.Count, pointerSize, descriptorSize);
-
-            if (dictionarySize < directSize)
-            {
-                builder.EmitUInt(checked((uint)descriptors.Count));
-
-                int indexSize = DispatchCellInfoEncoding.GetIndexSize(descriptors.Count);
-                foreach (int descriptorIndex in cellDescriptorIndices)
-                    DispatchCellInfoEncoding.EmitIndex(ref builder, descriptorIndex, indexSize);
-
-                builder.PadAlignment(pointerSize);
-
-                foreach (MethodDesc targetMethod in descriptors)
-                    EmitOwningType(ref builder, factory, targetMethod);
-
-                foreach (MethodDesc targetMethod in descriptors)
-                    EmitInstantiation(ref builder, factory, targetMethod);
-
-                foreach (MethodDesc targetMethod in descriptors)
-                    EmitFlagsAndToken(ref builder, factory, targetMethod);
-            }
-            else
-            {
-                foreach (DispatchCellNode cell in cells)
-                    EmitOwningType(ref builder, factory, cell.TargetMethod);
-
-                foreach (DispatchCellNode cell in cells)
-                    EmitInstantiation(ref builder, factory, cell.TargetMethod);
-
-                foreach (DispatchCellNode cell in cells)
-                    EmitFlagsAndToken(ref builder, factory, cell.TargetMethod);
-            }
-
-            return builder.ToObjectData();
-        }
-
-        private static void EmitOwningType(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
-        {
-            IEETypeNode owningType = factory.MaximallyConstructableType(targetMethod.OwningType);
-            if (factory.Target.SupportsRelativePointers)
-                builder.EmitReloc(owningType, RelocType.IMAGE_REL_BASED_RELPTR32);
-            else
-                builder.EmitPointerReloc(owningType);
-        }
-
-        private static void EmitInstantiation(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
-        {
-            ISymbolNode instantiation = factory.ConstructedGenericComposition(targetMethod.Instantiation);
-            if (factory.Target.SupportsRelativePointers)
-                builder.EmitReloc(instantiation, RelocType.IMAGE_REL_BASED_RELPTR32);
-            else
-                builder.EmitPointerReloc(instantiation);
-        }
-
-        private static void EmitFlagsAndToken(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
-        {
-            int token = factory.MetadataManager.GetMetadataHandleForMethod(factory, GetMethodForMetadata(targetMethod, out bool isAsyncVariant));
-            int flags = isAsyncVariant ? GvmDispatchCellFlags.IsAsyncVariant : 0;
-            builder.EmitInt((token & MetadataManager.MetadataOffsetMask) | flags);
+            return new ObjectData(writer.Save(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -170,29 +128,5 @@ namespace ILCompiler.DependencyAnalysis
             return targetMethodForMetadata;
         }
 
-        /// <summary>
-        /// Comparer that groups GVM dispatch cells by their callsite.
-        /// </summary>
-        private sealed class DispatchCellComparer : IComparer<DispatchCellNode>
-        {
-            private readonly CompilerComparer _comparer = CompilerComparer.Instance;
-
-            public int Compare(DispatchCellNode x, DispatchCellNode y)
-            {
-                int result = _comparer.Compare(x.CallSiteIdentifier, y.CallSiteIdentifier);
-                if (result != 0)
-                    return result;
-
-                MethodDesc methodX = x.TargetMethod;
-                MethodDesc methodY = y.TargetMethod;
-
-                result = _comparer.Compare(methodX, methodY);
-                if (result != 0)
-                    return result;
-
-                Debug.Assert(x == y);
-                return 0;
-            }
-        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellInfoSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellInfoSectionNode.cs
@@ -25,38 +25,84 @@ namespace ILCompiler.DependencyAnalysis
             if (relocsOnly)
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
 
+            var cells = new List<DispatchCellNode>();
+            foreach (DispatchCellNode node in new SortedSet<DispatchCellNode>(factory.MetadataManager.GetDispatchCells(), new DispatchCellComparer()))
+            {
+                if (node.TargetMethod.HasInstantiation)
+                    continue;
+
+                node.InitializeOffset(checked(cells.Count * node.Size));
+                cells.Add(node);
+            }
+
+            var descriptorIndices = new Dictionary<MethodDesc, int>();
+            var descriptors = new List<MethodDesc>();
+            var cellDescriptorIndices = new int[cells.Count];
+
+            for (int i = 0; i < cells.Count; i++)
+            {
+                MethodDesc targetMethod = cells[i].TargetMethod;
+                if (!descriptorIndices.TryGetValue(targetMethod, out int descriptorIndex))
+                {
+                    descriptorIndex = descriptors.Count;
+                    descriptorIndices.Add(targetMethod, descriptorIndex);
+                    descriptors.Add(targetMethod);
+                }
+
+                cellDescriptorIndices[i] = descriptorIndex;
+            }
+
             var builder = new ObjectDataBuilder(factory, relocsOnly);
             builder.AddSymbol(this);
 
             builder.RequireInitialAlignment(factory.Target.PointerSize);
 
-            int currentDispatchCellOffset = 0;
-            foreach (DispatchCellNode node in new SortedSet<DispatchCellNode>(factory.MetadataManager.GetDispatchCells(), new DispatchCellComparer()))
+            int pointerSize = factory.Target.SupportsRelativePointers ? sizeof(int) : factory.Target.PointerSize;
+            int descriptorSize = checked(pointerSize + sizeof(ushort));
+            int directSize = checked(cells.Count * descriptorSize);
+            int dictionarySize = DispatchCellInfoEncoding.GetDictionarySize(cells.Count, descriptors.Count, pointerSize, descriptorSize);
+
+            if (dictionarySize < directSize)
             {
-                MethodDesc targetMethod = node.TargetMethod;
-                if (targetMethod.HasInstantiation)
-                    continue;
+                builder.EmitUInt(checked((uint)descriptors.Count));
 
-                int targetSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod, targetMethod.OwningType);
+                int indexSize = DispatchCellInfoEncoding.GetIndexSize(descriptors.Count);
+                foreach (int descriptorIndex in cellDescriptorIndices)
+                    DispatchCellInfoEncoding.EmitIndex(ref builder, descriptorIndex, indexSize);
 
-                node.InitializeOffset(currentDispatchCellOffset);
+                builder.PadAlignment(pointerSize);
 
-                IEETypeNode interfaceType = GetInterfaceTypeNode(factory, targetMethod);
-                if (factory.Target.SupportsRelativePointers)
-                {
-                    builder.EmitReloc(interfaceType, RelocType.IMAGE_REL_BASED_RELPTR32);
-                    builder.EmitInt(targetSlot);
-                }
-                else
-                {
-                    builder.EmitPointerReloc(interfaceType);
-                    builder.EmitNaturalInt(targetSlot);
-                }
+                foreach (MethodDesc targetMethod in descriptors)
+                    EmitInterfaceType(ref builder, factory, targetMethod);
 
-                currentDispatchCellOffset += node.Size;
+                foreach (MethodDesc targetMethod in descriptors)
+                    EmitSlot(ref builder, factory, targetMethod);
+            }
+            else
+            {
+                foreach (DispatchCellNode cell in cells)
+                    EmitInterfaceType(ref builder, factory, cell.TargetMethod);
+
+                foreach (DispatchCellNode cell in cells)
+                    EmitSlot(ref builder, factory, cell.TargetMethod);
             }
 
             return builder.ToObjectData();
+        }
+
+        private static void EmitInterfaceType(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
+        {
+            IEETypeNode interfaceType = GetInterfaceTypeNode(factory, targetMethod);
+            if (factory.Target.SupportsRelativePointers)
+                builder.EmitReloc(interfaceType, RelocType.IMAGE_REL_BASED_RELPTR32);
+            else
+                builder.EmitPointerReloc(interfaceType);
+        }
+
+        private static void EmitSlot(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
+        {
+            int targetSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod, targetMethod.OwningType);
+            builder.EmitUShort(checked((ushort)targetSlot));
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellInfoSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellInfoSectionNode.cs
@@ -47,10 +47,10 @@ namespace ILCompiler.DependencyAnalysis
 
             var writer = new NativeWriter();
             Section section = writer.NewSection();
-            var entries = new VertexSequence();
+            var entries = new VertexArray(section);
             section.Place(entries);
 
-            // Cells are ordered by descriptor, so each entry describes one contiguous run.
+            int entryIndex = 0;
             for (int firstCell = 0; firstCell < cells.Count;)
             {
                 MethodDesc targetMethod = cells[firstCell].TargetMethod;
@@ -60,13 +60,15 @@ namespace ILCompiler.DependencyAnalysis
 
                 uint interfaceTypeIndex = _externalReferences.GetIndex(GetInterfaceTypeNode(factory, targetMethod));
                 int targetSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod, targetMethod.OwningType);
-                entries.Append(writer.GetTuple(
-                    writer.GetUnsignedConstant(checked((uint)(nextCell - firstCell))),
+                entries.Set(entryIndex++, writer.GetTuple(
+                    writer.GetUnsignedConstant(checked((uint)nextCell)),
                     writer.GetUnsignedConstant(interfaceTypeIndex),
                     writer.GetUnsignedConstant(checked((uint)targetSlot))));
 
                 firstCell = nextCell;
             }
+
+            entries.ExpandLayout();
 
             return new ObjectData(writer.Save(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellInfoSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellInfoSectionNode.cs
@@ -4,11 +4,11 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.NativeFormat;
 using Internal.Runtime;
 using Internal.Text;
 using Internal.TypeSystem;
 
-using Debug = System.Diagnostics.Debug;
 using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
 using DependencyListEntry = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyListEntry;
 
@@ -20,13 +20,20 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     public class InterfaceDispatchCellInfoSectionNode : ObjectNode, ISymbolDefinitionNode
     {
+        private readonly ExternalReferencesTableNode _externalReferences;
+
+        public InterfaceDispatchCellInfoSectionNode(ExternalReferencesTableNode externalReferences)
+        {
+            _externalReferences = externalReferences;
+        }
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             if (relocsOnly)
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
 
             var cells = new List<DispatchCellNode>();
-            foreach (DispatchCellNode node in new SortedSet<DispatchCellNode>(factory.MetadataManager.GetDispatchCells(), new DispatchCellComparer()))
+            foreach (DispatchCellNode node in new SortedSet<DispatchCellNode>(factory.MetadataManager.GetDispatchCells(), new DispatchCellInfoComparer()))
             {
                 if (node.TargetMethod.HasInstantiation)
                     continue;
@@ -35,74 +42,33 @@ namespace ILCompiler.DependencyAnalysis
                 cells.Add(node);
             }
 
-            var descriptorIndices = new Dictionary<MethodDesc, int>();
-            var descriptors = new List<MethodDesc>();
-            var cellDescriptorIndices = new int[cells.Count];
+            if (cells.Count == 0)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
 
-            for (int i = 0; i < cells.Count; i++)
+            var writer = new NativeWriter();
+            Section section = writer.NewSection();
+            var entries = new VertexSequence();
+            section.Place(entries);
+
+            // Cells are ordered by descriptor, so each entry describes one contiguous run.
+            for (int firstCell = 0; firstCell < cells.Count;)
             {
-                MethodDesc targetMethod = cells[i].TargetMethod;
-                if (!descriptorIndices.TryGetValue(targetMethod, out int descriptorIndex))
-                {
-                    descriptorIndex = descriptors.Count;
-                    descriptorIndices.Add(targetMethod, descriptorIndex);
-                    descriptors.Add(targetMethod);
-                }
+                MethodDesc targetMethod = cells[firstCell].TargetMethod;
+                int nextCell = firstCell + 1;
+                while (nextCell < cells.Count && cells[nextCell].TargetMethod == targetMethod)
+                    nextCell++;
 
-                cellDescriptorIndices[i] = descriptorIndex;
+                uint interfaceTypeIndex = _externalReferences.GetIndex(GetInterfaceTypeNode(factory, targetMethod));
+                int targetSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod, targetMethod.OwningType);
+                entries.Append(writer.GetTuple(
+                    writer.GetUnsignedConstant(checked((uint)(nextCell - firstCell))),
+                    writer.GetUnsignedConstant(interfaceTypeIndex),
+                    writer.GetUnsignedConstant(checked((uint)targetSlot))));
+
+                firstCell = nextCell;
             }
 
-            var builder = new ObjectDataBuilder(factory, relocsOnly);
-            builder.AddSymbol(this);
-
-            builder.RequireInitialAlignment(factory.Target.PointerSize);
-
-            int pointerSize = factory.Target.SupportsRelativePointers ? sizeof(int) : factory.Target.PointerSize;
-            int descriptorSize = checked(pointerSize + sizeof(ushort));
-            int directSize = checked(cells.Count * descriptorSize);
-            int dictionarySize = DispatchCellInfoEncoding.GetDictionarySize(cells.Count, descriptors.Count, pointerSize, descriptorSize);
-
-            if (dictionarySize < directSize)
-            {
-                builder.EmitUInt(checked((uint)descriptors.Count));
-
-                int indexSize = DispatchCellInfoEncoding.GetIndexSize(descriptors.Count);
-                foreach (int descriptorIndex in cellDescriptorIndices)
-                    DispatchCellInfoEncoding.EmitIndex(ref builder, descriptorIndex, indexSize);
-
-                builder.PadAlignment(pointerSize);
-
-                foreach (MethodDesc targetMethod in descriptors)
-                    EmitInterfaceType(ref builder, factory, targetMethod);
-
-                foreach (MethodDesc targetMethod in descriptors)
-                    EmitSlot(ref builder, factory, targetMethod);
-            }
-            else
-            {
-                foreach (DispatchCellNode cell in cells)
-                    EmitInterfaceType(ref builder, factory, cell.TargetMethod);
-
-                foreach (DispatchCellNode cell in cells)
-                    EmitSlot(ref builder, factory, cell.TargetMethod);
-            }
-
-            return builder.ToObjectData();
-        }
-
-        private static void EmitInterfaceType(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
-        {
-            IEETypeNode interfaceType = GetInterfaceTypeNode(factory, targetMethod);
-            if (factory.Target.SupportsRelativePointers)
-                builder.EmitReloc(interfaceType, RelocType.IMAGE_REL_BASED_RELPTR32);
-            else
-                builder.EmitPointerReloc(interfaceType);
-        }
-
-        private static void EmitSlot(ref ObjectDataBuilder builder, NodeFactory factory, MethodDesc targetMethod)
-        {
-            int targetSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod, targetMethod.OwningType);
-            builder.EmitUShort(checked((ushort)targetSlot));
+            return new ObjectData(writer.Save(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -150,29 +116,5 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        /// <summary>
-        /// Comparer that groups interface dispatch cells by their callsite.
-        /// </summary>
-        private sealed class DispatchCellComparer : IComparer<DispatchCellNode>
-        {
-            private readonly CompilerComparer _comparer = CompilerComparer.Instance;
-
-            public int Compare(DispatchCellNode x, DispatchCellNode y)
-            {
-                int result = _comparer.Compare(x.CallSiteIdentifier, y.CallSiteIdentifier);
-                if (result != 0)
-                    return result;
-
-                MethodDesc methodX = x.TargetMethod;
-                MethodDesc methodY = y.TargetMethod;
-
-                result = _comparer.Compare(methodX, methodY);
-                if (result != 0)
-                    return result;
-
-                Debug.Assert(x == y);
-                return 0;
-            }
-        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellInfoSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellInfoSectionNode.cs
@@ -50,7 +50,6 @@ namespace ILCompiler.DependencyAnalysis
             var entries = new VertexArray(section);
             section.Place(entries);
 
-            int entryIndex = 0;
             for (int firstCell = 0; firstCell < cells.Count;)
             {
                 MethodDesc targetMethod = cells[firstCell].TargetMethod;
@@ -60,10 +59,12 @@ namespace ILCompiler.DependencyAnalysis
 
                 uint interfaceTypeIndex = _externalReferences.GetIndex(GetInterfaceTypeNode(factory, targetMethod));
                 int targetSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod, targetMethod.OwningType);
-                entries.Set(entryIndex++, writer.GetTuple(
-                    writer.GetUnsignedConstant(checked((uint)nextCell)),
+                Vertex entry = writer.GetTuple(
                     writer.GetUnsignedConstant(interfaceTypeIndex),
-                    writer.GetUnsignedConstant(checked((uint)targetSlot))));
+                    writer.GetUnsignedConstant(checked((uint)targetSlot)));
+
+                for (int cell = firstCell; cell < nextCell; cell += DispatchCellNode.MaxCellInfoLookupDistance)
+                    entries.Set(cell, entry);
 
                 firstCell = nextCell;
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -225,13 +225,13 @@ namespace ILCompiler
             var stackTraceLineNumbersNode = new StackTraceLineNumbersNode(commonFixupsTableNode, stackTraceDocumentsNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.BlobIdStackTraceLineNumbers), stackTraceLineNumbersNode);
 
-            var interfaceDispatchCellInfoNode = new InterfaceDispatchCellInfoSectionNode();
+            var interfaceDispatchCellInfoNode = new InterfaceDispatchCellInfoSectionNode(nativeReferencesTableNode);
             header.Add(ReadyToRunSectionType.InterfaceDispatchCellInfoRegion, interfaceDispatchCellInfoNode);
 
             var interfaceDispatchCellNode = new InterfaceDispatchCellSectionNode();
             header.Add(ReadyToRunSectionType.InterfaceDispatchCellRegion, interfaceDispatchCellNode);
 
-            var gvmDispatchCellInfoNode = new GvmDispatchCellInfoSectionNode();
+            var gvmDispatchCellInfoNode = new GvmDispatchCellInfoSectionNode(nativeReferencesTableNode);
             header.Add(ReadyToRunSectionType.GvmDispatchCellInfoRegion, gvmDispatchCellInfoNode);
 
             var gvmDispatchCellNode = new GvmDispatchCellSectionNode();

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/GenericVirtualMethods.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/GenericVirtualMethods.cs
@@ -27,6 +27,7 @@ public static class GenericVirtualMethods
         }
     }
 
+
     class GVMDerivedClass : GVMClass, IInterfaceWithGVM
     {
         public override string GVM<T>(object o) 
@@ -159,6 +160,11 @@ public static class GenericVirtualMethods
         GVMClass testObject = new GVMDerivedClass();
         IInterfaceWithGVM igvm = testObject;
 
+        Assert.AreEqual("Called Derived.GVM<int>", CallSharedGvm0(igvm));
+        Assert.AreEqual("Called Derived.GVM<int>", CallSharedGvm1(igvm));
+        Assert.AreEqual("Called Derived.GVM<int>", CallSharedGvm2(igvm));
+        Assert.AreEqual("Called Derived.GVM<int>", CallSharedGvm3(igvm));
+
         // Test normal GVM call
         Assert.AreEqual("Called Derived.GVM<int>", testObject.GVM<int>(54));
         Assert.AreEqual("Called Derived.GVM<GVMClass>", testObject.GVM<GVMClass>(testObject));
@@ -207,6 +213,18 @@ public static class GenericVirtualMethods
         TestConstrainedCalls<GVMStructGeneric<object>>(new GVMStructGeneric<object>(), "Called GVMStructGeneric<object>.GVM<int>", "Called GVMStructGeneric<object>.GVM<GVMDerivedClass>", "Called GVMStructGeneric<object>.GVM<string>");
         TestConstrainedCalls<IInterfaceWithGVM>(new GVMStructGeneric<object>(), "Called GVMStructGeneric<object>.GVM<int>", "Called GVMStructGeneric<object>.GVM<GVMDerivedClass>", "Called GVMStructGeneric<object>.GVM<string>");
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string CallSharedGvm0(IInterfaceWithGVM instance) => instance.GVM<int>(54);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string CallSharedGvm1(IInterfaceWithGVM instance) => instance.GVM<int>(54);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string CallSharedGvm2(IInterfaceWithGVM instance) => instance.GVM<int>(54);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string CallSharedGvm3(IInterfaceWithGVM instance) => instance.GVM<int>(54);
 
     static class GenericStaticClass<T>
     {
@@ -495,4 +513,3 @@ public static class GenericVirtualMethods
         Assert.AreEqual<string>("CallOnDerived" , ((IOutVariant<Derived>)testClass).Func<object>());
     }
 }
-

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -19,6 +19,9 @@ public class Interfaces
         if (TestInterfaceCache() == Fail)
             return Fail;
 
+        if (TestSharedDescriptorCells() == Fail)
+            return Fail;
+
         if (TestAVInInterfaceCache() == Fail)
             return Fail;
 
@@ -162,6 +165,27 @@ public class Interfaces
 
         return 100;
     }
+
+    private static int TestSharedDescriptorCells()
+    {
+        MyInterface instance = new Foo7();
+        return CallSharedDescriptor0(instance) +
+            CallSharedDescriptor1(instance) +
+            CallSharedDescriptor2(instance) +
+            CallSharedDescriptor3(instance) == 28 ? Pass : Fail;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int CallSharedDescriptor0(MyInterface instance) => instance.GetAnInt();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int CallSharedDescriptor1(MyInterface instance) => instance.GetAnInt();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int CallSharedDescriptor2(MyInterface instance) => instance.GetAnInt();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int CallSharedDescriptor3(MyInterface instance) => instance.GetAnInt();
 
     private static int TestAVInInterfaceCache()
     {


### PR DESCRIPTION
Replaces the dispatch cell info encoding used for interface methods and generic virtual methods to use Native Layout. 

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: c5889318-fe12-47b1-946e-6969e02ef71d