### PR TITLE
Make `DocumentationSignatureParser` in ILLink public

### DIFF
--- a/src/tools/illink/src/linker/Linker/DocumentationSignatureParser.cs
+++ b/src/tools/illink/src/linker/Linker/DocumentationSignatureParser.cs
@@ -24,7 +24,7 @@ namespace Mono.Linker
     /// This API instead works with the Cecil OM. It can be used to refer to IL definitions
     /// where the signature of a member can contain references to instantiated generics.
     ///
-    internal static class DocumentationSignatureParser
+    public static class DocumentationSignatureParser
     {
         [Flags]
         public enum MemberType

--- a/src/tools/illink/src/linker/Linker/ITryResolve.cs
+++ b/src/tools/illink/src/linker/Linker/ITryResolve.cs
@@ -7,7 +7,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-    internal interface ITryResolveMetadata
+    public interface ITryResolveMetadata
     {
         MethodDefinition? TryResolve(MethodReference methodReference);
         TypeDefinition? TryResolve(TypeReference typeReference);


### PR DESCRIPTION
We'd like to access `DocumentationSignatureParser` from UnityLinker in order to reuse the functionality it provides.