### PR TITLE
[cDAC] Implement IXCLRDataModule.GetVersionId

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataModule.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataModule.cs
@@ -800,7 +800,36 @@ public sealed unsafe partial class ClrDataModule : ICustomQueryInterface, IXCLRD
         => LegacyFallbackHelper.CanFallback() && _legacyModule is not null ? _legacyModule.EndEnumAppDomains(handle) : HResults.E_NOTIMPL;
 
     int IXCLRDataModule.GetVersionId(Guid* vid)
-        => LegacyFallbackHelper.CanFallback() && _legacyModule is not null ? _legacyModule.GetVersionId(vid) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (vid is null)
+                throw new NullReferenceException();
+
+            ILoader loader = _target.Contracts.Loader;
+            Contracts.ModuleHandle moduleHandle = loader.GetModuleHandleFromModulePtr(_address);
+            MetadataReader reader = _target.Contracts.EcmaMetadata.GetMetadata(moduleHandle)
+                ?? throw Marshal.GetExceptionForHR(HResults.E_FAIL)!;
+            *vid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyModule is not null)
+        {
+            Guid vidLocal = default;
+            int hrLocal = _legacyModule.GetVersionId(vid is null ? null : &vidLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK && vid is not null)
+                Debug.Assert(*vid == vidLocal, $"cDAC: {*vid}, DAC: {vidLocal}");
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataModule2.SetJITCompilerFlags(uint flags)
     {

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataModuleTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataModuleTests.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
+using Xunit;
+using ModuleHandle = Microsoft.Diagnostics.DataContractReader.Contracts.ModuleHandle;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public unsafe class ClrDataModuleTests
+{
+    private static readonly MockTarget.Architecture s_arch = new() { IsLittleEndian = true, Is64Bit = true };
+    private static readonly TargetPointer s_modulePointer = new(0x1000);
+    private static readonly ModuleHandle s_moduleHandle = new(new TargetPointer(0x2000));
+
+    [Fact]
+    public void GetVersionId_ReturnsMetadataMvid()
+    {
+        Guid expected = Guid.NewGuid();
+        using MetadataReaderProvider provider = CreateMetadata(expected);
+        IXCLRDataModule module = CreateModule(provider.GetMetadataReader());
+
+        Guid actual;
+        Assert.Equal(HResults.S_OK, module.GetVersionId(&actual));
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void GetVersionId_MissingMetadataReturnsEFail()
+    {
+        IXCLRDataModule module = CreateModule(metadata: null);
+
+        Guid actual = default;
+        Assert.Equal(HResults.E_FAIL, module.GetVersionId(&actual));
+    }
+
+    private static IXCLRDataModule CreateModule(MetadataReader? metadata)
+    {
+        var loader = new Mock<ILoader>();
+        loader.Setup(l => l.GetModuleHandleFromModulePtr(s_modulePointer)).Returns(s_moduleHandle);
+        var ecmaMetadata = new Mock<IEcmaMetadata>();
+        ecmaMetadata.Setup(e => e.GetMetadata(s_moduleHandle)).Returns(metadata);
+
+        TestPlaceholderTarget target = new TestPlaceholderTarget.Builder(s_arch)
+            .UseReader((ulong _, Span<byte> _) => -1)
+            .AddMockContract(loader)
+            .AddMockContract(ecmaMetadata)
+            .Build();
+        return new ClrDataModule(s_modulePointer, target, legacyImpl: null);
+    }
+
+    private static MetadataReaderProvider CreateMetadata(Guid mvid)
+    {
+        MetadataBuilder builder = new();
+        builder.AddModule(0, builder.GetOrAddString("TestModule"), builder.GetOrAddGuid(mvid), default, default);
+        BlobBuilder blob = new();
+        new MetadataRootBuilder(builder).Serialize(blob, 0, 0);
+        return MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(blob.ToArray()));
+    }
+}


### PR DESCRIPTION
## Summary

Implements `IXCLRDataModule.GetVersionId`, which returns a module's version
identifier (MVID). Previously this returned `E_NOTIMPL` unless the legacy DAC
was available for fallback.

## Native semantic parity

- Reads the MVID via `MetadataReader.GetModuleDefinition().Mvid` / `GetGuid`,
  matching the native DAC implementation.
- Returns `E_FAIL` when the module has no metadata available, matching native.
- A `#if DEBUG` cross-check compares the result against the legacy DAC when
  one is present.

## Testing

- `ClrDataModuleTests.GetVersionId_ReturnsMetadataMvid` -- verifies a real MVID
  round-trips from ECMA metadata.
- `ClrDataModuleTests.GetVersionId_MissingMetadataReturnsEFail` -- verifies
  missing metadata returns `E_FAIL`.
- Full cDAC unit suite: 2703 passed, 16 skipped, 0 failed.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
