### PR TITLE
Use eng\common\dotnet.cmd instead of .\dotnet.cmd in crossgen2 comparison legs

### DIFF
--- a/eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
@@ -119,17 +119,6 @@ jobs:
         displayName: Create directories
         failOnStderr: true
 
-    # Pre-initialize the dotnet CLI so that sdk.txt is populated before the
-    # parallel crossgen2 fan-out. Without this, 236 parallel dotnet.cmd
-    # invocations race to create artifacts/toolset/sdk.txt, and some may
-    # read it before it exists, producing a "dotnet.exe not found" error.
-    - ${{ if ne(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/dotnet.sh --version
-        displayName: Pre-initialize dotnet CLI
-    - ${{ if eq(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)\dotnet.cmd --version
-        displayName: Pre-initialize dotnet CLI
-
     # Create baseline output on the host (x64) machine
     - task: PythonScript@0
       displayName: Create cross-platform crossgen baseline
@@ -151,7 +140,7 @@ jobs:
           arguments:
             crossgen_framework
             --crossgen    $(crossgen2location)
-            --dotnet      $(Build.SourcesDirectory)\dotnet.cmd
+            --dotnet      $(Build.SourcesDirectory)\eng\common\dotnet.cmd
             --core_root   $(workItemDirectory)\dlls
             --result_dir  $(workItemDirectory)\log
             --target_os   $(target_crossgen2_os)


### PR DESCRIPTION
dotnet.cmd unconditionally calls `InitializeDotnetCLI $true $true` which locks sdk.txt for a short period during startup. Later in the batch file, sdk.txt is read. In crossgen2 comparison jobs, over 200 parallel invocations happen at once, so occasionally sdk.txt is locked when trying to read, and the eventual call to the dotnet cli fails.

Instead, use `.\eng\common\dotnet.ps1` to invoke the cli, which doesn't touch sdk.txt.

Fixes https://github.com/dotnet/runtime/issues/131004
Fixes https://github.com/dotnet/runtime/issues/131005