### PR TITLE
Handle wasm this-arg in LowerVirtualVtableCall

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7356,21 +7356,26 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
 {
     noway_assert(call->gtCallType == CT_USER_FUNC);
 
-    GenTree* thisArgNode;
+    CallArg* thisArg;
     if (call->IsTailCallViaJitHelper())
     {
         assert(call->gtArgs.CountArgs() > 0);
-        thisArgNode = call->gtArgs.GetArgByIndex(0)->GetNode();
+        thisArg = call->gtArgs.GetArgByIndex(0);
     }
     else
     {
         assert(call->gtArgs.HasThisPointer());
-        thisArgNode = call->gtArgs.GetThisArg()->GetNode();
+        thisArg = call->gtArgs.GetThisArg();
     }
+    GenTree* thisArgNode = thisArg->GetNode();
 
     // get a reference to the thisPtr being passed
+#if HAS_FIXED_REGISTER_SET
     assert(thisArgNode->OperIs(GT_PUTARG_REG));
     GenTree* thisPtr = thisArgNode->AsUnOp()->gtGetOp1();
+#else
+    GenTree* thisPtr = thisArgNode;
+#endif
 
     // If what we are passing as the thisptr is not already a local, make a new local to place it in
     // because we will be creating expressions based on it.
@@ -7387,7 +7392,11 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
             vtableCallTemp = m_compiler->lvaGrabTemp(true DEBUGARG("virtual vtable call"));
         }
 
+#if HAS_FIXED_REGISTER_SET
         LIR::Use thisPtrUse(BlockRange(), &thisArgNode->AsUnOp()->gtOp1, thisArgNode);
+#else
+        LIR::Use thisPtrUse(BlockRange(), &thisArg->NodeRef(), call);
+#endif
         ReplaceWithLclVar(thisPtrUse, vtableCallTemp);
 
         lclNum = vtableCallTemp;


### PR DESCRIPTION
WASM has no fixed register set (`HAS_FIXED_REGISTER_SET == 0`), so call args are never wrapped in a `GT_PUTARG_REG` node during lowering — `Lowering::InsertPutArgReg` is gated on `HAS_FIXED_REGISTER_SET`, and `LowerPutArgStk` is `unreached()` on wasm. `LowerVirtualVtableCall`, however, asserted the this-arg was a `GT_PUTARG_REG` and read the this-ptr as its operand (`thisArgNode->AsUnOp()->gtGetOp1()`), so it asserts/mis-reads on wasm where the this-ptr is the arg node itself.

The sibling `LowerDelegateInvoke` already handles this exact case with a `#if HAS_FIXED_REGISTER_SET / #else` split. This mirrors that pattern in `LowerVirtualVtableCall`:

- Capture the `CallArg*` (not just its node) so the wasm use-edge can be built via `NodeRef()`.
- Fixed-reg targets keep the `assert(OperIs(GT_PUTARG_REG))` + operand-peel; wasm uses `thisArgNode` directly.
- The `ReplaceWithLclVar` use-edge is `&thisArgNode->AsUnOp()->gtOp1` on fixed-reg, `&thisArg->NodeRef()` (user `call`) on wasm.

Byte-for-byte equivalent on non-wasm targets — the `#if` arms are the pre-existing code. Fixes ~6.4k virtual/delegate-dispatch asserts observed in the wasm altjit over SPMI (e.g. `DelegateCombineImpl`, `MulticastDelegateCombineImpl`).

> [!NOTE]
> This PR description and the change were drafted with Copilot assistance.
