### PR TITLE
Disable newly added test on clrinterp

### DIFF
--- a/src/tests/profiler/elttransitions/elttransitions.cs
+++ b/src/tests/profiler/elttransitions/elttransitions.cs
@@ -37,6 +37,11 @@ namespace Profiler.Tests
 
         public static int Main(string[] args)
         {
+            if (!TestLibrary.PlatformDetection.IsICorProfilerEnterLeaveHooksEnabled)
+            {
+                return 100;
+            }
+
             if (args.Length > 1 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
             {
                 switch (args[1])


### PR DESCRIPTION
Currently interpreter doesn't have enter leave implemented. Disable test like others in the area. Test fails on CI following https://github.com/dotnet/runtime/pull/130639