### PR TITLE
[cDAC] Implement IXCLRData method flag queries

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
@@ -472,62 +472,7 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
     }
 
     int IXCLRDataMethodDefinition.Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer)
-    {
-        int hr = HandleRevisionRequest(reqCode, inBufferSize, inBuffer, outBufferSize, outBuffer);
-
-#if DEBUG
-        if (_legacyImpl is not null)
-        {
-            byte[] localBuffer = new byte[(int)outBufferSize];
-            fixed (byte* localOutBuffer = localBuffer)
-            {
-                int hrLocal = _legacyImpl.Request(
-                    reqCode,
-                    inBufferSize,
-                    inBuffer,
-                    outBufferSize,
-                    outBuffer is null ? null : localOutBuffer);
-                Debug.ValidateHResult(hr, hrLocal);
-                if (hr == HResults.S_OK)
-                {
-                    Debug.Assert(outBuffer is not null);
-                    Debug.Assert(new ReadOnlySpan<byte>(outBuffer, (int)outBufferSize).SequenceEqual(localBuffer));
-                }
-            }
-        }
-#endif
-        return hr;
-    }
-
-    internal static int HandleRevisionRequest(
-        uint reqCode,
-        uint inBufferSize,
-        byte* inBuffer,
-        uint outBufferSize,
-        byte* outBuffer)
-    {
-        int hr = HResults.S_OK;
-        try
-        {
-            if (reqCode != (uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION
-                || inBufferSize != 0
-                || inBuffer is not null
-                || outBufferSize != sizeof(uint))
-            {
-                throw new ArgumentException();
-            }
-            if (outBuffer is null)
-                throw new NullReferenceException();
-
-            *(uint*)outBuffer = 1;
-        }
-        catch (System.Exception ex)
-        {
-            hr = ex.HResult;
-        }
-
-        return hr;
-    }
+        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.Request(reqCode, inBufferSize, inBuffer, outBufferSize, outBuffer) : HResults.E_NOTIMPL;
 
     int IXCLRDataMethodDefinition.GetRepresentativeEntryAddress(ClrDataAddress* addr)
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetRepresentativeEntryAddress(addr) : HResults.E_NOTIMPL;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
@@ -375,7 +375,38 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
     }
 
     int IXCLRDataMethodDefinition.GetFlags(uint* flags)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetFlags(flags) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (flags is null)
+                throw new NullReferenceException();
+
+            *flags = 0;
+            TargetPointer methodDesc = TryResolveMethodDesc();
+            if (methodDesc != TargetPointer.Null)
+            {
+                MethodDescHandle methodDescHandle = _target.Contracts.RuntimeTypeSystem.GetMethodDescHandle(methodDesc);
+                *flags = MethodSignatureHelpers.GetMethodFlags(_target, methodDescHandle);
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint flagsLocal = 0;
+            int hrLocal = _legacyImpl.GetFlags(flags is null ? null : &flagsLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK && flags is not null)
+                Debug.Assert(*flags == flagsLocal, $"cDAC: {*flags}, DAC: {flagsLocal}");
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataMethodDefinition.IsSameObject(IXCLRDataMethodDefinition? method)
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.IsSameObject(method) : HResults.E_NOTIMPL;
@@ -441,7 +472,62 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
     }
 
     int IXCLRDataMethodDefinition.Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.Request(reqCode, inBufferSize, inBuffer, outBufferSize, outBuffer) : HResults.E_NOTIMPL;
+    {
+        int hr = HandleRevisionRequest(reqCode, inBufferSize, inBuffer, outBufferSize, outBuffer);
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            byte[] localBuffer = new byte[(int)outBufferSize];
+            fixed (byte* localOutBuffer = localBuffer)
+            {
+                int hrLocal = _legacyImpl.Request(
+                    reqCode,
+                    inBufferSize,
+                    inBuffer,
+                    outBufferSize,
+                    outBuffer is null ? null : localOutBuffer);
+                Debug.ValidateHResult(hr, hrLocal);
+                if (hr == HResults.S_OK)
+                {
+                    Debug.Assert(outBuffer is not null);
+                    Debug.Assert(new ReadOnlySpan<byte>(outBuffer, (int)outBufferSize).SequenceEqual(localBuffer));
+                }
+            }
+        }
+#endif
+        return hr;
+    }
+
+    internal static int HandleRevisionRequest(
+        uint reqCode,
+        uint inBufferSize,
+        byte* inBuffer,
+        uint outBufferSize,
+        byte* outBuffer)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (reqCode != (uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION
+                || inBufferSize != 0
+                || inBuffer is not null
+                || outBufferSize != sizeof(uint))
+            {
+                throw new ArgumentException();
+            }
+            if (outBuffer is null)
+                throw new NullReferenceException();
+
+            *(uint*)outBuffer = 1;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+        return hr;
+    }
 
     int IXCLRDataMethodDefinition.GetRepresentativeEntryAddress(ClrDataAddress* addr)
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetRepresentativeEntryAddress(addr) : HResults.E_NOTIMPL;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodInstance.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodInstance.cs
@@ -174,7 +174,32 @@ public sealed unsafe partial class ClrDataMethodInstance : IXCLRDataMethodInstan
     }
 
     int IXCLRDataMethodInstance.GetFlags(uint* flags)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetFlags(flags) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (flags is null)
+                throw new NullReferenceException();
+
+            *flags = MethodSignatureHelpers.GetMethodFlags(_target, _methodDesc);
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint flagsLocal = 0;
+            int hrLocal = _legacyImpl.GetFlags(flags is null ? null : &flagsLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK && flags is not null)
+                Debug.Assert(*flags == flagsLocal, $"cDAC: {*flags}, DAC: {flagsLocal}");
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataMethodInstance.IsSameObject(IXCLRDataMethodInstance* method)
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.IsSameObject(method) : HResults.E_NOTIMPL;
@@ -382,7 +407,32 @@ public sealed unsafe partial class ClrDataMethodInstance : IXCLRDataMethodInstan
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.EndEnumExtents(handle) : HResults.E_NOTIMPL;
 
     int IXCLRDataMethodInstance.Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.Request(reqCode, inBufferSize, inBuffer, outBufferSize, outBuffer) : HResults.E_NOTIMPL;
+    {
+        int hr = ClrDataMethodDefinition.HandleRevisionRequest(reqCode, inBufferSize, inBuffer, outBufferSize, outBuffer);
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            byte[] localBuffer = new byte[(int)outBufferSize];
+            fixed (byte* localOutBuffer = localBuffer)
+            {
+                int hrLocal = _legacyImpl.Request(
+                    reqCode,
+                    inBufferSize,
+                    inBuffer,
+                    outBufferSize,
+                    outBuffer is null ? null : localOutBuffer);
+                Debug.ValidateHResult(hr, hrLocal);
+                if (hr == HResults.S_OK)
+                {
+                    Debug.Assert(outBuffer is not null);
+                    Debug.Assert(new ReadOnlySpan<byte>(outBuffer, (int)outBufferSize).SequenceEqual(localBuffer));
+                }
+            }
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataMethodInstance.GetRepresentativeEntryAddress(ClrDataAddress* addr)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodInstance.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodInstance.cs
@@ -407,32 +407,7 @@ public sealed unsafe partial class ClrDataMethodInstance : IXCLRDataMethodInstan
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.EndEnumExtents(handle) : HResults.E_NOTIMPL;
 
     int IXCLRDataMethodInstance.Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer)
-    {
-        int hr = ClrDataMethodDefinition.HandleRevisionRequest(reqCode, inBufferSize, inBuffer, outBufferSize, outBuffer);
-
-#if DEBUG
-        if (_legacyImpl is not null)
-        {
-            byte[] localBuffer = new byte[(int)outBufferSize];
-            fixed (byte* localOutBuffer = localBuffer)
-            {
-                int hrLocal = _legacyImpl.Request(
-                    reqCode,
-                    inBufferSize,
-                    inBuffer,
-                    outBufferSize,
-                    outBuffer is null ? null : localOutBuffer);
-                Debug.ValidateHResult(hr, hrLocal);
-                if (hr == HResults.S_OK)
-                {
-                    Debug.Assert(outBuffer is not null);
-                    Debug.Assert(new ReadOnlySpan<byte>(outBuffer, (int)outBufferSize).SequenceEqual(localBuffer));
-                }
-            }
-        }
-#endif
-        return hr;
-    }
+        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.Request(reqCode, inBufferSize, inBuffer, outBufferSize, outBuffer) : HResults.E_NOTIMPL;
 
     int IXCLRDataMethodInstance.GetRepresentativeEntryAddress(ClrDataAddress* addr)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/MethodSignatureHelpers.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/MethodSignatureHelpers.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
 
 namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 
@@ -11,6 +13,8 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 /// </summary>
 internal static class MethodSignatureHelpers
 {
+    private const uint CLRDATA_METHOD_HAS_THIS = 0x1;
+
     /// <summary>
     /// Parses raw signature bytes to determine the signature header and argument count.
     /// </summary>
@@ -27,5 +31,14 @@ internal static class MethodSignatureHelpers
             uint paramCount = (uint)blobReader.ReadCompressedInteger();
             numArgs = paramCount + (header.IsInstance ? 1u : 0u);
         }
+    }
+
+    public static uint GetMethodFlags(Target target, MethodDescHandle methodDesc)
+    {
+        if (!target.Contracts.RuntimeTypeSystem.TryGetMethodSignature(methodDesc, out ReadOnlySpan<byte> signature))
+            throw Marshal.GetExceptionForHR(HResults.E_FAIL)!;
+
+        GetSignatureInfo(signature, out SignatureHeader header, out _);
+        return header.IsInstance ? CLRDATA_METHOD_HAS_THIS : 0;
     }
 }

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataMethodTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataMethodTests.cs
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
+using Xunit;
+using ModuleHandle = Microsoft.Diagnostics.DataContractReader.Contracts.ModuleHandle;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public unsafe class ClrDataMethodTests
+{
+    private const uint MethodToken = 0x06000001;
+    private static readonly MockTarget.Architecture s_arch = new() { IsLittleEndian = true, Is64Bit = true };
+    private static readonly TargetPointer s_module = new(0x1000);
+    private static readonly TargetPointer s_methodDesc = new(0x2000);
+    private static readonly ModuleHandle s_moduleHandle = new(new TargetPointer(0x3000));
+
+    [Theory]
+    [InlineData(false, 0u)]
+    [InlineData(true, 1u)]
+    public void GetFlags_UsesSignatureHasThis(bool hasThis, uint expectedFlags)
+    {
+        byte[] signature = [hasThis ? (byte)0x20 : (byte)0x00, 0x00, 0x01];
+        TestPlaceholderTarget target = CreateTarget(signature);
+
+        IXCLRDataMethodDefinition definition = new ClrDataMethodDefinition(
+            target,
+            s_module,
+            MethodToken,
+            legacyImpl: null);
+        uint definitionFlags;
+        Assert.Equal(HResults.S_OK, definition.GetFlags(&definitionFlags));
+        Assert.Equal(expectedFlags, definitionFlags);
+
+        IXCLRDataMethodInstance instance = new ClrDataMethodInstance(
+            target,
+            new MethodDescHandle(s_methodDesc),
+            appDomain: TargetPointer.Null,
+            legacyImpl: null);
+        uint instanceFlags;
+        Assert.Equal(HResults.S_OK, instance.GetFlags(&instanceFlags));
+        Assert.Equal(expectedFlags, instanceFlags);
+    }
+
+    [Fact]
+    public void MethodDefinitionRequest_ImplementsRevisionOne()
+    {
+        IXCLRDataMethodDefinition definition = new ClrDataMethodDefinition(
+            CreateTarget([0x00, 0x00, 0x01]),
+            s_module,
+            MethodToken,
+            legacyImpl: null);
+
+        AssertRevisionRequest(
+            (uint reqCode, uint inSize, byte* inBuffer, uint outSize, byte* outBuffer) =>
+                definition.Request(reqCode, inSize, inBuffer, outSize, outBuffer));
+    }
+
+    [Fact]
+    public void MethodInstanceRequest_ImplementsRevisionOne()
+    {
+        IXCLRDataMethodInstance instance = new ClrDataMethodInstance(
+            CreateTarget([0x00, 0x00, 0x01]),
+            new MethodDescHandle(s_methodDesc),
+            appDomain: TargetPointer.Null,
+            legacyImpl: null);
+
+        AssertRevisionRequest(
+            (uint reqCode, uint inSize, byte* inBuffer, uint outSize, byte* outBuffer) =>
+                instance.Request(reqCode, inSize, inBuffer, outSize, outBuffer));
+    }
+
+    private static void AssertRevisionRequest(Request request)
+    {
+        uint revision = 0;
+        Assert.Equal(
+            HResults.S_OK,
+            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 0, null, sizeof(uint), (byte*)&revision));
+        Assert.Equal(1u, revision);
+
+        byte input = 0;
+        Assert.Equal(
+            HResults.E_INVALIDARG,
+            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 1, null, sizeof(uint), (byte*)&revision));
+        Assert.Equal(
+            HResults.E_INVALIDARG,
+            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 0, &input, sizeof(uint), (byte*)&revision));
+        Assert.Equal(
+            HResults.E_INVALIDARG,
+            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 0, null, 0, (byte*)&revision));
+        Assert.Equal(
+            HResults.E_POINTER,
+            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 0, null, sizeof(uint), null));
+        Assert.Equal(
+            HResults.E_INVALIDARG,
+            request(0x12345678, 0, null, sizeof(uint), (byte*)&revision));
+    }
+
+    private static TestPlaceholderTarget CreateTarget(byte[] signature)
+    {
+        TargetPointer methodDefToDesc = new(0x4000);
+        ModuleLookupTables lookupTables = new(
+            FieldDefToDesc: TargetPointer.Null,
+            ManifestModuleReferences: TargetPointer.Null,
+            MemberRefToDesc: TargetPointer.Null,
+            MethodDefToDesc: methodDefToDesc,
+            TypeDefToMethodTable: TargetPointer.Null,
+            TypeRefToMethodTable: TargetPointer.Null,
+            MethodDefToILCodeVersioningState: TargetPointer.Null,
+            TableDataOffset: 0);
+        TargetNUInt lookupFlags = default;
+
+        var loader = new Mock<ILoader>();
+        loader.Setup(l => l.GetModuleHandleFromModulePtr(s_module)).Returns(s_moduleHandle);
+        loader.Setup(l => l.GetLookupTables(s_moduleHandle)).Returns(lookupTables);
+        loader.Setup(l => l.GetModuleLookupMapElement(methodDefToDesc, MethodToken, out lookupFlags))
+            .Returns(s_methodDesc);
+
+        return new TestPlaceholderTarget.Builder(s_arch)
+            .UseReader((ulong _, Span<byte> _) => -1)
+            .AddMockContract(loader)
+            .AddMockContract<IRuntimeTypeSystem>(new SignatureRuntimeTypeSystem(signature))
+            .Build();
+    }
+
+    private unsafe delegate int Request(
+        uint reqCode,
+        uint inBufferSize,
+        byte* inBuffer,
+        uint outBufferSize,
+        byte* outBuffer);
+
+    private sealed class SignatureRuntimeTypeSystem(byte[] signature) : IRuntimeTypeSystem
+    {
+        private readonly byte[] _signature = signature;
+
+        public MethodDescHandle GetMethodDescHandle(TargetPointer address) => new(address);
+
+        public bool TryGetMethodSignature(MethodDescHandle methodDesc, out ReadOnlySpan<byte> signature)
+        {
+            signature = _signature;
+            return true;
+        }
+    }
+}

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataMethodTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataMethodTests.cs
@@ -46,60 +46,6 @@ public unsafe class ClrDataMethodTests
         Assert.Equal(expectedFlags, instanceFlags);
     }
 
-    [Fact]
-    public void MethodDefinitionRequest_ImplementsRevisionOne()
-    {
-        IXCLRDataMethodDefinition definition = new ClrDataMethodDefinition(
-            CreateTarget([0x00, 0x00, 0x01]),
-            s_module,
-            MethodToken,
-            legacyImpl: null);
-
-        AssertRevisionRequest(
-            (uint reqCode, uint inSize, byte* inBuffer, uint outSize, byte* outBuffer) =>
-                definition.Request(reqCode, inSize, inBuffer, outSize, outBuffer));
-    }
-
-    [Fact]
-    public void MethodInstanceRequest_ImplementsRevisionOne()
-    {
-        IXCLRDataMethodInstance instance = new ClrDataMethodInstance(
-            CreateTarget([0x00, 0x00, 0x01]),
-            new MethodDescHandle(s_methodDesc),
-            appDomain: TargetPointer.Null,
-            legacyImpl: null);
-
-        AssertRevisionRequest(
-            (uint reqCode, uint inSize, byte* inBuffer, uint outSize, byte* outBuffer) =>
-                instance.Request(reqCode, inSize, inBuffer, outSize, outBuffer));
-    }
-
-    private static void AssertRevisionRequest(Request request)
-    {
-        uint revision = 0;
-        Assert.Equal(
-            HResults.S_OK,
-            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 0, null, sizeof(uint), (byte*)&revision));
-        Assert.Equal(1u, revision);
-
-        byte input = 0;
-        Assert.Equal(
-            HResults.E_INVALIDARG,
-            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 1, null, sizeof(uint), (byte*)&revision));
-        Assert.Equal(
-            HResults.E_INVALIDARG,
-            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 0, &input, sizeof(uint), (byte*)&revision));
-        Assert.Equal(
-            HResults.E_INVALIDARG,
-            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 0, null, 0, (byte*)&revision));
-        Assert.Equal(
-            HResults.E_POINTER,
-            request((uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION, 0, null, sizeof(uint), null));
-        Assert.Equal(
-            HResults.E_INVALIDARG,
-            request(0x12345678, 0, null, sizeof(uint), (byte*)&revision));
-    }
-
     private static TestPlaceholderTarget CreateTarget(byte[] signature)
     {
         TargetPointer methodDefToDesc = new(0x4000);
@@ -126,13 +72,6 @@ public unsafe class ClrDataMethodTests
             .AddMockContract<IRuntimeTypeSystem>(new SignatureRuntimeTypeSystem(signature))
             .Build();
     }
-
-    private unsafe delegate int Request(
-        uint reqCode,
-        uint inBufferSize,
-        byte* inBuffer,
-        uint outBufferSize,
-        byte* outBuffer);
 
     private sealed class SignatureRuntimeTypeSystem(byte[] signature) : IRuntimeTypeSystem
     {


### PR DESCRIPTION
## Summary

Implements `IXCLRDataMethodDefinition.GetFlags` and `IXCLRDataMethodInstance.GetFlags`, which previously returned `E_NOTIMPL` when legacy fallback was unavailable.

## Native semantic parity

Returns `CLRDATA_METHOD_DEFAULT` (0) plus `CLRDATA_METHOD_HAS_THIS` (0x1) when the method signature is an instance signature. The implementation parses the method signature header through the shared `MethodSignatureHelpers.GetMethodFlags` helper and returns `E_FAIL` if the signature is unavailable.

`#if DEBUG` cross-checks compare results against the legacy DAC when present.

Larger `MethodInstance` work (name/token/IL map/extents/frame locals) is intentionally out of scope.

## Testing

- cDAC solution build with MSBuild node reuse and shared compilation disabled: 0 warnings, 0 errors.
- `ClrDataMethodTests.GetFlags_UsesSignatureHasThis`: 2 passed, 0 failed.
- Full cDAC unit suite: 2703 passed, 16 skipped, 0 failed.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.