### PR TITLE
[release/10.0] [mono][wasm] Fix AOT + BlazorWebAssemblyLazyLoad startup crash

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -197,6 +197,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmEnableWebcil Condition="'$(_WasmEnableWebcil)' == ''">true</_WasmEnableWebcil>
       <_BlazorWebAssemblyJiterpreter>$(BlazorWebAssemblyJiterpreter)</_BlazorWebAssemblyJiterpreter>
       <_BlazorWebAssemblyRuntimeOptions>$(BlazorWebAssemblyRuntimeOptions)</_BlazorWebAssemblyRuntimeOptions>
+      <!-- With AOT, each AOT image hard-binds to every assembly it references when the image is
+           loaded. A BlazorWebAssemblyLazyLoad assembly is not present at runtime startup, so any
+           AOT image that references it would be marked unusable and its methods would fall back to
+           the interpreter (which can then hit unsupported constructs and abort). Enable lazy AOT
+           assembly loading so referenced lazy assemblies are only bound when they are loaded. -->
+      <_BlazorWebAssemblyRuntimeOptions Condition="'$(RunAOTCompilation)' == 'true' and @(BlazorWebAssemblyLazyLoad->Count()) != 0 and !$(_BlazorWebAssemblyRuntimeOptions.Contains('--aot-lazy-assembly-load'))">$([System.String]::Concat('$(_BlazorWebAssemblyRuntimeOptions)', ' --aot-lazy-assembly-load').Trim())</_BlazorWebAssemblyRuntimeOptions>
       <_WasmInlineBootConfig>$(WasmInlineBootConfig)</_WasmInlineBootConfig>
       <_WasmInlineBootConfig Condition="'$(_WasmInlineBootConfig)' == '' and '$(_TargetingNET100OrLater)' == 'true' and '$(WasmBootConfigFileName)' == ''">true</_WasmInlineBootConfig>
       <_WasmInlineBootConfig Condition="'$(_WasmInlineBootConfig)' == ''">false</_WasmInlineBootConfig>

--- a/src/mono/wasm/Wasm.Build.Tests/LazyLoadingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/LazyLoadingTests.cs
@@ -51,6 +51,28 @@ public class LazyLoadingTests : WasmTemplateTestsBase
     }
 
     [Fact]
+    [TestCategory("native-mono")]
+    public async Task LoadLazyAssemblyWithAOT()
+    {
+        // Regression coverage for https://github.com/dotnet/runtime/issues/125794:
+        // AOT combined with BlazorWebAssemblyLazyLoad must still initialize the runtime
+        // and lazily load assemblies at runtime. AOT is only supported when publishing
+        // in Release, so this exercises the publish + AOT + lazy-load combination that
+        // the Debug build/run tests above do not cover.
+        Configuration config = Configuration.Release;
+        ProjectInfo info = CopyTestAsset(config, aot: true, TestAsset.WasmBasicTestApp, "LazyLoadingTestsAOT");
+        PublishProject(info, config, new PublishOptions(AOT: true, ExtraMSBuildArgs: "-p:TestLazyLoading=true"));
+
+        RunResult result = await RunForPublishWithWebServer(new BrowserRunOptions(
+            config,
+            AOT: true,
+            TestScenario: "LazyLoadingTest"
+        ));
+
+        Assert.True(result.TestOutput.Any(m => m.Contains("FirstName")), "The lazy loading test didn't emit expected message with JSON");
+    }
+
+    [Fact]
     public async Task FailOnMissingLazyAssembly()
     {
         Configuration config = Configuration.Debug;


### PR DESCRIPTION
Backport of #131020 to release/10.0

/cc @lewing

1. Fixes Issue #125794

main PR: #131020

# Description

AOT-published Blazor WebAssembly apps that use `BlazorWebAssemblyLazyLoad` crash during Mono runtime startup — reported as an `appdomain.c` assertion (`condition '<disabled>' not met`) and, in other configurations, an `interp.c` `NIY … should not be reached` abort.

An AOT image hard-binds to every assembly it references when the image is loaded (`load_aot_module` in `aot-runtime.c` eagerly calls `load_image` for all referenced images unless the `aot-lazy-assembly-load` runtime option is set). A `BlazorWebAssemblyLazyLoad` assembly is not present at runtime startup (it is downloaded on demand), so when the main app's AOT image loads, resolving the lazy dependency fails, the image is marked unusable, and every method in it falls back to the interpreter, which then hits an unsupported construct and aborts.

The fix automatically enables the runtime's existing `aot-lazy-assembly-load` option from the WebAssembly SDK when AOT is combined with `BlazorWebAssemblyLazyLoad`. This defers binding of a referenced lazy assembly until it is actually loaded, keeping the referencing AOT image usable. The change is scoped to `RunAOTCompilation=true` + at least one `BlazorWebAssemblyLazyLoad` item, so non-AOT and non-lazy builds are unaffected.

# Customer Impact

Any Blazor WebAssembly app that combines AOT compilation with `BlazorWebAssemblyLazyLoad` crashes on startup and is completely unusable. Lazy loading is a common technique to reduce initial download size, and AOT is a common way to improve runtime performance, so customers who adopt both features together are blocked with no workaround other than disabling one of them.

# Regression

No. This is a long-standing interaction between AOT and lazy loading, not a regression introduced in the most recent release.

# Testing

Added `LoadLazyAssemblyWithAOT` to `LazyLoadingTests` (`native-mono`, Release + AOT + lazy load), which previously only covered the interpreter (Debug) configuration. The new test reproduces the crash without the fix and passes with it.

Verified locally by building the browser (Mono + CoreCLR runtime packs) and workload and running the new test:
- Without the fix: `module WasmBasicTestApp is unusable because dependency Json is not found` → `interp.c:4135` assertion → timed out waiting for `WASM EXIT`.
- With the fix: `AOT: image 'WasmBasicTestApp' found.`, `firstJsonLoad=true`, `{"FirstName":"John","LastName":"Doe"}`, `WASM EXIT 0`.

# Risk

Low. The change is a single, narrowly-scoped MSBuild property that only appends `--aot-lazy-assembly-load` when `RunAOTCompilation=true` and at least one `BlazorWebAssemblyLazyLoad` item is present. Builds that do not combine AOT with lazy loading are unaffected, and the option simply defers assembly binding that would otherwise fail.

> [!NOTE]
> This backport pull request was authored with GitHub Copilot.
