### PR TITLE
Update outerloop convert tests for saturating float/double casts

### DIFF
--- a/src/tests/JIT/IL_Conformance/Convert/TestConvertFromIntegral.cs
+++ b/src/tests/JIT/IL_Conformance/Convert/TestConvertFromIntegral.cs
@@ -702,7 +702,7 @@ namespace TestCasts
             GenerateTest<float, short>(-1F, sourceOp, convNoOvf, DontExpectException, -1);
             GenerateTest<float, short>(short.MaxValue, sourceOp, convNoOvf, DontExpectException, short.MaxValue);
             GenerateTest<float, short>(short.MinValue, sourceOp, convNoOvf, DontExpectException, short.MinValue);
-            GenerateTest<float, short>(ushort.MaxValue, sourceOp, convNoOvf, DontExpectException, -1);
+            GenerateTest<float, short>(ushort.MaxValue, sourceOp, convNoOvf, DontExpectException, 0, UnspecifiedBehaviour); // Saturates to short.MaxValue on CoreCLR, truncates on Mono (https://github.com/dotnet/runtime/issues/100368)
             GenerateTest<float, short>(ushort.MinValue, sourceOp, convNoOvf, DontExpectException, byte.MinValue);
             GenerateTest<float, short>(long.MaxValue, sourceOp, convNoOvf, DontExpectException, 0, UnspecifiedBehaviour);
             GenerateTest<float, short>(long.MinValue, sourceOp, convNoOvf, DontExpectException, 0, UnspecifiedBehaviour);
@@ -977,7 +977,7 @@ namespace TestCasts
             GenerateTest<double, short>(-1, sourceOp, convNoOvf, DontExpectException, -1);
             GenerateTest<double, short>(short.MaxValue, sourceOp, convNoOvf, DontExpectException, short.MaxValue);
             GenerateTest<double, short>(short.MinValue, sourceOp, convNoOvf, DontExpectException, short.MinValue);
-            GenerateTest<double, short>(ushort.MaxValue, sourceOp, convNoOvf, DontExpectException, -1);
+            GenerateTest<double, short>(ushort.MaxValue, sourceOp, convNoOvf, DontExpectException, 0, UnspecifiedBehaviour); // Saturates to short.MaxValue on CoreCLR, truncates on Mono (https://github.com/dotnet/runtime/issues/100368)
             GenerateTest<double, short>(ushort.MinValue, sourceOp, convNoOvf, DontExpectException, byte.MinValue);
             GenerateTest<double, short>(long.MaxValue, sourceOp, convNoOvf, DontExpectException, 0, UnspecifiedBehaviour);
             GenerateTest<double, short>(long.MinValue, sourceOp, convNoOvf, DontExpectException, 0, UnspecifiedBehaviour);

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b05617/b05617.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b05617/b05617.il
@@ -40,7 +40,7 @@ stloc.0
  sub
  sub
  or
-ldc.i8 4294967086
+ldc.i8 4294967043
 conv.u4
 sub
 

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b05617/b05617.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b05617/b05617.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Saturating float->small casts on CoreCLR; Mono still truncates (https://github.com/dotnet/runtime/issues/100368) -->
+    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' == 'mono'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
The saturating `float`/`double` -> small integral cast changes from #128604 were not reflected in two outerloop tests, breaking CI (see https://github.com/dotnet/runtime/pull/130962#issuecomment-5003512055).

----------

`JIT/Regression/CLR-x86-JIT/V1-M10/b05617`: under saturation `conv.u1` of `2.564783e7` now yields `255` (was `214`) and `conv.i1` of `5246667200` yields `127` (was `-1`). Propagating through the stack, the final `conv.u4` constant is updated `4294967086` -> `4294967043` so the test still returns `100`. Mono still truncates, so the test is marked unsupported on Mono, referencing the same tracking issue (#100368) used by the JIT regression test in #128604.

----------

`JIT/IL_Conformance/Convert/TestConvertFromIntegral`: the two checked `ushort.MaxValue -> short` via `Conv_I2` cases now saturate to `short.MaxValue` on CoreCLR instead of truncating to `-1`. Since the result is now runtime-divergent (Mono truncates), they are marked `UnspecifiedBehaviour`, consistent with how every other cross-runtime-divergent float->integral out-of-range case in this file is already handled. This keeps the rest of the file running on Mono.

Verified locally against a checked runtime: `b05617` returns `100` and `TestConvertFromIntegral` reports "All tests passed".

> [!NOTE]
> This PR description was drafted by Copilot.
