### PR TITLE
Fix SIP (sweep-in-plan) plan_allocated corruption in process_remaining_regions

### DIFF
--- a/src/coreclr/gc/plan_phase.cpp
+++ b/src/coreclr/gc/plan_phase.cpp
@@ -2981,7 +2981,18 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
 
         if (!heap_segment_swept_in_plan (current_region))
         {
-            heap_segment_plan_allocated (current_region) = generation_allocation_pointer (consing_gen);
+            // If the allocation region was swept in plan (SIP), heap_segment_non_sip above skipped
+            // it to land on this region. In that case the consing pointer belongs to the skipped
+            // region, not this one (and the skipped region may be at a higher or lower address, so
+            // the pointer can be below mem or above reserved). Either way this region is empty, so
+            // its plan_allocated is its mem.
+            uint8_t* plan_alloc = generation_allocation_pointer (consing_gen);
+            if ((plan_alloc < heap_segment_mem (current_region)) ||
+                (plan_alloc > heap_segment_reserved (current_region)))
+            {
+                plan_alloc = heap_segment_mem (current_region);
+            }
+            heap_segment_plan_allocated (current_region) = plan_alloc;
             dprintf (REGIONS_LOG, ("h%d setting alloc seg %p plan alloc to %p",
                 heap_number, heap_segment_mem (current_region),
                 heap_segment_plan_allocated (current_region)));


### PR DESCRIPTION
Fix SIP (sweep-in-plan) plan_allocated corruption in process_remaining_regions

## Problem

With the regions GC, setting `DOTNET_GCEnableSpecialRegions=1` trips a `_DEBUG` GC assert shortly after startup (SIGABRT in a Checked build). Two different asserts can fire depending on heap layout:

- `fix_generation_bounds` — `plan_allocated == mem`
- `verify_regions` — `heap_segment_allocated <= heap_segment_reserved` (`FATAL_GC_ERROR`)

Both trace back to a single root cause in `process_remaining_regions`.

## Root cause

When the allocation region for a generation is itself swept-in-plan (SIP), `heap_segment_non_sip()` skips it and returns a different, empty region. The region chain is not address-ordered, so the returned region may be at a **higher or lower** address than the skipped SIP region.

The code then assigned that region's `plan_allocated` directly from the consing pointer:

```cpp
heap_segment_plan_allocated (current_region) = generation_allocation_pointer (consing_gen);
```

But the consing pointer belongs to the **skipped** SIP region, not `current_region`, so it lies outside `current_region`'s `[mem, reserved]` range:

- **Below `mem`** → the region can later become gen0's start region, tripping `fix_generation_bounds` and corrupting gen0 bounds.
- **Above `reserved`** → `find_first_valid_region` copies `plan_allocated` into `allocated`, making `allocated > reserved` and tripping `verify_regions`.

## Fix

A region reached by skipping a SIP allocation region is empty regardless of address direction, so its `plan_allocated` is simply its `mem`. Clamp `plan_allocated` to `mem` whenever the consing pointer falls outside `[mem, reserved]`:

```cpp
uint8_t* plan_alloc = generation_allocation_pointer (consing_gen);
if ((plan_alloc < heap_segment_mem (current_region)) ||
    (plan_alloc > heap_segment_reserved (current_region)))
{
    plan_alloc = heap_segment_mem (current_region);
}
heap_segment_plan_allocated (current_region) = plan_alloc;
```

The clamp only triggers on the SIP-skip path (consing pointer out of range), so the default path is unchanged.

## Validation

Checked CLR, `linux-x64`.

- **Functional**: 56/56 GC tests that pass by default (`GC/API`, `GC/Scenarios`, `GC/Coverage`) also pass with `DOTNET_GCEnableSpecialRegions=1` after the fix. No regressions with the switch off.
- **Stress**: `DOTNET_GCStress=0xC` and `0xF` (the latter with a reduced gen0 size to force frequent compacting GCs) across allocation-heavy scenarios (linked-list, jagged-array, server-model, large-object). Results identical with the switch on and off.
