### PR TITLE
Add check that `libnethost` contains no LTCG objects

### DIFF
--- a/src/native/corehost/test/nativehost/CMakeLists.txt
+++ b/src/native/corehost/test/nativehost/CMakeLists.txt
@@ -67,10 +67,19 @@ target_compile_definitions(nativehost_static PRIVATE NETHOST_USE_AS_STATIC)
 
 target_link_libraries(nativehost_static PRIVATE
     libnethost
-    hostmisc
+    hostmisc_public
     $<$<BOOL:${PTHREAD_LIB}>:${PTHREAD_LIB}>)
 
 if (CLR_CMAKE_TARGET_WIN32)
     target_link_libraries(nativehost_static PRIVATE ole32 oleaut32)
+endif()
+
+if (MSVC)
+    # Add a linker hook to validate that modules with LTCG are not found.
+    # Shipped static libraries (libnethost) must have LTCG disabled to ensure
+    # that non-MSVC toolchains can work with them.
+    set_target_properties(nativehost_static PROPERTIES
+        INTERPROCEDURAL_OPTIMIZATION OFF
+        CXX_LINKER_LAUNCHER "${CMAKE_COMMAND};-P;${CMAKE_CURRENT_SOURCE_DIR}/run-linker-verify-no-ltcg.cmake")
 endif()
 

--- a/src/native/corehost/test/nativehost/run-linker-verify-no-ltcg.cmake
+++ b/src/native/corehost/test/nativehost/run-linker-verify-no-ltcg.cmake
@@ -2,7 +2,7 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 
 # Linker launcher that fails the build if an object compiled with LTCG (/GL) is
-# pulled in. Such objects are rejected by non-MSVC linkers. MSVC doesn't treat
+# pulled in. Such objects require an exactly matching MSVC toolchain version. MSVC doesn't treat
 # this as an error. It prints "module compiled with /GL found" and succeeds.
 # This launcher runs the link command and errors if that message is found.
 
@@ -29,8 +29,8 @@ endif()
 
 if("${_linker_stdout}${_linker_stderr}" MATCHES "module compiled with /GL found")
     message(FATAL_ERROR
-        "An object compiled with LTCG (/GL) was pulled into this link. LTCG objects are "
-        "rejected by non-MSVC linkers such as lld-link. Disable interprocedural optimization "
+        "An object compiled with LTCG (/GL) was pulled into this link. LTCG objects require"
+        "an exactly matching MSVC toolchain version. Disable interprocedural optimization "
         "(set INTERPROCEDURAL_OPTIMIZATION OFF) on the target that introduced the /GL object.")
 endif()
 

--- a/src/native/corehost/test/nativehost/run-linker-verify-no-ltcg.cmake
+++ b/src/native/corehost/test/nativehost/run-linker-verify-no-ltcg.cmake
@@ -1,0 +1,39 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+
+# Linker launcher that fails the build if an object compiled with LTCG (/GL) is
+# pulled in. Such objects are rejected by non-MSVC linkers. MSVC doesn't treat
+# this as an error. It prints "module compiled with /GL found" and succeeds.
+# This launcher runs the link command and errors if that message is found.
+
+# cmake -P <script> <linker> <linker-arg> ...
+# so the command starts at CMAKE_ARGV3.
+set(_command "")
+math(EXPR _last "${CMAKE_ARGC}-1")
+foreach(_i RANGE 3 ${_last})
+    list(APPEND _command "${CMAKE_ARGV${_i}}")
+endforeach()
+
+execute_process(
+    COMMAND ${_command}
+    OUTPUT_VARIABLE _linker_stdout
+    ERROR_VARIABLE _linker_stderr
+    RESULT_VARIABLE _linker_result)
+
+if(_linker_stdout)
+    message("${_linker_stdout}")
+endif()
+if(_linker_stderr)
+    message("${_linker_stderr}")
+endif()
+
+if("${_linker_stdout}${_linker_stderr}" MATCHES "module compiled with /GL found")
+    message(FATAL_ERROR
+        "An object compiled with LTCG (/GL) was pulled into this link. LTCG objects are "
+        "rejected by non-MSVC linkers such as lld-link. Disable interprocedural optimization "
+        "(set INTERPROCEDURAL_OPTIMIZATION OFF) on the target that introduced the /GL object.")
+endif()
+
+if(NOT _linker_result EQUAL 0)
+    message(FATAL_ERROR "Linker failed: ${_linker_result}")
+endif()


### PR DESCRIPTION
We have ended up with LTCG objects in libnethost more than once. Add a CMake linker launcher on the existing `nativehost_static` test that runs the link and fails the build if MSVC reports "module compiled with /GL found" (similar to the output check in https://github.com/dotnet/runtime/pull/111651).

cc @dotnet/appmodel @AaronRobinsonMSFT 