### PR TITLE
Speed up case-insensitive Enum parsing

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
@@ -51,7 +51,7 @@ namespace System.Reflection
         /// </summary>
         public Dictionary<string, TStorage> GetNamesToValuesIgnoreCase()
         {
-            return _namesToValuesIgnoreCase ?? Initialize();
+            return Volatile.Read(ref _namesToValuesIgnoreCase) ?? Initialize();
 
             Dictionary<string, TStorage> Initialize()
             {
@@ -68,9 +68,9 @@ namespace System.Reflection
                 }
 
                 // Publish atomically. If another thread raced and already published a lookup,
-                // reuse theirs so every caller observes a single cached instance. The plain
-                // read on the fast path above is safe: the reference is published with release
-                // semantics and readers reach the contents through a data-dependent access.
+                // reuse theirs so every caller observes a single cached instance. The fast-path
+                // Volatile.Read pairs an acquire load with this release publish so readers always
+                // observe a fully-initialized dictionary.
                 return Interlocked.CompareExchange(ref _namesToValuesIgnoreCase, lookup, null) ?? lookup;
             }
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
@@ -8,6 +8,7 @@ using System.Numerics;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Reflection
 {
@@ -40,6 +41,39 @@ namespace System.Reflection
 
         internal TStorage[] Values { get; }
         internal bool ValuesAreSequentialFromZero { get; }
+
+        // Lazily-built, cached case-insensitive name-to-value lookup used to accelerate
+        // case-insensitive parsing. Null until the first case-insensitive parse of this enum type.
+        private Dictionary<string, TStorage>? _namesToValuesIgnoreCase;
+
+        /// <summary>
+        /// Gets a case-insensitive name-to-value lookup, building and caching it on first use.
+        /// </summary>
+        public Dictionary<string, TStorage> GetNamesToValuesIgnoreCase()
+        {
+            return _namesToValuesIgnoreCase ?? Initialize();
+
+            Dictionary<string, TStorage> Initialize()
+            {
+                string[] names = Names;
+                TStorage[] values = Values;
+                var lookup = new Dictionary<string, TStorage>(names.Length, StringComparer.OrdinalIgnoreCase);
+
+                // Insert in Names order (which is sorted by value). For names that differ only by case,
+                // TryAdd keeps the first (lowest-value) entry, matching the original linear scan's
+                // "first match wins" behavior.
+                for (int i = 0; i < names.Length; i++)
+                {
+                    lookup.TryAdd(names[i], values[i]);
+                }
+
+                // Publish atomically. If another thread raced and already published a lookup,
+                // reuse theirs so every caller observes a single cached instance. The plain
+                // read on the fast path above is safe: the reference is published with release
+                // semantics and readers reach the contents through a data-dependent access.
+                return Interlocked.CompareExchange(ref _namesToValuesIgnoreCase, lookup, null) ?? lookup;
+            }
+        }
 
         /// <summary>Create a copy of <see cref="Values"/>.</summary>
         public unsafe TResult[] CloneValues<TResult>() where TResult : struct

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.InteropServices;
@@ -17,6 +18,10 @@ namespace System
             public readonly TStorage[] Values;
             public readonly string[] Names;
 
+            // Lazily-built, cached case-insensitive name-to-value lookup used to accelerate
+            // case-insensitive parsing. Null until the first case-insensitive parse of this enum type.
+            private Dictionary<string, TStorage>? _namesToValuesIgnoreCase;
+
             // Each entry contains a list of sorted pair of enum field names and values, sorted by values
             public EnumInfo(bool hasFlagsAttribute, TStorage[] values, string[] names)
             {
@@ -30,6 +35,31 @@ namespace System
                 }
 
                 ValuesAreSequentialFromZero = AreSequentialFromZero(values);
+            }
+
+            /// <summary>
+            /// Gets a case-insensitive name-to-value lookup, building and caching it on first use.
+            /// </summary>
+            public Dictionary<string, TStorage> GetNamesToValuesIgnoreCase()
+            {
+                return _namesToValuesIgnoreCase ??= CreateNamesToValuesIgnoreCase();
+
+                Dictionary<string, TStorage> CreateNamesToValuesIgnoreCase()
+                {
+                    string[] names = Names;
+                    TStorage[] values = Values;
+                    var lookup = new Dictionary<string, TStorage>(names.Length, StringComparer.OrdinalIgnoreCase);
+
+                    // Insert in Names order (which is sorted by value). For names that differ only by case,
+                    // TryAdd keeps the first (lowest-value) entry, matching the original linear scan's
+                    // "first match wins" behavior.
+                    for (int i = 0; i < names.Length; i++)
+                    {
+                        lookup.TryAdd(names[i], values[i]);
+                    }
+
+                    return lookup;
+                }
             }
 
             /// <summary>Create a copy of <see cref="Values"/>.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
@@ -43,7 +43,7 @@ namespace System
             /// </summary>
             public Dictionary<string, TStorage> GetNamesToValuesIgnoreCase()
             {
-                return _namesToValuesIgnoreCase ?? Initialize();
+                return Volatile.Read(ref _namesToValuesIgnoreCase) ?? Initialize();
 
                 Dictionary<string, TStorage> Initialize()
                 {
@@ -60,9 +60,9 @@ namespace System
                     }
 
                     // Publish atomically. If another thread raced and already published a lookup,
-                    // reuse theirs so every caller observes a single cached instance. The plain
-                    // read on the fast path above is safe: the reference is published with release
-                    // semantics and readers reach the contents through a data-dependent access.
+                    // reuse theirs so every caller observes a single cached instance. The fast-path
+                    // Volatile.Read pairs an acquire load with this release publish so readers always
+                    // observe a fully-initialized dictionary.
                     return Interlocked.CompareExchange(ref _namesToValuesIgnoreCase, lookup, null) ?? lookup;
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System
 {
@@ -42,9 +43,9 @@ namespace System
             /// </summary>
             public Dictionary<string, TStorage> GetNamesToValuesIgnoreCase()
             {
-                return _namesToValuesIgnoreCase ??= CreateNamesToValuesIgnoreCase();
+                return _namesToValuesIgnoreCase ?? Initialize();
 
-                Dictionary<string, TStorage> CreateNamesToValuesIgnoreCase()
+                Dictionary<string, TStorage> Initialize()
                 {
                     string[] names = Names;
                     TStorage[] values = Values;
@@ -58,7 +59,11 @@ namespace System
                         lookup.TryAdd(names[i], values[i]);
                     }
 
-                    return lookup;
+                    // Publish atomically. If another thread raced and already published a lookup,
+                    // reuse theirs so every caller observes a single cached instance. The plain
+                    // read on the fast path above is safe: the reference is published with release
+                    // semantics and readers reach the contents through a data-dependent access.
+                    return Interlocked.CompareExchange(ref _namesToValuesIgnoreCase, lookup, null) ?? lookup;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -6,6 +6,7 @@
 #define RARE_ENUMS
 #endif
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -1052,6 +1053,12 @@ namespace System
 
             bool parsed = true;
             TStorage localResult = default;
+
+            // For case-insensitive parsing, use a cached name->value lookup and match spans without allocating.
+            Dictionary<string, TStorage>.AlternateLookup<ReadOnlySpan<char>> ignoreCaseLookup = ignoreCase ?
+                enumInfo.GetNamesToValuesIgnoreCase().GetAlternateLookup<ReadOnlySpan<char>>() :
+                default;
+
             while (value.Length > 0)
             {
                 // Find the next separator.
@@ -1080,14 +1087,10 @@ namespace System
                 bool success = false;
                 if (ignoreCase)
                 {
-                    for (int i = 0; i < enumNames.Length; i++)
+                    if (ignoreCaseLookup.TryGetValue(subvalue, out TStorage matchedValue))
                     {
-                        if (subvalue.EqualsOrdinalIgnoreCase(enumNames[i]))
-                        {
-                            localResult |= enumValues[i];
-                            success = true;
-                            break;
-                        }
+                        localResult |= matchedValue;
+                        success = true;
                     }
                 }
                 else


### PR DESCRIPTION
Fixes #118548

### Motivation
Case-insensitive `Enum.TryParse`/`Enum.Parse` did an O(N) linear scan, calling `EqualsOrdinalIgnoreCase` against every enum name for each token. That's a hot path for web/query-string parsing and scales poorly as enum size grows.

### Change
Replace the per-token linear scan in `TryParseByName` with a lazily-built, cached `Dictionary<string, TStorage>` (`StringComparer.OrdinalIgnoreCase`) on the per-type `EnumInfo`, consumed via `AlternateLookup<ReadOnlySpan<char>>` so span tokens match without allocating strings. Names are inserted with `TryAdd` in value-sorted order, preserving the original first-match (lowest-value-wins) semantics for names that differ only by case. The exact-case path is unchanged. The cache is published with `Interlocked.CompareExchange`. The lookup is added to both `EnumInfo` implementations — the shared one (CoreCLR/Mono) and NativeAOT's `System.Reflection.EnumInfo`.

### Benchmarks (BDN + EgorBot)
Isolated A/B of the name-matching step (Release, .NET 11, Apple M5 Pro), scan vs. cached dictionary — **0 B allocated in every case**:

| Token shape | Crossover (dictionary starts winning) | N = 256 |
|---|---|---|
| match last member (scan worst case) | ~N = 3-4 | 564 ns → 9 ns |
| miss / invalid token | ~N = 16 | 119 ns → 6 ns |
| match first member | never (fixed ~5 ns dictionary overhead) | 3 ns → 10 ns |

The dictionary is O(1) (~8-9 ns) regardless of size; the scan is O(N). The full N = 2…256 sweep and the tiny-enum tradeoff are in the discussion below. @EgorBot runs the real end-to-end `Enum.TryParse` A/B on Linux AMD64 + macOS arm64.

### Validation
- **70,741** `System.Runtime` tests pass (0 related failures), including **821** `Enum` cases (case-insensitive parse, flags, case-collision edge cases).
- A baseline-vs-patched correctness probe (case-collision, flags, exact-case, whitespace, miss) produced identical results.

### Risks
- One reference-sized field plus a lazily-built dictionary per enum type that is parsed case-insensitively (built on first use only; enums never parsed case-insensitively pay nothing).
- Tiny enums (≤ ~8 members) matched near the front are a few ns slower and incur the one-time dictionary allocation; a size threshold could recover that case if preferred (see discussion).
- Thread safety: the cache is published via `Interlocked.CompareExchange`; a first-parse race only wastes a transient dictionary and never publishes a partial one.
- No public API change.

> [!NOTE]
> This pull request description was created with GitHub Copilot.
