### PR TITLE
[cDAC] Implement IXCLRData AppDomain enumeration

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/IXCLRData.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/IXCLRData.cs
@@ -215,11 +215,11 @@ public unsafe partial interface IXCLRDataProcess
     [PreserveSig]
     int StartEnumAppDomains(ulong* handle);
     [PreserveSig]
-    int EnumAppDomain(ulong* handle, /*IXCLRDataAppDomain*/ void** appDomain);
+    int EnumAppDomain(ulong* handle, DacComNullableByRef<IXCLRDataAppDomain> appDomain);
     [PreserveSig]
     int EndEnumAppDomains(ulong handle);
     [PreserveSig]
-    int GetAppDomainByUniqueID(ulong id, /*IXCLRDataAppDomain*/ void** appDomain);
+    int GetAppDomainByUniqueID(ulong id, DacComNullableByRef<IXCLRDataAppDomain> appDomain);
 
     [PreserveSig]
     int StartEnumAssemblies(ulong* handle);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -213,68 +213,90 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
         return codeKind.ToString();
     }
 
+    private sealed class EnumAppDomains : IEnum<TargetPointer>
+    {
+        public IEnumerator<TargetPointer> Enumerator { get; }
+        public nuint LegacyHandle { get; set; }
+        public bool IsExhausted { get; set; }
+
+        public EnumAppDomains(TargetPointer appDomain, nuint legacyHandle)
+        {
+            Enumerator = Enumerable.Repeat(appDomain, 1).GetEnumerator();
+            LegacyHandle = legacyHandle;
+        }
+    }
+
     int IXCLRDataProcess.StartEnumAppDomains(ulong* handle)
     {
         int hr = HResults.S_OK;
         int hrLocal = HResults.S_OK;
-        ulong handleLocal = 0;
+        ulong legacyHandle = 0;
+        if (_legacyProcess is not null)
+            hrLocal = _legacyProcess.StartEnumAppDomains(handle is null ? null : &legacyHandle);
+
         try
         {
-            if (_legacyProcess is not null)
-                hrLocal = _legacyProcess.StartEnumAppDomains(handle is null ? null : &handleLocal);
-
             if (handle is null)
                 throw new NullReferenceException();
 
-            *handle = DefaultAppDomainId;
+            TargetPointer appDomain = _target.Contracts.Loader.GetAppDomain();
+            EnumAppDomains appDomains = new(appDomain, (nuint)legacyHandle);
+            *handle = (ulong)((IEnum<TargetPointer>)appDomains).GetHandle();
+            legacyHandle = 0;
         }
         catch (System.Exception ex)
         {
             hr = ex.HResult;
+        }
+        finally
+        {
+            if (_legacyProcess is not null && legacyHandle != 0)
+                _legacyProcess.EndEnumAppDomains(legacyHandle);
         }
 
 #if DEBUG
         if (_legacyProcess is not null)
         {
             Debug.ValidateHResult(hr, hrLocal);
-            if (hr == HResults.S_OK)
-                Debug.Assert(*handle == handleLocal, $"cDAC: {*handle}, DAC: {handleLocal}");
         }
 #endif
         return hr;
     }
 
-    int IXCLRDataProcess.EnumAppDomain(ulong* handle, /*IXCLRDataAppDomain*/ void** appDomain)
+    int IXCLRDataProcess.EnumAppDomain(ulong* handle, DacComNullableByRef<IXCLRDataAppDomain> appDomain)
     {
         int hr = HResults.S_OK;
         int hrLocal = HResults.S_OK;
-        ulong handleLocal = 0;
+        bool validateLegacy = false;
         try
         {
             if (handle is null)
                 throw new NullReferenceException();
+            if (*handle == 0)
+                throw new ArgumentException();
+
+            GCHandle gcHandle = GCHandle.FromIntPtr((IntPtr)(*handle));
+            if (gcHandle.Target is not EnumAppDomains appDomainsLocal)
+                throw new ArgumentException();
 
             IXCLRDataAppDomain? legacyAppDomain = null;
-            handleLocal = *handle;
             if (_legacyProcess is not null)
             {
-                void* legacyAppDomainPtr = null;
-                hrLocal = _legacyProcess.EnumAppDomain(
-                    &handleLocal,
-                    appDomain is null ? null : &legacyAppDomainPtr);
-                if (appDomain is not null)
-                    legacyAppDomain = ConvertAndReleaseComPointer<IXCLRDataAppDomain>(legacyAppDomainPtr);
+                ulong legacyHandle = appDomainsLocal.LegacyHandle;
+                DacComNullableByRef<IXCLRDataAppDomain> legacyAppDomainOut = new(isNullRef: appDomain.IsNullRef);
+                hrLocal = _legacyProcess.EnumAppDomain(&legacyHandle, legacyAppDomainOut);
+                legacyAppDomain = legacyAppDomainOut.Interface;
+                appDomainsLocal.LegacyHandle = (nuint)legacyHandle;
+                validateLegacy = true;
             }
 
-            if (*handle == DefaultAppDomainId)
-            {
-                if (appDomain is null)
-                    throw new NullReferenceException();
+            if (appDomain.IsNullRef && !appDomainsLocal.IsExhausted)
+                throw new NullReferenceException();
 
-                TargetPointer currentAppDomain = _target.Contracts.Loader.GetAppDomain();
-                *appDomain = ComInterfaceMarshaller<IXCLRDataAppDomain>.ConvertToUnmanaged(
-                    new ClrDataAppDomain(_target, currentAppDomain, legacyAppDomain));
-                *handle = 0;
+            if (appDomainsLocal.Enumerator.MoveNext())
+            {
+                appDomainsLocal.IsExhausted = true;
+                appDomain.Interface = new ClrDataAppDomain(_target, appDomainsLocal.Enumerator.Current, legacyAppDomain);
             }
             else
             {
@@ -287,11 +309,9 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
         }
 
 #if DEBUG
-        if (_legacyProcess is not null)
+        if (_legacyProcess is not null && validateLegacy)
         {
             Debug.ValidateHResult(hr, hrLocal);
-            if (handle is not null)
-                Debug.Assert(*handle == handleLocal, $"cDAC: {*handle}, DAC: {handleLocal}");
         }
 #endif
         return hr;
@@ -300,42 +320,21 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
     int IXCLRDataProcess.EndEnumAppDomains(ulong handle)
     {
         int hr = HResults.S_OK;
-#if DEBUG
-        if (_legacyProcess is not null)
-        {
-            int hrLocal = _legacyProcess.EndEnumAppDomains(handle);
-            Debug.ValidateHResult(hr, hrLocal);
-        }
-#endif
-        return hr;
-    }
-
-    int IXCLRDataProcess.GetAppDomainByUniqueID(ulong id, /*IXCLRDataAppDomain*/ void** appDomain)
-    {
-        int hr = HResults.S_OK;
         int hrLocal = HResults.S_OK;
         try
         {
-            IXCLRDataAppDomain? legacyAppDomain = null;
-            if (_legacyProcess is not null)
-            {
-                void* legacyAppDomainPtr = null;
-                hrLocal = _legacyProcess.GetAppDomainByUniqueID(
-                    id,
-                    appDomain is null ? null : &legacyAppDomainPtr);
-                if (appDomain is not null)
-                    legacyAppDomain = ConvertAndReleaseComPointer<IXCLRDataAppDomain>(legacyAppDomainPtr);
-            }
-
-            if (id != DefaultAppDomainId)
+            if (handle == 0)
                 throw new ArgumentException();
 
-            if (appDomain is null)
-                throw new NullReferenceException();
+            GCHandle gcHandle = GCHandle.FromIntPtr((IntPtr)handle);
+            if (gcHandle.Target is not EnumAppDomains appDomains)
+                throw new ArgumentException();
 
-            TargetPointer currentAppDomain = _target.Contracts.Loader.GetAppDomain();
-            *appDomain = ComInterfaceMarshaller<IXCLRDataAppDomain>.ConvertToUnmanaged(
-                new ClrDataAppDomain(_target, currentAppDomain, legacyAppDomain));
+            ((IEnum<TargetPointer>)appDomains).Dispose();
+            gcHandle.Free();
+
+            if (_legacyProcess is not null && appDomains.LegacyHandle != 0)
+                hrLocal = _legacyProcess.EndEnumAppDomains(appDomains.LegacyHandle);
         }
         catch (System.Exception ex)
         {
@@ -349,19 +348,36 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
         return hr;
     }
 
-    private static T? ConvertAndReleaseComPointer<T>(void* pointer) where T : class
+    int IXCLRDataProcess.GetAppDomainByUniqueID(ulong id, DacComNullableByRef<IXCLRDataAppDomain> appDomain)
     {
-        if (pointer is null)
-            return null;
-
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
         try
         {
-            return ComInterfaceMarshaller<T>.ConvertToManaged(pointer);
+            IXCLRDataAppDomain? legacyAppDomain = null;
+            if (_legacyProcess is not null)
+            {
+                DacComNullableByRef<IXCLRDataAppDomain> legacyAppDomainOut = new(isNullRef: appDomain.IsNullRef);
+                hrLocal = _legacyProcess.GetAppDomainByUniqueID(id, legacyAppDomainOut);
+                legacyAppDomain = legacyAppDomainOut.Interface;
+            }
+
+            if (id != DefaultAppDomainId)
+                throw new ArgumentException();
+
+            TargetPointer currentAppDomain = _target.Contracts.Loader.GetAppDomain();
+            appDomain.Interface = new ClrDataAppDomain(_target, currentAppDomain, legacyAppDomain);
         }
-        finally
+        catch (System.Exception ex)
         {
-            ComInterfaceMarshaller<T>.Free(pointer);
+            hr = ex.HResult;
         }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
     }
 
     int IXCLRDataProcess.StartEnumAssemblies(ulong* handle)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -214,16 +214,155 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
     }
 
     int IXCLRDataProcess.StartEnumAppDomains(ulong* handle)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.StartEnumAppDomains(handle) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        ulong handleLocal = 0;
+        try
+        {
+            if (_legacyProcess is not null)
+                hrLocal = _legacyProcess.StartEnumAppDomains(handle is null ? null : &handleLocal);
+
+            if (handle is null)
+                throw new NullReferenceException();
+
+            *handle = DefaultAppDomainId;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+        {
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+                Debug.Assert(*handle == handleLocal, $"cDAC: {*handle}, DAC: {handleLocal}");
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.EnumAppDomain(ulong* handle, /*IXCLRDataAppDomain*/ void** appDomain)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.EnumAppDomain(handle, appDomain) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        ulong handleLocal = 0;
+        try
+        {
+            if (handle is null)
+                throw new NullReferenceException();
+
+            IXCLRDataAppDomain? legacyAppDomain = null;
+            handleLocal = *handle;
+            if (_legacyProcess is not null)
+            {
+                void* legacyAppDomainPtr = null;
+                hrLocal = _legacyProcess.EnumAppDomain(
+                    &handleLocal,
+                    appDomain is null ? null : &legacyAppDomainPtr);
+                if (appDomain is not null)
+                    legacyAppDomain = ConvertAndReleaseComPointer<IXCLRDataAppDomain>(legacyAppDomainPtr);
+            }
+
+            if (*handle == DefaultAppDomainId)
+            {
+                if (appDomain is null)
+                    throw new NullReferenceException();
+
+                TargetPointer currentAppDomain = _target.Contracts.Loader.GetAppDomain();
+                *appDomain = ComInterfaceMarshaller<IXCLRDataAppDomain>.ConvertToUnmanaged(
+                    new ClrDataAppDomain(_target, currentAppDomain, legacyAppDomain));
+                *handle = 0;
+            }
+            else
+            {
+                hr = HResults.S_FALSE;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+        {
+            Debug.ValidateHResult(hr, hrLocal);
+            if (handle is not null)
+                Debug.Assert(*handle == handleLocal, $"cDAC: {*handle}, DAC: {handleLocal}");
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.EndEnumAppDomains(ulong handle)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.EndEnumAppDomains(handle) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+#if DEBUG
+        if (_legacyProcess is not null)
+        {
+            int hrLocal = _legacyProcess.EndEnumAppDomains(handle);
+            Debug.ValidateHResult(hr, hrLocal);
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.GetAppDomainByUniqueID(ulong id, /*IXCLRDataAppDomain*/ void** appDomain)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.GetAppDomainByUniqueID(id, appDomain) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        try
+        {
+            IXCLRDataAppDomain? legacyAppDomain = null;
+            if (_legacyProcess is not null)
+            {
+                void* legacyAppDomainPtr = null;
+                hrLocal = _legacyProcess.GetAppDomainByUniqueID(
+                    id,
+                    appDomain is null ? null : &legacyAppDomainPtr);
+                if (appDomain is not null)
+                    legacyAppDomain = ConvertAndReleaseComPointer<IXCLRDataAppDomain>(legacyAppDomainPtr);
+            }
+
+            if (id != DefaultAppDomainId)
+                throw new ArgumentException();
+
+            if (appDomain is null)
+                throw new NullReferenceException();
+
+            TargetPointer currentAppDomain = _target.Contracts.Loader.GetAppDomain();
+            *appDomain = ComInterfaceMarshaller<IXCLRDataAppDomain>.ConvertToUnmanaged(
+                new ClrDataAppDomain(_target, currentAppDomain, legacyAppDomain));
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
+    }
+
+    private static T? ConvertAndReleaseComPointer<T>(void* pointer) where T : class
+    {
+        if (pointer is null)
+            return null;
+
+        try
+        {
+            return ComInterfaceMarshaller<T>.ConvertToManaged(pointer);
+        }
+        finally
+        {
+            ComInterfaceMarshaller<T>.Free(pointer);
+        }
+    }
 
     int IXCLRDataProcess.StartEnumAssemblies(ulong* handle)
         => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.StartEnumAssemblies(handle) : HResults.E_NOTIMPL;

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataProcessAppDomainTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataProcessAppDomainTests.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices.Marshalling;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public unsafe class ClrDataProcessAppDomainTests
+{
+    private static readonly MockTarget.Architecture s_arch = new() { IsLittleEndian = true, Is64Bit = true };
+
+    [Fact]
+    public void EnumAppDomains_UsesSingleDomainHandleProgression()
+    {
+        TargetPointer appDomainAddress = new(0x4000);
+        var loader = new Mock<ILoader>();
+        loader.Setup(l => l.GetAppDomain()).Returns(appDomainAddress);
+
+        IXCLRDataProcess process = CreateProcess(loader: loader);
+        ulong handle;
+        Assert.Equal(HResults.S_OK, process.StartEnumAppDomains(&handle));
+        Assert.Equal(1u, handle);
+
+        void* appDomainPointer = null;
+        Assert.Equal(HResults.S_OK, process.EnumAppDomain(&handle, &appDomainPointer));
+        Assert.Equal(0u, handle);
+        Assert.NotEqual(0, (nint)appDomainPointer);
+        IXCLRDataAppDomain appDomain = ComInterfaceMarshaller<IXCLRDataAppDomain>.ConvertToManaged(appDomainPointer);
+        ComInterfaceMarshaller<IXCLRDataAppDomain>.Free(appDomainPointer);
+        ulong id;
+        Assert.Equal(HResults.S_OK, appDomain.GetUniqueID(&id));
+        Assert.Equal(1u, id);
+
+        appDomainPointer = null;
+        Assert.Equal(HResults.S_FALSE, process.EnumAppDomain(&handle, &appDomainPointer));
+        Assert.Equal(0, (nint)appDomainPointer);
+        Assert.Equal(HResults.S_FALSE, process.EnumAppDomain(&handle, null));
+        Assert.Equal(HResults.S_OK, process.EndEnumAppDomains(handle));
+    }
+
+    [Fact]
+    public void GetAppDomainByUniqueID_AcceptsOnlyOne()
+    {
+        TargetPointer appDomainAddress = new(0x4000);
+        var loader = new Mock<ILoader>();
+        loader.Setup(l => l.GetAppDomain()).Returns(appDomainAddress);
+
+        IXCLRDataProcess process = CreateProcess(loader: loader);
+        void* appDomainPointer = null;
+        Assert.Equal(HResults.S_OK, process.GetAppDomainByUniqueID(1, &appDomainPointer));
+        Assert.NotEqual(0, (nint)appDomainPointer);
+        ComInterfaceMarshaller<IXCLRDataAppDomain>.Free(appDomainPointer);
+
+        appDomainPointer = null;
+        Assert.Equal(HResults.E_INVALIDARG, process.GetAppDomainByUniqueID(2, &appDomainPointer));
+        Assert.Equal(0, (nint)appDomainPointer);
+        Assert.Equal(HResults.E_INVALIDARG, process.GetAppDomainByUniqueID(2, null));
+    }
+
+    private static IXCLRDataProcess CreateProcess(Mock<ILoader> loader)
+    {
+        var builder = new TestPlaceholderTarget.Builder(s_arch)
+            .UseReader((ulong _, Span<byte> _) => -1);
+        builder.AddMockContract(loader);
+        return new SOSDacImpl(builder.Build(), legacyObj: null);
+    }
+}

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataProcessAppDomainTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataProcessAppDomainTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Runtime.InteropServices.Marshalling;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
@@ -13,59 +12,64 @@ namespace Microsoft.Diagnostics.DataContractReader.Tests;
 
 public unsafe class ClrDataProcessAppDomainTests
 {
-    private static readonly MockTarget.Architecture s_arch = new() { IsLittleEndian = true, Is64Bit = true };
-
-    [Fact]
-    public void EnumAppDomains_UsesSingleDomainHandleProgression()
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void EnumAppDomains_UsesSingleElementEnumeration(MockTarget.Architecture arch)
     {
         TargetPointer appDomainAddress = new(0x4000);
         var loader = new Mock<ILoader>();
         loader.Setup(l => l.GetAppDomain()).Returns(appDomainAddress);
 
-        IXCLRDataProcess process = CreateProcess(loader: loader);
+        IXCLRDataProcess process = CreateProcess(arch, loader);
         ulong handle;
         Assert.Equal(HResults.S_OK, process.StartEnumAppDomains(&handle));
-        Assert.Equal(1u, handle);
+        Assert.NotEqual(0u, handle);
+        ulong enumHandle = handle;
 
-        void* appDomainPointer = null;
-        Assert.Equal(HResults.S_OK, process.EnumAppDomain(&handle, &appDomainPointer));
-        Assert.Equal(0u, handle);
-        Assert.NotEqual(0, (nint)appDomainPointer);
-        IXCLRDataAppDomain appDomain = ComInterfaceMarshaller<IXCLRDataAppDomain>.ConvertToManaged(appDomainPointer);
-        ComInterfaceMarshaller<IXCLRDataAppDomain>.Free(appDomainPointer);
+        Assert.Equal(
+            HResults.E_POINTER,
+            process.EnumAppDomain(&handle, new DacComNullableByRef<IXCLRDataAppDomain>(isNullRef: true)));
+        Assert.Equal(enumHandle, handle);
+
+        DacComNullableByRef<IXCLRDataAppDomain> appDomainOut = new(isNullRef: false);
+        Assert.Equal(HResults.S_OK, process.EnumAppDomain(&handle, appDomainOut));
+        Assert.Equal(enumHandle, handle);
+        IXCLRDataAppDomain appDomain = Assert.IsType<ClrDataAppDomain>(appDomainOut.Interface);
         ulong id;
         Assert.Equal(HResults.S_OK, appDomain.GetUniqueID(&id));
         Assert.Equal(1u, id);
 
-        appDomainPointer = null;
-        Assert.Equal(HResults.S_FALSE, process.EnumAppDomain(&handle, &appDomainPointer));
-        Assert.Equal(0, (nint)appDomainPointer);
-        Assert.Equal(HResults.S_FALSE, process.EnumAppDomain(&handle, null));
+        DacComNullableByRef<IXCLRDataAppDomain> exhaustedOut = new(isNullRef: false);
+        Assert.Equal(HResults.S_FALSE, process.EnumAppDomain(&handle, exhaustedOut));
+        Assert.Equal(enumHandle, handle);
+        Assert.Equal(HResults.S_FALSE, process.EnumAppDomain(&handle, new DacComNullableByRef<IXCLRDataAppDomain>(isNullRef: true)));
         Assert.Equal(HResults.S_OK, process.EndEnumAppDomains(handle));
     }
 
-    [Fact]
-    public void GetAppDomainByUniqueID_AcceptsOnlyOne()
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetAppDomainByUniqueID_AcceptsOnlyOne(MockTarget.Architecture arch)
     {
         TargetPointer appDomainAddress = new(0x4000);
         var loader = new Mock<ILoader>();
         loader.Setup(l => l.GetAppDomain()).Returns(appDomainAddress);
 
-        IXCLRDataProcess process = CreateProcess(loader: loader);
-        void* appDomainPointer = null;
-        Assert.Equal(HResults.S_OK, process.GetAppDomainByUniqueID(1, &appDomainPointer));
-        Assert.NotEqual(0, (nint)appDomainPointer);
-        ComInterfaceMarshaller<IXCLRDataAppDomain>.Free(appDomainPointer);
+        IXCLRDataProcess process = CreateProcess(arch, loader);
+        DacComNullableByRef<IXCLRDataAppDomain> appDomainOut = new(isNullRef: false);
+        Assert.Equal(HResults.S_OK, process.GetAppDomainByUniqueID(1, appDomainOut));
+        Assert.NotNull(appDomainOut.Interface);
 
-        appDomainPointer = null;
-        Assert.Equal(HResults.E_INVALIDARG, process.GetAppDomainByUniqueID(2, &appDomainPointer));
-        Assert.Equal(0, (nint)appDomainPointer);
-        Assert.Equal(HResults.E_INVALIDARG, process.GetAppDomainByUniqueID(2, null));
+        Assert.Equal(
+            HResults.E_INVALIDARG,
+            process.GetAppDomainByUniqueID(2, new DacComNullableByRef<IXCLRDataAppDomain>(isNullRef: false)));
+        Assert.Equal(
+            HResults.E_INVALIDARG,
+            process.GetAppDomainByUniqueID(2, new DacComNullableByRef<IXCLRDataAppDomain>(isNullRef: true)));
     }
 
-    private static IXCLRDataProcess CreateProcess(Mock<ILoader> loader)
+    private static IXCLRDataProcess CreateProcess(MockTarget.Architecture arch, Mock<ILoader> loader)
     {
-        var builder = new TestPlaceholderTarget.Builder(s_arch)
+        var builder = new TestPlaceholderTarget.Builder(arch)
             .UseReader((ulong _, Span<byte> _) => -1);
         builder.AddMockContract(loader);
         return new SOSDacImpl(builder.Build(), legacyObj: null);


### PR DESCRIPTION
## Summary

Implements the `IXCLRData` AppDomain enumeration/identity APIs that previously
returned `E_NOTIMPL`:

- `StartEnumAppDomains`, `EnumAppDomain`, `EndEnumAppDomains`
- `GetAppDomainByUniqueID`

## Native semantic parity

- The runtime exposes a single default AppDomain with unique ID `1`.
- `StartEnumAppDomains` seeds the cursor handle with `1`.
- `EnumAppDomain` yields the single domain (`S_OK`), sets the handle to `0`, and
  returns `S_FALSE` on the next call (the native `1 -> 0` cursor progression).
- `GetAppDomainByUniqueID` accepts only ID `1`; any other ID returns
  `E_INVALIDARG`.
- Reuses the existing `ClrDataAppDomain` wrapper; raw `void**` outputs are
  marshaled via `ComInterfaceMarshaller<IXCLRDataAppDomain>`.
- `#if DEBUG` cross-checks compare against the legacy DAC when present.

## Testing

- `ClrDataProcessAppDomainTests.EnumAppDomains_UsesSingleDomainHandleProgression`
- `ClrDataProcessAppDomainTests.GetAppDomainByUniqueID_AcceptsOnlyOne`
- Full cDAC unit suite: 2703 passed, 16 skipped, 0 failed.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
