### PR TITLE
Track reflectability of delegates pointing to generic virtuals

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -182,6 +182,7 @@ namespace ILCompiler.DependencyAnalysis
 #if !READYTORUN
                                 TypeSystemEntity origin = (implementingMethodInstantiation.OwningType != potentialOverrideType) ? potentialOverrideType : null;
                                 factory.MetadataManager.NoteOverridingMethod(_method, implementingMethodInstantiation, origin);
+                                factory.MetadataManager.GetDependenciesForOverridingMethod(ref dynamicDependencies, factory, _method, implementingMethodInstantiation);
 #endif
                             }
 
@@ -240,6 +241,7 @@ namespace ILCompiler.DependencyAnalysis
                             dynamicDependencies.Add(new CombinedDependencyListEntry(node, null, "DerivedMethodInstantiation"));
 #if !READYTORUN
                         factory.MetadataManager.NoteOverridingMethod(_method, instantiatedTargetMethod);
+                        factory.MetadataManager.GetDependenciesForOverridingMethod(ref dynamicDependencies, factory, _method, instantiatedTargetMethod);
 
                         foundImpl = true;
 #endif

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DelegateTargetVirtualMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DelegateTargetVirtualMethodNode.cs
@@ -38,4 +38,40 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
     }
+
+    public sealed class ReflectableVirtualMethodImplNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly MethodDesc _declaration;
+        private readonly MethodDesc _implementation;
+
+        public ReflectableVirtualMethodImplNode(MethodDesc declaration, MethodDesc implementation)
+        {
+            Debug.Assert(declaration.GetCanonMethodTarget(CanonicalFormKind.Specific) == declaration);
+            Debug.Assert(implementation.GetCanonMethodTarget(CanonicalFormKind.Specific) == implementation);
+
+            _declaration = declaration;
+            _implementation = implementation;
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return $"Reflectable virtual method implementation: {_implementation} for {_declaration}";
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => true;
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
+        {
+            yield return new CombinedDependencyListEntry(
+                factory.ReflectedMethod(_implementation),
+                factory.ReflectedDelegateTargetVirtualMethod(_declaration),
+                "Virtual method declaration is reflectable");
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+    }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -364,6 +364,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new DelegateTargetVirtualMethodNode(method, reflected: false);
             });
 
+            _reflectableVirtualMethodImpls = new NodeCache<(MethodDesc Declaration, MethodDesc Implementation), ReflectableVirtualMethodImplNode>(methods =>
+            {
+                return new ReflectableVirtualMethodImplNode(methods.Declaration, methods.Implementation);
+            });
+
             _reflectedDelegates = new NodeCache<TypeDesc, ReflectedDelegateNode>(type =>
             {
                 return new ReflectedDelegateNode(type);
@@ -1225,6 +1230,12 @@ namespace ILCompiler.DependencyAnalysis
         public DelegateTargetVirtualMethodNode DelegateTargetVirtualMethod(MethodDesc method)
         {
             return _delegateTargetMethods.GetOrAdd(method);
+        }
+
+        private NodeCache<(MethodDesc Declaration, MethodDesc Implementation), ReflectableVirtualMethodImplNode> _reflectableVirtualMethodImpls;
+        public ReflectableVirtualMethodImplNode ReflectableVirtualMethodImpl(MethodDesc declaration, MethodDesc implementation)
+        {
+            return _reflectableVirtualMethodImpls.GetOrAdd((declaration, implementation));
         }
 
         private ReflectedDelegateNode _unknownReflectedDelegate = new ReflectedDelegateNode(null);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -640,9 +640,11 @@ namespace ILCompiler
             {
                 dependencies ??= new CombinedDependencyList();
                 dependencies.Add(new DependencyNodeCore<NodeFactory>.CombinedDependencyListEntry(
-                    factory.ReflectedMethod(impl.GetCanonMethodTarget(CanonicalFormKind.Specific)),
-                    factory.ReflectedDelegateTargetVirtualMethod(decl.GetCanonMethodTarget(CanonicalFormKind.Specific)),
-                    "Virtual method declaration is reflectable"));
+                    factory.ReflectableVirtualMethodImpl(
+                        decl.GetCanonMethodTarget(CanonicalFormKind.Specific),
+                        impl.GetCanonMethodTarget(CanonicalFormKind.Specific)),
+                    null,
+                    "Virtual method implementation discovered"));
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
@@ -91,6 +91,7 @@ namespace ILCompiler.DependencyAnalysisFramework
                 foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in
                     _node.SearchDynamicDependencies(analyzer._dynamicDependencyInterestingList, _next, analyzer._dependencyContext))
                 {
+                    Debug.Assert(dependency.OtherReasonNode is null || dependency.OtherReasonNode.Marked);
                     analyzer.AddToMarkStack(dependency.Node, dependency.Reason, _node, dependency.OtherReasonNode);
                 }
                 _next = analyzer._dynamicDependencyInterestingList.Count;
@@ -192,7 +193,7 @@ namespace ILCompiler.DependencyAnalysisFramework
             {
                 foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in node.GetConditionalStaticDependencies(_dependencyContext))
                 {
-                    if (dependency.OtherReasonNode.Marked)
+                    if (dependency.OtherReasonNode is null || dependency.OtherReasonNode.Marked)
                     {
                         AddToMarkStack(dependency.Node, dependency.Reason, node, dependency.OtherReasonNode);
                     }

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -2322,25 +2322,41 @@ internal static class ReflectionTest
         abstract class Base
         {
             public virtual void VirtualMethod() { }
+            public virtual void VirtualMethodShared<T>() { }
+            public virtual void VirtualMethodUnshared<T>() { }
             public abstract void AbstractMethod();
+            public abstract void AbstractMethodShared<T>();
+            public abstract void AbstractMethodUnshared<T>();
         }
 
         class Derived : Base, IBar
         {
             public override void AbstractMethod() { }
+            public override void AbstractMethodShared<T>() { }
+            public override void AbstractMethodUnshared<T>() { }
             public override void VirtualMethod() { }
+            public override void VirtualMethodShared<T>() { }
+            public override void VirtualMethodUnshared<T>() { }
             void IFoo.InterfaceMethod() { }
+            void IFoo.InterfaceMethodShared<T>() { }
+            void IFoo.InterfaceMethodUnshared<T>() { }
         }
 
         interface IFoo
         {
             void InterfaceMethod();
+            void InterfaceMethodShared<T>();
+            void InterfaceMethodUnshared<T>();
             void DefaultInterfaceMethod() { }
+            void DefaultInterfaceMethodShared<T>() { }
+            void DefaultInterfaceMethodUnshared<T>() { }
         }
 
         interface IBar : IFoo
         {
             void IFoo.DefaultInterfaceMethod() { }
+            void IFoo.DefaultInterfaceMethodShared<T>() { }
+            void IFoo.DefaultInterfaceMethodUnshared<T>() { }
         }
 
         static Base s_baseInstance = new Derived();
@@ -2354,16 +2370,48 @@ internal static class ReflectionTest
             if (abstractMethod.GetMethodInfo().Name != nameof(Derived.AbstractMethod))
                 throw new Exception();
 
+            Action abstractMethodShared = s_baseInstance.AbstractMethodShared<object>;
+            if (abstractMethodShared.GetMethodInfo().Name != nameof(Derived.AbstractMethodShared))
+                throw new Exception();
+
+            Action abstractMethodUnshared = s_baseInstance.AbstractMethodUnshared<int>;
+            if (abstractMethodUnshared.GetMethodInfo().Name != nameof(Derived.AbstractMethodUnshared))
+                throw new Exception();
+
             Action virtualMethod = s_baseInstance.VirtualMethod;
             if (virtualMethod.GetMethodInfo().Name != nameof(Derived.VirtualMethod))
+                throw new Exception();
+
+            Action virtualMethodShared = s_baseInstance.VirtualMethodShared<object>;
+            if (virtualMethodShared.GetMethodInfo().Name != nameof(Derived.VirtualMethodShared))
+                throw new Exception();
+
+            Action virtualMethodUnshared = s_baseInstance.VirtualMethodUnshared<int>;
+            if (virtualMethodUnshared.GetMethodInfo().Name != nameof(Derived.VirtualMethodUnshared))
                 throw new Exception();
 
             Action interfaceMethod = s_ifooInstance.InterfaceMethod;
             if (!interfaceMethod.GetMethodInfo().Name.EndsWith("IFoo.InterfaceMethod"))
                 throw new Exception();
 
+            Action interfaceMethodShared = s_ifooInstance.InterfaceMethodShared<object>;
+            if (!interfaceMethodShared.GetMethodInfo().Name.EndsWith("IFoo.InterfaceMethodShared"))
+                throw new Exception();
+
+            Action interfaceMethodUnshared = s_ifooInstance.InterfaceMethodUnshared<int>;
+            if (!interfaceMethodUnshared.GetMethodInfo().Name.EndsWith("IFoo.InterfaceMethodUnshared"))
+                throw new Exception();
+
             Action defaultMethod = s_ifooInstance.DefaultInterfaceMethod;
             if (!defaultMethod.GetMethodInfo().Name.EndsWith("IFoo.DefaultInterfaceMethod"))
+                throw new Exception();
+
+            Action defaultMethodShared = s_ifooInstance.DefaultInterfaceMethodShared<object>;
+            if (!defaultMethodShared.GetMethodInfo().Name.EndsWith("IFoo.DefaultInterfaceMethodShared"))
+                throw new Exception();
+
+            Action defaultMethodUnshared = s_ifooInstance.DefaultInterfaceMethodUnshared<int>;
+            if (!defaultMethodUnshared.GetMethodInfo().Name.EndsWith("IFoo.DefaultInterfaceMethodUnshared"))
                 throw new Exception();
         }
     }


### PR DESCRIPTION
`Delegate.Method` needs to work since it's not a trim-unsafe API.

I thought I maybe broke this in #129609, but the added test doesn't work in .NET 10 either, so I only broke a small aspect of this (GVMs were implicitly considered targets of reflection because of the `RuntimeMethodHandle` used as implementation detail).