### PR TITLE
Fix address sanitizer issues

### DIFF
--- a/src/coreclr/utilcode/ex.cpp
+++ b/src/coreclr/utilcode/ex.cpp
@@ -96,12 +96,7 @@ void Exception::Delete(Exception* pvMemory)
         return;
     }
 
-#ifdef DACCESS_COMPILE
     delete pvMemory;
-#else
-    ::delete pvMemory;
-#endif
-
 }
 
 void Exception::GetMessage(SString &result)

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3896,7 +3896,7 @@ void ReflectionModule::Destruct()
 
     Module::Destruct();
 
-    delete (uint32_t*)m_pDynamicMetadata;
+    delete[] (uint8_t*)m_pDynamicMetadata;
     m_pDynamicMetadata = (TADDR)NULL;
 
     m_CrstLeafLock.Destroy();
@@ -4033,7 +4033,7 @@ void ReflectionModule::CaptureModuleMetaDataToMemory()
     {
         CrstHolder ch(&m_CrstLeafLock);
 
-        delete (uint32_t*)m_pDynamicMetadata;
+        delete[] (uint8_t*)m_pDynamicMetadata;
 
         m_pDynamicMetadata = (TADDR)pBuffer.Extract();
     }


### PR DESCRIPTION
This fixes two issues discovered by the address sanitizer:
* ::delete called on base class pointer is not correct, as the :: tells the compiler to use sized delete and since that one gets size of the base class and not the real type, the sanitizer complains. It is currently benign, as the sized delete ignores the size.
* Deletion of an array via non-array delete operator (and using a wrong type)

Close #130031