### PR TITLE
Add wasm HardwareIntrinsics PR pipeline

### DIFF
--- a/eng/pipelines/coreclr/hardware-intrinsics-wasm.yml
+++ b/eng/pipelines/coreclr/hardware-intrinsics-wasm.yml
@@ -1,0 +1,28 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - eng/pipelines/coreclr/hardware-intrinsics-wasm.yml
+    - eng/pipelines/coreclr/templates/jit-hardware-intrinsics-wasm.yml
+    - src/coreclr/jit/*wasm*
+    - src/tests/JIT/HardwareIntrinsics/Wasm/**
+
+variables:
+  - template: /eng/pipelines/common/variables.yml
+  - template: /eng/pipelines/helix-platforms.yml
+
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    isOfficialBuild: false
+    stages:
+    - stage: Build
+      jobs:
+      - template: /eng/pipelines/coreclr/templates/jit-hardware-intrinsics-wasm.yml
+        parameters:
+          platforms:
+            - browser_wasm
+          testBuildArgs: '/p:EnableWasmHWIntrinsicsTests=true -tree:JIT/HardwareIntrinsics/Wasm'

--- a/eng/pipelines/coreclr/templates/jit-hardware-intrinsics-wasm.yml
+++ b/eng/pipelines/coreclr/templates/jit-hardware-intrinsics-wasm.yml
@@ -1,0 +1,39 @@
+parameters:
+  - name: platforms
+    type: object
+  - name: testBuildArgs
+    type: string
+
+jobs:
+# Build CoreCLR + libraries for wasm and compile the wasm HardwareIntrinsics
+# tests. Browser/V8 can't execute these tests yet (wasm SIMD support is
+# incomplete), so this is build-only coverage -- sendToHelix is false. See the
+# note in build-runtime-tests-and-send-to-helix.yml.
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    buildConfig: Release
+    runtimeFlavor: coreclr
+    platforms: ${{ parameters.platforms }}
+    variables:
+      - name: timeoutPerTestInMinutes
+        value: 60
+      - name: timeoutPerTestCollectionInMinutes
+        value: 180
+    jobParameters:
+      testGroup: outerloop
+      nameSuffix: CoreCLR
+      buildArgs: -s clr+libs+packs -c $(_BuildConfig) /p:TestAssemblies=false
+      timeoutInMinutes: 180
+      postBuildSteps:
+        - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+          parameters:
+            creator: dotnet-bot
+            testBuildArgs: ${{ parameters.testBuildArgs }}
+            testRunNamePrefixSuffix: CoreCLR
+            sendToHelix: false
+      extraVariablesTemplates:
+        - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+          parameters:
+            testGroup: outerloop


### PR DESCRIPTION
The wasm `HardwareIntrinsics` tests (`src/tests/JIT/HardwareIntrinsics/Wasm`) are gated by `HWITestsWasmOnly` -> `CLRTestTargetUnsupported` unless `TargetArchitecture == wasm` (plus an `EnableWasmHWIntrinsicsTests` opt-in). As a result, none of the existing PR-triggered intrinsics pipelines ever compile them:

- `runtime-coreclr hardware-intrinsics` (`src/coreclr/jit/**`, x86/x64/arm/osx) passes without building the wasm tree.
- `hardware-intrinsics-arm64` (`src/coreclr/jit/*arm64*`) is skipped for wasm-only changes.

So a break in the wasm intrinsic tests only surfaces in a rolling/outerloop browser-wasm build, which is what required the #130962 follow-up to #130850.

----------

This adds a wasm counterpart mirroring `hardware-intrinsics-arm64.yml`:

- `eng/pipelines/coreclr/hardware-intrinsics-wasm.yml` -- PR-triggered, filtered on `src/coreclr/jit/*wasm*` (covers `hwintrinsic*wasm*`, `lowerwasm.cpp`, `regallocwasm.cpp`) plus `src/tests/JIT/HardwareIntrinsics/Wasm/**`. Runs a `browser_wasm` leg with `/p:EnableWasmHWIntrinsicsTests=true -tree:JIT/HardwareIntrinsics/Wasm`.
- `eng/pipelines/coreclr/templates/jit-hardware-intrinsics-wasm.yml` -- modeled on the existing `wasi-wasm-coreclr-runtime-tests.yml` (`global-build-job`, `runtimeFlavor: coreclr`, `-s clr+libs+packs`). It is build-only (`sendToHelix: false`) since browser/V8 can''t execute these tests yet -- enough to catch compile breaks like #130962.

Like `hardware-intrinsics-arm64.yml`, the new pipeline still needs an Azure DevOps definition registered against the YAML to appear as a PR check.

> [!NOTE]
> This PR description was drafted by Copilot.
