### PR TITLE
Fix flaky PhysicalFilesWatcher timeout when root is deleted and recreated

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -628,6 +628,20 @@ namespace Microsoft.Extensions.FileProviders.Physical
                             }
                         }
                     }
+                    else if (!Directory.Exists(_root))
+                    {
+                        // The watcher still reports EnableRaisingEvents == true, but _root has been
+                        // deleted out from under it. When the watched directory is deleted, the OS
+                        // watch is torn down (on Linux the inotify watch is bound to the deleted
+                        // directory's inode, so recreating the directory will not resurrect it), yet
+                        // EnableRaisingEvents is only reset once OnError runs TryDisableFileSystemWatcher.
+                        // If a token is (re)registered before that happens, we would otherwise leave a
+                        // dead watcher in place and never observe the root being recreated. Tear down
+                        // the stale watch and fall back to watching for the root to reappear.
+                        _fileWatcher.EnableRaisingEvents = false;
+                        needsRootWatcher = true;
+                        _rootWasUnavailable = true;
+                    }
                 }
             }
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFilesWatcherTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFilesWatcherTests.cs
@@ -648,6 +648,37 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
             await changed;
         }
 
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS, "System.IO.FileSystem.Watcher is not supported on Browser/iOS/tvOS")]
+        public void CreateFileChangeToken_ReRegisterWhileRootMissing_TearsDownStaleWatcher()
+        {
+            using var root = new TempDirectory(GetTestFilePath());
+            string rootPath = root.Path;
+
+            using var fileSystemWatcher = new MockFileSystemWatcher(rootPath);
+
+            // Call BeginInit, which suspends the watcher so enabling it stores EnableRaisingEvents without starting a real
+            // OS watch. This lets us delete the root directory below without the watcher's background
+            // thread asynchronously raising Error (which would make this test racy) while still
+            // reproducing the state this test targets: EnableRaisingEvents == true over a dead watch.
+            fileSystemWatcher.BeginInit();
+
+            using var physicalFilesWatcher = new PhysicalFilesWatcher(rootPath, fileSystemWatcher, pollForChanges: false);
+
+            physicalFilesWatcher.CreateFileChangeToken("file.txt");
+            Assert.True(fileSystemWatcher.EnableRaisingEvents);
+
+            // The watched root is deleted out from under the watcher. On Linux the inotify watch is
+            // torn down (bound to the now-deleted inode), but EnableRaisingEvents keeps reporting true
+            // until OnError runs. A token can be re-registered in that window.
+            Directory.Delete(rootPath);
+
+            // Re-registering while the root is missing must tear down the stale watcher and fall back
+            // to watching for the root to reappear, rather than leaving the dead watch in place.
+            physicalFilesWatcher.CreateFileChangeToken("file.txt");
+            Assert.False(fileSystemWatcher.EnableRaisingEvents);
+        }
+
         [Theory]
         [MemberData(nameof(WatcherModeData))]
         public async Task WildcardToken_DoesNotThrow_WhenRootIsMissing(bool useActivePolling)


### PR DESCRIPTION
Fixes #129691.

## Problem

`PhysicalFilesWatcherTests.CreateFileChangeToken_RootDeletedAndRecreated_TokenFiresWhenFileCreated` intermittently fails with a 30s `System.TimeoutException` (the change token never fires), most frequently under jitstress/pgo legs on Linux.

## Root cause

`TryEnableFileSystemWatcher` decided whether to set up the `PendingCreationWatcher` (the fallback that watches for the root directory to reappear) solely based on `FileSystemWatcher.EnableRaisingEvents`.

On Linux, when the watched root directory is deleted, the runtime `FileSystemWatcher` tears down the inotify watch and queues an `Error`, but **does not** reset `EnableRaisingEvents` — it keeps reporting `true`. The only thing that flips it to `false` is `OnError` → `TryDisableFileSystemWatcher`.

The test deletes the root, then re-registers a token as soon as the initial token fires (from `OnError`'s `CancelAll`). This is a race:

- If the re-registration's `TryEnableFileSystemWatcher` runs **after** `OnError`'s `TryDisableFileSystemWatcher`, `EnableRaisingEvents` is `false` and the `PendingCreationWatcher` is set up correctly.
- If it runs **before** (which is what happens under load), `EnableRaisingEvents` is still `true`, so the `if (!EnableRaisingEvents)` block is skipped and no `PendingCreationWatcher` is created. `TryDisableFileSystemWatcher` then sees the freshly re-added token and does not disable. The result is a dead inotify watch bound to the deleted inode: recreating the root never re-arms it, and the token never fires.

## Fix

In `TryEnableFileSystemWatcher`, handle the case where the watcher still reports enabled but `_root` no longer exists: tear down the stale watch (`EnableRaisingEvents = false`) and fall back to the root creation watcher. Since the test re-registers while the root is still deleted, this closes the race deterministically.

> [!NOTE]
> This pull request was created by GitHub Copilot.
