### PR TITLE
Add missing helix-platforms variables to superpmi-collect

### DIFF
--- a/eng/pipelines/coreclr/superpmi-collect-test.yml
+++ b/eng/pipelines/coreclr/superpmi-collect-test.yml
@@ -4,6 +4,7 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - template: /eng/pipelines/helix-platforms.yml
 
 extends:
   template: /eng/pipelines/coreclr/templates/superpmi-collect-pipeline.yml

--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -25,6 +25,7 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - template: /eng/pipelines/helix-platforms.yml
 
 extends:
   template: /eng/pipelines/coreclr/templates/superpmi-collect-pipeline.yml


### PR DESCRIPTION
Hopefully fixes
```
 /Users/runner/work/1/s/.packages/microsoft.dotnet.helix.sdk/11.0.0-beta.26363.117/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(79,5): error : Helix API does not contain an entry for $(helix_macos_arm64_latest_internal) [/Users/runner/work/1/s/src/libraries/sendtohelixhelp.proj]
```
seen internally in superpmi-collect.