### PR TITLE
[wasm] Make the finalizer slot callable from R2R before returning it

### DIFF
--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -574,9 +574,8 @@ void CallDefaultConstructor(OBJECTREF ref)
 
     PCODE ctorCode = pMD->GetSingleCallableAddrOfCode();
 #ifdef FEATURE_PORTABLE_ENTRYPOINTS
-    // CallDefaultConstructor invokes the ctor via a typed call_indirect, so its portable
-    // entry point must resolve to real code (native R2R or a correctly-typed interpreter
-    // thunk) rather than a temporary precode.
+    // CallDefaultConstructor invokes the ctor via the function pointer, so its portable entrypoint
+    // must resolve to real code if possible.
     MethodDesc::EnsurePortableEntryPointIsCallableFromR2R(ctorCode);
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -788,11 +788,8 @@ extern "C" void* QCALLTYPE GCInterface_GetNextFinalizableObject(QCall::ObjectHan
         funcPtr = pMT->GetRestoredSlot(g_pObjectFinalizerMD->GetSlot());
 
 #ifdef FEATURE_PORTABLE_ENTRYPOINTS
-        // On portable-entrypoint (wasm) targets, RunFinalizers invokes the finalizer via a typed
-        // call_indirect, so the slot's portable entry point must resolve to real code (native R2R
-        // code or a correctly-typed interpreter thunk) rather than the temporary precode. The normal
-        // R2R method-entry fixups perform this for direct calls, but the finalizer slot is fetched
-        // directly here and so must be made callable explicitly, mirroring CallClassConstructor.
+        // RunFinalizers invokes the finalizer via the function pointer, so its portable entrypoint must
+        // resolve to real code if possible.
         MethodDesc::EnsurePortableEntryPointIsCallableFromR2R(funcPtr);
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
     }

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -786,6 +786,15 @@ extern "C" void* QCALLTYPE GCInterface_GetNextFinalizableObject(QCall::ObjectHan
         MethodTable* pMT = target->GetMethodTable();
 
         funcPtr = pMT->GetRestoredSlot(g_pObjectFinalizerMD->GetSlot());
+
+#ifdef FEATURE_PORTABLE_ENTRYPOINTS
+        // On portable-entrypoint (wasm) targets, RunFinalizers invokes the finalizer via a typed
+        // call_indirect, so the slot's portable entry point must resolve to real code (native R2R
+        // code or a correctly-typed interpreter thunk) rather than the temporary precode. The normal
+        // R2R method-entry fixups perform this for direct calls, but the finalizer slot is fetched
+        // directly here and so must be made callable explicitly, mirroring CallClassConstructor.
+        MethodDesc::EnsurePortableEntryPointIsCallableFromR2R(funcPtr);
+#endif // FEATURE_PORTABLE_ENTRYPOINTS
     }
 
     END_QCALL;

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3571,11 +3571,8 @@ BOOL MethodTable::RunClassInitEx(OBJECTREF *pThrowable)
         MethodTable* instantiatingArg = pCanonMT->IsSharedByGenericInstantiations() ? this : nullptr;
 
 #ifdef FEATURE_PORTABLE_ENTRYPOINTS
-        // On portable-entrypoint (wasm) targets, CallClassConstructor invokes the cctor via a
-        // typed call_indirect, so the slot's portable entry point must resolve to real code
-        // (native R2R code or a correctly-typed interpreter thunk) rather than the temporary
-        // precode. The normal R2R method-entry fixups perform this for direct calls, but the
-        // cctor slot is fetched directly here and so must be made callable explicitly.
+        // CallClassConstructor invokes the cctor via the function pointer, so its portable entrypoint
+        // must resolve to real code if possible.
         MethodDesc::EnsurePortableEntryPointIsCallableFromR2R(pCctorCode);
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 


### PR DESCRIPTION
## Summary

On `FEATURE_PORTABLE_ENTRYPOINTS` (wasm) targets, running finalizers under ReadyToRun traps with `RuntimeError: null function or function signature mismatch` in `System.GC.RunFinalizers`.

`RunFinalizers` invokes each object's `Finalize` via a typed `call_indirect` on the finalizer method's PortableEntryPoint (PEP). `GCInterface_GetNextFinalizableObject` returned the raw `GetRestoredSlot` result, which for a not-yet-prepared method is a **cold** PEP (`_pActualCode == 0`, prefers the interpreter). The `call_indirect` therefore targets wasm table slot 0 (the reserved null slot) and traps.

This is the finalizer manifestation of the cold-first-call R2R trap family in #130634.

Fixes #130839.

## Root cause

Per the documented invariant (`method.cpp:2947-2954`, `docs/design/coreclr/botr/clr-abi.md:865-871`), any slot fetched directly and then invoked via an R2R `call_indirect` must first be made callable — its PEP must resolve to real code (native R2R code or a correctly-typed interpreter thunk) rather than the temporary precode. Every other such call site already does this:

- `GetMultiCallableAddrOfCode`
- cctor slot (`methodtable.cpp:3579`)
- managed main entry (`assembly.cpp:1164`)
- default ctor (`callhelpers.cpp:580`)
- P/Invoke (`dllimport.cpp:5919`)
- `ExternalMethodFixupWorker` (`prestub.cpp:3074`)
- EnC (`method.cpp:3462`)

The finalizer QCall is the one missing site.

## Fix

One line, mirroring the class-constructor slot handling in `MethodTable::CallClassConstructor` (`methodtable.cpp:3579`):

```cpp
funcPtr = pMT->GetRestoredSlot(g_pObjectFinalizerMD->GetSlot());
#ifdef FEATURE_PORTABLE_ENTRYPOINTS
    MethodDesc::EnsurePortableEntryPointIsCallableFromR2R(funcPtr);
#endif
```

`EnsurePortableEntryPointIsCallableFromR2R` wires the R2R→interpreter thunk for the finalizer signature into `_pActualCode` (or leaves already-published native code in place), so the `call_indirect` resolves to real code instead of table slot 0. This is `WRAPPER_NO_CONTRACT` / load-safe (no GC transition), so no extra GC bookkeeping is needed — same as the cctor call site.

## Validation

The bug only *reproduces* with the (not-yet-merged) R2R-on-wasm bring-up stack, so there is no wasm-R2R CI leg to exercise it on `main` yet. Validated on the R2R-on-wasm prototype, controlling for corerun identity (md5) and harness confounds, across **both R2R modes**:

| test | R2R-corelib (interpreted finalizer) | R2R-full (crossgen'd finalizer) | interpreter |
|------|:---:|:---:|:---:|
| `b12795` | crash → **pass** | crash → **pass** | pass |
| `b38269` | crash → **pass** | crash → **pass** | pass |

A same-build R2R-corelib sweep of the JIT/Regression suite (fixed vs. no-fix corerun, with only this change varying) corroborates: the finalizer/GC tests flip crash→pass and every other test produces an identical result with and without the change — i.e. no regressions. The change is a correct addition to the documented call-site-makes-callable pattern and applies to `main` as-is.

## Notes for reviewers

- Draft because it cannot be CI-validated on `main` until the R2R-on-wasm consumption path lands.
- Related: #130634 (canonical cold-first-call family); #130839 (finalizer issue).

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
