### PR TITLE
[cDAC] Implement ISOSDacInterface.GetAssemblyLocation

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -467,7 +467,60 @@ public sealed unsafe partial class SOSDacImpl
         return hr;
     }
     int ISOSDacInterface.GetAssemblyLocation(ClrDataAddress assembly, int count, char* location, uint* pNeeded)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetAssemblyLocation(assembly, count, location, pNeeded) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (assembly == 0
+                || (location is null && pNeeded is null)
+                || (location is not null && count <= 0))
+            {
+                throw new ArgumentException();
+            }
+
+            ILoader loader = _target.Contracts.Loader;
+            Contracts.ModuleHandle handle = loader.GetModuleHandleFromAssemblyPtr(assembly.ToTargetPointer(_target));
+            string path = loader.GetPath(handle);
+            uint bufferSize = location is null ? 0 : checked((uint)count);
+            OutputBufferHelpers.CopyStringToBuffer(location, bufferSize, pNeeded, path);
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            char[] locationLocal = new char[count > 0 ? count : 1];
+            uint neededLocal = 0;
+            int hrLocal;
+            fixed (char* locationLocalPtr = locationLocal)
+            {
+                hrLocal = _legacyImpl.GetAssemblyLocation(
+                    assembly,
+                    count,
+                    location is null ? null : locationLocalPtr,
+                    pNeeded is null ? null : &neededLocal);
+            }
+
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+            {
+                if (pNeeded is not null)
+                    Debug.Assert(*pNeeded == neededLocal, $"cDAC: {*pNeeded}, DAC: {neededLocal}");
+
+                if (location is not null && count > 0)
+                {
+                    int compareLength = (int)Math.Min((uint)count, neededLocal);
+                    Debug.Assert(
+                        new ReadOnlySpan<char>(location, compareLength).SequenceEqual(locationLocal.AsSpan(0, compareLength)));
+                }
+            }
+        }
+#endif
+        return hr;
+    }
     int ISOSDacInterface.GetAssemblyModuleList(ClrDataAddress assembly, uint count, [In, MarshalUsing(CountElementName = "count"), Out] ClrDataAddress[]? modules, uint* pNeeded)
     {
         int hr = HResults.S_OK;

--- a/src/native/managed/cdac/tests/UnitTests/SOSDacInterfaceAssemblyLocationTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/SOSDacInterfaceAssemblyLocationTests.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
+using Xunit;
+using ModuleHandle = Microsoft.Diagnostics.DataContractReader.Contracts.ModuleHandle;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public unsafe class SOSDacInterfaceAssemblyLocationTests
+{
+    private static readonly MockTarget.Architecture s_arch = new() { IsLittleEndian = true, Is64Bit = true };
+    private static readonly TargetPointer s_assembly = new(0x1000);
+    private static readonly ModuleHandle s_module = new(new TargetPointer(0x2000));
+
+    [Theory]
+    [InlineData(@"C:\runtime\TestAssembly.dll")]
+    [InlineData("")]
+    public void GetAssemblyLocation_CopiesPathIncludingEmpty(string path)
+    {
+        ISOSDacInterface sos = CreateSOSDac(loader =>
+        {
+            loader.Setup(l => l.GetModuleHandleFromAssemblyPtr(s_assembly)).Returns(s_module);
+            loader.Setup(l => l.GetPath(s_module)).Returns(path);
+        });
+
+        uint needed;
+        Assert.Equal(
+            HResults.S_OK,
+            sos.GetAssemblyLocation(new ClrDataAddress(s_assembly.Value), 0, null, &needed));
+        Assert.Equal((uint)path.Length + 1, needed);
+        Assert.Equal(
+            HResults.S_OK,
+            sos.GetAssemblyLocation(new ClrDataAddress(s_assembly.Value), -1, null, &needed));
+
+        char[] buffer = new char[needed];
+        fixed (char* bufferPtr = buffer)
+        {
+            Assert.Equal(
+                HResults.S_OK,
+                sos.GetAssemblyLocation(new ClrDataAddress(s_assembly.Value), buffer.Length, bufferPtr, &needed));
+        }
+
+        Assert.Equal(path, new string(buffer, 0, path.Length));
+        Assert.Equal('\0', buffer[path.Length]);
+    }
+
+    [Fact]
+    public void GetAssemblyLocation_ValidatesArguments()
+    {
+        ISOSDacInterface sos = CreateSOSDac(_ => { });
+        char value = 'x';
+        uint needed;
+
+        Assert.Equal(HResults.E_INVALIDARG, sos.GetAssemblyLocation(default, 1, &value, &needed));
+        Assert.Equal(HResults.E_INVALIDARG, sos.GetAssemblyLocation(new ClrDataAddress(s_assembly.Value), 0, null, null));
+        Assert.Equal(HResults.E_INVALIDARG, sos.GetAssemblyLocation(new ClrDataAddress(s_assembly.Value), 0, &value, &needed));
+    }
+
+    private static ISOSDacInterface CreateSOSDac(Action<Mock<ILoader>> configure)
+    {
+        var loader = new Mock<ILoader>();
+        configure(loader);
+        TestPlaceholderTarget target = new TestPlaceholderTarget.Builder(s_arch)
+            .UseReader((ulong _, Span<byte> _) => -1)
+            .AddMockContract(loader)
+            .Build();
+        return new SOSDacImpl(target, legacyObj: null);
+    }
+}


### PR DESCRIPTION
## Summary

Implements `ISOSDacInterface.GetAssemblyLocation`, which returns an assembly's
on-disk path. Previously this returned `E_NOTIMPL` unless the legacy DAC was
available for fallback.

## Native semantic parity

- Resolves the module handle from the assembly pointer via
  `ILoader.GetModuleHandleFromAssemblyPtr` and the path via `ILoader.GetPath`.
- Copies the path into the caller's buffer using the standard string-copy
  protocol:
  - An empty path returns `S_OK` with `needed = 1` and a single NUL character.
  - `pNeeded` reports the required length **including** the NUL terminator.
  - Invalid argument combinations (`assembly == 0`, both outputs null, or a
    non-null buffer with `count <= 0`) return `E_INVALIDARG`.
- A `#if DEBUG` cross-check compares the result against the legacy DAC when
  present.

## Testing

- `SOSDacInterfaceAssemblyLocationTests.GetAssemblyLocation_CopiesPathIncludingEmpty`
  (non-empty and empty paths; size query then copy).
- `SOSDacInterfaceAssemblyLocationTests.GetAssemblyLocation_ValidatesArguments`.
- Full cDAC unit suite: 2704 passed, 16 skipped, 0 failed.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
