### PR TITLE
Use user-arg accessors when expanding runtime lookups

### DIFF
--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -183,12 +183,12 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
         return false;
     }
 
-    assert(call->gtArgs.CountArgs() == 2);
+    assert(call->gtArgs.CountUserArgs() == 2);
     // The call has the following signature:
     //
     //   type = call(genericCtx, signatureCns);
     //
-    const GenTree* signatureNode = call->gtArgs.GetArgByIndex(1)->GetNode();
+    const GenTree* signatureNode = call->gtArgs.GetUserArgByIndex(1)->GetNode();
     if (!signatureNode->IsCnsIntOrI())
     {
         // We expect the signature to be a constant node here (it's marked as DONT_CSE)
@@ -260,7 +260,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
         gtUpdateStmtSideEffects(stmt);
     }
 
-    GenTree* ctxTree = call->gtArgs.GetArgByIndex(0)->GetNode();
+    GenTree* ctxTree = call->gtArgs.GetUserArgByIndex(0)->GetNode();
 
     // Prepare slotPtr tree (TODO: consider sharing this part with impRuntimeLookup)
     GenTree* slotPtrTree   = gtCloneExpr(ctxTree);

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -872,7 +872,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
     JITDUMP("offsetOfThreadStaticBlocks= %u\n", dspOffset(threadStaticBlocksInfo.offsetOfThreadStaticBlocks));
     JITDUMP("offsetOfBaseOfThreadLocalData= %u\n", dspOffset(threadStaticBlocksInfo.offsetOfBaseOfThreadLocalData));
 
-    assert(call->gtArgs.CountArgs() == 1);
+    assert(call->gtArgs.CountUserArgs() == 1);
 
     // Split block right before the call tree
     BasicBlock* prevBb       = block;
@@ -1020,7 +1020,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
     // Cache the tls value
     tlsValueDef                              = gtNewStoreLclVarNode(tlsLclNum, tlsValue);
     GenTree* tlsLclValueUse                  = gtNewLclVarNode(tlsLclNum);
-    GenTree* typeThreadStaticBlockIndexValue = call->gtArgs.GetArgByIndex(0)->GetNode();
+    GenTree* typeThreadStaticBlockIndexValue = call->gtArgs.GetUserArgByIndex(0)->GetNode();
     assert(genActualType(typeThreadStaticBlockIndexValue) == TYP_INT);
 
     if (helper == CORINFO_HELP_GETDYNAMIC_NONGCTHREADSTATIC_BASE_NOCTOR_OPTIMIZED2)
@@ -2902,7 +2902,7 @@ bool Compiler::fgExpandStackArrayAllocation(BasicBlock* block, Statement* stmt, 
 
     // Initialize the array method table pointer.
     //
-    GenTree* const   mt      = call->gtArgs.GetArgByIndex(typeArgIndex)->GetNode();
+    GenTree* const   mt      = call->gtArgs.GetUserArgByIndex(typeArgIndex)->GetNode();
     GenTree* const   mtStore = gtNewStoreValueNode(TYP_I_IMPL, stackLocalAddress, mt);
     Statement* const mtStmt  = fgNewStmtFromTree(mtStore);
 
@@ -2910,7 +2910,7 @@ bool Compiler::fgExpandStackArrayAllocation(BasicBlock* block, Statement* stmt, 
 
     // Initialize the array length.
     //
-    GenTree* const   lengthArg     = call->gtArgs.GetArgByIndex(lengthArgIndex)->GetNode();
+    GenTree* const   lengthArg     = call->gtArgs.GetUserArgByIndex(lengthArgIndex)->GetNode();
     GenTree* const   lengthArgInt  = fgOptimizeCast(gtNewCastNode(TYP_INT, lengthArg, false, TYP_INT));
     GenTree* const   lengthAddress = gtNewOperNode(GT_ADD, TYP_I_IMPL, gtCloneExpr(stackLocalAddress),
                                                    gtNewIconNode(OFFSETOF__CORINFO_Array__length, TYP_I_IMPL));


### PR DESCRIPTION
`fgExpandRuntimeLookupsForCall` indexed the runtime-lookup helper call's arguments with the raw `CountArgs`/`GetArgByIndex` accessors, assuming exactly its two user args `(genericCtx, signatureCns)`.

On wasm, `AddFinalArgsAndDetermineABIInfo` prepends a non-user `WasmShadowStackPointer` arg to the front of every managed call during global morph, which runs before `fgExpandRuntimeLookups`. That leading arg shifts the raw indices, so:

- `assert(call->gtArgs.CountArgs() == 2)` fires (there are three args), and
- with asserts off, `GetArgByIndex(0)`/`GetArgByIndex(1)` read the shadow-stack pointer and the context instead of the context and the signature.

Switch to `CountUserArgs`/`GetUserArgByIndex`, which skip non-user args (`r2r cell`, `wasm sp`) the same way the rest of the JIT already reads helper-call args. This is behavior-identical on targets that don't prepend such args, and fixes shared-generic runtime lookups on wasm.

This shows up across shared-generic (`[System.__Canon]`) methods; it accounts for ~10k of the assert-failing methods in a wasm SuperPMI altjit replay over the libraries/coreclr test collections.

> [!NOTE]
> This PR was authored with GitHub Copilot.
