### PR TITLE
[Withdrawn] Pre-size the first Enumerable.Chunk buffer (no-go)

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Chunk.cs
@@ -77,9 +77,13 @@ namespace System.Linq
             if (e.MoveNext())
             {
                 // Now that we know we have at least one item, allocate an initial storage array. This is not
-                // the array we'll yield.  It starts out small in order to avoid significantly overallocating
-                // when the source has many fewer elements than the chunk size.
-                int arraySize = Math.Min(size, 4);
+                // the array we'll yield. If the source's count is known up front, size the first chunk exactly
+                // (capped at the chunk size) so that filling it involves no growth/resizes. Otherwise start
+                // small to avoid significantly overallocating when the source has many fewer elements than the
+                // chunk size; the fill loop below still grows the array as needed.
+                int arraySize = source.TryGetNonEnumeratedCount(out int countHint) && countHint > 0 ?
+                    Math.Min(size, countHint) :
+                    Math.Min(size, 4);
                 int i;
                 do
                 {


### PR DESCRIPTION
**Status: Withdrawn (no-go). Not merging.** Recording the rationale for future reference.

## What was proposed
Pre-size the first `Enumerable.Chunk` buffer for countable non-array sources using a non-enumerating count hint (`TryGetNonEnumeratedCount`), i.e. `Math.Min(size, count)` instead of growing `4→8→…→size` via `Array.Resize`. (Array sources are already special-cased and were untouched.)

## Why this is a no-go
1. **Previously declined by LINQ maintainers, and no new real-app evidence.** Essentially this exact change — including the "fold the count hint into the regular path" variant used here — was considered and rejected in #73134 (2022). The stated bar was evidence that Chunk's performance "make[s] a material difference in any application" and "data that it's frequently used with countable sources." This PR offered only microbenchmarks, which does not clear that bar. Issue #115079 has no maintainer buy-in.
2. **New correctness-adjacent perf regression.** `TryGetNonEnumeratedCount` calls `ICollection<T>.Count` / non-generic `ICollection.Count`, which is **O(n) and/or locking** for sources like `ConcurrentStack<T>` and `ConcurrentBag<T>`. This turns `source.Chunk(n).First()` from O(1) into O(n) and adds an extra full pass even for complete enumeration of such sources — the opposite of a performance win.
3. **Wasted work at small chunk sizes.** When `size <= 4`, the count hint can never beat the existing `Math.Min(size, 4)`, so the `Count` call is pure overhead.

## Outcome
No change to `main`. Closing as withdrawn. The lazy/uncountable guardrail and correctness of the prototype were confirmed, but the maintainer-precedent and the expensive-`Count` regression make this not worth pursuing without (a) fresh maintainer appetite on #115079 and (b) a design that restricts the hint to provably cheap count providers plus real-world justification.

> [!NOTE]
> This pull request description was created with GitHub Copilot.
