### PR TITLE
Fix three xarch lowering correctness/invariant issues

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -2981,7 +2981,7 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
                 {
                     assert((count == 1) || (count == 2) || (count == 4));
 
-                    if (!TryInvertMask(maskNode, simdSize, simdBaseType))
+                    if (!TryInvertMask(maskNode, simdSize, maskBaseType))
                     {
                         // We weren't able to invert the mask, so we need to do it here, keeping the upper
                         // n-bits clear. If we have 1 element, then the upper 7-bits need to be cleared. If we have

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -10493,7 +10493,10 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                                 }
                             }
 
-                            TryMakeSrcContainedOrRegOptional(node, op2);
+                            if (!op2->isContained())
+                            {
+                                TryMakeSrcContainedOrRegOptional(node, op2);
+                            }
                             break;
                         }
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6420,7 +6420,7 @@ GenTree* Lowering::TryLowerAndOpToExtractLowestSetBit(GenTreeOp* andNode)
     }
 
     // Subsequent nodes may rely on CPU flags set by these nodes in which case we cannot remove them
-    if (((opNode->gtFlags & GTF_SET_FLAGS) != 0) || ((negNode->gtFlags & GTF_SET_FLAGS) != 0))
+    if (((andNode->gtFlags & GTF_SET_FLAGS) != 0) || ((negNode->gtFlags & GTF_SET_FLAGS) != 0))
     {
         return nullptr;
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130844/Runtime_130844.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130844/Runtime_130844.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Exercises vector equality/inequality comparisons whose mask element type can
+// differ from the declared comparison base type, hitting the mask-inversion path
+// in LowerHWIntrinsicCmpOp on hardware with AVX512 (EVEX mask + KORTEST). The
+// element count is below 8 so an incorrect base type would produce spurious high
+// bits in the inverted constant mask.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public static class Runtime_130844
+{
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static bool EqDouble128(Vector128<double> a, Vector128<double> b) => a == b;
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static bool NeDouble128(Vector128<double> a, Vector128<double> b) => a != b;
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static bool EqDouble256(Vector256<double> a, Vector256<double> b) => a == b;
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static bool NeDouble256(Vector256<double> a, Vector256<double> b) => a != b;
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static bool EqLong128(Vector128<long> a, Vector128<long> b) => a == b;
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static bool NeLong128(Vector128<long> a, Vector128<long> b) => a != b;
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static bool EqLong256(Vector256<long> a, Vector256<long> b) => a == b;
+
+    // Reinterpret pattern: the comparison mask is produced with one element type
+    // but consumed against an AllBitsSet of a different element type.
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static bool EqualsAsInt128(Vector128<double> a, Vector128<double> b)
+        => Vector128.Equals(a, b).AsInt32() == Vector128<int>.AllBitsSet;
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static bool NotEqualsAsInt256(Vector256<double> a, Vector256<double> b)
+        => Vector256.Equals(a, b).AsInt32() != Vector256<int>.AllBitsSet;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Vector128<double> d128 = Vector128.Create(1.0, 2.0);
+        Vector128<double> d128b = Vector128.Create(1.0, 9.0);
+        Vector256<double> d256 = Vector256.Create(1.0, 2.0, 3.0, 4.0);
+        Vector256<double> d256b = Vector256.Create(1.0, 2.0, 3.0, 9.0);
+
+        Assert.True(EqDouble128(d128, d128));
+        Assert.False(EqDouble128(d128, d128b));
+        Assert.False(NeDouble128(d128, d128));
+        Assert.True(NeDouble128(d128, d128b));
+
+        Assert.True(EqDouble256(d256, d256));
+        Assert.False(EqDouble256(d256, d256b));
+        Assert.False(NeDouble256(d256, d256));
+        Assert.True(NeDouble256(d256, d256b));
+
+        Vector128<long> l128 = Vector128.Create(1L, 2L);
+        Vector128<long> l128b = Vector128.Create(1L, 9L);
+        Vector256<long> l256 = Vector256.Create(1L, 2L, 3L, 4L);
+        Vector256<long> l256b = Vector256.Create(1L, 2L, 3L, 9L);
+
+        Assert.True(EqLong128(l128, l128));
+        Assert.False(EqLong128(l128, l128b));
+        Assert.False(NeLong128(l128, l128));
+        Assert.True(NeLong128(l128, l128b));
+
+        Assert.True(EqLong256(l256, l256));
+        Assert.False(EqLong256(l256, l256b));
+
+        Assert.True(EqualsAsInt128(d128, d128));
+        Assert.False(EqualsAsInt128(d128, d128b));
+
+        Assert.False(NotEqualsAsInt256(d256, d256));
+        Assert.True(NotEqualsAsInt256(d256, d256b));
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130844/Runtime_130844.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130844/Runtime_130844.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130845/Runtime_130845.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130845/Runtime_130845.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Exercises the AND(X, NEG(X)) -> ExtractLowestSetBit (BLSI) lowering where the
+// result feeds a flags consumer (a compare-to-zero / branch). Validates that the
+// transform preserves both the produced value and the branch behavior.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Runtime_130845
+{
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static long IsolateLong(long x) => x & (-x);
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static int IsolateInt(int x) => x & (-x);
+
+    // The AND result feeds a branch, so its flags are consumed downstream.
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static int BranchOnIsolateLong(long x)
+    {
+        if ((x & (-x)) == 0)
+        {
+            return 42;
+        }
+        return 7;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static int BranchOnIsolateInt(int x)
+    {
+        if ((x & (-x)) != 0)
+        {
+            return 7;
+        }
+        return 42;
+    }
+
+    // The isolated value is also consumed by value, guarding against the AND
+    // being incorrectly replaced when its result is used beyond the flags.
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static long IsolateAndAddLong(long x)
+    {
+        long y = x & (-x);
+        if (y == 0)
+        {
+            return -1;
+        }
+        return y + 1;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        long[] longInputs = { 0, 1, 2, 6, 0x100, unchecked((long)0x8000_0000_0000_0000), -1, 0x5A5A_5A5A_0000_0000 };
+        foreach (long x in longInputs)
+        {
+            long expected = x & (-x);
+            Assert.Equal(expected, IsolateLong(x));
+            Assert.Equal((expected == 0) ? 42 : 7, BranchOnIsolateLong(x));
+            Assert.Equal((expected == 0) ? -1 : expected + 1, IsolateAndAddLong(x));
+        }
+
+        int[] intInputs = { 0, 1, 2, 6, 0x100, unchecked((int)0x8000_0000), -1, 0x5A5A_0000 };
+        foreach (int x in intInputs)
+        {
+            int expected = x & (-x);
+            Assert.Equal(expected, IsolateInt(x));
+            Assert.Equal((expected == 0) ? 42 : 7, BranchOnIsolateInt(x));
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130845/Runtime_130845.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130845/Runtime_130845.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130846/Runtime_130846.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130846/Runtime_130846.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Exercises the INSERTPS (Sse41.Insert for float) lowering path where op2 is a
+// zero vector and gets marked contained. Validates that the containment path
+// produces correct results across a range of constant control bytes.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+public static class Runtime_130846
+{
+    // Scalar reference for INSERTPS(a, b, imm8) with b == zero.
+    private static Vector128<float> Reference(Vector128<float> a, int imm8)
+    {
+        int count_d = (imm8 >> 4) & 0x3;
+        int zmask   = imm8 & 0xF;
+
+        Span<float> r = stackalloc float[4];
+        for (int i = 0; i < 4; i++)
+        {
+            r[i] = a.GetElement(i);
+        }
+
+        // op2 is zero, so the selected source element is 0.
+        r[count_d] = 0.0f;
+
+        for (int i = 0; i < 4; i++)
+        {
+            if (((zmask >> i) & 1) != 0)
+            {
+                r[i] = 0.0f;
+            }
+        }
+
+        return Vector128.Create(r[0], r[1], r[2], r[3]);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<float> Ins00(Vector128<float> x) => Sse41.Insert(x, Vector128<float>.Zero, 0x00);
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<float> Ins10(Vector128<float> x) => Sse41.Insert(x, Vector128<float>.Zero, 0x10);
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<float> Ins20(Vector128<float> x) => Sse41.Insert(x, Vector128<float>.Zero, 0x20);
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<float> Ins30(Vector128<float> x) => Sse41.Insert(x, Vector128<float>.Zero, 0x30);
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<float> Ins0E(Vector128<float> x) => Sse41.Insert(x, Vector128<float>.Zero, 0x0E);
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<float> Ins4D(Vector128<float> x) => Sse41.Insert(x, Vector128<float>.Zero, 0x4D);
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<float> Ins8B(Vector128<float> x) => Sse41.Insert(x, Vector128<float>.Zero, 0x8B);
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<float> Ins39(Vector128<float> x) => Sse41.Insert(x, Vector128<float>.Zero, 0x39);
+
+    [ConditionalFact(typeof(Sse41), nameof(Sse41.IsSupported))]
+    public static void TestEntryPoint()
+    {
+        Vector128<float> x = Vector128.Create(1.0f, 2.0f, 3.0f, 4.0f);
+
+        Assert.Equal(Reference(x, 0x00), Ins00(x));
+        Assert.Equal(Reference(x, 0x10), Ins10(x));
+        Assert.Equal(Reference(x, 0x20), Ins20(x));
+        Assert.Equal(Reference(x, 0x30), Ins30(x));
+        Assert.Equal(Reference(x, 0x0E), Ins0E(x));
+        Assert.Equal(Reference(x, 0x4D), Ins4D(x));
+        Assert.Equal(Reference(x, 0x8B), Ins8B(x));
+        Assert.Equal(Reference(x, 0x39), Ins39(x));
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_130846/Runtime_130846.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_130846/Runtime_130846.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
﻿Three independent xarch lowering fixes, each as its own commit so they can be reviewed (or split) individually. Each has a standalone JitBlue regression test named after its tracking issue.

----------

**`Fix incorrect base type passed to TryInvertMask for mask inversion`** (test: `Runtime_130844`)

Fixes #130844.

`LowerHWIntrinsicCmpOp` passed the node's `simdBaseType` to `TryInvertMask`, but the const-mask inversion path computes the number of valid mask bits from that base type (`GetBitMask(simdSize / genTypeSize(base))`). The mask's own base type (`maskBaseType`) can legitimately differ from the comparison's declared base type (e.g. an `op_Equality` declared `TYP_INT` over a `TYP_DOUBLE` mask), which would produce the wrong bit count and spurious high bits in the inverted mask. Pass `maskBaseType`, consistent with every other consumer in the block (element `count`, `NotMask`/`ShiftLeftMask`/`ShiftRightMask`). The other caller (`BlendVariableMask`) is unaffected since its base type already matches the mask.

Only observable on AVX512 (EVEX mask + `KORTEST`) and only in the `IsCnsMsk()` const-mask branch; correctness/consistency fix.

----------

**`Ensure the correct node is checked for flags in TryLowerAndOpToExtractLowestSetBit`** (test: `Runtime_130845`)

Fixes #130845.

The `GTF_SET_FLAGS` guard tested `opNode` (the surviving leaf operand -- a dead check) rather than `andNode`, the `GT_AND` root that is removed and replaced by the BLSI. `AND` and `BLSI` set the CPU flags differently, so if a downstream consumer reads the flags produced by the AND the transform is unsound. Check `andNode`, matching the sibling `TryLowerAndOpToResetLowestSetBit`, and drop the dead `opNode` sub-check.

Latent by lowering order today (the AND's `GTF_SET_FLAGS` is only set later, when the consuming compare-to-zero is lowered), so this is a consistency/hardening change.

----------

**`Don't mark INSERTPS op2 both contained and reg-optional`** (test: `Runtime_130846`)

Fixes #130846.

For `NI_X86Base_Insert` (FLOAT), when `op2` is a zero vector it is already `MakeSrcContained` (the zero is fully elided via the INSERTPS `zmask`), but `TryMakeSrcContainedOrRegOptional` then ran unconditionally and additionally marked it reg-optional -- violating the invariant that a node is not both contained and reg-optional. Guard the call on `!op2->isContained()`, making the op2 path symmetric with the `op1->IsVectorZero()` branch just above (which contains and never retries).

The reg-optional flag is inert at runtime (a contained zero `CNS_VEC` produces no operand uses), so no default-build assert fires; hardening fix confirmed via temporary instrumentation.

----------

All three come with JitBlue regression tests (proper ISA guards, scalar reference oracles). On non-AVX512 hardware all three are latent, so the tests are execution/coverage guards; #130844 specifically exercises the buggy EVEX path only on AVX512 CI.

> [!NOTE]
> This PR description and the accompanying changes were generated with the assistance of GitHub Copilot.
