### PR TITLE
Wire up orphaned Runtime_129288 regression test

### DIFF
--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -104,6 +104,7 @@
     <Compile Include="JitBlue\Runtime_128801\Runtime_128801.cs" />
     <Compile Include="JitBlue\Runtime_129076\Runtime_129076.cs" />
     <Compile Include="JitBlue\Runtime_129176\Runtime_129176.cs" />
+    <Compile Include="JitBlue\Runtime_129288\Runtime_129288.cs" />
     <Compile Include="JitBlue\Runtime_129527\Runtime_129527.cs" />
     <Compile Include="JitBlue\Runtime_129642\Runtime_129642.cs" />
     <Compile Include="JitBlue\Runtime_129970\Runtime_129970.cs" />


### PR DESCRIPTION
﻿`Runtime_129288.cs` was added in #129348 (`JIT: don't claim rotates set ZF on xarch`) as a merged-style xunit test (`[Fact] public static int TestEntryPoint()`), but it was never referenced by any `Regression_*.csproj`. Since the SDK-style CLR test projects set `EnableDefaultItems=false`, an unreferenced `.cs` is silently never built or run -- so CI has never exercised this test. This is the same class of bug fixed in #130832.

Add it to `Regression_ro_2.csproj` (an `Optimize=True` bucket, correct for this lowering/codegen correctness test), inserted in numeric order alongside its neighbors.

I also audited every other `.cs` under `src/tests/JIT/Regression/` for the same issue. The only genuine orphan was `Runtime_129288`. Six other unreferenced `.cs` files are intentionally uncompiled reference sources paired with a hand-written/generated `.il` + `.ilproj` (`Runtime_70259`, `Runtime_70607`, `Runtime_73615`, `Runtime_80731`, `Runtime_40607`, `DevDiv_754566`) and were left as-is.

> [!NOTE]
> This PR description and the change were generated with the assistance of GitHub Copilot.
