### PR TITLE
[cDAC] Implement IXCLRData task enumeration and identity APIs

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataTask.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataTask.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 [GeneratedComClass]
 public sealed unsafe partial class ClrDataTask : IXCLRDataTask
 {
+    private const uint InvalidOSThreadId = 0xbaadf00d;
+
     private readonly TargetPointer _address;
     private readonly Target _target;
     private readonly IXCLRDataTask? _legacyImpl;
@@ -54,9 +56,61 @@ public sealed unsafe partial class ClrDataTask : IXCLRDataTask
         return hr;
     }
     int IXCLRDataTask.GetUniqueID(ulong* id)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetUniqueID(id) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (id is null)
+                throw new NullReferenceException();
+
+            *id = _target.Contracts.Thread.GetThreadData(_address).Id;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            ulong idLocal = 0;
+            int hrLocal = _legacyImpl.GetUniqueID(id is null ? null : &idLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK && id is not null)
+                Debug.Assert(*id == idLocal, $"cDAC: {*id}, DAC: {idLocal}");
+        }
+#endif
+        return hr;
+    }
+
     int IXCLRDataTask.GetFlags(uint* flags)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetFlags(flags) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (flags is null)
+                throw new NullReferenceException();
+
+            // CLRDATA_TASK_DEFAULT
+            *flags = 0;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint flagsLocal = 0;
+            int hrLocal = _legacyImpl.GetFlags(flags is null ? null : &flagsLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK && flags is not null)
+                Debug.Assert(*flags == flagsLocal, $"cDAC: {*flags}, DAC: {flagsLocal}");
+        }
+#endif
+        return hr;
+    }
     int IXCLRDataTask.IsSameObject(IXCLRDataTask* task)
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.IsSameObject(task) : HResults.E_NOTIMPL;
     int IXCLRDataTask.GetManagedObject(DacComNullableByRef<IXCLRDataValue> value)
@@ -87,7 +141,41 @@ public sealed unsafe partial class ClrDataTask : IXCLRDataTask
     }
 
     int IXCLRDataTask.GetOSThreadID(uint* id)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetOSThreadID(id) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (id is null)
+                throw new NullReferenceException();
+
+            uint osId = (uint)_target.Contracts.Thread.GetThreadData(_address).OSId.Value;
+            if (osId == 0 || osId == InvalidOSThreadId)
+            {
+                *id = 0;
+                hr = HResults.S_FALSE;
+            }
+            else
+            {
+                *id = osId;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint idLocal = 0;
+            int hrLocal = _legacyImpl.GetOSThreadID(id is null ? null : &idLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr >= 0 && id is not null)
+                Debug.Assert(*id == idLocal, $"cDAC: {*id}, DAC: {idLocal}");
+        }
+#endif
+        return hr;
+    }
     int IXCLRDataTask.GetContext(uint contextFlags, uint contextBufSize, uint* contextSize, byte* contextBuffer)
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetContext(contextFlags, contextBufSize, contextSize, contextBuffer) : HResults.E_NOTIMPL;
     int IXCLRDataTask.SetContext(uint contextSize, byte* context)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -19,6 +19,18 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 /// </summary>
 public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProcess2
 {
+    private sealed class EnumTasks
+    {
+        public TargetPointer CurrentThread;
+        public ulong LegacyHandle;
+
+        public EnumTasks(TargetPointer currentThread, ulong legacyHandle)
+        {
+            CurrentThread = currentThread;
+            LegacyHandle = legacyHandle;
+        }
+    }
+
     int IXCLRDataProcess.Flush()
     {
         _target.Flush(FlushScope.All);
@@ -31,13 +43,135 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
     }
 
     int IXCLRDataProcess.StartEnumTasks(ulong* handle)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.StartEnumTasks(handle) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        ulong legacyHandle = 0;
+        try
+        {
+            if (_legacyProcess is not null)
+                hrLocal = _legacyProcess.StartEnumTasks(handle is null ? null : &legacyHandle);
+
+            if (handle is null)
+                throw new NullReferenceException();
+
+            *handle = 0;
+            TargetPointer firstThread = _target.Contracts.Thread.GetThreadStoreData().FirstThread;
+            if (firstThread == TargetPointer.Null)
+            {
+                hr = HResults.S_FALSE;
+            }
+            else
+            {
+                GCHandle gcHandle = GCHandle.Alloc(new EnumTasks(firstThread, legacyHandle));
+                *handle = unchecked((ulong)GCHandle.ToIntPtr(gcHandle).ToInt64());
+                legacyHandle = 0;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+        finally
+        {
+            if (_legacyProcess is not null && legacyHandle != 0)
+                _legacyProcess.EndEnumTasks(legacyHandle);
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.EnumTask(ulong* handle, DacComNullableByRef<IXCLRDataTask> task)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.EnumTask(handle, task) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        try
+        {
+            if (handle is null)
+                throw new NullReferenceException();
+
+            if (*handle == 0)
+            {
+                hr = HResults.S_FALSE;
+            }
+            else
+            {
+                GCHandle gcHandle = GCHandle.FromIntPtr((nint)(*handle));
+                if (gcHandle.Target is not EnumTasks state)
+                    throw new ArgumentException();
+
+                bool outputIsNull = task is null || task.IsNullRef;
+                IXCLRDataTask? legacyTask = null;
+                if (_legacyProcess is not null)
+                {
+                    DacComNullableByRef<IXCLRDataTask> legacyTaskOut = new(isNullRef: outputIsNull);
+                    ulong legacyHandle = state.LegacyHandle;
+                    hrLocal = _legacyProcess.EnumTask(&legacyHandle, legacyTaskOut);
+                    state.LegacyHandle = legacyHandle;
+                    legacyTask = legacyTaskOut.Interface;
+                }
+                if (outputIsNull)
+                    throw new NullReferenceException();
+                DacComNullableByRef<IXCLRDataTask> taskOutput = task ?? throw new NullReferenceException();
+
+                TargetPointer currentThread = state.CurrentThread;
+                Contracts.ThreadData threadData = _target.Contracts.Thread.GetThreadData(currentThread);
+                taskOutput.Interface = new ClrDataTask(currentThread, _target, legacyTask);
+
+                state.CurrentThread = threadData.NextThread;
+                if (state.CurrentThread == TargetPointer.Null)
+                {
+                    gcHandle.Free();
+                    *handle = 0;
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.EndEnumTasks(ulong handle)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.EndEnumTasks(handle) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        try
+        {
+            if (handle != 0)
+            {
+                GCHandle gcHandle = GCHandle.FromIntPtr((nint)handle);
+                if (gcHandle.Target is not EnumTasks state)
+                    throw new ArgumentException();
+
+                gcHandle.Free();
+                if (_legacyProcess is not null)
+                    hrLocal = _legacyProcess.EndEnumTasks(state.LegacyHandle);
+            }
+        }
+        catch (System.Exception ex)
+        {
+            // Native EndEnumTasks ignores the handle and always succeeds.
+            _ = ex;
+            hr = HResults.S_OK;
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.GetTaskByOSThreadID(uint osThreadID, DacComNullableByRef<IXCLRDataTask> task)
     {
@@ -75,7 +209,58 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
     }
 
     int IXCLRDataProcess.GetTaskByUniqueID(ulong taskID, DacComNullableByRef<IXCLRDataTask> task)
-        => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.GetTaskByUniqueID(taskID, task) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        try
+        {
+            bool outputIsNull = task is null || task.IsNullRef;
+            IXCLRDataTask? legacyTask = null;
+            if (_legacyProcess is not null)
+            {
+                DacComNullableByRef<IXCLRDataTask> legacyTaskOut = new(isNullRef: outputIsNull);
+                hrLocal = _legacyProcess.GetTaskByUniqueID(taskID, legacyTaskOut);
+                legacyTask = legacyTaskOut.Interface;
+            }
+
+            // Native FindClrThreadByTaskId performs a linear scan of the ThreadStore,
+            // comparing each thread's managed thread id to (DWORD)taskID. IThread.IdToThread
+            // must not be used here: recycled IdDispenser slots can hold free-list integers
+            // rather than Thread pointers, so a dispenser lookup could resolve a bogus thread.
+            IThread threadContract = _target.Contracts.Thread;
+            TargetPointer thread = TargetPointer.Null;
+            TargetPointer current = threadContract.GetThreadStoreData().FirstThread;
+            while (current != TargetPointer.Null)
+            {
+                Contracts.ThreadData threadData = threadContract.GetThreadData(current);
+                if (threadData.Id == (uint)taskID)
+                {
+                    thread = current;
+                    break;
+                }
+                current = threadData.NextThread;
+            }
+
+            if (thread == TargetPointer.Null)
+                throw new ArgumentException();
+
+            if (outputIsNull)
+                throw new NullReferenceException();
+            DacComNullableByRef<IXCLRDataTask> taskOutput = task ?? throw new NullReferenceException();
+
+            taskOutput.Interface = new ClrDataTask(thread, _target, legacyTask);
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyProcess is not null)
+            Debug.ValidateHResult(hr, hrLocal);
+#endif
+        return hr;
+    }
 
     int IXCLRDataProcess.GetFlags(uint* flags)
         => LegacyFallbackHelper.CanFallback() && _legacyProcess is not null ? _legacyProcess.GetFlags(flags) : HResults.E_NOTIMPL;

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataProcessTaskTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataProcessTaskTests.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public unsafe class ClrDataProcessTaskTests
+{
+    private static readonly MockTarget.Architecture s_arch = new() { IsLittleEndian = true, Is64Bit = true };
+
+    [Fact]
+    public void EnumTasks_ReturnsAllThreadsAndAdvancesCursor()
+    {
+        TargetPointer first = new(0x1000);
+        TargetPointer second = new(0x2000);
+        var thread = new Mock<IThread>();
+        thread.Setup(t => t.GetThreadStoreData()).Returns(new ThreadStoreData(2, first, TargetPointer.Null, TargetPointer.Null));
+        thread.Setup(t => t.GetThreadData(first)).Returns(
+            ClrDataTaskTests.CreateThreadData(first, id: 10, osId: 100, nextThread: second, state: ThreadState.Unstarted));
+        thread.Setup(t => t.GetThreadData(second)).Returns(
+            ClrDataTaskTests.CreateThreadData(second, id: 20, osId: 200, state: ThreadState.Detached));
+
+        IXCLRDataProcess process = CreateProcess(thread);
+        ulong handle;
+        Assert.Equal(HResults.S_OK, process.StartEnumTasks(&handle));
+        Assert.NotEqual(0u, handle);
+
+        DacComNullableByRef<IXCLRDataTask> taskOut = new(isNullRef: false);
+        Assert.Equal(HResults.S_OK, process.EnumTask(&handle, taskOut));
+        Assert.Equal(10u, GetTaskId(Assert.IsAssignableFrom<IXCLRDataTask>(taskOut.Interface)));
+        Assert.NotEqual(0u, handle);
+
+        taskOut = new DacComNullableByRef<IXCLRDataTask>(isNullRef: false);
+        Assert.Equal(HResults.S_OK, process.EnumTask(&handle, taskOut));
+        Assert.Equal(20u, GetTaskId(Assert.IsAssignableFrom<IXCLRDataTask>(taskOut.Interface)));
+        Assert.Equal(0u, handle);
+
+        taskOut = new DacComNullableByRef<IXCLRDataTask>(isNullRef: false);
+        Assert.Equal(HResults.S_FALSE, process.EnumTask(&handle, taskOut));
+        Assert.Null(taskOut.Interface);
+        Assert.Equal(
+            HResults.S_FALSE,
+            process.EnumTask(&handle, new DacComNullableByRef<IXCLRDataTask>(isNullRef: true)));
+        Assert.Equal(HResults.S_OK, process.EndEnumTasks(handle));
+    }
+
+    [Fact]
+    public void StartEnumTasks_NoThreadsReturnsSFalse()
+    {
+        var thread = new Mock<IThread>();
+        thread.Setup(t => t.GetThreadStoreData()).Returns(new ThreadStoreData(0, TargetPointer.Null, TargetPointer.Null, TargetPointer.Null));
+
+        IXCLRDataProcess process = CreateProcess(thread);
+        ulong handle = ulong.MaxValue;
+        Assert.Equal(HResults.S_FALSE, process.StartEnumTasks(&handle));
+        Assert.Equal(0u, handle);
+    }
+
+    [Fact]
+    public void EndEnumTasks_CanEndBeforeExhaustion()
+    {
+        TargetPointer first = new(0x1000);
+        var thread = new Mock<IThread>();
+        thread.Setup(t => t.GetThreadStoreData()).Returns(new ThreadStoreData(1, first, TargetPointer.Null, TargetPointer.Null));
+
+        IXCLRDataProcess process = CreateProcess(thread);
+        ulong handle;
+        Assert.Equal(HResults.S_OK, process.StartEnumTasks(&handle));
+        Assert.Equal(HResults.S_OK, process.EndEnumTasks(handle));
+    }
+
+    [Fact]
+    public void GetTaskByUniqueID_ScansThreadStoreByManagedId()
+    {
+        TargetPointer first = new(0x1000);
+        TargetPointer second = new(0x2000);
+        var thread = new Mock<IThread>();
+        thread.Setup(t => t.GetThreadStoreData()).Returns(new ThreadStoreData(2, first, TargetPointer.Null, TargetPointer.Null));
+        thread.Setup(t => t.GetThreadData(first)).Returns(
+            ClrDataTaskTests.CreateThreadData(first, id: 10, osId: 100, nextThread: second));
+        thread.Setup(t => t.GetThreadData(second)).Returns(
+            ClrDataTaskTests.CreateThreadData(second, id: 20, osId: 200));
+
+        IXCLRDataProcess process = CreateProcess(thread);
+
+        // Found via a linear scan of the thread store by managed thread id.
+        DacComNullableByRef<IXCLRDataTask> taskOut = new(isNullRef: false);
+        Assert.Equal(HResults.S_OK, process.GetTaskByUniqueID(20, taskOut));
+        Assert.Equal(20u, GetTaskId(Assert.IsAssignableFrom<IXCLRDataTask>(taskOut.Interface)));
+
+        // Native casts the id to a 32-bit DWORD before comparing.
+        taskOut = new DacComNullableByRef<IXCLRDataTask>(isNullRef: false);
+        Assert.Equal(HResults.S_OK, process.GetTaskByUniqueID((1ul << 32) | 10, taskOut));
+        Assert.Equal(10u, GetTaskId(Assert.IsAssignableFrom<IXCLRDataTask>(taskOut.Interface)));
+
+        // An id matching no live thread (e.g. a recycled dispenser slot value) returns E_INVALIDARG.
+        taskOut = new DacComNullableByRef<IXCLRDataTask>(isNullRef: false);
+        Assert.Equal(HResults.E_INVALIDARG, process.GetTaskByUniqueID(999, taskOut));
+        Assert.Null(taskOut.Interface);
+        Assert.Equal(
+            HResults.E_INVALIDARG,
+            process.GetTaskByUniqueID(999, new DacComNullableByRef<IXCLRDataTask>(isNullRef: true)));
+
+        // The dispenser lookup (IThread.IdToThread) must not be consulted: recycled slots
+        // can contain free-list integers rather than Thread pointers.
+        thread.Verify(t => t.IdToThread(It.IsAny<uint>()), Times.Never);
+    }
+
+    private static IXCLRDataProcess CreateProcess(Mock<IThread> thread)
+    {
+        var builder = new TestPlaceholderTarget.Builder(s_arch)
+            .UseReader((ulong _, Span<byte> _) => -1);
+        builder.AddMockContract(thread);
+        return new SOSDacImpl(builder.Build(), legacyObj: null);
+    }
+
+    private static ulong GetTaskId(IXCLRDataTask task)
+    {
+        ulong id;
+        Assert.Equal(HResults.S_OK, task.GetUniqueID(&id));
+        return id;
+    }
+}

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataTaskTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataTaskTests.cs
@@ -2,14 +2,50 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Diagnostics.DataContractReader.Tests;
 
 public unsafe class ClrDataTaskTests
 {
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetIdentityAndFlags(MockTarget.Architecture arch)
+    {
+        TargetPointer taskAddress = new(0x5000);
+        IXCLRDataTask task = CreateTask(arch, CreateThreadData(taskAddress, id: 42, osId: 1234));
+
+        ulong uniqueId;
+        Assert.Equal(HResults.S_OK, task.GetUniqueID(&uniqueId));
+        Assert.Equal(42u, uniqueId);
+
+        uint osId;
+        Assert.Equal(HResults.S_OK, task.GetOSThreadID(&osId));
+        Assert.Equal(1234u, osId);
+
+        uint flags;
+        Assert.Equal(HResults.S_OK, task.GetFlags(&flags));
+        Assert.Equal(0u, flags);
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(0xbaadf00du)]
+    public void GetOSThreadID_InvalidSentinelReturnsSFalse(uint storedId)
+    {
+        MockTarget.Architecture arch = new() { IsLittleEndian = true, Is64Bit = true };
+        TargetPointer taskAddress = new(0x5000);
+        IXCLRDataTask task = CreateTask(arch, CreateThreadData(taskAddress, id: 42, osId: storedId));
+
+        uint osId = uint.MaxValue;
+        Assert.Equal(HResults.S_FALSE, task.GetOSThreadID(&osId));
+        Assert.Equal(0u, osId);
+    }
+
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
     public void GetCurrentAppDomain(MockTarget.Architecture arch)
@@ -45,4 +81,47 @@ public unsafe class ClrDataTaskTests
         ClrDataAppDomain clrAppDomain = Assert.IsType<ClrDataAppDomain>(appDomain.Interface);
         Assert.Equal(new TargetPointer(expectedAppDomain), clrAppDomain.Address);
     }
+
+    private static IXCLRDataTask CreateTask(MockTarget.Architecture arch, ThreadData threadData)
+    {
+        var thread = new Mock<IThread>();
+        thread.Setup(t => t.GetThreadData(threadData.ThreadAddress)).Returns(threadData);
+
+        TestPlaceholderTarget target = new TestPlaceholderTarget.Builder(arch)
+            .UseReader((ulong _, Span<byte> _) => -1)
+            .AddMockContract(thread)
+            .Build();
+
+        return new ClrDataTask(threadData.ThreadAddress, target, legacyImpl: null);
+    }
+
+    internal static ThreadData CreateThreadData(
+        TargetPointer address,
+        uint id,
+        uint osId,
+        TargetPointer nextThread = default,
+        ThreadState state = default)
+        => new(
+            ThreadAddress: address,
+            Id: id,
+            OSId: new TargetNUInt(osId),
+            State: state,
+            PreemptiveGCDisabled: false,
+            AllocContextPointer: TargetPointer.Null,
+            AllocContextLimit: TargetPointer.Null,
+            Frame: TargetPointer.Null,
+            FirstNestedException: TargetPointer.Null,
+            ExposedObjectHandle: TargetPointer.Null,
+            LastThrownObjectHandle: TargetPointer.Null,
+            CurrentCustomDebuggerNotificationHandle: TargetPointer.Null,
+            LastThrownObjectIsUnhandled: false,
+            HasUnhandledException: false,
+            NextThread: nextThread,
+            ThreadHandle: TargetPointer.Null,
+            IsInteropDebuggingHijacked: false,
+            DebuggerFilterContext: TargetPointer.Null,
+            GCFrame: TargetPointer.Null,
+            IsExceptionInProgress: false,
+            OSExceptionRecord: TargetPointer.Null,
+            OSExceptionContextRecord: TargetPointer.Null);
 }


### PR DESCRIPTION
## Summary

Implements the `IXCLRData` task enumeration and identity APIs that previously
returned `E_NOTIMPL`:

- `IXCLRDataProcess`: `StartEnumTasks`, `EnumTask`, `EndEnumTasks`,
  `GetTaskByUniqueID`
- `IXCLRDataTask`: `GetUniqueID`, `GetOSThreadID`, `GetFlags`

## Native semantic parity

- **Enumeration** walks every thread in the ThreadStore
  (`FirstThread -> NextThread`) in native order, with no state filtering. A
  `GCHandle`-backed cursor is stored in the enumeration handle; `StartEnumTasks`
  returns `S_FALSE` when there are no threads; `EnumTask` returns `S_FALSE` once
  the cursor is exhausted.
- **GetTaskByUniqueID** matches native `FindClrThreadByTaskId`: it linearly
  scans the ThreadStore comparing each thread's managed thread id
  (`(DWORD)taskID`) and returns `E_INVALIDARG` when no thread matches. It
  deliberately does **not** use `IThread.IdToThread`, because recycled
  `IdDispenser` slots can contain free-list integers rather than `Thread`
  pointers -- so this API is independent of the `IdToThread` boundary fix.
- **IXCLRDataTask** identity: `GetUniqueID` returns the managed thread id;
  `GetOSThreadID` returns the OS thread id, or `S_FALSE` with `0` for the `0` /
  `0xbaadf00d` sentinels; `GetFlags` returns `CLRDATA_TASK_DEFAULT` (`0`).
- `#if DEBUG` cross-checks compare against the legacy DAC when present.

## Testing

- `ClrDataProcessTaskTests`: full enumeration including unstarted/detached
  threads, no-thread `S_FALSE`, early `EndEnumTasks`, and the `GetTaskByUniqueID`
  scan (valid / DWORD-truncated / unknown ids, plus an assertion that
  `IdToThread` is never called).
- `ClrDataTaskTests`: `GetUniqueID`/`GetOSThreadID`/`GetFlags` across all four
  architectures, plus the OS-thread-id sentinel cases.
- Full cDAC unit suite: 2711 passed, 16 skipped, 0 failed.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
