### PR TITLE
Modernize System.Text.Json product code

### DIFF
--- a/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
+++ b/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
@@ -45,7 +45,7 @@ namespace System.Text.Json.Reflection
             type.IsAssignableFromInternal(other) || other.IsAssignableFromInternal(type);
 
         private static bool HasJsonConstructorAttribute(ConstructorInfo constructorInfo)
-            => constructorInfo.GetCustomAttribute<JsonConstructorAttribute>() != null;
+            => constructorInfo.GetCustomAttribute<JsonConstructorAttribute>() is not null;
 
         public static bool HasRequiredMemberAttribute(this MemberInfo memberInfo)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/BitStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/BitStack.cs
@@ -141,7 +141,7 @@ namespace System.Text.Json
         private readonly bool PeekInArray()
         {
             int index = _currentDepth - AllocationFreeMaxDepth - 1;
-            Debug.Assert(_array != null);
+            Debug.Assert(_array is not null);
             Debug.Assert(index >= 0, $"Get - Negative - index: {index}, arrayLength: {_array.Length}");
 
             int elementIndex = Div32Rem(index, out int extraBits);
@@ -161,7 +161,7 @@ namespace System.Text.Json
 
         private void DoubleArray(int minSize)
         {
-            Debug.Assert(_array != null);
+            Debug.Assert(_array is not null);
             Debug.Assert(_array.Length < int.MaxValue / 2, $"Array too large - arrayLength: {_array.Length}");
             Debug.Assert(minSize >= 0 && minSize >= _array.Length);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
@@ -54,7 +54,7 @@ namespace System.Text.Json
 
             internal DbRow(JsonTokenType jsonTokenType, int location, int sizeOrLength)
             {
-                Debug.Assert(jsonTokenType > JsonTokenType.None && jsonTokenType <= JsonTokenType.Null);
+                Debug.Assert(jsonTokenType is > JsonTokenType.None and <= JsonTokenType.Null);
                 Debug.Assert((byte)jsonTokenType < 1 << 4);
                 Debug.Assert(location >= 0);
                 Debug.Assert(sizeOrLength >= UnknownSize);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
@@ -130,7 +130,7 @@ namespace System.Text.Json
                 // were more frequent anyways.
                 const int OneMegabyte = 1024 * 1024;
 
-                if (initialSize > OneMegabyte && initialSize <= 4 * OneMegabyte)
+                if (initialSize is > OneMegabyte and <= 4 * OneMegabyte)
                 {
                     initialSize = OneMegabyte;
                 }
@@ -151,7 +151,7 @@ namespace System.Text.Json
             public void Dispose()
             {
                 byte[]? data = Interlocked.Exchange(ref _data, null!);
-                if (data == null)
+                if (data is null)
                 {
                     return;
                 }
@@ -175,7 +175,7 @@ namespace System.Text.Json
                 {
                     if (_convertToAlloc)
                     {
-                        Debug.Assert(_data != null);
+                        Debug.Assert(_data is not null);
                         byte[] returnBuf = _data;
                         _data = _data.AsSpan(0, Length).ToArray();
                         _isLocked = true;
@@ -217,7 +217,7 @@ namespace System.Text.Json
             {
                 // StartArray or StartObject should have length -1, otherwise the length should not be -1.
                 Debug.Assert(
-                    (tokenType == JsonTokenType.StartArray || tokenType == JsonTokenType.StartObject) ==
+                    (tokenType is JsonTokenType.StartArray or JsonTokenType.StartObject) ==
                     (length == DbRow.UnknownSize));
 
                 if (Length >= _data.Length - DbRow.Size)
@@ -275,7 +275,7 @@ namespace System.Text.Json
             internal void SetNumberOfRows(int index, int numberOfRows)
             {
                 AssertValidIndex(index);
-                Debug.Assert(numberOfRows >= 1 && numberOfRows <= 0x0FFFFFFF);
+                Debug.Assert(numberOfRows is >= 1 and <= 0x0FFFFFFF);
 
                 Span<byte> dataPos = _data.AsSpan(index + NumberOfRowsOffset);
                 int current = MemoryMarshal.Read<int>(dataPos);
@@ -299,7 +299,7 @@ namespace System.Text.Json
 
             internal int FindIndexOfFirstUnsetSizeOrLength(JsonTokenType lookupType)
             {
-                Debug.Assert(lookupType == JsonTokenType.StartObject || lookupType == JsonTokenType.StartArray);
+                Debug.Assert(lookupType is JsonTokenType.StartObject or JsonTokenType.StartArray);
                 return FindOpenElement(lookupType);
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -124,7 +124,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(utf8Json);
 
             ArraySegment<byte> drained = ReadToEnd(utf8Json);
-            Debug.Assert(drained.Array != null);
+            Debug.Assert(drained.Array is not null);
             try
             {
                 return Parse(
@@ -154,10 +154,10 @@ namespace System.Text.Json
 
         internal static JsonDocument ParseValue(Stream utf8Json, JsonDocumentOptions options)
         {
-            Debug.Assert(utf8Json != null);
+            Debug.Assert(utf8Json is not null);
 
             ArraySegment<byte> drained = ReadToEnd(utf8Json);
-            Debug.Assert(drained.Array != null);
+            Debug.Assert(drained.Array is not null);
 
             byte[] owned = new byte[drained.Count];
             Buffer.BlockCopy(drained.Array, 0, owned, 0, drained.Count);
@@ -185,7 +185,7 @@ namespace System.Text.Json
 
         internal static JsonDocument ParseValue(string json, JsonDocumentOptions options)
         {
-            Debug.Assert(json != null);
+            Debug.Assert(json is not null);
             return ParseValue(json.AsSpan(), options);
         }
 
@@ -221,7 +221,7 @@ namespace System.Text.Json
             CancellationToken cancellationToken = default)
         {
             ArraySegment<byte> drained = await ReadToEndAsync(utf8Json, cancellationToken).ConfigureAwait(false);
-            Debug.Assert(drained.Array != null);
+            Debug.Assert(drained.Array is not null);
             try
             {
                 return Parse(
@@ -245,7 +245,7 @@ namespace System.Text.Json
             CancellationToken cancellationToken = default)
         {
             ArraySegment<byte> drained = await ReadToEndAsync(utf8Json, cancellationToken).ConfigureAwait(false);
-            Debug.Assert(drained.Array != null);
+            Debug.Assert(drained.Array is not null);
 
             byte[] owned = new byte[drained.Count];
             Buffer.BlockCopy(drained.Array, 0, owned, 0, drained.Count);
@@ -439,7 +439,7 @@ namespace System.Text.Json
             bool ret = TryParseValue(ref reader, out JsonDocument? document, shouldThrow: true, useArrayPools: true, allowDuplicateProperties);
 
             Debug.Assert(ret, "TryParseValue returned false with shouldThrow: true.");
-            Debug.Assert(document != null, "null document returned with shouldThrow: true.");
+            Debug.Assert(document is not null, "null document returned with shouldThrow: true.");
             return document;
         }
 
@@ -758,14 +758,12 @@ namespace System.Text.Json
         {
             // These tokens should already have been processed.
             Debug.Assert(
-                tokenType != JsonTokenType.Null &&
-                tokenType != JsonTokenType.False &&
-                tokenType != JsonTokenType.True);
+                tokenType is not (JsonTokenType.Null or JsonTokenType.False or JsonTokenType.True));
 
             ReadOnlySpan<byte> utf8JsonSpan = utf8Json.Span;
             MetadataDb database;
 
-            if (tokenType == JsonTokenType.String || tokenType == JsonTokenType.Number)
+            if (tokenType is JsonTokenType.String or JsonTokenType.Number)
             {
                 // For primitive types, we can avoid renting MetadataDb and creating StackRowStack.
                 database = MetadataDb.CreateLocked(utf8Json.Length);
@@ -859,7 +857,7 @@ namespace System.Text.Json
             }
             catch
             {
-                if (rented != null)
+                if (rented is not null)
                 {
                     // Holds document content, clear it before returning it.
                     rented.AsSpan(0, written).Clear();
@@ -941,7 +939,7 @@ namespace System.Text.Json
             }
             catch
             {
-                if (rented != null)
+                if (rented is not null)
                 {
                     // Holds document content, clear it before returning it.
                     rented.AsSpan(0, written).Clear();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.StackRowStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.StackRowStack.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json
                 _rentedBuffer = null!;
                 _topOfStack = 0;
 
-                if (toReturn != null)
+                if (toReturn is not null)
                 {
                     // The data in this rented buffer only conveys the positions and
                     // lengths of tokens in a document, but no content; so it does not
@@ -52,7 +52,7 @@ namespace System.Text.Json
 
             internal StackRow Pop()
             {
-                Debug.Assert(_rentedBuffer != null);
+                Debug.Assert(_rentedBuffer is not null);
                 Debug.Assert(_topOfStack <= _rentedBuffer!.Length - StackRow.Size);
 
                 StackRow row = MemoryMarshal.Read<StackRow>(_rentedBuffer.AsSpan(_topOfStack));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.TryGetProperty.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.TryGetProperty.cs
@@ -201,7 +201,7 @@ namespace System.Text.Json
                             }
                             finally
                             {
-                                if (rented != null)
+                                if (rented is not null)
                                 {
                                     rented.AsSpan(0, written).Clear();
                                     ArrayPool<byte>.Shared.Return(rented);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -45,10 +45,10 @@ namespace System.Text.Json
 
             // Both rented values better be null if we're not disposable.
             Debug.Assert(isDisposable ||
-                (extraRentedArrayPoolBytes == null && extraPooledByteBufferWriter == null));
+                (extraRentedArrayPoolBytes is null && extraPooledByteBufferWriter is null));
 
             // Both rented values can't be specified.
-            Debug.Assert(extraRentedArrayPoolBytes == null || extraPooledByteBufferWriter == null);
+            Debug.Assert(extraRentedArrayPoolBytes is null || extraPooledByteBufferWriter is null);
 
             _utf8Json = utf8Json;
             _parsedData = parsedData;
@@ -69,11 +69,11 @@ namespace System.Text.Json
             _parsedData.Dispose();
             _utf8Json = ReadOnlyMemory<byte>.Empty;
 
-            if (_extraRentedArrayPoolBytes != null)
+            if (_extraRentedArrayPoolBytes is not null)
             {
                 byte[]? extraRentedBytes = Interlocked.Exchange<byte[]?>(ref _extraRentedArrayPoolBytes, null);
 
-                if (extraRentedBytes != null)
+                if (extraRentedBytes is not null)
                 {
                     // When "extra rented bytes exist" it contains the document,
                     // and thus needs to be cleared before being returned.
@@ -81,7 +81,7 @@ namespace System.Text.Json
                     ArrayPool<byte>.Shared.Return(extraRentedBytes);
                 }
             }
-            else if (_extraPooledByteBufferWriter != null)
+            else if (_extraPooledByteBufferWriter is not null)
             {
                 PooledByteBufferWriter? extraBufferWriter = Interlocked.Exchange<PooledByteBufferWriter?>(ref _extraPooledByteBufferWriter, null);
                 extraBufferWriter?.Dispose();
@@ -326,7 +326,7 @@ namespace System.Text.Json
                 result = TextEquals(index, otherUtf8Text.Slice(0, written), isPropertyName, shouldUnescape: true);
             }
 
-            if (otherUtf8TextArray != null)
+            if (otherUtf8TextArray is not null)
             {
                 otherUtf8Text.Slice(0, written).Clear();
                 ArrayPool<byte>.Shared.Return(otherUtf8TextArray);
@@ -832,7 +832,7 @@ namespace System.Text.Json
 
         private static void ClearAndReturn(ArraySegment<byte> rented)
         {
-            if (rented.Array != null)
+            if (rented.Array is not null)
             {
                 rented.AsSpan().Clear();
                 ArrayPool<byte>.Shared.Return(rented.Array);
@@ -998,7 +998,7 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    Debug.Assert(tokenType >= JsonTokenType.String && tokenType <= JsonTokenType.Null);
+                    Debug.Assert(tokenType is >= JsonTokenType.String and <= JsonTokenType.Null);
                     numberOfRowsForValues++;
                     numberOfRowsForMembers++;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.Parse.cs
@@ -49,7 +49,7 @@ namespace System.Text.Json
             bool ret = JsonDocument.TryParseValue(ref reader, out JsonDocument? document, shouldThrow: true, useArrayPools: false);
 
             Debug.Assert(ret, "TryParseValue returned false with shouldThrow: true.");
-            Debug.Assert(document != null, "null document returned with shouldThrow: true.");
+            Debug.Assert(document is not null, "null document returned with shouldThrow: true.");
             return document.RootElement;
         }
 
@@ -63,7 +63,7 @@ namespace System.Text.Json
                 allowDuplicateProperties: allowDuplicateProperties);
 
             Debug.Assert(ret, "TryParseValue returned false with shouldThrow: true.");
-            Debug.Assert(document != null, "null document returned with shouldThrow: true.");
+            Debug.Assert(document is not null, "null document returned with shouldThrow: true.");
             return document.RootElement;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1442,7 +1442,7 @@ namespace System.Text.Json
 
             if (TokenType == JsonTokenType.Null)
             {
-                return text == null;
+                return text is null;
             }
 
             return TextEqualsHelper(text.AsSpan(), isPropertyName: false);
@@ -1661,7 +1661,7 @@ namespace System.Text.Json
                 case JsonTokenType.StartObject:
                     {
                         // null parent should have hit the None case
-                        Debug.Assert(_parent != null);
+                        Debug.Assert(_parent is not null);
                         return _parent.GetRawValueAsString(_idx);
                     }
                 case JsonTokenType.String:
@@ -1704,7 +1704,7 @@ namespace System.Text.Json
 
         private void CheckValidInstance()
         {
-            if (_parent == null)
+            if (_parent is null)
             {
                 throw new InvalidOperationException();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -187,6 +187,6 @@ namespace System.Text.Json
         /// Returns 0 on a default instance of <see cref="JsonEncodedText"/>.
         /// </remarks>
         public override int GetHashCode()
-            => _value is null ? 0 : _value.GetHashCode();
+            => _value?.GetHashCode() ?? 0;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json
 
         private JsonEncodedText(byte[] utf8Value)
         {
-            Debug.Assert(utf8Value != null);
+            Debug.Assert(utf8Value is not null);
 
             _value = JsonReaderHelper.GetTextFromUtf8(utf8Value);
             _utf8Value = utf8Value;
@@ -143,9 +143,9 @@ namespace System.Text.Json
         /// </remarks>
         public bool Equals(JsonEncodedText other)
         {
-            if (_value == null)
+            if (_value is null)
             {
-                return other._value == null;
+                return other._value is null;
             }
             else
             {
@@ -187,6 +187,6 @@ namespace System.Text.Json
         /// Returns 0 on a default instance of <see cref="JsonEncodedText"/>.
         /// </remarks>
         public override int GetHashCode()
-            => _value == null ? 0 : _value.GetHashCode();
+            => _value is null ? 0 : _value.GetHashCode();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Escaping.cs
@@ -45,7 +45,7 @@ namespace System.Text.Json
 
             byte[] escapedString = escapedValue.Slice(0, written).ToArray();
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(valueArray);
             }
@@ -73,7 +73,7 @@ namespace System.Text.Json
 
             byte[] propertySection = GetPropertyNameSection(escapedValue.Slice(0, written));
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(valueArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
@@ -212,7 +212,7 @@ namespace System.Text.Json
 
             bool success = spanLookup.TryGetValue(decodedKey, out result);
 
-            if (rentedBuffer != null)
+            if (rentedBuffer is not null)
             {
                 decodedKey.Clear();
                 ArrayPool<char>.Shared.Return(rentedBuffer);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonArray.cs
@@ -242,7 +242,7 @@ namespace System.Text.Json.Nodes
         {
             Parent?.GetPath(ref path, this);
 
-            if (child != null)
+            if (child is not null)
             {
                 int index = List.IndexOf(child);
                 Debug.Assert(index >= 0);
@@ -380,7 +380,7 @@ namespace System.Text.Json.Nodes
                 {
                     get
                     {
-                        if (Value == null)
+                        if (Value is null)
                         {
                             return $"null";
                         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
@@ -34,7 +34,7 @@ namespace System.Text.Json.Nodes
         {
             get
             {
-                if (!_options.HasValue && Parent != null)
+                if (!_options.HasValue && Parent is not null)
                 {
                     // Remember the parent options; if node is re-parented later we still want to keep the
                     // original options since they may have affected the way the node was created as is the case
@@ -137,7 +137,7 @@ namespace System.Text.Json.Nodes
         /// <returns>The JSON Path value.</returns>
         public unsafe string GetPath()
         {
-            if (Parent == null)
+            if (Parent is null)
             {
                 return "$";
             }
@@ -161,12 +161,12 @@ namespace System.Text.Json.Nodes
             get
             {
                 JsonNode? parent = Parent;
-                if (parent == null)
+                if (parent is null)
                 {
                     return this;
                 }
 
-                while (parent.Parent != null)
+                while (parent.Parent is not null)
                 {
                     parent = parent.Parent;
                 }
@@ -345,13 +345,13 @@ namespace System.Text.Json.Nodes
 
         internal void AssignParent(JsonNode parent)
         {
-            if (Parent != null)
+            if (Parent is not null)
             {
                 ThrowHelper.ThrowInvalidOperationException_NodeAlreadyHasParent();
             }
 
             JsonNode? p = parent;
-            while (p != null)
+            while (p is not null)
             {
                 if (p == this)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -264,7 +264,7 @@ namespace System.Text.Json.Nodes
         {
             Parent?.GetPath(ref path, this);
 
-            if (child != null)
+            if (child is not null)
             {
                 string propertyName = FindValue(child)!.Value.Key;
                 if (propertyName.AsSpan().ContainsSpecialCharacters())
@@ -315,7 +315,7 @@ namespace System.Text.Json.Nodes
 
         private void DetachParent(JsonNode? item)
         {
-            Debug.Assert(_dictionary != null, "Cannot have detachable nodes without a materialized dictionary.");
+            Debug.Assert(_dictionary is not null, "Cannot have detachable nodes without a materialized dictionary.");
 
             item?.Parent = null;
         }
@@ -380,7 +380,7 @@ namespace System.Text.Json.Nodes
                 {
                     get
                     {
-                        if (Value == null)
+                        if (Value is null)
                         {
                             return $"{PropertyName} = null";
                         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.CreateOverloads.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.CreateOverloads.cs
@@ -225,7 +225,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         [return: NotNullIfNotNull(nameof(value))]
-        public static JsonValue? Create(string? value, JsonNodeOptions? options = null) => value != null ? new JsonValuePrimitive<string>(value, JsonMetadataServices.StringConverter!, options) : null;
+        public static JsonValue? Create(string? value, JsonNodeOptions? options = null) => value is not null ? new JsonValuePrimitive<string>(value, JsonMetadataServices.StringConverter!, options) : null;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -153,7 +153,7 @@ namespace System.Text.Json.Nodes
 
         internal sealed override void GetPath(ref ValueStringBuilder path, JsonNode? child)
         {
-            Debug.Assert(child == null);
+            Debug.Assert(child is null);
 
             Parent?.GetPath(ref path, this);
         }
@@ -161,7 +161,7 @@ namespace System.Text.Json.Nodes
         internal static JsonValue CreateFromTypeInfo<T>(T value, JsonTypeInfo<T> jsonTypeInfo, JsonNodeOptions? options = null)
         {
             Debug.Assert(jsonTypeInfo.IsConfigured);
-            Debug.Assert(value != null);
+            Debug.Assert(value is not null);
 
             if (JsonValue<T>.TypeIsSupportedPrimitive &&
                 jsonTypeInfo is { EffectiveConverter.IsInternalConverter: true } &&

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfElement.cs
@@ -142,7 +142,7 @@ namespace System.Text.Json.Nodes
                     if (typeof(TypeToConvert) == typeof(string))
                     {
                         string? result = Value.GetString();
-                        Debug.Assert(result != null);
+                        Debug.Assert(result is not null);
                         value = (TypeToConvert)(object)result;
                         return true;
                     }
@@ -171,7 +171,7 @@ namespace System.Text.Json.Nodes
                     if (typeof(TypeToConvert) == typeof(char) || typeof(TypeToConvert) == typeof(char?))
                     {
                         string? result = Value.GetString();
-                        Debug.Assert(result != null);
+                        Debug.Assert(result is not null);
                         if (result.Length == 1)
                         {
                             value = (TypeToConvert)(object)result[0];

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfJsonPrimitive.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfJsonPrimitive.cs
@@ -76,7 +76,7 @@ namespace System.Text.Json.Nodes
             {
                 string? result = JsonReaderHelper.TranscodeHelper(_value.Span);
 
-                Debug.Assert(result != null);
+                Debug.Assert(result is not null);
                 value = (T)(object)result;
                 return true;
             }
@@ -108,7 +108,7 @@ namespace System.Text.Json.Nodes
             {
                 string? result = JsonReaderHelper.TranscodeHelper(_value.Span);
 
-                Debug.Assert(result != null);
+                Debug.Assert(result is not null);
                 if (result.Length == 1)
                 {
                     value = (T)(object)result[0];

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Nodes
 
         protected JsonValue(TValue value, JsonNodeOptions? options) : base(options)
         {
-            Debug.Assert(value != null);
+            Debug.Assert(value is not null);
             Debug.Assert(value is not JsonElement or JsonElement { ValueKind: not JsonValueKind.Null });
             Debug.Assert(value is not JsonNode);
             Value = value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTCustomized.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfTCustomized.cs
@@ -32,7 +32,7 @@ namespace System.Text.Json.Nodes
 
             JsonTypeInfo<TValue> jsonTypeInfo = _jsonTypeInfo;
 
-            if (options != null && options != jsonTypeInfo.Options)
+            if (options is not null && options != jsonTypeInfo.Options)
             {
                 options.MakeReadOnly();
                 jsonTypeInfo = (JsonTypeInfo<TValue>)options.GetTypeInfoInternal(typeof(TValue));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json
 
             bool result = TryDecodeBase64InPlace(utf8Unescaped, out bytes!);
 
-            if (unescapedArray != null)
+            if (unescapedArray is not null)
             {
                 utf8Unescaped.Clear();
                 ArrayPool<byte>.Shared.Return(unescapedArray);
@@ -57,7 +57,7 @@ namespace System.Text.Json
 
             string utf8String = TranscodeHelper(utf8Unescaped);
 
-            if (pooledName != null)
+            if (pooledName is not null)
             {
                 utf8Unescaped.Clear();
                 ArrayPool<byte>.Shared.Return(pooledName);
@@ -82,7 +82,7 @@ namespace System.Text.Json
             byte[] propertyName = utf8Unescaped.Slice(0, written).ToArray();
             Debug.Assert(propertyName.Length is not 0);
 
-            if (pooledName != null)
+            if (pooledName is not null)
             {
                 new Span<byte>(pooledName, 0, written).Clear();
                 ArrayPool<byte>.Shared.Return(pooledName);
@@ -109,7 +109,7 @@ namespace System.Text.Json
 
             bool result = other.SequenceEqual(utf8Unescaped);
 
-            if (unescapedArray != null)
+            if (unescapedArray is not null)
             {
                 utf8Unescaped.Clear();
                 ArrayPool<byte>.Shared.Return(unescapedArray);
@@ -147,9 +147,9 @@ namespace System.Text.Json
 
             bool result = other.SequenceEqual(utf8Unescaped);
 
-            if (unescapedArray != null)
+            if (unescapedArray is not null)
             {
-                Debug.Assert(escapedArray != null);
+                Debug.Assert(escapedArray is not null);
                 utf8Unescaped.Clear();
                 ArrayPool<byte>.Shared.Return(unescapedArray);
                 utf8Escaped.Clear();
@@ -188,13 +188,13 @@ namespace System.Text.Json
 
             bool result = utf8Unescaped1.SequenceEqual(utf8Unescaped2);
 
-            if (unescapedArray1 != null)
+            if (unescapedArray1 is not null)
             {
                 utf8Unescaped1.Clear();
                 ArrayPool<byte>.Shared.Return(unescapedArray1);
             }
 
-            if (unescapedArray2 != null)
+            if (unescapedArray2 is not null)
             {
                 utf8Unescaped2.Clear();
                 ArrayPool<byte>.Shared.Return(unescapedArray2);
@@ -229,7 +229,7 @@ namespace System.Text.Json
             {
                 bytes = null;
 
-                if (pooledArray != null)
+                if (pooledArray is not null)
                 {
                     byteSpan.Clear();
                     ArrayPool<byte>.Shared.Return(pooledArray);
@@ -241,7 +241,7 @@ namespace System.Text.Json
 
             bytes = byteSpan.Slice(0, bytesWritten).ToArray();
 
-            if (pooledArray != null)
+            if (pooledArray is not null)
             {
                 byteSpan.Clear();
                 ArrayPool<byte>.Shared.Return(pooledArray);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -2603,10 +2603,8 @@ namespace System.Text.Json
             }
         }
 
-        private PartialStateForRollback CaptureState()
-        {
-            return new PartialStateForRollback(_totalConsumed, _bytePositionInLine, _consumed, _currentPosition);
-        }
+        private PartialStateForRollback CaptureState() =>
+            new PartialStateForRollback(_totalConsumed, _bytePositionInLine, _consumed, _currentPosition);
 
         private readonly struct PartialStateForRollback
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -300,7 +300,7 @@ namespace System.Text.Json
             ReadOnlyMemory<byte> memory;
             while (true)
             {
-                Debug.Assert(!_isMultiSegment || _currentPosition.GetObject() != null);
+                Debug.Assert(!_isMultiSegment || _currentPosition.GetObject() is not null);
                 SequencePosition copy = _currentPosition;
                 _currentPosition = _nextPosition;
                 bool noMoreData = !_sequence.TryGet(ref _nextPosition, out memory, advance: true);
@@ -317,7 +317,7 @@ namespace System.Text.Json
                 // _currentPosition needs to point to last non-empty segment
                 // Since memory.Length == 0, we need to revert back to previous.
                 _currentPosition = copy;
-                Debug.Assert(!_isMultiSegment || _currentPosition.GetObject() != null);
+                Debug.Assert(!_isMultiSegment || _currentPosition.GetObject() is not null);
             }
 
             if (_isFinalBlock)
@@ -1141,7 +1141,7 @@ namespace System.Text.Json
             Debug.Assert(signResult == ConsumeNumberResult.OperationIncomplete);
 
             byte nextByte = data[i];
-            Debug.Assert(nextByte >= '0' && nextByte <= '9');
+            Debug.Assert(nextByte is >= (byte)'0' and <= (byte)'9');
 
             if (nextByte == '0')
             {
@@ -1174,14 +1174,14 @@ namespace System.Text.Json
 
                 Debug.Assert(result == ConsumeNumberResult.OperationIncomplete);
                 nextByte = data[i];
-                if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
+                if (nextByte is not ((byte)'.' or (byte)'E' or (byte)'e'))
                 {
                     RollBackState(rollBackState, isError: true);
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, nextByte);
                 }
             }
 
-            Debug.Assert(nextByte == '.' || nextByte == 'E' || nextByte == 'e');
+            Debug.Assert(nextByte is (byte)'.' or (byte)'E' or (byte)'e');
 
             if (nextByte == '.')
             {
@@ -1200,14 +1200,14 @@ namespace System.Text.Json
 
                 Debug.Assert(result == ConsumeNumberResult.OperationIncomplete);
                 nextByte = data[i];
-                if (nextByte != 'E' && nextByte != 'e')
+                if (nextByte is not ((byte)'E' or (byte)'e'))
                 {
                     RollBackState(rollBackState, isError: true);
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedNextDigitEValueNotFound, nextByte);
                 }
             }
 
-            Debug.Assert(nextByte == 'E' || nextByte == 'e');
+            Debug.Assert(nextByte is (byte)'E' or (byte)'e');
             i++;
             _bytePositionInLine++;
 
@@ -1341,7 +1341,7 @@ namespace System.Text.Json
                 }
             }
             nextByte = data[i];
-            if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
+            if (nextByte is not ((byte)'.' or (byte)'E' or (byte)'e'))
             {
                 RollBackState(rollBackState, isError: true);
                 ThrowHelper.ThrowJsonReaderException(ref this,
@@ -1490,7 +1490,7 @@ namespace System.Text.Json
             }
 
             byte nextByte = data[i];
-            if (nextByte == '+' || nextByte == '-')
+            if (nextByte is (byte)'+' or (byte)'-')
             {
                 i++;
                 _bytePositionInLine++;
@@ -2264,7 +2264,7 @@ namespace System.Text.Json
             }
 
             byte marker = localBuffer[0];
-            if (marker != JsonConstants.Slash && marker != JsonConstants.Asterisk)
+            if (marker is not (JsonConstants.Slash or JsonConstants.Asterisk))
             {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidCharacterAtStartOfComment, marker);
             }
@@ -2340,7 +2340,7 @@ namespace System.Text.Json
                 }
 
                 int idx = FindLineSeparatorMultiSegment(localBuffer, ref dangerousLineSeparatorBytesConsumed);
-                Debug.Assert(dangerousLineSeparatorBytesConsumed >= 0 && dangerousLineSeparatorBytesConsumed <= 2);
+                Debug.Assert(dangerousLineSeparatorBytesConsumed is >= 0 and <= 2);
 
                 if (idx != -1)
                 {
@@ -2498,7 +2498,7 @@ namespace System.Text.Json
             if (dangerousLineSeparatorBytesConsumed == 2)
             {
                 byte lastByte = localBuffer[0];
-                if (lastByte == 0xA8 || lastByte == 0xA9)
+                if (lastByte is 0xA8 or 0xA9)
                 {
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfLineSeparator);
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -183,7 +183,7 @@ namespace System.Text.Json
 
             int charsWritten = JsonReaderHelper.TranscodeHelper(unescapedSource, destination);
 
-            if (rentedBuffer != null)
+            if (rentedBuffer is not null)
             {
                 new Span<byte>(rentedBuffer, 0, unescapedSource.Length).Clear();
                 ArrayPool<byte>.Shared.Return(rentedBuffer);
@@ -219,7 +219,7 @@ namespace System.Text.Json
 
             bool success = JsonReaderHelper.TryUnescape(source, destination, out bytesWritten);
 
-            if (rentedBuffer != null)
+            if (rentedBuffer is not null)
             {
                 new Span<byte>(rentedBuffer, 0, source.Length).Clear();
                 ArrayPool<byte>.Shared.Return(rentedBuffer);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -170,7 +170,7 @@ namespace System.Text.Json
             {
                 if (_isInputSequence)
                 {
-                    Debug.Assert(_currentPosition.GetObject() != null);
+                    Debug.Assert(_currentPosition.GetObject() is not null);
                     return _sequence.GetPosition(_consumed, _currentPosition);
                 }
                 return default;
@@ -562,7 +562,7 @@ namespace System.Text.Json
                 result = TextEqualsHelper(otherUtf8Text.Slice(0, written));
             }
 
-            if (otherUtf8TextArray != null)
+            if (otherUtf8TextArray is not null)
             {
                 otherUtf8Text.Slice(0, written).Clear();
                 ArrayPool<byte>.Shared.Return(otherUtf8TextArray);
@@ -689,7 +689,7 @@ namespace System.Text.Json
         // Otherwise, return false.
         private static bool IsTokenTypeString(JsonTokenType tokenType)
         {
-            return tokenType == JsonTokenType.PropertyName || tokenType == JsonTokenType.String;
+            return tokenType is JsonTokenType.PropertyName or JsonTokenType.String;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1473,7 +1473,7 @@ namespace System.Text.Json
             Debug.Assert(signResult == ConsumeNumberResult.OperationIncomplete);
 
             byte nextByte = data[i];
-            Debug.Assert(nextByte >= '0' && nextByte <= '9');
+            Debug.Assert(nextByte is >= (byte)'0' and <= (byte)'9');
 
             if (nextByte == '0')
             {
@@ -1505,14 +1505,14 @@ namespace System.Text.Json
 
                 Debug.Assert(result == ConsumeNumberResult.OperationIncomplete);
                 nextByte = data[i];
-                if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
+                if (nextByte is not ((byte)'.' or (byte)'E' or (byte)'e'))
                 {
                     _bytePositionInLine += i;
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, nextByte);
                 }
             }
 
-            Debug.Assert(nextByte == '.' || nextByte == 'E' || nextByte == 'e');
+            Debug.Assert(nextByte is (byte)'.' or (byte)'E' or (byte)'e');
 
             if (nextByte == '.')
             {
@@ -1529,14 +1529,14 @@ namespace System.Text.Json
 
                 Debug.Assert(result == ConsumeNumberResult.OperationIncomplete);
                 nextByte = data[i];
-                if (nextByte != 'E' && nextByte != 'e')
+                if (nextByte is not ((byte)'E' or (byte)'e'))
                 {
                     _bytePositionInLine += i;
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedNextDigitEValueNotFound, nextByte);
                 }
             }
 
-            Debug.Assert(nextByte == 'E' || nextByte == 'e');
+            Debug.Assert(nextByte is (byte)'E' or (byte)'e');
             i++;
 
             signResult = ConsumeSign(ref data, ref i);
@@ -1624,7 +1624,7 @@ namespace System.Text.Json
                 }
             }
             nextByte = data[i];
-            if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
+            if (nextByte is not ((byte)'.' or (byte)'E' or (byte)'e'))
             {
                 _bytePositionInLine += i;
                 ThrowHelper.ThrowJsonReaderException(ref this,
@@ -1703,7 +1703,7 @@ namespace System.Text.Json
             }
 
             byte nextByte = data[i];
-            if (nextByte == '+' || nextByte == '-')
+            if (nextByte is (byte)'+' or (byte)'-')
             {
                 i++;
                 if (i >= data.Length)
@@ -2472,7 +2472,7 @@ namespace System.Text.Json
             }
 
             byte next = localBuffer[1];
-            if (localBuffer[0] == 0x80 && (next == 0xA8 || next == 0xA9))
+            if (localBuffer[0] == 0x80 && (next is 0xA8 or 0xA9))
             {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfLineSeparator);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
@@ -88,30 +88,30 @@ namespace System.Text.Json.Schema
         {
             get
             {
-                if (_trueOrFalse != null)
+                if (_trueOrFalse is not null)
                 {
                     // Boolean schemas admit no keywords
                     return 0;
                 }
 
                 int count = 0;
-                Count(Ref != null);
-                Count(Comment != null);
+                Count(Ref is not null);
+                Count(Comment is not null);
                 Count(Type != JsonSchemaType.Any);
-                Count(Format != null);
-                Count(Pattern != null);
-                Count(Constant != null);
-                Count(Properties != null);
-                Count(Required != null);
-                Count(Items != null);
-                Count(AdditionalProperties != null);
-                Count(Enum != null);
-                Count(Not != null);
-                Count(AnyOf != null);
+                Count(Format is not null);
+                Count(Pattern is not null);
+                Count(Constant is not null);
+                Count(Properties is not null);
+                Count(Required is not null);
+                Count(Items is not null);
+                Count(AdditionalProperties is not null);
+                Count(Enum is not null);
+                Count(Not is not null);
+                Count(AnyOf is not null);
                 Count(HasDefaultValue);
-                Count(MinLength != null);
-                Count(MaxLength != null);
-                Count(Deprecated != null);
+                Count(MinLength is not null);
+                Count(MaxLength is not null);
+                Count(Deprecated is not null);
 
                 return count;
 
@@ -124,7 +124,7 @@ namespace System.Text.Json.Schema
 
         public void MakeNullable()
         {
-            if (_trueOrFalse != null)
+            if (_trueOrFalse is not null)
             {
                 // boolean schemas do not admit type keywords.
                 return;
@@ -145,12 +145,12 @@ namespace System.Text.Json.Schema
 
             var objSchema = new JsonObject();
 
-            if (Ref != null)
+            if (Ref is not null)
             {
                 objSchema.Add(RefPropertyName, Ref);
             }
 
-            if (Comment != null)
+            if (Comment is not null)
             {
                 objSchema.Add(CommentPropertyName, Comment);
             }
@@ -160,22 +160,22 @@ namespace System.Text.Json.Schema
                 objSchema.Add(TypePropertyName, type);
             }
 
-            if (Format != null)
+            if (Format is not null)
             {
                 objSchema.Add(FormatPropertyName, Format);
             }
 
-            if (Pattern != null)
+            if (Pattern is not null)
             {
                 objSchema.Add(PatternPropertyName, Pattern);
             }
 
-            if (Constant != null)
+            if (Constant is not null)
             {
                 objSchema.Add(ConstPropertyName, Constant);
             }
 
-            if (Properties != null)
+            if (Properties is not null)
             {
                 var properties = new JsonObject();
                 foreach (KeyValuePair<string, JsonSchema> property in Properties)
@@ -186,7 +186,7 @@ namespace System.Text.Json.Schema
                 objSchema.Add(PropertiesPropertyName, properties);
             }
 
-            if (Required != null)
+            if (Required is not null)
             {
                 var requiredArray = new JsonArray();
                 foreach (string requiredProperty in Required)
@@ -197,27 +197,27 @@ namespace System.Text.Json.Schema
                 objSchema.Add(RequiredPropertyName, requiredArray);
             }
 
-            if (Items != null)
+            if (Items is not null)
             {
                 objSchema.Add(ItemsPropertyName, Items.ToJsonNode(options));
             }
 
-            if (AdditionalProperties != null)
+            if (AdditionalProperties is not null)
             {
                 objSchema.Add(AdditionalPropertiesPropertyName, AdditionalProperties.ToJsonNode(options));
             }
 
-            if (Enum != null)
+            if (Enum is not null)
             {
                 objSchema.Add(EnumPropertyName, Enum);
             }
 
-            if (Not != null)
+            if (Not is not null)
             {
                 objSchema.Add(NotPropertyName, Not.ToJsonNode(options));
             }
 
-            if (AnyOf != null)
+            if (AnyOf is not null)
             {
                 JsonArray anyOfArray = [];
                 foreach (JsonSchema schema in AnyOf)
@@ -254,7 +254,7 @@ namespace System.Text.Json.Schema
             {
                 if (ExporterContext is { } context)
                 {
-                    Debug.Assert(options.TransformSchemaNode != null, "context should only be populated if a callback is present.");
+                    Debug.Assert(options.TransformSchemaNode is not null, "context should only be populated if a callback is present.");
                     // Apply any user-defined transformations to the schema.
                     return options.TransformSchemaNode(context, schema);
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
@@ -79,8 +79,7 @@ namespace System.Text.Json.Schema
 
         public int? MaxLength { get; set { VerifyMutable(); field = value; } }
 
-        public bool? Deprecated { get => _deprecated; set { VerifyMutable(); _deprecated = value; } }
-        private bool? _deprecated;
+        public bool? Deprecated { get; set { VerifyMutable(); field = value; } }
 
         public JsonSchemaExporterContext? ExporterContext { get; set; }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchema.cs
@@ -45,56 +45,39 @@ namespace System.Text.Json.Schema
         /// </summary>
         private readonly bool? _trueOrFalse;
 
-        public string? Ref { get => _ref; set { VerifyMutable(); _ref = value; } }
-        private string? _ref;
+        public string? Ref { get; set { VerifyMutable(); field = value; } }
 
-        public string? Comment { get => _comment; set { VerifyMutable(); _comment = value; } }
-        private string? _comment;
+        public string? Comment { get; set { VerifyMutable(); field = value; } }
 
-        public JsonSchemaType Type { get => _type; set { VerifyMutable(); _type = value; } }
-        private JsonSchemaType _type = JsonSchemaType.Any;
+        public JsonSchemaType Type { get; set { VerifyMutable(); field = value; } } = JsonSchemaType.Any;
 
-        public string? Format { get => _format; set { VerifyMutable(); _format = value; } }
-        private string? _format;
+        public string? Format { get; set { VerifyMutable(); field = value; } }
 
-        public string? Pattern { get => _pattern; set { VerifyMutable(); _pattern = value; } }
-        private string? _pattern;
+        public string? Pattern { get; set { VerifyMutable(); field = value; } }
 
-        public JsonNode? Constant { get => _constant; set { VerifyMutable(); _constant = value; } }
-        private JsonNode? _constant;
+        public JsonNode? Constant { get; set { VerifyMutable(); field = value; } }
 
-        public List<KeyValuePair<string, JsonSchema>>? Properties { get => _properties; set { VerifyMutable(); _properties = value; } }
-        private List<KeyValuePair<string, JsonSchema>>? _properties;
+        public List<KeyValuePair<string, JsonSchema>>? Properties { get; set { VerifyMutable(); field = value; } }
 
-        public List<string>? Required { get => _required; set { VerifyMutable(); _required = value; } }
-        private List<string>? _required;
+        public List<string>? Required { get; set { VerifyMutable(); field = value; } }
 
-        public JsonSchema? Items { get => _items; set { VerifyMutable(); _items = value; } }
-        private JsonSchema? _items;
+        public JsonSchema? Items { get; set { VerifyMutable(); field = value; } }
 
-        public JsonSchema? AdditionalProperties { get => _additionalProperties; set { VerifyMutable(); _additionalProperties = value; } }
-        private JsonSchema? _additionalProperties;
+        public JsonSchema? AdditionalProperties { get; set { VerifyMutable(); field = value; } }
 
-        public JsonArray? Enum { get => _enum; set { VerifyMutable(); _enum = value; } }
-        private JsonArray? _enum;
+        public JsonArray? Enum { get; set { VerifyMutable(); field = value; } }
 
-        public JsonSchema? Not { get => _not; set { VerifyMutable(); _not = value; } }
-        private JsonSchema? _not;
+        public JsonSchema? Not { get; set { VerifyMutable(); field = value; } }
 
-        public List<JsonSchema>? AnyOf { get => _anyOf; set { VerifyMutable(); _anyOf = value; } }
-        private List<JsonSchema>? _anyOf;
+        public List<JsonSchema>? AnyOf { get; set { VerifyMutable(); field = value; } }
 
-        public bool HasDefaultValue { get => _hasDefaultValue; set { VerifyMutable(); _hasDefaultValue = value; } }
-        private bool _hasDefaultValue;
+        public bool HasDefaultValue { get; set { VerifyMutable(); field = value; } }
 
-        public JsonNode? DefaultValue { get => _defaultValue; set { VerifyMutable(); _defaultValue = value; } }
-        private JsonNode? _defaultValue;
+        public JsonNode? DefaultValue { get; set { VerifyMutable(); field = value; } }
 
-        public int? MinLength { get => _minLength; set { VerifyMutable(); _minLength = value; } }
-        private int? _minLength;
+        public int? MinLength { get; set { VerifyMutable(); field = value; } }
 
-        public int? MaxLength { get => _maxLength; set { VerifyMutable(); _maxLength = value; } }
-        private int? _maxLength;
+        public int? MaxLength { get; set { VerifyMutable(); field = value; } }
 
         public bool? Deprecated { get => _deprecated; set { VerifyMutable(); _deprecated = value; } }
         private bool? _deprecated;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
@@ -203,7 +203,7 @@ namespace System.Text.Json.Schema
                         }
                     }
                 }
-                else if (schema.Enum != null)
+                else if (schema.Enum is not null)
                 {
                     Debug.Assert(elementTypeInfo.Type.IsEnum, "The enum keyword should only be populated by schemas for enum types.");
                     schema.Enum.Add(null); // Append null to the enum array.
@@ -281,7 +281,7 @@ namespace System.Text.Json.Schema
                     });
 
                 case JsonTypeInfoKind.Enumerable:
-                    Debug.Assert(typeInfo.ElementTypeInfo != null);
+                    Debug.Assert(typeInfo.ElementTypeInfo is not null);
 
                     if (typeDiscriminator is null)
                     {
@@ -331,7 +331,7 @@ namespace System.Text.Json.Schema
                     }
 
                 case JsonTypeInfoKind.Dictionary:
-                    Debug.Assert(typeInfo.ElementTypeInfo != null);
+                    Debug.Assert(typeInfo.ElementTypeInfo is not null);
 
                     List<KeyValuePair<string, JsonSchema>>? dictProps = null;
                     List<string>? dictRequired = null;
@@ -459,7 +459,7 @@ namespace System.Text.Json.Schema
                     }
                 }
 
-                if (state.ExporterOptions.TransformSchemaNode != null)
+                if (state.ExporterOptions.TransformSchemaNode is not null)
                 {
                     // Prime the schema for invocation by the JsonNode transformer.
                     schema.ExporterContext = exporterContext;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConfigurationList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConfigurationList.cs
@@ -62,25 +62,16 @@ namespace System.Text.Json.Serialization
             OnCollectionModified();
         }
 
-        public bool Contains(TItem item)
-        {
-            return _list.Contains(item);
-        }
+        public bool Contains(TItem item) => _list.Contains(item);
 
         public void CopyTo(TItem[] array, int arrayIndex)
         {
             _list.CopyTo(array, arrayIndex);
         }
 
-        public List<TItem>.Enumerator GetEnumerator()
-        {
-            return _list.GetEnumerator();
-        }
+        public List<TItem>.Enumerator GetEnumerator() => _list.GetEnumerator();
 
-        public int IndexOf(TItem item)
-        {
-            return _list.IndexOf(item);
-        }
+        public int IndexOf(TItem item) => _list.IndexOf(item);
 
         public void Insert(int index, TItem item)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json.Serialization.Converters
             int index = state.Current.EnumeratorIndex;
 
             JsonConverter<TElement> elementConverter = GetElementConverter(ref state);
-            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling is null)
             {
                 // Fast path that avoids validation and extra indirection.
                 for (; index < array.Length; index++)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json.Serialization.Converters
             ref WriteStack state)
         {
             IEnumerator<KeyValuePair<TKey, TValue>> enumerator;
-            if (state.Current.CollectionEnumerator == null)
+            if (state.Current.CollectionEnumerator is null)
             {
                 enumerator = value.GetEnumerator();
                 state.Current.CollectionEnumerator = enumerator;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json.Serialization.Converters
             ref WriteStack state)
         {
             Dictionary<TKey, TValue>.Enumerator enumerator;
-            if (state.Current.CollectionEnumerator == null)
+            if (state.Current.CollectionEnumerator is null)
             {
                 enumerator = value.GetEnumerator();
                 if (!enumerator.MoveNext())
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Converters
             _keyConverter ??= GetConverter<TKey>(typeInfo.KeyTypeInfo!);
             _valueConverter ??= GetConverter<TValue>(typeInfo.ElementTypeInfo!);
 
-            if (!state.SupportContinuation && _valueConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            if (!state.SupportContinuation && _valueConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling is null)
             {
                 // Fast path that avoids validation and extra indirection.
                 do

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
@@ -49,7 +49,7 @@ namespace System.Text.Json.Serialization.Converters
         protected internal override bool OnWriteResume(Utf8JsonWriter writer, TDictionary value, JsonSerializerOptions options, ref WriteStack state)
         {
             IDictionaryEnumerator enumerator;
-            if (state.Current.CollectionEnumerator == null)
+            if (state.Current.CollectionEnumerator is null)
             {
                 enumerator = value.GetEnumerator();
                 state.Current.CollectionEnumerator = enumerator;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
@@ -43,7 +43,7 @@ namespace System.Text.Json.Serialization.Converters
             ref WriteStack state)
         {
             IEnumerator enumerator;
-            if (state.Current.CollectionEnumerator == null)
+            if (state.Current.CollectionEnumerator is null)
             {
                 enumerator = value.GetEnumerator();
                 state.Current.CollectionEnumerator = enumerator;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
@@ -73,7 +73,7 @@ namespace System.Text.Json.Serialization
 
             string? constructingTypeName = type.GetImmutableEnumerableConstructingTypeName();
 
-            return constructingTypeName == null
+            return constructingTypeName is null
                 ? null
                 : type.Assembly.GetType(constructingTypeName);
         }
@@ -86,7 +86,7 @@ namespace System.Text.Json.Serialization
 
             string? constructingTypeName = type.GetImmutableDictionaryConstructingTypeName();
 
-            return constructingTypeName == null
+            return constructingTypeName is null
                 ? null
                 : type.Assembly.GetType(constructingTypeName);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Converters
             Debug.Assert(value is not null);
 
             IEnumerator<TElement> enumerator;
-            if (state.Current.CollectionEnumerator == null)
+            if (state.Current.CollectionEnumerator is null)
             {
                 enumerator = value.GetEnumerator();
                 state.Current.CollectionEnumerator = enumerator;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
@@ -44,7 +44,7 @@ namespace System.Text.Json.Serialization.Converters
             int index = state.Current.EnumeratorIndex;
             JsonConverter<object?> elementConverter = GetElementConverter(ref state);
 
-            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling is null)
             {
                 // Fast path that avoids validation and extra indirection.
                 for (; index < list.Count; index++)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
@@ -42,7 +42,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             Func<IEnumerable<KeyValuePair<TKey, TValue>>, TDictionary>? creator =
                 (Func<IEnumerable<KeyValuePair<TKey, TValue>>, TDictionary>?)state.Current.JsonTypeInfo.CreateObjectWithArgs;
-            Debug.Assert(creator != null);
+            Debug.Assert(creator is not null);
             state.Current.ReturnValue = creator((Dictionary<TKey, TValue>)state.Current.ReturnValue!);
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
 
             Func<IEnumerable<TElement>, TCollection>? creator = (Func<IEnumerable<TElement>, TCollection>?)typeInfo.CreateObjectWithArgs;
-            Debug.Assert(creator != null);
+            Debug.Assert(creator is not null);
             state.Current.ReturnValue = creator((List<TElement>)state.Current.ReturnValue!);
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -54,7 +54,7 @@ namespace System.Text.Json.Serialization
 
         protected static JsonConverter<TElement> GetElementConverter(ref WriteStack state)
         {
-            Debug.Assert(state.Current.JsonPropertyInfo != null);
+            Debug.Assert(state.Current.JsonPropertyInfo is not null);
             return (JsonConverter<TElement>)state.Current.JsonPropertyInfo.EffectiveConverter;
         }
 
@@ -83,7 +83,7 @@ namespace System.Text.Json.Serialization
 
                 state.Current.JsonPropertyInfo = elementTypeInfo.PropertyInfoForTypeInfo;
                 JsonConverter<TElement> elementConverter = GetElementConverter(elementTypeInfo);
-                if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+                if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling is null)
                 {
                     // Fast path that avoids validation and extra indirection.
                     while (true)
@@ -181,7 +181,7 @@ namespace System.Text.Json.Serialization
 
                     if ((state.Current.MetadataPropertyNames & MetadataPropertyName.Id) != 0)
                     {
-                        Debug.Assert(state.ReferenceId != null);
+                        Debug.Assert(state.ReferenceId is not null);
                         Debug.Assert(options.ReferenceHandlingStrategy == JsonKnownReferenceHandler.Preserve);
                         Debug.Assert(state.Current.ReturnValue is TCollection);
                         state.ReferenceResolver.AddReference(state.ReferenceId, state.Current.ReturnValue);
@@ -296,7 +296,7 @@ namespace System.Text.Json.Serialization
         {
             bool success;
 
-            if (value == null)
+            if (value is null)
             {
                 writer.WriteNullValue();
                 success = true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -96,7 +96,7 @@ namespace System.Text.Json.Serialization
                 _keyConverter ??= GetConverter<TKey>(keyTypeInfo);
                 _valueConverter ??= GetConverter<TValue>(elementTypeInfo);
 
-                if (_valueConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+                if (_valueConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling is null)
                 {
                     // Process all elements.
                     while (true)
@@ -204,7 +204,7 @@ namespace System.Text.Json.Serialization
 
                     if ((state.Current.MetadataPropertyNames & MetadataPropertyName.Id) != 0)
                     {
-                        Debug.Assert(state.ReferenceId != null);
+                        Debug.Assert(state.ReferenceId is not null);
                         Debug.Assert(options.ReferenceHandlingStrategy == JsonKnownReferenceHandler.Preserve);
                         Debug.Assert(state.Current.ReturnValue is TDictionary);
                         state.ReferenceResolver.AddReference(state.ReferenceId, state.Current.ReturnValue);
@@ -337,7 +337,7 @@ namespace System.Text.Json.Serialization
             JsonSerializerOptions options,
             ref WriteStack state)
         {
-            if (dictionary == null)
+            if (dictionary is null)
             {
                 writer.WriteNullValue();
                 return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json.Serialization.Converters
                 return;
             }
 
-            if (state.Current.JsonTypeInfo.CreateObject == null)
+            if (state.Current.JsonTypeInfo.CreateObject is null)
             {
                 ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonTypeInfo.Type);
             }
@@ -41,7 +41,7 @@ namespace System.Text.Json.Serialization.Converters
             int index = state.Current.EnumeratorIndex;
             JsonConverter<TElement> elementConverter = GetElementConverter(ref state);
 
-            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling is null)
             {
                 // Fast path that avoids validation and extra indirection.
                 for (; index < list.Count; index++)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
@@ -23,7 +23,7 @@ namespace System.Text.Json.Serialization.Converters
                 return;
             }
 
-            if (state.Current.JsonTypeInfo.CreateObject == null)
+            if (state.Current.JsonTypeInfo.CreateObject is null)
             {
                 ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonTypeInfo.Type);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ReadOnlyMemoryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ReadOnlyMemoryConverter.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json.Serialization.Converters
 
             JsonConverter<T> elementConverter = GetElementConverter(ref state);
 
-            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling is null)
             {
                 // Fast path that avoids validation and extra indirection.
                 for (; index < value.Length; index++)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOfTConverter.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
                 return;
             }
 
-            if (state.Current.JsonTypeInfo.CreateObject == null)
+            if (state.Current.JsonTypeInfo.CreateObject is null)
             {
                 ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonTypeInfo.Type);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
@@ -16,7 +16,7 @@ namespace System.Text.Json.Serialization.Converters
         protected sealed override void Add(in object? value, ref ReadStack state)
         {
             var addMethodDelegate = ((Action<TCollection, object?>?)state.Current.JsonTypeInfo.AddMethodDelegate);
-            Debug.Assert(addMethodDelegate != null);
+            Debug.Assert(addMethodDelegate is not null);
             addMethodDelegate((TCollection)state.Current.ReturnValue!, value);
         }
 
@@ -30,20 +30,20 @@ namespace System.Text.Json.Serialization.Converters
             JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
             Func<object>? constructorDelegate = typeInfo.CreateObject;
 
-            if (constructorDelegate == null)
+            if (constructorDelegate is null)
             {
                 ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(Type, ref reader, ref state);
             }
 
             state.Current.ReturnValue = constructorDelegate();
 
-            Debug.Assert(typeInfo.AddMethodDelegate != null);
+            Debug.Assert(typeInfo.AddMethodDelegate is not null);
         }
 
         protected sealed override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
         {
             IEnumerator enumerator;
-            if (state.Current.CollectionEnumerator == null)
+            if (state.Current.CollectionEnumerator is null)
             {
                 enumerator = value.GetEnumerator();
                 state.Current.CollectionEnumerator = enumerator;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -51,7 +51,7 @@ namespace System.Text.Json.Serialization.Converters
         internal override bool OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
         {
             JsonTypeInfo jsonTypeInfo = state.Current.JsonTypeInfo;
-            Debug.Assert(jsonTypeInfo is JsonTypeInfo<T> typeInfo && typeInfo.SerializeHandler != null);
+            Debug.Assert(jsonTypeInfo is JsonTypeInfo<T> typeInfo && typeInfo.SerializeHandler is not null);
 
             if (!state.SupportContinuation &&
                 jsonTypeInfo.CanUseSerializeHandler &&

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json.Serialization.Converters
             Debug.Assert(obj is JsonObject);
             JsonObject jObject = (JsonObject)obj;
 
-            Debug.Assert(value == null || value is JsonNode);
+            Debug.Assert(value is null || value is JsonNode);
             JsonNode? jNodeValue = value;
 
             if (options.AllowDuplicateProperties)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -44,7 +44,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
                 else
                 {
-                    if (jsonTypeInfo.CreateObject == null)
+                    if (jsonTypeInfo.CreateObject is null)
                     {
                         ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo, ref reader, ref state);
                     }
@@ -53,7 +53,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
 
                 PopulatePropertiesFastPath(obj, jsonTypeInfo, options, ref reader, ref state);
-                Debug.Assert(obj != null);
+                Debug.Assert(obj is not null);
                 value = (T)obj;
                 return true;
             }
@@ -120,7 +120,7 @@ namespace System.Text.Json.Serialization.Converters
                     }
                     else
                     {
-                        if (jsonTypeInfo.CreateObject == null)
+                        if (jsonTypeInfo.CreateObject is null)
                         {
                             ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo, ref reader, ref state);
                         }
@@ -130,7 +130,7 @@ namespace System.Text.Json.Serialization.Converters
 
                     if ((state.Current.MetadataPropertyNames & MetadataPropertyName.Id) != 0)
                     {
-                        Debug.Assert(state.ReferenceId != null);
+                        Debug.Assert(state.ReferenceId is not null);
                         Debug.Assert(options.ReferenceHandlingStrategy == JsonKnownReferenceHandler.Preserve);
                         state.ReferenceResolver.AddReference(state.ReferenceId, obj);
                         state.ReferenceId = null;
@@ -145,7 +145,7 @@ namespace System.Text.Json.Serialization.Converters
                 else
                 {
                     obj = state.Current.ReturnValue!;
-                    Debug.Assert(obj != null);
+                    Debug.Assert(obj is not null);
                 }
 
                 // Process all properties.
@@ -199,7 +199,7 @@ namespace System.Text.Json.Serialization.Converters
                     }
                     else
                     {
-                        Debug.Assert(state.Current.JsonPropertyInfo != null);
+                        Debug.Assert(state.Current.JsonPropertyInfo is not null);
                         jsonPropertyInfo = state.Current.JsonPropertyInfo!;
                     }
 
@@ -260,11 +260,11 @@ namespace System.Text.Json.Serialization.Converters
             state.Current.ValidateAllRequiredPropertiesAreRead(jsonTypeInfo);
 
             // Unbox
-            Debug.Assert(obj != null);
+            Debug.Assert(obj is not null);
             value = (T)obj;
 
             // Check if we are trying to update the UTF-8 property cache.
-            if (state.Current.PropertyRefCacheBuilder != null)
+            if (state.Current.PropertyRefCacheBuilder is not null)
             {
                 jsonTypeInfo.UpdateUtf8PropertyCache(ref state.Current);
             }
@@ -313,7 +313,7 @@ namespace System.Text.Json.Serialization.Converters
             state.Current.ValidateAllRequiredPropertiesAreRead(jsonTypeInfo);
 
             // Check if we are trying to update the UTF-8 property cache.
-            if (state.Current.PropertyRefCacheBuilder != null)
+            if (state.Current.PropertyRefCacheBuilder is not null)
             {
                 jsonTypeInfo.UpdateUtf8PropertyCache(ref state.Current);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -20,9 +20,9 @@ namespace System.Text.Json.Serialization.Converters
 
             bool success = jsonParameterInfo.EffectiveConverter.TryReadAsObject(ref reader, jsonParameterInfo.ParameterType, jsonParameterInfo.Options, ref state, out object? arg);
 
-            if (success && !(arg == null && jsonParameterInfo.IgnoreNullTokensOnRead))
+            if (success && !(arg is null && jsonParameterInfo.IgnoreNullTokensOnRead))
             {
-                if (arg == null && !jsonParameterInfo.IsNullable && jsonParameterInfo.Options.RespectNullableAnnotations)
+                if (arg is null && !jsonParameterInfo.IsNullable && jsonParameterInfo.Options.RespectNullableAnnotations)
                 {
                     ThrowHelper.ThrowJsonException_ConstructorParameterDisallowNull(jsonParameterInfo.Name, state.Current.JsonTypeInfo.Type);
                 }
@@ -35,8 +35,8 @@ namespace System.Text.Json.Serialization.Converters
 
         protected sealed override object CreateObject(ref ReadStackFrame frame)
         {
-            Debug.Assert(frame.CtorArgumentState != null);
-            Debug.Assert(frame.JsonTypeInfo.CreateObjectWithArgs != null);
+            Debug.Assert(frame.CtorArgumentState is not null);
+            Debug.Assert(frame.JsonTypeInfo.CreateObjectWithArgs is not null);
 
             object[] arguments = (object[])frame.CtorArgumentState.Arguments;
             frame.CtorArgumentState.Arguments = null!;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Converters
             ref Utf8JsonReader reader,
             JsonParameterInfo jsonParameterInfo)
         {
-            Debug.Assert(state.Current.CtorArgumentState!.Arguments != null);
+            Debug.Assert(state.Current.CtorArgumentState!.Arguments is not null);
             var arguments = (Arguments<TArg0, TArg1, TArg2, TArg3>)state.Current.CtorArgumentState.Arguments;
 
             bool success;
@@ -90,7 +90,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
 
-            Debug.Assert(typeInfo.CreateObjectWithArgs != null);
+            Debug.Assert(typeInfo.CreateObjectWithArgs is not null);
 
             var arguments = new Arguments<TArg0, TArg1, TArg2, TArg3>();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -72,7 +72,7 @@ namespace System.Text.Json.Serialization.Converters
                     Utf8JsonReader tempReader;
 
                     FoundProperty[]? properties = argumentState.FoundProperties;
-                    Debug.Assert(properties != null);
+                    Debug.Assert(properties is not null);
 
                     for (int i = 0; i < argumentState.FoundPropertyCount; i++)
                     {
@@ -97,7 +97,7 @@ namespace System.Text.Json.Serialization.Converters
                         state.Current.JsonPropertyInfo = jsonPropertyInfo;
                         state.Current.NumberHandling = jsonPropertyInfo.EffectiveNumberHandling;
 
-                        bool useExtensionProperty = dataExtKey != null;
+                        bool useExtensionProperty = dataExtKey is not null;
 
                         if (useExtensionProperty)
                         {
@@ -206,7 +206,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 if ((state.Current.MetadataPropertyNames & MetadataPropertyName.Id) != 0)
                 {
-                    Debug.Assert(state.ReferenceId != null);
+                    Debug.Assert(state.ReferenceId is not null);
                     Debug.Assert(options.ReferenceHandlingStrategy == JsonKnownReferenceHandler.Preserve);
                     state.ReferenceResolver.AddReference(state.ReferenceId, obj);
                     state.ReferenceId = null;
@@ -222,9 +222,9 @@ namespace System.Text.Json.Serialization.Converters
                         object? propValue = argumentState.FoundPropertiesAsync![i].Item2;
                         string? dataExtKey = argumentState.FoundPropertiesAsync![i].Item3;
 
-                        if (dataExtKey == null)
+                        if (dataExtKey is null)
                         {
-                            Debug.Assert(jsonPropertyInfo.Set != null);
+                            Debug.Assert(jsonPropertyInfo.Set is not null);
 
                             if (propValue is not null || !jsonPropertyInfo.IgnoreNullTokensOnRead || default(T) is not null)
                             {
@@ -274,11 +274,11 @@ namespace System.Text.Json.Serialization.Converters
             jsonTypeInfo.OnDeserialized?.Invoke(obj);
 
             // Unbox
-            Debug.Assert(obj != null);
+            Debug.Assert(obj is not null);
             value = (T)obj;
 
             // Check if we are trying to update the UTF-8 property cache.
-            if (state.Current.PropertyRefCacheBuilder != null)
+            if (state.Current.PropertyRefCacheBuilder is not null)
             {
                 jsonTypeInfo.UpdateUtf8PropertyCache(ref state.Current);
             }
@@ -349,7 +349,7 @@ namespace System.Text.Json.Serialization.Converters
                         continue;
                     }
 
-                    Debug.Assert(jsonParameterInfo.MatchingProperty != null);
+                    Debug.Assert(jsonParameterInfo.MatchingProperty is not null);
                     ReadAndCacheConstructorArgument(ref state, ref reader, jsonParameterInfo);
 
                     state.Current.EndConstructorParameter();
@@ -360,7 +360,7 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         ArgumentState argumentState = state.Current.CtorArgumentState!;
 
-                        if (argumentState.FoundProperties == null)
+                        if (argumentState.FoundProperties is null)
                         {
                             argumentState.FoundProperties =
                                 ArrayPool<FoundProperty>.Shared.Rent(Math.Max(1, state.Current.JsonTypeInfo.PropertyCache.Length));
@@ -452,9 +452,9 @@ namespace System.Text.Json.Serialization.Converters
                     jsonPropertyInfo = state.Current.JsonPropertyInfo;
                 }
 
-                if (jsonParameterInfo != null)
+                if (jsonParameterInfo is not null)
                 {
-                    Debug.Assert(jsonPropertyInfo == null);
+                    Debug.Assert(jsonPropertyInfo is null);
 
                     if (!HandleConstructorArgumentWithContinuation(ref state, ref reader, jsonParameterInfo))
                     {
@@ -557,7 +557,7 @@ namespace System.Text.Json.Serialization.Converters
 
             ArgumentState argumentState = state.Current.CtorArgumentState!;
 
-            if (argumentState.FoundPropertiesAsync == null)
+            if (argumentState.FoundPropertiesAsync is null)
             {
                 argumentState.FoundPropertiesAsync = ArrayPool<FoundPropertyAsync>.Shared.Rent(Math.Max(1, state.Current.JsonTypeInfo.PropertyCache.Length));
             }
@@ -602,7 +602,7 @@ namespace System.Text.Json.Serialization.Converters
             // Set current JsonPropertyInfo to null to avoid conflicts on push.
             state.Current.JsonPropertyInfo = null;
 
-            Debug.Assert(state.Current.CtorArgumentState != null);
+            Debug.Assert(state.Current.CtorArgumentState is not null);
 
             InitializeConstructorArgumentCaches(ref state, options);
         }
@@ -618,7 +618,7 @@ namespace System.Text.Json.Serialization.Converters
             [NotNullWhen(true)] out JsonParameterInfo? jsonParameterInfo)
         {
             Debug.Assert(state.Current.JsonTypeInfo.Kind is JsonTypeInfoKind.Object);
-            Debug.Assert(state.Current.CtorArgumentState != null);
+            Debug.Assert(state.Current.CtorArgumentState is not null);
 
             jsonPropertyInfo = JsonSerializer.LookupProperty(
                 obj: null,
@@ -635,7 +635,7 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             jsonParameterInfo = jsonPropertyInfo.AssociatedParameter;
-            if (jsonParameterInfo != null)
+            if (jsonParameterInfo is not null)
             {
                 state.Current.JsonPropertyInfo = null;
                 state.Current.CtorArgumentState!.JsonParameterInfo = jsonParameterInfo;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteArrayConverter.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, byte[]? value, JsonSerializerOptions options)
         {
-            if (value == null)
+            if (value is null)
             {
                 writer.WriteNullValue();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -75,7 +75,7 @@ namespace System.Text.Json.Serialization.Converters
                 _nameCacheForReading.TryAdd(fieldInfo.JsonName, fieldInfo.Key);
             }
 
-            if (namingPolicy != null)
+            if (namingPolicy is not null)
             {
                 // Additionally populate the field index with the default names of fields that used a naming policy.
                 // This is done to preserve backward compat: default names should still be recognized by the parser.
@@ -204,7 +204,7 @@ namespace System.Text.Json.Serialization.Converters
 
             if (IsDefinedValueOrCombinationOfValues(key))
             {
-                Debug.Assert(s_isFlagsEnum || dictionaryKeyPolicy != null, "Should only be entered by flags enums or dictionary key policy.");
+                Debug.Assert(s_isFlagsEnum || dictionaryKeyPolicy is not null, "Should only be entered by flags enums or dictionary key policy.");
                 string stringValue = FormatEnumAsString(key, value, dictionaryKeyPolicy);
                 if (dictionaryKeyPolicy is null && _nameCacheForWriting.Count < NameCacheSizeSoftLimit)
                 {
@@ -285,7 +285,7 @@ namespace System.Text.Json.Serialization.Converters
             }
 
         End:
-            if (rentedBuffer != null)
+            if (rentedBuffer is not null)
             {
                 charBuffer.Clear();
                 ArrayPool<char>.Shared.Return(rentedBuffer);
@@ -434,7 +434,7 @@ namespace System.Text.Json.Serialization.Converters
             }
             else
             {
-                Debug.Assert(dictionaryKeyPolicy != null);
+                Debug.Assert(dictionaryKeyPolicy is not null);
 
                 foreach (EnumFieldInfo enumField in _enumFieldInfo)
                 {
@@ -556,14 +556,14 @@ namespace System.Text.Json.Serialization.Converters
                 ulong key = ConvertToUInt64(value);
                 EnumFieldNameKind kind;
 
-                if (enumMemberAttributes != null && enumMemberAttributes.TryGetValue(originalName, out string? attributeName))
+                if (enumMemberAttributes is not null && enumMemberAttributes.TryGetValue(originalName, out string? attributeName))
                 {
                     originalName = attributeName;
                     kind = EnumFieldNameKind.Attribute;
                 }
                 else
                 {
-                    kind = namingPolicy != null ? EnumFieldNameKind.NamingPolicy : EnumFieldNameKind.Default;
+                    kind = namingPolicy is not null ? EnumFieldNameKind.NamingPolicy : EnumFieldNameKind.Default;
                 }
 
                 string jsonName = ResolveAndValidateJsonName(originalName, namingPolicy, kind);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/HalfConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/HalfConverter.cs
@@ -62,7 +62,7 @@ namespace System.Text.Json.Serialization.Converters
             byteBuffer = byteBuffer.Slice(0, written);
 
             bool success = TryParse(byteBuffer, out result);
-            if (rentedByteBuffer != null)
+            if (rentedByteBuffer is not null)
             {
                 ArrayPool<byte>.Shared.Return(rentedByteBuffer);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int128Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int128Converter.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowFormatException(NumericType.Int128);
             }
 
-            if (rentedBuffer != null)
+            if (rentedBuffer is not null)
             {
                 ArrayPool<byte>.Shared.Return(rentedBuffer);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization.Converters
         public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
         {
             // For performance, lift up the writer implementation.
-            if (value == null)
+            if (value is null)
             {
                 writer.WriteNullValue();
             }
@@ -37,11 +37,11 @@ namespace System.Text.Json.Serialization.Converters
         {
             ArgumentNullException.ThrowIfNull(value);
 
-            if (options.DictionaryKeyPolicy != null && !isWritingExtensionDataProperty)
+            if (options.DictionaryKeyPolicy is not null && !isWritingExtensionDataProperty)
             {
                 value = options.DictionaryKeyPolicy.ConvertName(value);
 
-                if (value == null)
+                if (value is null)
                 {
                     ThrowHelper.ThrowInvalidOperationException_NamingPolicyReturnNull(options.DictionaryKeyPolicy);
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt128Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt128Converter.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowFormatException(NumericType.UInt128);
             }
 
-            if (rentedBuffer != null)
+            if (rentedBuffer is not null)
             {
                 ArrayPool<byte>.Shared.Return(rentedBuffer);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceResolver.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization
 
         internal override void PopReferenceForCycleDetection()
         {
-            Debug.Assert(_stackForCycleDetection != null);
+            Debug.Assert(_stackForCycleDetection is not null);
             _stackForCycleDetection.Pop();
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
@@ -37,7 +37,7 @@ namespace System.Text.Json.Serialization
                     else
                     {
                         // Standard discriminator-based resolution.
-                        Debug.Assert(state.PolymorphicTypeDiscriminator != null);
+                        Debug.Assert(state.PolymorphicTypeDiscriminator is not null);
                         Debug.Assert(resolver.UsesTypeDiscriminators);
                         resolver.TryGetDerivedJsonTypeInfo(state.PolymorphicTypeDiscriminator, out resolvedType);
                     }
@@ -83,8 +83,8 @@ namespace System.Text.Json.Serialization
         internal JsonConverter? ResolvePolymorphicConverter(object value, JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options, ref WriteStack state)
         {
             Debug.Assert(!IsValueType);
-            Debug.Assert(value != null && Type!.IsAssignableFrom(value.GetType()));
-            Debug.Assert(CanBePolymorphic || jsonTypeInfo.PolymorphicTypeResolver != null);
+            Debug.Assert(value is not null && Type!.IsAssignableFrom(value.GetType()));
+            Debug.Assert(CanBePolymorphic || jsonTypeInfo.PolymorphicTypeResolver is not null);
             Debug.Assert(state.PolymorphicTypeDiscriminator is null);
 
             JsonConverter? polymorphicConverter = null;
@@ -153,7 +153,7 @@ namespace System.Text.Json.Serialization
         {
             Debug.Assert(!IsValueType);
             Debug.Assert(!state.IsContinuation);
-            Debug.Assert(value != null);
+            Debug.Assert(value is not null);
 
             switch (options.ReferenceHandlingStrategy)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -39,16 +39,14 @@ namespace System.Text.Json.Serialization
 
         internal ConverterStrategy ConverterStrategy
         {
-            get => _converterStrategy;
+            get;
             init
             {
                 CanUseDirectReadOrWrite = value == ConverterStrategy.Value && IsInternalConverter;
                 RequiresReadAhead = value == ConverterStrategy.Value;
-                _converterStrategy = value;
+                field = value;
             }
         }
-
-        private ConverterStrategy _converterStrategy;
 
         /// <summary>
         /// Invoked by the base contructor to populate the initial value of the <see cref="ConverterStrategy"/> property.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -184,7 +184,7 @@ namespace System.Text.Json.Serialization
                     int originalPropertyDepth = reader.CurrentDepth;
                     long originalPropertyBytesConsumed = reader.BytesConsumed;
 
-                    if (state.Current.NumberHandling != null && IsInternalConverterForNumberType)
+                    if (state.Current.NumberHandling is not null && IsInternalConverterForNumberType)
                     {
                         value = ReadNumberWithCustomHandling(ref reader, state.Current.NumberHandling.Value, options);
                     }
@@ -245,7 +245,7 @@ namespace System.Text.Json.Serialization
                 state.Current.OriginalDepth = reader.CurrentDepth;
             }
 
-            if (parentObj != null && propertyInfo != null && !propertyInfo.IsForTypeInfo)
+            if (parentObj is not null && propertyInfo is not null && !propertyInfo.IsForTypeInfo)
             {
                 state.Current.HasParentObject = true;
             }
@@ -345,7 +345,7 @@ namespace System.Text.Json.Serialization
 
                 int originalPropertyDepth = writer.CurrentDepth;
 
-                if (state.Current.NumberHandling != null && IsInternalConverterForNumberType)
+                if (state.Current.NumberHandling is not null && IsInternalConverterForNumberType)
                 {
                     WriteNumberWithCustomHandling(writer, value, state.Current.NumberHandling.Value);
                 }
@@ -444,7 +444,7 @@ namespace System.Text.Json.Serialization
 
         internal bool TryWriteDataExtensionProperty(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
         {
-            Debug.Assert(value != null);
+            Debug.Assert(value is not null);
 
             if (!IsInternalConverter)
             {
@@ -454,7 +454,7 @@ namespace System.Text.Json.Serialization
             JsonDictionaryConverter<T>? dictionaryConverter = this as JsonDictionaryConverter<T>
                 ?? (this as JsonMetadataServicesConverter<T>)?.Converter as JsonDictionaryConverter<T>;
 
-            if (dictionaryConverter == null)
+            if (dictionaryConverter is null)
             {
                 // If not JsonDictionaryConverter<T> then we are JsonObject.
                 // Avoid a type reference to JsonObject and its converter to support trimming.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -54,7 +54,7 @@ namespace System.Text.Json
 
         private static JsonTypeInfo GetTypeInfo(JsonSerializerContext context, Type inputType)
         {
-            Debug.Assert(context != null);
+            Debug.Assert(context is not null);
             Debug.Assert(inputType != null);
 
             JsonTypeInfo? info = context.GetTypeInfo(inputType);
@@ -144,7 +144,7 @@ namespace System.Text.Json
 
         private static JsonTypeInfo<List<T?>> GetOrAddListTypeInfoForRootLevelValueMode<T>(JsonTypeInfo<T> elementTypeInfo)
         {
-            if (elementTypeInfo._asyncEnumerableRootLevelValueTypeInfo != null)
+            if (elementTypeInfo._asyncEnumerableRootLevelValueTypeInfo is not null)
             {
                 return (JsonTypeInfo<List<T?>>)elementTypeInfo._asyncEnumerableRootLevelValueTypeInfo;
             }
@@ -162,7 +162,7 @@ namespace System.Text.Json
 
         private static JsonTypeInfo<List<T?>> GetOrAddListTypeInfoForArrayMode<T>(JsonTypeInfo<T> elementTypeInfo)
         {
-            if (elementTypeInfo._asyncEnumerableArrayTypeInfo != null)
+            if (elementTypeInfo._asyncEnumerableArrayTypeInfo is not null)
             {
                 return (JsonTypeInfo<List<T?>>)elementTypeInfo._asyncEnumerableArrayTypeInfo;
             }
@@ -181,7 +181,7 @@ namespace System.Text.Json
 
         private static JsonTypeInfo<IAsyncEnumerable<T>> GetOrAddIAsyncEnumerableTypeInfoForSerialize<T>(JsonTypeInfo<T> elementTypeInfo)
         {
-            if (elementTypeInfo._asyncEnumerableRootLevelSerializer != null)
+            if (elementTypeInfo._asyncEnumerableRootLevelSerializer is not null)
             {
                 return (JsonTypeInfo<IAsyncEnumerable<T>>)elementTypeInfo._asyncEnumerableRootLevelSerializer;
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
@@ -178,7 +178,7 @@ namespace System.Text.Json
                                 // Found a $type property in a type that doesn't support polymorphism
                                 ThrowHelper.ThrowJsonException_MetadataUnexpectedProperty(propertyName, ref state);
                             }
-                            if (state.PolymorphicTypeDiscriminator != null)
+                            if (state.PolymorphicTypeDiscriminator is not null)
                             {
                                 // Found a duplicate $type property.
                                 ThrowHelper.ThrowJsonException_DuplicateMetadataProperty(state.Current.JsonPropertyName);
@@ -262,7 +262,7 @@ namespace System.Text.Json
                             ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
                         }
 
-                        if (state.ReferenceId != null)
+                        if (state.ReferenceId is not null)
                         {
                             ThrowHelper.ThrowNotSupportedException_ObjectWithParameterizedCtorRefMetadataNotSupported(s_refPropertyName, ref reader, ref state);
                         }
@@ -276,7 +276,7 @@ namespace System.Text.Json
                             ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
                         }
 
-                        if (state.ReferenceId != null)
+                        if (state.ReferenceId is not null)
                         {
                             ThrowHelper.ThrowNotSupportedException_ObjectWithParameterizedCtorRefMetadataNotSupported(s_refPropertyName, ref reader, ref state);
                         }
@@ -285,7 +285,7 @@ namespace System.Text.Json
                         break;
 
                     case MetadataPropertyName.Type:
-                        Debug.Assert(state.PolymorphicTypeDiscriminator == null);
+                        Debug.Assert(state.PolymorphicTypeDiscriminator is null);
 
                         switch (reader.TokenType)
                         {
@@ -414,7 +414,7 @@ namespace System.Text.Json
                     }
                     else if (property.EscapedNameEquals(s_idPropertyName))
                     {
-                        if (state.ReferenceId != null)
+                        if (state.ReferenceId is not null)
                         {
                             ThrowHelper.ThrowNotSupportedException_ObjectWithParameterizedCtorRefMetadataNotSupported(s_refPropertyName, ref reader, ref state);
                         }
@@ -431,7 +431,7 @@ namespace System.Text.Json
                     }
                     else if (property.EscapedNameEquals(s_refPropertyName))
                     {
-                        if (state.ReferenceId != null)
+                        if (state.ReferenceId is not null)
                         {
                             ThrowHelper.ThrowNotSupportedException_ObjectWithParameterizedCtorRefMetadataNotSupported(s_refPropertyName, ref reader, ref state);
                         }
@@ -478,7 +478,7 @@ namespace System.Text.Json
                     }
                     else if (property.Key == "$id")
                     {
-                        if (state.ReferenceId != null)
+                        if (state.ReferenceId is not null)
                         {
                             ThrowHelper.ThrowNotSupportedException_ObjectWithParameterizedCtorRefMetadataNotSupported(s_refPropertyName, ref reader, ref state);
                         }
@@ -490,7 +490,7 @@ namespace System.Text.Json
                     }
                     else if (property.Key == "$ref")
                     {
-                        if (state.ReferenceId != null)
+                        if (state.ReferenceId is not null)
                         {
                             ThrowHelper.ThrowNotSupportedException_ObjectWithParameterizedCtorRefMetadataNotSupported(s_refPropertyName, ref reader, ref state);
                         }
@@ -562,7 +562,7 @@ namespace System.Text.Json
         internal static T ResolveReferenceId<T>(ref ReadStack state)
         {
             Debug.Assert(!typeof(T).IsValueType);
-            Debug.Assert(state.ReferenceId != null);
+            Debug.Assert(state.ReferenceId is not null);
 
             string referenceId = state.ReferenceId;
             object value = state.ReferenceResolver.ResolveReference(referenceId);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json
 
                     if (createExtensionProperty)
                     {
-                        Debug.Assert(obj != null, "obj is null");
+                        Debug.Assert(obj is not null, "obj is null");
                         CreateExtensionDataProperty(obj, dataExtProperty, options);
                     }
 
@@ -107,7 +107,7 @@ namespace System.Text.Json
             JsonPropertyInfo jsonPropertyInfo,
             JsonSerializerOptions options)
         {
-            Debug.Assert(jsonPropertyInfo != null);
+            Debug.Assert(jsonPropertyInfo is not null);
 
             object? extensionData = jsonPropertyInfo.GetValueAsObject(obj);
 
@@ -116,7 +116,7 @@ namespace System.Text.Json
             bool isReadOnlyDictionary = jsonPropertyInfo.PropertyType == typeof(IReadOnlyDictionary<string, object>) ||
                                         jsonPropertyInfo.PropertyType == typeof(IReadOnlyDictionary<string, JsonElement>);
 
-            if (extensionData == null || (isReadOnlyDictionary && extensionData != null))
+            if (extensionData is null || (isReadOnlyDictionary && extensionData is not null))
             {
                 // Create the appropriate dictionary type. We already verified the types.
 #if DEBUG
@@ -137,7 +137,7 @@ namespace System.Text.Json
                 Func<object>? createObjectForExtensionDataProp = jsonPropertyInfo.JsonTypeInfo.CreateObject
                     ?? jsonPropertyInfo.JsonTypeInfo.CreateObjectForExtensionDataProperty;
 
-                if (createObjectForExtensionDataProp == null)
+                if (createObjectForExtensionDataProp is null)
                 {
                     // Avoid a reference to the JsonNode type for trimming
                     if (jsonPropertyInfo.PropertyType.FullName == JsonTypeInfo.JsonObjectTypeName)
@@ -148,7 +148,7 @@ namespace System.Text.Json
                     // create a Dictionary<TKey, TValue> instance seeded with any existing contents.
                     else if (jsonPropertyInfo.PropertyType == typeof(IReadOnlyDictionary<string, object>))
                     {
-                        if (extensionData != null)
+                        if (extensionData is not null)
                         {
                             var existing = (IReadOnlyDictionary<string, object>)extensionData;
                             var newDict = new Dictionary<string, object>();
@@ -162,13 +162,13 @@ namespace System.Text.Json
                         {
                             extensionData = new Dictionary<string, object>();
                         }
-                        Debug.Assert(jsonPropertyInfo.Set != null);
+                        Debug.Assert(jsonPropertyInfo.Set is not null);
                         jsonPropertyInfo.Set(obj, extensionData);
                         return;
                     }
                     else if (jsonPropertyInfo.PropertyType == typeof(IReadOnlyDictionary<string, JsonElement>))
                     {
-                        if (extensionData != null)
+                        if (extensionData is not null)
                         {
                             var existing = (IReadOnlyDictionary<string, JsonElement>)extensionData;
                             var newDict = new Dictionary<string, JsonElement>();
@@ -182,7 +182,7 @@ namespace System.Text.Json
                         {
                             extensionData = new Dictionary<string, JsonElement>();
                         }
-                        Debug.Assert(jsonPropertyInfo.Set != null);
+                        Debug.Assert(jsonPropertyInfo.Set is not null);
                         jsonPropertyInfo.Set(obj, extensionData);
                         return;
                     }
@@ -193,7 +193,7 @@ namespace System.Text.Json
                 }
 
                 extensionData = createObjectForExtensionDataProp();
-                Debug.Assert(jsonPropertyInfo.Set != null);
+                Debug.Assert(jsonPropertyInfo.Set is not null);
                 jsonPropertyInfo.Set(obj, extensionData);
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -401,7 +401,7 @@ namespace System.Text.Json
             }
             finally
             {
-                if (tempArray != null)
+                if (tempArray is not null)
                 {
                     utf8.Clear();
                     ArrayPool<byte>.Shared.Return(tempArray);
@@ -432,7 +432,7 @@ namespace System.Text.Json
             }
             finally
             {
-                if (tempArray != null)
+                if (tempArray is not null)
                 {
                     utf8.Clear();
                     ArrayPool<byte>.Shared.Return(tempArray);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
@@ -141,7 +141,7 @@ namespace System.Text.Json
         private static JsonElement WriteElementAsObject(object? value, JsonTypeInfo jsonTypeInfo)
         {
             JsonSerializerOptions options = jsonTypeInfo.Options;
-            Debug.Assert(options != null);
+            Debug.Assert(options is not null);
 
             Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(jsonTypeInfo.Options, out PooledByteBufferWriter output);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json
 
             MetadataPropertyName writtenMetadata = MetadataPropertyName.None;
 
-            if (state.NewReferenceId != null)
+            if (state.NewReferenceId is not null)
             {
                 writer.WriteString(s_metadataId, state.NewReferenceId);
                 writtenMetadata |= MetadataPropertyName.Id;
@@ -34,7 +34,7 @@ namespace System.Text.Json
 
             if (state.PolymorphicTypeDiscriminator is object discriminator)
             {
-                Debug.Assert(state.PolymorphicTypeResolver != null);
+                Debug.Assert(state.PolymorphicTypeResolver is not null);
 
                 JsonEncodedText propertyName =
                     state.PolymorphicTypeResolver.CustomTypeDiscriminatorPropertyNameJsonEncoded is JsonEncodedText customPropertyName
@@ -76,10 +76,10 @@ namespace System.Text.Json
         /// </summary>
         internal static bool TryGetReferenceForValue(object currentValue, ref WriteStack state, Utf8JsonWriter writer)
         {
-            Debug.Assert(state.NewReferenceId == null);
+            Debug.Assert(state.NewReferenceId is null);
 
             string referenceId = state.ReferenceResolver.GetReference(currentValue, out bool alreadyExists);
-            Debug.Assert(referenceId != null);
+            Debug.Assert(referenceId is not null);
 
             if (alreadyExists)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -51,7 +51,7 @@ namespace System.Text.Json.Serialization
         /// </summary>
         bool IBuiltInJsonTypeInfoResolver.IsCompatibleWithOptions(JsonSerializerOptions options)
         {
-            Debug.Assert(options != null);
+            Debug.Assert(options is not null);
 
             JsonSerializerOptions? generatedSerializerOptions = GeneratedSerializerOptions;
 
@@ -93,7 +93,7 @@ namespace System.Text.Json.Serialization
         /// </remarks>
         protected JsonSerializerContext(JsonSerializerOptions? options)
         {
-            if (options != null)
+            if (options is not null)
             {
                 options.VerifyMutable();
                 AssociateWithOptions(options);
@@ -109,7 +109,7 @@ namespace System.Text.Json.Serialization
 
         JsonTypeInfo? IJsonTypeInfoResolver.GetTypeInfo(Type type, JsonSerializerOptions options)
         {
-            if (options != null && options != _options)
+            if (options is not null && options != _options)
             {
                 ThrowHelper.ThrowInvalidOperationException_ResolverTypeInfoOptionsNotCompatible();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -161,7 +161,7 @@ namespace System.Text.Json
 
         internal bool TryGetTypeInfoCached(Type type, [NotNullWhen(true)] out JsonTypeInfo? typeInfo)
         {
-            if (_cachingContext == null)
+            if (_cachingContext is null)
             {
                 typeInfo = null;
                 return false;
@@ -188,7 +188,7 @@ namespace System.Text.Json
 
         internal bool TryGetPolymorphicTypeInfoForRootType(object rootValue, [NotNullWhen(true)] out JsonTypeInfo? polymorphicTypeInfo)
         {
-            Debug.Assert(rootValue != null);
+            Debug.Assert(rootValue is not null);
 
             Type runtimeType = rootValue.GetType();
             if (runtimeType != JsonTypeInfo.ObjectType)
@@ -429,7 +429,7 @@ namespace System.Text.Json
             public static CachingContext GetOrCreate(JsonSerializerOptions options)
             {
                 Debug.Assert(options.IsReadOnly, "Cannot create caching contexts for mutable JsonSerializerOptions instances");
-                Debug.Assert(options._typeInfoResolver != null);
+                Debug.Assert(options._typeInfoResolver is not null);
 
                 int hashCode = s_optionsComparer.GetHashCode(options);
 
@@ -513,7 +513,7 @@ namespace System.Text.Json
         {
             public bool Equals(JsonSerializerOptions? left, JsonSerializerOptions? right)
             {
-                Debug.Assert(left != null && right != null);
+                Debug.Assert(left is not null && right is not null);
 
                 return
                     left._dictionaryKeyPolicy == right._dictionaryKeyPolicy &&

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -909,7 +909,7 @@ namespace System.Text.Json
             get
             {
                 Debug.Assert(IsReadOnly);
-                Debug.Assert(TypeInfoResolver != null);
+                Debug.Assert(TypeInfoResolver is not null);
                 return _canUseFastPathSerializationLogic ??= TypeInfoResolver.IsCompatibleWithOptions(this);
             }
         }
@@ -1028,7 +1028,7 @@ namespace System.Text.Json
                 ThrowHelper.ThrowInvalidOperationException_JsonSerializerIsReflectionDisabled();
             }
 
-            Debug.Assert(_typeInfoResolver != null);
+            Debug.Assert(_typeInfoResolver is not null);
             // NB preserve write order.
             _isReadOnly = true;
             _isConfiguredForJsonSerializer = true;
@@ -1055,7 +1055,7 @@ namespace System.Text.Json
 
             JsonTypeInfo? info = resolver.GetTypeInfo(type, this);
 
-            if (info != null)
+            if (info is not null)
             {
                 if (info.Type != type)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
@@ -118,7 +118,7 @@ namespace System.Text.Json.Serialization.Metadata
                 }
 
                 // Since the object and IEnumerable converters cover all types, we should have a converter.
-                Debug.Assert(converter != null);
+                Debug.Assert(converter is not null);
                 return converter;
             }
         }
@@ -153,10 +153,10 @@ namespace System.Text.Json.Serialization.Metadata
             JsonConverter? converter = options.GetConverterFromList(typeToConvert);
 
             // Priority 2: Attempt to get converter from [JsonConverter] on the type being converted.
-            if (resolveJsonConverterAttribute && converter == null)
+            if (resolveJsonConverterAttribute && converter is null)
             {
                 JsonConverterAttribute? converterAttribute = typeToConvert.GetUniqueCustomAttribute<JsonConverterAttribute>(inherit: false);
-                if (converterAttribute != null)
+                if (converterAttribute is not null)
                 {
                     converter = GetConverterFromAttribute(converterAttribute, typeToConvert: typeToConvert, memberInfo: null, options);
                 }
@@ -188,7 +188,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 // Allow the attribute to create the converter.
                 converter = converterAttribute.CreateConverter(typeToConvert);
-                if (converter == null)
+                if (converter is null)
                 {
                     ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(declaringType, memberInfo, typeToConvert);
                 }
@@ -220,7 +220,7 @@ namespace System.Text.Json.Serialization.Metadata
                 converter = (JsonConverter)Activator.CreateInstance(converterType)!;
             }
 
-            Debug.Assert(converter != null);
+            Debug.Assert(converter is not null);
             if (!converter.CanConvert(typeToConvert))
             {
                 Type? underlyingType = Nullable.GetUnderlyingType(typeToConvert);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Helpers.cs
@@ -523,7 +523,7 @@ namespace System.Text.Json.Serialization.Metadata
                     continue;
                 }
 
-                bool hasJsonIncludeAttribute = propertyInfo.GetCustomAttribute<JsonIncludeAttribute>(inherit: false) != null;
+                bool hasJsonIncludeAttribute = propertyInfo.GetCustomAttribute<JsonIncludeAttribute>(inherit: false) is not null;
 
                 // Only include properties that either have a public getter or a public setter or have the JsonIncludeAttribute set.
                 if (propertyInfo.GetMethod?.IsPublic == true ||
@@ -545,7 +545,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             foreach (FieldInfo fieldInfo in currentType.GetFields(AllInstanceMembers))
             {
-                bool hasJsonIncludeAttribute = fieldInfo.GetCustomAttribute<JsonIncludeAttribute>(inherit: false) != null;
+                bool hasJsonIncludeAttribute = fieldInfo.GetCustomAttribute<JsonIncludeAttribute>(inherit: false) is not null;
                 if (hasJsonIncludeAttribute || (fieldInfo.IsPublic && typeInfo.Options.IncludeFields))
                 {
                     AddMember(
@@ -576,13 +576,13 @@ namespace System.Text.Json.Serialization.Metadata
             ref JsonTypeInfo.PropertyHierarchyResolutionState state)
         {
             JsonPropertyInfo? jsonPropertyInfo = CreatePropertyInfo(typeInfo, typeToConvert, memberInfo, typeNamingPolicy, nullabilityCtx, typeIgnoreCondition, typeInfo.Options, shouldCheckForRequiredKeyword, hasJsonIncludeAttribute);
-            if (jsonPropertyInfo == null)
+            if (jsonPropertyInfo is null)
             {
                 // ignored invalid property
                 return;
             }
 
-            Debug.Assert(jsonPropertyInfo.Name != null);
+            Debug.Assert(jsonPropertyInfo.Name is not null);
             typeInfo.PropertyList.AddPropertyWithConflictResolution(jsonPropertyInfo, ref state);
         }
 
@@ -735,7 +735,7 @@ namespace System.Text.Json.Serialization.Metadata
             bool hasJsonIncludeAttribute,
             JsonNamingPolicy? typeNamingPolicy)
         {
-            Debug.Assert(jsonPropertyInfo.AttributeProvider == null);
+            Debug.Assert(jsonPropertyInfo.AttributeProvider is null);
 
             switch (jsonPropertyInfo.AttributeProvider = memberInfo)
             {
@@ -765,7 +765,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             jsonPropertyInfo.IgnoreCondition = ignoreCondition;
-            jsonPropertyInfo.IsExtensionData = memberInfo.GetCustomAttribute<JsonExtensionDataAttribute>(inherit: false) != null;
+            jsonPropertyInfo.IsExtensionData = memberInfo.GetCustomAttribute<JsonExtensionDataAttribute>(inherit: false) is not null;
         }
 
         private static void DeterminePropertyPolicies(JsonPropertyInfo propertyInfo, MemberInfo memberInfo)
@@ -784,7 +784,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             JsonPropertyNameAttribute? nameAttribute = memberInfo.GetCustomAttribute<JsonPropertyNameAttribute>(inherit: false);
             string? name;
-            if (nameAttribute != null)
+            if (nameAttribute is not null)
             {
                 name = nameAttribute.Name;
             }
@@ -799,7 +799,7 @@ namespace System.Text.Json.Serialization.Metadata
                     : memberInfo.Name;
             }
 
-            if (name == null)
+            if (name is null)
             {
                 ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNameNull(propertyInfo);
             }
@@ -810,7 +810,7 @@ namespace System.Text.Json.Serialization.Metadata
         private static void DeterminePropertyIsRequired(JsonPropertyInfo propertyInfo, MemberInfo memberInfo, bool shouldCheckForRequiredKeyword)
         {
             propertyInfo.IsRequired =
-                memberInfo.GetCustomAttribute<JsonRequiredAttribute>(inherit: false) != null
+                memberInfo.GetCustomAttribute<JsonRequiredAttribute>(inherit: false) is not null
                 || (shouldCheckForRequiredKeyword && memberInfo.HasRequiredMemberAttribute());
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -63,7 +63,7 @@ namespace System.Text.Json.Serialization.Metadata
             // This should be the last update operation in the resolver to avoid resetting the flag.
             typeInfo.IsCustomized = false;
 
-            if (_modifiers != null)
+            if (_modifiers is not null)
             {
                 foreach (Action<JsonTypeInfo> modifier in _modifiers)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
@@ -326,7 +326,7 @@ namespace System.Text.Json.Serialization.Metadata
         internal static JsonConverter<T> GetTypedConverter<T>(JsonConverter converter)
         {
             JsonConverter<T>? typedConverter = converter as JsonConverter<T>;
-            if (typedConverter == null)
+            if (typedConverter is null)
             {
                 throw new InvalidOperationException(SR.Format(SR.SerializationConverterNotCompatible, typedConverter, typeof(T)));
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Helpers.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             JsonConverter<T> converter = GetConverter(objectInfo);
             var typeInfo = new JsonTypeInfo<T>(converter, options);
-            if (objectInfo.ObjectWithParameterizedConstructorCreator != null)
+            if (objectInfo.ObjectWithParameterizedConstructorCreator is not null)
             {
                 // NB parameter metadata must be populated *before* property metadata
                 // so that properties can be linked to their associated parameters.
@@ -44,7 +44,7 @@ namespace System.Text.Json.Serialization.Metadata
                 typeInfo.CreateObjectForExtensionDataProperty = ((JsonTypeInfo)typeInfo).CreateObject;
             }
 
-            if (objectInfo.PropertyMetadataInitializer != null)
+            if (objectInfo.PropertyMetadataInitializer is not null)
             {
                 typeInfo.SourceGenDelayedPropertyInitializer = objectInfo.PropertyMetadataInitializer;
             }
@@ -79,7 +79,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             ArgumentNullException.ThrowIfNull(collectionInfo);
 
-            converter = collectionInfo.SerializeHandler != null
+            converter = collectionInfo.SerializeHandler is not null
                 ? new JsonMetadataServicesConverter<T>(converter)
                 : converter;
 
@@ -106,12 +106,12 @@ namespace System.Text.Json.Serialization.Metadata
         private static JsonConverter<T> GetConverter<T>(JsonObjectInfoValues<T> objectInfo)
         {
 #pragma warning disable CS8714 // Nullability of type argument 'T' doesn't match 'notnull' constraint.
-            JsonConverter<T> converter = objectInfo.ObjectWithParameterizedConstructorCreator != null
+            JsonConverter<T> converter = objectInfo.ObjectWithParameterizedConstructorCreator is not null
                 ? new LargeObjectWithParameterizedConstructorConverter<T>()
                 : new ObjectDefaultConverter<T>();
 #pragma warning restore CS8714
 
-            return objectInfo.SerializeHandler != null
+            return objectInfo.SerializeHandler is not null
                 ? new JsonMetadataServicesConverter<T>(converter)
                 : converter;
         }
@@ -185,7 +185,7 @@ namespace System.Text.Json.Serialization.Metadata
                         {
                             // [JsonInclude] property is inaccessible and the source generator
                             // did not provide getter/setter delegates (e.g. older generator).
-                            Debug.Assert(jsonPropertyInfo.MemberName != null, "MemberName is not set by source gen");
+                            Debug.Assert(jsonPropertyInfo.MemberName is not null, "MemberName is not set by source gen");
                             ThrowHelper.ThrowInvalidOperationException_JsonIncludeOnInaccessibleProperty(jsonPropertyInfo.MemberName, jsonPropertyInfo.DeclaringType);
                         }
 
@@ -249,11 +249,11 @@ namespace System.Text.Json.Serialization.Metadata
             string? name;
 
             // Property name settings.
-            if (declaredJsonPropertyName != null)
+            if (declaredJsonPropertyName is not null)
             {
                 name = declaredJsonPropertyName;
             }
-            else if (propertyInfo.Options.PropertyNamingPolicy == null)
+            else if (propertyInfo.Options.PropertyNamingPolicy is null)
             {
                 name = declaredPropertyName;
             }
@@ -263,7 +263,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             // Compat: We need to do validation before we assign Name so that we get InvalidOperationException rather than ArgumentNullException
-            if (name == null)
+            if (name is null)
             {
                 ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNameNull(propertyInfo);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
@@ -33,7 +33,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             string? propertyName = propertyInfo.PropertyName;
-            if (propertyName == null)
+            if (propertyName is null)
             {
                 throw new ArgumentException(nameof(propertyInfo.PropertyName));
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
@@ -95,7 +95,7 @@ namespace System.Text.Json.Serialization.Metadata
             get
             {
                 // Use delayed initialization to ensure that reflection dependencies are pay-for-play.
-                Debug.Assert(MatchingProperty.DeclaringTypeInfo != null, "Declaring type metadata must have already been configured.");
+                Debug.Assert(MatchingProperty.DeclaringTypeInfo is not null, "Declaring type metadata must have already been configured.");
                 ICustomAttributeProvider? parameterInfo = _attributeProvider;
                 if (parameterInfo is null && MatchingProperty.DeclaringTypeInfo.ConstructorAttributeProvider is MethodBase ctorInfo)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPolymorphismOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPolymorphismOptions.cs
@@ -13,9 +13,6 @@ namespace System.Text.Json.Serialization.Metadata
     public class JsonPolymorphismOptions
     {
         private DerivedTypeList? _derivedTypes;
-        private bool _ignoreUnrecognizedTypeDiscriminators;
-        private JsonUnknownDerivedTypeHandling _unknownDerivedTypeHandling;
-        private string? _typeDiscriminatorPropertyName;
         private bool _isConfigured;
 
         /// <summary>
@@ -40,12 +37,12 @@ namespace System.Text.Json.Serialization.Metadata
         /// </exception>
         public bool IgnoreUnrecognizedTypeDiscriminators
         {
-            get => _ignoreUnrecognizedTypeDiscriminators;
+            get;
             set
             {
                 VerifyMutable();
                 _isConfigured = true;
-                _ignoreUnrecognizedTypeDiscriminators = value;
+                field = value;
             }
         }
 
@@ -57,12 +54,12 @@ namespace System.Text.Json.Serialization.Metadata
         /// </exception>
         public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling
         {
-            get => _unknownDerivedTypeHandling;
+            get;
             set
             {
                 VerifyMutable();
                 _isConfigured = true;
-                _unknownDerivedTypeHandling = value;
+                field = value;
             }
         }
 
@@ -76,12 +73,12 @@ namespace System.Text.Json.Serialization.Metadata
         [AllowNull]
         public string TypeDiscriminatorPropertyName
         {
-            get => _typeDiscriminatorPropertyName ?? JsonSerializer.TypePropertyName;
+            get => field ?? JsonSerializer.TypePropertyName;
             set
             {
                 VerifyMutable();
                 _isConfigured = true;
-                _typeDiscriminatorPropertyName = value;
+                field = value;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -47,15 +47,13 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public JsonConverter? CustomConverter
         {
-            get => _customConverter;
+            get;
             set
             {
                 VerifyMutable();
-                _customConverter = value;
+                field = value;
             }
         }
-
-        private JsonConverter? _customConverter;
 
         /// <summary>
         /// Gets or sets a getter delegate for the property.
@@ -201,7 +199,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public JsonObjectCreationHandling? ObjectCreationHandling
         {
-            get => _objectCreationHandling;
+            get;
             set
             {
                 VerifyMutable();
@@ -214,11 +212,10 @@ namespace System.Text.Json.Serialization.Metadata
                     }
                 }
 
-                _objectCreationHandling = value;
+                field = value;
             }
         }
 
-        private JsonObjectCreationHandling? _objectCreationHandling;
         internal JsonObjectCreationHandling EffectiveObjectCreationHandling { get; private set; }
 
         internal string? MemberName { get; set; } // Do not rename (legacy schema generation)
@@ -316,7 +313,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public bool IsExtensionData
         {
-            get => _isExtensionDataProperty;
+            get;
             set
             {
                 VerifyMutable();
@@ -326,11 +323,9 @@ namespace System.Text.Json.Serialization.Metadata
                     ThrowHelper.ThrowInvalidOperationException_SerializationDataExtensionPropertyInvalid(this);
                 }
 
-                _isExtensionDataProperty = value;
+                field = value;
             }
         }
-
-        private bool _isExtensionDataProperty;
 
         /// <summary>
         /// Specifies whether the current property is required for deserialization to be successful.
@@ -832,15 +827,13 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public int Order
         {
-            get => _order;
+            get;
             set
             {
                 VerifyMutable();
-                _order = value;
+                field = value;
             }
         }
-
-        private int _order;
 
         internal bool ReadJsonAndAddExtensionProperty(
             object obj,
@@ -1035,15 +1028,13 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public JsonNumberHandling? NumberHandling
         {
-            get => _numberHandling;
+            get;
             set
             {
                 VerifyMutable();
-                _numberHandling = value;
+                field = value;
             }
         }
-
-        private JsonNumberHandling? _numberHandling;
 
         /// <summary>
         /// Number handling after considering options and declaring type number handling

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -26,7 +26,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             get
             {
-                Debug.Assert(_effectiveConverter != null);
+                Debug.Assert(_effectiveConverter is not null);
                 return _effectiveConverter;
             }
         }
@@ -204,7 +204,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 VerifyMutable();
 
-                if (value != null)
+                if (value is not null)
                 {
                     if (!JsonSerializer.IsValidCreationHandlingValue(value.Value))
                     {
@@ -410,7 +410,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal void Configure()
         {
-            Debug.Assert(DeclaringTypeInfo != null);
+            Debug.Assert(DeclaringTypeInfo is not null);
             Debug.Assert(!IsConfigured);
 
             if (IsIgnored)
@@ -469,7 +469,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         private void ValidateAndCachePropertyName()
         {
-            Debug.Assert(Name != null);
+            Debug.Assert(Name is not null);
 
             if (Options.ReferenceHandlingStrategy is JsonKnownReferenceHandler.Preserve &&
                 this is { DeclaringType.IsValueType: false, IsIgnored: false, IsExtensionData: false } &&
@@ -488,7 +488,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         private void DetermineIgnoreCondition()
         {
-            if (_ignoreCondition != null)
+            if (_ignoreCondition is not null)
             {
                 // Do not apply global policy if already configured on the property level.
                 return;
@@ -520,12 +520,12 @@ namespace System.Text.Json.Serialization.Metadata
 
         private void DetermineSerializationCapabilities()
         {
-            Debug.Assert(EffectiveConverter != null, "Must have calculated the effective converter.");
+            Debug.Assert(EffectiveConverter is not null, "Must have calculated the effective converter.");
             CanSerialize = HasGetter;
             CanDeserialize = HasSetter;
 
             Debug.Assert(MemberType is 0 or MemberTypes.Field or MemberTypes.Property);
-            if (MemberType == 0 || _ignoreCondition != null)
+            if (MemberType == 0 || _ignoreCondition is not null)
             {
                 // No policy to be applied if either:
                 // 1. JsonPropertyInfo is a custom instance (not generated via reflection or sourcegen).
@@ -537,7 +537,7 @@ namespace System.Text.Json.Serialization.Metadata
             if ((EffectiveConverter.ConverterStrategy & (ConverterStrategy.Enumerable | ConverterStrategy.Dictionary)) != 0)
             {
                 // Properties of collections types that only have setters are not supported.
-                if (Get == null && Set != null && !_isUserSpecifiedSetter)
+                if (Get is null && Set is not null && !_isUserSpecifiedSetter)
                 {
                     CanDeserialize = false;
                 }
@@ -546,7 +546,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 // For read-only properties of non-collection types, apply IgnoreReadOnlyProperties/Fields policy,
                 // unless a `ShouldSerialize` predicate has been explicitly applied by the user (null or non-null).
-                if (Get != null && Set == null && IgnoreReadOnlyMember && !_isUserSpecifiedShouldSerialize)
+                if (Get is not null && Set is null && IgnoreReadOnlyMember && !_isUserSpecifiedShouldSerialize)
                 {
                     CanSerialize = false;
                 }
@@ -557,12 +557,12 @@ namespace System.Text.Json.Serialization.Metadata
 
         private void DetermineNumberHandlingForTypeInfo()
         {
-            Debug.Assert(DeclaringTypeInfo != null, "We should have ensured parent is assigned in JsonTypeInfo");
+            Debug.Assert(DeclaringTypeInfo is not null, "We should have ensured parent is assigned in JsonTypeInfo");
             Debug.Assert(!DeclaringTypeInfo.IsConfigured);
 
             JsonNumberHandling? declaringTypeNumberHandling = DeclaringTypeInfo.NumberHandling;
 
-            if (declaringTypeNumberHandling != null && declaringTypeNumberHandling != JsonNumberHandling.Strict && !EffectiveConverter.IsInternalConverter)
+            if (declaringTypeNumberHandling is not null && declaringTypeNumberHandling != JsonNumberHandling.Strict && !EffectiveConverter.IsInternalConverter)
             {
                 ThrowHelper.ThrowInvalidOperationException_NumberHandlingOnPropertyInvalid(this);
             }
@@ -585,9 +585,9 @@ namespace System.Text.Json.Serialization.Metadata
 
         private void DetermineNumberHandlingForProperty()
         {
-            Debug.Assert(DeclaringTypeInfo != null, "We should have ensured parent is assigned in JsonTypeInfo");
+            Debug.Assert(DeclaringTypeInfo is not null, "We should have ensured parent is assigned in JsonTypeInfo");
             Debug.Assert(!IsConfigured, "Should not be called post-configuration.");
-            Debug.Assert(_jsonTypeInfo != null, "Must have already been determined on configuration.");
+            Debug.Assert(_jsonTypeInfo is not null, "Must have already been determined on configuration.");
 
             bool numberHandlingIsApplicable = NumberHandingIsApplicable();
 
@@ -612,12 +612,12 @@ namespace System.Text.Json.Serialization.Metadata
 
         private void DetermineEffectiveObjectCreationHandlingForProperty()
         {
-            Debug.Assert(EffectiveConverter != null, "Must have calculated the effective converter.");
-            Debug.Assert(DeclaringTypeInfo != null, "We should have ensured parent is assigned in JsonTypeInfo");
+            Debug.Assert(EffectiveConverter is not null, "Must have calculated the effective converter.");
+            Debug.Assert(DeclaringTypeInfo is not null, "We should have ensured parent is assigned in JsonTypeInfo");
             Debug.Assert(!IsConfigured, "Should not be called post-configuration.");
 
             JsonObjectCreationHandling effectiveObjectCreationHandling = JsonObjectCreationHandling.Replace;
-            if (ObjectCreationHandling == null)
+            if (ObjectCreationHandling is null)
             {
                 // Consult type-level configuration, then global configuration.
                 // Ignore global configuration if we're using a parameterized constructor.
@@ -630,10 +630,10 @@ namespace System.Text.Json.Serialization.Metadata
                 bool canPopulate =
                     preferredCreationHandling == JsonObjectCreationHandling.Populate &&
                     EffectiveConverter.CanPopulate &&
-                    Get != null &&
-                    (!PropertyType.IsValueType || Set != null) &&
+                    Get is not null &&
+                    (!PropertyType.IsValueType || Set is not null) &&
                     !DeclaringTypeInfo.SupportsPolymorphicDeserialization &&
-                    !(Set == null && IgnoreReadOnlyMember);
+                    !(Set is null && IgnoreReadOnlyMember);
 
                 effectiveObjectCreationHandling = canPopulate ? JsonObjectCreationHandling.Populate : JsonObjectCreationHandling.Replace;
             }
@@ -644,24 +644,24 @@ namespace System.Text.Json.Serialization.Metadata
                     ThrowHelper.ThrowInvalidOperationException_ObjectCreationHandlingPopulateNotSupportedByConverter(this);
                 }
 
-                if (Get == null)
+                if (Get is null)
                 {
                     ThrowHelper.ThrowInvalidOperationException_ObjectCreationHandlingPropertyMustHaveAGetter(this);
                 }
 
-                if (PropertyType.IsValueType && Set == null)
+                if (PropertyType.IsValueType && Set is null)
                 {
                     ThrowHelper.ThrowInvalidOperationException_ObjectCreationHandlingPropertyValueTypeMustHaveASetter(this);
                 }
 
-                Debug.Assert(_jsonTypeInfo != null);
+                Debug.Assert(_jsonTypeInfo is not null);
                 Debug.Assert(_jsonTypeInfo.IsConfigurationStarted);
                 if (JsonTypeInfo.SupportsPolymorphicDeserialization)
                 {
                     ThrowHelper.ThrowInvalidOperationException_ObjectCreationHandlingPropertyCannotAllowPolymorphicDeserialization(this);
                 }
 
-                if (Set == null && IgnoreReadOnlyMember)
+                if (Set is null && IgnoreReadOnlyMember)
                 {
                     ThrowHelper.ThrowInvalidOperationException_ObjectCreationHandlingPropertyCannotAllowReadOnlyMember(this);
                 }
@@ -785,7 +785,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             get
             {
-                Debug.Assert(_name != null);
+                Debug.Assert(_name is not null);
                 return _name;
             }
             set
@@ -951,12 +951,12 @@ namespace System.Text.Json.Serialization.Metadata
                 return false;
 
             Debug.Assert(EffectiveConverter.CanPopulate, "Property is marked with Populate but converter cannot populate. This should have been validated in Configure");
-            Debug.Assert(state.Parent.ReturnValue != null, "Parent object is null");
+            Debug.Assert(state.Parent.ReturnValue is not null, "Parent object is null");
             Debug.Assert(!state.Current.IsPopulating, "We've called TryGetPrePopulatedValue more than once");
             object? value = Get!(state.Parent.ReturnValue);
             state.Current.ReturnValue = value;
-            state.Current.IsPopulating = value != null;
-            return value != null;
+            state.Current.IsPopulating = value is not null;
+            return value is not null;
         }
 
         internal JsonTypeInfo JsonTypeInfo

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -132,7 +132,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             get
             {
-                Debug.Assert(_typedEffectiveConverter != null);
+                Debug.Assert(_typedEffectiveConverter is not null);
                 return _typedEffectiveConverter;
             }
         }
@@ -187,7 +187,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 // If a reference cycle is detected, treat value as null.
                 value = default!;
-                Debug.Assert(value == null);
+                Debug.Assert(value is null);
             }
 
             if (IgnoreDefaultValuesOnWrite)
@@ -260,7 +260,7 @@ namespace System.Text.Json.Serialization.Metadata
                 return true;
             }
 
-            if (value == null)
+            if (value is null)
             {
                 success = true;
             }
@@ -305,7 +305,7 @@ namespace System.Text.Json.Serialization.Metadata
                 success = true;
                 state.Current.MarkPropertyAsRead(this);
             }
-            else if (EffectiveConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            else if (EffectiveConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling is null)
             {
                 // CanUseDirectReadOrWrite == false when using streams
                 Debug.Assert(!state.IsContinuation);
@@ -379,7 +379,7 @@ namespace System.Text.Json.Serialization.Metadata
             else
             {
                 // Optimize for internal converters by avoiding the extra call to TryRead.
-                if (EffectiveConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+                if (EffectiveConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling is null)
                 {
                     // CanUseDirectReadOrWrite == false when using streams
                     Debug.Assert(!state.IsContinuation);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -33,7 +33,7 @@ namespace System.Text.Json.Serialization.Metadata
             get
             {
                 Debug.Assert(IsConfigured);
-                return _parameterCache != null;
+                return _parameterCache is not null;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -36,11 +36,6 @@ namespace System.Text.Json.Serialization.Metadata
         internal BitArray? OptionalPropertiesMask { get; private set; }
         internal bool ShouldTrackRequiredProperties => OptionalPropertiesMask is not null;
 
-        private Action<object>? _onSerializing;
-        private Action<object>? _onSerialized;
-        private Action<object>? _onDeserializing;
-        private Action<object>? _onDeserialized;
-
         internal JsonTypeInfo(Type type, JsonConverter converter, JsonSerializerOptions options)
         {
             Type = type;
@@ -120,7 +115,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public Action<object>? OnSerializing
         {
-            get => _onSerializing;
+            get;
             set
             {
                 VerifyMutable();
@@ -130,7 +125,7 @@ namespace System.Text.Json.Serialization.Metadata
                     ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoOperationNotPossibleForKind(Kind);
                 }
 
-                _onSerializing = value;
+                field = value;
             }
         }
 
@@ -150,7 +145,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public Action<object>? OnSerialized
         {
-            get => _onSerialized;
+            get;
             set
             {
                 VerifyMutable();
@@ -160,7 +155,7 @@ namespace System.Text.Json.Serialization.Metadata
                     ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoOperationNotPossibleForKind(Kind);
                 }
 
-                _onSerialized = value;
+                field = value;
             }
         }
 
@@ -180,7 +175,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public Action<object>? OnDeserializing
         {
-            get => _onDeserializing;
+            get;
             set
             {
                 VerifyMutable();
@@ -196,7 +191,7 @@ namespace System.Text.Json.Serialization.Metadata
                     ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoOnDeserializingCallbacksNotSupported(Type);
                 }
 
-                _onDeserializing = value;
+                field = value;
             }
         }
 
@@ -216,7 +211,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public Action<object>? OnDeserialized
         {
-            get => _onDeserialized;
+            get;
             set
             {
                 VerifyMutable();
@@ -226,7 +221,7 @@ namespace System.Text.Json.Serialization.Metadata
                     ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoOperationNotPossibleForKind(Kind);
                 }
 
-                _onDeserialized = value;
+                field = value;
             }
         }
 
@@ -790,7 +785,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public JsonUnmappedMemberHandling? UnmappedMemberHandling
         {
-            get => _unmappedMemberHandling;
+            get;
             set
             {
                 VerifyMutable();
@@ -805,15 +800,11 @@ namespace System.Text.Json.Serialization.Metadata
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
-                _unmappedMemberHandling = value;
+                field = value;
             }
         }
 
-        private JsonUnmappedMemberHandling? _unmappedMemberHandling;
-
         internal JsonUnmappedMemberHandling EffectiveUnmappedMemberHandling { get; private set; }
-
-        private JsonObjectCreationHandling? _preferredPropertyObjectCreationHandling;
 
         /// <summary>
         /// Gets or sets the preferred <see cref="JsonObjectCreationHandling"/> value for properties contained in the type.
@@ -834,7 +825,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </remarks>
         public JsonObjectCreationHandling? PreferredPropertyObjectCreationHandling
         {
-            get => _preferredPropertyObjectCreationHandling;
+            get;
             set
             {
                 VerifyMutable();
@@ -849,7 +840,7 @@ namespace System.Text.Json.Serialization.Metadata
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
-                _preferredPropertyObjectCreationHandling = value;
+                field = value;
             }
         }
 
@@ -866,7 +857,7 @@ namespace System.Text.Json.Serialization.Metadata
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IJsonTypeInfoResolver? OriginatingResolver
         {
-            get => _originatingResolver;
+            get;
             set
             {
                 VerifyMutable();
@@ -879,11 +870,9 @@ namespace System.Text.Json.Serialization.Metadata
                     IsCustomized = false;
                 }
 
-                _originatingResolver = value;
+                field = value;
             }
         }
-
-        private IJsonTypeInfoResolver? _originatingResolver;
 
         /// <summary>
         /// Gets or sets an attribute provider corresponding to the deserialization constructor.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -305,14 +305,14 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 VerifyMutable();
 
-                if (value != null)
+                if (value is not null)
                 {
                     if (Kind == JsonTypeInfoKind.None)
                     {
                         ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoOperationNotPossibleForKind(Kind);
                     }
 
-                    if (value.DeclaringTypeInfo != null && value.DeclaringTypeInfo != this)
+                    if (value.DeclaringTypeInfo is not null && value.DeclaringTypeInfo != this)
                     {
                         ThrowHelper.ThrowArgumentException_JsonPolymorphismOptionsAssociatedWithDifferentJsonTypeInfo(nameof(value));
                     }
@@ -990,7 +990,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             PropertyInfoForTypeInfo.Configure();
 
-            if (PolymorphismOptions != null)
+            if (PolymorphismOptions is not null)
             {
                 // This needs to be done before ConfigureProperties() is called
                 // JsonPropertyInfo.Configure() must have this value available in order to detect Polymoprhic + cyclic class case
@@ -1293,7 +1293,7 @@ namespace System.Text.Json.Serialization.Metadata
                 return;
             }
 
-            if (_properties != null)
+            if (_properties is not null)
             {
                 foreach (JsonPropertyInfo property in _properties)
                 {
@@ -1558,7 +1558,7 @@ namespace System.Text.Json.Serialization.Metadata
                         ThrowHelper.ThrowInvalidOperationException_ExtensionDataConflictsWithUnmappedMemberHandling(Type, property);
                     }
 
-                    if (ExtensionDataProperty != null)
+                    if (ExtensionDataProperty is not null)
                     {
                         ThrowHelper.ThrowInvalidOperationException_SerializationDuplicateTypeAttribute(Type, typeof(JsonExtensionDataAttribute));
                     }
@@ -1677,7 +1677,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             if (ExtensionDataProperty is { AssociatedParameter: not null })
             {
-                Debug.Assert(ExtensionDataProperty.MemberName != null, "Custom property info cannot be data extension property");
+                Debug.Assert(ExtensionDataProperty.MemberName is not null, "Custom property info cannot be data extension property");
                 ThrowHelper.ThrowInvalidOperationException_ExtensionDataCannotBindToCtorParam(ExtensionDataProperty.MemberName, ExtensionDataProperty);
             }
 
@@ -1850,7 +1850,7 @@ namespace System.Text.Json.Serialization.Metadata
             public void AddPropertyWithConflictResolution(JsonPropertyInfo jsonPropertyInfo, ref PropertyHierarchyResolutionState state)
             {
                 Debug.Assert(!_jsonTypeInfo.IsConfigured);
-                Debug.Assert(jsonPropertyInfo.MemberName != null, "MemberName can be null in custom JsonPropertyInfo instances and should never be passed in this method");
+                Debug.Assert(jsonPropertyInfo.MemberName is not null, "MemberName can be null in custom JsonPropertyInfo instances and should never be passed in this method");
 
                 // Algorithm should be kept in sync with the Roslyn equivalent in JsonSourceGenerator.Parser.cs
                 string memberName = jsonPropertyInfo.MemberName;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json.Serialization.Metadata
                 // Even though this is already handled by JsonMetadataServicesConverter,
                 // this avoids creating a WriteStack and calling into the converter infrastructure.
 
-                Debug.Assert(SerializeHandler != null);
+                Debug.Assert(SerializeHandler is not null);
                 Debug.Assert(Converter is JsonMetadataServicesConverter<T>);
 
                 SerializeHandler(writer, rootValue!);
@@ -96,7 +96,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 // Short-circuit calls into SerializeHandler, if the `CanUseSerializeHandlerInStreaming` heuristic allows it.
 
-                Debug.Assert(SerializeHandler != null);
+                Debug.Assert(SerializeHandler is not null);
                 Debug.Assert(CanUseSerializeHandler);
                 Debug.Assert(Converter is JsonMetadataServicesConverter<T>);
 
@@ -256,7 +256,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 // Short-circuit calls into SerializeHandler, if the `CanUseSerializeHandlerInStreaming` heuristic allows it.
 
-                Debug.Assert(SerializeHandler != null);
+                Debug.Assert(SerializeHandler is not null);
                 Debug.Assert(CanUseSerializeHandler);
                 Debug.Assert(Converter is JsonMetadataServicesConverter<T>);
 
@@ -312,7 +312,7 @@ namespace System.Text.Json.Serialization.Metadata
                         bufferWriter.WriteToStream(utf8Json);
                         bufferWriter.Clear();
 
-                        Debug.Assert(state.PendingTask == null);
+                        Debug.Assert(state.PendingTask is null);
                     } while (!isFinalBlock);
 
                     if (CanUseSerializeHandler)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -63,15 +63,15 @@ namespace System.Text.Json.Serialization.Metadata
 
             if (Kind == JsonTypeInfoKind.None)
             {
-                Debug.Assert(_createObject == null);
-                Debug.Assert(_typedCreateObject == null);
+                Debug.Assert(_createObject is null);
+                Debug.Assert(_typedCreateObject is null);
                 ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoOperationNotPossibleForKind(Kind);
             }
 
             if (!Converter.SupportsCreateObjectDelegate)
             {
                 Debug.Assert(_createObject is null);
-                Debug.Assert(_typedCreateObject == null);
+                Debug.Assert(_typedCreateObject is null);
                 ThrowHelper.ThrowInvalidOperationException_CreateObjectConverterNotCompatible(Type);
             }
 
@@ -242,7 +242,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 Debug.Assert(!IsReadOnly, "We should not mutate read-only JsonTypeInfo");
                 _serialize = value;
-                HasSerializeHandler = value != null;
+                HasSerializeHandler = value is not null;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoResolverChain.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoResolverChain.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json.Serialization.Metadata
             foreach (IJsonTypeInfoResolver resolver in _list)
             {
                 JsonTypeInfo? typeInfo = resolver.GetTypeInfo(type, options);
-                if (typeInfo != null)
+                if (typeInfo is not null)
                 {
                     return typeInfo;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoResolverWithAddedModifiers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoResolverWithAddedModifiers.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             JsonTypeInfo? typeInfo = _source.GetTypeInfo(type, options);
 
-            if (typeInfo != null)
+            if (typeInfo is not null)
             {
                 foreach (Action<JsonTypeInfo> modifier in _modifiers)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -70,7 +70,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             if (UsesTypeDiscriminators)
             {
-                Debug.Assert(_discriminatorIdtoType != null, "Discriminator index must have been populated.");
+                Debug.Assert(_discriminatorIdtoType is not null, "Discriminator index must have been populated.");
 
                 if (!converterCanHaveMetadata)
                 {
@@ -186,7 +186,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             Debug.Assert(typeDiscriminator is int or string);
             Debug.Assert(UsesTypeDiscriminators);
-            Debug.Assert(_discriminatorIdtoType != null);
+            Debug.Assert(_discriminatorIdtoType is not null);
 
             if (_discriminatorIdtoType.TryGetValue(typeDiscriminator, out DerivedJsonTypeInfo? result))
             {
@@ -277,7 +277,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             Debug.Assert(typeInfo.IsConfigured);
 
-            if (typeInfo.PolymorphismOptions != null)
+            if (typeInfo.PolymorphismOptions is not null)
             {
                 // Type defines its own polymorphic configuration.
                 return null;
@@ -289,7 +289,7 @@ namespace System.Text.Json.Serialization.Metadata
             for (Type? candidate = typeInfo.Type.BaseType; candidate != null; candidate = candidate.BaseType)
             {
                 JsonTypeInfo? candidateInfo = ResolveAncestorTypeInfo(candidate, typeInfo.Options);
-                if (candidateInfo?.PolymorphismOptions != null)
+                if (candidateInfo?.PolymorphismOptions is not null)
                 {
                     // stop on the first ancestor that has a match
                     matchingResult = candidateInfo;
@@ -301,9 +301,9 @@ namespace System.Text.Json.Serialization.Metadata
             foreach (Type interfaceType in typeInfo.Type.GetInterfaces())
             {
                 JsonTypeInfo? candidateInfo = ResolveAncestorTypeInfo(interfaceType, typeInfo.Options);
-                if (candidateInfo?.PolymorphismOptions != null)
+                if (candidateInfo?.PolymorphismOptions is not null)
                 {
-                    if (matchingResult != null)
+                    if (matchingResult is not null)
                     {
                         // Resolve any conflicting matches.
                         if (matchingResult.Type.IsAssignableFrom(interfaceType))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PreserveReferenceResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PreserveReferenceResolver.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json.Serialization
 
         public override void AddReference(string referenceId, object value)
         {
-            Debug.Assert(_referenceIdToObjectMap != null);
+            Debug.Assert(_referenceIdToObjectMap is not null);
 
             if (!_referenceIdToObjectMap.TryAdd(referenceId, value))
             {
@@ -40,7 +40,7 @@ namespace System.Text.Json.Serialization
 
         public override string GetReference(object value, out bool alreadyExists)
         {
-            Debug.Assert(_objectToReferenceIdMap != null);
+            Debug.Assert(_objectToReferenceIdMap is not null);
 
             if (_objectToReferenceIdMap.TryGetValue(value, out string? referenceId))
             {
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization
 
         public override object ResolveReference(string referenceId)
         {
-            Debug.Assert(_referenceIdToObjectMap != null);
+            Debug.Assert(_referenceIdToObjectMap is not null);
 
             if (!_referenceIdToObjectMap.TryGetValue(referenceId, out object? value))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -218,7 +218,7 @@ namespace System.Text.Json
         public JsonConverter InitializePolymorphicReEntry(JsonTypeInfo derivedJsonTypeInfo)
         {
             Debug.Assert(!IsContinuation);
-            Debug.Assert(Current.PolymorphicJsonTypeInfo == null);
+            Debug.Assert(Current.PolymorphicJsonTypeInfo is null);
             Debug.Assert(Current.PolymorphicSerializationState == PolymorphicSerializationState.None);
 
             Current.PolymorphicJsonTypeInfo = Current.JsonTypeInfo;
@@ -237,7 +237,7 @@ namespace System.Text.Json
         /// </summary>
         public JsonConverter ResumePolymorphicReEntry()
         {
-            Debug.Assert(Current.PolymorphicJsonTypeInfo != null);
+            Debug.Assert(Current.PolymorphicJsonTypeInfo is not null);
             Debug.Assert(Current.PolymorphicSerializationState == PolymorphicSerializationState.PolymorphicReEntrySuspended);
 
             // Swap out the two values as we resume the polymorphic converter
@@ -251,7 +251,7 @@ namespace System.Text.Json
         /// </summary>
         public void ExitPolymorphicConverter(bool success)
         {
-            Debug.Assert(Current.PolymorphicJsonTypeInfo != null);
+            Debug.Assert(Current.PolymorphicJsonTypeInfo is not null);
             Debug.Assert(Current.PolymorphicSerializationState == PolymorphicSerializationState.PolymorphicReEntryStarted);
 
             // Swap out the two values as we exit the polymorphic converter
@@ -291,7 +291,7 @@ namespace System.Text.Json
                 string? propertyName = GetPropertyName(ref frame);
                 AppendPropertyName(sb, propertyName);
 
-                if (frame.JsonTypeInfo != null && frame.IsProcessingEnumerable())
+                if (frame.JsonTypeInfo is not null && frame.IsProcessingEnumerable())
                 {
                     if (frame.ReturnValue is not IEnumerable enumerable)
                     {
@@ -329,7 +329,7 @@ namespace System.Text.Json
 
             static void AppendPropertyName(StringBuilder sb, string? propertyName)
             {
-                if (propertyName != null)
+                if (propertyName is not null)
                 {
                     if (propertyName.AsSpan().ContainsSpecialCharacters())
                     {
@@ -351,9 +351,9 @@ namespace System.Text.Json
 
                 // Attempt to get the JSON property name from the frame.
                 byte[]? utf8PropertyName = frame.JsonPropertyName;
-                if (utf8PropertyName == null)
+                if (utf8PropertyName is null)
                 {
-                    if (frame.JsonPropertyNameAsString != null)
+                    if (frame.JsonPropertyNameAsString is not null)
                     {
                         // Attempt to get the JSON property name set manually for dictionary
                         // keys and KeyValuePair property names.
@@ -367,7 +367,7 @@ namespace System.Text.Json
                     }
                 }
 
-                if (utf8PropertyName != null)
+                if (utf8PropertyName is not null)
                 {
                     propertyName = Encoding.UTF8.GetString(utf8PropertyName);
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -114,18 +114,12 @@ namespace System.Text.Json
         /// <summary>
         /// Is the current object a Dictionary.
         /// </summary>
-        public bool IsProcessingDictionary()
-        {
-            return JsonTypeInfo.Kind is JsonTypeInfoKind.Dictionary;
-        }
+        public bool IsProcessingDictionary() => JsonTypeInfo.Kind is JsonTypeInfoKind.Dictionary;
 
         /// <summary>
         /// Is the current object an Enumerable.
         /// </summary>
-        public bool IsProcessingEnumerable()
-        {
-            return JsonTypeInfo.Kind is JsonTypeInfoKind.Enumerable;
-        }
+        public bool IsProcessingEnumerable() => JsonTypeInfo.Kind is JsonTypeInfoKind.Enumerable;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void MarkPropertyAsRead(JsonPropertyInfo propertyInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -121,7 +121,7 @@ namespace System.Text.Json
         /// <summary>
         /// Whether the current frame needs to write out any metadata.
         /// </summary>
-        public readonly bool CurrentContainsMetadata => NewReferenceId != null || PolymorphicTypeDiscriminator != null;
+        public readonly bool CurrentContainsMetadata => NewReferenceId is not null || PolymorphicTypeDiscriminator is not null;
 
         private void EnsurePushCapacity()
         {
@@ -154,7 +154,7 @@ namespace System.Text.Json
             JsonSerializerOptions options = jsonTypeInfo.Options;
             if (options.ReferenceHandlingStrategy != JsonKnownReferenceHandler.Unspecified)
             {
-                Debug.Assert(options.ReferenceHandler != null);
+                Debug.Assert(options.ReferenceHandler is not null);
                 ReferenceResolver = options.ReferenceHandler.CreateResolver(writing: true);
 
                 if (options.ReferenceHandlingStrategy == JsonKnownReferenceHandler.IgnoreCycles &&
@@ -418,7 +418,7 @@ namespace System.Text.Json
 
             static void AppendPropertyName(StringBuilder sb, string? propertyName)
             {
-                if (propertyName != null)
+                if (propertyName is not null)
                 {
                     if (propertyName.AsSpan().ContainsSpecialCharacters())
                     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -153,11 +153,11 @@ namespace System.Text.Json
         {
             if (declaringType == null)
             {
-                Debug.Assert(propertyName == null);
+                Debug.Assert(propertyName is null);
                 throw new ArgumentException(SR.Format(SR.CannotSerializeInvalidType, typeToConvert), paramName);
             }
 
-            Debug.Assert(propertyName != null);
+            Debug.Assert(propertyName is not null);
             throw new ArgumentException(SR.Format(SR.CannotSerializeInvalidMember, typeToConvert, propertyName, declaringType), paramName);
         }
 
@@ -244,7 +244,7 @@ namespace System.Text.Json
         [DoesNotReturn]
         public static void ThrowInvalidOperationException_SerializerOptionsReadOnly(JsonSerializerContext? context)
         {
-            string message = context == null
+            string message = context is null
                 ? SR.SerializerOptionsReadOnly
                 : SR.SerializerContextOptionsReadOnly;
 
@@ -491,7 +491,7 @@ namespace System.Text.Json
         [DoesNotReturn]
         public static void ReThrowWithPath(scoped ref ReadStack state, JsonReaderException ex)
         {
-            Debug.Assert(ex.Path == null);
+            Debug.Assert(ex.Path is null);
 
             string path = state.JsonPath();
             string message = ex.Message;
@@ -851,7 +851,7 @@ namespace System.Text.Json
         [DoesNotReturn]
         public static void ThrowInvalidOperationException_JsonPropertyInfoIsBoundToDifferentJsonTypeInfo(JsonPropertyInfo propertyInfo)
         {
-            Debug.Assert(propertyInfo.DeclaringTypeInfo != null, "We should not throw this exception when ParentTypeInfo is null");
+            Debug.Assert(propertyInfo.DeclaringTypeInfo is not null, "We should not throw this exception when ParentTypeInfo is null");
             throw new InvalidOperationException(SR.Format(SR.JsonPropertyInfoBoundToDifferentParent, propertyInfo.Name, propertyInfo.DeclaringTypeInfo.Type.FullName));
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -384,7 +384,7 @@ namespace System.Text.Json
             return new JsonReaderException(message, lineNumber, bytePositionInLine);
         }
 
-        private static bool IsPrintable(byte value) => value >= 0x20 && value < 0x7F;
+        private static bool IsPrintable(byte value) => value is >= 0x20 and < 0x7F;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string GetPrintableString(byte value)
@@ -612,7 +612,7 @@ namespace System.Text.Json
             switch (resource)
             {
                 case ExceptionResource.MismatchedObjectArray:
-                    Debug.Assert(token == JsonConstants.CloseBracket || token == JsonConstants.CloseBrace);
+                    Debug.Assert(token is JsonConstants.CloseBracket or JsonConstants.CloseBrace);
                     message = (tokenType == JsonTokenType.PropertyName) ?
                         SR.Format(SR.CannotWriteEndAfterProperty, (char)token) :
                         SR.Format(SR.MismatchedObjectArray, (char)token);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ValueQueue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ValueQueue.cs
@@ -37,7 +37,7 @@ namespace System.Text.Json
                     goto default;
 
                 default:
-                    Debug.Assert(_multiple != null);
+                    Debug.Assert(_multiple is not null);
                     _multiple.Enqueue(value);
                     break;
             }
@@ -58,7 +58,7 @@ namespace System.Text.Json
                     return true;
 
                 default:
-                    Debug.Assert(_multiple != null);
+                    Debug.Assert(_multiple is not null);
                     return _multiple.TryDequeue(out value);
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -125,7 +125,7 @@ namespace System.Text.Json
 
         private static void EscapeString(ReadOnlySpan<byte> value, Span<byte> destination, JavaScriptEncoder encoder, ref int consumed, ref int written, bool isFinalBlock)
         {
-            Debug.Assert(encoder != null);
+            Debug.Assert(encoder is not null);
 
             OperationStatus result = encoder.EncodeUtf8(value, destination, out int encoderBytesConsumed, out int encoderBytesWritten, isFinalBlock);
 
@@ -154,7 +154,7 @@ namespace System.Text.Json
             written = indexOfFirstByteToEscape;
             consumed = indexOfFirstByteToEscape;
 
-            if (encoder != null)
+            if (encoder is not null)
             {
                 destination = destination.Slice(indexOfFirstByteToEscape);
                 value = value.Slice(indexOfFirstByteToEscape);
@@ -249,7 +249,7 @@ namespace System.Text.Json
 
         private static void EscapeString(ReadOnlySpan<char> value, Span<char> destination, JavaScriptEncoder encoder, ref int consumed, ref int written, bool isFinalBlock)
         {
-            Debug.Assert(encoder != null);
+            Debug.Assert(encoder is not null);
 
             OperationStatus result = encoder.Encode(value, destination, out int encoderBytesConsumed, out int encoderCharsWritten, isFinalBlock);
 
@@ -278,7 +278,7 @@ namespace System.Text.Json
             written = indexOfFirstByteToEscape;
             consumed = indexOfFirstByteToEscape;
 
-            if (encoder != null)
+            if (encoder is not null)
             {
                 destination = destination.Slice(indexOfFirstByteToEscape);
                 value = value.Slice(indexOfFirstByteToEscape);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
@@ -212,7 +212,7 @@ namespace System.Text.Json
                 val = utf8FormattedNumber[i];
             }
 
-            if (val == 'e' || val == 'E')
+            if (val is (byte)'e' or (byte)'E')
             {
                 i++;
 
@@ -223,7 +223,7 @@ namespace System.Text.Json
 
                 val = utf8FormattedNumber[i];
 
-                if (val == '+' || val == '-')
+                if (val is (byte)'+' or (byte)'-')
                 {
                     i++;
                 }
@@ -324,7 +324,7 @@ namespace System.Text.Json
                 }
                 finally
                 {
-                    if (rented != null)
+                    if (rented is not null)
                     {
                         ArrayPool<byte>.Shared.Return(rented);
                     }
@@ -359,7 +359,7 @@ namespace System.Text.Json
                 }
                 finally
                 {
-                    if (rented != null)
+                    if (rented is not null)
                     {
                         ArrayPool<byte>.Shared.Return(rented);
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Bytes.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Bytes.cs
@@ -148,7 +148,7 @@ namespace System.Text.Json
 
             WriteBase64ByOptions(escapedPropertyName.Slice(0, written), bytes);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -171,7 +171,7 @@ namespace System.Text.Json
 
             WriteBase64ByOptions(escapedPropertyName.Slice(0, written), bytes);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -155,7 +155,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -178,7 +178,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -154,7 +154,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -177,7 +177,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
@@ -154,7 +154,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -177,7 +177,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
@@ -158,7 +158,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -181,7 +181,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
@@ -158,7 +158,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -181,7 +181,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.FormattedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.FormattedNumber.cs
@@ -128,7 +128,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -151,7 +151,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
@@ -154,7 +154,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -177,7 +177,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
@@ -273,7 +273,7 @@ namespace System.Text.Json
 
             WriteLiteralByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -296,7 +296,7 @@ namespace System.Text.Json
 
             WriteLiteralByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
@@ -227,7 +227,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -250,7 +250,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
@@ -134,7 +134,7 @@ namespace System.Text.Json
 
             WriteStringByOptionsPropertyName(propertyName);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -293,7 +293,7 @@ namespace System.Text.Json
 
             WriteStringByOptionsPropertyName(utf8PropertyName);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }
@@ -483,7 +483,7 @@ namespace System.Text.Json
         {
             ArgumentNullException.ThrowIfNull(propertyName);
 
-            if (value == null)
+            if (value is null)
             {
                 WriteNull(propertyName.AsSpan());
             }
@@ -563,7 +563,7 @@ namespace System.Text.Json
         /// </remarks>
         public void WriteString(JsonEncodedText propertyName, string? value)
         {
-            if (value == null)
+            if (value is null)
             {
                 WriteNull(propertyName);
             }
@@ -809,7 +809,7 @@ namespace System.Text.Json
         /// </remarks>
         public void WriteString(ReadOnlySpan<char> propertyName, string? value)
         {
-            if (value == null)
+            if (value is null)
             {
                 WriteNull(propertyName);
             }
@@ -881,7 +881,7 @@ namespace System.Text.Json
         /// </remarks>
         public void WriteString(ReadOnlySpan<byte> utf8PropertyName, string? value)
         {
-            if (value == null)
+            if (value is null)
             {
                 WriteNull(utf8PropertyName);
             }
@@ -908,7 +908,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName, escapedValue.Slice(0, written));
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(valueArray);
             }
@@ -931,7 +931,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName, escapedValue.Slice(0, written));
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<char>.Shared.Return(valueArray);
             }
@@ -954,7 +954,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName.Slice(0, written), escapedValue);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -977,7 +977,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedPropertyName.Slice(0, written), escapedValue);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }
@@ -1108,12 +1108,12 @@ namespace System.Text.Json
 
             WriteStringByOptions(propertyName, value);
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<char>.Shared.Return(valueArray);
             }
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -1168,12 +1168,12 @@ namespace System.Text.Json
 
             WriteStringByOptions(utf8PropertyName, utf8Value);
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(valueArray);
             }
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }
@@ -1228,12 +1228,12 @@ namespace System.Text.Json
 
             WriteStringByOptions(propertyName, utf8Value);
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(valueArray);
             }
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -1288,12 +1288,12 @@ namespace System.Text.Json
 
             WriteStringByOptions(utf8PropertyName, value);
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<char>.Shared.Return(valueArray);
             }
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
@@ -236,7 +236,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -259,7 +259,7 @@ namespace System.Text.Json
 
             WriteNumberByOptions(escapedPropertyName.Slice(0, written), value);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Raw.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Raw.cs
@@ -217,7 +217,7 @@ namespace System.Text.Json
             }
             finally
             {
-                if (tempArray != null)
+                if (tempArray is not null)
                 {
                     utf8Json.Clear();
                     ArrayPool<byte>.Shared.Return(tempArray);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
@@ -46,7 +46,7 @@ namespace System.Text.Json
         /// </remarks>
         public void WriteStringValue(string? value)
         {
-            if (value == null)
+            if (value is null)
             {
                 WriteNullValue();
             }
@@ -116,7 +116,7 @@ namespace System.Text.Json
         // TODO: https://github.com/dotnet/runtime/issues/29293
         private void WriteStringMinimized(ReadOnlySpan<char> escapedValue, int maxRequiredBytes)
         {
-            Debug.Assert(maxRequiredBytes >= 0 && maxRequiredBytes < int.MaxValue - 3);
+            Debug.Assert(maxRequiredBytes is >= 0 and < int.MaxValue - 3);
 
             // 2 quotes + optional 1 list separator, plus precomputed max bytes for the payload.
             int maxRequired = maxRequiredBytes + 3;
@@ -199,7 +199,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedValue.Slice(0, written), requiredBytes);
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<char>.Shared.Return(valueArray);
             }
@@ -346,7 +346,7 @@ namespace System.Text.Json
 
             WriteStringByOptions(escapedValue.Slice(0, written));
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(valueArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.StringSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.StringSegment.cs
@@ -155,7 +155,7 @@ namespace System.Text.Json
                 PartialUtf16StringData = value.Slice(consumed);
             }
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<char>.Shared.Return(valueArray);
             }
@@ -321,7 +321,7 @@ namespace System.Text.Json
                 PartialUtf8StringData = utf8Value.Slice(consumed);
             }
 
-            if (valueArray != null)
+            if (valueArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(valueArray);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -299,7 +299,7 @@ namespace System.Text.Json
         {
             CheckNotDisposed();
 
-            if (utf8Json == null)
+            if (utf8Json is null)
             {
                 throw new ArgumentNullException(nameof(utf8Json));
             }
@@ -310,7 +310,7 @@ namespace System.Text.Json
             }
 
             _stream = utf8Json;
-            if (_arrayBufferWriter == null)
+            if (_arrayBufferWriter is null)
             {
                 _arrayBufferWriter = new ArrayBufferWriter<byte>();
             }
@@ -425,10 +425,10 @@ namespace System.Text.Json
 
         private void CheckNotDisposed()
         {
-            if (_stream == null)
+            if (_stream is null)
             {
                 // The conditions are ordered with stream first as that would be the most common mode
-                if (_output == null)
+                if (_output is null)
                 {
                     ThrowHelper.ThrowObjectDisposedException_Utf8JsonWriter();
                 }
@@ -451,9 +451,9 @@ namespace System.Text.Json
 
             _memory = default;
 
-            if (_stream != null)
+            if (_stream is not null)
             {
-                Debug.Assert(_arrayBufferWriter != null);
+                Debug.Assert(_arrayBufferWriter is not null);
                 if (BytesPending != 0)
                 {
                     _arrayBufferWriter.Advance(BytesPending);
@@ -472,7 +472,7 @@ namespace System.Text.Json
             }
             else
             {
-                Debug.Assert(_output != null);
+                Debug.Assert(_output is not null);
                 if (BytesPending != 0)
                 {
                     _output.Advance(BytesPending);
@@ -496,10 +496,10 @@ namespace System.Text.Json
         /// </remarks>
         public void Dispose()
         {
-            if (_stream == null)
+            if (_stream is null)
             {
                 // The conditions are ordered with stream first as that would be the most common mode
-                if (_output == null)
+                if (_output is null)
                 {
                     return;
                 }
@@ -527,10 +527,10 @@ namespace System.Text.Json
         /// </remarks>
         public async ValueTask DisposeAsync()
         {
-            if (_stream == null)
+            if (_stream is null)
             {
                 // The conditions are ordered with stream first as that would be the most common mode
-                if (_output == null)
+                if (_output is null)
                 {
                     return;
                 }
@@ -560,9 +560,9 @@ namespace System.Text.Json
 
             _memory = default;
 
-            if (_stream != null)
+            if (_stream is not null)
             {
-                Debug.Assert(_arrayBufferWriter != null);
+                Debug.Assert(_arrayBufferWriter is not null);
                 if (BytesPending != 0)
                 {
                     _arrayBufferWriter.Advance(BytesPending);
@@ -577,7 +577,7 @@ namespace System.Text.Json
             }
             else
             {
-                Debug.Assert(_output != null);
+                Debug.Assert(_output is not null);
                 if (BytesPending != 0)
                 {
                     _output.Advance(BytesPending);
@@ -873,7 +873,7 @@ namespace System.Text.Json
 
             WriteStartByOptions(escapedPropertyName.Slice(0, written), token);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<byte>.Shared.Return(propertyArray);
             }
@@ -1022,7 +1022,7 @@ namespace System.Text.Json
 
             WriteStartByOptions(escapedPropertyName.Slice(0, written), token);
 
-            if (propertyArray != null)
+            if (propertyArray is not null)
             {
                 ArrayPool<char>.Shared.Return(propertyArray);
             }
@@ -1217,9 +1217,9 @@ namespace System.Text.Json
 
             Debug.Assert(BytesPending != 0);
 
-            if (_stream != null)
+            if (_stream is not null)
             {
-                Debug.Assert(_arrayBufferWriter != null);
+                Debug.Assert(_arrayBufferWriter is not null);
 
                 int needed = BytesPending + sizeHint;
                 JsonHelpers.ValidateInt32MaxArrayLength((uint)needed);
@@ -1230,7 +1230,7 @@ namespace System.Text.Json
             }
             else
             {
-                Debug.Assert(_output != null);
+                Debug.Assert(_output is not null);
 
                 _output.Advance(BytesPending);
                 BytesCommitted += BytesPending;
@@ -1252,15 +1252,15 @@ namespace System.Text.Json
 
             int sizeHint = Math.Max(InitialGrowthSize, requiredSize);
 
-            if (_stream != null)
+            if (_stream is not null)
             {
-                Debug.Assert(_arrayBufferWriter != null);
+                Debug.Assert(_arrayBufferWriter is not null);
                 _memory = _arrayBufferWriter.GetMemory(sizeHint);
                 Debug.Assert(_memory.Length >= sizeHint);
             }
             else
             {
-                Debug.Assert(_output != null);
+                Debug.Assert(_output is not null);
                 _memory = _output.GetMemory(sizeHint);
 
                 if (_memory.Length < sizeHint)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
@@ -63,7 +63,7 @@ namespace System.Text.Json
 
         public static void ReturnWriterAndBuffer(Utf8JsonWriter writer, PooledByteBufferWriter bufferWriter)
         {
-            Debug.Assert(t_threadLocalState != null);
+            Debug.Assert(t_threadLocalState is not null);
             ThreadLocalState state = t_threadLocalState;
 
             writer.ResetAllStateForCacheReuse();
@@ -75,7 +75,7 @@ namespace System.Text.Json
 
         public static void ReturnWriter(Utf8JsonWriter writer)
         {
-            Debug.Assert(t_threadLocalState != null);
+            Debug.Assert(t_threadLocalState is not null);
             ThreadLocalState state = t_threadLocalState;
 
             writer.ResetAllStateForCacheReuse();


### PR DESCRIPTION
Adopts modern C# syntax in `System.Text.Json` product sources without changing behavior or public API.

- Replaces 34 single-use private backing fields with C# 14 field-backed properties while preserving validation and side effects.
- Converts six single-expression methods to expression-bodied members.
- Replaces 415 built-in null comparisons with `is null` or `is not null`.
- Replaces 32 stable constant and range comparisons with equivalent `or`, `not`, and relational patterns.

The pattern audit deliberately retains 56 null comparisons that bind to user-defined reflection equality operators and 19 compound checks whose conversion would reduce property or mutable-field reads. Project configuration and tests are unchanged. I also audited escaped literals and formatting calls, but retained the existing forms where raw strings or interpolation would not improve readability or would bypass localized resource formatting.

**Validation**

- `build.cmd clr+libs -rc release`
- `System.Text.Json.csproj` across `net462`, `netstandard2.0`, `net10.0`, and `net11.0`
- `dotnet build /t:test` for the main `System.Text.Json` tests and all four Roslyn 3.11/4.4 source-generation test projects, with zero failures

> [!NOTE]
> This pull request was prepared by GitHub Copilot.