### PR TITLE
[wasm] Implement WasmBase LeadingZeroCount/TrailingZeroCount JIT intrinsics

### DIFF
--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -1014,7 +1014,7 @@ static const HWIntrinsicIsaRange hwintrinsicIsaRangeArray[] = {
     { NI_Illegal, NI_Illegal },                                 //      SveSha3_Arm64
     { NI_Illegal, NI_Illegal },                                 //      SveSm4_Arm64
 #elif defined(TARGET_WASM)
-    { NI_Illegal, NI_Illegal },                                 //      WasmBase
+    { FIRST_NI_WasmBase, LAST_NI_WasmBase },                    // WasmBase
     { FIRST_NI_PackedSimd, LAST_NI_PackedSimd },                // PackedSimd
     { FIRST_NI_Vector, LAST_NI_Vector },                        // Vector128
 #else

--- a/src/coreclr/jit/hwintrinsiclistwasm.h
+++ b/src/coreclr/jit/hwintrinsiclistwasm.h
@@ -83,11 +83,12 @@ HARDWARE_INTRINSIC(PackedSimd,      ZeroExtendWideningUpper,                    
 #define LAST_NI_PackedSimd NI_PackedSimd_ZeroExtendWideningUpper
 
 //  WasmBase Intrinsics
-//  These scalar intrinsics are special-imported (see hwintrinsicwasm.cpp) and lowered to the existing
-//  NI_PRIMITIVE_*ZeroCount GT_INTRINSIC nodes, which codegen already emits as wasm clz/ctz.
+//  These scalar intrinsics are special-imported (see hwintrinsicwasm.cpp) and always rewritten into the
+//  existing NI_PRIMITIVE_*ZeroCount GT_INTRINSIC nodes (which codegen already emits as wasm clz/ctz), so
+//  they never materialize as GenTreeHWIntrinsic nodes -- hence HW_Flag_InvalidNodeId.
 #define FIRST_NI_WasmBase           NI_WasmBase_LeadingZeroCount
-HARDWARE_INTRINSIC(WasmBase,        LeadingZeroCount,                                                0,               1,     INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                      INS_invalid,                      INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          -1,        -1,         HW_Category_Scalar,                 HW_Flag_SpecialImport|HW_Flag_NoFloatingPointUsed)
-HARDWARE_INTRINSIC(WasmBase,        TrailingZeroCount,                                               0,               1,     INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                      INS_invalid,                      INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          -1,        -1,         HW_Category_Scalar,                 HW_Flag_SpecialImport|HW_Flag_NoFloatingPointUsed)
+HARDWARE_INTRINSIC(WasmBase,        LeadingZeroCount,                                                0,               1,     INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                      INS_invalid,                      INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          -1,        -1,         HW_Category_Scalar,                 HW_Flag_InvalidNodeId|HW_Flag_NoFloatingPointUsed)
+HARDWARE_INTRINSIC(WasmBase,        TrailingZeroCount,                                               0,               1,     INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                      INS_invalid,                      INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          -1,        -1,         HW_Category_Scalar,                 HW_Flag_InvalidNodeId|HW_Flag_NoFloatingPointUsed)
 #define LAST_NI_WasmBase            NI_WasmBase_TrailingZeroCount
 #endif // FEATURE_HW_INTRINSICS
 

--- a/src/coreclr/jit/hwintrinsiclistwasm.h
+++ b/src/coreclr/jit/hwintrinsiclistwasm.h
@@ -81,6 +81,14 @@ HARDWARE_INTRINSIC(PackedSimd,      Xor,                                        
 HARDWARE_INTRINSIC(PackedSimd,      ZeroExtendWideningLower,                                         16,              1,     INS_i16x8_extend_low_u_i8x16,         INS_i16x8_extend_low_u_i8x16,         INS_i32x4_extend_low_u_i16x8,         INS_i32x4_extend_low_u_i16x8,         INS_i64x2_extend_low_u_i32x4,     INS_i64x2_extend_low_u_i32x4,     INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          -1,        -1,         HW_Category_SIMD,                   HW_Flag_BaseTypeFromFirstArg)
 HARDWARE_INTRINSIC(PackedSimd,      ZeroExtendWideningUpper,                                         16,              1,     INS_i16x8_extend_high_u_i8x16,        INS_i16x8_extend_high_u_i8x16,        INS_i32x4_extend_high_u_i16x8,        INS_i32x4_extend_high_u_i16x8,        INS_i64x2_extend_high_u_i32x4,    INS_i64x2_extend_high_u_i32x4,    INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          -1,        -1,         HW_Category_SIMD,                   HW_Flag_BaseTypeFromFirstArg)
 #define LAST_NI_PackedSimd NI_PackedSimd_ZeroExtendWideningUpper
+
+//  WasmBase Intrinsics
+//  These scalar intrinsics are special-imported (see hwintrinsicwasm.cpp) and lowered to the existing
+//  NI_PRIMITIVE_*ZeroCount GT_INTRINSIC nodes, which codegen already emits as wasm clz/ctz.
+#define FIRST_NI_WasmBase           NI_WasmBase_LeadingZeroCount
+HARDWARE_INTRINSIC(WasmBase,        LeadingZeroCount,                                                0,               1,     INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                      INS_invalid,                      INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          -1,        -1,         HW_Category_Scalar,                 HW_Flag_SpecialImport|HW_Flag_NoFloatingPointUsed)
+HARDWARE_INTRINSIC(WasmBase,        TrailingZeroCount,                                               0,               1,     INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                      INS_invalid,                      INS_invalid,                          INS_invalid,                          INS_invalid,                          INS_invalid,                          -1,        -1,         HW_Category_Scalar,                 HW_Flag_SpecialImport|HW_Flag_NoFloatingPointUsed)
+#define LAST_NI_WasmBase            NI_WasmBase_TrailingZeroCount
 #endif // FEATURE_HW_INTRINSICS
 
 #undef HARDWARE_INTRINSIC

--- a/src/coreclr/jit/hwintrinsicwasm.cpp
+++ b/src/coreclr/jit/hwintrinsicwasm.cpp
@@ -105,6 +105,26 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
     switch (intrinsic)
     {
+        case NI_WasmBase_LeadingZeroCount:
+        {
+            assert(sig->numArgs == 1);
+
+            op1     = impPopStack().val;
+            retNode = new (this, GT_INTRINSIC) GenTreeIntrinsic(retType, op1, NI_PRIMITIVE_LeadingZeroCount,
+                                                                nullptr R2RARG(CORINFO_CONST_LOOKUP{IAT_VALUE}));
+            break;
+        }
+
+        case NI_WasmBase_TrailingZeroCount:
+        {
+            assert(sig->numArgs == 1);
+
+            op1     = impPopStack().val;
+            retNode = new (this, GT_INTRINSIC) GenTreeIntrinsic(retType, op1, NI_PRIMITIVE_TrailingZeroCount,
+                                                                nullptr R2RARG(CORINFO_CONST_LOOKUP{IAT_VALUE}));
+            break;
+        }
+
         case NI_PackedSimd_CompareGreaterThan:
         {
             assert(sig->numArgs == 2);


### PR DESCRIPTION
## Summary

The internal `System.Runtime.Intrinsics.Wasm.WasmBase` class (already on `main`) declares `LeadingZeroCount`/`TrailingZeroCount` (int/uint/long/ulong) as self-recursive intrinsic stubs, but the RyuJIT-wasm backend left them unimplemented — the WasmBase `IsaRange` was `{ NI_Illegal, NI_Illegal }`, so these fell back to the managed software implementation.

This wires the two intrinsics into the RyuJIT-wasm backend so they lower to native wasm `clz`/`ctz`:

- **`hwintrinsic.cpp`** — give WasmBase a real IsaRange `{ FIRST_NI_WasmBase, LAST_NI_WasmBase }`.
- **`hwintrinsiclistwasm.h`** — add the two scalar `HARDWARE_INTRINSIC` entries (`HW_Category_Scalar`, `HW_Flag_SpecialImport|HW_Flag_NoFloatingPointUsed`), matching the established xarch scalar `LeadingZeroCount`/`TrailingZeroCount` pattern (simdSize `0`).
- **`hwintrinsicwasm.cpp`** — special-import each to a `GT_INTRINSIC` over the existing `NI_PRIMITIVE_LeadingZeroCount`/`NI_PRIMITIVE_TrailingZeroCount`, which wasm codegen already lowers to `i32.clz`/`i64.clz` and `i32.ctz`/`i64.ctz` (see `codegenwasm.cpp`).

**Consumer:** `System.Numerics.BitOperations` (`LeadingZeroCount`/`Log2`/`TrailingZeroCount`) routes through `WasmBase.LeadingZeroCount(value)` when `WasmBase.IsSupported`. Implementing these makes core bit operations use native wasm `clz`/`ctz` on RyuJIT-wasm instead of the software fallback.

## API review

No new or changed public API. `WasmBase` is `internal` and already shipped on `main`; this PR only implements its JIT lowering. No API review required.

## Validation

- ✅ **JIT compiles clean.** The wasm cross-JIT (`clrjit_universal_wasm_arm64`) builds with 0 warnings / 0 errors after a full recompile of the changed sources (`clr.jit -c Release`). Baseline `clr+libs -rc Release` and `clr -os browser -c Release` also build clean.
- ✅ **Lowering target already exists.** `NI_PRIMITIVE_*ZeroCount` `GT_INTRINSIC` nodes for `TYP_INT`/`TYP_LONG` are already handled by `codegenwasm.cpp` (emits `i32/i64.clz`/`ctz`), so the intrinsics reuse a proven codegen path.
- ⚠️ **Runtime execution not verified locally.** Attempting to run under the experimental wasm-CoreCLR `corerun.js` fails at `coreclr_initialize` (`0x80070057`) **even for the pre-built `tieringtest.dll` smoke test** — a pre-existing bring-up limitation of the experimental runtime in this environment (note the `System.Private.CoreLib.NotReadyYet.wasm` artifact), unrelated to this change and occurring before any JIT/intrinsic code runs. Existing `System.Numerics.BitOperations` tests already cover `LeadingZeroCount`/`TrailingZeroCount` for all overloads and will exercise this path once the wasm runtime can execute.

Opening as **draft** because end-to-end runtime execution could not be verified locally (blocked by the experimental runtime, not by this change).

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.