### PR TITLE
Buffer consecutive text nodes when loading XContainer to avoid O(n^2)

### DIFF
--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
@@ -834,6 +834,10 @@ namespace System.Xml.Linq
 
             ContentReader cr = new ContentReader(this);
             while (cr.ReadContentFrom(this, r) && r.Read()) ;
+
+            // Materialize any text still buffered when the reader stops at end-of-input rather
+            // than a matching EndElement (e.g. document-level trailing whitespace on an XDocument).
+            cr.FlushBufferedText();
         }
 
         internal void ReadContentFrom(XmlReader r, LoadOptions o)
@@ -847,6 +851,10 @@ namespace System.Xml.Linq
 
             ContentReader cr = new ContentReader(this, r, o);
             while (cr.ReadContentFromContainer(this, r) && r.Read()) ;
+
+            // Materialize any text still buffered when the reader stops at end-of-input rather
+            // than a matching EndElement (e.g. document-level trailing whitespace on an XDocument).
+            cr.FlushBufferedText();
         }
 
         internal async Task ReadContentFromAsync(XmlReader r, CancellationToken cancellationToken)
@@ -859,6 +867,10 @@ namespace System.Xml.Linq
                 cancellationToken.ThrowIfCancellationRequested();
             }
             while (await cr.ReadContentFromAsync(this, r).ConfigureAwait(false) && await r.ReadAsync().ConfigureAwait(false));
+
+            // Materialize any text still buffered when the reader stops at end-of-input rather
+            // than a matching EndElement (e.g. document-level trailing whitespace on an XDocument).
+            cr.FlushBufferedText();
         }
 
         internal async Task ReadContentFromAsync(XmlReader r, LoadOptions o, CancellationToken cancellationToken)
@@ -876,6 +888,10 @@ namespace System.Xml.Linq
                 cancellationToken.ThrowIfCancellationRequested();
             }
             while (await cr.ReadContentFromContainerAsync(this, r).ConfigureAwait(false) && await r.ReadAsync().ConfigureAwait(false));
+
+            // Materialize any text still buffered when the reader stops at end-of-input rather
+            // than a matching EndElement (e.g. document-level trailing whitespace on an XDocument).
+            cr.FlushBufferedText();
         }
 
         private sealed class ContentReader
@@ -885,6 +901,7 @@ namespace System.Xml.Linq
             private readonly IXmlLineInfo? _lineInfo;
             private XContainer _currentContainer;
             private string? _baseUri;
+            private StringBuilder? _textBuffer;
 
             public ContentReader(XContainer rootContainer)
             {
@@ -898,9 +915,37 @@ namespace System.Xml.Linq
                 _lineInfo = (o & LoadOptions.SetLineInfo) != 0 ? r as IXmlLineInfo : null;
             }
 
+            // Consecutive text nodes are buffered and materialized as a single string in one
+            // pass rather than being concatenated one chunk at a time. Some readers (notably the
+            // one used by DataContractSerializer over a stream) deliver a single logical text
+            // value as many small text nodes; appending each of them individually via
+            // AddStringSkipNotify concatenates immutable strings and degrades to O(n^2).
+            // Buffering keeps loading linear. Every read loop calls this once before handling any
+            // non-text node (so document order is preserved) and once more after the loop ends
+            // (so trailing buffered text is not lost when the reader stops at end-of-input rather
+            // than an EndElement).
+            internal void FlushBufferedText()
+            {
+                if (_textBuffer is StringBuilder sb && sb.Length > 0)
+                {
+                    _currentContainer.AddStringSkipNotify(sb.ToString());
+                    sb.Clear();
+                }
+            }
+
             public bool ReadContentFrom(XContainer rootContainer, XmlReader r)
             {
-                switch (r.NodeType)
+                XmlNodeType nodeType = r.NodeType;
+                if (nodeType is XmlNodeType.Text or XmlNodeType.SignificantWhitespace or XmlNodeType.Whitespace)
+                {
+                    (_textBuffer ??= new StringBuilder()).Append(r.Value);
+                    return true;
+                }
+
+                // Any non-text node ends the current run of text, so materialize it first.
+                FlushBufferedText();
+
+                switch (nodeType)
                 {
                     case XmlNodeType.Element:
                         XElement e = new XElement(_eCache.Get(r.NamespaceURI).GetName(r.LocalName));
@@ -923,11 +968,6 @@ namespace System.Xml.Linq
                         if (_currentContainer == rootContainer) return false;
                         _currentContainer = _currentContainer.parent!;
                         break;
-                    case XmlNodeType.Text:
-                    case XmlNodeType.SignificantWhitespace:
-                    case XmlNodeType.Whitespace:
-                        _currentContainer.AddStringSkipNotify(r.Value);
-                        break;
                     case XmlNodeType.CDATA:
                         _currentContainer.AddNodeSkipNotify(new XCData(r.Value));
                         break;
@@ -947,14 +987,24 @@ namespace System.Xml.Linq
                     case XmlNodeType.EndEntity:
                         break;
                     default:
-                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, r.NodeType));
+                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, nodeType));
                 }
                 return true;
             }
 
             public async ValueTask<bool> ReadContentFromAsync(XContainer rootContainer, XmlReader r)
             {
-                switch (r.NodeType)
+                XmlNodeType nodeType = r.NodeType;
+                if (nodeType is XmlNodeType.Text or XmlNodeType.SignificantWhitespace or XmlNodeType.Whitespace)
+                {
+                    (_textBuffer ??= new StringBuilder()).Append(await r.GetValueAsync().ConfigureAwait(false));
+                    return true;
+                }
+
+                // Any non-text node ends the current run of text, so materialize it first.
+                FlushBufferedText();
+
+                switch (nodeType)
                 {
                     case XmlNodeType.Element:
                         XElement e = new XElement(_eCache.Get(r.NamespaceURI).GetName(r.LocalName));
@@ -979,11 +1029,6 @@ namespace System.Xml.Linq
                         if (_currentContainer == rootContainer) return false;
                         _currentContainer = _currentContainer.parent!;
                         break;
-                    case XmlNodeType.Text:
-                    case XmlNodeType.SignificantWhitespace:
-                    case XmlNodeType.Whitespace:
-                        _currentContainer.AddStringSkipNotify(await r.GetValueAsync().ConfigureAwait(false));
-                        break;
                     case XmlNodeType.CDATA:
                         _currentContainer.AddNodeSkipNotify(new XCData(await r.GetValueAsync().ConfigureAwait(false)));
                         break;
@@ -1003,7 +1048,7 @@ namespace System.Xml.Linq
                     case XmlNodeType.EndEntity:
                         break;
                     default:
-                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, r.NodeType));
+                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, nodeType));
                 }
                 return true;
             }
@@ -1012,8 +1057,22 @@ namespace System.Xml.Linq
             {
                 XNode? newNode = null;
                 string baseUri = r.BaseURI;
+                XmlNodeType nodeType = r.NodeType;
 
-                switch (r.NodeType)
+                // Fast path: coalesce a run of adjacent text. Text that must carry its own
+                // baseUri or line info can't be coalesced, so it falls through to be created as a
+                // standalone XText node in the switch below.
+                if (nodeType is XmlNodeType.Text or XmlNodeType.SignificantWhitespace or XmlNodeType.Whitespace
+                    && !((_baseUri != null && _baseUri != baseUri) || (_lineInfo != null && _lineInfo.HasLineInfo())))
+                {
+                    (_textBuffer ??= new StringBuilder()).Append(r.Value);
+                    return true;
+                }
+
+                // Any other node ends the current run of text, so materialize it first.
+                FlushBufferedText();
+
+                switch (nodeType)
                 {
                     case XmlNodeType.Element:
                     {
@@ -1072,15 +1131,9 @@ namespace System.Xml.Linq
                     case XmlNodeType.Text:
                     case XmlNodeType.SignificantWhitespace:
                     case XmlNodeType.Whitespace:
-                        if ((_baseUri != null && _baseUri != baseUri) ||
-                            (_lineInfo != null && _lineInfo.HasLineInfo()))
-                        {
-                            newNode = new XText(r.Value);
-                        }
-                        else
-                        {
-                            _currentContainer.AddStringSkipNotify(r.Value);
-                        }
+                        // Only reached for text that needs its own baseUri/line info; plain text
+                        // runs are coalesced by the fast path above.
+                        newNode = new XText(r.Value);
                         break;
                     case XmlNodeType.CDATA:
                         newNode = new XCData(r.Value);
@@ -1101,7 +1154,7 @@ namespace System.Xml.Linq
                     case XmlNodeType.EndEntity:
                         break;
                     default:
-                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, r.NodeType));
+                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, nodeType));
                 }
 
                 if (newNode != null)
@@ -1126,8 +1179,22 @@ namespace System.Xml.Linq
             {
                 XNode? newNode = null;
                 string baseUri = r.BaseURI!;
+                XmlNodeType nodeType = r.NodeType;
 
-                switch (r.NodeType)
+                // Fast path: coalesce a run of adjacent text. Text that must carry its own
+                // baseUri or line info can't be coalesced, so it falls through to be created as a
+                // standalone XText node in the switch below.
+                if (nodeType is XmlNodeType.Text or XmlNodeType.SignificantWhitespace or XmlNodeType.Whitespace
+                    && !((_baseUri != null && _baseUri != baseUri) || (_lineInfo != null && _lineInfo.HasLineInfo())))
+                {
+                    (_textBuffer ??= new StringBuilder()).Append(await r.GetValueAsync().ConfigureAwait(false));
+                    return true;
+                }
+
+                // Any other node ends the current run of text, so materialize it first.
+                FlushBufferedText();
+
+                switch (nodeType)
                 {
                     case XmlNodeType.Element:
                         {
@@ -1188,15 +1255,9 @@ namespace System.Xml.Linq
                     case XmlNodeType.Text:
                     case XmlNodeType.SignificantWhitespace:
                     case XmlNodeType.Whitespace:
-                        if ((_baseUri != null && _baseUri != baseUri) ||
-                            (_lineInfo != null && _lineInfo.HasLineInfo()))
-                        {
-                            newNode = new XText(await r.GetValueAsync().ConfigureAwait(false));
-                        }
-                        else
-                        {
-                            _currentContainer.AddStringSkipNotify(await r.GetValueAsync().ConfigureAwait(false));
-                        }
+                        // Only reached for text that needs its own baseUri/line info; plain text
+                        // runs are coalesced by the fast path above.
+                        newNode = new XText(await r.GetValueAsync().ConfigureAwait(false));
                         break;
                     case XmlNodeType.CDATA:
                         newNode = new XCData(await r.GetValueAsync().ConfigureAwait(false));
@@ -1217,7 +1278,7 @@ namespace System.Xml.Linq
                     case XmlNodeType.EndEntity:
                         break;
                     default:
-                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, r.NodeType));
+                        throw new InvalidOperationException(SR.Format(SR.InvalidOperation_UnexpectedNodeType, nodeType));
                 }
 
                 if (newNode != null)

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
@@ -901,6 +901,7 @@ namespace System.Xml.Linq
             private readonly IXmlLineInfo? _lineInfo;
             private XContainer _currentContainer;
             private string? _baseUri;
+            private string? _textValue;
             private StringBuilder? _textBuffer;
 
             public ContentReader(XContainer rootContainer)
@@ -915,22 +916,49 @@ namespace System.Xml.Linq
                 _lineInfo = (o & LoadOptions.SetLineInfo) != 0 ? r as IXmlLineInfo : null;
             }
 
-            // Consecutive text nodes are buffered and materialized as a single string in one
-            // pass rather than being concatenated one chunk at a time. Some readers (notably the
-            // one used by DataContractSerializer over a stream) deliver a single logical text
-            // value as many small text nodes; appending each of them individually via
-            // AddStringSkipNotify concatenates immutable strings and degrades to O(n^2).
-            // Buffering keeps loading linear. Every read loop calls this once before handling any
-            // non-text node (so document order is preserved) and once more after the loop ends
-            // (so trailing buffered text is not lost when the reader stops at end-of-input rather
-            // than an EndElement).
+            private void BufferText(string value)
+            {
+                if (_textBuffer is not null)
+                {
+                    _textBuffer.Append(value);
+                }
+                else if (_textValue is null)
+                {
+                    _textValue = value;
+                }
+                else
+                {
+                    _textBuffer = new StringBuilder(_textValue).Append(value);
+                    _textValue = null;
+                }
+            }
+
+            // A single text node is retained as its original string. Consecutive text nodes are
+            // promoted to a StringBuilder and materialized in one pass rather than being
+            // concatenated one chunk at a time. Some readers (notably the one used by
+            // DataContractSerializer over a stream) deliver a single logical text value as many
+            // small text nodes; appending each of them individually via AddStringSkipNotify
+            // concatenates immutable strings and degrades to O(n^2). Every read loop calls this
+            // once before handling any non-text node (so document order is preserved) and once
+            // more after the loop ends (so trailing buffered text is not lost when the reader
+            // stops at end-of-input rather than an EndElement).
             internal void FlushBufferedText()
             {
-                if (_textBuffer is StringBuilder sb && sb.Length > 0)
+                if (_textBuffer is StringBuilder buffer)
                 {
-                    _currentContainer.AddStringSkipNotify(sb.ToString());
-                    sb.Clear();
+                    if (buffer.Length > 0)
+                    {
+                        _currentContainer.AddStringSkipNotify(buffer.ToString());
+                    }
+
+                    _textBuffer = null;
                 }
+                else if (!string.IsNullOrEmpty(_textValue))
+                {
+                    _currentContainer.AddStringSkipNotify(_textValue);
+                }
+
+                _textValue = null;
             }
 
             public bool ReadContentFrom(XContainer rootContainer, XmlReader r)
@@ -938,7 +966,7 @@ namespace System.Xml.Linq
                 XmlNodeType nodeType = r.NodeType;
                 if (nodeType is XmlNodeType.Text or XmlNodeType.SignificantWhitespace or XmlNodeType.Whitespace)
                 {
-                    (_textBuffer ??= new StringBuilder()).Append(r.Value);
+                    BufferText(r.Value);
                     return true;
                 }
 
@@ -997,7 +1025,7 @@ namespace System.Xml.Linq
                 XmlNodeType nodeType = r.NodeType;
                 if (nodeType is XmlNodeType.Text or XmlNodeType.SignificantWhitespace or XmlNodeType.Whitespace)
                 {
-                    (_textBuffer ??= new StringBuilder()).Append(await r.GetValueAsync().ConfigureAwait(false));
+                    BufferText(await r.GetValueAsync().ConfigureAwait(false));
                     return true;
                 }
 
@@ -1065,7 +1093,7 @@ namespace System.Xml.Linq
                 if (nodeType is XmlNodeType.Text or XmlNodeType.SignificantWhitespace or XmlNodeType.Whitespace
                     && !((_baseUri != null && _baseUri != baseUri) || (_lineInfo != null && _lineInfo.HasLineInfo())))
                 {
-                    (_textBuffer ??= new StringBuilder()).Append(r.Value);
+                    BufferText(r.Value);
                     return true;
                 }
 
@@ -1187,7 +1215,7 @@ namespace System.Xml.Linq
                 if (nodeType is XmlNodeType.Text or XmlNodeType.SignificantWhitespace or XmlNodeType.Whitespace
                     && !((_baseUri != null && _baseUri != baseUri) || (_lineInfo != null && _lineInfo.HasLineInfo())))
                 {
-                    (_textBuffer ??= new StringBuilder()).Append(await r.GetValueAsync().ConfigureAwait(false));
+                    BufferText(await r.GetValueAsync().ConfigureAwait(false));
                     return true;
                 }
 

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/RegressionTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/RegressionTests.cs
@@ -1,10 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.Test.ModuleCore;
 using Xunit;
 
@@ -228,6 +231,189 @@ namespace System.Xml.Linq.Tests
             yield return new object[] { Tuple.Create(1, "Melitta", 7.5), typeof(Tuple) };
             yield return new object[] { new Guid(), typeof(Guid) };
             yield return new object[] { d, typeof(Dictionary<int, string>) };
+        }
+
+        // When a reader delivers a single logical text value as many small text nodes (as the
+        // reader used by DataContractSerializer over a stream does), loading must remain linear
+        // and still coalesce the chunks into a single, correct text value rather than
+        // concatenating them one at a time.
+        [Theory]
+        [InlineData(1)]
+        [InlineData(7)]
+        public void LoadCoalescesChunkedTextIntoSingleNode(int chunkSize)
+        {
+            var original = new XElement("root", string.Join("\n", Enumerable.Repeat(new string('a', 40), 100)));
+            string xml = original.ToString(SaveOptions.DisableFormatting);
+
+            XElement loaded = LoadChunked(xml, chunkSize, LoadOptions.None);
+
+            Assert.Equal(original.Value, loaded.Value);
+            XText textNode = Assert.IsType<XText>(Assert.Single(loaded.Nodes()));
+            Assert.Equal(original.Value, textNode.Value);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(3)]
+        public void LoadChunkedTextPreservesMixedContent(int chunkSize)
+        {
+            const string xml = "<root>hello world<child>inner text</child>trailing text</root>";
+
+            XElement loaded = LoadChunked(xml, chunkSize, LoadOptions.None);
+
+            Assert.Equal(xml, loaded.ToString(SaveOptions.DisableFormatting));
+            Assert.Equal("hello world", ((XText)loaded.FirstNode).Value);
+            Assert.Equal("inner text", loaded.Element("child").Value);
+            Assert.Equal("trailing text", ((XText)loaded.LastNode).Value);
+        }
+
+        [Fact]
+        public void LoadChunkedTextWithBaseUriOptionCoalesces()
+        {
+            // LoadOptions.SetBaseUri routes through the ContentReader "container" code path.
+            var original = new XElement("root", string.Join("\n", Enumerable.Repeat(new string('b', 30), 80)));
+            string xml = original.ToString(SaveOptions.DisableFormatting);
+
+            XElement loaded = LoadChunked(xml, chunkSize: 1, LoadOptions.SetBaseUri);
+
+            Assert.Equal(original.Value, loaded.Value);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(7)]
+        public async Task LoadAsyncCoalescesChunkedText(int chunkSize)
+        {
+            var original = new XElement("root", string.Join("\n", Enumerable.Repeat(new string('c', 40), 100)));
+            string xml = original.ToString(SaveOptions.DisableFormatting);
+
+            using var reader = new ChunkingXmlReader(XmlReader.Create(new StringReader(xml)), chunkSize);
+            XElement loaded = await XElement.LoadAsync(reader, LoadOptions.None, default);
+
+            Assert.Equal(original.Value, loaded.Value);
+            Assert.Equal(original.Value, Assert.IsType<XText>(Assert.Single(loaded.Nodes())).Value);
+        }
+
+        private static XElement LoadChunked(string xml, int chunkSize, LoadOptions options)
+        {
+            using var reader = new ChunkingXmlReader(XmlReader.Create(new StringReader(xml)), chunkSize);
+            return XElement.Load(reader, options);
+        }
+
+        // With buffering, loading a heavily-chunked text value is O(n). Reverting to per-chunk
+        // string concatenation makes it O(n^2), which would take minutes for this input instead
+        // of well under a second, so the generous time bound only trips on an algorithmic
+        // regression, not on normal machine-speed variance.
+        [Fact]
+        public void LoadChunkedLargeTextRemainsLinear()
+        {
+            const int length = 750_000;
+            string xml = "<root>" + new string('a', length) + "</root>";
+
+            var stopwatch = Stopwatch.StartNew();
+            XElement loaded = LoadChunked(xml, chunkSize: 1, LoadOptions.None);
+            stopwatch.Stop();
+
+            Assert.Equal(length, loaded.Value.Length);
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(30),
+                $"Chunked load took {stopwatch.Elapsed.TotalSeconds:F1}s; expected linear-time completion.");
+        }
+
+        // Wraps an XmlReader and reports each text node's value in fixed-size chunks, emulating
+        // readers that surface large text content as many small text nodes.
+        private sealed class ChunkingXmlReader : XmlReader
+        {
+            private readonly XmlReader _inner;
+            private readonly int _chunkSize;
+            private string? _pendingText;
+            private int _position;
+
+            public ChunkingXmlReader(XmlReader inner, int chunkSize)
+            {
+                _inner = inner;
+                _chunkSize = chunkSize;
+            }
+
+            public override bool Read()
+            {
+                if (_pendingText != null)
+                {
+                    _position += _chunkSize;
+                    if (_position < _pendingText.Length)
+                    {
+                        return true;
+                    }
+
+                    _pendingText = null;
+                    _position = 0;
+                }
+
+                if (!_inner.Read())
+                {
+                    return false;
+                }
+
+                if (_inner.NodeType == XmlNodeType.Text && _inner.Value.Length > _chunkSize)
+                {
+                    _pendingText = _inner.Value;
+                    _position = 0;
+                }
+
+                return true;
+            }
+
+            public override Task<bool> ReadAsync() => Task.FromResult(Read());
+
+            public override Task<string> GetValueAsync() => Task.FromResult(Value);
+
+            public override XmlNodeType NodeType => _pendingText != null ? XmlNodeType.Text : _inner.NodeType;
+
+            public override string Value
+            {
+                get
+                {
+                    if (_pendingText != null)
+                    {
+                        return _pendingText.Substring(_position, Math.Min(_chunkSize, _pendingText.Length - _position));
+                    }
+
+                    return _inner.Value;
+                }
+            }
+
+            public override int AttributeCount => _inner.AttributeCount;
+            public override string BaseURI => _inner.BaseURI;
+            public override int Depth => _inner.Depth;
+            public override bool EOF => _inner.EOF;
+            public override bool IsEmptyElement => _inner.IsEmptyElement;
+            public override string LocalName => _inner.LocalName;
+            public override string NamespaceURI => _inner.NamespaceURI;
+            public override XmlNameTable NameTable => _inner.NameTable;
+            public override string Prefix => _inner.Prefix;
+            public override ReadState ReadState => _inner.ReadState;
+
+            public override string GetAttribute(int i) => _inner.GetAttribute(i);
+            public override string? GetAttribute(string name) => _inner.GetAttribute(name);
+            public override string? GetAttribute(string name, string? namespaceURI) => _inner.GetAttribute(name, namespaceURI);
+            public override string? LookupNamespace(string prefix) => _inner.LookupNamespace(prefix);
+            public override bool MoveToAttribute(string name) => _inner.MoveToAttribute(name);
+            public override bool MoveToAttribute(string name, string? ns) => _inner.MoveToAttribute(name, ns);
+            public override bool MoveToElement() => _inner.MoveToElement();
+            public override bool MoveToFirstAttribute() => _inner.MoveToFirstAttribute();
+            public override bool MoveToNextAttribute() => _inner.MoveToNextAttribute();
+            public override bool ReadAttributeValue() => _inner.ReadAttributeValue();
+            public override void ResolveEntity() => _inner.ResolveEntity();
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _inner.Dispose();
+                }
+
+                base.Dispose(disposing);
+            }
         }
     }
 }

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/RegressionTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/RegressionTests.cs
@@ -252,6 +252,18 @@ namespace System.Xml.Linq.Tests
             Assert.Equal(original.Value, textNode.Value);
         }
 
+        [Fact]
+        public void LoadSingleTextNodeReusesReaderValue()
+        {
+            const string xml = "<root>single text value</root>";
+            using var reader = new ChunkingXmlReader(XmlReader.Create(new StringReader(xml)), int.MaxValue);
+
+            XElement loaded = XElement.Load(reader, LoadOptions.None);
+
+            XText textNode = Assert.IsType<XText>(Assert.Single(loaded.Nodes()));
+            Assert.Same(reader.LastTextValue, textNode.Value);
+        }
+
         [Theory]
         [InlineData(1)]
         [InlineData(3)]
@@ -329,6 +341,8 @@ namespace System.Xml.Linq.Tests
             private string? _pendingText;
             private int _position;
 
+            public string? LastTextValue { get; private set; }
+
             public ChunkingXmlReader(XmlReader inner, int chunkSize)
             {
                 _inner = inner;
@@ -373,12 +387,22 @@ namespace System.Xml.Linq.Tests
             {
                 get
                 {
+                    string value;
                     if (_pendingText != null)
                     {
-                        return _pendingText.Substring(_position, Math.Min(_chunkSize, _pendingText.Length - _position));
+                        value = _pendingText.Substring(_position, Math.Min(_chunkSize, _pendingText.Length - _position));
+                    }
+                    else
+                    {
+                        value = _inner.Value;
                     }
 
-                    return _inner.Value;
+                    if (NodeType == XmlNodeType.Text)
+                    {
+                        LastTextValue = value;
+                    }
+
+                    return value;
                 }
             }
 


### PR DESCRIPTION
XContainer's IXmlSerializable/load path materialized each text node individually via AddStringSkipNotify, which concatenates immutable strings. When an XmlReader surfaces a single logical text value as many small consecutive text nodes (e.g. DataContractSerializer reading over a stream, or IXmlSerializable.ReadXml), this degrades to O(n^2) and makes deserialization pathologically slow.

Buffer runs of adjacent text (Text/SignificantWhitespace/Whitespace) into a StringBuilder and materialize them in a single pass, keeping the load linear. Rather than sprinkling flush calls across every non-text branch, each of the four ContentReader read methods is split in two: a fast path that appends coalescable text to the buffer and returns, and a slow path that flushes the buffer once before switching over any non-text node. The buffer is also flushed at the end of each driving loop so trailing document-level text (e.g. whitespace after an XDocument's root element, where the reader stops at end-of-input rather than a matching EndElement) is preserved.

The resulting node tree is identical to before: AddStringSkipNotify still coalesces consecutive strings, flushing always happens before the current container or base URI changes, and text requiring its own base URI or line info continues to fall through to a standalone XText.

Fixes #37893
