### PR TITLE
Fix runtime-wasm-perf Mono job by supplying the CoreCLR browser-wasm runtime pack

### DIFF
--- a/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
@@ -12,21 +12,16 @@ jobs:
       nameSuffix: wasm
       isOfficialBuild: false
       # The wasm-tools workload manifest now includes the CoreCLR browser-wasm runtime pack
-      # (https://github.com/dotnet/runtime/pull/130380), so installing the workload requires
-      # that pack in the local feed. The Mono build doesn't produce it, so depend on the
-      # CoreCLR build job and download the pack from it.
+      # (https://github.com/dotnet/runtime/pull/130380), so installing the workload needs that
+      # pack staged into the local feed. It's produced by the wasm_coreclr build job, so depend
+      # on it and download its published runtime pack before the workload install.
       dependsOn:
       - build_browser_wasm_linux_Release_wasm_coreclr
       postBuildSteps:
-        - task: DownloadPipelineArtifact@2
-          displayName: Download CoreCLR browser-wasm runtime pack
-          inputs:
-            buildType: current
-            artifactName: BrowserWasmCoreCLRRuntimePack
-            targetPath: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
         - template: /eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
           parameters:
             configForBuild: Release
+            downloadCoreClrRuntimePack: true
 
 # Build CoreCLR runtime for browser-wasm (used by --wasm-coreclr benchmarks)
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -47,18 +42,4 @@ jobs:
             artifactName: BrowserWasmCoreCLR
             sdkDirName: dotnet-none
             includeRefPack: false
-        # Publish the CoreCLR browser-wasm runtime pack nuget separately so the Mono perf
-        # build can install the wasm-tools workload, whose manifest now includes this pack
-        # (see https://github.com/dotnet/runtime/pull/130380).
-        - script: >-
-            mkdir -p $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtime-pack &&
-            cp $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/Microsoft.NETCore.App.Runtime.browser-wasm.*.nupkg $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtime-pack
-          displayName: "Stage CoreCLR browser-wasm runtime pack nuget"
-        - template: /eng/pipelines/common/templates/publish-pipeline-artifacts.yml
-          parameters:
-            isOfficialBuild: false
-            displayName: Publish CoreCLR browser-wasm runtime pack
-            inputs:
-              targetPath: $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtime-pack
-              artifactName: BrowserWasmCoreCLRRuntimePack
-            condition: succeeded()
+            publishCoreClrRuntimePack: true

--- a/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
@@ -11,7 +11,19 @@ jobs:
       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       nameSuffix: wasm
       isOfficialBuild: false
+      # The wasm-tools workload manifest now includes the CoreCLR browser-wasm runtime pack
+      # (https://github.com/dotnet/runtime/pull/130380), so installing the workload requires
+      # that pack in the local feed. The Mono build doesn't produce it, so depend on the
+      # CoreCLR build job and download the pack from it.
+      dependsOn:
+      - build_browser_wasm_linux_Release_wasm_coreclr
       postBuildSteps:
+        - task: DownloadPipelineArtifact@2
+          displayName: Download CoreCLR browser-wasm runtime pack
+          inputs:
+            buildType: current
+            artifactName: BrowserWasmCoreCLRRuntimePack
+            targetPath: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping
         - template: /eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
           parameters:
             configForBuild: Release
@@ -35,3 +47,18 @@ jobs:
             artifactName: BrowserWasmCoreCLR
             sdkDirName: dotnet-none
             includeRefPack: false
+        # Publish the CoreCLR browser-wasm runtime pack nuget separately so the Mono perf
+        # build can install the wasm-tools workload, whose manifest now includes this pack
+        # (see https://github.com/dotnet/runtime/pull/130380).
+        - script: >-
+            mkdir -p $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtime-pack &&
+            cp $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/Microsoft.NETCore.App.Runtime.browser-wasm.*.nupkg $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtime-pack
+          displayName: "Stage CoreCLR browser-wasm runtime pack nuget"
+        - template: /eng/pipelines/common/templates/publish-pipeline-artifacts.yml
+          parameters:
+            isOfficialBuild: false
+            displayName: Publish CoreCLR browser-wasm runtime pack
+            inputs:
+              targetPath: $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtime-pack
+              artifactName: BrowserWasmCoreCLRRuntimePack
+            condition: succeeded()

--- a/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
@@ -4,8 +4,29 @@ parameters:
   runtimeFlavor: 'mono'
   sdkDirName: 'dotnet-latest'
   includeRefPack: true
+  # The Mono (default) build installs the wasm-tools workload, whose manifest now includes the
+  # CoreCLR browser-wasm runtime pack (Microsoft.NETCore.App.Runtime.browser-wasm). A Mono-only
+  # build doesn't produce that pack, so download it from the CoreCLR build job and stage it into
+  # the local package feed before installing the workload.
+  downloadCoreClrRuntimePack: false
+  # The CoreCLR build publishes its runtime pack so the Mono build (above) can consume it.
+  publishCoreClrRuntimePack: false
 
 steps:
+  # Stage the CoreCLR browser-wasm runtime pack (built by the wasm_coreclr job) into the local
+  # package feed so the wasm-tools workload install below can resolve it.
+  - ${{ if eq(parameters.downloadCoreClrRuntimePack, true) }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: "Download CoreCLR runtime pack for workload install"
+      inputs:
+        buildType: current
+        artifactName: BrowserWasmCoreCLRRuntimePack_$(_hostedOs)
+        targetPath: $(Build.SourcesDirectory)/artifacts/coreclr-runtimepack
+    - script: >-
+        mkdir -p $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping &&
+        cp $(Build.SourcesDirectory)/artifacts/coreclr-runtimepack/*.nupkg $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/
+      displayName: "Stage CoreCLR runtime pack into local feed"
+
   - script: >-
       ./dotnet.sh build -p:TargetOS=browser -p:TargetArchitecture=wasm /nr:false /p:TreatWarningsAsErrors=true
       /p:Configuration=${{ parameters.configForBuild }}
@@ -29,6 +50,21 @@ steps:
   - ${{ if eq(parameters.includeRefPack, true) }}:
     - script: cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging
       displayName: "Stage ref pack directory"
+
+  # Publish the CoreCLR browser-wasm runtime pack nuget on its own so the Mono build job can stage
+  # it into its local feed for the wasm-tools workload install.
+  - ${{ if eq(parameters.publishCoreClrRuntimePack, true) }}:
+    - script: >-
+        mkdir -p $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack &&
+        find $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping -maxdepth 1 -name 'Microsoft.NETCore.App.Runtime.browser-wasm.*.nupkg' -not -name '*.symbols.nupkg' -exec cp {} $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack \;
+      displayName: "Stage CoreCLR runtime pack for workload"
+    - template: /eng/pipelines/common/templates/publish-pipeline-artifacts.yml
+      parameters:
+        isOfficialBuild: false
+        displayName: Publish CoreCLR runtime pack for workload
+        inputs:
+          targetPath: $(Build.SourcesDirectory)/artifacts/staging-coreclr-runtimepack
+          artifactName: BrowserWasmCoreCLRRuntimePack_$(_hostedOs)
 
   - template: /eng/pipelines/common/upload-artifact-step.yml
     parameters:


### PR DESCRIPTION
## Problem

The `runtime-wasm-perf` pipeline's Mono build job fails at the "Install workload using artifacts" step:

> `microsoft.netcore.app.runtime.browser-wasm` version `<x>-ci` is not found in the local feed

## Root cause

#130380 added the CoreCLR browser-wasm runtime pack (`Microsoft.NETCore.App.Runtime.browser-wasm`) to the shared `wasm-tools` workload manifest. Installing the workload from the local package feed now requires that pack to be present. The Mono perf build job (`-s mono+libs+host+packs`) never produces it, so `dotnet workload install wasm-tools` fails. The CoreCLR perf job passes because the workload install is a no-op for the CoreCLR flavor (`_GetWorkloadsToInstall` only selects workloads for `RuntimeFlavor == 'Mono'`).

#130380 already handled this for the Wasm.Build.Tests pipelines (via the `includeCoreClrRuntimePack` parameter in `browser-wasm-build-tests.yml`), but left the `runtime-wasm-perf` Mono job broken.

## Fix

Mirror the approach used for the WBT pipelines:

- The CoreCLR perf build job (`wasm_coreclr`) publishes the CoreCLR browser-wasm runtime pack nuget as a new `BrowserWasmCoreCLRRuntimePack` pipeline artifact.
- The Mono perf build job (`wasm`) now depends on the CoreCLR build job and downloads that pack into its local `Shipping` package feed before the workload-install step.

This serializes the Mono build after the CoreCLR build (they previously ran in parallel), which is the same producer/consumer relationship the WBT pipelines already use.

## Testing

This is a CI-pipeline-only change that can't be exercised locally. The logic was verified by tracing the workload-install targets (`BuiltNuGetsDir` = `artifacts/packages/<config>/Shipping`, download lands in the feed before install, no interference with the Mono-only pack-count check in `workloads-browser.targets`) and confirming the `dependsOn` job name matches the generated job name. It needs a `runtime-wasm-perf` pipeline run to validate end to end.

> [!NOTE]
> This pull request was authored by GitHub Copilot.