### PR TITLE
Add peephole optimization to reduce MaskToVec and VecToMask conversions

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -34161,16 +34161,16 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
         if (tryHandle)
         {
             unsigned            simdBaseTypeSize = genTypeSize(simdBaseType);
-            GenTreeHWIntrinsic* cvtOp            = op->AsHWIntrinsic();
+            GenTreeHWIntrinsic* innerOp          = op->AsHWIntrinsic();
 
-            if (cvtOp->OperIsConvertMaskToVector())
+            if (innerOp->OperIsConvertMaskToVector())
             {
-                if ((genTypeSize(cvtOp->GetSimdBaseType()) == simdBaseTypeSize))
+                if ((genTypeSize(innerOp->GetSimdBaseType()) == simdBaseTypeSize))
                 {
                     // We need the operand to be the same kind of mask; otherwise
                     // the bitwise operation can differ in how it performs
 
-                    GenTree* maskNode = cvtOp->Op(1);
+                    GenTree* maskNode = innerOp->Op(1);
 
 #if defined(TARGET_ARM64)
                     DEBUG_DESTROY_NODE(op1);
@@ -34180,6 +34180,27 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
                     return maskNode;
                 }
             }
+
+            bool       isScalar = false;
+            genTreeOps oper     = innerOp->GetOperForHWIntrinsicId(&isScalar);
+#if defined(TARGET_XARCH)
+            // CvtMask(NOT(x)) => NOT(CvMask(x))
+            if (oper == GT_NOT || (oper == GT_XOR && innerOp->Op(2)->IsVectorAllBitsSet()))
+            {
+
+                GenTree* notOperand = innerOp->Op(1);
+
+                GenTree* innerMask = gtNewSimdCvtVectorToMaskNode(TYP_MASK, notOperand, simdBaseType, simdSize);
+                innerMask->SetMorphed(this);
+
+                GenTree* notMask =
+                    gtNewSimdHWIntrinsicNode(TYP_MASK, innerMask, NI_AVX512_NotMask, simdBaseType, simdSize);
+                notMask->SetMorphed(this);
+
+                DEBUG_DESTROY_NODE(op, tree);
+                return gtFoldExprHWIntrinsic(notMask->AsHWIntrinsic());
+            }
+#endif
         }
     }
 #else


### PR DESCRIPTION
On x64, specifically when supporting AVX512 there is an issue in the code gen which leads to extraneous MaskToVec and VecToMask conversions. This can be observed specifically on the System.Numerics.Tensors.IndexOfMax\<Int32\> benchmark.

The generated assembly will look like this:
<img width="533" height="358" alt="image" src="https://github.com/user-attachments/assets/a0fcd2ae-b698-44fe-aaba-f48d63798a50" />

This can be fixed by examining every VecToMask conversion and seeing if it fits this form:

**MASK_2** = VecToMask(NOT(**LCL_VAR**))
and **LCL_VAR** is defined earlier in the program as the following:
**LCL_VAR** = MaskToVec(**MASK_1**)

Then we can reduce this expression to become:

**MASK_2** = NOT(**MASK_1**)

The fixed assembly looks like this:
<img width="964" height="245" alt="image" src="https://github.com/user-attachments/assets/06100fb9-2b02-47d6-ae2f-1546a9e7c02f" />


This fix causes a ~47 reduction for 128 BufferLength and ~55% reduction in runtime for 3079 BufferLength. The runtime on System.Numerics.Tensors.IndexOfMax\<Int32\> is compared below.

Before changes:
<img width="975" height="93" alt="image" src="https://github.com/user-attachments/assets/50602ad0-d83f-4bb9-bef4-bae0a27e0c78" />


After changes:
<img width="975" height="91" alt="image" src="https://github.com/user-attachments/assets/a1dda872-a3e4-4712-9482-1823791289c1" />


