### PR TITLE
Add System.Security.Cryptography Copilot instructions

### DIFF
--- a/.github/instructions/system-security-cryptography.instructions.md
+++ b/.github/instructions/system-security-cryptography.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: "src/libraries/System.Security.Cryptography/**"
+---
+
+# System.Security.Cryptography — Folder-Specific Guidance
+
+## Code Style
+
+- Prefer scoped `using (...) { ... }` statements over `using` declarations (`using var ...`) so resource lifetimes and disposal scopes are explicit. This reinforces `csharp_prefer_simple_using_statement = false:none` in `.editorconfig`.
+- When an `if` statement follows another statement in the same block, insert a blank line before the `if`. Do not add an artificial leading blank line when the `if` is the first statement in a block.
+
+## Correctness
+
+- Check the success result of `Try*` methods and any bytes-written value, whether returned directly or through an `out` parameter. When control flow guarantees an expected result or byte count, use `Debug.Assert`, a parameterless `CryptographicException`, or both, as appropriate.
+
+## Security
+
+- Clear owned writable buffers containing keys or other secret material with `CryptographicOperations.ZeroMemory` as soon as they are no longer needed. For rented buffers, return them with `ArrayPool<T>.Return(..., clearArray: true)`.
+- Use `CryptographicOperations.FixedTimeEquals` for secret-dependent comparisons; do not implement ad hoc comparison loops or use ordinary sequence equality.
+
+## Tests
+
+- Avoid throwing `SkipTestException`, which creates noisy test output. Prefer `[ConditionalFact]` or `[ConditionalTheory]` with a condition; when that is not possible, return early from the test.

--- a/.github/instructions/system-security-cryptography.instructions.md
+++ b/.github/instructions/system-security-cryptography.instructions.md
@@ -16,7 +16,7 @@ applyTo: "src/libraries/System.Security.Cryptography/**"
 
 ## Security
 
-- Clear owned writable buffers containing keys or other secret material with `CryptographicOperations.ZeroMemory` as soon as they are no longer needed. Use `CryptoPool.Rent` and `CryptoPool.Return` for rented buffers. For pinned arrays that should be cleared on disposal, use `PinAndClear.Track`.
+- Clear owned writable buffers containing keys or other secret material with `CryptographicOperations.ZeroMemory` as soon as they are no longer needed. Use `CryptoPoolLease` or `CryptoPool.Rent` and `CryptoPool.Return` for rented buffers. For pinned arrays that should be cleared on disposal, use `PinAndClear.Track`.
 - Use `CryptographicOperations.FixedTimeEquals` for secret-dependent comparisons; do not implement ad hoc comparison loops or use ordinary sequence equality.
 
 ## Tests

--- a/.github/instructions/system-security-cryptography.instructions.md
+++ b/.github/instructions/system-security-cryptography.instructions.md
@@ -8,6 +8,7 @@ applyTo: "src/libraries/System.Security.Cryptography/**"
 
 - Prefer scoped `using (...) { ... }` statements over `using` declarations (`using var ...`) so resource lifetimes and disposal scopes are explicit. This reinforces `csharp_prefer_simple_using_statement = false:none` in `.editorconfig`.
 - When an `if` statement follows another statement in the same block, insert a blank line before the `if`. Do not add an artificial leading blank line when the `if` is the first statement in a block.
+- Declare members of internal types as `internal`, not `public`, except when `public` accessibility is required to implement a contract such as an interface.
 
 ## Correctness
 

--- a/.github/instructions/system-security-cryptography.instructions.md
+++ b/.github/instructions/system-security-cryptography.instructions.md
@@ -16,7 +16,7 @@ applyTo: "src/libraries/System.Security.Cryptography/**"
 
 ## Security
 
-- Clear owned writable buffers containing keys or other secret material with `CryptographicOperations.ZeroMemory` as soon as they are no longer needed. For rented buffers, return them with `ArrayPool<T>.Return(..., clearArray: true)`.
+- Clear owned writable buffers containing keys or other secret material with `CryptographicOperations.ZeroMemory` as soon as they are no longer needed. Use `CryptoPool.Rent` and `CryptoPool.Return` for rented buffers. For pinned arrays that should be cleared on disposal, use `PinAndClear.Track`.
 - Use `CryptographicOperations.FixedTimeEquals` for secret-dependent comparisons; do not implement ad hoc comparison loops or use ordinary sequence equality.
 
 ## Tests


### PR DESCRIPTION
Adds path-specific GitHub Copilot guidance for `System.Security.Cryptography`, covering established code style, correctness, sensitive-data handling, constant-time comparisons, and test skipping conventions.

Documentation-only change; no build or tests were run.

> [!NOTE]
> This pull request description was generated by GitHub Copilot.