### PR TITLE
[wasm][coreCLR] R2R: VM-side load of a flat webcil composite image

### DIFF
--- a/src/coreclr/inc/CrstTypes.def
+++ b/src/coreclr/inc/CrstTypes.def
@@ -529,3 +529,9 @@ End
 Crst PregeneratedStringThunks
     AcquiredBefore UnresolvedClassLock
 End
+
+// Guards the de-duplication set used when relocating host-probed webcil (WASM) R2R images.
+// It is a leaf that acquires no other Crst while held, so it is Unordered.
+Crst WebcilImageRelocation
+    Unordered
+End

--- a/src/coreclr/inc/crsttypes_generated.h
+++ b/src/coreclr/inc/crsttypes_generated.h
@@ -118,8 +118,9 @@ enum CrstType
     CrstUnwindInfoTablePendingLock = 100,
     CrstUnwindInfoTablePublishLock = 101,
     CrstVSDIndirectionCellLock = 102,
-    CrstWrapperTemplate = 103,
-    kNumberOfCrstTypes = 104
+    CrstWebcilImageRelocation = 103,
+    CrstWrapperTemplate = 104,
+    kNumberOfCrstTypes = 105
 };
 
 #endif // __CRST_TYPES_INCLUDED
@@ -233,6 +234,7 @@ int g_rgCrstLevelMap[] =
     2,          // CrstUnwindInfoTablePendingLock
     3,          // CrstUnwindInfoTablePublishLock
     3,          // CrstVSDIndirectionCellLock
+    -1,         // CrstWebcilImageRelocation
     3,          // CrstWrapperTemplate
 };
 
@@ -342,6 +344,7 @@ LPCSTR g_rgCrstNameMap[] =
     "CrstUnwindInfoTablePendingLock",
     "CrstUnwindInfoTablePublishLock",
     "CrstVSDIndirectionCellLock",
+    "CrstWebcilImageRelocation",
     "CrstWrapperTemplate",
 };
 

--- a/src/coreclr/inc/webcildecoder.h
+++ b/src/coreclr/inc/webcildecoder.h
@@ -200,7 +200,13 @@ private:
     // ------------------------------------------------------------
 
     BOOL HasReadyToRunHeader() const;
-    BOOL IsComponentAssembly() const { return FALSE; }
+    BOOL IsComponentAssembly() const
+    {
+        // A webcil composite's component assemblies carry the R2R COMPONENT flag; the flat FALSE
+        // default would make PEImageLayout::IsComponentAssembly() (routed here via DECODER_DISPATCH)
+        // report every webcil image as non-component, disabling composite R2R load.
+        return HasReadyToRunHeader() && (GetReadyToRunHeader()->CoreHeader.Flags & READYTORUN_FLAG_COMPONENT) != 0;
+    }
     READYTORUN_HEADER *GetReadyToRunHeader() const;
     BOOL IsNativeMachineFormat() const { return true; } // This can only be loaded on a Wasm runtime which matches the necessary load environment, which means these are always in the native machine format.
     PTR_CVOID GetNativeManifestMetadata(COUNT_T *pSize) const;

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -207,13 +207,15 @@ namespace
             }
         }
 
-        *header = (READYTORUN_HEADER *)peLoadedImage->GetExport("RTR_HEADER");
 #ifdef TARGET_WASM
-        // Webcil composites do not expose a named "RTR_HEADER" export the way PE R2R images do;
-        // fall back to the decoder's R2R header. Gated on IsWebcilFormat() so a PE composite that
-        // is genuinely missing the export still fails validation below rather than being accepted.
-        if (*header == NULL && peLoadedImage->IsWebcilFormat() && peLoadedImage->HasReadyToRunHeader())
+        // On WebAssembly the runtime only loads flat webcil composites, which do not expose a named
+        // "RTR_HEADER" export the way PE R2R images do; obtain the R2R header from the decoder instead.
+        // PE R2R images (which rely on the export) cannot be loaded on WASM, so the export path is never
+        // taken here. A genuinely non-R2R image still fails validation below via the NULL header check.
+        if (peLoadedImage->HasReadyToRunHeader())
             *header = peLoadedImage->GetReadyToRunHeader();
+#else // TARGET_WASM
+        *header = (READYTORUN_HEADER *)peLoadedImage->GetExport("RTR_HEADER");
 #endif // TARGET_WASM
         if (*header == NULL)
         {

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -208,6 +208,13 @@ namespace
         }
 
         *header = (READYTORUN_HEADER *)peLoadedImage->GetExport("RTR_HEADER");
+#ifdef TARGET_WASM
+        // Webcil composites do not expose a named "RTR_HEADER" export the way PE R2R images do;
+        // fall back to the decoder's R2R header. Gated on IsWebcilFormat() so a PE composite that
+        // is genuinely missing the export still fails validation below rather than being accepted.
+        if (*header == NULL && peLoadedImage->IsWebcilFormat() && peLoadedImage->HasReadyToRunHeader())
+            *header = peLoadedImage->GetReadyToRunHeader();
+#endif // TARGET_WASM
         if (*header == NULL)
         {
             COMPlusThrowHR(COR_E_BADIMAGEFORMAT);

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -49,6 +49,10 @@ void PEImage::Startup()
     s_ijwFixupDataHash = ::new PtrHashMap;
     s_ijwFixupDataHash->Init(CompareIJWDataBase, FALSE, &ijwLock);
 
+#ifdef TARGET_WASM
+    PEImageLayout::Startup();
+#endif // TARGET_WASM
+
     RETURN;
 }
 

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -248,6 +248,21 @@ void PEImageLayout::ApplyBaseRelocations(bool relocationMustWriteCopy)
     SSIZE_T tableBaseDelta = GetTableBaseOffset();
 #endif // FEATURE_WEBCIL
 
+#ifdef TARGET_WASM
+    // Host-probed webcil R2R images share one in-memory buffer, so the binder can open the same
+    // image twice (identity probe + load) and relocate it twice. WASM table-index relocations are
+    // additive (index += tableBase), so re-relocating doubles tableBase and corrupts indirect calls.
+    // Skip if this base was already relocated. INTERIM: production should relocate the buffer once at
+    // the host-probe boundary and skip webcil here; not synchronized (single-threaded wasm runtime).
+    typedef SetSHash< TADDR,
+                      NoRemoveSHashTraits< NonDacAwareSHashTraits< SetSHashTraits<TADDR> > > > RelocatedWebcilSet;
+    static RelocatedWebcilSet s_relocatedWebcilBases;
+    const bool isHostProbedWebcil = IsWebcilFormat();
+    const TADDR webcilBase = isHostProbedWebcil ? (TADDR)GetBase() : (TADDR)0;
+    if (isHostProbedWebcil && s_relocatedWebcilBases.Contains(webcilBase))
+        return;
+#endif // TARGET_WASM
+
     // Nothing to do - image is loaded at preferred base and no table base offset
     if (delta == 0
 #ifdef FEATURE_WEBCIL
@@ -306,6 +321,8 @@ void PEImageLayout::ApplyBaseRelocations(bool relocationMustWriteCopy)
 
         DWORD rva = VAL32(r->VirtualAddress);
 
+        // For webcil (wasm-only) this relies on the flat-mapped invariant PointerToRawData ==
+        // VirtualAddress, so GetBase() + rva is the correct address (equivalent to GetRvaData(rva)).
         BYTE * pageAddress = (BYTE *)GetBase() + rva;
 
         // Check whether the page is outside the unprotected region.
@@ -455,6 +472,13 @@ void PEImageLayout::ApplyBaseRelocations(bool relocationMustWriteCopy)
     {
         ClrFlushInstructionCache(pFlushRegion, cbFlushRegion);
     }
+
+#ifdef TARGET_WASM
+    // Record the base only now that relocations have been applied successfully, so a throw partway
+    // through does not leave the shared buffer marked relocated and cause a later open to skip it.
+    if (isHostProbedWebcil)
+        s_relocatedWebcilBases.Add(webcilBase);
+#endif // TARGET_WASM
 }
 
 static SIZE_T AllocatedPart(PVOID part)

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -40,6 +40,19 @@ static bool AllowR2RForImage(PEImage* pOwner)
 #ifndef DACCESS_COMPILE
 extern BOOL g_useDefaultBaseAddr;
 
+#ifdef TARGET_WASM
+// Guards s_relocatedWebcilBases in ApplyBaseRelocations so concurrent loads of the same shared
+// host-probed webcil buffer cannot relocate it more than once. Initialized by PEImageLayout::Startup.
+static CrstStatic s_webcilRelocationCrst;
+
+/*static*/
+void PEImageLayout::Startup()
+{
+    WRAPPER_NO_CONTRACT;
+    s_webcilRelocationCrst.Init(CrstWebcilImageRelocation);
+}
+#endif // TARGET_WASM
+
 PEImageLayout* PEImageLayout::CreateFromByteArray(PEImage* pOwner, const BYTE* array, COUNT_T size)
 {
     STANDARD_VM_CONTRACT;
@@ -250,17 +263,30 @@ void PEImageLayout::ApplyBaseRelocations(bool relocationMustWriteCopy)
 
 #ifdef TARGET_WASM
     // Host-probed webcil R2R images share one in-memory buffer, so the binder can open the same
-    // image twice (identity probe + load) and relocate it twice. WASM table-index relocations are
-    // additive (index += tableBase), so re-relocating doubles tableBase and corrupts indirect calls.
-    // Skip if this base was already relocated. INTERIM: production should relocate the buffer once at
-    // the host-probe boundary and skip webcil here; not synchronized (single-threaded wasm runtime).
+    // image twice (identity probe + load). WASM table-index relocations are additive
+    // (index += tableBase), so relocating the shared buffer twice doubles tableBase and corrupts
+    // indirect calls. Track the buffers already relocated and skip re-relocation.
+    //
+    // The lock is taken before the Contains check and held for the rest of the method so that, when
+    // WASM is built with threads (FEATURE_MULTITHREADING), two concurrent loads of the same shared
+    // buffer cannot both pass the check and relocate it twice.
+    //
+    // INTERIM: the intended production fix is to relocate the host-probed buffer once at the point the
+    // host hands it to the runtime and skip webcil relocation here entirely, removing this set.
     typedef SetSHash< TADDR,
                       NoRemoveSHashTraits< NonDacAwareSHashTraits< SetSHashTraits<TADDR> > > > RelocatedWebcilSet;
     static RelocatedWebcilSet s_relocatedWebcilBases;
-    const bool isHostProbedWebcil = IsWebcilFormat();
-    const TADDR webcilBase = isHostProbedWebcil ? (TADDR)GetBase() : (TADDR)0;
-    if (isHostProbedWebcil && s_relocatedWebcilBases.Contains(webcilBase))
-        return;
+    CrstHolder relocationGuard(&s_webcilRelocationCrst);
+    if (IsWebcilFormat())
+    {
+        const TADDR webcilBase = (TADDR)GetBase();
+        if (s_relocatedWebcilBases.Contains(webcilBase))
+            return;
+        // Record before applying: once we commit to relocating this shared buffer, no other load may
+        // additively relocate it again. A failure partway through relocation is unrecoverable for the
+        // additive model and fails the load regardless, so there is no "safe" point to record instead.
+        s_relocatedWebcilBases.Add(webcilBase);
+    }
 #endif // TARGET_WASM
 
     // Nothing to do - image is loaded at preferred base and no table base offset
@@ -472,13 +498,6 @@ void PEImageLayout::ApplyBaseRelocations(bool relocationMustWriteCopy)
     {
         ClrFlushInstructionCache(pFlushRegion, cbFlushRegion);
     }
-
-#ifdef TARGET_WASM
-    // Record the base only now that relocations have been applied successfully, so a throw partway
-    // through does not leave the shared buffer marked relocated and cause a later open to skip it.
-    if (isHostProbedWebcil)
-        s_relocatedWebcilBases.Add(webcilBase);
-#endif // TARGET_WASM
 }
 
 static SIZE_T AllocatedPart(PVOID part)

--- a/src/coreclr/vm/peimagelayout.h
+++ b/src/coreclr/vm/peimagelayout.h
@@ -57,6 +57,10 @@ public:
 
 public:
 #ifndef DACCESS_COMPILE
+#ifdef TARGET_WASM
+    // One-time initialization of the lock guarding webcil relocation de-duplication.
+    static void Startup();
+#endif // TARGET_WASM
     static PEImageLayout* CreateFromByteArray(PEImage* pOwner, const BYTE* array, COUNT_T size);
 #ifndef TARGET_UNIX
     static PEImageLayout* CreateFromHMODULE(HMODULE hModule,PEImage* pOwner);

--- a/src/coreclr/vm/peimagelayout.inl
+++ b/src/coreclr/vm/peimagelayout.inl
@@ -637,7 +637,7 @@ inline PTR_CVOID PEImageLayout::GetNativeManifestMetadata(COUNT_T *pSize) const
 inline BOOL PEImageLayout::IsComponentAssembly() const
 {
     WRAPPER_NO_CONTRACT;
-    PE_OR_WEBCIL(IsComponentAssembly(), FALSE)
+    DECODER_DISPATCH(IsComponentAssembly())
 }
 
 inline BOOL PEImageLayout::HasReadyToRunHeader() const

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -537,7 +537,14 @@ static NativeImage *AcquireCompositeImage(Module * pModule, PEImageLayout * pLay
         return NULL;
 
     LPCUTF8 ownerCompositeExecutableName = NULL;
-    if (pLayout->IsMapped())
+    if (pLayout->IsWebcilFormat())
+    {
+        // Webcil is wasm-only and flat-mapped by construction (PointerToRawData == VirtualAddress),
+        // so this is equivalent to GetBase() + virtualAddress; use the decoder's GetRvaData as the
+        // format-correct idiom for resolving an RVA.
+        ownerCompositeExecutableName = (LPCUTF8)pLayout->GetRvaData(virtualAddress);
+    }
+    else if (pLayout->IsMapped())
     {
         ownerCompositeExecutableName = (LPCUTF8)pLayout->GetBase() + virtualAddress;
     }


### PR DESCRIPTION
## What

Minimal, OS-neutral VM plumbing so the runtime can **load a flat webcil-in-wasm composite R2R image**. crossgen2 emits the wasm startup R2R composite as a flat webcil image, but the R2R/PE-decoder load path assumes a mapped PE — a named `RTR_HEADER` export and `IsMapped()` RVA addressing — so today the VM can't find the R2R header or address sections in a flat webcil composite. Four small touch-points close that gap:

| File | Change |
|---|---|
| `vm/nativeimage.cpp` | webcil composite exposes no named `RTR_HEADER` export → fall back to the decoder's R2R header |
| `vm/readytoruninfo.cpp` | treat flat webcil as RVA-addressable directly from base (`IsWebcilFormat()` alongside `IsMapped()`) |
| `vm/peimagelayout.inl` | route `IsComponentAssembly()` through the webcil decoder (`DECODER_DISPATCH`) |
| `vm/peimagelayout.cpp` | guard against re-applying base relocations to a host-probed shared buffer |

Guarded on `TARGET_WASM` / `FEATURE_PORTABLE_ENTRYPOINTS`, so the **same code serves browser and wasi** from one path.

## Why

Part of #130524. Addresses the composite-loadability open question in #130519 ("whether the composite container is fully browser-loadable today or needs work"). This is the VM-*consumer* half — the *producer*/packaging side stays with #130519.

## Feedback wanted — the relocation guard

The one design question in this PR is the `peimagelayout.cpp` guard. Host-probed webcil R2R images are backed by a **single shared in-memory buffer**, not a copy-on-write file mapping. The assembly binder can open such an image more than once (identity probe + load) as **independent** `PEImage`/layout objects over the *same* buffer, and each open would re-run `ApplyBaseRelocations` on that memory. WASM table-index relocations are additive (`index += tableBase`), so a second application doubles `tableBase` and pushes indirect-call indices out of the function table.

This PR guards it with a VM-local set of already-relocated base addresses (`SetSHash<TADDR>`). Because the duplicate opens are distinct objects sharing one buffer, a per-`PEImageLayout`/per-`PEImage` flag wouldn't dedup them — the state has to key on the shared resource. It is intentionally **not** synchronized (relies on the current single-threaded wasm runtime) and is marked INTERIM in-code.

The cleaner production direction is probably to **relocate the host-probed buffer once at the point it's handed to the runtime and skip webcil in `ApplyBaseRelocations` entirely** — but that reaches into the host/probe boundary, which is out of scope for this VM-only load change. Guidance on the preferred layer here is the main thing I'm looking for.

## Scope / out of scope

**Out:** composite *production*/packaging (#130519); the CoreLib-R2R execution gates — QCall/PInvoke, class-init, etc. (#129850); SIMD instruction-set reporting; the host-side merge/probe mechanism.

## Testing

- Compiles under `./build.sh clr -os wasi -c Release` (the `TARGET_WASM` branches are only exercised by a wasm build).
- Validated on the WASI R2R prototype: a composite `System.Private.CoreLib` R2R image (~49k R2R functions) loads and dispatches through exactly these four changes.
- **Cannot run standalone yet** — a loaded CoreLib R2R image needs the execution gates tracked in #129850 to get past startup. This PR is the load prerequisite for that work, landing incrementally behind the wasm guards like the rest of the wasm R2R bring-up.

> [!NOTE]
> This PR (code and description) was drafted with GitHub Copilot assistance.
