### PR TITLE
[Apple] Preserve Norwegian locale names in hybrid globalization

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
@@ -441,6 +441,20 @@ namespace System.Globalization.Tests
             Assert.Equal(cultureName, culture.ToString(), ignoreCase: true);
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnApplePlatform))]
+        [InlineData("no", "no", "no", "nor", "")]
+        [InlineData("no-NO", "no-NO", "no", "nor", "no")]
+        [InlineData("iw", "he", "he", "heb", "")]
+        public void Ctor_String_HybridAppleLanguageNames(string name, string expectedName, string expectedTwoLetterName, string expectedThreeLetterName, string expectedParentName)
+        {
+            CultureInfo culture = new CultureInfo(name);
+
+            Assert.Equal(expectedName, culture.Name);
+            Assert.Equal(expectedTwoLetterName, culture.TwoLetterISOLanguageName);
+            Assert.Equal(expectedThreeLetterName, culture.ThreeLetterISOLanguageName);
+            Assert.Equal(expectedParentName, culture.Parent.Name);
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnApplePlatform))]
         public void Ctor_String_Invalid()
         {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
@@ -231,6 +231,7 @@ namespace System.Globalization.Tests
             yield return new object[] { "nb-NO", new [] { "nb-NO" } };
             yield return new object[] { "ne", new [] { "ne" }};
             yield return new object[] { "ne-NP", new [] { "ne-NP" }};
+            yield return new object[] { "no", new [] { "no" } };
             yield return new object[] { "nl", new [] { "nl" } };
             yield return new object[] { "nl-BE", new [] { "nl-BE" } };
             yield return new object[] { "nl-NL", new [] { "nl-NL" } };
@@ -356,7 +357,6 @@ namespace System.Globalization.Tests
             yield return new object[] { "zu", new [] { "zu" }};
             yield return new object[] { "zu-ZA", new [] { "zu-ZA" }};
             yield return new object[] { CultureInfo.CurrentCulture.Name, new [] { CultureInfo.CurrentCulture.Name } };
-            yield return new object[] { "no", new [] { "no" } };
 
             if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
             {
@@ -441,11 +441,10 @@ namespace System.Globalization.Tests
             Assert.Equal(cultureName, culture.ToString(), ignoreCase: true);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnApplePlatform))]
+        [Theory]
         [InlineData("no", "no", "no", "nor", "")]
         [InlineData("no-NO", "no-NO", "no", "nor", "no")]
-        [InlineData("iw", "he", "he", "heb", "")]
-        public void Ctor_String_HybridAppleLanguageNames(string name, string expectedName, string expectedTwoLetterName, string expectedThreeLetterName, string expectedParentName)
+        public void Ctor_String_NorwegianLanguageNames(string name, string expectedName, string expectedTwoLetterName, string expectedThreeLetterName, string expectedParentName)
         {
             CultureInfo culture = new CultureInfo(name);
 

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
@@ -441,7 +441,7 @@ namespace System.Globalization.Tests
             Assert.Equal(cultureName, culture.ToString(), ignoreCase: true);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
         [InlineData("no", "no", "no", "nor", "")]
         [InlineData("no-NO", "no-NO", "no", "nor", "no")]
         public void Ctor_String_NorwegianLanguageNames(string name, string expectedName, string expectedTwoLetterName, string expectedThreeLetterName, string expectedParentName)

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
@@ -356,6 +356,7 @@ namespace System.Globalization.Tests
             yield return new object[] { "zu", new [] { "zu" }};
             yield return new object[] { "zu-ZA", new [] { "zu-ZA" }};
             yield return new object[] { CultureInfo.CurrentCulture.Name, new [] { CultureInfo.CurrentCulture.Name } };
+            yield return new object[] { "no", new [] { "no" } };
 
             if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
             {
@@ -366,7 +367,6 @@ namespace System.Globalization.Tests
                 yield return new object[] { "ha-Latn", new [] { "ha-Latn" }};
                 yield return new object[] { "ha-Latn-NG", new [] { "ha-Latn-NG" }};
                 yield return new object[] { "mn-Cyrl", new [] { "mn-Cyrl" }};
-                yield return new object[] { "no", new [] { "no" } };
                 yield return new object[] { "sr-Cyrl", new [] { "sr-Cyrl" } };
                 yield return new object[] { "sr-Cyrl-BA", new [] { "sr-Cyrl-BA" }};
                 yield return new object[] { "sr-Cyrl-CS", new [] { "sr-Cyrl-CS" }};

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -69,7 +69,9 @@ static NSString* GetLocaleIdentifier(NSString *localeName, NSLocale *canonicalLo
 
     if (languageCode == nil ||
         canonicalLanguageCode == nil ||
-        [languageCode isEqualToString:canonicalLanguageCode])
+        localeIdentifier == nil ||
+        [languageCode isEqualToString:canonicalLanguageCode] ||
+        localeIdentifier.length < canonicalLanguageCode.length)
     {
         return localeIdentifier;
     }

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -49,6 +49,8 @@ static NSString* GetLanguageSubtag(NSString *localeName)
 
 static NSString* GetLocaleLanguageCode(NSString *localeName, NSLocale *canonicalLocale)
 {
+    // Foundation canonicalizes "no" (Norwegian) to "nb" (Norwegian Bokmål), unlike ICU which
+    // keeps "no". Preserve "no" so culture names match Windows/Android (see dotnet/runtime#112249).
     NSString *languageSubtag = GetLanguageSubtag(localeName);
     if ([languageSubtag caseInsensitiveCompare:@"no"] == NSOrderedSame &&
         [canonicalLocale.languageCode isEqualToString:@"nb"])

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -38,7 +38,7 @@ char* DetectDefaultAppleLocaleName(void)
 
 #if defined(APPLE_HYBRID_GLOBALIZATION)
 
-static NSString* GetLanguageCode(NSString *localeName)
+static NSString* GetLanguageSubtag(NSString *localeName)
 {
     NSRange separatorRange = [localeName rangeOfCharacterFromSet:
         [NSCharacterSet characterSetWithCharactersInString:@"-_@"]];
@@ -47,18 +47,32 @@ static NSString* GetLanguageCode(NSString *localeName)
     return localeName;
 }
 
-static bool ShouldPreserveNorwegianLanguageCode(NSString *localeName, NSLocale *canonicalLocale)
+static NSString* GetLocaleLanguageCode(NSString *localeName, NSLocale *canonicalLocale)
 {
-    return [GetLanguageCode(localeName) caseInsensitiveCompare:@"no"] == NSOrderedSame &&
-        [canonicalLocale.languageCode isEqualToString:@"nb"];
+    NSString *languageSubtag = GetLanguageSubtag(localeName);
+    if ([languageSubtag caseInsensitiveCompare:@"no"] == NSOrderedSame &&
+        [canonicalLocale.languageCode isEqualToString:@"nb"])
+    {
+        return @"no";
+    }
+
+    return canonicalLocale.languageCode;
 }
 
 static NSString* GetLocaleIdentifier(NSString *localeName, NSLocale *canonicalLocale)
 {
-    NSString *value = canonicalLocale.localeIdentifier;
-    return ShouldPreserveNorwegianLanguageCode(localeName, canonicalLocale) ?
-        [@"no" stringByAppendingString:[value substringFromIndex:2]] :
-        value;
+    NSString *canonicalLanguageCode = canonicalLocale.languageCode;
+    NSString *languageCode = GetLocaleLanguageCode(localeName, canonicalLocale);
+    NSString *localeIdentifier = canonicalLocale.localeIdentifier;
+
+    if (languageCode == nil ||
+        canonicalLanguageCode == nil ||
+        [languageCode isEqualToString:canonicalLanguageCode])
+    {
+        return localeIdentifier;
+    }
+
+    return [languageCode stringByAppendingString:[localeIdentifier substringFromIndex:canonicalLanguageCode.length]];
 }
 
 const char* GlobalizationNative_GetLocaleNameNative(const char* localeName)
@@ -267,16 +281,12 @@ const char* GlobalizationNative_GetLocaleInfoStringNative(const char* localeName
                 break;
             case LocaleString_Iso639LanguageTwoLetterName:
             {
-                value = ShouldPreserveNorwegianLanguageCode(locName, currentLocale) ?
-                    @"no" :
-                    currentLocale.languageCode;
+                value = GetLocaleLanguageCode(locName, currentLocale);
                 break;
             }
             case LocaleString_Iso639LanguageThreeLetterName:
             {
-                NSString *languageCode = ShouldPreserveNorwegianLanguageCode(locName, currentLocale) ?
-                    @"no" :
-                    currentLocale.languageCode;
+                NSString *languageCode = GetLocaleLanguageCode(locName, currentLocale);
                 return languageCode == nil ? strdup("") : strdup(getISO3LanguageByLangCode([languageCode UTF8String]));
             }
             case LocaleString_Iso3166CountryName:

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -37,14 +37,67 @@ char* DetectDefaultAppleLocaleName(void)
 }
 
 #if defined(APPLE_HYBRID_GLOBALIZATION)
+
+// Helper: extracts the language code (prefix before first '-', '_', or '@') from a locale name.
+static NSString* GetLanguageCode(NSString *localeName)
+{
+    NSRange separatorRange = [localeName rangeOfCharacterFromSet:
+        [NSCharacterSet characterSetWithCharactersInString:@"-_@"]];
+    if (separatorRange.location != NSNotFound)
+        return [localeName substringToIndex:separatorRange.location];
+    return localeName;
+}
+
+// Counts the number of locale subtag separators ('-' or '_') in a string.
+static NSUInteger CountSegmentSeparators(NSString *localeName)
+{
+    NSUInteger count = 0;
+    for (NSUInteger i = 0; i < localeName.length; i++)
+    {
+        unichar c = [localeName characterAtIndex:i];
+        if (c == '-' || c == '_')
+            count++;
+        else if (c == '@')
+            break; // keywords are not subtags
+    }
+    return count;
+}
+
 const char* GlobalizationNative_GetLocaleNameNative(const char* localeName)
 {
     @autoreleasepool
     {
         NSString *locName = [[NSString alloc] initWithUTF8String:localeName];
         NSLocale *currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:locName];
-        const char* value = [currentLocale.localeIdentifier UTF8String];
-        return strdup(value);
+        NSString *canonicalId = currentLocale.localeIdentifier;
+
+        if (canonicalId.length == 0)
+            return strdup("");
+
+        // Apple's Foundation canonicalizes some language codes differently from ICU:
+        // e.g., "no" -> "nb", "iw" -> "he", "in" -> "id", "tl" -> "fil".
+        // To maintain cross-platform consistency with ICU/Windows behavior,
+        // preserve the original language code when Apple changes it.
+        // Only apply when the locale structure is preserved (same segment count),
+        // to avoid corrupting grandfathered tags like "zh-min-nan" -> "nan".
+        NSString *inputLang = GetLanguageCode(locName);
+        NSString *canonLang = GetLanguageCode(canonicalId);
+
+        if ([inputLang caseInsensitiveCompare:canonLang] != NSOrderedSame &&
+            CountSegmentSeparators(locName) == CountSegmentSeparators(canonicalId))
+        {
+            // Apple changed the language code. Reconstruct with the original (lowercased).
+            NSString *suffix = @"";
+            NSRange canonSepRange = [canonicalId rangeOfCharacterFromSet:
+                [NSCharacterSet characterSetWithCharactersInString:@"-_@"]];
+            if (canonSepRange.location != NSNotFound)
+                suffix = [canonicalId substringFromIndex:canonSepRange.location];
+
+            NSString *result = [[inputLang lowercaseString] stringByAppendingString:suffix];
+            return strdup([result UTF8String]);
+        }
+
+        return strdup([canonicalId UTF8String]);
     }
 }
 
@@ -238,12 +291,31 @@ const char* GlobalizationNative_GetLocaleInfoStringNative(const char* localeName
                 value = numberFormatter.minusSign;
                 break;
             case LocaleString_Iso639LanguageTwoLetterName:
-                value = [currentLocale objectForKey:NSLocaleLanguageCode];
+            {
+                // Use the language code from the input locale name to avoid Apple's
+                // canonicalization (e.g., "no" -> "nb"). The input preserves the original.
+                NSString *inputLang = GetLanguageCode(locName);
+                NSString *nativeLang = [currentLocale objectForKey:NSLocaleLanguageCode];
+                if (nativeLang != nil && [inputLang caseInsensitiveCompare:nativeLang] != NSOrderedSame)
+                    value = [inputLang lowercaseString];
+                else
+                    value = nativeLang;
                 break;
+            }
             case LocaleString_Iso639LanguageThreeLetterName:
             {
-                NSString *iso639_2 = [currentLocale objectForKey:NSLocaleLanguageCode];
-                return iso639_2 == nil ? strdup("") : strdup(getISO3LanguageByLangCode([iso639_2 UTF8String]));
+                NSString *inputLang = GetLanguageCode(locName);
+                NSString *nativeLang = [currentLocale objectForKey:NSLocaleLanguageCode];
+                NSString *lowercased = nil;
+                const char *twoLetterCode;
+                if (nativeLang != nil && [inputLang caseInsensitiveCompare:nativeLang] != NSOrderedSame)
+                {
+                    lowercased = [inputLang lowercaseString];
+                    twoLetterCode = [lowercased UTF8String];
+                }
+                else
+                    twoLetterCode = nativeLang == nil ? "" : [nativeLang UTF8String];
+                return strdup(getISO3LanguageByLangCode(twoLetterCode));
             }
             case LocaleString_Iso3166CountryName:
                 value = [currentLocale objectForKey:NSLocaleCountryCode];

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -38,7 +38,6 @@ char* DetectDefaultAppleLocaleName(void)
 
 #if defined(APPLE_HYBRID_GLOBALIZATION)
 
-// Helper: extracts the language code (prefix before first '-', '_', or '@') from a locale name.
 static NSString* GetLanguageCode(NSString *localeName)
 {
     NSRange separatorRange = [localeName rangeOfCharacterFromSet:
@@ -48,19 +47,18 @@ static NSString* GetLanguageCode(NSString *localeName)
     return localeName;
 }
 
-// Counts the number of locale subtag separators ('-' or '_') in a string.
-static NSUInteger CountSegmentSeparators(NSString *localeName)
+static bool ShouldPreserveNorwegianLanguageCode(NSString *localeName, NSLocale *canonicalLocale)
 {
-    NSUInteger count = 0;
-    for (NSUInteger i = 0; i < localeName.length; i++)
-    {
-        unichar c = [localeName characterAtIndex:i];
-        if (c == '-' || c == '_')
-            count++;
-        else if (c == '@')
-            break; // keywords are not subtags
-    }
-    return count;
+    return [GetLanguageCode(localeName) caseInsensitiveCompare:@"no"] == NSOrderedSame &&
+        [canonicalLocale.languageCode isEqualToString:@"nb"];
+}
+
+static NSString* GetLocaleIdentifier(NSString *localeName, NSLocale *canonicalLocale)
+{
+    NSString *value = canonicalLocale.localeIdentifier;
+    return ShouldPreserveNorwegianLanguageCode(localeName, canonicalLocale) ?
+        [@"no" stringByAppendingString:[value substringFromIndex:2]] :
+        value;
 }
 
 const char* GlobalizationNative_GetLocaleNameNative(const char* localeName)
@@ -69,35 +67,12 @@ const char* GlobalizationNative_GetLocaleNameNative(const char* localeName)
     {
         NSString *locName = [[NSString alloc] initWithUTF8String:localeName];
         NSLocale *currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:locName];
-        NSString *canonicalId = currentLocale.localeIdentifier;
+        NSString *value = GetLocaleIdentifier(locName, currentLocale);
 
-        if (canonicalId.length == 0)
+        if (value.length == 0)
             return strdup("");
 
-        // Apple's Foundation canonicalizes some language codes differently from ICU:
-        // e.g., "no" -> "nb", "iw" -> "he", "in" -> "id", "tl" -> "fil".
-        // To maintain cross-platform consistency with ICU/Windows behavior,
-        // preserve the original language code when Apple changes it.
-        // Only apply when the locale structure is preserved (same segment count),
-        // to avoid corrupting grandfathered tags like "zh-min-nan" -> "nan".
-        NSString *inputLang = GetLanguageCode(locName);
-        NSString *canonLang = GetLanguageCode(canonicalId);
-
-        if ([inputLang caseInsensitiveCompare:canonLang] != NSOrderedSame &&
-            CountSegmentSeparators(locName) == CountSegmentSeparators(canonicalId))
-        {
-            // Apple changed the language code. Reconstruct with the original (lowercased).
-            NSString *suffix = @"";
-            NSRange canonSepRange = [canonicalId rangeOfCharacterFromSet:
-                [NSCharacterSet characterSetWithCharactersInString:@"-_@"]];
-            if (canonSepRange.location != NSNotFound)
-                suffix = [canonicalId substringFromIndex:canonSepRange.location];
-
-            NSString *result = [[inputLang lowercaseString] stringByAppendingString:suffix];
-            return strdup([result UTF8String]);
-        }
-
-        return strdup([canonicalId UTF8String]);
+        return strdup([value UTF8String]);
     }
 }
 
@@ -292,30 +267,17 @@ const char* GlobalizationNative_GetLocaleInfoStringNative(const char* localeName
                 break;
             case LocaleString_Iso639LanguageTwoLetterName:
             {
-                // Use the language code from the input locale name to avoid Apple's
-                // canonicalization (e.g., "no" -> "nb"). The input preserves the original.
-                NSString *inputLang = GetLanguageCode(locName);
-                NSString *nativeLang = [currentLocale objectForKey:NSLocaleLanguageCode];
-                if (nativeLang != nil && [inputLang caseInsensitiveCompare:nativeLang] != NSOrderedSame)
-                    value = [inputLang lowercaseString];
-                else
-                    value = nativeLang;
+                value = ShouldPreserveNorwegianLanguageCode(locName, currentLocale) ?
+                    @"no" :
+                    currentLocale.languageCode;
                 break;
             }
             case LocaleString_Iso639LanguageThreeLetterName:
             {
-                NSString *inputLang = GetLanguageCode(locName);
-                NSString *nativeLang = [currentLocale objectForKey:NSLocaleLanguageCode];
-                NSString *lowercased = nil;
-                const char *twoLetterCode;
-                if (nativeLang != nil && [inputLang caseInsensitiveCompare:nativeLang] != NSOrderedSame)
-                {
-                    lowercased = [inputLang lowercaseString];
-                    twoLetterCode = [lowercased UTF8String];
-                }
-                else
-                    twoLetterCode = nativeLang == nil ? "" : [nativeLang UTF8String];
-                return strdup(getISO3LanguageByLangCode(twoLetterCode));
+                NSString *languageCode = ShouldPreserveNorwegianLanguageCode(locName, currentLocale) ?
+                    @"no" :
+                    currentLocale.languageCode;
+                return languageCode == nil ? strdup("") : strdup(getISO3LanguageByLangCode([languageCode UTF8String]));
             }
             case LocaleString_Iso3166CountryName:
                 value = [currentLocale objectForKey:NSLocaleCountryCode];
@@ -343,7 +305,8 @@ const char* GlobalizationNative_GetLocaleInfoStringNative(const char* localeName
             case LocaleString_ParentName:
             {
                 char localeNameTemp[FULLNAME_CAPACITY];
-                const char* lName = [currentLocale.localeIdentifier UTF8String];
+                NSString *localeIdentifier = GetLocaleIdentifier(locName, currentLocale);
+                const char* lName = [localeIdentifier UTF8String];
                 GetParent(lName, localeNameTemp, FULLNAME_CAPACITY);
                 return strdup(localeNameTemp);
             }
@@ -911,4 +874,3 @@ int32_t GlobalizationNative_IsPredefinedLocaleNative(const char* localeName)
     }
 }
 #endif
-


### PR DESCRIPTION
## Summary

- preserve the requested `no` culture name and ISO language codes when Foundation canonicalizes it to `nb`
- preserve `no-NO` parent fallback to `no` for resource lookup
- centralize Apple locale language-code resolution and add cross-platform Norwegian regression coverage

Fixes #112249

## Testing

- [x] CoreCLR iOS Simulator native/runtime-pack build
- [x] Norwegian culture regression theory: 2 passed, 0 failed
- [x] `CultureInfo` constructor matrix: 348 passed, 0 failed
- [x] `GetCultureInfo` canonicalization matrix: 22 passed, 0 failed

> [!NOTE]
> This PR description was generated with GitHub Copilot.