### PR TITLE
[wasm] Publish __stack_pointer before SuppressGCTransition native calls

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2906,6 +2906,21 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
 
     params.wasmSignature = m_compiler->info.compCompHnd->getWasmTypeSymbol(typeStack.Data(), typeStack.Height());
 
+    // R2R keeps its shadow SP in a local and leaves the __stack_pointer global stale; the PInvoke
+    // prolog (JIT_PInvokeBegin) normally publishes the current SP to __stack_pointer before native
+    // code runs, but that prolog/epilog is skipped for SuppressGCTransition calls (see Lowering).
+    // Without a publish, the native SuppressGCTransition callee allocates its shadow frame from the
+    // stale global (our caller's SP, above our frame) and overlaps/clobbers our address-taken locals.
+    // Publish our shadow SP here so the callee allocates below our frame. This is a net-zero operation
+    // on the Wasm operand stack, so it is safe to emit with the call arguments already pushed.
+    if (call->IsUnmanaged() && call->IsSuppressGCTransition() &&
+        (GetStackPointerReg(m_compiler->funCurrentFuncIdx()) != REG_NA))
+    {
+        GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetStackPointerRegIndex());
+        GetEmitter()->emitIns_I(INS_global_set, EA_HANDLE_CNS_RELOC,
+                                (cnsval_ssize_t)(size_t)m_compiler->eeGetWasmWellKnownGlobals()->stackPointer);
+    }
+
     // A non-null target expression always indicates an indirect call on Wasm,
     // as currently the only possible result of the target expression would be a
     // table index which must be used via call_indirect

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2913,8 +2913,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     // stale global (our caller's SP, above our frame) and overlaps/clobbers our address-taken locals.
     // Publish our shadow SP here so the callee allocates below our frame. This is a net-zero operation
     // on the Wasm operand stack, so it is safe to emit with the call arguments already pushed.
-    if (call->IsUnmanaged() && call->IsSuppressGCTransition() &&
-        (GetStackPointerReg(m_compiler->funCurrentFuncIdx()) != REG_NA))
+    if (call->IsUnmanaged() && call->IsSuppressGCTransition())
     {
         GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetStackPointerRegIndex());
         GetEmitter()->emitIns_I(INS_global_set, EA_HANDLE_CNS_RELOC,


### PR DESCRIPTION
## Summary

On `FEATURE_PORTABLE_ENTRYPOINTS` (wasm) R2R, generated code keeps its shadow stack pointer in a local and leaves the `__stack_pointer` global stale. The P/Invoke prolog (`JIT_PInvokeBegin`) normally publishes it before native code runs, but that prolog is **skipped for `SuppressGCTransition` calls**. A native `SuppressGCTransition` callee (emscripten, which uses `__stack_pointer`) then allocates its shadow frame from the stale global — the caller's SP, *above* the R2R frame — and clobbers the caller's address-taken locals.

This manifests in R2R exception handling: `FindFirstPassHandler` spills its by-ref `StackFrameIterator`, calls the `SuppressGCTransition` QCall `RhpEHEnumInitFromStackFrameIterator`, the callee clobbers the spilled pointer, and the next `frameIter.ControlPC` read faults with a spurious `NullReferenceException`. EH dispatch can't GC-transition mid-unwind, which is why its QCalls are `SuppressGCTransition` and hit this path.

Fixes #130923.

## Fix

Publish the shadow SP to the `__stack_pointer` global just before the call, so the callee allocates its shadow frame below the current frame. The publish is net-zero on the wasm operand stack, so it is safe to emit after the call arguments are pushed. The `stackPointer` global handle comes from the `getWasmWellKnownGlobals` JIT-EE API (added in #129717) and is referenced via a `WASM_GLOBAL_INDEX_LEB` relocation, matching the existing `global.get` uses in wasm codegen.

## Validation

The bug only *reproduces* with the (not-yet-merged) R2R-on-wasm bring-up stack, so there is no wasm-R2R CI leg on `main` yet. Verified `codegenwasm.cpp` compiles clean in the wasm JIT (`clr.jit`, 0 errors). Behaviorally validated on the R2R-on-wasm prototype: unfixed crashes, fixed passes, plus a byte-identical R2R↔interpreter battery.

## Notes for reviewers

- Draft because it cannot be CI-validated on `main` until the R2R-on-wasm consumption path lands.
- Depends on the `getWasmWellKnownGlobals` API from #129717 (fixes #129712), now on `main`.
- Related bring-up family: #130634.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
