### PR TITLE
[mono][wasm] Fix AOT + BlazorWebAssemblyLazyLoad startup crash

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -202,6 +202,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmWebcilVersion Condition="'$(_WasmWebcilVersion)' == ''">0</_WasmWebcilVersion>
       <_BlazorWebAssemblyJiterpreter>$(BlazorWebAssemblyJiterpreter)</_BlazorWebAssemblyJiterpreter>
       <_BlazorWebAssemblyRuntimeOptions>$(BlazorWebAssemblyRuntimeOptions)</_BlazorWebAssemblyRuntimeOptions>
+      <!-- With AOT, each AOT image hard-binds to every assembly it references when the image is
+           loaded. A BlazorWebAssemblyLazyLoad assembly is not present at runtime startup, so any
+           AOT image that references it would be marked unusable and its methods would fall back to
+           the interpreter (which can then hit unsupported constructs and abort). Enable lazy AOT
+           assembly loading so referenced lazy assemblies are only bound when they are loaded. -->
+      <_BlazorWebAssemblyRuntimeOptions Condition="'$(RunAOTCompilation)' == 'true' and @(BlazorWebAssemblyLazyLoad->Count()) != 0 and !$(_BlazorWebAssemblyRuntimeOptions.Contains('--aot-lazy-assembly-load'))">$([System.String]::Concat('$(_BlazorWebAssemblyRuntimeOptions)', ' --aot-lazy-assembly-load').Trim())</_BlazorWebAssemblyRuntimeOptions>
       <_WasmInlineBootConfig Condition="'$(_WasmInlineBootConfig)' == '' and '$(_TargetingNET100OrLater)' == 'true'">true</_WasmInlineBootConfig>
       <_WasmInlineBootConfig Condition="'$(_WasmInlineBootConfig)' == ''">false</_WasmInlineBootConfig>
       <!-- true = wasm assets will have hard fingerprint; false = wasm assets won't have even soft fingerprint -->

--- a/src/mono/wasm/Wasm.Build.Tests/LazyLoadingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/LazyLoadingTests.cs
@@ -74,6 +74,28 @@ public class LazyLoadingTests : WasmTemplateTestsBase
     }
 
     [Fact]
+    [TestCategory("native-mono")]
+    public async Task LoadLazyAssemblyWithAOT()
+    {
+        // Regression coverage for https://github.com/dotnet/runtime/issues/125794:
+        // AOT combined with BlazorWebAssemblyLazyLoad must still initialize the runtime
+        // and lazily load assemblies at runtime. AOT is only supported when publishing
+        // in Release, so this exercises the publish + AOT + lazy-load combination that
+        // the Debug build/run tests above do not cover.
+        Configuration config = Configuration.Release;
+        ProjectInfo info = CopyTestAsset(config, aot: true, TestAsset.WasmBasicTestApp, "LazyLoadingTestsAOT");
+        PublishProject(info, config, new PublishOptions(AOT: true, ExtraMSBuildArgs: "-p:TestLazyLoading=true"));
+
+        RunResult result = await RunForPublishWithWebServer(new BrowserRunOptions(
+            config,
+            AOT: true,
+            TestScenario: "LazyLoadingTest"
+        ));
+
+        Assert.True(result.TestOutput.Any(m => m.Contains("FirstName")), "The lazy loading test didn't emit expected message with JSON");
+    }
+
+    [Fact]
     public async Task FailOnMissingLazyAssembly()
     {
         Configuration config = Configuration.Debug;


### PR DESCRIPTION
## Summary

Fixes #125794. AOT-published Blazor WebAssembly apps that use `BlazorWebAssemblyLazyLoad` crash during Mono runtime startup — reported as `appdomain.c` assertion (`condition '<disabled>' not met`) and, in other configurations, `interp.c` `NIY … should not be reached`.

## Root cause

An AOT image *hard-binds* to every assembly it references when the image is loaded. `load_aot_module` in `src/mono/mono/mini/aot-runtime.c` eagerly calls `load_image` for all referenced images unless the `aot-lazy-assembly-load` runtime option is set:

```c
/* … we have to load all referenced assemblies non-lazily … */
if (!mono_opt_aot_lazy_assembly_load) {
    for (guint32 i = 0; i < amodule->image_table_len; ++i)
        load_image (amodule, i, load_error);
}
```

A `BlazorWebAssemblyLazyLoad` assembly is **not present at runtime startup** (it is downloaded on demand). So when the main app's AOT image is loaded, resolving its lazy dependency fails and the image is marked *"unusable because dependency `<asm>` is not found"*. Every method in that image then falls back to the interpreter, which hits an unsupported construct and aborts:

```
[MONO] AOT: module WasmBasicTestApp is unusable because dependency Json is not found.
MONO interpreter: NIY encountered in method <Module>:.cctor ()
[MONO] * Assertion: should not be reached at .../mono/mini/interp/interp.c:4135
```

## Fix

Automatically enable the runtime's existing `aot-lazy-assembly-load` option from the WebAssembly SDK when AOT is combined with `BlazorWebAssemblyLazyLoad`. This defers binding of a referenced lazy assembly until it is actually loaded, so the referencing AOT image stays usable. The option flows through `runtimeOptions` in the boot config → `mono_wasm_parse_runtime_options` → `mono_options_parse_options`.

The change is scoped to `RunAOTCompilation=true` + at least one `BlazorWebAssemblyLazyLoad` item, so non-AOT and non-lazy builds are unaffected.

## Test

`LazyLoadingTests` previously only covered the interpreter (Debug) configuration. Added `LoadLazyAssemblyWithAOT` (`native-mono`, Release + AOT + lazy load) which reproduces the crash without the fix and passes with it.

### Verification

Built the browser (Mono + CoreCLR runtime packs) and workload locally and ran the new test.

- **Without the fix:** `module WasmBasicTestApp is unusable because dependency Json is not found` → `interp.c:4135` assertion → timed out waiting for `WASM EXIT`. ❌
- **With the fix:** `AOT: image 'WasmBasicTestApp' found.`, `firstJsonLoad=true`, `{"FirstName":"John","LastName":"Doe"}`, `WASM EXIT 0`. ✅

> [!NOTE]
> This pull request was authored with GitHub Copilot.