### PR TITLE
Fix publishing of ILLink test results

### DIFF
--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -75,6 +75,7 @@ extends:
           jobParameters:
             testGroup: innerloop
             enablePublishTestResults: true
+            testResultsFormat: 'xunit'
             timeoutInMinutes: 120
             nameSuffix: ILLink_Tests
             condition:
@@ -86,6 +87,17 @@ extends:
             postBuildSteps:
             - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch $(archType) $(_osParameter) -s tools.illinktests -test -c $(_BuildConfig) $(crossArg) $(_officialBuildParameter) /p:ToolsConfiguration=Debug
               displayName: Run ILLink Tests
+            # The illink tools and tests build as Debug (ToolsConfiguration=Debug), so arcade writes
+            # their xUnit results to artifacts/TestResults/Debug. The publish step searches
+            # artifacts/TestResults/$(_BuildConfig) (Release), so copy the results across to get them
+            # published. Runs even on test failure so failures still surface in the Tests tab.
+            - task: CopyFiles@2
+              displayName: Copy ILLink test results for publishing
+              condition: succeededOrFailed()
+              inputs:
+                sourceFolder: $(Build.SourcesDirectory)/artifacts/TestResults/Debug
+                contents: '**/*.xml'
+                targetFolder: $(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)
 
       #
       # Build Release config vertical for Windows and Linux


### PR DESCRIPTION
illink tests build as Debug but the leg runs Release, so results were written to TestResults/Debug while publish searched TestResults/Release. Copy them across and set testResultsFormat: xunit.
