### PR TITLE
[cDAC] Implement IXCLRData frame type queries

### DIFF
--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -58,6 +58,10 @@ enum StackwalkFlag
 // Gets the Frame address at the given stack dataframe. Returns TargetPointer.Null if the current dataframe does not have a valid Frame.
 TargetPointer GetFrameAddress(IStackDataFrameHandle stackDataFrameHandle);
 
+// Returns true if the stack dataframe is an explicit Frame carrying FRAME_ATTR_EXCEPTION
+// (a FaultingExceptionFrame or SoftwareExceptionFrame).
+bool IsExceptionFrame(IStackDataFrameHandle stackDataFrameHandle);
+
 // Gets the Frame name associated with the given Frame identifier. If no matching Frame name found returns an empty string.
 string GetFrameName(TargetPointer frameIdentifier);
 
@@ -494,6 +498,12 @@ If the Frame is not valid, returns `TargetPointer.Null`.
 
 ```csharp
 TargetPointer GetFrameAddress(IStackDataFrameHandle stackDataFrameHandle);
+```
+
+
+`IsExceptionFrame` returns true when the `IStackDataFrameHandle` is positioned on an explicit capital "F" Frame that carries `FRAME_ATTR_EXCEPTION` -- that is, a `FaultingExceptionFrame` or `SoftwareExceptionFrame`. It returns false for all other frames.
+```csharp
+bool IsExceptionFrame(IStackDataFrameHandle stackDataFrameHandle);
 ```
 
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
@@ -94,6 +94,7 @@ public interface IStackWalk : IContract
     IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData, bool resolveInteriorPointers) => throw new NotImplementedException();
     byte[] GetRawContext(IStackDataFrameHandle stackDataFrameHandle, StackwalkFlag flags = StackwalkFlag.Default) => throw new NotImplementedException();
     TargetPointer GetFrameAddress(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
+    bool IsExceptionFrame(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
     string GetFrameName(TargetPointer frameIdentifier) => throw new NotImplementedException();
     TargetPointer GetMethodDescPtr(TargetPointer framePtr) => throw new NotImplementedException();
     TargetPointer GetMethodDescPtr(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -35,7 +35,8 @@ internal partial class StackWalk_1 : IStackWalk
         TargetPointer FrameAddress,
         ThreadData ThreadData,
         bool IsResumableFrame = false,
-        bool IsActiveFrame = false) : IStackDataFrameHandle
+        bool IsActiveFrame = false,
+        bool IsExceptionFrame = false) : IStackDataFrameHandle
     { }
 
     private class StackWalkData(IPlatformAgnosticContext context, StackWalkState state, FrameIterator frameIter, ThreadData threadData)
@@ -113,7 +114,20 @@ internal partial class StackWalk_1 : IStackWalk
         {
             bool isResumable = IsCurrentFrameResumable();
             bool isActiveFrame = IsFirst && State == StackWalkState.Frameless;
-            return new(Context.Clone(), State, FrameIter.CurrentFrameAddress, ThreadData, isResumable, isActiveFrame);
+            bool isExceptionFrame = IsCurrentFrameException();
+            return new(Context.Clone(), State, FrameIter.CurrentFrameAddress, ThreadData, isResumable, isActiveFrame, isExceptionFrame);
+        }
+
+        public bool IsCurrentFrameException()
+        {
+            if (State is not (StackWalkState.Frame or StackWalkState.SkippedFrame))
+                return false;
+
+            // FaultingExceptionFrame and SoftwareExceptionFrame are the explicit frames that
+            // carry FRAME_ATTR_EXCEPTION, which native RawGetFrameType maps to
+            // CLRDATA_DETFRAME_EXCEPTION_FILTER.
+            FrameType ft = FrameIter.GetCurrentFrameType();
+            return ft is FrameType.FaultingExceptionFrame or FrameType.SoftwareExceptionFrame;
         }
     }
 
@@ -1039,6 +1053,12 @@ internal partial class StackWalk_1 : IStackWalk
             return handle.FrameAddress;
         }
         return TargetPointer.Null;
+    }
+
+    bool IStackWalk.IsExceptionFrame(IStackDataFrameHandle stackDataFrameHandle)
+    {
+        StackDataFrameHandle handle = AssertCorrectHandle(stackDataFrameHandle);
+        return handle.IsExceptionFrame;
     }
 
     TargetCodePointer IStackWalk.GetInstructionPointer(IStackDataFrameHandle stackDataFrameHandle)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
@@ -34,7 +34,40 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
 
     // IXCLRDataFrame implementation
     int IXCLRDataFrame.GetFrameType(uint* simpleType, uint* detailedType)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetFrameType(simpleType, detailedType) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            // Unlike IXCLRDataStackWalk.GetFrameType, the native IXCLRDataFrame.GetFrameType
+            // dereferences both outputs unconditionally, so a null output yields E_POINTER.
+            if (simpleType is null || detailedType is null)
+                throw new NullReferenceException();
+
+            ClrDataStackWalk.GetFrameTypes(_target, _dataFrame, simpleType, detailedType);
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint simpleTypeLocal = 0;
+            uint detailedTypeLocal = 0;
+            int hrLocal = _legacyImpl.GetFrameType(
+                simpleType is null ? null : &simpleTypeLocal,
+                detailedType is null ? null : &detailedTypeLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK && simpleType is not null && detailedType is not null)
+            {
+                Debug.Assert(*simpleType == simpleTypeLocal, $"cDAC: {*simpleType}, DAC: {simpleTypeLocal}");
+                Debug.Assert(*detailedType == detailedTypeLocal, $"cDAC: {*detailedType}, DAC: {detailedTypeLocal}");
+            }
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataFrame.GetContext(
         uint contextFlags,

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 [GeneratedComClass]
 public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
 {
+    private const uint SimpleFrameUnrecognized = 0x1;
+    private const uint SimpleFrameManagedMethod = 0x2;
+    private const uint SimpleFrameRuntimeUnmanagedCode = 0x8;
+    private const uint DetailedFrameUnrecognized = 0;
+    private const uint DetailedFrameExceptionFilter = 3;
+
     private readonly TargetPointer _threadAddr;
     private readonly uint _flags;
     private readonly Target _target;
@@ -57,6 +63,29 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
         => frame.State is StackWalkState.Frameless
                        or StackWalkState.Frame
                        or StackWalkState.SkippedFrame;
+
+    internal static void GetFrameTypes(Target target, IStackDataFrameHandle frame, uint* simpleType, uint* detailedType)
+    {
+        if (simpleType is not null)
+        {
+            *simpleType = frame.State switch
+            {
+                StackWalkState.Frameless => SimpleFrameManagedMethod,
+                StackWalkState.Frame or StackWalkState.SkippedFrame => SimpleFrameRuntimeUnmanagedCode,
+                _ => SimpleFrameUnrecognized,
+            };
+        }
+
+        if (detailedType is not null)
+        {
+            // Native RawGetFrameType reports CLRDATA_DETFRAME_EXCEPTION_FILTER for an explicit
+            // frame carrying FRAME_ATTR_EXCEPTION (FaultingExceptionFrame / SoftwareExceptionFrame),
+            // and CLRDATA_DETFRAME_UNRECOGNIZED otherwise.
+            *detailedType = target.Contracts.StackWalk.IsExceptionFrame(frame)
+                ? DetailedFrameExceptionFilter
+                : DetailedFrameUnrecognized;
+        }
+    }
 
     int IXCLRDataStackWalk.GetContext(uint contextFlags, uint contextBufSize, uint* contextSize, [MarshalUsing(CountElementName = "contextBufSize"), Out] byte[] contextBuf)
     {
@@ -134,7 +163,40 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
         return hr;
     }
     int IXCLRDataStackWalk.GetFrameType(uint* simpleType, uint* detailedType)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetFrameType(simpleType, detailedType) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (_currentFrameIsValid)
+                GetFrameTypes(_target, _dataFrames.Current, simpleType, detailedType);
+            else
+                hr = HResults.S_FALSE;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint simpleTypeLocal = 0;
+            uint detailedTypeLocal = 0;
+            int hrLocal = _legacyImpl.GetFrameType(
+                simpleType is null ? null : &simpleTypeLocal,
+                detailedType is null ? null : &detailedTypeLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+            {
+                if (simpleType is not null)
+                    Debug.Assert(*simpleType == simpleTypeLocal, $"cDAC: {*simpleType}, DAC: {simpleTypeLocal}");
+                if (detailedType is not null)
+                    Debug.Assert(*detailedType == detailedTypeLocal, $"cDAC: {*detailedType}, DAC: {detailedTypeLocal}");
+            }
+        }
+#endif
+        return hr;
+    }
     int IXCLRDataStackWalk.GetStackSizeSkipped(ulong* stackSizeSkipped)
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetStackSizeSkipped(stackSizeSkipped) : HResults.E_NOTIMPL;
     int IXCLRDataStackWalk.Next()

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataFrameDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataFrameDumpTests.cs
@@ -18,6 +18,21 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "StackWalk";
 
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetFrameType_ManagedFrameReturnsManagedMethod(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IXCLRDataFrame frame = new ClrDataFrame(Target, GetFirstFramelessFrame(), legacyImpl: null);
+
+        uint simpleType;
+        uint detailedType;
+        AssertHResult(HResults.S_OK, frame.GetFrameType(&simpleType, &detailedType));
+        Assert.Equal(0x2u, simpleType);
+        Assert.Equal(0u, detailedType);
+    }
+
     // ========== GetContext ==========
 
     [ConditionalTheory]
@@ -504,6 +519,33 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
     }
 
     // ========== Helpers ==========
+
+    private IStackDataFrameHandle GetFirstFramelessFrame()
+    {
+        IThread threadContract = Target.Contracts.Thread;
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        TargetPointer thread = threadContract.GetThreadStoreData().FirstThread;
+        while (thread != TargetPointer.Null)
+        {
+            ThreadData threadData = threadContract.GetThreadData(thread);
+            try
+            {
+                foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(threadData))
+                {
+                    if (frame.State == StackWalkState.Frameless)
+                        return frame;
+                }
+            }
+            catch (System.Exception)
+            {
+            }
+
+            thread = threadData.NextThread;
+        }
+
+        Assert.Fail("No frameless managed frame found.");
+        throw new InvalidOperationException("Unreachable");
+    }
 
     private IStackDataFrameHandle GetFirstManagedFrame()
     {

--- a/src/native/managed/cdac/tests/UnitTests/ClrDataStackWalkTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ClrDataStackWalkTests.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public unsafe class ClrDataStackWalkTests
+{
+    private static readonly MockTarget.Architecture s_arch = new() { IsLittleEndian = true, Is64Bit = true };
+
+    [Theory]
+    [InlineData(StackWalkState.Frameless, 0x2u)]
+    [InlineData(StackWalkState.Frame, 0x8u)]
+    [InlineData(StackWalkState.SkippedFrame, 0x8u)]
+    [InlineData(StackWalkState.Complete, 0x1u)]
+    public void FrameGetFrameType_MapsSimpleTypeWithUnrecognizedDetail(StackWalkState state, uint expectedSimpleType)
+    {
+        TestFrame frame = new(state);
+        IXCLRDataFrame clrFrame = new ClrDataFrame(CreateTarget(frame, isExceptionFrame: false), frame, legacyImpl: null);
+
+        uint simpleType;
+        uint detailedType;
+        Assert.Equal(HResults.S_OK, clrFrame.GetFrameType(&simpleType, &detailedType));
+        Assert.Equal(expectedSimpleType, simpleType);
+        Assert.Equal(0u, detailedType);
+    }
+
+    [Fact]
+    public void FrameGetFrameType_ExceptionFrameReportsExceptionFilter()
+    {
+        TestFrame frame = new(StackWalkState.Frame);
+        IXCLRDataFrame clrFrame = new ClrDataFrame(CreateTarget(frame, isExceptionFrame: true), frame, legacyImpl: null);
+
+        uint simpleType;
+        uint detailedType;
+        Assert.Equal(HResults.S_OK, clrFrame.GetFrameType(&simpleType, &detailedType));
+        Assert.Equal(0x8u, simpleType);
+        Assert.Equal(3u, detailedType); // CLRDATA_DETFRAME_EXCEPTION_FILTER
+    }
+
+    [Fact]
+    public void FrameGetFrameType_NullOutputReturnsEPointer()
+    {
+        TestFrame frame = new(StackWalkState.Frameless);
+        IXCLRDataFrame clrFrame = new ClrDataFrame(CreateTarget(frame, isExceptionFrame: false), frame, legacyImpl: null);
+
+        uint simpleType;
+        Assert.Equal(HResults.E_POINTER, clrFrame.GetFrameType(&simpleType, null));
+    }
+
+    [Fact]
+    public void StackWalkGetFrameType_MapsVisibleFramesAndReturnsSFalseAfterEnd()
+    {
+        TestFrame frameless = new(StackWalkState.Frameless);
+        TestFrame frame = new(StackWalkState.Frame);
+        TestFrame skipped = new(StackWalkState.SkippedFrame);
+        IStackDataFrameHandle[] frames = [frameless, frame, skipped];
+        IXCLRDataStackWalk stackWalk = CreateStackWalk(frames, exceptionFrame: skipped);
+
+        AssertFrameType(stackWalk, 0x2, 0);
+        Assert.Equal(HResults.S_OK, stackWalk.Next());
+        AssertFrameType(stackWalk, 0x8, 0);
+        Assert.Equal(HResults.S_OK, stackWalk.Next());
+        AssertFrameType(stackWalk, 0x8, 3); // skipped frame is an exception frame -> EXCEPTION_FILTER
+        Assert.Equal(HResults.S_FALSE, stackWalk.Next());
+
+        uint simpleType = uint.MaxValue;
+        uint detailedType = uint.MaxValue;
+        Assert.Equal(HResults.S_FALSE, stackWalk.GetFrameType(&simpleType, &detailedType));
+        Assert.Equal(uint.MaxValue, simpleType);
+        Assert.Equal(uint.MaxValue, detailedType);
+    }
+
+    [Fact]
+    public void StackWalkGetFrameType_AllowsNullOutputs()
+    {
+        IXCLRDataStackWalk stackWalk = CreateStackWalk([new TestFrame(StackWalkState.Frameless)]);
+        Assert.Equal(HResults.S_OK, stackWalk.GetFrameType(null, null));
+    }
+
+    private static TestPlaceholderTarget CreateTarget(IStackDataFrameHandle frame, bool isExceptionFrame)
+    {
+        var stackWalk = new Mock<IStackWalk>();
+        stackWalk.Setup(s => s.IsExceptionFrame(frame)).Returns(isExceptionFrame);
+        return new TestPlaceholderTarget.Builder(s_arch)
+            .UseReader((ulong _, Span<byte> _) => -1)
+            .AddMockContract(stackWalk)
+            .Build();
+    }
+
+    private static IXCLRDataStackWalk CreateStackWalk(IStackDataFrameHandle[] frames, IStackDataFrameHandle? exceptionFrame = null)
+    {
+        TargetPointer threadAddress = new(0x1000);
+        ThreadData threadData = default;
+        var thread = new Mock<IThread>();
+        thread.Setup(t => t.GetThreadData(threadAddress)).Returns(threadData);
+        var stackWalk = new Mock<IStackWalk>();
+        stackWalk.Setup(s => s.CreateStackWalk(threadData)).Returns(frames);
+        stackWalk.Setup(s => s.IsExceptionFrame(It.IsAny<IStackDataFrameHandle>()))
+            .Returns((IStackDataFrameHandle f) => exceptionFrame is not null && ReferenceEquals(f, exceptionFrame));
+
+        TestPlaceholderTarget target = new TestPlaceholderTarget.Builder(s_arch)
+            .UseReader((ulong _, Span<byte> _) => -1)
+            .AddMockContract(thread)
+            .AddMockContract(stackWalk)
+            .Build();
+        return new ClrDataStackWalk(threadAddress, flags: 0, target, legacyImpl: null);
+    }
+
+    private static void AssertFrameType(IXCLRDataStackWalk stackWalk, uint expectedSimpleType, uint expectedDetailedType)
+    {
+        uint simpleType;
+        uint detailedType;
+        Assert.Equal(HResults.S_OK, stackWalk.GetFrameType(&simpleType, &detailedType));
+        Assert.Equal(expectedSimpleType, simpleType);
+        Assert.Equal(expectedDetailedType, detailedType);
+    }
+
+    private sealed class TestFrame(StackWalkState state) : IStackDataFrameHandle
+    {
+        public StackWalkState State { get; } = state;
+    }
+}


### PR DESCRIPTION
## Summary

Implements the two `IXCLRData` frame-type queries that previously returned
`E_NOTIMPL`:

- `IXCLRDataStackWalk.GetFrameType`
- `IXCLRDataFrame.GetFrameType`

## Native semantic parity

- **Simple type** maps from the stack-walk state (matching native
  `RawGetFrameType`): `Frameless -> MANAGED_METHOD (0x2)`;
  `Frame`/`SkippedFrame -> RUNTIME_UNMANAGED_CODE (0x8)`; otherwise
  `UNRECOGNIZED (0x1)`.
- **Detailed type** reports `CLRDATA_DETFRAME_EXCEPTION_FILTER (3)` for an
  explicit frame carrying `FRAME_ATTR_EXCEPTION` (`FaultingExceptionFrame` or
  `SoftwareExceptionFrame`), and `CLRDATA_DETFRAME_UNRECOGNIZED (0)` otherwise.
- `IXCLRDataStackWalk.GetFrameType` returns `S_FALSE` and writes nothing once the
  stack walk is exhausted; `IXCLRDataFrame.GetFrameType` returns `E_POINTER` for
  null outputs (both matching native).

## Contract support

Rather than exposing internal `StackWalkState`/frame helpers to the Legacy
layer, this adds a small semantic query
`bool IStackWalk.IsExceptionFrame(IStackDataFrameHandle)`. The classification is
snapshotted when the data frame handle is produced (alongside the existing
resumable/active-frame snapshot). `docs/design/datacontracts/StackWalk.md` is
updated for the new method.

## Testing

- `ClrDataStackWalkTests`: simple-type mappings; an explicit exception frame
  reporting `detailedType = 3`; stack-walk exhaustion (`S_FALSE`, no write); and
  null-output behavior (`S_OK` for the stack walk, `E_POINTER` for the frame).
- `IXCLRDataFrameDumpTests`: frame-type coverage against generated dumps.
- Full cDAC unit suite: 2709 passed, 16 skipped, 0 failed.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
