### PR TITLE
Clarify WASM shuffle/swizzle codegen comments

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -29356,6 +29356,9 @@ GenTree* Compiler::gtNewSimdShuffleNode(
     uint64_t value  = 0;
     simd_t   vecCns = {};
 
+    // i8x16.swizzle indexes bytes, so expand each element-granular selector into elementSize
+    // consecutive byte indices. An out-of-range selector becomes 0xFF bytes so swizzle's native
+    // "index >= 16 -> 0" behavior zero-fills that element.
     for (size_t index = 0; index < elementCount; index++)
     {
         value = op2->GetIntegralVectorConstElement(index, simdBaseType);
@@ -29369,8 +29372,6 @@ GenTree* Compiler::gtNewSimdShuffleNode(
         }
         else
         {
-            // Swizzle selects zero for any byte index that is out of range (>= 16), so mark every
-            // byte of an out-of-range element accordingly.
             for (uint32_t i = 0; i < elementSize; i++)
             {
                 vecCns.u8[(index * elementSize) + i] = 0xFF;

--- a/src/coreclr/jit/hwintrinsiccodegenwasm.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenwasm.cpp
@@ -43,7 +43,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 if ((info.id == NI_PackedSimd_Swizzle) && node->Op(2)->isContained())
                 {
                     // A constant, fully in-range mask was lowered to an immediate i8x16.shuffle.
-                    // genConsumeMultiOpOperands left the source on the value stack once (the mask
+                    // prior codegen left the source on the value stack once (the mask
                     // operand is contained, so no v128.const was materialized). i8x16.shuffle
                     // selects from two vectors, so push the source a second time and encode the
                     // mask as the 16-byte shuffle immediate.


### PR DESCRIPTION
Post-merge follow-up to #130850, addressing three review comments from @adamperlin.

- `hwintrinsiccodegenwasm.cpp`: reword the contained-mask Swizzle->`i8x16.shuffle` remark. On Wasm `genConsumeMultiOpOperands` only updates liveness and doesn't touch the value stack, so the comment now says "prior codegen left the source on the value stack once" rather than attributing it to `genConsumeMultiOpOperands`.

----------

- `gentree.cpp` (`TARGET_WASM` Shuffle-lowering branch): add a lead-in comment describing the element->byte-index expansion -- each element-granular selector expands into `elementSize` consecutive byte indices for `i8x16.swizzle`, and an out-of-range selector becomes `0xFF` bytes so swizzle's native `index >= 16 -> 0` behavior zero-fills that element. Dropped the now-redundant inline else-block comment.

The third comment (`lowerwasm.cpp`, feeding a constant-zero second operand to `i8x16.shuffle` instead of the source twice) is addressed in the thread rather than in code: a `local.get` of the existing source is smaller than materializing a 16-byte `v128.const` zero, and it can't remove the special case since the Swizzle node is 2-operand (source, mask->immediate) with no second-vector slot.

Comment-only; no functional change.

> [!NOTE]
> This PR description was drafted by Copilot on behalf of @tannergooding.
