### PR TITLE
Link statically to GrowableFunctionTable

### DIFF
--- a/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
@@ -109,6 +109,7 @@ if(CLR_CMAKE_TARGET_WIN32)
         ${STATIC_MT_CRT_LIB}
         ${STATIC_MT_VCRT_LIB}
         kernel32.lib
+        ntdll.lib
         advapi32.lib
         ole32.lib
         oleaut32.lib

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -778,8 +778,6 @@ void EEStartupHelper()
         IfFailGoLog(EnsureRtlFunctions());
 #endif // !TARGET_UNIX
 
-        UnwindInfoTable::Initialize();
-
         // Fire the runtime information ETW event
         ETW::InfoLog::RuntimeInformation(ETW::InfoLog::InfoStructs::Normal);
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -92,8 +92,6 @@ unsigned   ExecutionManager::m_LCG_JumpStubBlockFullCount;
 
 #if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(DACCESS_COMPILE)
 
-static bool s_publishingActive;              // Publishing to ETW is turned on
-
 namespace
 {
     // Uses unsigned subtraction to handle sequence counter wrapping correctly.
@@ -225,7 +223,6 @@ UnwindInfoTable::~UnwindInfoTable()
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-    _ASSERTE(s_publishingActive);
 
     // We do this lock free to because too many places still want no-trigger.   It should be OK
     // It would be cleaner if we could take the lock (we did not have to be GC_NOTRIGGER)
@@ -276,8 +273,6 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
         GC_TRIGGERS;
     }
     CONTRACTL_END;
-
-    _ASSERTE(s_publishingActive);
 
     if (m_registrationFailed)
         return;
@@ -515,9 +510,6 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     CONTRACTL_END;
     _ASSERTE(unwindInfoPtr != NULL);
 
-    if (!s_publishingActive)
-        return;
-
     UnwindInfoTable* unwindInfo = VolatileLoad(unwindInfoPtr);
     if (unwindInfo == NULL)
         return;
@@ -570,8 +562,6 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
 /* static */ void UnwindInfoTable::PublishUnwindInfoForMethod(TADDR baseAddress, PT_RUNTIME_FUNCTION methodUnwindData, int methodUnwindDataCount)
 {
     STANDARD_VM_CONTRACT;
-    if (!s_publishingActive)
-        return;
 
     TADDR entry = baseAddress + methodUnwindData->BeginAddress;
     RangeSection * pRS = ExecutionManager::FindCodeRange(entry, ExecutionManager::GetScanFlags());
@@ -606,9 +596,6 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     }
     CONTRACTL_END;
 
-    if (!s_publishingActive)
-        return;
-
     RangeSection * pRS = ExecutionManager::FindCodeRange(entryPoint, ExecutionManager::GetScanFlags());
     _ASSERTE(pRS != NULL);
     if (pRS != NULL)
@@ -625,24 +612,6 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     }
 }
 
-/*****************************************************************************/
-// We only do this on Windows x64 (other platforms use frame-based stack crawling),
-// We want good stack traces so we need to publish unwind information so ETW can
-// walk the stack.
-/* static */ void UnwindInfoTable::Initialize()
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_NOTRIGGER;
-    }
-    CONTRACTL_END;
-
-    _ASSERTE(!s_publishingActive);
-
-    s_publishingActive = true;
-}
-
 #else
 /* static */ void UnwindInfoTable::PublishUnwindInfoForMethod(TADDR baseAddress, T_RUNTIME_FUNCTION* methodUnwindData, int methodUnwindDataCount)
 {
@@ -650,11 +619,6 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
 }
 
 /* static */ void UnwindInfoTable::UnpublishUnwindInfoForMethod(TADDR entryPoint)
-{
-    LIMITED_METHOD_CONTRACT;
-}
-
-/* static */ void UnwindInfoTable::Initialize()
 {
     LIMITED_METHOD_CONTRACT;
 }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -92,19 +92,6 @@ unsigned   ExecutionManager::m_LCG_JumpStubBlockFullCount;
 
 #if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(DACCESS_COMPILE)
 
-// Support for new style unwind information (to allow OS to stack crawl JIT compiled code).
-
-typedef NTSTATUS (WINAPI* RtlAddGrowableFunctionTableFnPtr) (
-        PVOID *DynamicTable, PRUNTIME_FUNCTION FunctionTable, ULONG EntryCount,
-        ULONG MaximumEntryCount, ULONG_PTR rangeStart, ULONG_PTR rangeEnd);
-typedef VOID (WINAPI* RtlGrowFunctionTableFnPtr) (PVOID DynamicTable, ULONG NewEntryCount);
-typedef VOID (WINAPI* RtlDeleteGrowableFunctionTableFnPtr) (PVOID DynamicTable);
-
-// OS entry points (only exist on Win8 and above)
-static RtlAddGrowableFunctionTableFnPtr pRtlAddGrowableFunctionTable;
-static RtlGrowFunctionTableFnPtr pRtlGrowFunctionTable;
-static RtlDeleteGrowableFunctionTableFnPtr pRtlDeleteGrowableFunctionTable;
-
 static bool s_publishingActive;              // Publishing to ETW is turned on
 
 namespace
@@ -200,40 +187,6 @@ namespace
 }
 
 /****************************************************************************/
-// initialize the entry points for new win8 unwind info publishing functions.
-// return true if the initialize is successful (the functions exist)
-bool InitUnwindFtns()
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-    }
-    CONTRACTL_END;
-
-    HINSTANCE hNtdll = GetModuleHandle(W("ntdll.dll"));
-    if (hNtdll != NULL)
-    {
-        void* growFunctionTable = GetProcAddress(hNtdll, "RtlGrowFunctionTable");
-        void* deleteGrowableFunctionTable = GetProcAddress(hNtdll, "RtlDeleteGrowableFunctionTable");
-        void* addGrowableFunctionTable = GetProcAddress(hNtdll, "RtlAddGrowableFunctionTable");
-
-        // All or nothing AddGroableFunctionTable is last (marker)
-        if (growFunctionTable != NULL &&
-            deleteGrowableFunctionTable != NULL &&
-            addGrowableFunctionTable != NULL)
-        {
-            pRtlGrowFunctionTable = (RtlGrowFunctionTableFnPtr) growFunctionTable;
-            pRtlDeleteGrowableFunctionTable = (RtlDeleteGrowableFunctionTableFnPtr) deleteGrowableFunctionTable;
-            pRtlAddGrowableFunctionTable = (RtlAddGrowableFunctionTableFnPtr) addGrowableFunctionTable;
-        }
-        // Don't call FreeLibrary(hNtdll) because GetModuleHandle did *NOT* increment the reference count!
-    }
-
-    return (pRtlAddGrowableFunctionTable != NULL);
-}
-
-/****************************************************************************/
 UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd)
     : m_publishLock(CrstUnwindInfoTablePublishLock)
     , m_pendingLock(CrstUnwindInfoTablePendingLock)
@@ -285,7 +238,7 @@ UnwindInfoTable::~UnwindInfoTable()
 void UnwindInfoTable::Register()
 {
     // Caller holds m_publishLock.
-    NTSTATUS ret = pRtlAddGrowableFunctionTable(&hHandle, pTable, cTableCurCount, cTableMaxCount, iRangeStart, iRangeEnd);
+    NTSTATUS ret = RtlAddGrowableFunctionTable(&hHandle, pTable, cTableCurCount, cTableMaxCount, iRangeStart, iRangeEnd);
     if (ret != STATUS_SUCCESS)
     {
         _ASSERTE(!"Failed to publish UnwindInfo (ignorable)");
@@ -307,7 +260,7 @@ void UnwindInfoTable::UnRegister()
     if (handle != 0)
     {
         STRESS_LOG3(LF_JIT, LL_INFO100, "UnwindInfoTable::UnRegister Handle: %p [%p, %p]\n", handle, iRangeStart, iRangeEnd);
-        pRtlDeleteGrowableFunctionTable(handle);
+        RtlDeleteGrowableFunctionTable(handle);
     }
 }
 
@@ -408,7 +361,7 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
 
         if (hHandle != NULL)
         {
-            pRtlGrowFunctionTable(hHandle, cTableCurCount);
+            RtlGrowFunctionTable(hHandle, cTableCurCount);
         }
         else
         {
@@ -686,10 +639,6 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     CONTRACTL_END;
 
     _ASSERTE(!s_publishingActive);
-
-    // If we don't have the APIs we need, give up
-    if (!InitUnwindFtns())
-        return;
 
     s_publishingActive = true;
 }

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -593,7 +593,7 @@ public:
 
 typedef DPTR(class UnwindInfoTable) PTR_UnwindInfoTable;
 // On Windows x64, publish OS UnwindInfo (accessed from RUNTIME_FUNCTION
-// structures) to support the ability unwind the stack. In Win8 and above
+// structures) to support the ability to unwind the stack. In Win8 and above
 // new APIs were defined that allow incremental publishing via a table.
 //
 // UnwindInfoTable is a class that wraps the OS APIs that we use to publish

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -593,9 +593,7 @@ public:
 
 typedef DPTR(class UnwindInfoTable) PTR_UnwindInfoTable;
 // On Windows x64, publish OS UnwindInfo (accessed from RUNTIME_FUNCTION
-// structures) to support the ability unwind the stack. Unfortunately the pre-Win8
-// APIs defined a callback API for publishing this data dynamically that ETW does
-// not use (and really can't because the walk happens in the kernel). In Win8
+// structures) to support the ability unwind the stack. In Win8 and above
 // new APIs were defined that allow incremental publishing via a table.
 //
 // UnwindInfoTable is a class that wraps the OS APIs that we use to publish
@@ -614,8 +612,6 @@ public:
     // These are wrapper functions over the UnwindInfoTable functions that are specific to JIT compile code
     static void PublishUnwindInfoForMethod(TADDR baseAddress, T_RUNTIME_FUNCTION* methodUnwindData, int methodUnwindDataCount);
     static void UnpublishUnwindInfoForMethod(TADDR entryPoint);
-
-    static void Initialize();
 
 #if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 private:


### PR DESCRIPTION
`RtlAddGrowableFunctionTable` and related APIs were introduced in Windows 8.

The functions are present in the WindowsAPI allow list of NativeAOT, so I think linking ntdll is acceptible here.