### PR TITLE
Reject folding local addresses the emitter cannot encode

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3324,7 +3324,8 @@ inline bool Compiler::fgIsBigOffset(size_t offset)
 // IsValidLclAddr: Can the given local address be represented as "LCL_ADDR"?
 //
 // Local address nodes cannot point beyond the local and can only store
-// 16 bits worth of offset.
+// 16 bits worth of offset. Additionally, the emitter can only encode byte-sized
+// offsets for locals numbered 32768 or greater.
 //
 // Arguments:
 //    lclNum - The local's number
@@ -3341,6 +3342,16 @@ inline bool Compiler::IsValidLclAddr(unsigned lclNum, unsigned offset)
         return (offset == 0);
     }
 #endif
+
+    // The emitter only supports byte-sized offsets for locals numbered 32768 or greater
+    // (see emitLclVarAddr::initLclVarAddr). Reject larger offsets here so such accesses are
+    // kept as explicit address computations instead of being folded into a LCL_FLD or a
+    // contained LCL_ADDR, both of which the emitter would be unable to encode.
+    if ((lclNum >= 32768) && (offset >= 256))
+    {
+        return false;
+    }
+
     return (offset < UINT16_MAX) && (offset < lvaLclExactSize(lclNum));
 }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10569,16 +10569,15 @@ GenTree* Compiler::fgOptimizeAddition(GenTreeOp* add)
             GenTreeLclVarCommon* lclAddrNode = op1->AsLclVarCommon();
             GenTreeIntCon*       offsetNode  = op2->AsIntCon();
             ssize_t              consVal     = offsetNode->IconValue();
+            ssize_t              newOffset   = static_cast<ssize_t>(lclAddrNode->GetLclOffs()) + consVal;
 
-            // Note: the emitter does not expect out-of-bounds access for LCL_ADDR.
-            if (FitsIn<uint16_t>(consVal) && IsValidLclAddr(lclAddrNode->GetLclNum(), (uint32_t)consVal))
+            // Note: the emitter does not expect out-of-bounds access for LCL_ADDR. Validate the
+            // resulting offset rather than just the addend, so repeated folds cannot accumulate an
+            // offset the emitter is unable to encode.
+            if (FitsIn<uint16_t>(newOffset) && IsValidLclAddr(lclAddrNode->GetLclNum(), (uint32_t)newOffset))
             {
-                ClrSafeInt<uint16_t> newOffset =
-                    ClrSafeInt<uint16_t>(lclAddrNode->GetLclOffs()) + ClrSafeInt<uint16_t>(consVal);
-                assert(!newOffset.IsOverflow());
-
                 lclAddrNode->SetOper(GT_LCL_ADDR);
-                lclAddrNode->AsLclFld()->SetLclOffs(newOffset.Value());
+                lclAddrNode->AsLclFld()->SetLclOffs(static_cast<uint16_t>(newOffset));
                 assert(lvaGetDesc(lclAddrNode)->lvDoNotEnregister);
 
                 lclAddrNode->SetVNsFromNode(add);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10569,23 +10569,28 @@ GenTree* Compiler::fgOptimizeAddition(GenTreeOp* add)
             GenTreeLclVarCommon* lclAddrNode = op1->AsLclVarCommon();
             GenTreeIntCon*       offsetNode  = op2->AsIntCon();
             ssize_t              consVal     = offsetNode->IconValue();
-            ssize_t              newOffset   = static_cast<ssize_t>(lclAddrNode->GetLclOffs()) + consVal;
 
             // Note: the emitter does not expect out-of-bounds access for LCL_ADDR. Validate the
             // resulting offset rather than just the addend, so repeated folds cannot accumulate an
-            // offset the emitter is unable to encode.
-            if (FitsIn<uint16_t>(newOffset) && IsValidLclAddr(lclAddrNode->GetLclNum(), (uint32_t)newOffset))
+            // offset the emitter is unable to encode. Both operands are bounded to [0, UINT16_MAX],
+            // so the addition below cannot overflow.
+            if (FitsIn<uint16_t>(consVal))
             {
-                lclAddrNode->SetOper(GT_LCL_ADDR);
-                lclAddrNode->AsLclFld()->SetLclOffs(static_cast<uint16_t>(newOffset));
-                assert(lvaGetDesc(lclAddrNode)->lvDoNotEnregister);
+                unsigned newOffset = lclAddrNode->GetLclOffs() + static_cast<unsigned>(consVal);
 
-                lclAddrNode->SetVNsFromNode(add);
+                if (FitsIn<uint16_t>(newOffset) && IsValidLclAddr(lclAddrNode->GetLclNum(), newOffset))
+                {
+                    lclAddrNode->SetOper(GT_LCL_ADDR);
+                    lclAddrNode->AsLclFld()->SetLclOffs(static_cast<uint16_t>(newOffset));
+                    assert(lvaGetDesc(lclAddrNode)->lvDoNotEnregister);
 
-                DEBUG_DESTROY_NODE(offsetNode);
-                DEBUG_DESTROY_NODE(add);
+                    lclAddrNode->SetVNsFromNode(add);
 
-                return lclAddrNode;
+                    DEBUG_DESTROY_NODE(offsetNode);
+                    DEBUG_DESTROY_NODE(add);
+
+                    return lclAddrNode;
+                }
             }
         }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_126584/Runtime_126584.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_126584/Runtime_126584.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection.Emit;
+using TestLibrary;
+using Xunit;
+
+// A struct large enough that initializing it reaches offsets >= 256.
+public struct Big_126584
+{
+    public long A0, A1, A2, A3, A4, A5, A6, A7, A8, A9;
+    public long A10, A11, A12, A13, A14, A15, A16, A17, A18, A19;
+    public long A20, A21, A22, A23, A24, A25, A26, A27, A28, A29;
+    public long A30, A31, A32, A33, A34, A35, A36, A37, A38, A39;
+}
+
+public class Runtime_126584
+{
+    // The emitter can only encode byte-sized offsets for locals numbered >= 32768. A struct
+    // block-init of such a local reaching offset >= 256 must not be folded into the stack
+    // addressing form, which the emitter cannot encode. Reflection.Emit is used to build a
+    // method with enough locals to push the struct past that boundary without a huge source file.
+    [ConditionalFact(typeof(Utilities), nameof(Utilities.IsReflectionEmitSupported))]
+    public static void TestEntryPoint()
+    {
+        var method = new DynamicMethod("M0", typeof(long), new[] { typeof(bool) }, typeof(Runtime_126584).Module);
+        ILGenerator il = method.GetILGenerator();
+
+        const int DummyLocalCount = 33000;
+        for (int i = 0; i < DummyLocalCount; i++)
+        {
+            il.DeclareLocal(typeof(int));
+        }
+        LocalBuilder big = il.DeclareLocal(typeof(Big_126584));
+
+        // Initialize the struct behind a branch so it isn't hoisted into the prolog.
+        Label skip = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, skip);
+        il.Emit(OpCodes.Ldloca, big);
+        il.Emit(OpCodes.Initobj, typeof(Big_126584));
+        il.MarkLabel(skip);
+
+        // Read a field past offset 255 so the access survives.
+        il.Emit(OpCodes.Ldloca, big);
+        il.Emit(OpCodes.Ldfld, typeof(Big_126584).GetField(nameof(Big_126584.A39)));
+        il.Emit(OpCodes.Ret);
+
+        var func = (Func<bool, long>)method.CreateDelegate(typeof(Func<bool, long>));
+        Assert.Equal(0, func(true));
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_126584/Runtime_126584.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_126584/Runtime_126584.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <!-- Force the MinOpts path where the emitter encoding limit was hit. -->
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #126584.

The emitter only supports byte-sized offsets (`< 256`) for local variable numbers `>= 32768` -- see `emitLclVarAddr::initLclVarAddr`, which otherwise hits `IMPL_LIMITATION("JIT doesn't support offsets larger than 255 into valuetypes for local vars > 32767")`. `Compiler::IsValidLclAddr` already encodes the other emitter limits (16-bit offset, in-bounds) but didn't account for this one.

As a result, a struct block-init of a local numbered `>= 32768` whose access reaches offset `>= 256` could be contained/folded into the stack (`S_R`) addressing form by `ContainBlockStoreAddress`, and then fail at emit time. Since the fold only happens under MinOpts here, it surfaced as an `InvalidProgramException` in Debug but not Release. The IL is valid (ILVerify agrees); the JIT was simply generating an address form the emitter can't encode.

The fix rejects that case in `IsValidLclAddr`. Returning `false` there declines only the fold -- `lclmorph` then keeps the access as an explicit address computation and codegen materializes it into a register (the `ARX` form, which uses a real base register + 32-bit displacement and has no varNum-encoding limit). This also covers direct `LCL_FLD` accesses at offset `>= 256` for such locals, not just the block-init path.

The constants `32768` and `256` mirror `emitLclVarAddr::initLclVarAddr` exactly.

`fgOptimizeAddition` folds `ADD(LCL_ADDR, const)` into a single `LCL_ADDR`. That is a FullOpts-only sibling of the same problem: it previously validated only the addend, so repeated folds could accumulate an offset the emitter can't encode. It now validates the resulting offset through `IsValidLclAddr`, with the addend bounded to `[0, UINT16_MAX]` first so the sum is computed without signed overflow.

----------

Added a regression test (`Runtime_126584`). It uses `Reflection.Emit` to build a MinOpts method with >32768 IL locals plus a `>= 256`-byte struct block-init, which is the minimal shape that reproduces the emitter limit without carrying a ~1.5MB source file. It is gated on `IsReflectionEmitSupported`, so it skips on NativeAOT and other no-dynamic-code scenarios. Harness-validated both directions: it fails against the baseline JIT (`InvalidProgramException` in `M0`) and passes with the fix.

The repro is CPU-independent -- despite the issue title, the bug isn't AVX-512-specific; those ISAs just perturbed the local numbering/codegen enough to expose it.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.