### PR TITLE
[wasm] Disable optimistic instruction sets for WASI R2R

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -87,7 +87,7 @@ namespace ILCompiler
                 Helpers.GetTargetSpec(Get(_command.TargetArchitecture), Get(_command.TargetOS));
             bool allowOptimistic = _command.OptimizationMode != OptimizationMode.PreferSize;
 
-            if (targetOS is TargetOS.iOS or TargetOS.tvOS or TargetOS.iOSSimulator or TargetOS.tvOSSimulator or TargetOS.MacCatalyst or TargetOS.Browser)
+            if (targetOS is TargetOS.iOS or TargetOS.tvOS or TargetOS.iOSSimulator or TargetOS.tvOSSimulator or TargetOS.MacCatalyst or TargetOS.Browser or TargetOS.Wasi)
             {
                 // These platforms do not support jitted code, so we want to ensure that we don't
                 // need to fall back to the interpreter for any hardware-intrinsic optimizations.


### PR DESCRIPTION
## Summary

crossgen2 disables optimistic (non-baseline) hardware-intrinsic instruction sets for target OSes that run interpreter-only with no JIT fallback, so an R2R image never bakes in an optimistic intrinsic the target can't execute and can't fall back to the interpreter for. WASI is such a target (wasm, interpreter + R2R, no JIT) — exactly like Browser and the Apple mobile targets — but was omitted from the list. Add `TargetOS.Wasi` alongside them.

```csharp
if (targetOS is TargetOS.iOS or TargetOS.tvOS or TargetOS.iOSSimulator or TargetOS.tvOSSimulator
    or TargetOS.MacCatalyst or TargetOS.Browser or TargetOS.Wasi)
```

One-token change, correct by parity with the existing interpreter-only targets. crossgen2 builds clean (`clr.aot`, 0 errors).

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
