### PR TITLE
Fix linux-musl-rsicv64 build

### DIFF
--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -762,6 +762,11 @@ int minipal_getcpufeatures(void)
             result |= RiscV64IntrinsicConstants_Zbs;
         }
 
+#ifndef RISCV_HWPROBE_EXT_ZICOND
+// Alpine 3.24's linux-headers package was built on 6.6 LTS kernel, which doesn't define this extension
+#define RISCV_HWPROBE_EXT_ZICOND (1ULL << 35)
+#endif
+
         if (pairs[0].value & RISCV_HWPROBE_EXT_ZICOND)
         {
             result |= RiscV64IntrinsicConstants_Zicond;

--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -763,7 +763,7 @@ int minipal_getcpufeatures(void)
         }
 
 #ifndef RISCV_HWPROBE_EXT_ZICOND
-// Alpine 3.24's linux-headers package was built on 6.6 LTS kernel, which doesn't define this extension
+// Alpine 3.21's linux-headers package was built on 6.6 LTS kernel, which doesn't define this extension
 #define RISCV_HWPROBE_EXT_ZICOND (1ULL << 35)
 #endif
 


### PR DESCRIPTION
Define RISCV_HWPROBE_EXT_ZICOND for compatibility with Alpine.