### PR TITLE
Add regression test for #124749

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_124749/Runtime_124749.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124749/Runtime_124749.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+// fgOptimizeHWIntrinsic transforms "(-v1) + v2" to "v2 - v1", reversing the
+// evaluation order of the operands. When CSE has planted a store to a local in
+// v1 that is read by v2, and assertion propagation re-morphs the tree, the swap
+// schedules the read before its def, tripping a use-before-def assert during
+// Rationalization.
+
+public class Runtime_124749
+{
+    public static byte[] s_2;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void M0()
+    {
+        var vr1 = Vector256.CreateScalar(1U);
+        var vr3 = Vector256.Create<uint>(1);
+        var vr5 = Vector256.Create<uint>(0);
+        var vr7 = Vector256.Create<uint>(1);
+        var vr6 = Avx512CD.VL.LeadingZeroCount(vr7);
+        var vr4 = Avx2.CompareEqual(vr5, vr6);
+        var vr2 = Avx2.Subtract(vr3, vr4);
+        if (Avx.TestZ(vr1, vr2))
+        {
+            var vr0 = s_2[0];
+        }
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        if (!Avx512CD.VL.IsSupported)
+        {
+            return;
+        }
+
+        try
+        {
+            M0();
+        }
+        catch (NullReferenceException)
+        {
+            // Expected if the branch reading the uninitialized "s_2" is taken.
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_124749/Runtime_124749.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124749/Runtime_124749.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
﻿Adds a JIT regression test for the `'"'"'!"Write to unaliased local overlaps outstanding read"'"'"'` assert (lir.cpp) reported in #124749, found by Fuzzlyn.

The bug was already fixed by #128962. `fgOptimizeHWIntrinsic` rewrites `Add(Neg(X), Y)` to `Sub(Y, X)`, reversing operand evaluation order (for SIMD, negation is `Subtract(0, X)`). When CSE had planted a `COMMA(STORE cse_temp, use)` def inside `X` and left a bare `LCL_VAR cse_temp` use as `Y`, the swap scheduled the use before its def, tripping the use-before-def assert during Rationalization. #128962 guards the transform with `gtCanSwapOrder(op1, op2)`, which returns `false` here because `op1` carries `GTF_ASG` (the store) while `op2` is non-invariant.

This just adds coverage; there is no product change.

----------

Verification:
- Reproduced the exact assert in `Program:M0()` via SPMI replay at the collection'"'"'s compatible commit; backporting only the `gtCanSwapOrder` guard made it disappear.
- On current `main`, removing the guard and rebuilding `clrjit.dll` reproduced the assert through this repro; restoring it produced a clean run.

I could not execute-verify locally as this machine lacks AVX512, so the test no-ops here, but the SPMI collection is this exact repro and validates it on AVX512 legs.

Closes #124749

> [!NOTE]
> This PR description was drafted by Copilot.
