### PR TITLE
Use stdcall for `dotnet_execute` in `dotnet-aot`

### DIFF
--- a/docs/design/features/sharedfx-lookup.md
+++ b/docs/design/features/sharedfx-lookup.md
@@ -47,7 +47,7 @@ The exact algorithm how versions as matched is described (with some history) in 
 Starting in .NET 11, once the SDK directory is resolved, the muxer checks for a `dotnet-aot` shared library in that directory. If the library exists and exports the `dotnet_execute` entry point, the muxer invokes it instead of running the managed `dotnet.dll`:
 
 ``` C
-int dotnet_execute(
+int __stdcall dotnet_execute(
     const char_t *host_path,     // path to the dotnet host executable
     const char_t *dotnet_root,   // path to the dotnet root directory
     const char_t *sdk_dir,       // path to the resolved SDK directory
@@ -55,6 +55,8 @@ int dotnet_execute(
     int argc,                    // user's command-line arguments (excluding dotnet executable itself)
     const char_t **argv);
 ```
+
+The entry point uses the `__stdcall` calling convention on Windows and the default calling convention elsewhere.
 
 If the `dotnet-aot` library is not found or does not have the expected entry point, the muxer falls back to running the managed `dotnet.dll` as a framework-dependent app.
 

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -87,7 +87,7 @@ namespace
             return false;
 
         // See docs/design/features/sharedfx-lookup.md#sdk-search
-        typedef int (__cdecl *dotnet_execute_fn)(
+        typedef int (__stdcall *dotnet_execute_fn)(
             const pal::char_t* host_path,
             const pal::char_t* dotnet_root,
             const pal::char_t* sdk_dir,

--- a/src/native/corehost/test/mockaotsdk/CMakeLists.txt
+++ b/src/native/corehost/test/mockaotsdk/CMakeLists.txt
@@ -3,6 +3,11 @@
 
 add_library(mockaotsdk SHARED mockaotsdk.cpp)
 
+if(CLR_CMAKE_TARGET_WIN32)
+    target_sources(mockaotsdk PRIVATE
+        mockaotsdk.def)
+endif()
+
 target_link_libraries(mockaotsdk PRIVATE hostmisc)
 
 target_compile_definitions(mockaotsdk PRIVATE EXPORT_SHARED_API)

--- a/src/native/corehost/test/mockaotsdk/mockaotsdk.cpp
+++ b/src/native/corehost/test/mockaotsdk/mockaotsdk.cpp
@@ -11,7 +11,7 @@ std::vector<char> tostr(const pal::char_t* value)
     return vect;
 }
 
-SHARED_API int __cdecl dotnet_execute(
+SHARED_API int __stdcall dotnet_execute(
     const pal::char_t* host_path,
     const pal::char_t* dotnet_root,
     const pal::char_t* sdk_dir,

--- a/src/native/corehost/test/mockaotsdk/mockaotsdk.def
+++ b/src/native/corehost/test/mockaotsdk/mockaotsdk.def
@@ -1,0 +1,5 @@
+; Licensed to the .NET Foundation under one or more agreements.
+; The .NET Foundation licenses this file to you under the MIT license.
+
+EXPORTS
+        dotnet_execute


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/130903

cc @dotnet/appmodel @AaronRobinsonMSFT 