### PR TITLE
Skip profiler leave callback on wasm instead of asserting

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3756,7 +3756,9 @@ void CodeGen::genEmitGSCookieCheck(bool tailCall)
 #ifdef PROFILING_SUPPORTED
 void CodeGen::genProfilingLeaveCallback(unsigned helper)
 {
-    NYI_WASM("genProfilingLeaveCallback");
+    // Profiler ELT hooks are not yet implemented on WASM. The matching enter callback in
+    // genFnProlog is already skipped (#if !TARGET_WASM), so emit nothing here rather than
+    // asserting; this keeps WASM consistently free of ELT hooks. See #130953.
 }
 #endif
 


### PR DESCRIPTION
Turns the `genProfilingLeaveCallback` `NYI_WASM` stub into an explicit no-op on WASM.

`genReturn` and `genJmpPlaceArgs` call `genProfilingLeaveCallback` whenever `compIsProfilerHookNeeded()`, but the matching **enter** callback in `genFnProlog` is compiled out for WASM (`#if !TARGET_WASM`). So WASM would emit a leave hook with no matching enter hook. In normal builds `NYI_WASM` is a no-op, but under the `JitWasmNyiToR2RUnsupported` diagnostic it asserts and flags profiler-leave as an unimplemented oper, rejecting those methods for R2R.

This makes the interim behavior explicit and symmetric with the enter side: emit nothing, keeping WASM consistently free of ELT hooks. It is not a working profiler-ELT implementation — the full enter/leave/tailcall codegen for WASM is tracked by #130953.

No behavioral change in normal DEBUG/Release builds (both no-op already); the change only affects the `JitWasmNyiToR2RUnsupported` diagnostic path.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.
