### PR TITLE
[perf][wasm] Stage CoreCLR wasm runtime pack for Mono workload install

### DIFF
--- a/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
@@ -11,10 +11,16 @@ jobs:
       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       nameSuffix: wasm
       isOfficialBuild: false
+      # The wasm-tools workload manifest now includes the CoreCLR browser-wasm runtime pack, so the
+      # workload install below needs that pack staged into the local feed. It's produced by the
+      # wasm_coreclr build job, so depend on it and download its published runtime pack.
+      dependsOn:
+      - build_browser_wasm_linux_Release_wasm_coreclr
       postBuildSteps:
         - template: /eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
           parameters:
             configForBuild: Release
+            downloadCoreClrRuntimePack: true
 
 # Build CoreCLR runtime for browser-wasm (used by --wasm-coreclr benchmarks)
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -35,3 +41,4 @@ jobs:
             artifactName: BrowserWasmCoreCLR
             sdkDirName: dotnet-none
             includeRefPack: false
+            publishCoreClrRuntimePack: true

--- a/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
@@ -16,17 +16,15 @@ steps:
   # Stage the CoreCLR browser-wasm runtime pack (built by the wasm_coreclr job) into the local
   # package feed so the wasm-tools workload install below can resolve it.
   - ${{ if eq(parameters.downloadCoreClrRuntimePack, true) }}:
-    - task: DownloadBuildArtifacts@0
+    - task: DownloadPipelineArtifact@2
       displayName: "Download CoreCLR runtime pack for workload install"
       inputs:
         buildType: current
         artifactName: BrowserWasmCoreCLRRuntimePack_$(_hostedOs)
-        downloadType: single
-        downloadPath: $(Build.SourcesDirectory)/artifacts/coreclr-runtimepack
-
+        targetPath: $(Build.SourcesDirectory)/artifacts/coreclr-runtimepack
     - script: >-
         mkdir -p $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping &&
-        cp $(Build.SourcesDirectory)/artifacts/coreclr-runtimepack/BrowserWasmCoreCLRRuntimePack_$(_hostedOs)/*.nupkg $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/
+        cp $(Build.SourcesDirectory)/artifacts/coreclr-runtimepack/*.nupkg $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/
       displayName: "Stage CoreCLR runtime pack into local feed"
 
   - script: >-
@@ -60,13 +58,12 @@ steps:
         mkdir -p $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack &&
         find $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping -maxdepth 1 -name 'Microsoft.NETCore.App.Runtime.browser-wasm.*.nupkg' -not -name '*.symbols.nupkg' -exec cp {} $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack \;
       displayName: "Stage CoreCLR runtime pack for workload"
-
-    - template: /eng/pipelines/common/templates/publish-build-artifacts.yml
+    - template: /eng/pipelines/common/templates/publish-pipeline-artifacts.yml
       parameters:
         isOfficialBuild: false
         displayName: Publish CoreCLR runtime pack for workload
         inputs:
-          PathtoPublish: $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack
+          targetPath: $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack
           artifactName: BrowserWasmCoreCLRRuntimePack_$(_hostedOs)
 
   - template: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
@@ -4,8 +4,31 @@ parameters:
   runtimeFlavor: 'mono'
   sdkDirName: 'dotnet-latest'
   includeRefPack: true
+  # The Mono (default) build installs the wasm-tools workload, whose manifest now includes the
+  # CoreCLR browser-wasm runtime pack (Microsoft.NETCore.App.Runtime.browser-wasm). A Mono-only
+  # build doesn't produce that pack, so download it from the CoreCLR build job and stage it into
+  # the local package feed before installing the workload.
+  downloadCoreClrRuntimePack: false
+  # The CoreCLR build publishes its runtime pack so the Mono build (above) can consume it.
+  publishCoreClrRuntimePack: false
 
 steps:
+  # Stage the CoreCLR browser-wasm runtime pack (built by the wasm_coreclr job) into the local
+  # package feed so the wasm-tools workload install below can resolve it.
+  - ${{ if eq(parameters.downloadCoreClrRuntimePack, true) }}:
+    - task: DownloadBuildArtifacts@0
+      displayName: "Download CoreCLR runtime pack for workload install"
+      inputs:
+        buildType: current
+        artifactName: BrowserWasmCoreCLRRuntimePack_$(_hostedOs)
+        downloadType: single
+        downloadPath: $(Build.SourcesDirectory)/artifacts/coreclr-runtimepack
+
+    - script: >-
+        mkdir -p $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping &&
+        cp $(Build.SourcesDirectory)/artifacts/coreclr-runtimepack/BrowserWasmCoreCLRRuntimePack_$(_hostedOs)/*.nupkg $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/
+      displayName: "Stage CoreCLR runtime pack into local feed"
+
   - script: >-
       ./dotnet.sh build -p:TargetOS=browser -p:TargetArchitecture=wasm /nr:false /p:TreatWarningsAsErrors=true
       /p:Configuration=${{ parameters.configForBuild }}
@@ -29,6 +52,22 @@ steps:
   - ${{ if eq(parameters.includeRefPack, true) }}:
     - script: cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging
       displayName: "Stage ref pack directory"
+
+  # Publish the CoreCLR browser-wasm runtime pack nuget on its own so the Mono build job can stage
+  # it into its local feed for the wasm-tools workload install.
+  - ${{ if eq(parameters.publishCoreClrRuntimePack, true) }}:
+    - script: >-
+        mkdir -p $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack &&
+        find $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping -maxdepth 1 -name 'Microsoft.NETCore.App.Runtime.browser-wasm.*.nupkg' -not -name '*.symbols.nupkg' -exec cp {} $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack \;
+      displayName: "Stage CoreCLR runtime pack for workload"
+
+    - template: /eng/pipelines/common/templates/publish-build-artifacts.yml
+      parameters:
+        isOfficialBuild: false
+        displayName: Publish CoreCLR runtime pack for workload
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack
+          artifactName: BrowserWasmCoreCLRRuntimePack_$(_hostedOs)
 
   - template: /eng/pipelines/common/upload-artifact-step.yml
     parameters:


### PR DESCRIPTION
## Summary

Fixes the `runtime-wasm-perf` pipeline, which fails at **"Install workload using artifacts"** in the `browser-wasm linux Release wasm` (Mono) build job:

```
Version 11.0.0-ci of package microsoft.netcore.app.runtime.browser-wasm is not found in NuGet feeds ...
```

## Root cause

#130380 ("Enable wasm-tools workload for CoreCLR WASM targets") added the CoreCLR runtime pack `Microsoft.NETCore.App.Runtime.browser-wasm` to the `wasm-tools` workload manifest. The Mono perf build (`-s mono+libs+host+packs`) only produces the Mono runtime pack, and `packs` only builds the pack matching the build's `RuntimeFlavor` (`DotNetBuildAllRuntimePacks` even explicitly excludes CoreCLR for wasm). So the Mono job's local package feed never contains the CoreCLR pack the workload now requires, and the workload install fails.

The `wasm_coreclr` job's install "succeeds" only because `_GetWorkloadsToInstall` lists workloads solely when `RuntimeFlavor == Mono`, making its install a no-op.

#130380 already solved this for the main/extra-platforms CI by adding a **separate CoreCLR build + downloading its runtime pack** into the workload-install job (`includeCoreClrRuntimePack`). The perf pipeline was never given the same treatment.

## Fix

The perf pipeline already builds both flavors in two jobs, so this reuses the existing CoreCLR pack instead of duplicating a build — mirroring the #130380 pattern:

- **`perf-wasm-prepare-artifacts-steps.yml`** — two opt-in parameters:
  - `publishCoreClrRuntimePack`: the CoreCLR job publishes its `Microsoft.NETCore.App.Runtime.browser-wasm` nupkg as artifact `BrowserWasmCoreCLRRuntimePack_$(_hostedOs)`.
  - `downloadCoreClrRuntimePack`: the Mono job downloads it and stages it into `artifacts/packages/Release/Shipping/` **before** the workload install.
- **`perf-wasm-build-jobs.yml`** — `wasm_coreclr` sets `publishCoreClrRuntimePack: true`; the `wasm` (Mono) job sets `downloadCoreClrRuntimePack: true` and `dependsOn: build_browser_wasm_linux_Release_wasm_coreclr`.

The staged CoreCLR pack doesn't interfere with the Mono job's existing `_GetRuntimePackNuGetsToBuild` logic (which only matches `Microsoft.NETCore.App.Runtime.Mono.*`), and only the net11/Current manifest requires this pack, so the `11.0.0-ci` pack from the same commit satisfies it.

## Tradeoff

The Mono build now depends on the CoreCLR build (previously parallel), adding wall-clock to this PR-triggered sanity pipeline. The alternative — building `clr` inside the Mono job — doesn't work cleanly because no single build produces both wasm runtime packs, and duplicating the full CoreCLR build is heavier. The download approach matches the established #130380 pattern.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.