### PR TITLE
[cDAC] Include the highest assigned ID in IdToThread lookup

### DIFF
--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -286,7 +286,7 @@ TargetPointer IThread.IdToThread(uint id)
     TargetPointer idDispenser = target.ReadPointer(idDispenserPointer);
     uint HighestId = target.ReadPointer(idDispenser + /* IdDispenser::HighestId offset */);
     TargetPointer threadPtr = TargetPointer.Null;
-    if (id < HighestId)
+    if (id <= HighestId)
         threadPtr = target.ReadPointer(idDispenser + /* IdDispenser::IdToThread offset + (index into IdToThread array * size of array elements (== size of target pointer)) */);
     return threadPtr;
 }

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -284,7 +284,7 @@ TargetPointer IThread.IdToThread(uint id)
 {
     TargetPointer idDispenserPointer = target.ReadGlobalPointer(Constants.Globals.ThinlockThreadIdDispenser);
     TargetPointer idDispenser = target.ReadPointer(idDispenserPointer);
-    uint HighestId = target.ReadPointer(idDispenser + /* IdDispenser::HighestId offset */);
+    uint HighestId = target.Read<uint>(idDispenser + /* IdDispenser::HighestId offset */);
     TargetPointer threadPtr = TargetPointer.Null;
     if (id <= HighestId)
         threadPtr = target.ReadPointer(idDispenser + /* IdDispenser::IdToThread offset + (index into IdToThread array * size of array elements (== size of target pointer)) */);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -205,7 +205,7 @@ internal readonly struct Thread_1 : IThread
         TargetPointer idDispenser = _target.ReadPointer(idDispenserPtr);
         Data.IdDispenser idDispenserObj = _target.ProcessedData.GetOrAdd<Data.IdDispenser>(idDispenser);
         TargetPointer threadPtr = TargetPointer.Null;
-        if (id < idDispenserObj.HighestId)
+        if (id <= idDispenserObj.HighestId)
             threadPtr = _target.ReadPointer(idDispenserObj.IdToThread + (ulong)(id * _target.PointerSize));
         return threadPtr;
     }

--- a/src/native/managed/cdac/tests/UnitTests/ThreadTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ThreadTests.cs
@@ -44,6 +44,57 @@ public unsafe class ThreadTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
+    public void IdToThread_IncludesHighestId(MockTarget.Architecture arch)
+    {
+        const uint HighestId = 3;
+        const ulong ExpectedThread = 0x7000;
+        TargetTestHelpers helpers = new(arch);
+        var builder = new TestPlaceholderTarget.Builder(arch);
+        MockMemorySpace.BumpAllocator allocator = builder.MemoryBuilder.CreateAllocator(0x1000, 0x9000);
+        TargetTestHelpers.LayoutResult layout = helpers.LayoutFields(
+        [
+            new(nameof(Data.IdDispenser.IdToThread), DataType.pointer),
+            new(nameof(Data.IdDispenser.HighestId), DataType.uint32),
+        ]);
+
+        MockMemorySpace.HeapFragment idToThread = allocator.Allocate(
+            (ulong)((HighestId + 1) * helpers.PointerSize),
+            "IdToThread");
+        helpers.WritePointer(
+            idToThread.Data.AsSpan((int)HighestId * helpers.PointerSize, helpers.PointerSize),
+            ExpectedThread);
+
+        MockMemorySpace.HeapFragment dispenser = allocator.Allocate(layout.Stride, "IdDispenser");
+        helpers.WritePointer(
+            dispenser.Data.AsSpan(layout.Fields[nameof(Data.IdDispenser.IdToThread)].Offset, helpers.PointerSize),
+            idToThread.Address);
+        helpers.Write(
+            dispenser.Data.AsSpan(layout.Fields[nameof(Data.IdDispenser.HighestId)].Offset, sizeof(uint)),
+            HighestId);
+
+        MockMemorySpace.HeapFragment global = allocator.Allocate((ulong)helpers.PointerSize, "ThinlockThreadIdDispenser");
+        helpers.WritePointer(global.Data, dispenser.Address);
+        MockMemorySpace.HeapFragment threadStoreGlobal = allocator.Allocate((ulong)helpers.PointerSize, "ThreadStore");
+        helpers.WritePointer(threadStoreGlobal.Data, 0);
+
+        Target target = builder
+            .AddTypes(new Dictionary<DataType, Target.TypeInfo>
+            {
+                [DataType.IdDispenser] = new Target.TypeInfo { Fields = layout.Fields, Size = layout.Stride },
+                [DataType.Thread] = new Target.TypeInfo { Fields = new Dictionary<string, Target.FieldInfo>(), Size = 0 },
+            })
+            .AddGlobals(
+                (Constants.Globals.ThinlockThreadIdDispenser, global.Address),
+                (Constants.Globals.ThreadStore, threadStoreGlobal.Address))
+            .AddContract<IThread>("c1")
+            .Build();
+
+        Assert.Equal(new TargetPointer(ExpectedThread), target.Contracts.Thread.IdToThread(HighestId));
+        Assert.Equal(TargetPointer.Null, target.Contracts.Thread.IdToThread(HighestId + 1));
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
     public void GetThreadStoreData(MockTarget.Architecture arch)
     {
         int threadCount = 15;


### PR DESCRIPTION
## Summary

`IdDispenser::IdToThread` in the runtime resolves a thread by ID using an
inclusive upper bound (`if (id <= m_highestId)`). The cDAC
`IThread.IdToThread` implementation used an exclusive `<` comparison and
therefore never resolved the thread occupying the highest assigned ID slot --
an off-by-one that returned a null thread pointer for the highest valid ID.

## Native semantic parity

- Native `IdDispenser::IdToThread` (`src/coreclr/vm/threads.h`):
  `if (id <= m_highestId) result = m_idToThread[id];`
- `Thread_1.cs` now uses `id <= idDispenserObj.HighestId`, matching the
  inclusive bound.
- The `Thread.md` contract pseudocode is updated to match.

This change is limited to the `IdToThread` lookup boundary. Recycled
dispenser slot validation (the free-list check in
`IdToThreadWithValidation`) is intentionally out of scope.

## Testing

- Added `ThreadTests.IdToThread_IncludesHighestId` (runs on all four
  architecture combinations) verifying the highest ID resolves to the
  expected thread while `HighestId + 1` returns null.
- Full cDAC unit suite: 2705 passed, 16 skipped, 0 failed.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
