### PR TITLE
Handle cross-targeting Vector<T> size mismatch in the JIT

### DIFF
--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -314,6 +314,17 @@ var_types Compiler::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeHnd, u
                         {
                             return TYP_UNDEF;
                         }
+
+                        // Vector<T>'s length is target-dependent, so under a cross-targeting altjit (e.g.
+                        // SuperPMI replaying a context captured for a target with a different Vector<T>
+                        // length) our size can disagree with the VM's. Treat it as a regular struct then,
+                        // keeping every size query consistent with the VM rather than emitting SIMD codegen
+                        // against a mismatched size.
+                        if (size != info.compCompHnd->getClassSize(typeHnd))
+                        {
+                            assert(!info.compMatchedVM);
+                            return TYP_UNDEF;
+                        }
                         break;
                     }
 

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -320,10 +320,12 @@ var_types Compiler::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeHnd, u
                         // length) our size can disagree with the VM's. Treat it as a regular struct then,
                         // keeping every size query consistent with the VM rather than emitting SIMD codegen
                         // against a mismatched size.
-                        if (size != info.compCompHnd->getClassSize(typeHnd))
+                        if (!info.compMatchedVM)
                         {
-                            assert(!info.compMatchedVM);
-                            return TYP_UNDEF;
+                            if (size != info.compCompHnd->getClassSize(typeHnd))
+                            {
+                                return TYP_UNDEF;
+                            }
                         }
                         break;
                     }


### PR DESCRIPTION
`getBaseTypeAndSizeOfSIMDType` asserts that the JIT-computed SIMD size equals the VM's class size. `Vector<T>` is the only case whose size is target-dependent (`getVectorTByteLength`), so under a cross-targeting altjit -- e.g. SuperPMI replaying an x64-captured context with the wasm altjit, where the recorded class size reflects the host's `Vector<T>` length -- the two legitimately differ and the assert fires (`simd.cpp (448)`, during `Morph - Inlining`, over `System.Numerics.Vector<T>` methods).

Rather than relax the assert and carry a size the VM disagrees with (which would leave later size queries inconsistent and emit misleading SIMD codegen), treat `Vector<T>` as a regular struct when the sizes disagree -- the same way the `FEATURE_HW_INTRINSICS` path already degrades on an unrecognized size. This keeps every size query consistent with the VM and only affects mismatched-VM altjit scenarios; matched VMs are unchanged (there `size == getClassSize` always holds, exactly what the existing assert guarantees).

----------

Validated via SuperPMI base-vs-diff over the libraries MCH (`libraries_tests_no_tiered_compilation.run`, 397,158 contexts) with the wasm altjit and `JitWasmSimdNyiToR2RUnsupported=1`:

| Signature | Base | Diff |
| --- | --- | --- |
| `simd.cpp (448)` | 137 | 0 |
| every other assert signature | -- | byte-identical |

Total assert occurrences drop by exactly 137 with no new signatures introduced; the formerly-asserting `Vector<T>` methods now replay as SuperPMI misses (a collection gap already tolerated for the wasm SIMD-NYI path).

> [!NOTE]
> This PR description was drafted by Copilot.