### PR TITLE
Keep runtimelab IntermediateArtifacts on classic build artifacts

### DIFF
--- a/eng/pipelines/common/upload-intermediate-artifacts-step.yml
+++ b/eng/pipelines/common/upload-intermediate-artifacts-step.yml
@@ -13,10 +13,20 @@ steps:
     TargetFolder: '$(Build.StagingDirectory)/IntermediateArtifacts/${{ parameters.name }}'
     CleanTargetFolder: true
 
-- template: /eng/pipelines/common/templates/publish-pipeline-artifacts.yml
-  parameters:
-    isOfficialBuild: ${{ parameters.isOfficialBuild }}
+# NOTE: Uses classic build (container) artifacts because the dotnet/runtimelab consumer relies on
+# multiple jobs merging into one same-named 'IntermediateArtifacts' artifact, which pipeline
+# artifacts don't support. Can be removed/migrated once runtimelab no longer needs this.
+- ${{ if parameters.isOfficialBuild }}:
+  - task: 1ES.PublishBuildArtifacts@1
     displayName: Publish intermediate artifacts
     inputs:
-      targetPath: '$(Build.StagingDirectory)/IntermediateArtifacts'
-      artifactName: IntermediateArtifacts
+      PathtoPublish: '$(Build.StagingDirectory)/IntermediateArtifacts'
+      ArtifactName: IntermediateArtifacts
+      ArtifactType: container
+- ${{ else }}:
+  - task: PublishBuildArtifacts@1
+    displayName: Publish intermediate artifacts
+    inputs:
+      PathtoPublish: '$(Build.StagingDirectory)/IntermediateArtifacts'
+      ArtifactName: IntermediateArtifacts
+      ArtifactType: container


### PR DESCRIPTION
#128498 migrated this step to PublishPipelineArtifact, which would break runtimelab consumers: they still require multiple jobs publishing to the same 'IntermediateArtifacts' artifact. Revert just this step to 1ES.PublishBuildArtifacts@1 / PublishBuildArtifacts@1.

This can be removed once all runtimelab branches moves to v3/v4 publishing.