### PR TITLE
[cDAC] Implement ISOSDacInterface.GetHeapAllocData

### DIFF
--- a/docs/design/datacontracts/GC.md
+++ b/docs/design/datacontracts/GC.md
@@ -39,6 +39,8 @@ public readonly struct GCGenerationData
     public TargetPointer AllocationStart { get; init; }
     public TargetPointer AllocationContextPointer { get; init; }
     public TargetPointer AllocationContextLimit { get; init; }
+    public long AllocationBytes { get; init; }
+    public long AllocationBytesLoh { get; init; }
 }
 
 public readonly struct GCHeapSegmentData
@@ -699,6 +701,10 @@ private List<GCGeneration> GetGenerationData(TargetPointer generationTableArrayS
             target.ReadPointer(generationAddress + /* Generation::AllocationContext offset */ + /* GCAllocContext::Pointer offset */);
         generationData.AllocationContextLimit =
             target.ReadPointer(generationAddress + /* Generation::AllocationContext offset */ + /* GCAllocContext::Limit offset */);
+        generationData.AllocationBytes =
+            target.Read<long>(generationAddress + /* Generation::AllocationContext offset */ + /* GCAllocContext::AllocBytes offset */);
+        generationData.AllocationBytesLoh =
+            target.Read<long>(generationAddress + /* Generation::AllocationContext offset */ + /* GCAllocContext::AllocBytesLoh offset */);
 
         generationTable.Add(generationData);
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IGC.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IGC.cs
@@ -68,6 +68,8 @@ public readonly struct GCGenerationData
     public TargetPointer AllocationStart { get; init; }
     public TargetPointer AllocationContextPointer { get; init; }
     public TargetPointer AllocationContextLimit { get; init; }
+    public long AllocationBytes { get; init; }
+    public long AllocationBytesLoh { get; init; }
 }
 
 public readonly struct GCHeapSegmentData

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GC_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/GC/GC_1.cs
@@ -235,6 +235,8 @@ internal struct GC_1 : IGC
             AllocationStart = gen.AllocationStart ?? 0,
             AllocationContextPointer = gen.AllocationContext.Pointer,
             AllocationContextLimit = gen.AllocationContext.Limit,
+            AllocationBytes = gen.AllocationContext.AllocBytes,
+            AllocationBytesLoh = gen.AllocationContext.AllocBytesLoh,
         }).ToList();
         return generationDataList;
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ISOSDacInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ISOSDacInterface.cs
@@ -114,6 +114,12 @@ public struct DacpAllocData
     public ClrDataAddress allocBytesLoh;
 }
 
+[System.Runtime.CompilerServices.InlineArray(GCConstants.DAC_NUMBERGENERATIONS)]
+internal struct DacpGenerationAllocData
+{
+    private DacpAllocData _element0;
+}
+
 public struct DacpModuleData
 {
     public enum TransientFlags : uint

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1880,7 +1880,108 @@ public sealed unsafe partial class SOSDacImpl
         return hr;
     }
     int ISOSDacInterface.GetHeapAllocData(uint count, void* data, uint* pNeeded)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetHeapAllocData(count, data, pNeeded) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        uint needed = 0;
+        bool isServer = false;
+        try
+        {
+            if (data is null && pNeeded is null)
+                throw new ArgumentException();
+
+            IGC gc = _target.Contracts.GC;
+            isServer = gc.GetGCIdentifiers().Contains(GCIdentifiers.Server);
+            List<TargetPointer>? heapAddresses = null;
+            if (isServer)
+            {
+                heapAddresses = gc.GetGCHeaps().ToList();
+                needed = (uint)heapAddresses.Count;
+            }
+            else
+            {
+                needed = 1;
+            }
+
+            if (pNeeded is not null)
+                *pNeeded = needed;
+
+            if (data is not null)
+            {
+                // Native server GC writes one record for every heap whenever data is non-null,
+                // while workstation GC requires count >= 1.
+                uint heapsToWrite = isServer ? needed : Math.Min(count, needed);
+                DacpAllocData* output = (DacpAllocData*)data;
+                for (uint heapIndex = 0; heapIndex < heapsToWrite; heapIndex++)
+                {
+                    GCHeapData heap;
+                    if (isServer)
+                    {
+                        if (heapAddresses is null)
+                            throw new InvalidOperationException("Server GC heap addresses are unavailable.");
+                        heap = gc.GetHeapData(heapAddresses[(int)heapIndex]);
+                    }
+                    else
+                    {
+                        heap = gc.GetHeapData();
+                    }
+                    IReadOnlyList<GCGenerationData> generations = heap.GenerationTable;
+                    if (generations.Count < GCConstants.DAC_NUMBERGENERATIONS)
+                        throw new InvalidOperationException($"Expected at least {GCConstants.DAC_NUMBERGENERATIONS} generations.");
+
+                    for (int generationIndex = 0; generationIndex < GCConstants.DAC_NUMBERGENERATIONS; generationIndex++)
+                    {
+                        GCGenerationData generation = generations[generationIndex];
+                        int outputIndex = checked((int)heapIndex * GCConstants.DAC_NUMBERGENERATIONS + generationIndex);
+                        output[outputIndex].allocBytes = (ClrDataAddress)unchecked((ulong)generation.AllocationBytes);
+                        output[outputIndex].allocBytesLoh = (ClrDataAddress)unchecked((ulong)generation.AllocationBytesLoh);
+                    }
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint localCapacity = Math.Max(count, needed);
+            DacpGenerationAllocData[] dataLocal = new DacpGenerationAllocData[checked((int)localCapacity)];
+            uint neededLocal = 0;
+            fixed (DacpGenerationAllocData* dataLocalPtr = dataLocal)
+            {
+                int hrLocal = _legacyImpl.GetHeapAllocData(
+                    count,
+                    data is null ? null : dataLocalPtr,
+                    pNeeded is null ? null : &neededLocal);
+                Debug.ValidateHResult(hr, hrLocal);
+                if (hr == HResults.S_OK)
+                {
+                    if (pNeeded is not null)
+                        Debug.Assert(*pNeeded == neededLocal, $"cDAC: {*pNeeded}, DAC: {neededLocal}");
+
+                    if (data is not null)
+                    {
+                        DacpAllocData* output = (DacpAllocData*)data;
+                        DacpAllocData* outputLocal = (DacpAllocData*)dataLocalPtr;
+                        uint heapsToCompare = isServer ? needed : Math.Min(count, needed);
+                        for (uint heapIndex = 0; heapIndex < heapsToCompare; heapIndex++)
+                        {
+                            for (int generationIndex = 0; generationIndex < GCConstants.DAC_NUMBERGENERATIONS; generationIndex++)
+                            {
+                                int index = checked((int)heapIndex * GCConstants.DAC_NUMBERGENERATIONS + generationIndex);
+                                Debug.Assert(output[index].allocBytes == outputLocal[index].allocBytes);
+                                Debug.Assert(output[index].allocBytesLoh == outputLocal[index].allocBytesLoh);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+#endif
+        return hr;
+    }
     int ISOSDacInterface.GetHeapAnalyzeData(ClrDataAddress addr, DacpGcHeapAnalyzeData* data)
     {
         int hr = HResults.S_OK;

--- a/src/native/managed/cdac/tests/DumpTests/ServerGCDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/ServerGCDumpTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
 using Xunit;
 
@@ -15,7 +16,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 /// Uses the ServerGC debuggee dump, which enables server GC and allocates
 /// objects across multiple heaps.
 /// </summary>
-public class ServerGCDumpTests : DumpTestBase
+public unsafe class ServerGCDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "ServerGC";
 
@@ -116,6 +117,40 @@ public class ServerGCDumpTests : DumpTestBase
             Assert.NotNull(heapData.GenerationTable);
             Assert.True(heapData.GenerationTable.Count > 0,
                 $"Expected generation table for heap 0x{heap:X} to be non-empty");
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "GC contract is not available in .NET 10 dumps")]
+    public void GetHeapAllocData_MatchesEachHeapGenerationAllocationContexts(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IGC gc = Target.Contracts.GC;
+        List<TargetPointer> heaps = gc.GetGCHeaps().ToList();
+        ISOSDacInterface sos = new SOSDacImpl(Target, legacyObj: null);
+
+        uint needed;
+        Assert.Equal(System.HResults.S_OK, sos.GetHeapAllocData(0, null, &needed));
+        Assert.Equal((uint)heaps.Count, needed);
+
+        DacpGenerationAllocData[] data = new DacpGenerationAllocData[heaps.Count];
+        fixed (DacpGenerationAllocData* dataPtr = data)
+        {
+            Assert.Equal(System.HResults.S_OK, sos.GetHeapAllocData(needed, dataPtr, &needed));
+        }
+        for (int heapIndex = 0; heapIndex < heaps.Count; heapIndex++)
+        {
+            IReadOnlyList<GCGenerationData> generations = gc.GetHeapData(heaps[heapIndex]).GenerationTable;
+            for (int generationIndex = 0; generationIndex < GCConstants.DAC_NUMBERGENERATIONS; generationIndex++)
+            {
+                Assert.Equal(
+                    unchecked((ulong)generations[generationIndex].AllocationBytes),
+                    (ulong)data[heapIndex][generationIndex].allocBytes);
+                Assert.Equal(
+                    unchecked((ulong)generations[generationIndex].AllocationBytesLoh),
+                    (ulong)data[heapIndex][generationIndex].allocBytesLoh);
+            }
         }
     }
 

--- a/src/native/managed/cdac/tests/DumpTests/WorkstationGCDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/WorkstationGCDumpTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
 using Xunit;
 
@@ -15,7 +16,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 /// Uses the GCRoots debuggee dump, which pins objects and creates GC handles
 /// under the default workstation GC.
 /// </summary>
-public class WorkstationGCDumpTests : DumpTestBase
+public unsafe class WorkstationGCDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "GCRoots";
 
@@ -141,6 +142,29 @@ public class WorkstationGCDumpTests : DumpTestBase
             Assert.NotEqual(TargetPointer.Null, limit);
             Assert.True(pointer <= limit,
                 $"Expected allocPtr (0x{pointer:X}) <= allocLimit (0x{limit:X})");
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "GC contract is not available in .NET 10 dumps")]
+    public void GetHeapAllocData_MatchesGenerationAllocationContexts(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IGC gc = Target.Contracts.GC;
+        ISOSDacInterface sos = new SOSDacImpl(Target, legacyObj: null);
+
+        uint needed;
+        Assert.Equal(System.HResults.S_OK, sos.GetHeapAllocData(0, null, &needed));
+        Assert.Equal(1u, needed);
+
+        DacpGenerationAllocData data = default;
+        Assert.Equal(System.HResults.S_OK, sos.GetHeapAllocData(1, &data, &needed));
+        IReadOnlyList<GCGenerationData> generations = gc.GetHeapData().GenerationTable;
+        for (int i = 0; i < GCConstants.DAC_NUMBERGENERATIONS; i++)
+        {
+            Assert.Equal(unchecked((ulong)generations[i].AllocationBytes), (ulong)data[i].allocBytes);
+            Assert.Equal(unchecked((ulong)generations[i].AllocationBytesLoh), (ulong)data[i].allocBytesLoh);
         }
     }
 

--- a/src/native/managed/cdac/tests/UnitTests/GCTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/GCTests.cs
@@ -17,10 +17,10 @@ public class GCTests
     {
         var generations = new MockGCBuilder.Generation[]
         {
-            new() { StartSegment = 0xAA00_0000, AllocationStart = 0xAA00_1000, AllocContextPointer = 0xAA00_2000, AllocContextLimit = 0xAA00_3000 },
-            new() { StartSegment = 0xBB00_0000, AllocationStart = 0xBB00_1000, AllocContextPointer = 0, AllocContextLimit = 0 },
-            new() { StartSegment = 0xCC00_0000, AllocationStart = 0xCC00_1000, AllocContextPointer = 0, AllocContextLimit = 0 },
-            new() { StartSegment = 0xDD00_0000, AllocationStart = 0xDD00_1000, AllocContextPointer = 0, AllocContextLimit = 0 },
+            new() { StartSegment = 0xAA00_0000, AllocationStart = 0xAA00_1000, AllocContextPointer = 0xAA00_2000, AllocContextLimit = 0xAA00_3000, AllocationBytes = 101, AllocationBytesLoh = 201 },
+            new() { StartSegment = 0xBB00_0000, AllocationStart = 0xBB00_1000, AllocContextPointer = 0, AllocContextLimit = 0, AllocationBytes = 102, AllocationBytesLoh = 202 },
+            new() { StartSegment = 0xCC00_0000, AllocationStart = 0xCC00_1000, AllocContextPointer = 0, AllocContextLimit = 0, AllocationBytes = 103, AllocationBytesLoh = 203 },
+            new() { StartSegment = 0xDD00_0000, AllocationStart = 0xDD00_1000, AllocContextPointer = 0, AllocContextLimit = 0, AllocationBytes = 104, AllocationBytesLoh = 204 },
         };
 
         ulong[] fillPointers = [0x1000, 0x2000, 0x3000, 0x4000, 0x5000, 0x6000, 0x7000];
@@ -43,6 +43,8 @@ public class GCTests
             Assert.Equal(generations[i].AllocationStart, (ulong)heapData.GenerationTable[i].AllocationStart);
             Assert.Equal(generations[i].AllocContextPointer, (ulong)heapData.GenerationTable[i].AllocationContextPointer);
             Assert.Equal(generations[i].AllocContextLimit, (ulong)heapData.GenerationTable[i].AllocationContextLimit);
+            Assert.Equal(generations[i].AllocationBytes, heapData.GenerationTable[i].AllocationBytes);
+            Assert.Equal(generations[i].AllocationBytesLoh, heapData.GenerationTable[i].AllocationBytesLoh);
         }
     }
 

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.GC.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.GC.cs
@@ -300,6 +300,8 @@ internal sealed class MockGCBuilder
         public ulong AllocationStart;
         public ulong AllocContextPointer;
         public ulong AllocContextLimit;
+        public long AllocationBytes;
+        public long AllocationBytesLoh;
     }
 
     public MockGCBuilder(MockMemorySpace.Builder builder)
@@ -360,6 +362,8 @@ internal sealed class MockGCBuilder
             MockGCAllocContext allocationContext = generation.GetAllocationContext(GCAllocContextLayout);
             allocationContext.Pointer = generations[i].AllocContextPointer;
             allocationContext.Limit = generations[i].AllocContextLimit;
+            allocationContext.AllocBytes = generations[i].AllocationBytes;
+            allocationContext.AllocBytesLoh = generations[i].AllocationBytesLoh;
             generation.StartSegment = generations[i].StartSegment;
             generation.AllocationStart = generations[i].AllocationStart;
         }
@@ -424,6 +428,8 @@ internal sealed class MockGCBuilder
             MockGCAllocContext allocationContext = generation.GetAllocationContext(GCAllocContextLayout);
             allocationContext.Pointer = generations[i].AllocContextPointer;
             allocationContext.Limit = generations[i].AllocContextLimit;
+            allocationContext.AllocBytes = generations[i].AllocationBytes;
+            allocationContext.AllocBytesLoh = generations[i].AllocationBytesLoh;
             generation.StartSegment = generations[i].StartSegment;
             generation.AllocationStart = generations[i].AllocationStart;
         }

--- a/src/native/managed/cdac/tests/UnitTests/SOSDacInterfaceHeapAllocDataTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/SOSDacInterfaceHeapAllocDataTests.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public unsafe class SOSDacInterfaceHeapAllocDataTests
+{
+    private static readonly MockTarget.Architecture s_arch = new() { IsLittleEndian = true, Is64Bit = true };
+
+    [Fact]
+    public void GetHeapAllocData_WorkstationUsesFourDacGenerationSlots()
+    {
+        GCHeapData heap = new() { GenerationTable = CreateGenerations(100) };
+        var gc = new Mock<IGC>();
+        gc.Setup(g => g.GetGCIdentifiers()).Returns([GCIdentifiers.Workstation]);
+        gc.Setup(g => g.GetHeapData()).Returns(heap);
+        ISOSDacInterface sos = CreateSOSDac(gc);
+
+        uint needed;
+        Assert.Equal(HResults.S_OK, sos.GetHeapAllocData(0, null, &needed));
+        Assert.Equal(1u, needed);
+        gc.Verify(g => g.GetHeapData(), Times.Never);
+
+        DacpGenerationAllocData data = default;
+        Assert.Equal(HResults.S_OK, sos.GetHeapAllocData(1, &data, &needed));
+        for (int i = 0; i < GCConstants.DAC_NUMBERGENERATIONS; i++)
+        {
+            Assert.Equal((ulong)(100 + i), (ulong)data[i].allocBytes);
+            Assert.Equal((ulong)(200 + i), (ulong)data[i].allocBytesLoh);
+        }
+
+        data[0].allocBytes = new ClrDataAddress(0xfeed);
+        Assert.Equal(HResults.S_OK, sos.GetHeapAllocData(0, &data, &needed));
+        Assert.Equal(0xfeedul, (ulong)data[0].allocBytes);
+        Assert.Equal(HResults.E_INVALIDARG, sos.GetHeapAllocData(0, null, null));
+    }
+
+    [Fact]
+    public void GetHeapAllocData_ServerReturnsOneRecordPerHeap()
+    {
+        TargetPointer firstHeap = new(0x3000);
+        TargetPointer secondHeap = new(0x4000);
+        var gc = new Mock<IGC>();
+        gc.Setup(g => g.GetGCIdentifiers()).Returns([GCIdentifiers.Server]);
+        gc.Setup(g => g.GetGCHeaps()).Returns([firstHeap, secondHeap]);
+        gc.Setup(g => g.GetHeapData(firstHeap)).Returns(new GCHeapData { GenerationTable = CreateGenerations(1000) });
+        gc.Setup(g => g.GetHeapData(secondHeap)).Returns(new GCHeapData { GenerationTable = CreateGenerations(2000) });
+        ISOSDacInterface sos = CreateSOSDac(gc);
+
+        uint needed;
+        Assert.Equal(HResults.S_OK, sos.GetHeapAllocData(0, null, &needed));
+        Assert.Equal(2u, needed);
+        gc.Verify(g => g.GetHeapData(It.IsAny<TargetPointer>()), Times.Never);
+
+        DacpGenerationAllocData* data = stackalloc DacpGenerationAllocData[2];
+        Assert.Equal(HResults.S_OK, sos.GetHeapAllocData(2, data, &needed));
+        Assert.Equal(1000ul, (ulong)data[0][0].allocBytes);
+        Assert.Equal(1003ul, (ulong)data[0][3].allocBytes);
+        Assert.Equal(2000ul, (ulong)data[1][0].allocBytes);
+        Assert.Equal(2003ul, (ulong)data[1][3].allocBytes);
+
+        DacpGenerationAllocData* partial = stackalloc DacpGenerationAllocData[2];
+        Assert.Equal(HResults.S_OK, sos.GetHeapAllocData(1, partial, &needed));
+        Assert.Equal(2u, needed);
+        Assert.Equal(1000ul, (ulong)partial[0][0].allocBytes);
+        Assert.Equal(2000ul, (ulong)partial[1][0].allocBytes);
+    }
+
+    private static ISOSDacInterface CreateSOSDac(Mock<IGC> gc)
+    {
+        TestPlaceholderTarget target = new TestPlaceholderTarget.Builder(s_arch)
+            .UseReader((ulong _, Span<byte> _) => -1)
+            .AddMockContract(gc)
+            .Build();
+        return new SOSDacImpl(target, legacyObj: null);
+    }
+
+    private static GCGenerationData[] CreateGenerations(long start)
+        =>
+        [
+            new() { AllocationBytes = start, AllocationBytesLoh = start + 100 },
+            new() { AllocationBytes = start + 1, AllocationBytesLoh = start + 101 },
+            new() { AllocationBytes = start + 2, AllocationBytesLoh = start + 102 },
+            new() { AllocationBytes = start + 3, AllocationBytesLoh = start + 103 },
+            new() { AllocationBytes = start + 9999, AllocationBytesLoh = start + 19999 },
+        ];
+}


### PR DESCRIPTION
## Summary

Implements `ISOSDacInterface.GetHeapAllocData`, which reports per-generation
allocation byte counts for workstation and server GC.

## Native semantic parity

- Exposes generation allocation byte counts semantically on `GCGenerationData`
  (`AllocationBytes` / `AllocationBytesLoh`), read from the existing
  `Data.GCAllocContext.AllocBytes` / `AllocBytesLoh` fields -- **no data
  descriptor change is required**.
- **Workstation GC**: reports a single record for the shared generation table
  when `count >= 1`; `pNeeded = 1`.
- **Server GC**: reports one record per heap; matching the native quirk, it
  writes a record for every heap whenever `data` is non-null regardless of
  `count`; `pNeeded = heap count`.
- Each record contains exactly four DAC generation slots -- gen0, gen1, gen2,
  and LOH (POH excluded) -- matching `DAC_NUMBERGENERATIONS`.
- `(data == null && pNeeded == null)` returns `E_INVALIDARG`.
- A `#if DEBUG` cross-check compares against the legacy DAC when present.

## Docs

- `docs/design/datacontracts/GC.md` documents the new
  `GCGenerationData.AllocationBytes` / `AllocationBytesLoh` fields and their read
  pseudocode.

## Testing

- `SOSDacInterfaceHeapAllocDataTests`: workstation four-slot layout + argument
  validation; server one-record-per-heap including the count-independent write
  quirk.
- `GCTests` / `MockDescriptors.GC` updated to cover the new allocation-byte
  fields.
- `ServerGCDumpTests` / `WorkstationGCDumpTests`: added `GetHeapAllocData`
  coverage (integration tests that run in the cDAC dump-tests pipeline against
  generated dumps).
- Full cDAC unit suite: 2703 passed, 16 skipped, 0 failed.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
