### PR TITLE
[wasm] Fix v128.load / v128.store opcodes in the R2R ObjectWriter

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
@@ -145,8 +145,8 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         MemoryFill = unchecked((int)0xFC00000B),
         TableInit = unchecked((int)0xFC00000C),
         TableGrow = unchecked((int)0xFC00000F),
-        V128Load = unchecked((int)0xFD00000A),
-        V128Store = unchecked((int)0xFD000000),
+        V128Load = unchecked((int)0xFD000000),
+        V128Store = unchecked((int)0xFD00000B),
     }
 
     public static class WasmExprKindExtensions


### PR DESCRIPTION
## Summary

The `WasmExprKind` opcode constants for the two 128-bit memory instructions in the R2R wasm ObjectWriter were wrong:

```csharp
V128Load  = unchecked((int)0xFD00000A),   // sub-opcode 0x0A is v128.load64_splat
V128Store = unchecked((int)0xFD000000),   // sub-opcode 0x00 is v128.load
```

The SIMD sub-opcodes are `v128.load` = `0x00` and `v128.store` = `0x0B` (the encoder writes byte 0 = `kind >> 24` = `0xFD` prefix, then the low 24 bits as the ULEB sub-opcode). So `V128.Store()` emitted a `v128.load` and `V128.Load()` emitted a `v128.load64_splat`.

Any thunk that spills/reloads a `v128` argument — e.g. the delay-load helper for a method call with `Vector128<T>` parameters — therefore produced an **invalid module**:

```
WebAssembly.Module(): Compiling function #N failed:
v128.load[0] expected type i32, found local.get of type v128
```

(the "store" was actually a load, consuming the v128 value as the address), or, on the reload side, a **corrupted vector** (`load64_splat` reads 8 bytes and splats them instead of loading the full 16).

## Fix

```csharp
V128Load  = unchecked((int)0xFD000000),   // v128.load  = 0xFD 0x00
V128Store = unchecked((int)0xFD00000B),   // v128.store = 0xFD 0x0B
```

I audited the rest of the `WasmExprKind` opcodes (base, `0xFC` bulk-memory/table, SIMD) against the spec — these two were the only incorrect entries.

## Why it was latent

Nothing emitted `V128.Store`/`V128.Load` until `Vector128<T>` began flowing through these thunks by value (the wasm v128 ABI work in #130866). Verified end-to-end on the R2R-on-wasm prototype: with this fix, a `Vector128` method call whose delay-load thunk spills/reloads the vector produces a valid module that executes correctly as R2R (the emitted thunk now shows `v128.store` on spill and `v128.load` on reload). Helps unblock #130866.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
