### PR TITLE
Async Profiler: Optimize async dispatcher allocation.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -1596,6 +1596,8 @@ namespace System.Runtime.CompilerServices
                 info.CurrentTask = task;
                 AsyncProfiler.InitInfo(ref info.AsyncProfilerInfo);
 
+                info.AsyncProfilerInfo.DispatcherId = (ulong)task.Id;
+
                 if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -13,31 +13,25 @@ namespace System.Runtime.CompilerServices
     {
         internal static partial class DispatcherIds
         {
-            public static ulong GetDispatcherId(ref AsyncDispatcherInfo info)
-            {
-                if (info.CurrentTask != null)
-                {
-                    return (ulong)info.CurrentTask.Id;
-                }
-                return 0;
-            }
+            public static ulong GetDispatcherId(Task dispatcher) => (ulong)dispatcher.Id;
+
+            public static ulong GetDispatcherId(ref AsyncDispatcherInfo info) => info.AsyncProfilerInfo.DispatcherId;
 
             public static unsafe ulong CaptureParentDispatcherId()
             {
                 AsyncDispatcherInfo* v2 = AsyncDispatcherInfo.t_current;
                 AsyncStateMachineDispatcherInfo* v1 = AsyncStateMachineDispatcherInfo.t_current;
 
-                Task? parent = null;
                 if (v2 != null && (v1 == null || (void*)v2 < (void*)v1))
                 {
-                    parent = v2->CurrentTask;
+                    return v2->AsyncProfilerInfo.DispatcherId;
                 }
                 else if (v1 != null)
                 {
-                    parent = v1->Dispatcher;
+                    return v1->AsyncProfilerInfo.DispatcherId;
                 }
 
-                return parent != null ? (ulong)parent.Id : 0;
+                return 0;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -153,18 +153,26 @@ namespace System.Runtime.CompilerServices
 
         internal ref struct Info
         {
+            public ulong DispatcherId;
             public object? Context;
             public object? CurrentContinuation;
-            public bool CurrentContinuationCompleted;
+            public IAsyncStateMachineBox? LastContinuation;
             public ref nint ContinuationTable;
             public uint ContinuationIndex;
+            public bool CurrentContinuationCompleted;
+            public bool CurrentContinuationResumes;
+            public bool ReachedLastContinuation;
         }
 
         internal static void InitInfo(ref Info info)
         {
+            info.DispatcherId = 0;
             info.Context = null;
             info.CurrentContinuation = null;
+            info.LastContinuation = null;
             info.CurrentContinuationCompleted = false;
+            info.CurrentContinuationResumes = false;
+            info.ReachedLastContinuation = false;
             ContinuationWrapper.InitInfo(ref info);
         }
 
@@ -894,37 +902,26 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class DispatcherIds
         {
-            public static ulong GetDispatcherId(Task dispatcher) => (ulong)dispatcher.Id;
+            public static ulong GetDispatcherId(IAsyncStateMachineDispatcher dispatcher) =>
+                dispatcher.DispatcherId;
 
-            public static ulong GetDispatcherId(ref AsyncStateMachineDispatcherInfo info)
-            {
-                if (info.Dispatcher != null)
-                {
-                    return GetDispatcherId(info.Dispatcher);
-                }
-                return 0;
-            }
+            public static ulong GetDispatcherId(ref AsyncStateMachineDispatcherInfo info) =>
+                info.AsyncProfilerInfo.DispatcherId;
 
 #if !RUNTIME_ASYNC_SUPPORTED
             public static unsafe ulong CaptureParentDispatcherId()
             {
                 AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
-                if (info == null)
-                {
-                    return 0;
-                }
-
-                AsyncStateMachineDispatcher? parent = info->Dispatcher;
-                return parent is not null ? (ulong)parent.Id : 0;
+                return info != null ? info->AsyncProfilerInfo.DispatcherId : 0;
             }
 #endif
         }
 
         internal static partial class CreateAsyncContext
         {
-            public static void Create(AsyncStateMachineDispatcher dispatcher, ref Info info, ulong parentDispatcherId, ulong dispatcherId)
+            public static void Create(ref AsyncStateMachineDispatcherInfo info, ulong parentDispatcherId, ulong dispatcherId)
             {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
                 SyncPoint.Check(context);
 
@@ -934,7 +931,7 @@ namespace System.Runtime.CompilerServices
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                     {
-                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
+                        ResumeAsyncContext.Append(ref info, context, currentTimestamp);
                     }
 
                     if (IsEnabled.CreateStateMachineAsyncContextEvent(activeEventKeywords))
@@ -961,16 +958,16 @@ namespace System.Runtime.CompilerServices
                 AsyncThreadContext.Release(context);
             }
 
-            public static void Append(AsyncStateMachineDispatcher dispatcher, ref Info info)
+            public static void Append(ref AsyncStateMachineDispatcherInfo info)
             {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
                 SyncPoint.Check(context);
 
                 EventKeywords activeEventKeywords = context.ActiveEventKeywords;
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords) && IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                 {
-                    ResumeAsyncContext.Append(dispatcher, context, Stopwatch.GetTimestamp());
+                    ResumeAsyncContext.Append(ref info, context, Stopwatch.GetTimestamp());
                 }
 
                 AsyncThreadContext.Release(context);
@@ -1028,21 +1025,21 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            public static void Append(AsyncStateMachineDispatcher dispatcher, AsyncThreadContext context, long currentTimestamp)
+            public static void Append(ref AsyncStateMachineDispatcherInfo info, AsyncThreadContext context, long currentTimestamp)
             {
-                if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ContinuationChainChanged)
+                if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(context.ActiveEventKeywords) && info.ContinuationChainChanged)
                 {
-                    AsyncCallstack.EmitEvent(dispatcher, context, dispatcher.NextContinuationForDiagnostics, currentTimestamp, AsyncEventID.AppendStateMachineAsyncCallstack, DispatcherIds.GetDispatcherId(dispatcher));
+                    AsyncCallstack.EmitEvent(ref info, context, info.NextContinuationForDiagnostics, currentTimestamp, AsyncEventID.AppendStateMachineAsyncCallstack, DispatcherIds.GetDispatcherId(ref info));
                 }
             }
 
-            public static void Append(AsyncStateMachineDispatcher dispatcher, IAsyncStateMachineBox enteringBox, AsyncThreadContext context, long currentTimestamp)
+            public static void Append(ref AsyncStateMachineDispatcherInfo info, IAsyncStateMachineBox enteringBox, AsyncThreadContext context, long currentTimestamp)
             {
-                if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(context.ActiveEventKeywords) && dispatcher.ReachedLastContinuation)
+                if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(context.ActiveEventKeywords) && info.AsyncProfilerInfo.ReachedLastContinuation)
                 {
-                    if (!ReferenceEquals(enteringBox, dispatcher.LastContinuation))
+                    if (!ReferenceEquals(enteringBox, info.AsyncProfilerInfo.LastContinuation))
                     {
-                        AsyncCallstack.EmitEvent(dispatcher, context, enteringBox, currentTimestamp, AsyncEventID.AppendStateMachineAsyncCallstack, DispatcherIds.GetDispatcherId(dispatcher));
+                        AsyncCallstack.EmitEvent(ref info, context, enteringBox, currentTimestamp, AsyncEventID.AppendStateMachineAsyncCallstack, DispatcherIds.GetDispatcherId(ref info));
                     }
                 }
             }
@@ -1067,25 +1064,15 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class SuspendAsyncContext
         {
-            public static void Suspend(AsyncStateMachineDispatcher dispatcher, ref Info info)
+            public static void Suspend(ref Info info)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
 
                 SyncPoint.Check(context);
 
-                EventKeywords activeEventKeywords = context.ActiveEventKeywords;
-                if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
+                if (IsEnabled.SuspendStateMachineAsyncContextEvent(context.ActiveEventKeywords))
                 {
-                    long currentTimestamp = Stopwatch.GetTimestamp();
-                    if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
-                    {
-                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
-                    }
-
-                    if (IsEnabled.SuspendStateMachineAsyncContextEvent(activeEventKeywords))
-                    {
-                        EmitEvent(context, currentTimestamp, AsyncEventID.SuspendStateMachineAsyncContext);
-                    }
+                    EmitEvent(context, Stopwatch.GetTimestamp(), AsyncEventID.SuspendStateMachineAsyncContext);
                 }
 
                 AsyncThreadContext.Release(context);
@@ -1100,9 +1087,9 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class CompleteAsyncContext
         {
-            public static void Complete(AsyncStateMachineDispatcher dispatcher, ref Info info)
+            public static void Complete(ref AsyncStateMachineDispatcherInfo info)
             {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
                 SyncPoint.Check(context);
 
@@ -1112,7 +1099,7 @@ namespace System.Runtime.CompilerServices
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                     {
-                        ResumeAsyncContext.Append(dispatcher, context, currentTimestamp);
+                        ResumeAsyncContext.Append(ref info, context, currentTimestamp);
                     }
 
                     if (IsEnabled.CompleteStateMachineAsyncContextEvent(activeEventKeywords))
@@ -1163,9 +1150,9 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class ResumeAsyncMethod
         {
-            public static void Resume(AsyncStateMachineDispatcher dispatcher, IAsyncStateMachineBox box, ref Info info)
+            public static void Resume(ref AsyncStateMachineDispatcherInfo info, IAsyncStateMachineBox box)
             {
-                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
+                AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
                 EventKeywords activeEventKeywords = context.ActiveEventKeywords;
                 if (IsEnabled.AnyAsyncEvents(activeEventKeywords))
@@ -1173,7 +1160,7 @@ namespace System.Runtime.CompilerServices
                     long currentTimestamp = Stopwatch.GetTimestamp();
                     if (IsEnabled.ResumeStateMachineAsyncCallstackEvent(activeEventKeywords))
                     {
-                        ResumeAsyncContext.Append(dispatcher, box, context, currentTimestamp);
+                        ResumeAsyncContext.Append(ref info, box, context, currentTimestamp);
                     }
 
                     if (IsEnabled.ResumeStateMachineAsyncMethodEvent(activeEventKeywords))
@@ -1624,11 +1611,11 @@ namespace System.Runtime.CompilerServices
 
                 EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, AsyncEventID.ResumeStateMachineAsyncCallstack, 0, dispatcherId, ref state);
 
-                info.Dispatcher.LastContinuation = IsTruncated(in state) ? null : ResolveAsyncStateMachineBox(state.LastContinuation);
-                info.Dispatcher.ReachedLastContinuation = false;
+                info.AsyncProfilerInfo.LastContinuation = IsTruncated(in state) ? null : ResolveAsyncStateMachineBox(state.LastContinuation);
+                info.AsyncProfilerInfo.ReachedLastContinuation = false;
             }
 
-            public static void EmitEvent(AsyncStateMachineDispatcher dispatcher, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong dispatcherId)
+            public static void EmitEvent(ref AsyncStateMachineDispatcherInfo info, AsyncThreadContext context, object? continuation, long currentTimestamp, AsyncEventID eventID, ulong dispatcherId)
             {
                 Debug.Assert(eventID == AsyncEventID.ResumeStateMachineAsyncCallstack || eventID == AsyncEventID.AppendStateMachineAsyncCallstack);
 
@@ -1642,14 +1629,14 @@ namespace System.Runtime.CompilerServices
 
                         EmitAsyncCallstack(context, currentTimestamp, currentTimestamp - context.LastEventTimestamp, eventID, 0, dispatcherId, ref state);
 
-                        dispatcher.LastContinuation = IsTruncated(in state) ? null : ResolveAsyncStateMachineBox(state.LastContinuation);
+                        info.AsyncProfilerInfo.LastContinuation = IsTruncated(in state) ? null : ResolveAsyncStateMachineBox(state.LastContinuation);
                     }
                     else
                     {
-                        dispatcher.LastContinuation = null;
+                        info.AsyncProfilerInfo.LastContinuation = null;
                     }
 
-                    dispatcher.ReachedLastContinuation = false;
+                    info.AsyncProfilerInfo.ReachedLastContinuation = false;
                 }
             }
 
@@ -1680,7 +1667,7 @@ namespace System.Runtime.CompilerServices
 
                 while (state.Count < maxAsyncCallstackFrames && state.Continuation != null)
                 {
-                    if (state.Continuation is AsyncStateMachineDispatcher)
+                    if (state.Continuation is IAsyncStateMachineDispatcher { IsLeaf: true })
                     {
                         state.Continuation = null;
                         break;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -919,7 +919,7 @@ namespace System.Runtime.CompilerServices
 
         internal static partial class CreateAsyncContext
         {
-            public static void Create(ref AsyncStateMachineDispatcherInfo info, ulong parentDispatcherId, ulong dispatcherId)
+            public static void Create(ref AsyncStateMachineDispatcherInfo info, IAsyncStateMachineDispatcher dispatcher)
             {
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info.AsyncProfilerInfo);
 
@@ -936,6 +936,9 @@ namespace System.Runtime.CompilerServices
 
                     if (IsEnabled.CreateStateMachineAsyncContextEvent(activeEventKeywords))
                     {
+                        ulong parentDispatcherId = AsyncProfiler.DispatcherIds.CaptureParentDispatcherId();
+                        ulong dispatcherId = AsyncProfiler.DispatcherIds.GetDispatcherId(dispatcher);
+
                         EmitEvent(context, currentTimestamp, parentDispatcherId, dispatcherId, AsyncEventID.CreateStateMachineAsyncContext);
                     }
                 }
@@ -943,7 +946,7 @@ namespace System.Runtime.CompilerServices
                 AsyncThreadContext.Release(context);
             }
 
-            public static void Create(ulong parentDispatcherId, ulong dispatcherId)
+            public static void Create(IAsyncStateMachineDispatcher dispatcher)
             {
                 Info info = default;
                 AsyncThreadContext context = AsyncThreadContext.Acquire(ref info);
@@ -952,6 +955,9 @@ namespace System.Runtime.CompilerServices
 
                 if (IsEnabled.CreateStateMachineAsyncContextEvent(context.ActiveEventKeywords))
                 {
+                    ulong parentDispatcherId = AsyncProfiler.DispatcherIds.CaptureParentDispatcherId();
+                    ulong dispatcherId = AsyncProfiler.DispatcherIds.GetDispatcherId(dispatcher);
+
                     EmitEvent(context, Stopwatch.GetTimestamp(), parentDispatcherId, dispatcherId, AsyncEventID.CreateStateMachineAsyncContext);
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
@@ -19,7 +19,7 @@ namespace System.Runtime.CompilerServices
 #else
         [FieldOffset(4)]
 #endif
-        public AsyncStateMachineDispatcher? Dispatcher;
+        public Task? Dispatcher;
 
 #if TARGET_64BIT
         [FieldOffset(16)]
@@ -45,16 +45,21 @@ namespace System.Runtime.CompilerServices
 #endif
         }
 
-        internal static unsafe AsyncStateMachineDispatcher? GetActiveDispatcher()
+        internal object? NextContinuationForDiagnostics
         {
-            if (!IsSupported)
+            get
             {
-                return null;
-            }
+                IAsyncStateMachineBox? last = AsyncProfilerInfo.LastContinuation;
+                if (last is Task task)
+                {
+                    return task.ContinuationForDiagnostics;
+                }
 
-            AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
-            return info != null ? info->Dispatcher : null;
+                return last is not null && last.GetDiagnosticData(out _, out _, out object? next) ? next : null;
+            }
         }
+
+        internal bool ContinuationChainChanged => NextContinuationForDiagnostics != null;
 
         internal static unsafe IAsyncStateMachineBox CreateDispatcher(IAsyncStateMachineBox box, AsyncInstrumentation.Flags flags)
         {
@@ -63,42 +68,71 @@ namespace System.Runtime.CompilerServices
                 return box;
             }
 
-            if (box is AsyncStateMachineDispatcher)
+            IAsyncStateMachineDispatcher? dispatcherBox = box as IAsyncStateMachineDispatcher;
+
+            if (dispatcherBox?.IsLeaf == true)
             {
                 return box;
             }
 
             AsyncStateMachineDispatcherInfo* info = AsyncStateMachineDispatcherInfo.t_current;
-            AsyncStateMachineDispatcher? activeDispatcher = info != null ? info->Dispatcher : null;
+            Task? activeDispatcher = info != null ? info->Dispatcher : null;
 
-            if (activeDispatcher != null && ReferenceEquals(activeDispatcher.InnerBox, box))
+            if (activeDispatcher is AsyncStateMachineDispatcher reusedDispatcher)
+            {
+                if (ReferenceEquals(reusedDispatcher.InnerBox, box))
+                {
+                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+                    {
+                        AsyncProfiler.CreateAsyncContext.Append(ref *info);
+                    }
+
+                    info->AsyncProfilerInfo.CurrentContinuationResumes = true;
+                    return reusedDispatcher;
+                }
+            }
+            else if (ReferenceEquals(activeDispatcher, box))
             {
                 if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
                 {
-                    AsyncProfiler.CreateAsyncContext.Append(activeDispatcher, ref info->AsyncProfilerInfo);
+                    AsyncProfiler.CreateAsyncContext.Append(ref *info);
                 }
 
-                return activeDispatcher;
+                Debug.Assert(dispatcherBox != null);
+                dispatcherBox!.IsLeaf = true;
+
+                info->AsyncProfilerInfo.CurrentContinuationResumes = true;
+                return box;
+            }
+
+            if (dispatcherBox is Task)
+            {
+                EmitCreateAsyncContext(info, dispatcherBox, flags);
+                dispatcherBox.IsLeaf = true;
+                return box;
             }
 
             AsyncStateMachineDispatcher dispatcher = new AsyncStateMachineDispatcher(box);
+            EmitCreateAsyncContext(info, dispatcher, flags);
+            return dispatcher;
+        }
 
+        private static unsafe void EmitCreateAsyncContext(AsyncStateMachineDispatcherInfo* info, IAsyncStateMachineDispatcher dispatcher, AsyncInstrumentation.Flags flags)
+        {
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
                 ulong parentDispatcherId = AsyncProfiler.DispatcherIds.CaptureParentDispatcherId();
                 ulong dispatcherId = AsyncProfiler.DispatcherIds.GetDispatcherId(dispatcher);
 
-                if (activeDispatcher != null)
+                if (info != null)
                 {
-                    AsyncProfiler.CreateAsyncContext.Create(activeDispatcher, ref info->AsyncProfilerInfo, parentDispatcherId, dispatcherId);
+                    AsyncProfiler.CreateAsyncContext.Create(ref *info, parentDispatcherId, dispatcherId);
                 }
                 else
                 {
                     AsyncProfiler.CreateAsyncContext.Create(parentDispatcherId, dispatcherId);
                 }
             }
-
-            return dispatcher;
         }
 
         internal static unsafe void UnwindAsyncFrame(object completingBox, AsyncInstrumentation.Flags flags)
@@ -128,7 +162,7 @@ namespace System.Runtime.CompilerServices
             }
 
             AsyncStateMachineDispatcherInfo* info = t_current;
-            AsyncStateMachineDispatcher? activeDispatcher = info != null ? info->Dispatcher : null;
+            Task? activeDispatcher = info != null ? info->Dispatcher : null;
             if (activeDispatcher == null)
             {
                 return;
@@ -141,27 +175,61 @@ namespace System.Runtime.CompilerServices
 
             bool methodEventEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags);
             bool callstackEnabled = AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags);
-            if (!methodEventEnabled && !(callstackEnabled && activeDispatcher.LastContinuation != null))
+            if (!methodEventEnabled && !(callstackEnabled && info->AsyncProfilerInfo.LastContinuation != null))
             {
                 return;
             }
 
-            ResumeAsyncMethod(activeDispatcher, info, box, methodEventEnabled, callstackEnabled);
+            ResumeAsyncMethod(info, box, methodEventEnabled, callstackEnabled);
         }
 
-        private static unsafe void ResumeAsyncMethod(AsyncStateMachineDispatcher activeDispatcher, AsyncStateMachineDispatcherInfo* info, IAsyncStateMachineBox box, bool methodEventEnabled, bool callstackEnabled)
+        private static unsafe void ResumeAsyncMethod(AsyncStateMachineDispatcherInfo* info, IAsyncStateMachineBox box, bool methodEventEnabled, bool callstackEnabled)
         {
-            bool callstackEventEnabled = callstackEnabled && activeDispatcher.ReachedLastContinuation;
+            bool callstackEventEnabled = callstackEnabled && info->AsyncProfilerInfo.ReachedLastContinuation;
 
-            if (!activeDispatcher.ReachedLastContinuation && ReferenceEquals(activeDispatcher.LastContinuation, box))
+            if (!info->AsyncProfilerInfo.ReachedLastContinuation && ReferenceEquals(info->AsyncProfilerInfo.LastContinuation, box))
             {
-                activeDispatcher.ReachedLastContinuation = true;
+                info->AsyncProfilerInfo.ReachedLastContinuation = true;
             }
 
             if (methodEventEnabled || callstackEventEnabled)
             {
-                AsyncProfiler.ResumeAsyncMethod.Resume(activeDispatcher, box, ref info->AsyncProfilerInfo);
+                AsyncProfiler.ResumeAsyncMethod.Resume(ref *info, box);
             }
+        }
+
+        internal static bool SuspendOrCompleteContext(ref AsyncStateMachineDispatcherInfo info, AsyncInstrumentation.Flags flags)
+        {
+            bool suspended = false;
+
+            try
+            {
+                // A node ends this dispatch in a suspend only when the method has not completed and
+                // it re-armed itself as a leaf (it will be resumed again under this same node).
+                // Otherwise the node is done: the method completed, or leaf-ship was handed off to a
+                // child context that took over the chain (this node won't be resumed again).
+                suspended = !info.AsyncProfilerInfo.CurrentContinuationCompleted && info.AsyncProfilerInfo.CurrentContinuationResumes;
+                if (suspended)
+                {
+                    if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
+                    {
+                        AsyncProfiler.SuspendAsyncContext.Suspend(ref info.AsyncProfilerInfo);
+                    }
+                }
+                else
+                {
+                    if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
+                    {
+                        AsyncProfiler.CompleteAsyncContext.Complete(ref info);
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Best-effort instrumentation: swallow so the dispatch frame is always popped.
+            }
+
+            return suspended;
         }
 
         internal static unsafe void CompleteAsyncMethod(object completingBox, AsyncInstrumentation.Flags flags)
@@ -184,36 +252,31 @@ namespace System.Runtime.CompilerServices
         }
     }
 
-    internal sealed class AsyncStateMachineDispatcher : Task<VoidTaskResult>, IAsyncStateMachineBox
+    internal interface IAsyncStateMachineDispatcher
+    {
+        bool IsLeaf { get; set; }
+        ulong DispatcherId { get; }
+    }
+
+    internal sealed class AsyncStateMachineDispatcher : Task<VoidTaskResult>, IAsyncStateMachineBox, IAsyncStateMachineDispatcher
     {
         private IAsyncStateMachineBox? _inner;
 
         internal IAsyncStateMachineBox? InnerBox => _inner;
 
-        internal IAsyncStateMachineBox? LastContinuation;
-
-        internal bool ReachedLastContinuation;
-
-        internal object? NextContinuationForDiagnostics
-        {
-            get
-            {
-                IAsyncStateMachineBox? last = LastContinuation;
-                if (last is Task task)
-                {
-                    return task.ContinuationForDiagnostics;
-                }
-
-                return last is not null && last.GetDiagnosticData(out _, out _, out object? next) ? next : null;
-            }
-        }
-
-        internal bool ContinuationChainChanged => NextContinuationForDiagnostics != null;
-
         internal AsyncStateMachineDispatcher(IAsyncStateMachineBox inner) : base()
         {
             _inner = inner;
         }
+
+        // The wrapper is always the leaf dispatcher for its inner box, so this is permanently true;
+        bool IAsyncStateMachineDispatcher.IsLeaf
+        {
+            get => true;
+            set { }
+        }
+
+        ulong IAsyncStateMachineDispatcher.DispatcherId => (ulong)Id;
 
         internal sealed override void ExecuteDirectly(Thread? threadPoolThread) => MoveNext();
 
@@ -234,17 +297,23 @@ namespace System.Runtime.CompilerServices
             AsyncProfiler.InitInfo(ref info.AsyncProfilerInfo);
 
             info.Dispatcher = this;
+            info.AsyncProfilerInfo.DispatcherId = (ulong)Id;
             info.AsyncProfilerInfo.CurrentContinuation = inner;
 
-            LastContinuation = null;
-            ReachedLastContinuation = false;
+            AsyncInstrumentation.Flags flags = AsyncInstrumentation.LoadFlags();
 
             try
             {
-                InstrumentedMoveNext(ref info, inner);
+                if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+                {
+                    AsyncProfiler.ResumeAsyncContext.Resume(ref info);
+                }
+
+                inner.MoveNext();
             }
             finally
             {
+                AsyncStateMachineDispatcherInfo.SuspendOrCompleteContext(ref info, flags);
                 refInfo = info.Next;
             }
         }
@@ -261,9 +330,6 @@ namespace System.Runtime.CompilerServices
         {
             _inner?.ClearStateUponCompletion();
             _inner = null;
-
-            LastContinuation = null;
-            ReachedLastContinuation = false;
         }
 
         public bool GetDiagnosticData(out ulong methodId, out int state, out object? nextContinuation)
@@ -278,32 +344,6 @@ namespace System.Runtime.CompilerServices
             state = -1;
             nextContinuation = null;
             return false;
-        }
-
-        private void InstrumentedMoveNext(ref AsyncStateMachineDispatcherInfo info, IAsyncStateMachineBox inner)
-        {
-            AsyncInstrumentation.Flags flags = AsyncInstrumentation.LoadFlags();
-            try
-            {
-                if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
-                {
-                    AsyncProfiler.ResumeAsyncContext.Resume(ref info);
-                }
-
-                inner.MoveNext();
-            }
-            finally
-            {
-                bool isCompleted = info.AsyncProfilerInfo.CurrentContinuationCompleted;
-                if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags) && isCompleted)
-                {
-                    AsyncProfiler.CompleteAsyncContext.Complete(this, ref info.AsyncProfilerInfo);
-                }
-                else if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags) && !isCompleted)
-                {
-                    AsyncProfiler.SuspendAsyncContext.Suspend(this, ref info.AsyncProfilerInfo);
-                }
-            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
@@ -121,16 +121,13 @@ namespace System.Runtime.CompilerServices
         {
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags) || AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
             {
-                ulong parentDispatcherId = AsyncProfiler.DispatcherIds.CaptureParentDispatcherId();
-                ulong dispatcherId = AsyncProfiler.DispatcherIds.GetDispatcherId(dispatcher);
-
                 if (info != null)
                 {
-                    AsyncProfiler.CreateAsyncContext.Create(ref *info, parentDispatcherId, dispatcherId);
+                    AsyncProfiler.CreateAsyncContext.Create(ref *info, dispatcher);
                 }
                 else
                 {
-                    AsyncProfiler.CreateAsyncContext.Create(parentDispatcherId, dispatcherId);
+                    AsyncProfiler.CreateAsyncContext.Create(dispatcher);
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -303,7 +303,7 @@ namespace System.Runtime.CompilerServices
         {
             private bool _isLeaf;
 
-            private ulong _dispatcherId;
+            private int _dispatcherId;
 
             bool IAsyncStateMachineDispatcher.IsLeaf
             {
@@ -317,10 +317,10 @@ namespace System.Runtime.CompilerServices
                 {
                     if (_dispatcherId == 0)
                     {
-                        _dispatcherId = (ulong)NewId();
+                        _dispatcherId = NewId();
                     }
 
-                    return _dispatcherId;
+                    return (ulong)_dispatcherId;
                 }
             }
 
@@ -346,7 +346,7 @@ namespace System.Runtime.CompilerServices
                 AsyncProfiler.InitInfo(ref info.AsyncProfilerInfo);
 
                 info.Dispatcher = this;
-                info.AsyncProfilerInfo.DispatcherId = _dispatcherId;
+                info.AsyncProfilerInfo.DispatcherId = (ulong)_dispatcherId;
                 info.AsyncProfilerInfo.CurrentContinuation = this;
 
                 _isLeaf = false;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -313,15 +313,16 @@ namespace System.Runtime.CompilerServices
 
             ulong IAsyncStateMachineDispatcher.DispatcherId
             {
-                get
-                {
-                    if (_dispatcherId == 0)
-                    {
-                        _dispatcherId = NewId();
-                    }
+                get => GetDispatcherId();
+            }
 
-                    return (ulong)_dispatcherId;
+            private ulong GetDispatcherId()
+            {
+                if (_dispatcherId == 0)
+                {
+                    _dispatcherId = NewId();
                 }
+                return (ulong)_dispatcherId;
             }
 
             private protected override void InstrumentedMoveNext(Thread? threadPoolThread, AsyncInstrumentation.Flags flags)
@@ -346,7 +347,7 @@ namespace System.Runtime.CompilerServices
                 AsyncProfiler.InitInfo(ref info.AsyncProfilerInfo);
 
                 info.Dispatcher = this;
-                info.AsyncProfilerInfo.DispatcherId = (ulong)_dispatcherId;
+                info.AsyncProfilerInfo.DispatcherId = GetDispatcherId();
                 info.AsyncProfilerInfo.CurrentContinuation = this;
 
                 _isLeaf = false;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -229,31 +229,53 @@ namespace System.Runtime.CompilerServices
                 // cases is we lose the ability to properly step in the debugger, as the debugger uses that
                 // object's identity to track this specific builder/state machine.  As such, we proceed to
                 // overwrite whatever's there anyway, even if it's non-null.
+                AsyncStateMachineBox<TStateMachine> box;
+                AsyncInstrumentation.Flags flags = AsyncInstrumentation.Flags.Disabled;
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out flags))
+                {
 #if NATIVEAOT
-                // DebugFinalizableAsyncStateMachineBox looks like a small type, but it actually is not because
-                // it will have a copy of all the slots from its parent. It will add another hundred(s) bytes
-                // per each async method in NativeAOT binaries without adding much value. Avoid
-                // generating this extra code until a better solution is implemented.
-                var box = new AsyncStateMachineBox<TStateMachine>();
+                    // DebugFinalizableAsyncStateMachineBox looks like a small type, but it actually is not because
+                    // it will have a copy of all the slots from its parent. It will add another hundred(s) bytes
+                    // per each async method in NativeAOT binaries without adding much value. Avoid
+                    // generating this extra code until a better solution is implemented.
+                    box = new AsyncStateMachineBox<TStateMachine>();
 #else
-                AsyncStateMachineBox<TStateMachine> box = AsyncMethodBuilderCore.TrackAsyncMethodCompletion ?
-                    CreateDebugFinalizableAsyncStateMachineBox<TStateMachine>() :
-                    new AsyncStateMachineBox<TStateMachine>();
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags) && AsyncMethodBuilderCore.TrackAsyncMethodCompletion)
+                    {
+                        box = CreateDebugFinalizableAsyncStateMachineBox<TStateMachine>();
+                    }
+                    else if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
+                    {
+                        box = CreateAsyncProfilerAsyncStateMachineBox<TStateMachine>();
+                    }
+                    else
+                    {
+                        box = new AsyncStateMachineBox<TStateMachine>();
+                    }
 #endif
+                }
+                else
+                {
+                    box = new AsyncStateMachineBox<TStateMachine>();
+                }
+
                 taskField = box; // important: this must be done before storing stateMachine into box.StateMachine!
                 box.StateMachine = stateMachine;
                 box.Context = currentContext;
 
-                // Log the creation of the state machine box object / task for this async method.
-                if (TplEventSource.Log.IsEnabled())
+                if (flags != AsyncInstrumentation.Flags.Disabled)
                 {
-                    AsyncMethodBuilderCore.LogTraceOperationBegin(box, stateMachine.GetType());
-                }
+                    // Log the creation of the state machine box object / task for this async method.
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    {
+                        AsyncMethodBuilderCore.LogTraceOperationBegin(box, stateMachine.GetType());
+                    }
 
-                // And if async debugging is enabled, track the task.
-                if (Threading.Tasks.Task.s_asyncDebuggingEnabled)
-                {
-                    Threading.Tasks.Task.AddToActiveTasks(box);
+                    // And if async debugging is enabled, track the task.
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
+                    {
+                        Threading.Tasks.Task.AddToActiveTasks(box);
+                    }
                 }
                 result = box;
             }
@@ -262,6 +284,98 @@ namespace System.Runtime.CompilerServices
         }
 
 #if !NATIVEAOT
+        // Avoid forcing the JIT to build AsyncProfilerAsyncStateMachineBox<TStateMachine> unless the async profiler is active.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static AsyncStateMachineBox<TStateMachine> CreateAsyncProfilerAsyncStateMachineBox<TStateMachine>()
+            where TStateMachine : IAsyncStateMachine =>
+            new AsyncProfilerAsyncStateMachineBox<TStateMachine>();
+
+        /// <summary>
+        /// A strongly-typed box allocated instead of <see cref="AsyncStateMachineBox{TStateMachine}"/>
+        /// while the async profiler is active. It carries the dispatcher machinery (dispatcher frame
+        /// and node identity) so the base box stays free of profiler-only state and behavior
+        /// on the common, profiler-disabled path.
+        /// </summary>
+        /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
+        private class AsyncProfilerAsyncStateMachineBox<TStateMachine> : // SOS DumpAsync command depends on this name
+            AsyncStateMachineBox<TStateMachine>, IAsyncStateMachineDispatcher
+            where TStateMachine : IAsyncStateMachine
+        {
+            private bool _isLeaf;
+
+            private ulong _dispatcherId;
+
+            bool IAsyncStateMachineDispatcher.IsLeaf
+            {
+                get => _isLeaf;
+                set => _isLeaf = value;
+            }
+
+            ulong IAsyncStateMachineDispatcher.DispatcherId
+            {
+                get
+                {
+                    if (_dispatcherId == 0)
+                    {
+                        _dispatcherId = (ulong)NewId();
+                    }
+
+                    return _dispatcherId;
+                }
+            }
+
+            private protected override void InstrumentedMoveNext(Thread? threadPoolThread, AsyncInstrumentation.Flags flags)
+            {
+                if (_isLeaf)
+                {
+                    MoveNextAsDispatcher(threadPoolThread, flags);
+                    return;
+                }
+
+                base.InstrumentedMoveNext(threadPoolThread, flags);
+            }
+
+            private unsafe void MoveNextAsDispatcher(Thread? threadPoolThread, AsyncInstrumentation.Flags flags)
+            {
+                AsyncStateMachineDispatcherInfo info;
+                ref AsyncStateMachineDispatcherInfo* refInfo = ref AsyncStateMachineDispatcherInfo.t_current;
+                AsyncStateMachineDispatcherInfo* refPreviousInfo = refInfo;
+                refInfo = &info;
+                info.Next = refPreviousInfo;
+
+                AsyncProfiler.InitInfo(ref info.AsyncProfilerInfo);
+
+                info.Dispatcher = this;
+                info.AsyncProfilerInfo.DispatcherId = _dispatcherId;
+                info.AsyncProfilerInfo.CurrentContinuation = this;
+
+                _isLeaf = false;
+
+                try
+                {
+                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+                    {
+                        AsyncProfiler.ResumeAsyncContext.Resume(ref info);
+                    }
+
+                    AsyncStateMachineDispatcherInfo.ResumeAsyncMethod(this, flags);
+
+                    MoveNext(threadPoolThread, flags);
+                }
+                finally
+                {
+                    // SuspendOrCompleteContext never throws, so the frame is always popped afterwards.
+                    bool suspended = AsyncStateMachineDispatcherInfo.SuspendOrCompleteContext(ref info, flags);
+                    if (!suspended)
+                    {
+                        _dispatcherId = 0;
+                    }
+
+                    refInfo = info.Next;
+                }
+            }
+        }
+
         // Avoid forcing the JIT to build DebugFinalizableAsyncStateMachineBox<TStateMachine> unless it's actually needed.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static AsyncStateMachineBox<TStateMachine> CreateDebugFinalizableAsyncStateMachineBox<TStateMachine>()
@@ -274,7 +388,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
         private sealed class DebugFinalizableAsyncStateMachineBox<TStateMachine> : // SOS DumpAsync command depends on this name
-            AsyncStateMachineBox<TStateMachine>
+            AsyncProfilerAsyncStateMachineBox<TStateMachine>
             where TStateMachine : IAsyncStateMachine
         {
             ~DebugFinalizableAsyncStateMachineBox()
@@ -368,20 +482,32 @@ namespace System.Runtime.CompilerServices
 
             private void MoveNext(Thread? threadPoolThread)
             {
-                Debug.Assert(!IsCompleted);
-
                 AsyncInstrumentation.Flags flags = AsyncInstrumentation.Flags.Disabled;
                 if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out flags))
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncProfiler(flags))
                     {
-                        AsyncStateMachineDispatcherInfo.ResumeAsyncMethod(this, flags);
+                        InstrumentedMoveNext(threadPoolThread, flags);
+                        return;
                     }
+                }
 
-                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                    {
-                        TplEventSource.Log.TraceSynchronousWorkBegin(this.Id, CausalitySynchronousWork.Execution);
-                    }
+                MoveNext(threadPoolThread, flags);
+            }
+
+            private protected virtual void InstrumentedMoveNext(Thread? threadPoolThread, AsyncInstrumentation.Flags flags)
+            {
+                AsyncStateMachineDispatcherInfo.ResumeAsyncMethod(this, flags);
+                MoveNext(threadPoolThread, flags);
+            }
+
+            private protected void MoveNext(Thread? threadPoolThread, AsyncInstrumentation.Flags flags)
+            {
+                Debug.Assert(!IsCompleted);
+
+                if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                {
+                    TplEventSource.Log.TraceSynchronousWorkBegin(this.Id, CausalitySynchronousWork.Execution);
                 }
 
                 ExecutionContext? context = Context;
@@ -421,10 +547,23 @@ namespace System.Runtime.CompilerServices
 
                 // This logic may be invoked multiple times on the same instance and needs to be robust against that.
 
-                // If async debugging is enabled, remove the task from tracking.
-                if (s_asyncDebuggingEnabled)
+                if (AsyncInstrumentation.IsActive && AsyncInstrumentation.LoadFlags(out AsyncInstrumentation.Flags flags))
                 {
-                    RemoveFromActiveTasks(this);
+                    // If async debugging is enabled, remove the task from tracking.
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
+                    {
+                        RemoveFromActiveTasks(this);
+                    }
+
+#if !NATIVEAOT
+                    // In case this is a state machine box with a finalizer, suppress its finalization
+                    // as it's now complete. We only need the finalizer to run if the box is collected
+                    // without having been completed.
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags) && AsyncMethodBuilderCore.TrackAsyncMethodCompletion)
+                    {
+                        GC.SuppressFinalize(this);
+                    }
+#endif
                 }
 
                 // Clear out state now that the async method has completed.
@@ -432,16 +571,6 @@ namespace System.Runtime.CompilerServices
                 // if this Task / state machine box is held onto.
                 StateMachine = default;
                 Context = default;
-
-#if !NATIVEAOT
-                // In case this is a state machine box with a finalizer, suppress its finalization
-                // as it's now complete.  We only need the finalizer to run if the box is collected
-                // without having been completed.
-                if (AsyncMethodBuilderCore.TrackAsyncMethodCompletion)
-                {
-                    GC.SuppressFinalize(this);
-                }
-#endif
             }
 
             /// <summary>Gets the state machine as a boxed object.  This should only be used for debugging purposes.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -205,11 +205,17 @@ namespace System.Runtime.CompilerServices
                     {
                         stateMachineBox = AsyncStateMachineDispatcherInfo.CreateDispatcher(stateMachineBox, flags);
                     }
-                    else if (continueOnCapturedContext)
+                    else
                     {
-                        bool customSyncContext = SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext);
-                        bool customTaskScheduler = TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default;
-                        if (customSyncContext || customTaskScheduler)
+                        bool createDispatcher = false;
+                        if (continueOnCapturedContext)
+                        {
+                            bool customSyncContext = SynchronizationContext.Current is SynchronizationContext syncCtx && syncCtx.GetType() != typeof(SynchronizationContext);
+                            bool customTaskScheduler = TaskScheduler.InternalCurrent is TaskScheduler scheduler && scheduler != TaskScheduler.Default;
+                            createDispatcher = customSyncContext || customTaskScheduler;
+                        }
+
+                        if (createDispatcher)
                         {
                             stateMachineBox = AsyncStateMachineDispatcherInfo.CreateDispatcher(stateMachineBox, flags);
                         }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -1730,6 +1730,22 @@ namespace System.Threading.Tasks.Tests
             return false;
         }
 
+        // Walk-break sibling exclusion: verifies that none of the given callstacks leak a frame
+        // belonging to a concurrent sibling dispatcher. Each dispatcher's walk must stop at its own
+        // boundary, so a branch's Resume callstack must contain only its own frame(s) and never a
+        // foreign marker. This guards against an under-breaking walk that would cross into a sibling.
+        private static void AssertCallstacksExcludeForeignMarkers(ParsedEventStream stream, List<ParsedEvent> callstacks, string ownMarker, params string[] foreignMarkers)
+        {
+            foreach (var cs in callstacks)
+            {
+                foreach (string foreign in foreignMarkers)
+                {
+                    AssertFalse(stream, cs.HasMarkerFrame(foreign),
+                        $"Callstack for {ownMarker} (DispatcherId {cs.DispatcherId}) leaked a sibling frame '{foreign}'");
+                }
+            }
+        }
+
         // For a given context, simulates the async callstack depth by walking events in order:
         // ResumeAsyncCallstack sets the depth to frame count, CompleteAsyncMethod decrements,
         // UnwindAsyncException subtracts unwound frames. Asserts depth reaches zero.

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1931,32 +1931,34 @@ namespace System.Threading.Tasks.Tests
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task StateMachineAsync_NestedChildResume_FlattensPerSegment_Child_Marker()
+        private static async Task StateMachineAsync_NestedChildResume_FlattensPerSegment_Child_Marker(Task childGate)
         {
-            await Task.Yield();
+            await childGate;
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task StateMachineAsync_NestedChildResume_FlattensPerSegment_Middle_Marker()
+        private static async Task StateMachineAsync_NestedChildResume_FlattensPerSegment_Middle_Marker(Task middleGate1, Task childGate, Task middleGate2)
         {
             // Suspend once so this box becomes a leaf dispatcher, then resume and await a nested child
             // async method (its own dispatcher). When that child completes it inline-resumes this box;
-            // the trailing yield then re-suspends this same box, which under the flattened per-segment
-            // model starts a fresh dispatcher segment parented to the just-completed child.
-            await Task.Yield();
-            await StateMachineAsync_NestedChildResume_FlattensPerSegment_Child_Marker();
-            await Task.Yield();
+            // the trailing gate then re-suspends this same box, which under the flattened per-segment
+            // model starts a fresh dispatcher segment parented to the just-completed child. The gates are
+            // completed inline on a single thread so the child deterministically inline-resumes this box;
+            // thread-pool scheduling (e.g. Task.Yield) would otherwise collapse this into one reused segment.
+            await middleGate1;
+            await StateMachineAsync_NestedChildResume_FlattensPerSegment_Child_Marker(childGate);
+            await middleGate2;
         }
 
         [RuntimeAsyncMethodGeneration(false)]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static async Task StateMachineAsync_NestedChildResume_FlattensPerSegment_Marker()
+        private static async Task StateMachineAsync_NestedChildResume_FlattensPerSegment_Marker(Task outerGate, Task middleGate1, Task childGate, Task middleGate2)
         {
             // Suspend/resume first so this outer marker is a live dispatcher (non-zero parent id) by
             // the time the middle frame below first suspends.
-            await Task.Yield();
-            await StateMachineAsync_NestedChildResume_FlattensPerSegment_Middle_Marker();
+            await outerGate;
+            await StateMachineAsync_NestedChildResume_FlattensPerSegment_Middle_Marker(middleGate1, childGate, middleGate2);
         }
 
         [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
@@ -1964,7 +1966,28 @@ namespace System.Threading.Tasks.Tests
         {
             var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
             {
-                RunScenarioAndFlush(() => StateMachineAsync_NestedChildResume_FlattensPerSegment_Marker());
+                RunScenarioAndFlush(async () =>
+                {
+                    var outerGate = new TaskCompletionSource();
+                    var middleGate1 = new TaskCompletionSource();
+                    var childGate = new TaskCompletionSource();
+                    var middleGate2 = new TaskCompletionSource();
+
+                    Task marker = StateMachineAsync_NestedChildResume_FlattensPerSegment_Marker(
+                        outerGate.Task, middleGate1.Task, childGate.Task, middleGate2.Task);
+
+                    // Drive each stage inline on this thread. Completing a default TaskCompletionSource runs
+                    // its continuation synchronously, so each SetResult advances the chain to its next suspend:
+                    // the child completes inline and inline-resumes the middle box, which is the deterministic
+                    // condition that produces the flattened per-segment split (a fresh middle segment parented
+                    // to the child). Thread-pool scheduling would otherwise collapse the middle into one segment.
+                    outerGate.SetResult();
+                    middleGate1.SetResult();
+                    childGate.SetResult();
+                    middleGate2.SetResult();
+
+                    await marker;
+                });
             });
 
             // DumpAllEvents(events);

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -1353,6 +1353,17 @@ namespace System.Threading.Tasks.Tests
             AssertExactlyOneCreateAndComplete(stream, branchCCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchC_Marker));
             AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAll_TracksAllBranches_Marker));
 
+            // Each branch is an independent dispatcher; its walk must stop at its own boundary and
+            // never leak a concurrent sibling's (or the outer marker's) frame into its callstack.
+            string branchAMarker = nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchA_Marker);
+            string branchBMarker = nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchB_Marker);
+            string branchCMarker = nameof(StateMachineAsync_WhenAll_TracksAllBranches_BranchC_Marker);
+            string outerMarker = nameof(StateMachineAsync_WhenAll_TracksAllBranches_Marker);
+            AssertCallstacksExcludeForeignMarkers(stream, branchACallstacks, branchAMarker, branchBMarker, branchCMarker, outerMarker);
+            AssertCallstacksExcludeForeignMarkers(stream, branchBCallstacks, branchBMarker, branchAMarker, branchCMarker, outerMarker);
+            AssertCallstacksExcludeForeignMarkers(stream, branchCCallstacks, branchCMarker, branchAMarker, branchBMarker, outerMarker);
+            AssertCallstacksExcludeForeignMarkers(stream, markerCallstacks, outerMarker, branchAMarker, branchBMarker, branchCMarker);
+
             // The outer marker's chain should fire the standard Create -> Resume -> Complete sequence in its own dispatcher tree, in that order.
             ulong markerDispatcherId = markerCallstacks[0].DispatcherId;
             var markerIds = stream.ChainEventsFromDispatcher(markerDispatcherId).Select(e => e.EventId).ToList();
@@ -1434,6 +1445,17 @@ namespace System.Threading.Tasks.Tests
             AssertExactlyOneCreateAndComplete(stream, slow1Callstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow1_Marker));
             AssertExactlyOneCreateAndComplete(stream, slow2Callstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow2_Marker));
             AssertCreateBalancesSuspendAndCompleteInChain(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_WhenAny_TracksAllBranches_Marker));
+
+            // Each branch is an independent dispatcher; its walk must stop at its own boundary and
+            // never leak a concurrent sibling's (or the outer marker's) frame into its callstack.
+            string fastMarker = nameof(StateMachineAsync_WhenAny_TracksAllBranches_Fast_Marker);
+            string slow1Marker = nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow1_Marker);
+            string slow2Marker = nameof(StateMachineAsync_WhenAny_TracksAllBranches_Slow2_Marker);
+            string whenAnyOuterMarker = nameof(StateMachineAsync_WhenAny_TracksAllBranches_Marker);
+            AssertCallstacksExcludeForeignMarkers(stream, fastCallstacks, fastMarker, slow1Marker, slow2Marker, whenAnyOuterMarker);
+            AssertCallstacksExcludeForeignMarkers(stream, slow1Callstacks, slow1Marker, fastMarker, slow2Marker, whenAnyOuterMarker);
+            AssertCallstacksExcludeForeignMarkers(stream, slow2Callstacks, slow2Marker, fastMarker, slow1Marker, whenAnyOuterMarker);
+            AssertCallstacksExcludeForeignMarkers(stream, markerCallstacks, whenAnyOuterMarker, fastMarker, slow1Marker, slow2Marker);
 
             // The outer marker's chain: exactly one Create, at least two Resumes (one after
             // WhenAny, one after WhenAll on the slow branches), then Complete.
@@ -1905,6 +1927,113 @@ namespace System.Threading.Tasks.Tests
             // Inner cancelled task + outer marker must each see exactly one Create and one Complete in their own dispatcher tree.
             AssertExactlyOneCreateAndComplete(stream, innerCallstacks[0].DispatcherId, nameof(StateMachineAsync_TaskCancellation_Inner_Marker));
             AssertExactlyOneCreateAndComplete(stream, markerCallstacks[0].DispatcherId, nameof(StateMachineAsync_TaskCancellation_Marker));
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_NestedChildResume_FlattensPerSegment_Child_Marker()
+        {
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_NestedChildResume_FlattensPerSegment_Middle_Marker()
+        {
+            // Suspend once so this box becomes a leaf dispatcher, then resume and await a nested child
+            // async method (its own dispatcher). When that child completes it inline-resumes this box;
+            // the trailing yield then re-suspends this same box, which under the flattened per-segment
+            // model starts a fresh dispatcher segment parented to the just-completed child.
+            await Task.Yield();
+            await StateMachineAsync_NestedChildResume_FlattensPerSegment_Child_Marker();
+            await Task.Yield();
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_NestedChildResume_FlattensPerSegment_Marker()
+        {
+            // Suspend/resume first so this outer marker is a live dispatcher (non-zero parent id) by
+            // the time the middle frame below first suspends.
+            await Task.Yield();
+            await StateMachineAsync_NestedChildResume_FlattensPerSegment_Middle_Marker();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
+        public void StateMachineAsync_NestedChildResume_FlattensPerSegment()
+        {
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
+            {
+                RunScenarioAndFlush(() => StateMachineAsync_NestedChildResume_FlattensPerSegment_Marker());
+            });
+
+            // DumpAllEvents(events);
+
+            var stream = ParseAllEvents(events);
+
+            // Resume callstacks whose leaf (top) frame is the given marker: the callstacks captured while
+            // that method's own box was the running continuation. A box that merely appears deeper in
+            // someone else's callstack (e.g. Middle inside the child's [Child, Middle, Marker]) is
+            // excluded, so this isolates the segments a box was resumed under in its own right.
+            List<ParsedEvent> LeafResumes(string markerName) =>
+                stream.CallstacksWithMarker(AsyncEventID.ResumeStateMachineAsyncCallstack, markerName)
+                    .Where(c => c.Frames.Count > 0
+                        && (GetMethodNameFromMethodId(c.CallstackType, c.Frames[0].MethodId)?.Contains(markerName, StringComparison.Ordinal) ?? false))
+                    .ToList();
+
+            var outerResumes = LeafResumes(nameof(StateMachineAsync_NestedChildResume_FlattensPerSegment_Marker));
+            var middleResumes = LeafResumes(nameof(StateMachineAsync_NestedChildResume_FlattensPerSegment_Middle_Marker));
+            var childResumes = LeafResumes(nameof(StateMachineAsync_NestedChildResume_FlattensPerSegment_Child_Marker));
+
+            AssertNotEmpty(stream, outerResumes);
+            AssertNotEmpty(stream, middleResumes);
+            AssertNotEmpty(stream, childResumes);
+
+            ulong childDispatcherId = childResumes[0].DispatcherId;
+
+            // The middle box suspends, resumes, awaits a nested child dispatcher, then (after the child
+            // inline-resumes it) re-suspends. Under the flattened per-segment model each resumed segment
+            // gets its own unique dispatcher id, so the middle box surfaces as exactly two distinct
+            // segments rather than one reused context.
+            var middleSegmentIds = middleResumes.Select(c => c.DispatcherId).Distinct().ToList();
+            AssertEqual(stream, 2, middleSegmentIds.Count);
+
+            // Flattening: the post-child bubble-up resumes the middle box as a flat [Middle, Marker]
+            // continuation. No middle resume callstack is nested under (contains) the child dispatcher's
+            // frame, so the child's callstack suffix is never duplicated into the parent's resume.
+            foreach (var resume in middleResumes)
+            {
+                AssertFalse(stream, resume.HasMarkerFrame(nameof(StateMachineAsync_NestedChildResume_FlattensPerSegment_Child_Marker)),
+                    $"Middle resume callstack (DispatcherId {resume.DispatcherId}) is nested under its child dispatcher; flattening failed");
+            }
+
+            // Each middle segment is created exactly once, and exactly one of the two segments is parented
+            // to the just-completed child dispatcher. That "child as parent" edge is the intended
+            // per-segment relationship: the same box resumed in a new chain is a child of the context that
+            // inline-resumed it, not an inverted parent/child edge.
+            var middleCreates = stream.All
+                .Where(e => e.EventId == AsyncEventID.CreateStateMachineAsyncContext && middleSegmentIds.Contains(e.DispatcherId))
+                .ToList();
+            AssertEqual(stream, 2, middleCreates.Count);
+            AssertEqual(stream, 1, middleCreates.Count(c => c.ParentDispatcherId == childDispatcherId));
+
+            // Whole-scenario balance: walking the full dispatcher tree from the outer marker, every
+            // segment that is created is also completed exactly once, with no leaked Suspend and no
+            // double Complete (each created id is unique and pairs with a single Complete).
+            var chain = stream.ChainEventsFromDispatcher(outerResumes[0].DispatcherId);
+            var createdIds = chain.Where(e => e.EventId == AsyncEventID.CreateStateMachineAsyncContext)
+                .Select(e => e.DispatcherId)
+                .ToList();
+            AssertNotEmpty(stream, createdIds);
+            AssertEqual(stream, createdIds.Count, createdIds.Distinct().Count());
+
+            foreach (ulong id in createdIds)
+            {
+                int completes = chain.Count(e => e.EventId == AsyncEventID.CompleteStateMachineAsyncContext && e.DispatcherId == id);
+                int suspends = chain.Count(e => e.EventId == AsyncEventID.SuspendStateMachineAsyncContext && e.DispatcherId == id);
+                AssertEqual(stream, 1, completes);
+                AssertEqual(stream, 0, suspends);
+            }
         }
 
         [RuntimeAsyncMethodGeneration(false)]


### PR DESCRIPTION
### Summary

Eliminates the separate per-suspension async-dispatcher heap allocation on the default (non-pooling) `Task / ValueTask` async path when the async profiler is active. The state-machine box now doubles as its own dispatcher, so profiling suspend-heavy async code no longer adds an allocation per suspension segment.

### Background

When the async profiler is enabled, each suspension needs an async dispatcher to carry the profiler's per-segment context identity and emit the create/resume/suspend/complete events. Previously this was a standalone `AsyncStateMachineDispatcher` object allocated as a wrapper around the state-machine box on every leaf suspension - one extra heap allocation per suspension segment, scaling with suspension frequency.

### Change

• Merged box. Introduces `AsyncProfilerAsyncStateMachineBox<TStateMachine>` - an `AsyncStateMachineBox<TStateMachine>` subclass that also implements `IAsyncStateMachineDispatcher`. It carries the dispatcher state and a `MoveNextAsDispatcher` path. When the profiler is active, `GetStateMachineBox` allocates this box (which the default async path allocates anyway) so the dispatcher piggybacks on it - zero extra allocations.
• Per-segment dispatcher id. The id is minted on demand and reset when a segment completes, giving each suspension segment a unique, stable id. The terminal rule emits Suspend (id retained) when the box re-arms itself as a leaf, and Complete (id reset) when the method completes or hands leaf-ship to a child - producing correct flattening of inline resume cascades.
• Fallback preserved. The standalone `AsyncStateMachineDispatcher` wrapper is still used only where the box isn't an `IAsyncStateMachineDispatcher`, so opt-in pooling is unaffected.
•  `DebugFinalizableAsyncStateMachineBox<T>` now derives from the profiler box, and `GetStateMachineBox` prioritizes it when TPL async-method-completion tracking is enabled — so a single box provides both the finalizer diagnostics and the dispatcher machinery when the profiler and completion tracking are active simultaneously.
• V2 (runtime-async) dispatcher-id retrieval is unified to read the cached id from the dispatcher/context.

### Performance

On the default non-pooling async path, the profiler now adds no per-suspension dispatcher allocations - the box that async already allocates serves as the dispatcher (the marginal cost is two extra fields on that box). The dispatch frame is stack-based and the id mint is an interlocked increment, so no additional heap traffic. Pooling (opt-in) retains its wrapper dispatcher. Fully-synchronous async methods allocate no box and are unaffected. All is gated by async profiler flags.

### Compatibility

• NativeAOT: zero impact - the merged box, factory, and finalizable box are not included on NativeAOT.
• R2R SPC: The async profiler box is a generic type reached only via the `NoInlining` factory, so it's instantiated per-state-machine-type at JIT time on demand, not pre-baked into R2R images.
• `AsyncProfilerAsyncStateMachineBox<TStateMachine>` only triggered when async profiler is enabled, so only JIT-compiled on demand. Code is also guarded by instrumentation feature flags, so when disabled, it will be DCE:ed out.
• No public API changes; all new members live on  internal  profiler types.

### Testing

New/extended coverage in `AsyncProfilerV1Tests.cs` and shared parser infra in `AsyncProfilerTests.cs`, including per-segment flattening (`StateMachineAsync_NestedChildResume_FlattensPerSegment`), inline vs. pooled re-suspend parity, and single-await lifecycle parity across pooling/non-pooling and critical/notify awaiter variants. Full V1/V2 profiler suites pass.