### PR TITLE
[wasm] Correctly materialize integer constants in genCodeForConstant

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1897,9 +1897,10 @@ void CodeGen::genCodeForConstant(GenTree* treeNode)
             {
                 ins = INS_i32_const;
                 // Wasm integers are sign-agnostic: any 32-bit pattern is a valid i32.const,
-                // reduced to its signed value for a canonical SLEB128 encoding.
+                // reduced to its signed value for a canonical SLEB128 encoding. Truncating
+                // through uint32_t keeps the low-32-bit reduction well-defined.
                 assert(FitsIn<INT32>(bits) || FitsIn<UINT32>(bits));
-                bits = static_cast<int32_t>(bits);
+                bits = static_cast<int32_t>(static_cast<uint32_t>(bits));
                 break;
             }
             case TYP_LONG:

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1875,8 +1875,10 @@ void CodeGen::genCodeForConstant(GenTree* treeNode)
         icon = treeNode->AsIntConCommon();
         if (icon->IsIconHandle())
         {
-            // Wasm has no absolute-address literals; every handle is materialized as a
-            // module-base-relative constant and relocated, regardless of opts.compReloc.
+            // Wasm has no absolute-address literals; every handle is materialized as a module-base-
+            // relative constant and relocated. compReloc is always on for a real AOT compile, so a
+            // handle only reaches here without needing a reloc under a cross-VM SuperPMI replay.
+            assert(icon->ImmedValNeedsReloc(m_compiler) || m_compiler->RunningSuperPmiReplay());
             GetEmitter()->emitAddressConstant((void*)icon->IntegralValue());
             WasmProduceReg(treeNode);
             return;

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1894,7 +1894,10 @@ void CodeGen::genCodeForConstant(GenTree* treeNode)
             case TYP_INT:
             {
                 ins = INS_i32_const;
-                assert(FitsIn<INT32>(bits));
+                // Wasm integers are sign-agnostic: any 32-bit pattern is a valid i32.const,
+                // reduced to its signed value for a canonical SLEB128 encoding.
+                assert(FitsIn<INT32>(bits) || FitsIn<UINT32>(bits));
+                bits = (int32_t)bits;
                 break;
             }
             case TYP_LONG:

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1899,7 +1899,7 @@ void CodeGen::genCodeForConstant(GenTree* treeNode)
                 // Wasm integers are sign-agnostic: any 32-bit pattern is a valid i32.const,
                 // reduced to its signed value for a canonical SLEB128 encoding.
                 assert(FitsIn<INT32>(bits) || FitsIn<UINT32>(bits));
-                bits = (int32_t)bits;
+                bits = static_cast<int32_t>(bits);
                 break;
             }
             case TYP_LONG:

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1873,8 +1873,10 @@ void CodeGen::genCodeForConstant(GenTree* treeNode)
     if ((type == TYP_INT) || (type == TYP_LONG))
     {
         icon = treeNode->AsIntConCommon();
-        if (icon->ImmedValNeedsReloc(m_compiler))
+        if (icon->IsIconHandle())
         {
+            // Wasm has no absolute-address literals; every handle is materialized as a
+            // module-base-relative constant and relocated, regardless of opts.compReloc.
             GetEmitter()->emitAddressConstant((void*)icon->IntegralValue());
             WasmProduceReg(treeNode);
             return;


### PR DESCRIPTION
Two independent correctness fixes to `genCodeForConstant` for the wasm backend, both uncovered while triaging the `FitsIn<INT32>` assert wall in SuperPMI replay of the wasm altjit.

----------

**Always relocate wasm handle constants regardless of `compReloc`**

`ImmedValNeedsReloc` is `opts.compReloc && IsIconHandle()`. Under a runtime-JIT configuration (`compReloc` off) a handle icon skips `emitAddressConstant` and falls into the literal `i32.const` path, then asserts `FitsIn<INT32>` on its 64-bit host address. Wasm has no absolute-address literal — every handle must be materialized as a module-base-relative relocated constant — so this is gated on `IsIconHandle()` instead. This is a strict superset of the old condition: identical when `compReloc` is on, and additionally routes the `compReloc`-off handle case through the reloc path that the real target always takes.

**Accept any 32-bit pattern when emitting a wasm `i32.const`**

Wasm integers are sign-agnostic and `i32.const` has no unsigned form (it is a sign-agnostic 32-bit bit pattern encoded as SLEB128), so an unsigned constant such as `0xFFFFFFFF` typed `TYP_INT` is a valid literal even though it does not fit a signed `INT32`. The assert is relaxed to also accept `UINT32`, and the value is reduced to its signed 32-bit form for a canonical SLEB128 encoding. Int→long widening stays explicit (`i64.extend_s_i32` / `i64.extend_u_i32`, chosen by the cast), so the truncation cannot introduce a wrong sign extension.

----------

**Measured impact** — SuperPMI replay of the wasm altjit over `coreclr_tests` and `libraries_tests_no_tiered_compilation`, `FitsIn<INT32>(bits)` assertions and total replay `ISSUE`s:

| | coreclr `FitsIn` | libs `FitsIn` | coreclr total ISSUE | libs total ISSUE |
|---|---:|---:|---:|---:|
| before | 151,242 | 118,936 | 179,560 | 141,917 |
| after | 1,440 | 5,274 | 47,610 | 30,288 |

The handle-routing fix accounts for essentially all of the reduction; the `i32.const` relaxation additionally unblocks the unsigned-pattern case (e.g. `UIntPtr` generic math). Methods unblocked by these fixes progress further and re-expose known, pre-existing downstream NYI/assert signatures — no new signatures are introduced.

**Out of scope:** the residual `FitsIn` count is dominated by non-handle 64-bit host-address constants (frozen-object / static-base addresses baked as plain `CNS_INT`) that only appear under x64-host SuperPMI replay of a runtime-JIT collection; on a real wasm32 target these are 32-bit values or reloc handles. The relaxed assert correctly keeps firing on them rather than silently truncating a genuine 64-bit value.

> [!NOTE]
> This PR description was drafted by GitHub Copilot.
