### PR TITLE
Embed debug info in host object libraries to avoid LNK4099

### DIFF
--- a/src/native/corehost/CMakeLists.txt
+++ b/src/native/corehost/CMakeLists.txt
@@ -98,6 +98,13 @@ if(NOT CLR_CMAKE_TARGET_BROWSER)
     # consumption (libnethost, libhostfxr), so LTCG must be disabled to ensure
     # that non-MSVC toolchains can work with them.
     set_target_properties(minipal_objects PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
+    if (MSVC)
+        # Embed debug info in the object files (/Z7). CMake does not assign a
+        # compile PDB to OBJECT libraries, so the objects archived into the shipped
+        # libnethost/libhostfxr would otherwise reference an absent vc140.pdb,
+        # producing LNK4099 for consumers.
+        set_target_properties(minipal_objects PROPERTIES MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+    endif()
 
     add_subdirectory(hostcommon)
     add_subdirectory(hostmisc)

--- a/src/native/corehost/hostmisc/CMakeLists.txt
+++ b/src/native/corehost/hostmisc/CMakeLists.txt
@@ -80,6 +80,12 @@ if(NOT CLR_CMAKE_TARGET_BROWSER)
     target_link_libraries(hostmisc_public PUBLIC minipal_objects)
 endif()
 set_target_properties(hostmisc_public PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
+if (MSVC)
+    # Embed debug info in the object files (/Z7). CMake does not assign a compile
+    # PDB to OBJECT libraries, so the objects archived into the shipped libhostfxr
+    # would otherwise reference an absent vc140.pdb, producing LNK4099 for consumers.
+    set_target_properties(hostmisc_public PROPERTIES MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+endif()
 
 add_library(hostmisc::public ALIAS hostmisc_public)
 
@@ -90,3 +96,9 @@ if(NOT CLR_CMAKE_TARGET_BROWSER)
     target_link_libraries(hostmisc_c PUBLIC minipal_objects)
 endif()
 set_target_properties(hostmisc_c PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
+if (MSVC)
+    # Embed debug info in the object files (/Z7). CMake does not assign a compile
+    # PDB to OBJECT libraries, so the objects archived into the shipped libnethost
+    # would otherwise reference an absent vc140.pdb, producing LNK4099 for consumers.
+    set_target_properties(hostmisc_c PROPERTIES MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+endif()


### PR DESCRIPTION
The object libraries embedded into the shipped libnethost.lib and libhostfxr.lib were referencing a vc140.pdb. Consumers linking these static libraries get LNK4099 warnings.

Compile these object libraries with embedded debug info (/Z7) instead. This matches what we do for NativeAOT Runtime.GC.* and for the cDAC descriptor.

cc @dotnet/appmodel @AaronRobinsonMSFT 

Fixes https://github.com/dotnet/runtime/issues/116527