### PR TITLE
Implement wasm codegen for sub-16 SIMD load/store

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2722,10 +2722,11 @@ void CodeGen::genCodeForFrameSize(GenTree* tree)
 //
 void CodeGen::genLoadLclTypeSimd12(GenTreeLclVarCommon* tree)
 {
-    bool     fpBased;
-    unsigned frameOffset = (unsigned)(m_compiler->lvaFrameAddress(tree->GetLclNum(), &fpBased) + tree->GetLclOffs());
-    unsigned fpIndex     = GetFramePointerRegIndex();
-    emitter* emit        = GetEmitter();
+    bool fpBased;
+    int  frameOffset = m_compiler->lvaFrameAddress(tree->GetLclNum(), &fpBased) + (int)tree->GetLclOffs();
+    noway_assert(frameOffset >= 0); // WASM address modes are unsigned.
+    unsigned fpIndex = GetFramePointerRegIndex();
+    emitter* emit    = GetEmitter();
 
     emit->emitIns_I(INS_local_get, EA_PTRSIZE, fpIndex);
     emit->emitIns_I(INS_local_get, EA_PTRSIZE, fpIndex);
@@ -2778,11 +2779,12 @@ void CodeGen::genStoreIndTypeSimd12(GenTreeStoreInd* tree)
 
     if (addr->OperIs(GT_LCL_ADDR))
     {
-        bool     fpBased;
-        unsigned frameOffset = (unsigned)(m_compiler->lvaFrameAddress(addr->AsLclVarCommon()->GetLclNum(), &fpBased) +
-                                          addr->AsLclVarCommon()->GetLclOffs());
-        emit->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());         // [fp]
-        emit->emitIns_I(INS_local_get, EA_16BYTE, WasmRegToIndex(valReg));             // [fp, value]
+        bool fpBased;
+        int  frameOffset = m_compiler->lvaFrameAddress(addr->AsLclVarCommon()->GetLclNum(), &fpBased) +
+                          (int)addr->AsLclVarCommon()->GetLclOffs();
+        noway_assert(frameOffset >= 0);                                        // WASM address modes are unsigned.
+        emit->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex()); // [fp]
+        emit->emitIns_I(INS_local_get, EA_16BYTE, WasmRegToIndex(valReg));     // [fp, value]
         emit->emitIns_MemargLane(INS_v128_store32_lane, EA_4BYTE, frameOffset + 8, 2); // []
     }
     else

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2597,8 +2597,15 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
         NYI_WASM_SIMD("SIMD16 local field load");
     }
 
-    GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
-    GetEmitter()->emitIns_S(ins_Load(type), emitTypeSize(tree), tree->GetLclNum(), tree->GetLclOffs());
+    if (type == TYP_SIMD12)
+    {
+        genLoadLclTypeSimd12(tree);
+    }
+    else
+    {
+        GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
+        GetEmitter()->emitIns_S(ins_Load(type), emitTypeSize(tree), tree->GetLclNum(), tree->GetLclOffs());
+    }
     WasmProduceReg(tree);
 }
 
@@ -2621,8 +2628,15 @@ void CodeGen::genCodeForLclVar(GenTreeLclVar* tree)
     {
         var_types type = varDsc->GetRegisterType(tree);
 
-        GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
-        GetEmitter()->emitIns_S(ins_Load(type), emitTypeSize(type), tree->GetLclNum(), 0);
+        if (type == TYP_SIMD12)
+        {
+            genLoadLclTypeSimd12(tree);
+        }
+        else
+        {
+            GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
+            GetEmitter()->emitIns_S(ins_Load(type), emitTypeSize(type), tree->GetLclNum(), 0);
+        }
         WasmProduceReg(tree);
     }
     else
@@ -2696,6 +2710,90 @@ void CodeGen::genCodeForFrameSize(GenTree* tree)
 }
 
 //------------------------------------------------------------------------
+// genLoadLclTypeSimd12: Load a TYP_SIMD12 (i.e. Vector3) local into a v128.
+//
+// Arguments:
+//    tree - the GT_LCL_FLD or GT_LCL_VAR node
+//
+// Notes:
+//    Vector3 has no native wasm valtype, so it lives as a v128 with the low 12 bytes
+//    populated. The frame address is pushed twice: v128.load64_zero fills lanes 0-1
+//    (zeroing the rest) and v128.load32_lane fills lane 2 from bytes 8-11.
+//
+void CodeGen::genLoadLclTypeSimd12(GenTreeLclVarCommon* tree)
+{
+    bool     fpBased;
+    unsigned frameOffset = (unsigned)(m_compiler->lvaFrameAddress(tree->GetLclNum(), &fpBased) + tree->GetLclOffs());
+    unsigned fpIndex     = GetFramePointerRegIndex();
+    emitter* emit        = GetEmitter();
+
+    emit->emitIns_I(INS_local_get, EA_PTRSIZE, fpIndex);
+    emit->emitIns_I(INS_local_get, EA_PTRSIZE, fpIndex);
+    emit->emitIns_I(INS_v128_load64_zero, EA_8BYTE, frameOffset);
+    emit->emitIns_MemargLane(INS_v128_load32_lane, EA_4BYTE, frameOffset + 8, 2);
+}
+
+//------------------------------------------------------------------------
+// genLoadIndTypeSimd12: Load a TYP_SIMD12 (i.e. Vector3) value through an indirection.
+//
+// Arguments:
+//    tree - the GT_IND node
+//
+// Notes:
+//    One copy of the address is already on the value stack (from genConsumeAddress) and
+//    is multiply-used, so the trailing v128.load32_lane can re-push it for the upper 4 bytes.
+//
+void CodeGen::genLoadIndTypeSimd12(GenTreeIndir* tree)
+{
+    emitter* emit = GetEmitter();
+
+    emit->emitIns_I(INS_local_get, EA_PTRSIZE, WasmRegToIndex(GetMultiUseOperandReg(tree->Addr())));
+    emit->emitIns_I(INS_v128_load64_zero, EA_8BYTE, 0);
+    emit->emitIns_MemargLane(INS_v128_load32_lane, EA_4BYTE, 8, 2);
+}
+
+//------------------------------------------------------------------------
+// genStoreIndTypeSimd12: Store a TYP_SIMD12 (i.e. Vector3) value through an indirection.
+//
+// Arguments:
+//    tree - the GT_STOREIND node
+//
+// Notes:
+//    On entry the value stack holds [addr, value]. The value is teed into an internal v128
+//    local so it survives the low-8 store; the address is then re-materialized to store the
+//    upper 4 bytes via a lane store - re-emitting the frame pointer for a LCL_ADDR, or
+//    re-pushing the multiply-used address register otherwise.
+//
+void CodeGen::genStoreIndTypeSimd12(GenTreeStoreInd* tree)
+{
+    emitter* emit = GetEmitter();
+    GenTree* addr = tree->Addr();
+
+    InternalRegs* regs = internalRegisters.GetAll(tree);
+    assert(regs->Count() == 1);
+    regNumber valReg = regs->Extract();
+
+    emit->emitIns_I(INS_local_tee, EA_16BYTE, WasmRegToIndex(valReg)); // [addr, value]
+    emit->emitIns_MemargLane(INS_v128_store64_lane, EA_8BYTE, 0, 0);   // []
+
+    if (addr->OperIs(GT_LCL_ADDR))
+    {
+        bool     fpBased;
+        unsigned frameOffset = (unsigned)(m_compiler->lvaFrameAddress(addr->AsLclVarCommon()->GetLclNum(), &fpBased) +
+                                          addr->AsLclVarCommon()->GetLclOffs());
+        emit->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());         // [fp]
+        emit->emitIns_I(INS_local_get, EA_16BYTE, WasmRegToIndex(valReg));             // [fp, value]
+        emit->emitIns_MemargLane(INS_v128_store32_lane, EA_4BYTE, frameOffset + 8, 2); // []
+    }
+    else
+    {
+        emit->emitIns_I(INS_local_get, EA_PTRSIZE, WasmRegToIndex(GetMultiUseOperandReg(addr))); // [addr]
+        emit->emitIns_I(INS_local_get, EA_16BYTE, WasmRegToIndex(valReg));                       // [addr, value]
+        emit->emitIns_MemargLane(INS_v128_store32_lane, EA_4BYTE, 8, 2);                         // []
+    }
+}
+
+//------------------------------------------------------------------------
 // genCodeForIndir: Produce code for a GT_IND node.
 //
 // Arguments:
@@ -2705,8 +2803,7 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 {
     assert(tree->OperIs(GT_IND));
 
-    var_types   type = tree->TypeGet();
-    instruction ins  = ins_Load(type);
+    var_types type = tree->TypeGet();
 
     genConsumeAddress(tree->Addr());
 
@@ -2718,7 +2815,14 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 
     // TODO-WASM: Memory barriers
 
-    GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), 0);
+    if (type == TYP_SIMD12)
+    {
+        genLoadIndTypeSimd12(tree);
+    }
+    else
+    {
+        GetEmitter()->emitIns_I(ins_Load(type), emitActualTypeSize(type), 0);
+    }
 
     WasmProduceReg(tree);
 }
@@ -2762,11 +2866,22 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             // module. Bail until SIMD16 store is properly supported.
             NYI_WASM_SIMD("SIMD16 store indirect");
         }
-        instruction ins = ins_Store(type);
 
         // TODO-WASM: Memory barriers
 
-        GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), 0);
+        if (type == TYP_SIMD8)
+        {
+            // stack: [addr, value] -> store the low 8 bytes.
+            GetEmitter()->emitIns_MemargLane(INS_v128_store64_lane, EA_8BYTE, 0, 0);
+        }
+        else if (type == TYP_SIMD12)
+        {
+            genStoreIndTypeSimd12(tree);
+        }
+        else
+        {
+            GetEmitter()->emitIns_I(ins_Store(type), emitActualTypeSize(type), 0);
+        }
     }
 
     genUpdateLife(tree);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2725,6 +2725,7 @@ void CodeGen::genLoadLclTypeSimd12(GenTreeLclVarCommon* tree)
     bool fpBased;
     int  frameOffset = m_compiler->lvaFrameAddress(tree->GetLclNum(), &fpBased) + (int)tree->GetLclOffs();
     noway_assert(frameOffset >= 0); // WASM address modes are unsigned.
+    assert(fpBased);
     unsigned fpIndex = GetFramePointerRegIndex();
     emitter* emit    = GetEmitter();
 
@@ -2782,9 +2783,10 @@ void CodeGen::genStoreIndTypeSimd12(GenTreeStoreInd* tree)
         bool fpBased;
         int  frameOffset = m_compiler->lvaFrameAddress(addr->AsLclVarCommon()->GetLclNum(), &fpBased) +
                           (int)addr->AsLclVarCommon()->GetLclOffs();
-        noway_assert(frameOffset >= 0);                                        // WASM address modes are unsigned.
-        emit->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex()); // [fp]
-        emit->emitIns_I(INS_local_get, EA_16BYTE, WasmRegToIndex(valReg));     // [fp, value]
+        noway_assert(frameOffset >= 0); // WASM address modes are unsigned.
+        assert(fpBased);
+        emit->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());         // [fp]
+        emit->emitIns_I(INS_local_get, EA_16BYTE, WasmRegToIndex(valReg));             // [fp, value]
         emit->emitIns_MemargLane(INS_v128_store32_lane, EA_4BYTE, frameOffset + 8, 2); // []
     }
     else

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2741,8 +2741,8 @@ void CodeGen::genLoadLclTypeSimd12(GenTreeLclVarCommon* tree)
 //    tree - the GT_IND node
 //
 // Notes:
-//    One copy of the address is already on the value stack (from genConsumeAddress) and
-//    is multiply-used, so the trailing v128.load32_lane can re-push it for the upper 4 bytes.
+//    The address is left on the value stack by prior codegen and is multiply-used, so the
+//    trailing v128.load32_lane can re-push it for the upper 4 bytes.
 //
 void CodeGen::genLoadIndTypeSimd12(GenTreeIndir* tree)
 {

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2070,6 +2070,10 @@ instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*
         case TYP_DOUBLE:
             return INS_f64_load;
 #if defined(FEATURE_SIMD)
+        case TYP_SIMD8:
+            // SIMD8 (Vector2) lives as a v128 with the low 8 bytes populated. SIMD12 (Vector3) is
+            // handled at the callers since it needs a trailing lane load for the upper 4 bytes.
+            return INS_v128_load64_zero;
         case TYP_SIMD16:
             return INS_v128_load;
 #endif

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -164,9 +164,13 @@ GenTree* Lowering::LowerStoreLoc(GenTreeLclVarCommon* storeLoc)
 //
 GenTree* Lowering::LowerStoreIndir(GenTreeStoreInd* node)
 {
-    if ((node->gtFlags & GTF_IND_NONFAULTING) == 0)
+    if (((node->gtFlags & GTF_IND_NONFAULTING) == 0) ||
+        (node->TypeIs(TYP_SIMD12) && !node->Addr()->OperIs(GT_LCL_ADDR)))
     {
         // We need to be able to null check the address, and that requires multiple uses of the address operand.
+        // SIMD12 stores also re-materialize the address for the trailing lane store, so force it there as well -
+        // unless the address is a re-materializable LCL_ADDR (the local-to-stack store rewrite), which codegen
+        // re-emits directly.
         SetMultiplyUsed(node->Addr() DEBUGARG("LowerStoreIndir faulting Addr"));
     }
 
@@ -459,8 +463,10 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
         return;
     }
 
-    if (indirNode->OperIs(GT_IND) && ((indirNode->gtFlags & GTF_IND_NONFAULTING) == 0))
+    if (indirNode->OperIs(GT_IND) &&
+        (((indirNode->gtFlags & GTF_IND_NONFAULTING) == 0) || indirNode->TypeIs(TYP_SIMD12)))
     {
+        // SIMD12 loads re-materialize the address for the trailing lane load, so force it there regardless.
         SetMultiplyUsed(indirNode->Addr() DEBUGARG("ContainCheckIndir faulting load Addr"));
     }
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -171,7 +171,7 @@ GenTree* Lowering::LowerStoreIndir(GenTreeStoreInd* node)
         // SIMD12 stores also re-materialize the address for the trailing lane store, so force it there as well -
         // unless the address is a re-materializable LCL_ADDR (the local-to-stack store rewrite), which codegen
         // re-emits directly.
-        SetMultiplyUsed(node->Addr() DEBUGARG("LowerStoreIndir faulting Addr"));
+        SetMultiplyUsed(node->Addr() DEBUGARG("LowerStoreIndir Addr (null check or simd12 lane store)"));
     }
 
     ContainCheckStoreIndir(node);
@@ -467,7 +467,7 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
         (((indirNode->gtFlags & GTF_IND_NONFAULTING) == 0) || indirNode->TypeIs(TYP_SIMD12)))
     {
         // SIMD12 loads re-materialize the address for the trailing lane load, so force it there regardless.
-        SetMultiplyUsed(indirNode->Addr() DEBUGARG("ContainCheckIndir faulting load Addr"));
+        SetMultiplyUsed(indirNode->Addr() DEBUGARG("ContainCheckIndir load Addr (null check or simd12 lane load)"));
     }
 
     // TODO-WASM-CQ: contain suitable LEAs here. Take note of the fact that for this to be correct we must prove the

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -662,6 +662,14 @@ void WasmRegAlloc::CollectReferencesForIndir(GenTreeIndir* node)
 {
     GenTree* const addr = node->Addr();
     ConsumeTemporaryRegForOperand(addr DEBUGARG("indirection address"));
+
+    if (node->OperIs(GT_STOREIND) && node->TypeIs(TYP_SIMD12))
+    {
+        // The SIMD12 store stashes the v128 value so it can re-push it for the trailing lane store.
+        regNumber internalReg = RequestInternalRegister(node, TYP_SIMD16);
+        regNumber releasedReg = ReleaseTemporaryRegister(WasmRegToType(internalReg));
+        assert(releasedReg == internalReg);
+    }
 }
 
 //------------------------------------------------------------------------
@@ -799,6 +807,16 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
 
     LIR::ReadOnlyRange storeRange(store, store);
     m_compiler->GetLowering()->LowerRange(m_currentBlock, storeRange);
+
+    if (store->OperIs(GT_STOREIND) && store->TypeIs(TYP_SIMD12))
+    {
+        // genStoreIndTypeSimd12 tees the value into a v128 temporary to split the store into an 8-byte and a
+        // 4-byte lane store. The main collection walk does not revisit this freshly-introduced node, so request
+        // that internal register here. The re-materializable LCL_ADDR address needs no temporary.
+        regNumber internalReg = RequestInternalRegister(store, TYP_SIMD16);
+        regNumber releasedReg = ReleaseTemporaryRegister(WasmRegToType(internalReg));
+        assert(releasedReg == internalReg);
+    }
 
     // FIXME-WASM: Should we be doing this here?
     // CollectReferencesForNode(store);


### PR DESCRIPTION
`Vector2` (`TYP_SIMD8`) and `Vector3` (`TYP_SIMD12`) have no native wasm valtype, so they live as a `v128` with the low 8/12 bytes populated. Previously the wasm JIT bailed out via the `ins_Load`/`ins_Store` NYIs for these types; this implements the split lane load/store sequences instead.

The emitted sequences are:

- **simd8 load**: `v128.load64_zero 0`
- **simd8 store**: `v128.store64_lane 0, lane 0`
- **simd12 load**: `local.get addr; v128.load64_zero 0; v128.load32_lane 8, lane 2`
- **simd12 store**: tee the value into a `v128` temporary, `v128.store64_lane 0, lane 0` for the low 8 bytes, then re-materialize the address and `v128.store32_lane 8, lane 2` for the upper 4 bytes

`v128.load64_zero` fills lanes 0-1 (zeroing the rest); the trailing lane store/load handles bytes 8-11 for the `Vector3` case.

----------

The `TYP_SIMD12` address is forced multiply-used (loads and heap stores re-materialize it for the trailing lane op). The local-to-stack store rewrite (`RewriteLocalStackStore`) produces a `STOREIND(LCL_ADDR, value)` whose address is a re-materializable `GT_LCL_ADDR`, so that case is excluded from multiply-use and codegen re-emits the frame pointer directly. Because that synthesized `STOREIND` is not revisited by the main collection walk, its internal `v128` tee register is requested in `RewriteLocalStackStore`.

----------

Measured on the corelib crossgen2 browser SuperPMI collection (27,540 contexts): hard asserts drop from **403 to 30**, eliminating **373** `SIMD8`/`SIMD12` load/store asserts with no regressions. The residual 30 are the pre-existing `NYIRAW` oper catch-all, unrelated to this change.

Full effectiveness requires #130866 (which removes the shadowing SIMD-ABI bailouts for SIMD params/locals/stores/call-args); standalone, this change already clears the 373 asserts above on that collection.

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot.
