### PR TITLE
Fix two latent HWIntrinsic miscompiles in gentree.cpp

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -25983,9 +25983,6 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                     }
                     else
                     {
-                        needsFixup = cnsNode->IsVectorZero();
-                    }
-                    {
                         needsFixup = cnsNode->IsVectorNegativeZero(simdBaseType);
                     }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -31103,7 +31103,7 @@ genTreeOps GenTreeHWIntrinsic::GetOperForHWIntrinsicId(bool* isScalar, bool getE
                 {
                     oper = GT_NEG;
                 }
-                else if (isScalar && op1->IsCnsVec() && op1->AsVecCon()->IsScalarZero(simdBaseType))
+                else if (*isScalar && op1->IsCnsVec() && op1->AsVecCon()->IsScalarZero(simdBaseType))
                 {
                     oper = GT_NEG;
                 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130830/Runtime_130830.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130830/Runtime_130830.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Runtime_130830;
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public static class Runtime_130830
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Vector128<int> result = Test(Vector128.Create(10), Vector128.Create(100));
+        Assert.Equal(Vector128.Create(90, 91, 92, 93), result);
+    }
+
+    // The low lane of the constant is zero but the constant is not all-zero, so the
+    // subtract must not be treated as a negate; otherwise the constant is dropped and
+    // the result collapses to <90, 90, 90, 90>.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> Test(Vector128<int> v1, Vector128<int> v2)
+    {
+        return (Vector128.Create(0, 1, 2, 3) - v1) + v2;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130831/Runtime_130831.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130831/Runtime_130831.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Runtime_130831;
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Runtime_130831
+{
+    // xunit's Assert.Equal for float/double compares bitwise, so it distinguishes -0.0 from +0.0.
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Equal(-0.0, MinNegZeroConst(+0.0));
+        Assert.Equal(-0.0, MinNumberZeroConst(-0.0));
+
+        Assert.Equal(-0.0f, MinNegZeroConst(+0.0f));
+        Assert.Equal(-0.0f, MinNumberZeroConst(-0.0f));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static double MinNegZeroConst(double value) => double.Min(value, -0.0);
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static double MinNumberZeroConst(double value) => double.MinNumber(value, +0.0);
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static float MinNegZeroConst(float value) => float.Min(value, -0.0f);
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static float MinNumberZeroConst(float value) => float.MinNumber(value, +0.0f);
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130831/Runtime_130831.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130831/Runtime_130831.cs
@@ -3,20 +3,22 @@
 
 namespace Runtime_130831;
 
+using System;
 using System.Runtime.CompilerServices;
 using Xunit;
 
 public static class Runtime_130831
 {
-    // xunit's Assert.Equal for float/double compares bitwise, so it distinguishes -0.0 from +0.0.
+    // Compare the exact bit pattern: Double/Single.Equals treat -0.0 and +0.0 as equal,
+    // so a plain Assert.Equal would not observe a wrong-signed-zero result.
     [Fact]
     public static void TestEntryPoint()
     {
-        Assert.Equal(-0.0, MinNegZeroConst(+0.0));
-        Assert.Equal(-0.0, MinNumberZeroConst(-0.0));
+        Assert.Equal(BitConverter.DoubleToInt64Bits(-0.0), BitConverter.DoubleToInt64Bits(MinNegZeroConst(+0.0)));
+        Assert.Equal(BitConverter.DoubleToInt64Bits(-0.0), BitConverter.DoubleToInt64Bits(MinNumberZeroConst(-0.0)));
 
-        Assert.Equal(-0.0f, MinNegZeroConst(+0.0f));
-        Assert.Equal(-0.0f, MinNumberZeroConst(-0.0f));
+        Assert.Equal(BitConverter.SingleToInt32Bits(-0.0f), BitConverter.SingleToInt32Bits(MinNegZeroConst(+0.0f)));
+        Assert.Equal(BitConverter.SingleToInt32Bits(-0.0f), BitConverter.SingleToInt32Bits(MinNumberZeroConst(-0.0f)));
     }
 
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130831/Runtime_130831.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130831/Runtime_130831.cs
@@ -12,6 +12,7 @@ public static class Runtime_130831
     // Compare the exact bit pattern: Double/Single.Equals treat -0.0 and +0.0 as equal,
     // so a plain Assert.Equal would not observe a wrong-signed-zero result.
     [Fact]
+    [SkipOnMono("https://github.com/dotnet/runtime/issues/131130", TestPlatforms.Any)]
     public static void TestEntryPoint()
     {
         Assert.Equal(BitConverter.DoubleToInt64Bits(-0.0), BitConverter.DoubleToInt64Bits(MinNegZeroConst(+0.0)));

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -114,6 +114,8 @@
     <Compile Include="JitBlue\Runtime_130248\Runtime_130248.cs" />
     <Compile Include="JitBlue\Runtime_130286\Runtime_130286.cs" />
     <Compile Include="JitBlue\Runtime_130425\Runtime_130425.cs" />
+    <Compile Include="JitBlue\Runtime_130830\Runtime_130830.cs" />
+    <Compile Include="JitBlue\Runtime_130831\Runtime_130831.cs" />
     <Compile Include="JitBlue\Runtime_10337\Runtime_10337.cs" />
     <Compile Include="JitBlue\Runtime_125160\Runtime_125160.cs" />
   </ItemGroup>


### PR DESCRIPTION
Two latent correctness fixes found while auditing `gentree.cpp`, each with a regression test.

----------

**Fix `GetOperForHWIntrinsicId` testing the `isScalar` pointer instead of `*isScalar`** (#130830)

`GetOperForHWIntrinsicId` refines a `GT_SUB` into a `GT_NEG` when the constant `op1` is a scalar zero, but it guarded on the `isScalar` out-param pointer (always non-null) rather than the dereferenced value. This let a **packed** subtract whose constant has a zero low lane but is not all-zero (e.g. `Vector128.Create(0, 1, 2, 3) - x`) be reported as a negate. `fgOptimizeHWIntrinsic`'s `(-v1) + v2 => v2 - v1` transform then drops the constant entirely.

----------

**Fix stray block clobbering `needsFixup` in `gtNewSimdMinMaxNode`** (#130831)

A stray unconditional block in the min branch of the floating constant fast path overwrote `needsFixup` for all four cases, making the preceding if/else dead. `needsFixup` signals that a signed-zero constant needs the AVX512 fixup so `min(+0, -0)` keeps the correct sign of zero; with it wrongly forced `false`, `Min`/`MinNumber` against a signed-zero constant miscompiles. The min branch now mirrors the already-correct max branch.

Existing coverage in `JitBlue/Runtime_98068` exercises `Min`/`MinNumber` const-folding but always pairs an operand with `NaN`, so the finite opposite-signed-zero case was never tested.

----------

Both are pre-existing on `main`, found by inspection. Tests added under `JitBlue/Runtime_130830` and `JitBlue/Runtime_130831`.

CC. @dotnet/jit-contrib

> [!NOTE]
> This PR description was authored with the help of GitHub Copilot.
