### PR TITLE
Enable previously suppressed tests on CoreCLR browser

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -71,6 +71,8 @@ namespace TestLibrary
         public static bool IsExceptionInteropSupported => IsWindows && !Utilities.IsNativeAot && !Utilities.IsMonoRuntime && !Utilities.IsCoreClrInterpreter;
 
         public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;
+        public static bool IsCoreCLR => !IsMonoRuntime && Utilities.IsNotNativeAot;
+        public static bool IsNotCoreCLR => !IsCoreCLR;
 
         static string _variant = Environment.GetEnvironmentVariable("DOTNET_RUNTIME_VARIANT");
 

--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -72,7 +72,6 @@ namespace TestLibrary
 
         public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;
         public static bool IsCoreCLR => !IsMonoRuntime && Utilities.IsNotNativeAot;
-        public static bool IsNotCoreCLR => !IsCoreCLR;
 
         static string _variant = Environment.GetEnvironmentVariable("DOTNET_RUNTIME_VARIANT");
 

--- a/src/tests/GC/Coverage/271010.cs
+++ b/src/tests/GC/Coverage/271010.cs
@@ -12,7 +12,11 @@ using Xunit;
 
 public class Test_271010 {
 
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/5933", TestRuntimes.CoreCLR)]
+    public static bool IsCoreClrOnNonBrowser =>
+        TestLibrary.Utilities.IsNotMonoRuntime &&
+        !OperatingSystem.IsBrowser();
+
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/5933", typeof(Test_271010), nameof(IsCoreClrOnNonBrowser))]
     [Fact]
     public static int TestEntryPoint() {
 

--- a/src/tests/GC/Coverage/271010.cs
+++ b/src/tests/GC/Coverage/271010.cs
@@ -13,8 +13,8 @@ using Xunit;
 public class Test_271010 {
 
     public static bool IsCoreClrOnNonBrowser =>
-        TestLibrary.Utilities.IsNotMonoRuntime &&
-        !OperatingSystem.IsBrowser();
+        TestLibrary.PlatformDetection.IsCoreCLR &&
+        !TestLibrary.PlatformDetection.IsBrowser;
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/5933", typeof(Test_271010), nameof(IsCoreClrOnNonBrowser))]
     [Fact]

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.cs
@@ -35,7 +35,7 @@ public unsafe class HwiSideEffects
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/114250", TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/114250", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsBrowser), nameof(TestLibrary.PlatformDetection.IsMonoRuntime))]
     public static void TestProblemWithThrowingLoads()
     {
         Assert.True(ProblemWithThrowingLoads(null));

--- a/src/tests/JIT/Methodical/eh/interactions/switchinfinally.cs
+++ b/src/tests/JIT/Methodical/eh/interactions/switchinfinally.cs
@@ -87,7 +87,8 @@ namespace test3
         /// The main entry point for the application.
         /// </summary>
         [Fact]
-        [ActiveIssue("needs triage", TestPlatforms.Browser | TestPlatforms.Wasi | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+        [ActiveIssue("needs triage", TestPlatforms.Wasi | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+        [ActiveIssue("needs triage", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsBrowser), nameof(TestLibrary.PlatformDetection.IsMonoRuntime))]
         public static int TestEntryPoint()
         {
             //Start recording

--- a/src/tests/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125.cs
@@ -6934,7 +6934,6 @@ namespace Runtime_64125
             return true;
         }
 
-        [ActiveIssue("needs triage", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
         [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter), nameof(PlatformDetection.IsMonoRuntime))]
         [Fact]

--- a/src/tests/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125.cs
@@ -6934,8 +6934,9 @@ namespace Runtime_64125
             return true;
         }
 
-        [ActiveIssue("needs triage", TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
-        [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
+        [ActiveIssue("needs triage", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+        [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
+        [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter), nameof(PlatformDetection.IsMonoRuntime))]
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/91923", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile))]
         public static unsafe int TestEntryPoint()

--- a/src/tests/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125.tt
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125.tt
@@ -89,7 +89,6 @@ namespace Runtime_64125
             return true;
         }
 
-        [ActiveIssue("needs triage", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
         [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter), nameof(PlatformDetection.IsMonoRuntime))]
         [Fact]

--- a/src/tests/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125.tt
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125.tt
@@ -12,6 +12,8 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using TestLibrary;
+using Xunit;
 
 namespace Runtime_64125
 {
@@ -67,7 +69,7 @@ namespace Runtime_64125
 #>
     }
 
-    class Program
+    public class Program
     {
         static unsafe void Init(byte* bytes, int byteCount)
         {
@@ -87,7 +89,12 @@ namespace Runtime_64125
             return true;
         }
 
-        static unsafe int Main()
+        [ActiveIssue("needs triage", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+        [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
+        [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter), nameof(PlatformDetection.IsMonoRuntime))]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91923", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile))]
+        public static unsafe int TestEntryPoint()
         {
             var anyLocation = new AnyLocation();
 

--- a/src/tests/JIT/SIMD/Matrix4x4.cs
+++ b/src/tests/JIT/SIMD/Matrix4x4.cs
@@ -9,6 +9,12 @@ public class Matrix4x4Test
     private const int Pass = 100;
     private const int Fail = -1;
 
+    public static bool IsInterpreterExceptCoreClrBrowser =>
+        TestLibrary.Utilities.IsCoreClrInterpreter &&
+        (!OperatingSystem.IsBrowser() ||
+         TestLibrary.Utilities.IsMonoRuntime ||
+         TestLibrary.Utilities.IsNativeAot);
+
     public static int Matrix4x4CreateScaleCenterTest3()
     {
         int returnVal = Pass;
@@ -31,7 +37,7 @@ public class Matrix4x4Test
         return returnVal;
     }
 
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/123104", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/123104", typeof(Matrix4x4Test), nameof(IsInterpreterExceptCoreClrBrowser))]
     [Fact]
     public static int TestEntryPoint()
     {

--- a/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
+++ b/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
@@ -11,7 +11,7 @@ using TestLibrary;
 
 public unsafe class StackallocTests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/84398", TestPlatforms.Windows, runtimes: TestRuntimes.Mono)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/84398", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsMonoRuntime))]
     [Fact]
     public static int TestEntryPoint()
     {

--- a/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
+++ b/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
@@ -11,11 +11,7 @@ using TestLibrary;
 
 public unsafe class StackallocTests
 {
-    public static bool IsMonoOrNativeAot =>
-        PlatformDetection.IsMonoRuntime ||
-        Utilities.IsNativeAot;
-
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/84398", typeof(StackallocTests), nameof(IsMonoOrNativeAot))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/84398", typeof(PlatformDetection), nameof(PlatformDetection.IsNotCoreCLR))]
     [Fact]
     public static int TestEntryPoint()
     {

--- a/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
+++ b/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
@@ -11,7 +11,7 @@ using TestLibrary;
 
 public unsafe class StackallocTests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/84398", typeof(PlatformDetection), nameof(PlatformDetection.IsNotCoreCLR))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/84398", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsMonoRuntime))]
     [Fact]
     public static int TestEntryPoint()
     {

--- a/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
+++ b/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
@@ -11,7 +11,11 @@ using TestLibrary;
 
 public unsafe class StackallocTests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/84398", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsMonoRuntime))]
+    public static bool IsMonoOrNativeAot =>
+        PlatformDetection.IsMonoRuntime ||
+        Utilities.IsNativeAot;
+
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/84398", typeof(StackallocTests), nameof(IsMonoOrNativeAot))]
     [Fact]
     public static int TestEntryPoint()
     {

--- a/src/tests/baseservices/invalid_operations/Arrays.cs
+++ b/src/tests/baseservices/invalid_operations/Arrays.cs
@@ -12,7 +12,8 @@ public class Arrays
 {
     private class TestClass { }
 
-    [ActiveIssue("Function mismatch", TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+    [ActiveIssue("Function mismatch", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+    [ActiveIssue("Function mismatch", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
     [ActiveIssue("Doesn't compile with LLVM AOT.", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoAnyAOT))]
     [Fact]
     public static void TypeMismatch_ArrayElement()
@@ -24,8 +25,9 @@ public class Arrays
         Assert.IsType<ArrayTypeMismatchException>(e.InnerException);
     }
 
+    [ActiveIssue("Function mismatch", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+    [ActiveIssue("Function mismatch", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
     [ActiveIssue("Doesn't compile with LLVM AOT.", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoAnyAOT))]
-    [ActiveIssue("Function mismatch", TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
     [Fact]
     public static void TypeMismatch_MultidimensionalArrayElement()
     {
@@ -36,8 +38,9 @@ public class Arrays
         Assert.IsType<ArrayTypeMismatchException>(e.InnerException);
     }
 
+    [ActiveIssue("Function mismatch", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+    [ActiveIssue("Function mismatch", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
     [ActiveIssue("Doesn't compile with LLVM AOT.", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoAnyAOT))]
-    [ActiveIssue("Function mismatch", TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
     [Fact]
     public static void TypeMismatch_ClassElement()
     {

--- a/src/tests/baseservices/invalid_operations/ManagedPointers.cs
+++ b/src/tests/baseservices/invalid_operations/ManagedPointers.cs
@@ -11,8 +11,9 @@ using TestLibrary;
 
 public unsafe class ManagedPointers
 {
+    [ActiveIssue("Function mismatch", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+    [ActiveIssue("Function mismatch", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
     [ActiveIssue("Doesn't compile with LLVM AOT.", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoAnyAOT))]
-    [ActiveIssue("Function mismatch", TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
     [Fact]
     public static void Validate_BoxingHelpers_NullByRef()
     {
@@ -31,8 +32,9 @@ public unsafe class ManagedPointers
         });
     }
 
+    [ActiveIssue("Function mismatch", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+    [ActiveIssue("Function mismatch", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
     [ActiveIssue("Doesn't compile with LLVM AOT.", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoAnyAOT))]
-    [ActiveIssue("Function mismatch", TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
     [Fact]
     [Xunit.SkipOnCoreClrAttribute("Depends on marshalled calli", RuntimeTestModes.InterpreterActive)]
     public static void Validate_GeneratedILStubs_NullByRef()
@@ -58,8 +60,9 @@ public unsafe class ManagedPointers
         static nint PassByRef(void* a) => (nint)a;
     }
 
+    [ActiveIssue("Function mismatch", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+    [ActiveIssue("Function mismatch", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoRuntime))]
     [ActiveIssue("Doesn't compile with LLVM AOT.", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoAnyAOT))]
-    [ActiveIssue("Function mismatch", TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
     [Fact]
     public static void Validate_IntrinsicMethodsWithByRef_NullByRef()
     {


### PR DESCRIPTION
## Summary

Narrow several runtime-test `ActiveIssue` conditions so tests that work with CoreCLR on browser/wasm are no longer suppressed.

- Keep browser suppressions where they are still needed for Mono.
- Enable the affected SIMD, JIT, GC, hardware-intrinsics, and base-services tests on CoreCLR browser.
- Keep `StackallocBlkTests` suppressed for Mono and NativeAOT while enabling it on CoreCLR desktop and browser.
- Add shared CoreCLR runtime detection to `PlatformDetection`.
- Synchronize the `Runtime_64125` T4 template with its generated source.

## Testing

- `./build.sh clr+libs -lc release -rc checked`
- `./build.sh -arch wasm -os browser -c Debug -subset clr+libs`
- Browser/wasm priority-1 test build
- Affected runners: 5,654 total, 5,643 passed, 0 failed, 11 skipped
- Broad browser suite: 14,691 total, 14,296 passed, 2 failed, 393 skipped

The two broad-suite failures are unrelated upstream regressions:

- `TestConvertFromIntegral` in `JIT.IL_Conformance`
- `b05617` in `JIT.Regression.Regression_7`

All executable tests affected by this change passed.

> [!NOTE]
> This description was generated with GitHub Copilot.