### PR TITLE
[mono][wasm] Fix pinvoke with 64-bit enum argument

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2887,7 +2887,14 @@ interp_type_as_ptr (MonoType *tp)
 	if ((tp)->type == MONO_TYPE_CHAR)
 		return TRUE;
 	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (tp)))
-		return TRUE;
+		/*
+		 * An enum is only pointer-compatible if its underlying type is. Checking the
+		 * underlying type ensures a 64-bit enum (e.g. 'enum : ulong') is not treated as a
+		 * pointer-sized icall argument on 32-bit targets such as wasm32, where it would
+		 * otherwise be passed through do_icall's gpointer signature and cause a native
+		 * call_indirect signature mismatch.
+		 */
+		return interp_type_as_ptr (mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (tp)));
 	if (is_scalar_vtype (tp))
 		return TRUE;
 	return FALSE;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2886,15 +2886,19 @@ interp_type_as_ptr (MonoType *tp)
 		return TRUE;
 	if ((tp)->type == MONO_TYPE_CHAR)
 		return TRUE;
-	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (tp)))
+	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (tp))) {
 		/*
-		 * An enum is only pointer-compatible if its underlying type is. Checking the
-		 * underlying type ensures a 64-bit enum (e.g. 'enum : ulong') is not treated as a
-		 * pointer-sized icall argument on 32-bit targets such as wasm32, where it would
-		 * otherwise be passed through do_icall's gpointer signature and cause a native
-		 * call_indirect signature mismatch.
+		 * A 64-bit enum (e.g. 'enum : ulong') must not be treated as a pointer-sized icall
+		 * argument on 32-bit targets such as wasm32: it would otherwise be passed through
+		 * do_icall's gpointer signature and cause a native call_indirect signature mismatch.
+		 * Defer to the underlying type, which is width-guarded, for those cases; enums with
+		 * a smaller underlying type keep their existing classification.
 		 */
-		return interp_type_as_ptr (mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (tp)));
+		MonoType *base_type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (tp));
+		if (base_type->type == MONO_TYPE_I8 || base_type->type == MONO_TYPE_U8)
+			return interp_type_as_ptr (base_type);
+		return TRUE;
+	}
 	if (is_scalar_vtype (tp))
 		return TRUE;
 	return FALSE;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2886,18 +2886,21 @@ interp_type_as_ptr (MonoType *tp)
 		return TRUE;
 	if ((tp)->type == MONO_TYPE_CHAR)
 		return TRUE;
-	if ((tp)->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (tp))) {
-		/*
-		 * A 64-bit enum (e.g. 'enum : ulong') must not be treated as a pointer-sized icall
-		 * argument on 32-bit targets such as wasm32: it would otherwise be passed through
-		 * do_icall's gpointer signature and cause a native call_indirect signature mismatch.
-		 * Defer to the underlying type, which is width-guarded, for those cases; enums with
-		 * a smaller underlying type keep their existing classification.
-		 */
-		MonoType *base_type = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (tp));
-		if (base_type->type == MONO_TYPE_I8 || base_type->type == MONO_TYPE_U8)
-			return interp_type_as_ptr (base_type);
-		return TRUE;
+	if ((tp)->type == MONO_TYPE_VALUETYPE) {
+		MonoClass *tp_klass = m_type_data_get_klass_unchecked (tp);
+		if (m_class_is_enumtype (tp_klass)) {
+			/*
+			 * A 64-bit enum (e.g. 'enum : ulong') must not be treated as a pointer-sized icall
+			 * argument on 32-bit targets such as wasm32: it would otherwise be passed through
+			 * do_icall's gpointer signature and cause a native call_indirect signature mismatch.
+			 * Defer to the underlying type, which is width-guarded, for those cases; enums with
+			 * a smaller underlying type keep their existing classification.
+			 */
+			MonoType *base_type = mono_class_enum_basetype_internal (tp_klass);
+			if (base_type && (base_type->type == MONO_TYPE_I8 || base_type->type == MONO_TYPE_U8))
+				return interp_type_as_ptr (base_type);
+			return TRUE;
+		}
 	}
 	if (is_scalar_vtype (tp))
 		return TRUE;

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -408,6 +408,9 @@ namespace Wasm.Build.Tests
             Assert.Contains(result.TestOutput, m => m.Contains("iares[0]=32"));
             Assert.Contains(result.TestOutput, m => m.Contains("iares[1]=2"));
             Assert.Contains("fares.elements[1]=2", result.TestOutput);
+            // https://github.com/dotnet/runtime/issues/112262: 64-bit enum pinvoke args
+            Assert.Contains("eu (eu)=18374966859414961921", result.TestOutput);
+            Assert.Contains("ei (ei)=-2", result.TestOutput);
         }
 
         [Theory]

--- a/src/mono/wasm/testassets/EntryPoints/PInvoke/AbiRules.cs
+++ b/src/mono/wasm/testassets/EntryPoints/PInvoke/AbiRules.cs
@@ -26,6 +26,9 @@ public struct MyInlineArray {
     public int element0;
 }
 
+public enum U64Enum : ulong { A = 0, B = 0xFF00FF00FF00FF00UL }
+public enum I64Enum : long { A = 0, B = -3 }
+
 public class Test
 {
     public static unsafe int Main(string[] argv)
@@ -66,6 +69,14 @@ public class Test
         var fares = accept_and_return_fixedarray(fa);
         Console.WriteLine("TestOutput -> fares.elements[1]=" + fares.elements[1]);
 
+        // Regression test for https://github.com/dotnet/runtime/issues/112262: a pinvoke
+        // with a 64-bit enum argument must not be routed through the pointer-sized fast
+        // icall path on wasm, otherwise the native call traps with a signature mismatch.
+        var euRes = direct_enum_u64(U64Enum.B);
+        Console.WriteLine("TestOutput -> eu (eu)=" + (ulong)euRes);
+        var eiRes = direct_enum_i64(I64Enum.B);
+        Console.WriteLine("TestOutput -> ei (ei)=" + (long)eiRes);
+
         int exitCode = (int)res.Value;
         return exitCode;
     }
@@ -104,4 +115,10 @@ public class Test
 
     [DllImport("wasm-abi", EntryPoint="accept_and_return_inlinearray")]
     public static extern MyInlineArray accept_and_return_inlinearray(MyInlineArray arg);
+
+    [DllImport("wasm-abi", EntryPoint="accept_and_return_ulong")]
+    public static extern U64Enum direct_enum_u64(U64Enum arg);
+
+    [DllImport("wasm-abi", EntryPoint="accept_and_return_long")]
+    public static extern I64Enum direct_enum_i64(I64Enum arg);
 }

--- a/src/mono/wasm/testassets/native-libs/wasm-abi.c
+++ b/src/mono/wasm/testassets/native-libs/wasm-abi.c
@@ -69,3 +69,13 @@ MyInlineArray accept_and_return_inlinearray (MyInlineArray arg) {
 MyInlineArray accept_and_return_fixedarray (MyInlineArray arg) {
     return accept_and_return_inlinearray (arg);
 }
+
+// Regression coverage for https://github.com/dotnet/runtime/issues/112262:
+// a pinvoke whose argument is a 64-bit enum must be passed as a real i64 on wasm.
+unsigned long long accept_and_return_ulong (unsigned long long arg) {
+    return arg + 1;
+}
+
+long long accept_and_return_long (long long arg) {
+    return arg + 1;
+}


### PR DESCRIPTION
## Summary

Fixes #112262. A P/Invoke whose argument is an enum with a **64-bit underlying type** (e.g. `[Flags] enum Flags : ulong`) crashes on wasm at the call site with `RuntimeError: null function or function signature mismatch`.

## Root cause

`interp_type_as_ptr()` (interp/transform.c) decides whether a native call can take the fast `MINT_CALLI_NAT_FAST` → `do_icall` path, which passes every argument as a pointer-sized `gpointer`. It treated **every enum as pointer-compatible without checking its underlying type**:

```c
if (tp->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (...))
    return TRUE;   // ignores underlying type
```

Raw `long`/`ulong` are already correctly excluded on 32-bit targets via the `#if SIZEOF_VOID_P == 8` guard (which is why the documented workaround — casting the enum to `ulong` — works), but a 64-bit **enum** slipped through. `do_icall` then called the native `void(int64_t)` as `void(int32_t)` on wasm32 → `call_indirect` signature mismatch.

## Fix

Only a 64-bit enum can be misclassified as pointer-sized on a 32-bit target, so for enums with an `I8`/`U8` underlying type defer to the underlying type (which is `SIZEOF_VOID_P`-guarded); all other enums keep their existing classification. Behavior only changes for enums with a 64-bit underlying type on 32-bit targets such as wasm32; `enum:int`/`enum:uint`/smaller enums and all enums on 64-bit hosts are unchanged.

`interp_type_as_ptr` is interp-transform-only; the AOT (`type_to_c`) and jiterpreter (`mono_type_to_ldind`) signature paths already reduce enums to their underlying type, so no parallel change is needed.

## Test

Extended the existing WASM ABI pinvoke test (`AbiRules.cs` + `wasm-abi.c`) with `enum:ulong` and `enum:long` direct pinvokes — the two cases the fix changes. `EnsureWasmAbiRulesAreFollowedInInterpreter` (the interpreter path where the bug lives) exercises the regression.

### Verification

Built the browser Mono runtime with the fix and ran the WASM ABI interpreter test end-to-end:
- **Without the fix:** `void(enum:ulong)` pinvoke → `function signature mismatch`, app aborts before running.
- **With the fix:** test passes; native round-trips the full 64-bit value (`eu (eu)=18374966859414961921`, `ei (ei)=-2`).

Also verified out-of-band that a pinvoke argument of every enum width — `byte`/`sbyte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong` — round-trips correctly on wasm with this change.

> [!NOTE]
> This pull request was authored with GitHub Copilot.