### PR TITLE
[mono][wasm] Respect [Un]SupportedOSPlatform in the Mono pinvoke generator

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -423,6 +423,23 @@ namespace Wasm.Build.Tests
             await EnsureWasmAbiRulesAreFollowed(config, aot);
 
         [Theory]
+        [BuildAndRun(aot: false)]
+        [TestCategory("native-mono")]
+        public void UnsupportedOSPlatformPInvokeIsSkipped(Configuration config, bool aot)
+        {
+            // https://github.com/dotnet/runtime/issues/110870: a Windows-only pinvoke with
+            // non-blittable parameters must be skipped (not analyzed) when building for the
+            // browser, so it must not emit WASM0060/WASM0062/WASM0001.
+            ProjectInfo info = CopyTestAsset(config, aot, TestAsset.WasmBasicTestApp, "osplatform_pinvoke",
+                extraProperties: "<WasmBuildNative>true</WasmBuildNative>");
+            ReplaceFile(Path.Combine("Common", "Program.cs"), Path.Combine(BuildEnvironment.TestAssetsPath, "EntryPoints", "PInvoke", "UnsupportedOSPlatform.cs"));
+            (_, string output) = BuildProject(info, config, new BuildOptions(AssertAppBundle: false, AOT: aot), isNativeBuild: true);
+            Assert.DoesNotContain("WASM0001", output);
+            Assert.DoesNotContain("WASM0060", output);
+            Assert.DoesNotContain("WASM0062", output);
+        }
+
+        [Theory]
         [BuildAndRun(aot: true, config: Configuration.Release)]
         [TestCategory("native-mono")]
         public void EnsureComInteropCompilesInAOT(Configuration config, bool aot)

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -792,6 +792,7 @@
       PInvokeOutputPath="$(_WasmPInvokeTablePath)"
       InterpToNativeOutputPath="$(_WasmInterpToNativeTablePath)"
       CacheFilePath="$(_WasmM2NCachePath)"
+      TargetOS="$(TargetOS)"
       IsLibraryMode="$(_IsLibraryMode)">
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ManagedToNativeGenerator>

--- a/src/mono/wasm/testassets/EntryPoints/PInvoke/UnsupportedOSPlatform.cs
+++ b/src/mono/wasm/testassets/EntryPoints/PInvoke/UnsupportedOSPlatform.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+public class Test
+{
+    public static int Main(string[] argv)
+    {
+        Console.WriteLine("TestOutput -> Main running");
+        return 42;
+    }
+}
+
+// Regression coverage for https://github.com/dotnet/runtime/issues/110870:
+// a Windows-only P/Invoke with non-blittable parameters must be skipped by the wasm
+// pinvoke collector when building for the browser, and must not emit WASM0060/WASM0062/WASM0001.
+[SupportedOSPlatform("windows")]
+internal static class Win32Interop
+{
+    [DllImport("gdi32.dll")]
+    public static extern int GetCharABCWidthsFloat(HandleRef hdc, uint iFirst, uint iLast, [Out] ABCFLOAT[] lpABCF);
+
+    [DllImport("user32.dll")]
+    public static extern int MethodWithNonBlittableObject(object arg, HandleRef handle);
+}
+
+internal struct ABCFLOAT
+{
+#pragma warning disable CS0649 // fields are only used to describe the native struct layout
+    public float abcfA;
+    public float abcfB;
+    public float abcfC;
+#pragma warning restore CS0649
+}

--- a/src/tasks/WasmAppBuilder/mono/ManagedToNativeGenerator.cs
+++ b/src/tasks/WasmAppBuilder/mono/ManagedToNativeGenerator.cs
@@ -34,6 +34,10 @@ public class ManagedToNativeGenerator : Task
 
     public bool IsLibraryMode { get; set; }
 
+    public string TargetOS { get; set; } = "browser";
+
+    private static readonly string[] s_knownTargetOSes = new[] { "browser", "wasi" };
+
     [Output]
     public string[]? FileWrites { get; private set; }
 
@@ -48,6 +52,19 @@ public class ManagedToNativeGenerator : Task
         if (PInvokeModules!.Length == 0)
         {
             Log.LogError($"{nameof(ManagedToNativeGenerator)}.{nameof(PInvokeModules)} cannot be empty");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(TargetOS))
+        {
+            Log.LogError($"{nameof(ManagedToNativeGenerator)}.{nameof(TargetOS)} cannot be empty; expected one of: {string.Join(", ", s_knownTargetOSes)}");
+            return false;
+        }
+
+        TargetOS = TargetOS.Trim().ToLowerInvariant();
+        if (Array.IndexOf(s_knownTargetOSes, TargetOS) < 0)
+        {
+            Log.LogError($"{nameof(ManagedToNativeGenerator)}.{nameof(TargetOS)} '{TargetOS}' is not recognized; expected one of: {string.Join(", ", s_knownTargetOSes)}");
             return false;
         }
 
@@ -70,7 +87,7 @@ public class ManagedToNativeGenerator : Task
         List<string> managedAssemblies = FilterOutUnmanagedBinaries(Assemblies);
         if (ShouldRun(managedAssemblies))
         {
-            var pinvoke = new PInvokeTableGenerator(FixupSymbolName, log, IsLibraryMode);
+            var pinvoke = new PInvokeTableGenerator(FixupSymbolName, log, IsLibraryMode, TargetOS);
             var icall = new IcallTableGenerator(RuntimeIcallTableFile, FixupSymbolName, log, isCoreClr: false);
 
             var resolver = new PathAssemblyResolver(managedAssemblies);

--- a/src/tasks/WasmAppBuilder/mono/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/mono/PInvokeCollector.cs
@@ -60,11 +60,15 @@ internal sealed class PInvokeComparer : IEqualityComparer<PInvoke>
 
 internal sealed class PInvokeCollector {
     private readonly Dictionary<Assembly, bool> _assemblyDisableRuntimeMarshallingAttributeCache = new();
+    private readonly Dictionary<Type, bool> _typeUnsupportedOnPlatformCache = new();
+    private readonly Dictionary<Assembly, bool> _assemblyUnsupportedOnPlatformCache = new();
+    private readonly string _targetOS;
     private LogAdapter Log { get; init; }
 
-    public PInvokeCollector(LogAdapter log)
+    public PInvokeCollector(LogAdapter log, string targetOS)
     {
         Log = log;
+        _targetOS = targetOS;
     }
 
     public void CollectPInvokes(List<PInvoke> pinvokes, List<PInvokeCallback> callbacks, HashSet<string> signatures, Type type)
@@ -102,6 +106,9 @@ internal sealed class PInvokeCollector {
         {
             if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
             {
+                if (IsUnsupportedOnPlatform(method))
+                    return;
+
                 var dllimport = method.CustomAttributes.First(attr => attr.AttributeType.Name == "DllImportAttribute");
                 var wasmLinkage = method.CustomAttributes.Any(attr => attr.AttributeType.Name == "WasmImportLinkageAttribute");
                 var module = (string)dllimport.ConstructorArguments[0].Value!;
@@ -122,6 +129,9 @@ internal sealed class PInvokeCollector {
         bool DoesMethodHaveCallbacks(MethodInfo method, LogAdapter log)
         {
             if (!MethodHasCallbackAttributes(method))
+                return false;
+
+            if (IsUnsupportedOnPlatform(method))
                 return false;
 
             if (TryIsMethodGetParametersUnsupported(method, out string? reason))
@@ -206,6 +216,102 @@ internal sealed class PInvokeCollector {
         }
 
         return value;
+    }
+
+    private bool IsUnsupportedOnPlatform(MethodInfo method)
+    {
+        PlatformSupport methodResult = EvaluatePlatformAttributes(CustomAttributeData.GetCustomAttributes(method));
+        if (methodResult == PlatformSupport.Unsupported)
+            return true;
+        if (methodResult == PlatformSupport.Supported)
+            return false;
+
+        return IsUnsupportedOnPlatform(method.DeclaringType);
+    }
+
+    private bool IsUnsupportedOnPlatform(Type? type)
+    {
+        if (type is null)
+            return false;
+
+        if (_typeUnsupportedOnPlatformCache.TryGetValue(type, out bool cached))
+            return cached;
+
+        bool value;
+        PlatformSupport typeResult = EvaluatePlatformAttributes(CustomAttributeData.GetCustomAttributes(type));
+        if (typeResult == PlatformSupport.Unsupported)
+        {
+            value = true;
+        }
+        else if (typeResult == PlatformSupport.Supported)
+        {
+            value = false;
+        }
+        else if (type.DeclaringType is not null)
+        {
+            value = IsUnsupportedOnPlatform(type.DeclaringType);
+        }
+        else
+        {
+            value = IsAssemblyUnsupportedOnPlatform(type.Assembly);
+        }
+
+        _typeUnsupportedOnPlatformCache[type] = value;
+        return value;
+    }
+
+    private bool IsAssemblyUnsupportedOnPlatform(Assembly assembly)
+    {
+        if (!_assemblyUnsupportedOnPlatformCache.TryGetValue(assembly, out bool value))
+        {
+            PlatformSupport asmResult = EvaluatePlatformAttributes(assembly.GetCustomAttributesData());
+            value = asmResult == PlatformSupport.Unsupported;
+            _assemblyUnsupportedOnPlatformCache[assembly] = value;
+        }
+
+        return value;
+    }
+
+    private enum PlatformSupport
+    {
+        Unknown,     // No platform attributes were observed at this scope
+        Supported,   // Explicitly supported here (target appears in a SupportedOSPlatform list)
+        Unsupported, // Explicitly unsupported here (target matches UnsupportedOSPlatform, or
+                     // SupportedOSPlatform is present and does not list the target)
+    }
+
+    private PlatformSupport EvaluatePlatformAttributes(IList<CustomAttributeData> attrs)
+    {
+        bool hasSupportedOSPlatform = false;
+        bool hasSupportedTarget = false;
+        foreach (CustomAttributeData cattr in attrs)
+        {
+            try
+            {
+                if (cattr.AttributeType.FullName == "System.Runtime.Versioning.UnsupportedOSPlatformAttribute" &&
+                    cattr.ConstructorArguments.Count > 0 &&
+                    cattr.ConstructorArguments[0].Value?.ToString() == _targetOS)
+                {
+                    return PlatformSupport.Unsupported;
+                }
+                if (cattr.AttributeType.FullName == "System.Runtime.Versioning.SupportedOSPlatformAttribute" &&
+                    cattr.ConstructorArguments.Count > 0)
+                {
+                    hasSupportedOSPlatform = true;
+                    if (cattr.ConstructorArguments[0].Value?.ToString() == _targetOS)
+                        hasSupportedTarget = true;
+                }
+            }
+            catch
+            {
+                // Assembly not found, ignore
+            }
+        }
+
+        if (hasSupportedOSPlatform)
+            return hasSupportedTarget ? PlatformSupport.Supported : PlatformSupport.Unsupported;
+
+        return PlatformSupport.Unknown;
     }
 }
 

--- a/src/tasks/WasmAppBuilder/mono/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/mono/PInvokeTableGenerator.cs
@@ -28,11 +28,11 @@ internal sealed class PInvokeTableGenerator
     private readonly PInvokeCollector _pinvokeCollector;
     private readonly bool _isLibraryMode;
 
-    public PInvokeTableGenerator(Func<string, string> fixupSymbolName, LogAdapter log, bool isLibraryMode = false)
+    public PInvokeTableGenerator(Func<string, string> fixupSymbolName, LogAdapter log, bool isLibraryMode, string targetOS)
     {
         Log = log;
         _fixupSymbolName = fixupSymbolName;
-        _pinvokeCollector = new(log);
+        _pinvokeCollector = new(log, targetOS);
         _isLibraryMode = isLibraryMode;
     }
 


### PR DESCRIPTION
## Summary

Fixes #110870. Building a browser-wasm app that references a **Windows-only** P/Invoke with non-blittable parameters (e.g. the gdi32 `GetCharABCWidthsFloat`, which takes `HandleRef` / `object`) emits spurious diagnostics on the **Mono** wasm backend:

```
WASM0060 : Type System.Object is not blittable: Not a ValueType
WASM0062 : Type System.Runtime.InteropServices.HandleRef is not blittable: Field _wrapper is not blittable
WASM0001 : Could not get pinvoke, or callbacks for method '...GetCharABCWidthsFloat' because 'System.NotSupportedException: Unsupported parameter type ...'
```

## Root cause

The Mono pinvoke collector (`src/tasks/WasmAppBuilder/mono/PInvokeCollector.cs`) analyzed **every** P/Invoke and callback in every referenced assembly, without consulting `[SupportedOSPlatform]` / `[UnsupportedOSPlatform]`. So a method that is only usable on Windows still had its (non-blittable) signature analyzed when targeting the browser, producing the warnings.

The **CoreCLR** collector already handles this — it skips a method up front via `IsUnsupportedOnPlatform` / `EvaluatePlatformAttributes`, driven by a `TargetOS`. That check was never ported to the Mono collector, so #110870 still reproduces on Mono while it's fixed on CoreCLR.

## Fix

Mirror the CoreCLR platform check into the Mono generator:
- Thread `TargetOS` through `ManagedToNativeGenerator` → `PInvokeTableGenerator` → `PInvokeCollector` (the shared `<ManagedToNativeGenerator>` invocation now passes `TargetOS="$(TargetOS)"`; the Mono task gets a `TargetOS` property defaulting to `browser`, mirroring CoreCLR).
- Skip pinvokes and callbacks whose method, declaring type (including nesting), or assembly is unsupported on the target OS — i.e. `[UnsupportedOSPlatform(target)]`, or a `[SupportedOSPlatform(...)]` list that doesn't include the target.

Only affects the Mono wasm build task; CoreCLR is unchanged.

## Test

Adds `PInvokeTableGeneratorTests.UnsupportedOSPlatformPInvokeIsSkipped`: builds a browser app containing a `[SupportedOSPlatform("windows")]` non-blittable pinvoke and asserts none of `WASM0001`/`WASM0060`/`WASM0062` are emitted.

### Verification

Built the Mono wasm build task and ran a repro (browser app with a `[SupportedOSPlatform("windows")]` gdi32-style pinvoke taking `HandleRef`/`object`), plus the new WBT test:
- **Without the fix:** `WASM0060` + `WASM0062` + `WASM0001` (matching the report).
- **With the fix:** 0 warnings; the new test passes (Debug + Release).

> [!NOTE]
> This pull request was authored with GitHub Copilot.
