### PR TITLE
[cDAC] Implement IXCLRData module enumeration and address lookup

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -19,6 +19,18 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 /// </summary>
 public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProcess2
 {
+    private sealed class EnumModules : IEnum<Contracts.ModuleHandle>
+    {
+        public IEnumerator<Contracts.ModuleHandle> Enumerator { get; }
+        public nuint LegacyHandle { get; set; }
+
+        public EnumModules(IEnumerator<Contracts.ModuleHandle> enumerator, nuint legacyHandle)
+        {
+            Enumerator = enumerator;
+            LegacyHandle = legacyHandle;
+        }
+    }
+
     int IXCLRDataProcess.Flush()
     {
         _target.Flush(FlushScope.All);
@@ -235,16 +247,178 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
         => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.EndEnumAssemblies(handle) : HResults.E_NOTIMPL;
 
     int IXCLRDataProcess.StartEnumModules(ulong* handle)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.StartEnumModules(handle) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        ulong legacyHandle = 0;
+        try
+        {
+            if (_legacyProcess is not null)
+                hrLocal = _legacyProcess.StartEnumModules(handle is null ? null : &legacyHandle);
+
+            if (handle is null)
+                throw new NullReferenceException();
+
+            *handle = 0;
+            ILoader loader = _target.Contracts.Loader;
+            TargetPointer appDomain = loader.GetAppDomain();
+            IEnumerator<Contracts.ModuleHandle> enumerator = loader.GetModuleHandles(
+                appDomain,
+                AssemblyIterationFlags.IncludeLoaded | AssemblyIterationFlags.IncludeExecution).GetEnumerator();
+            EnumModules state = new(enumerator, (nuint)legacyHandle);
+            *handle = (ulong)((IEnum<Contracts.ModuleHandle>)state).GetHandle();
+            legacyHandle = 0;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+        finally
+        {
+            if (_legacyProcess is not null && legacyHandle != 0)
+                _legacyProcess.EndEnumModules(legacyHandle);
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.EnumModule(ulong* handle, DacComNullableByRef<IXCLRDataModule> mod)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.EnumModule(handle, mod) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        try
+        {
+            if (handle is null)
+                throw new NullReferenceException();
+            if (*handle == 0)
+                throw new ArgumentException();
+
+            GCHandle gcHandle = GCHandle.FromIntPtr((nint)(*handle));
+            if (gcHandle.Target is not EnumModules state)
+                throw new ArgumentException();
+
+            bool outputIsNull = mod is null || mod.IsNullRef;
+            IXCLRDataModule? legacyModule = null;
+            if (_legacyProcess is not null)
+            {
+                DacComNullableByRef<IXCLRDataModule> legacyModuleOut = new(isNullRef: outputIsNull);
+                ulong legacyHandle = state.LegacyHandle;
+                hrLocal = _legacyProcess.EnumModule(&legacyHandle, legacyModuleOut);
+                state.LegacyHandle = (nuint)legacyHandle;
+                legacyModule = legacyModuleOut.Interface;
+            }
+
+            if (state.Enumerator.MoveNext())
+            {
+                if (outputIsNull)
+                    throw new NullReferenceException();
+                DacComNullableByRef<IXCLRDataModule> moduleOutput = mod ?? throw new NullReferenceException();
+
+                TargetPointer module = _target.Contracts.Loader.GetModule(state.Enumerator.Current);
+                moduleOutput.Interface = new ClrDataModule(module, _target, legacyModule);
+            }
+            else
+            {
+                hr = HResults.S_FALSE;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.EndEnumModules(ulong handle)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.EndEnumModules(handle) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        try
+        {
+            if (handle != 0)
+            {
+                GCHandle gcHandle = GCHandle.FromIntPtr((nint)handle);
+                if (gcHandle.Target is not EnumModules state)
+                    throw new ArgumentException();
+
+                ((IEnum<Contracts.ModuleHandle>)state).Dispose();
+                gcHandle.Free();
+                if (_legacyProcess is not null)
+                    hrLocal = _legacyProcess.EndEnumModules(state.LegacyHandle);
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.GetModuleByAddress(ClrDataAddress address, DacComNullableByRef<IXCLRDataModule> mod)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.GetModuleByAddress(address, mod) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_FALSE;
+        int hrLocal = HResults.S_OK;
+        try
+        {
+            bool outputIsNull = mod is null || mod.IsNullRef;
+            IXCLRDataModule? legacyModule = null;
+            if (_legacyProcess is not null)
+            {
+                DacComNullableByRef<IXCLRDataModule> legacyModuleOut = new(isNullRef: outputIsNull);
+                hrLocal = _legacyProcess.GetModuleByAddress(address, legacyModuleOut);
+                legacyModule = legacyModuleOut.Interface;
+            }
+
+            ILoader loader = _target.Contracts.Loader;
+            TargetPointer appDomain = loader.GetAppDomain();
+            ulong targetAddress = address.ToTargetPointer(_target).Value;
+            foreach (Contracts.ModuleHandle moduleHandle in loader.GetModuleHandles(
+                appDomain,
+                AssemblyIterationFlags.IncludeLoaded | AssemblyIterationFlags.IncludeExecution))
+            {
+                if (!loader.TryGetLoadedImageContents(moduleHandle, out TargetPointer baseAddress, out uint size, out _)
+                    || baseAddress == TargetPointer.Null)
+                {
+                    continue;
+                }
+
+                if (targetAddress >= baseAddress.Value && targetAddress - baseAddress.Value < size)
+                {
+                    if (outputIsNull)
+                        throw new NullReferenceException();
+                    DacComNullableByRef<IXCLRDataModule> moduleOutput = mod ?? throw new NullReferenceException();
+                    TargetPointer module = loader.GetModule(moduleHandle);
+                    moduleOutput.Interface = new ClrDataModule(module, _target, legacyModule);
+                    hr = HResults.S_OK;
+                    break;
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
+    }
 
     internal sealed class EnumMethodInstances : IEnum<MethodDescHandle>
     {

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataProcessModuleTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataProcessModuleTests.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
+using Xunit;
+using ModuleHandle = Microsoft.Diagnostics.DataContractReader.Contracts.ModuleHandle;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public unsafe class ClrDataProcessModuleTests
+{
+    private static readonly MockTarget.Architecture s_arch = new() { IsLittleEndian = true, Is64Bit = true };
+
+    [Fact]
+    public void EnumModules_UsesLoadedExecutionOrderAndExhausts()
+    {
+        TargetPointer appDomain = new(0x4000);
+        ModuleHandle firstHandle = new(new TargetPointer(0x5000));
+        ModuleHandle secondHandle = new(new TargetPointer(0x6000));
+        TargetPointer firstModule = new(0x7000);
+        TargetPointer secondModule = new(0x8000);
+        var loader = new Mock<ILoader>();
+        loader.Setup(l => l.GetAppDomain()).Returns(appDomain);
+        loader.Setup(l => l.GetModuleHandles(
+                appDomain,
+                AssemblyIterationFlags.IncludeLoaded | AssemblyIterationFlags.IncludeExecution))
+            .Returns([firstHandle, secondHandle]);
+        loader.Setup(l => l.GetModule(firstHandle)).Returns(firstModule);
+        loader.Setup(l => l.GetModule(secondHandle)).Returns(secondModule);
+
+        IXCLRDataProcess process = CreateProcess(loader);
+        ulong handle;
+        Assert.Equal(HResults.S_OK, process.StartEnumModules(&handle));
+        Assert.NotEqual(0u, handle);
+
+        DacComNullableByRef<IXCLRDataModule> moduleOut = new(isNullRef: false);
+        Assert.Equal(HResults.S_OK, process.EnumModule(&handle, moduleOut));
+        Assert.Equal(firstModule, Assert.IsType<ClrDataModule>(moduleOut.Interface).Address);
+
+        moduleOut = new DacComNullableByRef<IXCLRDataModule>(isNullRef: false);
+        Assert.Equal(HResults.S_OK, process.EnumModule(&handle, moduleOut));
+        Assert.Equal(secondModule, Assert.IsType<ClrDataModule>(moduleOut.Interface).Address);
+
+        moduleOut = new DacComNullableByRef<IXCLRDataModule>(isNullRef: false);
+        Assert.Equal(HResults.S_FALSE, process.EnumModule(&handle, moduleOut));
+        Assert.Null(moduleOut.Interface);
+        Assert.Equal(
+            HResults.S_FALSE,
+            process.EnumModule(&handle, new DacComNullableByRef<IXCLRDataModule>(isNullRef: true)));
+        Assert.Equal(HResults.S_OK, process.EndEnumModules(handle));
+    }
+
+    [Fact]
+    public void GetModuleByAddress_SkipsNoImageAndUsesInteriorRange()
+    {
+        TargetPointer appDomain = new(0x4000);
+        ModuleHandle noImageHandle = new(new TargetPointer(0x5000));
+        ModuleHandle imageHandle = new(new TargetPointer(0x6000));
+        TargetPointer imageModule = new(0x7000);
+        TargetPointer noImageBase = TargetPointer.Null;
+        uint noImageSize = 0;
+        uint noImageFlags = 0;
+        TargetPointer imageBase = new(0x1000_0000);
+        uint imageSize = 0x2000;
+        uint imageFlags = 0;
+
+        var loader = new Mock<ILoader>();
+        loader.Setup(l => l.GetAppDomain()).Returns(appDomain);
+        loader.Setup(l => l.GetModuleHandles(
+                appDomain,
+                AssemblyIterationFlags.IncludeLoaded | AssemblyIterationFlags.IncludeExecution))
+            .Returns([noImageHandle, imageHandle]);
+        loader.Setup(l => l.TryGetLoadedImageContents(noImageHandle, out noImageBase, out noImageSize, out noImageFlags))
+            .Returns(false);
+        loader.Setup(l => l.TryGetLoadedImageContents(imageHandle, out imageBase, out imageSize, out imageFlags))
+            .Returns(true);
+        loader.Setup(l => l.GetModule(imageHandle)).Returns(imageModule);
+
+        IXCLRDataProcess process = CreateProcess(loader);
+        DacComNullableByRef<IXCLRDataModule> moduleOut = new(isNullRef: false);
+        Assert.Equal(HResults.S_OK, process.GetModuleByAddress(new ClrDataAddress(imageBase.Value + 0x100), moduleOut));
+        Assert.Equal(imageModule, Assert.IsType<ClrDataModule>(moduleOut.Interface).Address);
+
+        moduleOut = new DacComNullableByRef<IXCLRDataModule>(isNullRef: false);
+        Assert.Equal(HResults.S_FALSE, process.GetModuleByAddress(new ClrDataAddress(imageBase.Value + imageSize), moduleOut));
+        Assert.Null(moduleOut.Interface);
+    }
+
+    private static IXCLRDataProcess CreateProcess(Mock<ILoader> loader)
+    {
+        var builder = new TestPlaceholderTarget.Builder(s_arch)
+            .UseReader((ulong _, Span<byte> _) => -1);
+        builder.AddMockContract(loader);
+        return new SOSDacImpl(builder.Build(), legacyObj: null);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `IXCLRData` module enumeration and address-lookup APIs that
previously returned `E_NOTIMPL`:

- `StartEnumModules`, `EnumModule`, `EndEnumModules`
- `GetModuleByAddress`

## Native semantic parity

- **Enumeration** walks the current AppDomain's modules via
  `ILoader.GetModuleHandles(appDomain, IncludeLoaded | IncludeExecution)` --
  matching the native iteration flags and order. Each `EnumModule` call yields a
  `ClrDataModule`; enumeration returns `S_FALSE` when exhausted. A
  `GCHandle`-backed cursor is stored in the enumeration handle.
- **GetModuleByAddress** treats the input as an arbitrary address and scans
  loaded modules, returning the module whose loaded PE image range
  `[base, base + size)` contains the address (via `TryGetLoadedImageContents`).
  Modules with no loaded image are skipped; a miss returns `S_FALSE`. The
  address is **not** treated as a `Module*`.
- `#if DEBUG` cross-checks compare against the legacy DAC when present.

## Testing

- `ClrDataProcessModuleTests.EnumModules_UsesLoadedExecutionOrderAndExhausts` --
  enumeration order, per-module wrapper, and exhaustion.
- `ClrDataProcessModuleTests.GetModuleByAddress_SkipsNoImageAndUsesInteriorRange`
  -- interior-address hit, no-image skip, and boundary miss (`base + size`).
- Full cDAC unit suite: 2703 passed, 16 skipped, 0 failed.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
