### PR TITLE
LibraryImportGenerator: prep for unsafe-v2

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.cs
@@ -139,12 +139,14 @@ namespace Microsoft.Interop
             SignatureContext stub,
             BlockSyntax stubCode)
         {
-            // Create stub function
+            // Create stub function. The generated body performs unmanaged operations (pointers, fixed,
+            // stackalloc, calling the extern local P/Invoke), so it is wrapped in an explicit unsafe block
+            // rather than relying on an unsafe modifier on the containing type.
             return MethodDeclaration(stub.StubReturnType, userDeclaredMethod.Identifier)
                 .AddAttributeLists(stub.AdditionalAttributes.ToArray())
                 .WithModifiers(StripTriviaFromModifiers(userDeclaredMethod.Modifiers))
                 .WithParameterList(ParameterList(SeparatedList(stub.StubParameters)))
-                .WithBody(stubCode);
+                .WithBody(Block(UnsafeStatement(stubCode)));
         }
 
         private static LibraryImportCompilationData? ProcessLibraryImportAttribute(AttributeData attrData)
@@ -283,7 +285,7 @@ namespace Microsoft.Interop
             dllImport = dllImport.WithLeadingTrivia(Comment("// Local P/Invoke"));
             code = code.AddStatements(dllImport);
 
-            return pinvokeStub.ContainingSyntaxContext.WrapMemberInContainingSyntaxWithUnsafeModifier(PrintGeneratedSource(pinvokeStub.StubMethodSyntaxTemplate, pinvokeStub.SignatureContext, code));
+            return pinvokeStub.ContainingSyntaxContext.WrapMemberInContainingSyntax(PrintGeneratedSource(pinvokeStub.StubMethodSyntaxTemplate, pinvokeStub.SignatureContext, code));
         }
 
         private static MemberDeclarationSyntax PrintForwarderStub(ContainingSyntax userDeclaredMethod, IncrementalStubGenerationContext stub)
@@ -309,7 +311,7 @@ namespace Microsoft.Interop
                         SingletonSeparatedList(
                             CreateForwarderDllImport(pinvokeData))));
 
-            MemberDeclarationSyntax toPrint = stub.ContainingSyntaxContext.WrapMemberInContainingSyntaxWithUnsafeModifier(stubMethod);
+            MemberDeclarationSyntax toPrint = stub.ContainingSyntaxContext.WrapMemberInContainingSyntax(stubMethod);
 
             return toPrint;
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -153,12 +153,14 @@ namespace Microsoft.Interop
             SignatureContext stub,
             BlockSyntax stubCode)
         {
-            // Create stub function
+            // Create stub function. The generated body performs unmanaged operations (pointers, fixed,
+            // stackalloc, calling the extern local P/Invoke), so it is wrapped in an explicit unsafe block
+            // rather than relying on an unsafe modifier on the containing type.
             return MethodDeclaration(stub.StubReturnType, userDeclaredMethod.Identifier)
                 .AddAttributeLists(stub.AdditionalAttributes.ToArray())
                 .WithModifiers(StripTriviaFromModifiers(userDeclaredMethod.Modifiers))
                 .WithParameterList(ParameterList(SeparatedList(stub.StubParameters)))
-                .WithBody(stubCode);
+                .WithBody(Block(UnsafeStatement(stubCode)));
         }
 
         private static LibraryImportCompilationData? ProcessLibraryImportAttribute(AttributeData attrData)
@@ -330,7 +332,7 @@ namespace Microsoft.Interop
             dllImport = dllImport.WithLeadingTrivia(Comment("// Local P/Invoke"));
             code = code.AddStatements(dllImport);
 
-            return pinvokeStub.ContainingSyntaxContext.WrapMemberInContainingSyntaxWithUnsafeModifier(PrintGeneratedSource(pinvokeStub.StubMethodSyntaxTemplate, pinvokeStub.SignatureContext, code));
+            return pinvokeStub.ContainingSyntaxContext.WrapMemberInContainingSyntax(PrintGeneratedSource(pinvokeStub.StubMethodSyntaxTemplate, pinvokeStub.SignatureContext, code));
         }
 
         private static MemberDeclarationSyntax PrintForwarderStub(ContainingSyntax userDeclaredMethod, IncrementalStubGenerationContext stub)
@@ -361,7 +363,7 @@ namespace Microsoft.Interop
                         SingletonSeparatedList(
                             CreateForwarderDllImport(pinvokeData))));
 
-            MemberDeclarationSyntax toPrint = stub.ContainingSyntaxContext.WrapMemberInContainingSyntaxWithUnsafeModifier(stubMethod);
+            MemberDeclarationSyntax toPrint = stub.ContainingSyntaxContext.WrapMemberInContainingSyntax(stubMethod);
 
             return toPrint;
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ContainingSyntaxContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ContainingSyntaxContext.cs
@@ -99,19 +99,21 @@ namespace Microsoft.Interop
             return code;
         }
 
-        public MemberDeclarationSyntax WrapMemberInContainingSyntaxWithUnsafeModifier(MemberDeclarationSyntax member)
+        /// <summary>
+        /// Wraps <paramref name="member"/> in its containing types and namespace.
+        /// Unlike the containing-type modifiers that are copied verbatim from the user's declaration,
+        /// this intentionally does not add an <c>unsafe</c> modifier to any containing type: generated
+        /// members that require an unsafe context open an explicit <c>unsafe</c> block in their body instead.
+        /// This keeps the output valid under both the legacy and the updated (unsafe-evolution) memory-safety rules.
+        /// </summary>
+        public MemberDeclarationSyntax WrapMemberInContainingSyntax(MemberDeclarationSyntax member)
         {
-            bool addedUnsafe = false;
             MemberDeclarationSyntax wrappedMember = member;
             foreach (var containingType in ContainingSyntax)
             {
                 TypeDeclarationSyntax type = TypeDeclaration(containingType.TypeKind, containingType.Identifier)
                     .WithModifiers(containingType.Modifiers)
                     .AddMembers(wrappedMember);
-                if (!addedUnsafe)
-                {
-                    type = type.WithModifiers(type.Modifiers.AddToModifiers(SyntaxKind.UnsafeKeyword));
-                }
                 if (containingType.TypeParameters is not null)
                 {
                     type = type.AddTypeParameterListParameters(containingType.TypeParameters.Parameters.ToArray());

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ContainingSyntaxContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ContainingSyntaxContext.cs
@@ -101,10 +101,6 @@ namespace Microsoft.Interop
 
         /// <summary>
         /// Wraps <paramref name="member"/> in its containing types and namespace.
-        /// Unlike the containing-type modifiers that are copied verbatim from the user's declaration,
-        /// this intentionally does not add an <c>unsafe</c> modifier to any containing type: generated
-        /// members that require an unsafe context open an explicit <c>unsafe</c> block in their body instead.
-        /// This keeps the output valid under both the legacy and the updated (unsafe-evolution) memory-safety rules.
         /// </summary>
         public MemberDeclarationSyntax WrapMemberInContainingSyntax(MemberDeclarationSyntax member)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -906,8 +906,10 @@ namespace LibraryImportGenerator.UnitTests
                 TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck
             };
 
+            // The generator no longer emits an 'unsafe' modifier on the containing type, and the trivial
+            // (forwarder) stubs it produces here contain no unsafe code, so no CS0227 is reported. The
+            // analyzer still reports SYSLIB1062 once per compilation to recommend enabling AllowUnsafeBlocks.
             test.ExpectedDiagnostics.Add(VerifyAnalyzerCS.Diagnostic("SYSLIB1062"));
-            test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("CS0227").WithLocation(0));
 
             await test.RunAsync();
         }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -906,9 +906,7 @@ namespace LibraryImportGenerator.UnitTests
                 TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck
             };
 
-            // The generator no longer emits an 'unsafe' modifier on the containing type, and the trivial
-            // (forwarder) stubs it produces here contain no unsafe code, so no CS0227 is reported. The
-            // analyzer still reports SYSLIB1062 once per compilation to recommend enabling AllowUnsafeBlocks.
+            // The analyzer reports SYSLIB1062 once per compilation to recommend enabling AllowUnsafeBlocks.
             test.ExpectedDiagnostics.Add(VerifyAnalyzerCS.Diagnostic("SYSLIB1062"));
 
             await test.RunAsync();

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/UnsafeCodeGeneration.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/UnsafeCodeGeneration.cs
@@ -98,6 +98,59 @@ namespace LibraryImportGenerator.UnitTests
             }.RunAsync();
         }
 
+        [Fact]
+        public async Task UserDeclaredUnsafeOnForwarderMethodIsPreserved()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class C
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static unsafe partial void Method();
+                }
+                """;
+            await new UnsafeShapeTest(compilation =>
+            {
+                MethodDeclarationSyntax stub = GetGeneratedStubSyntax(compilation, "C", "Method");
+                // A forwarder is a bodyless `extern` stub; the user's `unsafe` modifier is copied verbatim onto it.
+                Assert.Null(stub.Body);
+                Assert.True(stub.Modifiers.Any(SyntaxKind.ExternKeyword));
+                Assert.True(stub.Modifiers.Any(SyntaxKind.UnsafeKeyword));
+                AssertNoUnsafeModifierOnContainingTypes(stub);
+            })
+            {
+                TestCode = source,
+                TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task UserDeclaredUnsafeOnWrapperMethodIsPreserved()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class C
+                {
+                    [LibraryImport("DoesNotExist", StringMarshalling = StringMarshalling.Utf16)]
+                    public static unsafe partial void Method(string s, int* i);
+                }
+                """;
+            await new UnsafeShapeTest(compilation =>
+            {
+                MethodDeclarationSyntax stub = GetGeneratedStubSyntax(compilation, "C", "Method");
+                // The user's `unsafe` modifier (required for the `int*` parameter) is copied verbatim onto the stub.
+                Assert.True(stub.Modifiers.Any(SyntaxKind.UnsafeKeyword));
+                AssertNoUnsafeModifierOnContainingTypes(stub);
+                // The body is still wrapped in an explicit `unsafe` block, independent of the method modifier.
+                StatementSyntax onlyStatement = Assert.Single(stub.Body!.Statements);
+                Assert.IsType<UnsafeStatementSyntax>(onlyStatement);
+            })
+            {
+                TestCode = source,
+                TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck
+            }.RunAsync();
+        }
+
         private static MethodDeclarationSyntax GetGeneratedStubSyntax(Compilation compilation, string typeName, string methodName)
         {
             INamedTypeSymbol type = compilation.GetTypeByMetadataName(typeName)!;

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/UnsafeCodeGeneration.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/UnsafeCodeGeneration.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+using VerifyCS = Microsoft.Interop.UnitTests.Verifiers.CSharpSourceGeneratorVerifier<Microsoft.Interop.LibraryImportGenerator, Microsoft.Interop.Analyzers.LibraryImportDiagnosticsAnalyzer>;
+
+namespace LibraryImportGenerator.UnitTests
+{
+    public class UnsafeCodeGeneration
+    {
+        // The generator must not add an `unsafe` modifier to the containing type; instead any stub that
+        // needs an unsafe context opens an explicit `unsafe` block in its body. This keeps the generated
+        // output valid regardless of whether an `unsafe` modifier on a type establishes a body context.
+        // These are structural assertions because the compile-only tests can't distinguish the two shapes:
+        // both a class-level `unsafe` modifier and a body `unsafe` block compile under the test LangVersion.
+
+        [Fact]
+        public async Task WrapperStubWrapsBodyInUnsafeBlockAndDoesNotMarkContainingTypeUnsafe()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class C
+                {
+                    [LibraryImport("DoesNotExist", StringMarshalling = StringMarshalling.Utf16)]
+                    public static partial void Method(string s);
+                }
+                """;
+            await new UnsafeShapeTest(compilation =>
+            {
+                MethodDeclarationSyntax stub = GetGeneratedStubSyntax(compilation, "C", "Method");
+                AssertNoUnsafeModifierOnContainingTypes(stub);
+                StatementSyntax onlyStatement = Assert.Single(stub.Body!.Statements);
+                Assert.IsType<UnsafeStatementSyntax>(onlyStatement);
+            })
+            {
+                TestCode = source,
+                TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task ForwarderStubDoesNotMarkContainingTypeUnsafe()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class C
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method();
+                }
+                """;
+            await new UnsafeShapeTest(compilation =>
+            {
+                MethodDeclarationSyntax stub = GetGeneratedStubSyntax(compilation, "C", "Method");
+                // A forwarder is a bodyless `extern` stub, so it has no `unsafe` block to rely on.
+                Assert.Null(stub.Body);
+                Assert.True(stub.Modifiers.Any(SyntaxKind.ExternKeyword));
+                AssertNoUnsafeModifierOnContainingTypes(stub);
+            })
+            {
+                TestCode = source,
+                TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task UserDeclaredUnsafeOnContainingTypeIsPreserved()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+                unsafe partial class C
+                {
+                    [LibraryImport("DoesNotExist", StringMarshalling = StringMarshalling.Utf16)]
+                    public static partial void Method(string s);
+                }
+                """;
+            await new UnsafeShapeTest(compilation =>
+            {
+                MethodDeclarationSyntax stub = GetGeneratedStubSyntax(compilation, "C", "Method");
+                // The generator copies the user's type modifiers verbatim, so a user-authored `unsafe` is kept.
+                TypeDeclarationSyntax containingType = stub.Ancestors().OfType<TypeDeclarationSyntax>().First();
+                Assert.True(containingType.Modifiers.Any(SyntaxKind.UnsafeKeyword));
+                // The body is still wrapped in an explicit `unsafe` block, independent of the type modifier.
+                StatementSyntax onlyStatement = Assert.Single(stub.Body!.Statements);
+                Assert.IsType<UnsafeStatementSyntax>(onlyStatement);
+            })
+            {
+                TestCode = source,
+                TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck
+            }.RunAsync();
+        }
+
+        private static MethodDeclarationSyntax GetGeneratedStubSyntax(Compilation compilation, string typeName, string methodName)
+        {
+            INamedTypeSymbol type = compilation.GetTypeByMetadataName(typeName)!;
+            IMethodSymbol method = type.GetMembers(methodName).OfType<IMethodSymbol>().Single();
+            // The generated stub is the implementing part of the user's partial method declaration.
+            IMethodSymbol implementation = method.PartialImplementationPart ?? method;
+            return (MethodDeclarationSyntax)implementation.DeclaringSyntaxReferences.Single().GetSyntax();
+        }
+
+        private static void AssertNoUnsafeModifierOnContainingTypes(MethodDeclarationSyntax stub)
+        {
+            foreach (TypeDeclarationSyntax containingType in stub.Ancestors().OfType<TypeDeclarationSyntax>())
+            {
+                Assert.DoesNotContain(containingType.Modifiers, modifier => modifier.IsKind(SyntaxKind.UnsafeKeyword));
+            }
+        }
+
+        private sealed class UnsafeShapeTest : VerifyCS.Test
+        {
+            private readonly Action<Compilation> _verifyCompilation;
+
+            public UnsafeShapeTest(Action<Compilation> verifyCompilation)
+                : base(referenceAncillaryInterop: false)
+            {
+                _verifyCompilation = verifyCompilation;
+            }
+
+            protected override void VerifyFinalCompilation(Compilation compilation) => _verifyCompilation(compilation);
+        }
+    }
+}


### PR DESCRIPTION
Prep for [unsafe-v2](https://github.com/dotnet/csharplang/blob/main/proposals/unsafe-evolution.md) where `unsafe` on types is illegal and `unsafe` on methods no longer opens an unsafe context in the body. Emit code valid under both old and new rules:

- Don't add `unsafe` to the generated stub's containing type (user's own modifiers are still copied as-is).
- Wrap wrapper-stub bodies in an `unsafe { }` block instead.
- Forwarder stubs (bodyless `extern`) are unchanged.

The exact behavior of LIG in unsafe-v2 context is currently blocked by https://github.com/dotnet/roslyn/issues/84555 decision.