### PR TITLE
Add RuntimeHelpers.IsRuntimeAsync intrinsic

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -4032,6 +4032,19 @@ bool InterpCompiler::EmitNamedIntrinsicCall(NamedIntrinsic ni, bool nonVirtualCa
             return true;
         }
 
+        case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync:
+        {
+            int32_t result = m_methodInfo->args.isAsyncCall() ? 1 : 0;
+
+            AddIns(INTOP_LDC_I4);
+            m_pLastNewIns->data[0] = result;
+
+            PushInterpType(InterpTypeI4, nullptr);
+            m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+
+            return true;
+        }
+
         case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences:
         {
             CORINFO_CLASS_HANDLE clsHnd = sig.sigInst.methInst[0];
@@ -5140,6 +5153,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                     ni == NI_System_StubHelpers_NextCallReturnAddress ||
                     ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_SetNextCallGenericContext ||
                     ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_SetNextCallAsyncContinuation ||
+                    ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync ||
                     ni == NI_System_Runtime_CompilerServices_AsyncHelpers_AsyncCallContinuation ||
                     ni == NI_System_Runtime_CompilerServices_AsyncHelpers_AsyncSuspend ||
                     ni == NI_System_Runtime_CompilerServices_AsyncHelpers_TailAwait);

--- a/src/coreclr/interpreter/intrinsics.cpp
+++ b/src/coreclr/interpreter/intrinsics.cpp
@@ -108,6 +108,8 @@ NamedIntrinsic GetNamedIntrinsic(COMP_HANDLE compHnd, CORINFO_METHOD_HANDLE comp
             {
                 if (!strcmp(methodName, "IsReferenceOrContainsReferences"))
                     return NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences;
+                else if (!strcmp(methodName, "IsRuntimeAsync"))
+                    return NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync;
                 else if (!strcmp(methodName, "GetMethodTable"))
                     return NI_System_Runtime_CompilerServices_RuntimeHelpers_GetMethodTable;
                 else if (!strcmp(methodName, "SetNextCallGenericContext"))

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1170,6 +1170,12 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                                 foldableIntrinsic = true;
                                 break;
 
+                            case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync:
+                                // RuntimeHelpers.IsRuntimeAsync is always folded into a const
+                                pushedStack.PushConstant();
+                                foldableIntrinsic = true;
+                                break;
+
                             // These are foldable if the first argument is a constant
                             case NI_PRIMITIVE_LeadingZeroCount:
                             case NI_PRIMITIVE_Log2:

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3508,6 +3508,12 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
         return gtNewNothingNode();
     }
 
+    if (ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync)
+    {
+        JITDUMP("\nExpanding RuntimeHelpers.IsRuntimeAsync to %s early\n", compIsAsync() ? "true" : "false");
+        return compIsAsync() ? gtNewTrue() : gtNewFalse();
+    }
+
     bool betterToExpand = false;
 
     // Allow some lightweight intrinsics in Tier0 which can improve throughput
@@ -3790,13 +3796,6 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                     JITDUMP("\nConverting RuntimeHelpers.IsKnownConstant to:\n");
                     DISPTREE(retNode);
                 }
-                break;
-            }
-
-            case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync:
-            {
-                retNode = compIsAsync() ? gtNewTrue() : gtNewFalse();
-                JITDUMP("\nExpanding RuntimeHelpers.IsRuntimeAsync to %s early\n", compIsAsync() ? "true" : "false");
                 break;
             }
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3524,7 +3524,6 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
         {
             // This one is just `return true/false`
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsKnownConstant:
-            case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync:
 
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_WriteBarrier:
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3518,6 +3518,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
         {
             // This one is just `return true/false`
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsKnownConstant:
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync:
 
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_WriteBarrier:
 
@@ -3789,6 +3790,13 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                     JITDUMP("\nConverting RuntimeHelpers.IsKnownConstant to:\n");
                     DISPTREE(retNode);
                 }
+                break;
+            }
+
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync:
+            {
+                retNode = compIsAsync() ? gtNewTrue() : gtNewFalse();
+                JITDUMP("\nExpanding RuntimeHelpers.IsRuntimeAsync to %s early\n", compIsAsync() ? "true" : "false");
                 break;
             }
 
@@ -11428,6 +11436,10 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                             else if (strcmp(methodName, "IsKnownConstant") == 0)
                             {
                                 result = NI_System_Runtime_CompilerServices_RuntimeHelpers_IsKnownConstant;
+                            }
+                            else if (strcmp(methodName, "IsRuntimeAsync") == 0)
+                            {
+                                result = NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync;
                             }
                             else if (strcmp(methodName, "WriteBarrier") == 0)
                             {

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -124,6 +124,7 @@ enum NamedIntrinsic : unsigned short
     NI_System_Runtime_CompilerServices_RuntimeHelpers_CreateSpan,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_IsKnownConstant,
+    NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_GetMethodTable,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_WriteBarrier,

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -1,10 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -72,13 +73,23 @@ namespace System.IO
         // We don't guarantee thread safety on StreamReader, but we should at
         // least prevent users from trying to read anything while an Async
         // read from the same thread is in progress.
+        //
+        // When a read is issued from a runtime-async method we call directly into a
+        // runtime-async read method that tracks progress via the _asyncIOInProgress flag
+        // (set/cleared by ThrowOnReadsScope). Otherwise we track the returned Task in
+        // _asyncReadTask. RuntimeHelpers.IsRuntimeAsync() is folded to a constant by the
+        // JIT/interpreter, so only one of the two approaches is emitted per compilation.
+        // CheckAsyncTaskInProgress checks both so either kind of in-progress read is caught.
         private Task _asyncReadTask = Task.CompletedTask;
+        private bool _asyncIOInProgress;
 
         private void CheckAsyncTaskInProgress()
         {
-            // We are not locking the access to _asyncReadTask because this is not meant to guarantee thread safety.
+            // We are not locking this access because this is not meant to guarantee thread safety.
             // We are simply trying to deter calling any Read APIs while an async Read from the same thread is in progress.
-            if (!_asyncReadTask.IsCompleted)
+            // Depending on whether the caller was compiled as runtime-async, an in-progress read is tracked either
+            // by _asyncReadTask (task approach) or by _asyncIOInProgress (bool approach), so we check both here.
+            if (!_asyncReadTask.IsCompleted || _asyncIOInProgress)
             {
                 ThrowAsyncIOInProgress();
             }
@@ -87,6 +98,24 @@ namespace System.IO
         [DoesNotReturn]
         private static void ThrowAsyncIOInProgress() =>
             throw new InvalidOperationException(SR.InvalidOperation_AsyncIOInProgress);
+
+        private ThrowOnReadsScope GuardAgainstOtherReads()
+        {
+            return new ThrowOnReadsScope(this);
+        }
+
+        private readonly struct ThrowOnReadsScope : IDisposable
+        {
+            private readonly StreamReader _reader;
+
+            public ThrowOnReadsScope(StreamReader reader)
+            {
+                reader._asyncIOInProgress = true;
+                _reader = reader;
+            }
+
+            public void Dispose() => _reader._asyncIOInProgress = false;
+        }
 
         // StreamReader by default will ignore illegal UTF8 characters. We don't want to
         // throw here because we want to be able to read ill-formed data without choking.
@@ -898,14 +927,20 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
+            if (RuntimeHelpers.IsRuntimeAsync())
+            {
+                return new ValueTask<string?>(ReadLineAsyncInternal(cancellationToken));
+            }
+
             Task<string?> task = ReadLineAsyncInternal(cancellationToken);
             _asyncReadTask = task;
-
             return new ValueTask<string?>(task);
         }
 
         private async Task<string?> ReadLineAsyncInternal(CancellationToken cancellationToken)
         {
+            using ThrowOnReadsScope _ = GuardAgainstOtherReads();
+
             if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(false)) == 0)
             {
                 return null;
@@ -1026,14 +1061,20 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
+            if (RuntimeHelpers.IsRuntimeAsync())
+            {
+                return ReadToEndAsyncInternal(cancellationToken);
+            }
+
             Task<string> task = ReadToEndAsyncInternal(cancellationToken);
             _asyncReadTask = task;
-
             return task;
         }
 
         private async Task<string> ReadToEndAsyncInternal(CancellationToken cancellationToken)
         {
+            using ThrowOnReadsScope _ = GuardAgainstOtherReads();
+
             // Call ReadBuffer, then pull data out of charBuffer.
             StringBuilder sb = new StringBuilder(_charLen - _charPos);
             do
@@ -1070,10 +1111,20 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
+            if (RuntimeHelpers.IsRuntimeAsync())
+            {
+                return ReadAsyncInternalWithGuard(new Memory<char>(buffer, index, count), CancellationToken.None);
+            }
+
             Task<int> task = ReadAsyncInternal(new Memory<char>(buffer, index, count), CancellationToken.None).AsTask();
             _asyncReadTask = task;
-
             return task;
+
+            async Task<int> ReadAsyncInternalWithGuard(Memory<char> buffer, CancellationToken cancellationToken)
+            {
+                using ThrowOnReadsScope _ = GuardAgainstOtherReads();
+                return await ReadAsyncInternal(buffer, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         public override ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
@@ -1281,10 +1332,20 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
+            if (RuntimeHelpers.IsRuntimeAsync())
+            {
+                return ReadBlockAsyncWithGuard(buffer, index, count);
+            }
+
             Task<int> task = base.ReadBlockAsync(buffer, index, count);
             _asyncReadTask = task;
-
             return task;
+
+            async Task<int> ReadBlockAsyncWithGuard(char[] buffer, int index, int count)
+            {
+                using ThrowOnReadsScope _ = GuardAgainstOtherReads();
+                return await base.ReadBlockAsync(buffer, index, count).ConfigureAwait(false);
+            }
         }
 
         public override ValueTask<int> ReadBlockAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
@@ -1304,6 +1365,11 @@ namespace System.IO
                 return ValueTask.FromCanceled<int>(cancellationToken);
             }
 
+            if (RuntimeHelpers.IsRuntimeAsync())
+            {
+                return ReadBlockAsyncInternalWithGuard(buffer, cancellationToken);
+            }
+
             ValueTask<int> vt = ReadBlockAsyncInternal(buffer, cancellationToken);
             if (vt.IsCompletedSuccessfully)
             {
@@ -1313,6 +1379,12 @@ namespace System.IO
             Task<int> t = vt.AsTask();
             _asyncReadTask = t;
             return new ValueTask<int>(t);
+
+            async ValueTask<int> ReadBlockAsyncInternalWithGuard(Memory<char> buffer, CancellationToken token)
+            {
+                using ThrowOnReadsScope _ = GuardAgainstOtherReads();
+                return await ReadBlockAsyncInternal(buffer, token).ConfigureAwait(false);
+            }
         }
 
         private async ValueTask<int> ReadBufferAsync(CancellationToken cancellationToken)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -1,11 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -73,23 +72,13 @@ namespace System.IO
         // We don't guarantee thread safety on StreamReader, but we should at
         // least prevent users from trying to read anything while an Async
         // read from the same thread is in progress.
-        //
-        // When a read is issued from a runtime-async method we call directly into a
-        // runtime-async read method that tracks progress via the _asyncIOInProgress flag
-        // (set/cleared by ThrowOnReadsScope). Otherwise we track the returned Task in
-        // _asyncReadTask. RuntimeHelpers.IsRuntimeAsync() is folded to a constant by the
-        // JIT/interpreter, so only one of the two approaches is emitted per compilation.
-        // CheckAsyncTaskInProgress checks both so either kind of in-progress read is caught.
         private Task _asyncReadTask = Task.CompletedTask;
-        private bool _asyncIOInProgress;
 
         private void CheckAsyncTaskInProgress()
         {
-            // We are not locking this access because this is not meant to guarantee thread safety.
+            // We are not locking the access to _asyncReadTask because this is not meant to guarantee thread safety.
             // We are simply trying to deter calling any Read APIs while an async Read from the same thread is in progress.
-            // Depending on whether the caller was compiled as runtime-async, an in-progress read is tracked either
-            // by _asyncReadTask (task approach) or by _asyncIOInProgress (bool approach), so we check both here.
-            if (!_asyncReadTask.IsCompleted || _asyncIOInProgress)
+            if (!_asyncReadTask.IsCompleted)
             {
                 ThrowAsyncIOInProgress();
             }
@@ -98,24 +87,6 @@ namespace System.IO
         [DoesNotReturn]
         private static void ThrowAsyncIOInProgress() =>
             throw new InvalidOperationException(SR.InvalidOperation_AsyncIOInProgress);
-
-        private ThrowOnReadsScope GuardAgainstOtherReads()
-        {
-            return new ThrowOnReadsScope(this);
-        }
-
-        private readonly struct ThrowOnReadsScope : IDisposable
-        {
-            private readonly StreamReader _reader;
-
-            public ThrowOnReadsScope(StreamReader reader)
-            {
-                reader._asyncIOInProgress = true;
-                _reader = reader;
-            }
-
-            public void Dispose() => _reader._asyncIOInProgress = false;
-        }
 
         // StreamReader by default will ignore illegal UTF8 characters. We don't want to
         // throw here because we want to be able to read ill-formed data without choking.
@@ -927,20 +898,14 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
-            if (RuntimeHelpers.IsRuntimeAsync())
-            {
-                return new ValueTask<string?>(ReadLineAsyncInternal(cancellationToken));
-            }
-
             Task<string?> task = ReadLineAsyncInternal(cancellationToken);
             _asyncReadTask = task;
+
             return new ValueTask<string?>(task);
         }
 
         private async Task<string?> ReadLineAsyncInternal(CancellationToken cancellationToken)
         {
-            using ThrowOnReadsScope _ = GuardAgainstOtherReads();
-
             if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(false)) == 0)
             {
                 return null;
@@ -1061,20 +1026,14 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
-            if (RuntimeHelpers.IsRuntimeAsync())
-            {
-                return ReadToEndAsyncInternal(cancellationToken);
-            }
-
             Task<string> task = ReadToEndAsyncInternal(cancellationToken);
             _asyncReadTask = task;
+
             return task;
         }
 
         private async Task<string> ReadToEndAsyncInternal(CancellationToken cancellationToken)
         {
-            using ThrowOnReadsScope _ = GuardAgainstOtherReads();
-
             // Call ReadBuffer, then pull data out of charBuffer.
             StringBuilder sb = new StringBuilder(_charLen - _charPos);
             do
@@ -1111,20 +1070,10 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
-            if (RuntimeHelpers.IsRuntimeAsync())
-            {
-                return ReadAsyncInternalWithGuard(new Memory<char>(buffer, index, count), CancellationToken.None);
-            }
-
             Task<int> task = ReadAsyncInternal(new Memory<char>(buffer, index, count), CancellationToken.None).AsTask();
             _asyncReadTask = task;
-            return task;
 
-            async Task<int> ReadAsyncInternalWithGuard(Memory<char> buffer, CancellationToken cancellationToken)
-            {
-                using ThrowOnReadsScope _ = GuardAgainstOtherReads();
-                return await ReadAsyncInternal(buffer, cancellationToken).ConfigureAwait(false);
-            }
+            return task;
         }
 
         public override ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
@@ -1332,20 +1281,10 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
-            if (RuntimeHelpers.IsRuntimeAsync())
-            {
-                return ReadBlockAsyncWithGuard(buffer, index, count);
-            }
-
             Task<int> task = base.ReadBlockAsync(buffer, index, count);
             _asyncReadTask = task;
-            return task;
 
-            async Task<int> ReadBlockAsyncWithGuard(char[] buffer, int index, int count)
-            {
-                using ThrowOnReadsScope _ = GuardAgainstOtherReads();
-                return await base.ReadBlockAsync(buffer, index, count).ConfigureAwait(false);
-            }
+            return task;
         }
 
         public override ValueTask<int> ReadBlockAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
@@ -1365,11 +1304,6 @@ namespace System.IO
                 return ValueTask.FromCanceled<int>(cancellationToken);
             }
 
-            if (RuntimeHelpers.IsRuntimeAsync())
-            {
-                return ReadBlockAsyncInternalWithGuard(buffer, cancellationToken);
-            }
-
             ValueTask<int> vt = ReadBlockAsyncInternal(buffer, cancellationToken);
             if (vt.IsCompletedSuccessfully)
             {
@@ -1379,12 +1313,6 @@ namespace System.IO
             Task<int> t = vt.AsTask();
             _asyncReadTask = t;
             return new ValueTask<int>(t);
-
-            async ValueTask<int> ReadBlockAsyncInternalWithGuard(Memory<char> buffer, CancellationToken token)
-            {
-                using ThrowOnReadsScope _ = GuardAgainstOtherReads();
-                return await ReadBlockAsyncInternal(buffer, token).ConfigureAwait(false);
-            }
         }
 
         private async ValueTask<int> ReadBufferAsync(CancellationToken cancellationToken)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -179,6 +179,11 @@ namespace System.Runtime.CompilerServices
         internal static bool IsKnownConstant<T>(T t) where T : struct => false;
 #pragma warning restore IDE0060
 
+        // Returns true if the method being compiled is a runtime-async method.
+        // This is folded to a compile-time constant by the JIT and the interpreter.
+        [Intrinsic]
+        internal static bool IsRuntimeAsync() => false;
+
         /// <returns>true if the given type is a reference type or a value type that contains references or by-refs; otherwise, false.</returns>
         [Intrinsic]
         public static bool IsReferenceOrContainsReferences<T>() where T : allows ref struct => IsReferenceOrContainsReferences<T>();


### PR DESCRIPTION
The interpreter and JIT fold this intrinsic to a constant based on whether the calling function is runtime async.

The motivation is cases like #130872 and #130689 where there is a worry about potentially regressing async1 callers, especially for .NET 11 where runtime async is opt-in in Roslyn.