### PR TITLE
Add CPU feature detection using elf_aux_info

### DIFF
--- a/src/native/minipal/configure.cmake
+++ b/src/native/minipal/configure.cmake
@@ -10,6 +10,7 @@ check_include_files("sys/resource.h" HAVE_RESOURCE_H)
 check_function_exists(sysctlbyname HAVE_SYSCTLBYNAME)
 check_function_exists(fsync HAVE_FSYNC)
 
+check_symbol_exists(elf_aux_info "sys/auxv.h" HAVE_ELF_AUX_INFO)
 check_symbol_exists(arc4random_buf "stdlib.h" HAVE_ARC4RANDOM_BUF)
 check_symbol_exists(getrandom "sys/random.h" HAVE_GETRANDOM)
 check_symbol_exists(getentropy "unistd.h" HAVE_GETENTROPY)

--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -7,6 +7,13 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <sys/types.h>
+
+#include "minipalconfig.h"
+
+#if HAVE_ELF_AUX_INFO
+#include <sys/auxv.h>
+#endif
 
 #include "cpufeatures.h"
 #include "cpuid.h"
@@ -40,8 +47,6 @@
 #endif
 
 #else // HOST_WINDOWS
-
-#include "minipalconfig.h"
 
 #if HAVE_AUXV_HWCAP_H
 
@@ -510,8 +515,17 @@ int minipal_getcpufeatures(void)
 #if defined(HOST_ARM64)
 #if defined(HOST_UNIX)
 
+#if HAVE_AUXV_HWCAP_H || HAVE_ELF_AUX_INFO
 #if HAVE_AUXV_HWCAP_H
     unsigned long hwCap = getauxval(AT_HWCAP);
+    unsigned long hwCap2 = getauxval(AT_HWCAP2);
+#elif HAVE_ELF_AUX_INFO
+    unsigned long hwCap = 0;
+    unsigned long hwCap2 = 0;
+
+    elf_aux_info(AT_HWCAP, &hwCap, sizeof(hwCap));
+    elf_aux_info(AT_HWCAP2, &hwCap2, sizeof(hwCap2));
+#endif
 
     if ((hwCap & HWCAP_ASIMD) == 0)
     {
@@ -555,8 +569,6 @@ int minipal_getcpufeatures(void)
     if (hwCap & HWCAP_SVE)
         result |= ARM64IntrinsicConstants_Sve;
 
-    unsigned long hwCap2 = getauxval(AT_HWCAP2);
-
     if (hwCap2 & HWCAP2_SVE2)
         result |= ARM64IntrinsicConstants_Sve2;
 
@@ -571,10 +583,7 @@ int minipal_getcpufeatures(void)
 
     if (hwCap2 & HWCAP2_CSSC)
         result |= ARM64IntrinsicConstants_Cssc;
-
-#else // !HAVE_AUXV_HWCAP_H
-
-#if HAVE_SYSCTLBYNAME
+#elif HAVE_SYSCTLBYNAME
     int64_t valueFromSysctl = 0;
     size_t sz = sizeof(valueFromSysctl);
 
@@ -646,7 +655,6 @@ int minipal_getcpufeatures(void)
     if ((sysctlbyname("hw.optional.arm.FEAT_CSSC", &valueFromSysctl, &sz, NULL, 0) == 0) && (valueFromSysctl != 0))
         result |= ARM64IntrinsicConstants_Cssc;
 #endif // HAVE_SYSCTLBYNAME
-#endif // HAVE_AUXV_HWCAP_H
 #endif // HOST_UNIX
 
 #if defined(HOST_WINDOWS)

--- a/src/native/minipal/minipalconfig.h.in
+++ b/src/native/minipal/minipalconfig.h.in
@@ -9,6 +9,7 @@
 #cmakedefine01 HAVE_RESOURCE_H
 #cmakedefine01 HAVE_O_CLOEXEC
 #cmakedefine01 HAVE_SYSCTLBYNAME
+#cmakedefine01 HAVE_ELF_AUX_INFO
 #cmakedefine01 HAVE_CLOCK_MONOTONIC_COARSE
 #cmakedefine01 HAVE_CLOCK_GETTIME_NSEC_NP
 #cmakedefine01 BIGENDIAN


### PR DESCRIPTION
When running AOT smoke tests on freebsd-arm64, it was failing AOT apps with:

```sh
[6](https://github.com/am11/CrossRepoCITesting/actions/runs/29426499240/job/87390152366#step:5:336)
  Running /home/runner/work/CrossRepoCITesting/CrossRepoCITesting/runtime/artifacts/tests/coreclr/freebsd.arm64.Checked/nativeaot/SmokeTests/PInvoke/PInvoke/native/PInvoke...
  
  The current CPU is missing one or more of the following instruction sets: AdvSimd
  Abort trap
```

It's a net11.0 regression from https://github.com/dotnet/runtime/pull/118101; now passing: https://github.com/am11/CrossRepoCITesting/actions/runs/29519372748/job/87692356810