### PR TITLE
Unify sync and async options validation contracts

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         /// <summary>
         /// Order:
         ///  IHostLifetime.WaitForStartAsync
-        ///  Services.GetService{IStartupValidator}().ValidateAsync() (or .Validate() for a sync-only validator)
+        ///  Startup validation: a custom sync IStartupValidator (if any) via Validate(), otherwise every IAsyncStartupValidator via ValidateAsync()
         ///  IHostedLifecycleService.StartingAsync
         ///  IHostedService.Start
         ///  IHostedLifecycleService.StartedAsync
@@ -95,14 +95,20 @@ namespace Microsoft.Extensions.Hosting.Internal
                 {
                     // Run startup validation before resolving hosted services so a hosted service that
                     // reads validated options in its constructor observes the validated instance.
-                    IStartupValidator? validator = Services.GetService<IStartupValidator>();
-                    if (validator is IAsyncStartupValidator asyncValidator)
+                    IStartupValidator? startupValidator = Services.GetService<IStartupValidator>();
+                    if (startupValidator is not null && startupValidator is not IAsyncStartupValidator)
                     {
-                        await asyncValidator.ValidateAsync(cancellationToken).ConfigureAwait(false);
+                        // A custom IStartupValidator takes precedence for back-compatibility and fully controls
+                        // startup validation, overriding any registered IAsyncStartupValidator instances
+                        // (including the one registered by ValidateOnStart).
+                        startupValidator.Validate();
                     }
                     else
                     {
-                        validator?.Validate();
+                        foreach (IAsyncStartupValidator asyncValidator in Services.GetServices<IAsyncStartupValidator>())
+                        {
+                            await asyncValidator.ValidateAsync(cancellationToken).ConfigureAwait(false);
+                        }
                     }
 
                     _hostedServices ??= Services.GetRequiredService<IEnumerable<IHostedService>>();

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -65,8 +65,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         /// <summary>
         /// Order:
         ///  IHostLifetime.WaitForStartAsync
-        ///  Services.GetService{IStartupValidator}().Validate()
-        ///  Services.GetService{IAsyncStartupValidator}().ValidateAsync()
+        ///  Services.GetService{IStartupValidator}().ValidateAsync() (or .Validate() for a sync-only validator)
         ///  IHostedLifecycleService.StartingAsync
         ///  IHostedService.Start
         ///  IHostedLifecycleService.StartedAsync
@@ -94,26 +93,20 @@ namespace Microsoft.Extensions.Hosting.Internal
 
                 try
                 {
-                    _hostedServices ??= Services.GetRequiredService<IEnumerable<IHostedService>>();
-                    _hostedLifecycleServices = GetHostLifecycles(_hostedServices);
-
-                    // Two-stage startup validation:
-                    // Stage 1 (sync): Run IStartupValidator.Validate() — iterates _validators dictionary
-                    //   (or user's custom implementation if registered).
-                    //   If sync validation fails, skip async to avoid expensive I/O on invalid config.
-                    // Stage 2 (async): Run IAsyncStartupValidator.ValidateAsync() — iterates _asyncValidators
-                    //   dictionary (or user's custom implementation if registered).
-                    //
-                    // Each interface is resolved independently via DI. TryAddTransient semantics ensure
-                    // user-registered implementations replace the built-in for each interface separately.
+                    // Run startup validation before resolving hosted services so a hosted service that
+                    // reads validated options in its constructor observes the validated instance.
                     IStartupValidator? validator = Services.GetService<IStartupValidator>();
-                    validator?.Validate();
-
-                    IAsyncStartupValidator? asyncValidator = Services.GetService<IAsyncStartupValidator>();
-                    if (asyncValidator is not null)
+                    if (validator is IAsyncStartupValidator asyncValidator)
                     {
                         await asyncValidator.ValidateAsync(cancellationToken).ConfigureAwait(false);
                     }
+                    else
+                    {
+                        validator?.Validate();
+                    }
+
+                    _hostedServices ??= Services.GetRequiredService<IEnumerable<IHostedService>>();
+                    _hostedLifecycleServices = GetHostLifecycles(_hostedServices);
                 }
                 catch (Exception ex)
                 {

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/OptionsBuilderExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/OptionsBuilderExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -402,6 +403,125 @@ namespace Microsoft.Extensions.Hosting.Tests
 
                 ValidateFailure<ComplexOptions>(error, 3, "Virtual", "Integer");
             }
+        }
+
+        [Fact]
+        public async Task ValidateOnStart_CustomSyncStartupValidator_OverridesAsyncValidationOnStart()
+        {
+            var custom = new TrackingStartupValidator();
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.AddSingleton<IStartupValidator>(custom);
+                services.AddOptions<ComplexOptions>()
+                    .Configure(o => o.Boolean = false)
+                    .Validate(o => o.Boolean, "should not run")
+                    .ValidateOnStart();
+            });
+
+            using (var host = hostBuilder.Build())
+            {
+                // The custom synchronous validator takes precedence and fully controls startup validation,
+                // so the failing ValidateOnStart (async) validation never runs and the host starts.
+                await host.StartAsync();
+            }
+
+            Assert.True(custom.Validated);
+        }
+
+        [Fact]
+        public async Task ValidateOnStart_CustomSyncStartupValidatorThatFails_ThrowsOnStart()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+                services.AddSingleton<IStartupValidator>(new ThrowingStartupValidator()));
+
+            using (var host = hostBuilder.Build())
+            {
+                await Assert.ThrowsAsync<OptionsValidationException>(async () => await host.StartAsync());
+            }
+        }
+
+        [Fact]
+        public async Task ValidateOnStart_MultipleAsyncStartupValidators_AllRunOnStart()
+        {
+            var custom = new TrackingAsyncStartupValidator();
+            bool validateOnStartRan = false;
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.AddSingleton<IAsyncStartupValidator>(custom);
+                services.AddOptions<ComplexOptions>()
+                    .Configure(o => o.Boolean = true)
+                    .Validate(o =>
+                    {
+                        validateOnStartRan = true;
+                        return o.Boolean;
+                    })
+                    .ValidateOnStart();
+            });
+
+            using (var host = hostBuilder.Build())
+            {
+                await host.StartAsync();
+            }
+
+            // Both the custom async validator and the built-in ValidateOnStart validator participate.
+            Assert.True(custom.Validated);
+            Assert.True(validateOnStartRan);
+        }
+
+        [Fact]
+        public async Task ValidateOnStart_StandaloneAsyncStartupValidator_RunsOnStart()
+        {
+            var custom = new TrackingAsyncStartupValidator();
+            var hostBuilder = CreateHostBuilder(services => services.AddSingleton<IAsyncStartupValidator>(custom));
+
+            using (var host = hostBuilder.Build())
+            {
+                await host.StartAsync();
+            }
+
+            Assert.True(custom.Validated);
+        }
+
+        [Fact]
+        public async Task ValidateOnStart_AsyncStartupValidatorThatFails_ThrowsOnStart()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+                services.AddSingleton<IAsyncStartupValidator>(new ThrowingAsyncStartupValidator()));
+
+            using (var host = hostBuilder.Build())
+            {
+                await Assert.ThrowsAsync<OptionsValidationException>(async () => await host.StartAsync());
+            }
+        }
+
+        private sealed class TrackingStartupValidator : IStartupValidator
+        {
+            public bool Validated { get; private set; }
+
+            public void Validate() => Validated = true;
+        }
+
+        private sealed class TrackingAsyncStartupValidator : IAsyncStartupValidator
+        {
+            public bool Validated { get; private set; }
+
+            public Task ValidateAsync(CancellationToken cancellationToken = default)
+            {
+                Validated = true;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class ThrowingStartupValidator : IStartupValidator
+        {
+            public void Validate() =>
+                throw new OptionsValidationException("name", typeof(object), new[] { "sync startup validation failed" });
+        }
+
+        private sealed class ThrowingAsyncStartupValidator : IAsyncStartupValidator
+        {
+            public Task ValidateAsync(CancellationToken cancellationToken = default) =>
+                throw new OptionsValidationException("name", typeof(object), new[] { "async startup validation failed" });
         }
 
         private static void ValidateFailure(Type type, OptionsValidationException e, int count = 1, params string[] errorsToMatch)

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
@@ -35,9 +35,6 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             var instance = new DataAnnotationValidateOptions<TOptions>(optionsBuilder.Name);
             optionsBuilder.Services.AddSingleton<IValidateOptions<TOptions>>(instance);
-#if NET11_0_OR_GREATER
-            optionsBuilder.Services.AddSingleton<IAsyncValidateOptions<TOptions>>(instance);
-#endif
             return optionsBuilder;
         }
     }

--- a/src/libraries/Microsoft.Extensions.Options/gen/DiagDescriptors.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/DiagDescriptors.cs
@@ -119,5 +119,17 @@ namespace Microsoft.Extensions.Options.Generators
             messageFormat: SR.TypeCannotBeUsedWithTheValidationAttributeMessage,
             category: Category,
             defaultSeverity: DiagnosticSeverity.Warning);
+
+        public static DiagnosticDescriptor AsyncValidationRequiresNet11 { get; } = Make(
+            id: "SYSLIB1218",
+            title: SR.AsyncValidationRequiresNet11Title,
+            messageFormat: SR.AsyncValidationRequiresNet11Message,
+            category: Category);
+
+        public static DiagnosticDescriptor AlreadyImplementsValidateAsyncMethod { get; } = Make(
+            id: "SYSLIB1219",
+            title: SR.AlreadyImplementsValidateAsyncMethodTitle,
+            messageFormat: SR.AlreadyImplementsValidateAsyncMethodMessage,
+            category: Category);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -130,6 +130,14 @@ namespace Microsoft.Extensions.Options.Generators
                 var modelToValidate = vt.ModelsToValidate[i];
 
                 GenModelValidationMethod(modelToValidate, vt.IsSynthetic, ref staticValidationAttributesDict, ref staticValidatorsDict);
+
+                // Only emit the async validation method when the validator type explicitly implements
+                // IAsyncValidateOptions<T> for this model and the required async validation symbols are available (.NET 11+).
+                if (modelToValidate.GenerateAsyncValidateMethod && _symbolHolder.AsyncValidateOptionsSymbol is not null && _symbolHolder.IAsyncValidatableObjectSymbol is not null)
+                {
+                    OutLn();
+                    GenAsyncModelValidationMethod(modelToValidate, vt.IsSynthetic, ref staticValidationAttributesDict, ref staticValidatorsDict);
+                }
             }
 
             OutCloseBrace();
@@ -732,6 +740,251 @@ namespace Microsoft.Extensions.Options.Generators
             GenModelSelfValidationIfNecessary(modelToValidate);
             OutLn($"return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();");
             OutCloseBrace();
+        }
+
+        private void GenAsyncModelValidationMethod(
+            ValidatedModel modelToValidate,
+            bool makeStatic,
+            ref Dictionary<string, StaticFieldInfo> staticValidationAttributesDict,
+            ref Dictionary<string, StaticFieldInfo> staticValidatorsDict)
+        {
+            // Determine whether the generated method body will contain any await. When it won't (for example the model
+            // only self-validates synchronously via IValidatableObject, or every nested validator resolves to a
+            // synchronous one), we emit a non-async method that returns a completed Task to avoid a CS1998
+            // "async method lacks await" warning. Only nested validators that actually emit ValidateAsync are awaited.
+            bool willAwait = modelToValidate.SelfValidatesAsync;
+            if (!willAwait)
+            {
+                foreach (var vm in modelToValidate.MembersToValidate)
+                {
+                    if (vm.ValidationAttributes.Count > 0 ||
+                        vm.TransValidatorEmitsAsync ||
+                        vm.EnumerationValidatorEmitsAsync)
+                    {
+                        willAwait = true;
+                        break;
+                    }
+                }
+            }
+
+            OutLn($"/// <summary>");
+            OutLn($"/// Validates a specific named options instance asynchronously (or all when <paramref name=\"name\"/> is <see langword=\"null\" />).");
+            OutLn($"/// </summary>");
+            OutLn($"/// <param name=\"name\">The name of the options instance being validated.</param>");
+            OutLn($"/// <param name=\"options\">The options instance.</param>");
+            OutLn($"/// <param name=\"cancellationToken\">The <see cref=\"global::System.Threading.CancellationToken\"/> to monitor for cancellation requests.</param>");
+            OutLn($"/// <returns>A task representing the asynchronous validation operation, containing the validation result.</returns>");
+            OutGeneratedCodeAttribute();
+
+            if (_symbolHolder.UnconditionalSuppressMessageAttributeSymbol is not null)
+            {
+                // We disable the warning on `new ValidationContext(object)` usage as we use it in a safe way that not require executing the reflection code.
+                // This is done by initializing the DisplayName in the context which is the part trigger reflection if it is not initialized. For
+                // projects targeting .NET 10 and above, we can avoid the suppression since we use the new trim-safe constructor.
+                OutLn("#if !NET");
+                OutLn($"[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(\"Trimming\", \"IL2026:RequiresUnreferencedCode\",");
+                OutLn($"     Justification = \"The created ValidationContext object is used in a way that never call reflection\")]");
+                OutLn("#endif");
+            }
+
+            OutLn($"public {(makeStatic ? "static " : string.Empty)}{(willAwait ? "async " : string.Empty)}global::System.Threading.Tasks.Task<global::Microsoft.Extensions.Options.ValidateOptionsResult> ValidateAsync(string? name, {modelToValidate.Name} options, global::System.Threading.CancellationToken cancellationToken = default)");
+            OutOpenBrace();
+            OutLn($"global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;");
+            OutLn("#if NET");
+            OutLn($"var context = new {StaticValidationContextType}(options, \"{modelToValidate.SimpleName}\", null, null);");
+            OutLn("#else");
+            OutLn($"var context = new {StaticValidationContextType}(options);");
+            OutLn("#endif");
+
+            int capacity = modelToValidate.MembersToValidate.Count == 0 ? 0 : modelToValidate.MembersToValidate.Max(static vm => vm.ValidationAttributes.Count);
+            if (capacity > 0)
+            {
+                OutLn($"var validationResults = new {StaticListType}<{StaticValidationResultType}>();");
+                OutLn($"var validationAttributes = new {StaticListType}<{StaticValidationAttributeType}>({capacity});");
+            }
+            OutLn();
+
+            bool cleanListsBeforeUse = false;
+            foreach (var vm in modelToValidate.MembersToValidate)
+            {
+                if (vm.ValidationAttributes.Count > 0)
+                {
+                    GenAsyncMemberValidation(vm, ref staticValidationAttributesDict, cleanListsBeforeUse);
+                    cleanListsBeforeUse = true;
+                    OutLn();
+                }
+
+                if (vm.TransValidatorType is not null)
+                {
+                    GenAsyncTransitiveValidation(vm, ref staticValidatorsDict);
+                    OutLn();
+                }
+
+                if (vm.EnumerationValidatorType is not null)
+                {
+                    GenAsyncEnumerationValidation(vm, ref staticValidatorsDict);
+                    OutLn();
+                }
+            }
+
+            GenAsyncModelSelfValidationIfNecessary(modelToValidate);
+
+            if (willAwait)
+            {
+                OutLn($"return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();");
+            }
+            else
+            {
+                OutLn($"return global::System.Threading.Tasks.Task.FromResult(builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build());");
+            }
+
+            OutCloseBrace();
+        }
+
+        private void GenAsyncMemberValidation(ValidatedMember vm, ref Dictionary<string, StaticFieldInfo> staticValidationAttributesDict, bool cleanListsBeforeUse)
+        {
+            OutLn($"context.MemberName = \"{vm.Name}\";");
+            OutLn($"context.DisplayName = string.IsNullOrEmpty(name) ? \"{vm.Name}\" : $\"{{name}}.{vm.Name}\";");
+
+            if (cleanListsBeforeUse)
+            {
+                OutLn($"validationResults.Clear();");
+                OutLn($"validationAttributes.Clear();");
+            }
+
+            foreach (var attr in vm.ValidationAttributes)
+            {
+                var staticValidationAttributeInstance = GetOrAddStaticValidationAttribute(ref staticValidationAttributesDict, attr);
+                OutLn($"validationAttributes.Add({_staticValidationAttributeHolderClassFQN}.{staticValidationAttributeInstance.FieldName});");
+            }
+
+            OutLn($"if (!await global::System.ComponentModel.DataAnnotations.Validator.TryValidateValueAsync(options.{vm.Name}{_TryGetValueNullableAnnotation}, context, validationResults, validationAttributes, cancellationToken).ConfigureAwait(false))");
+            OutOpenBrace();
+            OutLn($"(builder ??= new()).AddResults(validationResults);");
+            OutCloseBrace();
+        }
+
+        private void GenAsyncTransitiveValidation(ValidatedMember vm, ref Dictionary<string, StaticFieldInfo> staticValidatorsDict)
+        {
+            string callSequence;
+            if (vm.TransValidateTypeIsSynthetic)
+            {
+                callSequence = vm.TransValidatorType!;
+            }
+            else
+            {
+                var staticValidatorInstance = GetOrAddStaticValidator(ref staticValidatorsDict, vm.TransValidatorType!);
+
+                callSequence = $"{_staticValidatorHolderClassFQN}.{staticValidatorInstance.FieldName}";
+            }
+
+            var valueAccess = (vm.IsNullable && vm.IsValueType) ? ".Value" : string.Empty;
+
+            var baseName = $"string.IsNullOrEmpty(name) ? \"{vm.Name}\" : $\"{{name}}.{vm.Name}\"";
+
+            // A nested validator only emits ValidateAsync when it was synthesized for an async context. When the resolved
+            // validator does not emit ValidateAsync (a user-supplied validator, or a synthesized one shared with a
+            // synchronous parent), we fall back to its synchronous Validate method to guarantee the generated code compiles.
+            string resultExpression = vm.TransValidatorEmitsAsync
+                ? $"await {callSequence}.ValidateAsync({baseName}, options.{vm.Name}{valueAccess}, cancellationToken).ConfigureAwait(false)"
+                : $"{callSequence}.Validate({baseName}, options.{vm.Name}{valueAccess})";
+
+            if (vm.IsNullable)
+            {
+                OutLn($"if (options.{vm.Name} is not null)");
+                OutOpenBrace();
+                OutLn($"(builder ??= new()).AddResult({resultExpression});");
+                OutCloseBrace();
+            }
+            else
+            {
+                OutLn($"(builder ??= new()).AddResult({resultExpression});");
+            }
+        }
+
+        private void GenAsyncEnumerationValidation(ValidatedMember vm, ref Dictionary<string, StaticFieldInfo> staticValidatorsDict)
+        {
+            var valueAccess = (vm.IsValueType && vm.IsNullable) ? ".Value" : string.Empty;
+            var enumeratedValueAccess = (vm.EnumeratedIsNullable && vm.EnumeratedIsValueType) ? ".Value" : string.Empty;
+            string callSequence;
+            if (vm.EnumerationValidatorTypeIsSynthetic)
+            {
+                callSequence = vm.EnumerationValidatorType!;
+            }
+            else
+            {
+                var staticValidatorInstance = GetOrAddStaticValidator(ref staticValidatorsDict, vm.EnumerationValidatorType!);
+
+                callSequence = $"{_staticValidatorHolderClassFQN}.{staticValidatorInstance.FieldName}";
+            }
+
+            bool awaitItem = vm.EnumerationValidatorEmitsAsync;
+
+            if (vm.IsNullable)
+            {
+                OutLn($"if (options.{vm.Name} is not null)");
+            }
+
+            OutOpenBrace();
+
+            OutLn($"var count = 0;");
+            OutLn($"foreach (var o in options.{vm.Name}{valueAccess})");
+            OutOpenBrace();
+
+            if (vm.EnumeratedIsNullable)
+            {
+                OutLn($"if (o is not null)");
+                OutOpenBrace();
+                var propertyName = $"string.IsNullOrEmpty(name) ? $\"{vm.Name}[{{count}}]\" : $\"{{name}}.{vm.Name}[{{count}}]\"";
+                string itemResult = awaitItem
+                    ? $"await {callSequence}.ValidateAsync({propertyName}, o{enumeratedValueAccess}, cancellationToken).ConfigureAwait(false)"
+                    : $"{callSequence}.Validate({propertyName}, o{enumeratedValueAccess})";
+                OutLn($"(builder ??= new()).AddResult({itemResult});");
+                OutCloseBrace();
+
+                if (!vm.EnumeratedMayBeNull)
+                {
+                    OutLn($"else");
+                    OutOpenBrace();
+                    var error = $"string.IsNullOrEmpty(name) ? $\"{vm.Name}[{{count}}] is null\" : $\"{{name}}.{vm.Name}[{{count}}] is null\"";
+                    OutLn($"(builder ??= new()).AddError({error});");
+                    OutCloseBrace();
+                }
+
+                OutLn($"count++;");
+            }
+            else
+            {
+                var propertyName = $"string.IsNullOrEmpty(name) ? $\"{vm.Name}[{{count++}}]\" : $\"{{name}}.{vm.Name}[{{count++}}]\"";
+                string itemResult = awaitItem
+                    ? $"await {callSequence}.ValidateAsync({propertyName}, o{enumeratedValueAccess}, cancellationToken).ConfigureAwait(false)"
+                    : $"{callSequence}.Validate({propertyName}, o{enumeratedValueAccess})";
+                OutLn($"(builder ??= new()).AddResult({itemResult});");
+            }
+
+            OutCloseBrace();
+            OutCloseBrace();
+        }
+
+        private void GenAsyncModelSelfValidationIfNecessary(ValidatedModel modelToValidate)
+        {
+            if (modelToValidate.SelfValidatesAsync)
+            {
+                OutLn($"context.MemberName = \"ValidateAsync\";");
+                OutLn($"context.DisplayName = string.IsNullOrEmpty(name) ? \"ValidateAsync\" : $\"{{name}}.ValidateAsync\";");
+                OutLn($"await foreach (var asyncValidationResult in global::System.Threading.Tasks.TaskAsyncEnumerableExtensions.ConfigureAwait(((global::System.ComponentModel.DataAnnotations.IAsyncValidatableObject)options).ValidateAsync(context, cancellationToken), false))");
+                OutOpenBrace();
+                OutLn($"(builder ??= new()).AddResult(asyncValidationResult);");
+                OutCloseBrace();
+                OutLn();
+            }
+            else if (modelToValidate.SelfValidates)
+            {
+                OutLn($"context.MemberName = \"Validate\";");
+                OutLn($"context.DisplayName = string.IsNullOrEmpty(name) ? \"Validate\" : $\"{{name}}.Validate\";");
+                OutLn($"(builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));");
+                OutLn();
+            }
         }
 
         private void GenMemberValidation(ValidatedMember vm, ref Dictionary<string, StaticFieldInfo> staticValidationAttributesDict, bool cleanListsBeforeUse)

--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -882,9 +882,9 @@ namespace Microsoft.Extensions.Options.Generators
 
             var baseName = $"string.IsNullOrEmpty(name) ? \"{vm.Name}\" : $\"{{name}}.{vm.Name}\"";
 
-            // A nested validator only emits ValidateAsync when it was synthesized for an async context. When the resolved
-            // validator does not emit ValidateAsync (a user-supplied validator, or a synthesized one shared with a
-            // synchronous parent), we fall back to its synchronous Validate method to guarantee the generated code compiles.
+            // A nested validator emits an awaited ValidateAsync call only when it was synthesized for an async context or
+            // when it implements IAsyncValidateOptions<T> for the member type.
+            // Otherwise we fall back to its synchronous Validate method to guarantee the generated code compiles.
             string resultExpression = vm.TransValidatorEmitsAsync
                 ? $"await {callSequence}.ValidateAsync({baseName}, options.{vm.Name}{valueAccess}, cancellationToken).ConfigureAwait(false)"
                 : $"{callSequence}.Validate({baseName}, options.{vm.Name}{valueAccess})";

--- a/src/libraries/Microsoft.Extensions.Options/gen/Model/ValidatedMember.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Model/ValidatedMember.cs
@@ -16,5 +16,7 @@ namespace Microsoft.Extensions.Options.Generators
         bool IsValueType,
         bool EnumeratedIsNullable,
         bool EnumeratedIsValueType,
-        bool EnumeratedMayBeNull);
+        bool EnumeratedMayBeNull,
+        bool TransValidatorEmitsAsync = false,
+        bool EnumerationValidatorEmitsAsync = false);
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Model/ValidatedModel.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Model/ValidatedModel.cs
@@ -9,5 +9,7 @@ namespace Microsoft.Extensions.Options.Generators
         string Name,
         string SimpleName,
         bool SelfValidates,
+        bool SelfValidatesAsync,
+        bool GenerateAsyncValidateMethod,
         List<ValidatedMember> MembersToValidate);
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -97,14 +97,24 @@ namespace Microsoft.Extensions.Options.Generators
                                 continue;
                             }
 
+                            // Decide, per model, whether we additionally emit a ValidateAsync method. We do so when the
+                            // validator type explicitly implements IAsyncValidateOptions<T> for this specific model (and the
+                            // async symbols are available). A multi-model validator therefore only gets async validation for
+                            // the models it opted into. If the user already hand-wrote a matching ValidateAsync, we skip
+                            // generation to avoid emitting a duplicate member. The async requirement is propagated to any
+                            // synthesized child validators reached from this model.
+                            bool generateAsync = ValidatorImplementsAsyncInterfaceFor(validatorType, modelType)
+                                && !AlreadyImplementsValidateAsyncMethod(validatorType, modelType);
+
                             Location? modelTypeLocation = modelType.GetLocation();
                             Location lowerLocationInCompilation = modelTypeLocation is not null && modelTypeLocation.SourceTree is not null && _compilation.ContainsSyntaxTree(modelTypeLocation.SourceTree)
                                 ? modelTypeLocation
                                 : syntax.GetLocation();
 
-                            var membersToValidate = GetMembersToValidate(modelType, true, lowerLocationInCompilation, validatorType);
+                            var membersToValidate = GetMembersToValidate(modelType, true, lowerLocationInCompilation, validatorType, generateAsync);
                             bool selfValidate = ModelSelfValidates(modelType);
-                            if (membersToValidate.Count == 0 && !selfValidate)
+                            bool selfValidateAsync = generateAsync && ModelSelfValidatesAsync(modelType);
+                            if (membersToValidate.Count == 0 && !selfValidate && !selfValidateAsync)
                             {
                                 // this type lacks any eligible members
                                 Diag(DiagDescriptors.NoEligibleMembersFromValidator, syntax.GetLocation(), modelType.ToString(), validatorType.ToString());
@@ -115,6 +125,8 @@ namespace Microsoft.Extensions.Options.Generators
                                 GetFQN(modelType),
                                 modelType.Name,
                                 selfValidate,
+                                selfValidateAsync,
+                                generateAsync,
                                 membersToValidate));
                         }
 
@@ -204,6 +216,17 @@ namespace Microsoft.Extensions.Options.Generators
                     && m.Parameters[0].Type.SpecialType == SpecialType.System_String
                     && SymbolEqualityComparer.Default.Equals(m.Parameters[1].Type, modelType));
 
+        // Detects a user-supplied ValidateAsync(string, TModel, CancellationToken) overload so the generator doesn't emit
+        // a duplicate member for a validator that already provides its own asynchronous implementation.
+        private static bool AlreadyImplementsValidateAsyncMethod(INamespaceOrTypeSymbol validatorType, ISymbol modelType)
+            => validatorType
+                .GetMembers("ValidateAsync")
+                .Where(m => m.Kind == SymbolKind.Method)
+                .Select(m => (IMethodSymbol)m)
+                .Any(m => m.Parameters.Length == NumValidationMethodArgs + 1
+                    && m.Parameters[0].Type.SpecialType == SpecialType.System_String
+                    && SymbolEqualityComparer.Default.Equals(m.Parameters[1].Type, modelType));
+
         /// <summary>
         /// Checks whether the given type contain any unbound generic type arguments.
         /// </summary>
@@ -263,7 +286,7 @@ namespace Microsoft.Extensions.Options.Generators
             return null;
         }
 
-        private List<ValidatedMember> GetMembersToValidate(ITypeSymbol modelType, bool speculate, Location lowerLocationInCompilation, ITypeSymbol validatorType)
+        private List<ValidatedMember> GetMembersToValidate(ITypeSymbol modelType, bool speculate, Location lowerLocationInCompilation, ITypeSymbol validatorType, bool isAsync)
         {
             // make a list of the most derived members in the model type
 
@@ -297,7 +320,7 @@ namespace Microsoft.Extensions.Options.Generators
                     ? memberLocation
                     : lowerLocationInCompilation;
 
-                var memberInfo = GetMemberInfo(member, speculate, location, modelType, validatorType);
+                var memberInfo = GetMemberInfo(member, speculate, location, modelType, validatorType, isAsync);
                 if (memberInfo is not null)
                 {
                     if (member.DeclaredAccessibility != Accessibility.Public)
@@ -313,7 +336,7 @@ namespace Microsoft.Extensions.Options.Generators
             return membersToValidate;
         }
 
-        private ValidatedMember? GetMemberInfo(ISymbol member, bool speculate, Location location, ITypeSymbol modelType, ITypeSymbol validatorType)
+        private ValidatedMember? GetMemberInfo(ISymbol member, bool speculate, Location location, ITypeSymbol modelType, ITypeSymbol validatorType, bool isAsync)
         {
             ITypeSymbol memberType;
             switch (member)
@@ -346,6 +369,8 @@ namespace Microsoft.Extensions.Options.Generators
             var enumeratedMayBeNull = false;
             var transValidatorIsSynthetic = false;
             var enumerationValidatorIsSynthetic = false;
+            var transValidatorEmitsAsync = false;
+            var enumerationValidatorEmitsAsync = false;
 
             foreach (var attribute in member.GetAttributes().Where(a => a.AttributeClass is not null))
             {
@@ -399,7 +424,7 @@ namespace Microsoft.Extensions.Options.Generators
                     if (transValidatorTypeName == null)
                     {
                         transValidatorIsSynthetic = true;
-                        transValidatorTypeName = AddSynthesizedValidator(memberType, member, location, validatorType);
+                        transValidatorTypeName = AddSynthesizedValidator(memberType, member, location, validatorType, isAsync, out transValidatorEmitsAsync);
                     }
 
                     // pop the stack
@@ -462,7 +487,7 @@ namespace Microsoft.Extensions.Options.Generators
                     if (enumerationValidatorTypeName == null)
                     {
                         enumerationValidatorIsSynthetic = true;
-                        enumerationValidatorTypeName = AddSynthesizedValidator(enumeratedType, member, location, validatorType);
+                        enumerationValidatorTypeName = AddSynthesizedValidator(enumeratedType, member, location, validatorType, isAsync, out enumerationValidatorEmitsAsync);
                     }
 
                     // pop the stack
@@ -551,7 +576,7 @@ namespace Microsoft.Extensions.Options.Generators
             {
                 if (!HasOpenGenerics(memberType, out var genericType))
                 {
-                    var membersToValidate = GetMembersToValidate(memberType, false, location, validatorType);
+                    var membersToValidate = GetMembersToValidate(memberType, false, location, validatorType, isAsync);
                     if (membersToValidate.Count > 0)
                     {
                         Diag(DiagDescriptors.PotentiallyMissingTransitiveValidation, location, memberType.Name, member.Name);
@@ -567,7 +592,7 @@ namespace Microsoft.Extensions.Options.Generators
                 {
                     if (!HasOpenGenerics(enumeratedType, out var genericType))
                     {
-                        var membersToValidate = GetMembersToValidate(enumeratedType, false, location, validatorType);
+                        var membersToValidate = GetMembersToValidate(enumeratedType, false, location, validatorType, isAsync);
                         if (membersToValidate.Count > 0)
                         {
                             Diag(DiagDescriptors.PotentiallyMissingEnumerableValidation, location, enumeratedType.Name, member.Name);
@@ -589,7 +614,9 @@ namespace Microsoft.Extensions.Options.Generators
                     memberType.IsValueType,
                     enumeratedIsNullable,
                     enumeratedIsValueType,
-                    enumeratedMayBeNull);
+                    enumeratedMayBeNull,
+                    transValidatorEmitsAsync,
+                    enumerationValidatorEmitsAsync);
             }
 
             return null;
@@ -681,8 +708,9 @@ namespace Microsoft.Extensions.Options.Generators
             }
         }
 
-        private string? AddSynthesizedValidator(ITypeSymbol modelType, ISymbol member, Location location, ITypeSymbol validatorType)
+        private string? AddSynthesizedValidator(ITypeSymbol modelType, ISymbol member, Location location, ITypeSymbol validatorType, bool isAsync, out bool emitsAsync)
         {
+            emitsAsync = false;
             var mt = modelType.WithNullableAnnotation(NullableAnnotation.None);
             if (mt.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
             {
@@ -692,12 +720,17 @@ namespace Microsoft.Extensions.Options.Generators
 
             if (_synthesizedValidators.TryGetValue(mt, out var validator))
             {
+                // A synthesized validator is cached by model type only, so a validator synthesized for a synchronous
+                // parent may be reused by an asynchronous one. Report the capability of the cached validator (rather than
+                // the current request) so the caller only awaits a ValidateAsync method that will actually be emitted.
+                emitsAsync = validator.ModelsToValidate.Count > 0 && validator.ModelsToValidate[0].GenerateAsyncValidateMethod;
                 return "global::" + validator.Namespace + "." + validator.Name;
             }
 
             bool selfValidate = ModelSelfValidates(mt);
-            var membersToValidate = GetMembersToValidate(mt, true, location, validatorType);
-            if (membersToValidate.Count == 0 && !selfValidate)
+            bool selfValidateAsync = isAsync && ModelSelfValidatesAsync(mt);
+            var membersToValidate = GetMembersToValidate(mt, true, location, validatorType, isAsync);
+            if (membersToValidate.Count == 0 && !selfValidate && !selfValidateAsync)
             {
                 // this type lacks any eligible members
                 Diag(DiagDescriptors.NoEligibleMember, location, mt.ToString(), member.ToString());
@@ -708,6 +741,8 @@ namespace Microsoft.Extensions.Options.Generators
                 GetFQN(mt),
                 mt.Name,
                 selfValidate,
+                selfValidateAsync,
+                isAsync,
                 membersToValidate);
 
             var validatorTypeName = "__" + mt.Name + "Validator__";
@@ -722,6 +757,7 @@ namespace Microsoft.Extensions.Options.Generators
                 new[] { model });
 
             _synthesizedValidators[mt] = result;
+            emitsAsync = isAsync;
             return "global::" + (result.Namespace.Length > 0 ? result.Namespace + "." + result.Name : result.Name);
         }
 
@@ -736,6 +772,43 @@ namespace Microsoft.Extensions.Options.Generators
             foreach (var implementingInterface in modelType.AllInterfaces)
             {
                 if (SymbolEqualityComparer.Default.Equals(implementingInterface.OriginalDefinition, _symbolHolder.IValidatableObjectSymbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool ModelSelfValidatesAsync(ITypeSymbol modelType)
+        {
+            if (_symbolHolder.IAsyncValidatableObjectSymbol is null)
+            {
+                return false;
+            }
+
+            foreach (var implementingInterface in modelType.AllInterfaces)
+            {
+                if (SymbolEqualityComparer.Default.Equals(implementingInterface.OriginalDefinition, _symbolHolder.IAsyncValidatableObjectSymbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool ValidatorImplementsAsyncInterfaceFor(ITypeSymbol validatorType, ITypeSymbol modelType)
+        {
+            if (_symbolHolder.AsyncValidateOptionsSymbol is null)
+            {
+                return false;
+            }
+
+            foreach (var implementingInterface in validatorType.AllInterfaces)
+            {
+                if (SymbolEqualityComparer.Default.Equals(implementingInterface.OriginalDefinition, _symbolHolder.AsyncValidateOptionsSymbol)
+                    && SymbolEqualityComparer.Default.Equals(implementingInterface.TypeArguments.First(), modelType))
                 {
                     return true;
                 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -26,7 +26,12 @@ namespace Microsoft.Extensions.Options.Generators
         private readonly Action<Diagnostic> _reportDiagnostic;
         private readonly SymbolHolder _symbolHolder;
         private readonly OptionsSourceGenContext _optionsSourceGenContext;
-        private readonly Dictionary<ITypeSymbol, ValidatorType> _synthesizedValidators = new(SymbolEqualityComparer.Default);
+        // Synthesized validators are cached per model type. A model reached from a synchronous root and a model
+        // reached from an asynchronous root produce different generated types (the latter also emits ValidateAsync),
+        // so each model caches its synchronous and asynchronous validators separately. Keying by model type alone
+        // would let an asynchronous root reuse a synchronous-only validator (or vice versa) depending on discovery
+        // order, which would silently drop nested async validation.
+        private readonly Dictionary<ITypeSymbol, (ValidatorType? Sync, ValidatorType? Async)> _synthesizedValidators = new(SymbolEqualityComparer.Default);
         private readonly HashSet<ITypeSymbol> _visitedModelTypes = new(SymbolEqualityComparer.Default);
 
         public Parser(
@@ -157,7 +162,19 @@ namespace Microsoft.Extensions.Options.Generators
                 }
             }
 
-            results.AddRange(_synthesizedValidators.Values);
+            foreach (var entry in _synthesizedValidators.Values)
+            {
+                if (entry.Sync is not null)
+                {
+                    results.Add(entry.Sync);
+                }
+
+                if (entry.Async is not null)
+                {
+                    results.Add(entry.Async);
+                }
+            }
+
             _synthesizedValidators.Clear();
 
             if (results.Count > 0 && _compilation is CSharpCompilation { LanguageVersion : LanguageVersion version and < LanguageVersion.CSharp8 })
@@ -718,13 +735,13 @@ namespace Microsoft.Extensions.Options.Generators
                 mt = ((INamedTypeSymbol)mt).TypeArguments[0];
             }
 
-            if (_synthesizedValidators.TryGetValue(mt, out var validator))
+            _synthesizedValidators.TryGetValue(mt, out var cached);
+            ValidatorType? reusable = isAsync ? cached.Async : cached.Sync;
+            if (reusable is not null)
             {
-                // A synthesized validator is cached by model type only, so a validator synthesized for a synchronous
-                // parent may be reused by an asynchronous one. Report the capability of the cached validator (rather than
-                // the current request) so the caller only awaits a ValidateAsync method that will actually be emitted.
-                emitsAsync = validator.ModelsToValidate.Count > 0 && validator.ModelsToValidate[0].GenerateAsyncValidateMethod;
-                return "global::" + validator.Namespace + "." + validator.Name;
+                // A validator matching the requested capability was already synthesized for this model, so reuse it.
+                emitsAsync = isAsync;
+                return "global::" + (reusable.Namespace.Length > 0 ? reusable.Namespace + "." + reusable.Name : reusable.Name);
             }
 
             bool selfValidate = ModelSelfValidates(mt);
@@ -745,7 +762,9 @@ namespace Microsoft.Extensions.Options.Generators
                 isAsync,
                 membersToValidate);
 
-            var validatorTypeName = "__" + mt.Name + "Validator__";
+            // Asynchronous validators get a distinct name so a model reached from both a synchronous and an
+            // asynchronous root can emit two non-conflicting synthesized types. Synchronous naming is unchanged.
+            var validatorTypeName = "__" + mt.Name + (isAsync ? "AsyncValidator__" : "Validator__");
 
             var result = new ValidatorType(
                 mt.ContainingNamespace.IsGlobalNamespace ? string.Empty : mt.ContainingNamespace.ToString()!,
@@ -756,7 +775,7 @@ namespace Microsoft.Extensions.Options.Generators
                 true,
                 new[] { model });
 
-            _synthesizedValidators[mt] = result;
+            _synthesizedValidators[mt] = isAsync ? (cached.Sync, result) : (result, cached.Async);
             emitsAsync = isAsync;
             return "global::" + (result.Namespace.Length > 0 ? result.Namespace + "." + result.Name : result.Name);
         }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -451,6 +451,7 @@ namespace Microsoft.Extensions.Options.Generators
                                 if (transValidatorType.Constructors.Where(c => !c.Parameters.Any()).Any())
                                 {
                                     transValidatorTypeName = transValidatorType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                                    transValidatorEmitsAsync = isAsync && ValidatorImplementsAsyncInterfaceFor(transValidatorType, memberType);
                                 }
                                 else
                                 {
@@ -514,6 +515,7 @@ namespace Microsoft.Extensions.Options.Generators
                                 if (enumerationValidatorType.Constructors.Where(c => c.Parameters.Length == 0).Any())
                                 {
                                     enumerationValidatorTypeName = enumerationValidatorType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                                    enumerationValidatorEmitsAsync = isAsync && ValidatorImplementsAsyncInterfaceFor(enumerationValidatorType, enumeratedType);
                                 }
                                 else
                                 {

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -103,13 +103,32 @@ namespace Microsoft.Extensions.Options.Generators
                             }
 
                             // Decide, per model, whether we additionally emit a ValidateAsync method. We do so when the
-                            // validator type explicitly implements IAsyncValidateOptions<T> for this specific model (and the
-                            // async symbols are available). A multi-model validator therefore only gets async validation for
-                            // the models it opted into. If the user already hand-wrote a matching ValidateAsync, we skip
-                            // generation to avoid emitting a duplicate member. The async requirement is propagated to any
-                            // synthesized child validators reached from this model.
-                            bool generateAsync = ValidatorImplementsAsyncInterfaceFor(validatorType, modelType)
-                                && !AlreadyImplementsValidateAsyncMethod(validatorType, modelType);
+                            // validator type explicitly implements IAsyncValidateOptions<T> for this specific model. A
+                            // multi-model validator therefore only gets async validation for the models it opted into.
+                            // The async requirement is propagated to any synthesized child validators reached from this model.
+                            bool wantsAsync = ValidatorImplementsAsyncInterfaceFor(validatorType, modelType);
+
+                            if (wantsAsync && AlreadyImplementsValidateAsyncMethod(validatorType, modelType))
+                            {
+                                // The user hand-wrote a matching ValidateAsync on an [OptionsValidator] type. This is an
+                                // error (symmetric with SYSLIB1205 for a hand-written Validate): a generated synchronous
+                                // Validate combined with a hand-written ValidateAsync would validate differently on the
+                                // sync vs async access paths, silently skipping the generated attribute validation on the
+                                // async path. Report it and skip only the async generation - the synchronous Validate is
+                                // still generated so the sole failure surfaced is this diagnostic, not a cascading CS0535.
+                                Diag(DiagDescriptors.AlreadyImplementsValidateAsyncMethod, syntax.GetLocation(), validatorType.Name);
+                                wantsAsync = false;
+                            }
+
+                            // Asynchronous validation relies on the async DataAnnotations APIs (IAsyncValidatableObject /
+                            // Validator.TryValidateValueAsync), which are only available when targeting .NET 11 or later.
+                            // When they are unavailable, emit a diagnostic instead of generating code that wouldn't compile.
+                            bool generateAsync = wantsAsync;
+                            if (wantsAsync && _symbolHolder.IAsyncValidatableObjectSymbol is null)
+                            {
+                                Diag(DiagDescriptors.AsyncValidationRequiresNet11, syntax.GetLocation(), validatorType.Name);
+                                generateAsync = false;
+                            }
 
                             Location? modelTypeLocation = modelType.GetLocation();
                             Location lowerLocationInCompilation = modelTypeLocation is not null && modelTypeLocation.SourceTree is not null && _compilation.ContainsSyntaxTree(modelTypeLocation.SourceTree)
@@ -222,27 +241,44 @@ namespace Microsoft.Extensions.Options.Generators
             => type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat.WithGenericsOptions(SymbolDisplayGenericsOptions.None));
 
         /// <summary>
-        /// Checks whether the given validator already implement the IValidationOptions&gt;T&lt; interface.
+        /// Checks whether the given validator already implements the generated <c>Validate</c> method
+        /// (implicitly or as an explicit interface implementation).
         /// </summary>
         private static bool AlreadyImplementsValidateMethod(INamespaceOrTypeSymbol validatorType, ISymbol modelType)
             => validatorType
-                .GetMembers("Validate")
-                .Where(m => m.Kind == SymbolKind.Method)
-                .Select(m => (IMethodSymbol)m)
-                .Any(m => m.Parameters.Length == NumValidationMethodArgs
-                    && m.Parameters[0].Type.SpecialType == SpecialType.System_String
-                    && SymbolEqualityComparer.Default.Equals(m.Parameters[1].Type, modelType));
+                .GetMembers()
+                .OfType<IMethodSymbol>()
+                .Any(m => MatchesGeneratedValidateSignature(m, "Validate", NumValidationMethodArgs, modelType, requireCancellationToken: false));
 
         // Detects a user-supplied ValidateAsync(string, TModel, CancellationToken) overload so the generator doesn't emit
         // a duplicate member for a validator that already provides its own asynchronous implementation.
         private static bool AlreadyImplementsValidateAsyncMethod(INamespaceOrTypeSymbol validatorType, ISymbol modelType)
             => validatorType
-                .GetMembers("ValidateAsync")
-                .Where(m => m.Kind == SymbolKind.Method)
-                .Select(m => (IMethodSymbol)m)
-                .Any(m => m.Parameters.Length == NumValidationMethodArgs + 1
-                    && m.Parameters[0].Type.SpecialType == SpecialType.System_String
-                    && SymbolEqualityComparer.Default.Equals(m.Parameters[1].Type, modelType));
+                .GetMembers()
+                .OfType<IMethodSymbol>()
+                .Any(m => MatchesGeneratedValidateSignature(m, "ValidateAsync", NumValidationMethodArgs + 1, modelType, requireCancellationToken: true));
+
+        // Matches a method with the signature the generator would emit, whether declared implicitly or as an explicit
+        // interface implementation. The return type is intentionally ignored (C# does not overload on return type), and
+        // no display-string comparison is used.
+        private static bool MatchesGeneratedValidateSignature(IMethodSymbol method, string name, int parameterCount, ISymbol modelType, bool requireCancellationToken)
+        {
+            bool nameMatches = method.Name == name
+                || method.ExplicitInterfaceImplementations.Any(impl => impl.Name == name);
+
+            if (!nameMatches
+                || method.Parameters.Length != parameterCount
+                || method.Parameters[0].Type.SpecialType != SpecialType.System_String
+                || !SymbolEqualityComparer.Default.Equals(method.Parameters[1].Type, modelType))
+            {
+                return false;
+            }
+
+            return !requireCancellationToken || IsCancellationToken(method.Parameters[parameterCount - 1].Type);
+        }
+
+        private static bool IsCancellationToken(ITypeSymbol type)
+            => type is { Name: "CancellationToken", ContainingNamespace: { Name: "Threading", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } } };
 
         /// <summary>
         /// Checks whether the given type contain any unbound generic type arguments.

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
@@ -117,11 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AlreadyImplementsValidateAsyncMethodMessage" xml:space="preserve">
+    <value>Type {0} already implements the ValidateAsync method.</value>
+  </data>
+  <data name="AlreadyImplementsValidateAsyncMethodTitle" xml:space="preserve">
+    <value>A type already includes an implementation of the 'ValidateAsync' method.</value>
+  </data>
   <data name="AlreadyImplementsValidateMethodMessage" xml:space="preserve">
     <value>Type {0} already implements the Validate method.</value>
   </data>
   <data name="AlreadyImplementsValidateMethodTitle" xml:space="preserve">
     <value>A type already includes an implementation of the 'Validate' method.</value>
+  </data>
+  <data name="AsyncValidationRequiresNet11Message" xml:space="preserve">
+    <value>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</value>
+  </data>
+  <data name="AsyncValidationRequiresNet11Title" xml:space="preserve">
+    <value>Asynchronous options validation requires targeting .NET 11 or later.</value>
   </data>
   <data name="CantBeStaticClassMessage" xml:space="preserve">
     <value>[OptionsValidator] cannot be applied to static class {0}.</value>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">Typ {0} již implementuje metodu Validate.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">Typ už obsahuje implementaci metody Validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">Der Typ "{0}" implementiert bereits die Validate-Methode.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">Ein Typ enthält bereits eine Implementierung der Validate-Methode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">El tipo {0} ya implementa el método Validate.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">Un tipo ya incluye una implementación del método “Validate”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">Le type {0} implémente déjà la méthode Validate.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">Un type inclut déjà une implémentation de la méthode 'Validate'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">Il tipo {0} implementa già il metodo Validate.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">Un tipo include già un'implementazione del metodo 'Validate'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">型 {0} に Validate メソッドが既に実装されています。</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">型には 'Validate' メソッドの実装が既に含まれています。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">형식 {0}은(는) Validate 메서드를 이미 구현하고 있습니다.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">형식에 'Validate' 메서드 구현이 이미 포함되어 있습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">Typ {0} już implementuje metodę Validate.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">Typ zawiera już implementację metody „Validate”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">O tipo {0} já implementa o método Validar.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">Um tipo já inclui uma implementação do método "Validar".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">Тип {0} уже реализует метод Validate.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">Тип уже содержит реализацию метода Validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">{0} türü Doğrulama yöntemini zaten uyguluyor.</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">Bir tür zaten 'Validate' yönteminin bir uygulamasını içeriyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">类型 {0} 已实现 Validate 方法。</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">类型已包含“Validate”方法的实现。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodMessage">
+        <source>Type {0} already implements the ValidateAsync method.</source>
+        <target state="new">Type {0} already implements the ValidateAsync method.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyImplementsValidateAsyncMethodTitle">
+        <source>A type already includes an implementation of the 'ValidateAsync' method.</source>
+        <target state="new">A type already includes an implementation of the 'ValidateAsync' method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
         <target state="translated">類型 {0} 已實作 [驗證] 方法。</target>
@@ -10,6 +20,16 @@
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
         <target state="translated">類型已經包含 [驗證] 方法的實作。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Message">
+        <source>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</source>
+        <target state="new">Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AsyncValidationRequiresNet11Title">
+        <source>Asynchronous options validation requires targeting .NET 11 or later.</source>
+        <target state="new">Asynchronous options validation requires targeting .NET 11 or later.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">

--- a/src/libraries/Microsoft.Extensions.Options/gen/SymbolHolder.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/SymbolHolder.cs
@@ -25,5 +25,7 @@ namespace Microsoft.Extensions.Options.Generators
         INamedTypeSymbol TypeSymbol,
         INamedTypeSymbol TimeSpanSymbol,
         INamedTypeSymbol ValidateObjectMembersAttributeSymbol,
-        INamedTypeSymbol ValidateEnumeratedItemsAttributeSymbol);
+        INamedTypeSymbol ValidateEnumeratedItemsAttributeSymbol,
+        INamedTypeSymbol? IAsyncValidatableObjectSymbol = null,
+        INamedTypeSymbol? AsyncValidateOptionsSymbol = null);
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/SymbolLoader.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/SymbolLoader.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Extensions.Options.Generators
         internal const string ValidateEnumeratedItemsAttribute = "Microsoft.Extensions.Options.ValidateEnumeratedItemsAttribute";
         internal const string GenericIEnumerableType = "System.Collections.Generic.IEnumerable`1";
         internal const string UnconditionalSuppressMessageAttributeType = "System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute";
+        internal const string IAsyncValidatableObjectType = "System.ComponentModel.DataAnnotations.IAsyncValidatableObject";
+        internal const string IAsyncValidateOptionsType = "Microsoft.Extensions.Options.IAsyncValidateOptions`1";
 
         public static bool TryLoad(Compilation compilation, out SymbolHolder? symbolHolder)
         {
@@ -81,6 +83,11 @@ namespace Microsoft.Extensions.Options.Generators
             }
     #pragma warning restore S1067 // Expressions should not be too complex
 
+            // Optional async validation symbols (available in .NET 11+).
+            // When absent (e.g. downlevel targets), the generator degrades to emitting only the synchronous Validate method.
+            var iAsyncValidatableObjectSymbol = GetSymbol(IAsyncValidatableObjectType);
+            var asyncValidateOptionsSymbol = GetSymbol(IAsyncValidateOptionsType);
+
             symbolHolder = new(
                 optionsValidatorSymbol,
                 validationAttributeSymbol,
@@ -98,7 +105,9 @@ namespace Microsoft.Extensions.Options.Generators
                 typeSymbol,
                 timeSpanSymbol,
                 validateObjectMembersAttribute,
-                validateEnumeratedItemsAttribute);
+                validateEnumeratedItemsAttribute,
+                iAsyncValidatableObjectSymbol,
+                asyncValidateOptionsSymbol);
 
             return true;
         }

--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
@@ -225,7 +225,6 @@ namespace Microsoft.Extensions.Options
     public partial class OptionsManager<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions> : Microsoft.Extensions.Options.IOptions<TOptions>, Microsoft.Extensions.Options.IOptionsSnapshot<TOptions> where TOptions : class
     {
         public OptionsManager(Microsoft.Extensions.Options.IOptionsFactory<TOptions> factory) { }
-        public OptionsManager(Microsoft.Extensions.Options.IOptionsFactory<TOptions> factory, Microsoft.Extensions.Options.IOptionsMonitorCache<TOptions> validatedCache) { }
         public TOptions Value { get { throw null; } }
         public virtual TOptions Get(string? name) { throw null; }
     }

--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
@@ -225,6 +225,7 @@ namespace Microsoft.Extensions.Options
     public partial class OptionsManager<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions> : Microsoft.Extensions.Options.IOptions<TOptions>, Microsoft.Extensions.Options.IOptionsSnapshot<TOptions> where TOptions : class
     {
         public OptionsManager(Microsoft.Extensions.Options.IOptionsFactory<TOptions> factory) { }
+        public OptionsManager(Microsoft.Extensions.Options.IOptionsFactory<TOptions> factory, Microsoft.Extensions.Options.IOptionsMonitorCache<TOptions> validatedCache) { }
         public TOptions Value { get { throw null; } }
         public virtual TOptions Get(string? name) { throw null; }
     }

--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static partial class OptionsBuilderExtensions
     {
         public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> ValidateOnStart<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder) where TOptions : class { throw null; }
+        public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> ValidateOnChange<TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder, Microsoft.Extensions.Options.OptionsReloadValidationBehavior behavior = Microsoft.Extensions.Options.OptionsReloadValidationBehavior.KeepLastGood, System.Action<string?, System.Exception>? onError = null) where TOptions : class { throw null; }
     }
     public static partial class OptionsServiceCollectionExtensions
     {
@@ -234,10 +235,16 @@ namespace Microsoft.Extensions.Options
     public partial class OptionsMonitor<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions> : Microsoft.Extensions.Options.IOptionsMonitor<TOptions>, System.IDisposable where TOptions : class
     {
         public OptionsMonitor(Microsoft.Extensions.Options.IOptionsFactory<TOptions> factory, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IOptionsChangeTokenSource<TOptions>> sources, Microsoft.Extensions.Options.IOptionsMonitorCache<TOptions> cache) { }
+        public OptionsMonitor(Microsoft.Extensions.Options.IOptionsFactory<TOptions> factory, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IOptionsChangeTokenSource<TOptions>> sources, Microsoft.Extensions.Options.IOptionsMonitorCache<TOptions> cache, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.ReloadValidationConfiguration<TOptions>> reloadValidationConfigs) { }
         public TOptions CurrentValue { get { throw null; } }
         public void Dispose() { }
         public virtual TOptions Get(string? name) { throw null; }
         public System.IDisposable OnChange(System.Action<TOptions, string> listener) { throw null; }
+    }
+    public enum OptionsReloadValidationBehavior
+    {
+        KeepLastGood = 0,
+        FailReads = 1,
     }
     public partial class OptionsValidationException : System.Exception
     {
@@ -317,6 +324,13 @@ namespace Microsoft.Extensions.Options
         public string? Name { get { throw null; } }
         public virtual void PostConfigure(string? name, TOptions options) { }
         public void PostConfigure(TOptions options) { }
+    }
+    public sealed partial class ReloadValidationConfiguration<TOptions> where TOptions : class
+    {
+        public ReloadValidationConfiguration(string name, Microsoft.Extensions.Options.OptionsReloadValidationBehavior behavior, System.Action<string?, System.Exception>? onError) { }
+        public Microsoft.Extensions.Options.OptionsReloadValidationBehavior Behavior { get { throw null; } }
+        public string Name { get { throw null; } }
+        public System.Action<string?, System.Exception>? OnError { get { throw null; } }
     }
     [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class ValidateEnumeratedItemsAttribute : System.Attribute

--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Extensions.Options
     {
         void Validate();
     }
-    public partial interface IAsyncStartupValidator : Microsoft.Extensions.Options.IStartupValidator
+    public partial interface IAsyncStartupValidator
     {
         System.Threading.Tasks.Task ValidateAsync(System.Threading.CancellationToken cancellationToken = default);
     }

--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Extensions.Options
     {
         void Validate();
     }
-    public partial interface IAsyncStartupValidator
+    public partial interface IAsyncStartupValidator : Microsoft.Extensions.Options.IStartupValidator
     {
         System.Threading.Tasks.Task ValidateAsync(System.Threading.CancellationToken cancellationToken = default);
     }
@@ -153,7 +153,7 @@ namespace Microsoft.Extensions.Options
     {
         Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, TOptions options);
     }
-    public partial interface IAsyncValidateOptions<in TOptions> where TOptions : class
+    public partial interface IAsyncValidateOptions<TOptions> : Microsoft.Extensions.Options.IValidateOptions<TOptions> where TOptions : class
     {
         System.Threading.Tasks.Task<Microsoft.Extensions.Options.ValidateOptionsResult> ValidateAsync(string? name, TOptions options, System.Threading.CancellationToken cancellationToken = default);
     }
@@ -425,6 +425,7 @@ namespace Microsoft.Extensions.Options
         public string FailureMessage { get { throw null; } }
         public string? Name { get { throw null; } }
         public System.Func<TOptions, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> Validation { get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, TOptions options) { throw null; }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Options.ValidateOptionsResult> ValidateAsync(string? name, TOptions options, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
     public partial class AsyncValidateOptions<TOptions, TDep> : Microsoft.Extensions.Options.IAsyncValidateOptions<TOptions> where TOptions : class
@@ -434,6 +435,7 @@ namespace Microsoft.Extensions.Options
         public string FailureMessage { get { throw null; } }
         public string? Name { get { throw null; } }
         public System.Func<TOptions, TDep, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> Validation { get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, TOptions options) { throw null; }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Options.ValidateOptionsResult> ValidateAsync(string? name, TOptions options, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
     public partial class AsyncValidateOptions<TOptions, TDep1, TDep2> : Microsoft.Extensions.Options.IAsyncValidateOptions<TOptions> where TOptions : class
@@ -444,6 +446,7 @@ namespace Microsoft.Extensions.Options
         public string FailureMessage { get { throw null; } }
         public string? Name { get { throw null; } }
         public System.Func<TOptions, TDep1, TDep2, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> Validation { get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, TOptions options) { throw null; }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Options.ValidateOptionsResult> ValidateAsync(string? name, TOptions options, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
     public partial class AsyncValidateOptions<TOptions, TDep1, TDep2, TDep3> : Microsoft.Extensions.Options.IAsyncValidateOptions<TOptions> where TOptions : class
@@ -455,6 +458,7 @@ namespace Microsoft.Extensions.Options
         public string FailureMessage { get { throw null; } }
         public string? Name { get { throw null; } }
         public System.Func<TOptions, TDep1, TDep2, TDep3, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> Validation { get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, TOptions options) { throw null; }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Options.ValidateOptionsResult> ValidateAsync(string? name, TOptions options, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
     public partial class AsyncValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4> : Microsoft.Extensions.Options.IAsyncValidateOptions<TOptions> where TOptions : class
@@ -467,6 +471,7 @@ namespace Microsoft.Extensions.Options
         public string FailureMessage { get { throw null; } }
         public string? Name { get { throw null; } }
         public System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> Validation { get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, TOptions options) { throw null; }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Options.ValidateOptionsResult> ValidateAsync(string? name, TOptions options, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
     public partial class AsyncValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> : Microsoft.Extensions.Options.IAsyncValidateOptions<TOptions> where TOptions : class
@@ -480,6 +485,7 @@ namespace Microsoft.Extensions.Options
         public string FailureMessage { get { throw null; } }
         public string? Name { get { throw null; } }
         public System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> Validation { get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, TOptions options) { throw null; }
         public System.Threading.Tasks.Task<Microsoft.Extensions.Options.ValidateOptionsResult> ValidateAsync(string? name, TOptions options, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
@@ -217,6 +217,7 @@ namespace Microsoft.Extensions.Options
     {
         public OptionsFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IConfigureOptions<TOptions>> setups, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IPostConfigureOptions<TOptions>> postConfigures) { }
         public OptionsFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IConfigureOptions<TOptions>> setups, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IPostConfigureOptions<TOptions>> postConfigures, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IValidateOptions<TOptions>> validations) { }
+        public OptionsFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IConfigureOptions<TOptions>> setups, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IPostConfigureOptions<TOptions>> postConfigures, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IValidateOptions<TOptions>> validations, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IAsyncValidateOptions<TOptions>> asyncValidations) { }
         public TOptions Create(string name) { throw null; }
         protected virtual TOptions CreateInstance(string name) { throw null; }
     }

--- a/src/libraries/Microsoft.Extensions.Options/src/AsyncValidateOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/AsyncValidateOptions.cs
@@ -44,6 +44,24 @@ namespace Microsoft.Extensions.Options
         public string FailureMessage { get; }
 
         /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null"/>).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string? name, TOptions options)
+        {
+            // null name is used to configure all named options
+            if (Name is null || name == Name)
+            {
+                return ValidateOptionsResult.Fail(SR.Format(SR.AsyncValidatorSyncValidationUnsupported, typeof(TOptions)));
+            }
+
+            // ignored if not validating this instance
+            return ValidateOptionsResult.Skip;
+        }
+
+        /// <summary>
         /// Asynchronously validates a specific named options instance (or all when <paramref name="name"/> is null).
         /// </summary>
         /// <param name="name">The name of the options instance being validated.</param>
@@ -111,6 +129,22 @@ namespace Microsoft.Extensions.Options
         /// Gets the error to return when validation fails.
         /// </summary>
         public string FailureMessage { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null"/>).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string? name, TOptions options)
+        {
+            if (Name is null || name == Name)
+            {
+                return ValidateOptionsResult.Fail(SR.Format(SR.AsyncValidatorSyncValidationUnsupported, typeof(TOptions)));
+            }
+
+            return ValidateOptionsResult.Skip;
+        }
 
         /// <inheritdoc/>
         public async Task<ValidateOptionsResult> ValidateAsync(string? name, TOptions options, CancellationToken cancellationToken = default)
@@ -180,6 +214,22 @@ namespace Microsoft.Extensions.Options
         /// Gets the error to return when validation fails.
         /// </summary>
         public string FailureMessage { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null"/>).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string? name, TOptions options)
+        {
+            if (Name is null || name == Name)
+            {
+                return ValidateOptionsResult.Fail(SR.Format(SR.AsyncValidatorSyncValidationUnsupported, typeof(TOptions)));
+            }
+
+            return ValidateOptionsResult.Skip;
+        }
 
         /// <inheritdoc/>
         public async Task<ValidateOptionsResult> ValidateAsync(string? name, TOptions options, CancellationToken cancellationToken = default)
@@ -257,6 +307,22 @@ namespace Microsoft.Extensions.Options
         /// Gets the error to return when validation fails.
         /// </summary>
         public string FailureMessage { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null"/>).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string? name, TOptions options)
+        {
+            if (Name is null || name == Name)
+            {
+                return ValidateOptionsResult.Fail(SR.Format(SR.AsyncValidatorSyncValidationUnsupported, typeof(TOptions)));
+            }
+
+            return ValidateOptionsResult.Skip;
+        }
 
         /// <inheritdoc/>
         public async Task<ValidateOptionsResult> ValidateAsync(string? name, TOptions options, CancellationToken cancellationToken = default)
@@ -342,6 +408,22 @@ namespace Microsoft.Extensions.Options
         /// Gets the error to return when validation fails.
         /// </summary>
         public string FailureMessage { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null"/>).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string? name, TOptions options)
+        {
+            if (Name is null || name == Name)
+            {
+                return ValidateOptionsResult.Fail(SR.Format(SR.AsyncValidatorSyncValidationUnsupported, typeof(TOptions)));
+            }
+
+            return ValidateOptionsResult.Skip;
+        }
 
         /// <inheritdoc/>
         public async Task<ValidateOptionsResult> ValidateAsync(string? name, TOptions options, CancellationToken cancellationToken = default)
@@ -435,6 +517,22 @@ namespace Microsoft.Extensions.Options
         /// Gets the error to return when validation fails.
         /// </summary>
         public string FailureMessage { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null"/>).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string? name, TOptions options)
+        {
+            if (Name is null || name == Name)
+            {
+                return ValidateOptionsResult.Fail(SR.Format(SR.AsyncValidatorSyncValidationUnsupported, typeof(TOptions)));
+            }
+
+            return ValidateOptionsResult.Skip;
+        }
 
         /// <inheritdoc/>
         public async Task<ValidateOptionsResult> ValidateAsync(string? name, TOptions options, CancellationToken cancellationToken = default)

--- a/src/libraries/Microsoft.Extensions.Options/src/IAsyncStartupValidator.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IAsyncStartupValidator.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Options
     /// <summary>
     /// Used by hosts to asynchronously validate options during startup.
     /// </summary>
-    public interface IAsyncStartupValidator
+    public interface IAsyncStartupValidator : IStartupValidator
     {
         /// <summary>
         /// Calls all registered <see cref="IAsyncValidateOptions{TOptions}"/> validators.

--- a/src/libraries/Microsoft.Extensions.Options/src/IAsyncStartupValidator.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IAsyncStartupValidator.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Options
     /// <summary>
     /// Used by hosts to asynchronously validate options during startup.
     /// </summary>
-    public interface IAsyncStartupValidator : IStartupValidator
+    public interface IAsyncStartupValidator
     {
         /// <summary>
         /// Calls all registered <see cref="IAsyncValidateOptions{TOptions}"/> validators.

--- a/src/libraries/Microsoft.Extensions.Options/src/IAsyncValidateOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IAsyncValidateOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Options
     /// Asynchronously validates options.
     /// </summary>
     /// <typeparam name="TOptions">The options type to validate.</typeparam>
-    public interface IAsyncValidateOptions<in TOptions> where TOptions : class
+    public interface IAsyncValidateOptions<TOptions> : IValidateOptions<TOptions> where TOptions : class
     {
         /// <summary>
         /// Asynchronously validates a specified named options instance (or all if <paramref name="name"/> is <see langword="null"/>).

--- a/src/libraries/Microsoft.Extensions.Options/src/Microsoft.Extensions.Options.csproj
+++ b/src/libraries/Microsoft.Extensions.Options/src/Microsoft.Extensions.Options.csproj
@@ -40,7 +40,8 @@
     <ProjectReference Include="$(LibrariesProjectRoot)System.Collections.Concurrent\src\System.Collections.Concurrent.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.ComponentModel\src\System.ComponentModel.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.ComponentModel.Annotations\src\System.ComponentModel.Annotations.csproj" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\src\System.Runtime.csproj" />
+  <ProjectReference Include="$(LibrariesProjectRoot)System.Diagnostics.Tracing\src\System.Diagnostics.Tracing.csproj" />
+  <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Threading\src\System.Threading.csproj" />
   </ItemGroup>
 

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilder.cs
@@ -591,7 +591,7 @@ namespace Microsoft.Extensions.Options
         {
             ArgumentNullException.ThrowIfNull(validation);
 
-            Services.AddSingleton<IAsyncValidateOptions<TOptions>>(new AsyncValidateOptions<TOptions>(Name, validation, failureMessage));
+            Services.AddSingleton<IValidateOptions<TOptions>>(new AsyncValidateOptions<TOptions>(Name, validation, failureMessage));
             return this;
         }
 
@@ -615,7 +615,7 @@ namespace Microsoft.Extensions.Options
         {
             ArgumentNullException.ThrowIfNull(validation);
 
-            Services.AddTransient<IAsyncValidateOptions<TOptions>>(sp =>
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
                 new AsyncValidateOptions<TOptions, TDep>(Name, sp.GetRequiredService<TDep>(), validation, failureMessage));
             return this;
         }
@@ -646,7 +646,7 @@ namespace Microsoft.Extensions.Options
         {
             ArgumentNullException.ThrowIfNull(validation);
 
-            Services.AddTransient<IAsyncValidateOptions<TOptions>>(sp =>
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
                 new AsyncValidateOptions<TOptions, TDep1, TDep2>(Name,
                     sp.GetRequiredService<TDep1>(),
                     sp.GetRequiredService<TDep2>(),
@@ -685,7 +685,7 @@ namespace Microsoft.Extensions.Options
         {
             ArgumentNullException.ThrowIfNull(validation);
 
-            Services.AddTransient<IAsyncValidateOptions<TOptions>>(sp =>
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
                 new AsyncValidateOptions<TOptions, TDep1, TDep2, TDep3>(Name,
                     sp.GetRequiredService<TDep1>(),
                     sp.GetRequiredService<TDep2>(),
@@ -729,7 +729,7 @@ namespace Microsoft.Extensions.Options
         {
             ArgumentNullException.ThrowIfNull(validation);
 
-            Services.AddTransient<IAsyncValidateOptions<TOptions>>(sp =>
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
                 new AsyncValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4>(Name,
                     sp.GetRequiredService<TDep1>(),
                     sp.GetRequiredService<TDep2>(),
@@ -778,7 +778,7 @@ namespace Microsoft.Extensions.Options
         {
             ArgumentNullException.ThrowIfNull(validation);
 
-            Services.AddTransient<IAsyncValidateOptions<TOptions>>(sp =>
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
                 new AsyncValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5>(Name,
                     sp.GetRequiredService<TDep1>(),
                     sp.GetRequiredService<TDep2>(),

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilderExtensions.cs
@@ -45,8 +45,15 @@ namespace Microsoft.Extensions.DependencyInjection
                         if (factory is OptionsFactory<TOptions> asyncFactory)
                         {
                             TOptions validated = await asyncFactory.CreateAsync(name, ct).ConfigureAwait(false);
-                            cache.TryRemove(name);
-                            cache.TryAdd(name, validated);
+                            if (cache is OptionsCache<TOptions> optionsCache)
+                            {
+                                optionsCache.AddOrReplace(name, validated);
+                            }
+                            else
+                            {
+                                cache.TryRemove(name);
+                                cache.TryAdd(name, validated);
+                            }
                         }
                         else
                         {

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,47 +26,35 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             ArgumentNullException.ThrowIfNull(optionsBuilder);
 
+            string name = optionsBuilder.Name;
+
             optionsBuilder.Services.TryAddTransient<IStartupValidator, StartupValidator>();
-            optionsBuilder.Services.TryAddTransient<IAsyncStartupValidator, StartupValidator>();
             optionsBuilder.Services.AddOptions<StartupValidatorOptions>()
-                .Configure<IOptionsMonitor<TOptions>>((vo, options) =>
+                .Configure<IOptionsMonitor<TOptions>, IOptionsFactory<TOptions>, IOptionsMonitorCache<TOptions>>((vo, monitor, factory, cache) =>
                 {
-                    // This adds an action that resolves the options value to force evaluation
-                    // We don't care about the result as duplicates are not important
-                    vo._validators[(typeof(TOptions), optionsBuilder.Name)] = () => options.Get(optionsBuilder.Name);
-                });
+                    // Sync path (custom sync-only IStartupValidator): force evaluation through the
+                    // monitor, which runs every validator (including an async validator's fail-fast
+                    // synchronous Validate) and populates the cache.
+                    vo._validators[(typeof(TOptions), name)] = () => monitor.Get(name);
 
-            // Register async validator entries if any IAsyncValidateOptions<TOptions> are registered
-            optionsBuilder.Services.AddOptions<StartupValidatorOptions>()
-                .Configure<IOptionsMonitor<TOptions>, IEnumerable<IAsyncValidateOptions<TOptions>>>((vo, options, asyncValidators) =>
-                {
-                    // Materialize the validators into a list to check if any are registered
-                    var validators = new List<IAsyncValidateOptions<TOptions>>(asyncValidators);
-                    if (validators.Count > 0)
+                    // Async path: run the complete validation (both sync and async validators) for
+                    // this (type, name) and seed the monitor cache with the validated instance so the
+                    // first Get after startup returns it instead of re-running Create.
+                    vo._asyncValidators[(typeof(TOptions), name)] = async (CancellationToken ct) =>
                     {
-                        vo._asyncValidators[(typeof(TOptions), optionsBuilder.Name)] = async (CancellationToken ct) =>
+                        if (factory is OptionsFactory<TOptions> asyncFactory)
                         {
-                            // Retrieve the options value (already created by sync Validate() call)
-                            TOptions optionsValue = options.Get(optionsBuilder.Name);
-
-                            // Run async validators
-                            List<string>? failures = null;
-                            foreach (IAsyncValidateOptions<TOptions> validator in validators)
-                            {
-                                ValidateOptionsResult result = await validator.ValidateAsync(optionsBuilder.Name, optionsValue, ct).ConfigureAwait(false);
-                                if (result is not null && result.Failed)
-                                {
-                                    failures ??= new List<string>();
-                                    failures.AddRange(result.Failures);
-                                }
-                            }
-
-                            if (failures is not null && failures.Count > 0)
-                            {
-                                throw new OptionsValidationException(optionsBuilder.Name, typeof(TOptions), failures);
-                            }
-                        };
-                    }
+                            TOptions validated = await asyncFactory.CreateAsync(name, ct).ConfigureAwait(false);
+                            cache.TryRemove(name);
+                            cache.TryAdd(name, validated);
+                        }
+                        else
+                        {
+                            // Custom IOptionsFactory<TOptions>: no async validation path is available,
+                            // so fall back to synchronous evaluation (also populates the cache).
+                            monitor.Get(name);
+                        }
+                    };
                 });
 
             return optionsBuilder;

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilderExtensions.cs
@@ -28,7 +28,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
             string name = optionsBuilder.Name;
 
+            // Register the built-in validator as a single IStartupValidator (for back-compatibility)
+            // and as an enumerable IAsyncStartupValidator so the host can run it alongside any custom async validators.
             optionsBuilder.Services.TryAddTransient<IStartupValidator, StartupValidator>();
+            optionsBuilder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IAsyncStartupValidator, StartupValidator>());
             optionsBuilder.Services.AddOptions<StartupValidatorOptions>()
                 .Configure<IOptionsMonitor<TOptions>, IOptionsFactory<TOptions>, IOptionsMonitorCache<TOptions>>((vo, monitor, factory, cache) =>
                 {

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilderExtensions.cs
@@ -66,5 +66,34 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return optionsBuilder;
         }
+
+        /// <summary>
+        /// Enables eager asynchronous revalidation of the options whenever their configuration reloads, instead of the
+        /// default lazy revalidation on next access.
+        /// </summary>
+        /// <typeparam name="TOptions">The type of options.</typeparam>
+        /// <param name="optionsBuilder">The <see cref="OptionsBuilder{TOptions}"/> to configure.</param>
+        /// <param name="behavior">How reads are served when revalidation of a reloaded configuration fails.</param>
+        /// <param name="onError">An optional callback invoked with the options name and the exception when revalidation of a reloaded configuration fails.</param>
+        /// <returns>The <see cref="OptionsBuilder{TOptions}"/> so that additional calls can be chained.</returns>
+        /// <remarks>
+        /// On reload the options are re-created and validated in the background (running every registered validator,
+        /// awaiting asynchronous ones); the last successfully validated value keeps being served until the new value
+        /// validates, at which point it is swapped in atomically. This does not run startup validation; combine it with
+        /// <see cref="ValidateOnStart{TOptions}(OptionsBuilder{TOptions})"/> to also validate the initial value.
+        /// </remarks>
+        public static OptionsBuilder<TOptions> ValidateOnChange<TOptions>(
+            this OptionsBuilder<TOptions> optionsBuilder,
+            OptionsReloadValidationBehavior behavior = OptionsReloadValidationBehavior.KeepLastGood,
+            Action<string?, Exception>? onError = null)
+            where TOptions : class
+        {
+            ArgumentNullException.ThrowIfNull(optionsBuilder);
+
+            optionsBuilder.Services.AddOptions();
+            optionsBuilder.Services.AddSingleton(new ReloadValidationConfiguration<TOptions>(optionsBuilder.Name, behavior, onError));
+
+            return optionsBuilder;
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsCache.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsCache.cs
@@ -105,6 +105,31 @@ namespace Microsoft.Extensions.Options
         }
 
         /// <summary>
+        /// Adds or replaces a named options instance atomically.
+        /// </summary>
+        /// <param name="name">The name of the options instance.</param>
+        /// <param name="options">The options instance.</param>
+        internal void AddOrReplace(string? name, TOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+
+            name ??= Options.DefaultName;
+
+            if (GetType() != typeof(OptionsCache<TOptions>))
+            {
+                TryRemove(name);
+                TryAdd(name, options);
+                return;
+            }
+
+            _cache[name] = new Lazy<TOptions>(
+#if !(NET || NETSTANDARD2_1)
+                () =>
+#endif
+                options);
+        }
+
+        /// <summary>
         /// Tries to remove an options instance.
         /// </summary>
         /// <param name="name">The name of the options instance.</param>

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsEventSource.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.Extensions.Options
+{
+    [EventSource(Name = "Microsoft-Extensions-Options")]
+    internal sealed partial class OptionsEventSource : EventSource
+    {
+        public static readonly OptionsEventSource Log = new OptionsEventSource();
+
+        [Event(1, Level = EventLevel.Error)]
+        public void ReloadValidationFailed(string optionsName, string optionsType, string exception)
+        {
+            WriteEvent(1, optionsName, optionsType, exception);
+        }
+
+        [NonEvent]
+        public void ReloadValidationFailed(string? optionsName, Type optionsType, Exception exception)
+        {
+            if (IsEnabled(EventLevel.Error, EventKeywords.All))
+            {
+                ReloadValidationFailed(optionsName ?? string.Empty, optionsType.ToString(), exception.ToString());
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.Options
         private readonly IConfigureOptions<TOptions>[] _setups;
         private readonly IPostConfigureOptions<TOptions>[] _postConfigures;
         private readonly IValidateOptions<TOptions>[] _validations;
+        private readonly bool _hasAsyncOnlyValidators;
 
         /// <summary>
         /// Initializes a new instance with the specified options configurations.
@@ -48,6 +49,27 @@ namespace Microsoft.Extensions.Options
         }
 
         /// <summary>
+        /// Initializes a new instance with the specified options configurations.
+        /// </summary>
+        /// <param name="setups">The configuration actions to run.</param>
+        /// <param name="postConfigures">The initialization actions to run.</param>
+        /// <param name="validations">The validations to run.</param>
+        /// <param name="asyncValidations">Services registered as <see cref="IAsyncValidateOptions{TOptions}"/>, used to detect an invalid registration.</param>
+        /// <exception cref="InvalidOperationException">A validator is registered only as <see cref="IAsyncValidateOptions{TOptions}"/> and not as <see cref="IValidateOptions{TOptions}"/>.</exception>
+        public OptionsFactory(IEnumerable<IConfigureOptions<TOptions>> setups, IEnumerable<IPostConfigureOptions<TOptions>> postConfigures, IEnumerable<IValidateOptions<TOptions>> validations, IEnumerable<IAsyncValidateOptions<TOptions>> asyncValidations)
+            : this(setups, postConfigures, validations)
+        {
+            // Any service resolved here is registered only as the IAsyncValidateOptions<TOptions> interface,
+            // which is an invalid registration. Synchronous paths enumerate IValidateOptions<TOptions> and would never see it.
+            // The error is surfaced when the options are created via Create or CreateAsync.
+            foreach (IAsyncValidateOptions<TOptions> _ in asyncValidations)
+            {
+                _hasAsyncOnlyValidators = true;
+                break;
+            }
+        }
+
+        /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
@@ -56,6 +78,8 @@ namespace Microsoft.Extensions.Options
         /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         public TOptions Create(string name)
         {
+            ThrowIfAsyncOnlyValidatorRegistered();
+
             TOptions options = CreateAndConfigure(name);
 
             if (_validations.Length > 0)
@@ -76,6 +100,8 @@ namespace Microsoft.Extensions.Options
         /// </summary>
         internal async Task<TOptions> CreateAsync(string name, CancellationToken cancellationToken)
         {
+            ThrowIfAsyncOnlyValidatorRegistered();
+
             TOptions options = CreateAndConfigure(name);
 
             if (_validations.Length > 0)
@@ -133,6 +159,18 @@ namespace Microsoft.Extensions.Options
                 throw new OptionsValidationException(name, typeof(TOptions), failures);
             }
         }
+
+        private void ThrowIfAsyncOnlyValidatorRegistered()
+        {
+            if (_hasAsyncOnlyValidators)
+            {
+                throw new InvalidOperationException(SR.Format(SR.AsyncOnlyValidatorRegistration, typeof(TOptions)));
+            }
+        }
+
+        /// <summary>
+        /// Creates a new instance of type <typeparamref name="TOptions"/>.
+        /// </summary>
         /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
         /// <returns>The created <typeparamref name="TOptions"/> instance.</returns>
         /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Options
 {
@@ -54,6 +56,49 @@ namespace Microsoft.Extensions.Options
         /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         public TOptions Create(string name)
         {
+            TOptions options = CreateAndConfigure(name);
+
+            if (_validations.Length > 0)
+            {
+                List<string>? failures = null;
+                foreach (IValidateOptions<TOptions> validate in _validations)
+                {
+                    CollectFailures(ref failures, validate.Validate(name, options));
+                }
+                ThrowIfValidationFailed(name, failures);
+            }
+
+            return options;
+        }
+
+        /// <summary>
+        /// Creates, configures, and asynchronously validates a <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
+        /// </summary>
+        internal async Task<TOptions> CreateAsync(string name, CancellationToken cancellationToken)
+        {
+            TOptions options = CreateAndConfigure(name);
+
+            if (_validations.Length > 0)
+            {
+                List<string>? failures = null;
+                foreach (IValidateOptions<TOptions> validate in _validations)
+                {
+                    // Dispatch in registration order depending on capability:
+                    // async validators are awaited, all others run synchronously.
+                    ValidateOptionsResult result = validate is IAsyncValidateOptions<TOptions> asyncValidate
+                        ? await asyncValidate.ValidateAsync(name, options, cancellationToken).ConfigureAwait(false)
+                        : validate.Validate(name, options);
+
+                    CollectFailures(ref failures, result);
+                }
+                ThrowIfValidationFailed(name, failures);
+            }
+
+            return options;
+        }
+
+        private TOptions CreateAndConfigure(string name)
+        {
             TOptions options = CreateInstance(name);
             foreach (IConfigureOptions<TOptions> setup in _setups)
             {
@@ -70,30 +115,24 @@ namespace Microsoft.Extensions.Options
             {
                 post.PostConfigure(name, options);
             }
-
-            if (_validations.Length > 0)
-            {
-                var failures = new List<string>();
-                foreach (IValidateOptions<TOptions> validate in _validations)
-                {
-                    ValidateOptionsResult result = validate.Validate(name, options);
-                    if (result is not null && result.Failed)
-                    {
-                        failures.AddRange(result.Failures);
-                    }
-                }
-                if (failures.Count > 0)
-                {
-                    throw new OptionsValidationException(name, typeof(TOptions), failures);
-                }
-            }
-
             return options;
         }
 
-        /// <summary>
-        /// Creates a new instance of type <typeparamref name="TOptions"/>.
-        /// </summary>
+        private static void CollectFailures(ref List<string>? failures, ValidateOptionsResult? result)
+        {
+            if (result is not null && result.Failed)
+            {
+                (failures ??= new List<string>()).AddRange(result.Failures);
+            }
+        }
+
+        private static void ThrowIfValidationFailed(string name, List<string>? failures)
+        {
+            if (failures is { Count: > 0 })
+            {
+                throw new OptionsValidationException(name, typeof(TOptions), failures);
+            }
+        }
         /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
         /// <returns>The created <typeparamref name="TOptions"/> instance.</returns>
         /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Extensions.Options
         private readonly IPostConfigureOptions<TOptions>[] _postConfigures;
         private readonly IValidateOptions<TOptions>[] _validations;
         private readonly bool _hasAsyncOnlyValidators;
+        private readonly bool _hasAsyncValidators;
 
         /// <summary>
         /// Initializes a new instance with the specified options configurations.
@@ -46,6 +47,15 @@ namespace Microsoft.Extensions.Options
             _setups = setups as IConfigureOptions<TOptions>[] ?? new List<IConfigureOptions<TOptions>>(setups).ToArray();
             _postConfigures = postConfigures as IPostConfigureOptions<TOptions>[] ?? new List<IPostConfigureOptions<TOptions>>(postConfigures).ToArray();
             _validations = validations as IValidateOptions<TOptions>[] ?? new List<IValidateOptions<TOptions>>(validations).ToArray();
+
+            foreach (IValidateOptions<TOptions> validation in _validations)
+            {
+                if (validation is IAsyncValidateOptions<TOptions>)
+                {
+                    _hasAsyncValidators = true;
+                    break;
+                }
+            }
         }
 
         /// <summary>
@@ -68,6 +78,11 @@ namespace Microsoft.Extensions.Options
                 break;
             }
         }
+
+        // True when at least one validator registered as IValidateOptions<TOptions> also implements
+        // IAsyncValidateOptions<TOptions>, so a synchronous Create may fail for a genuinely-asynchronous validator.
+        // Used by the options managers to prefer a startup-validated value over re-running synchronous validation.
+        internal bool HasAsyncValidators => _hasAsyncValidators;
 
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsManager.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsManager.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.Options
     {
         private readonly IOptionsFactory<TOptions> _factory;
         private readonly OptionsCache<TOptions> _cache = new OptionsCache<TOptions>(); // Note: this is a private cache
+        private readonly IOptionsMonitorCache<TOptions>? _validatedCache;
 
         /// <summary>
         /// Initializes a new instance with the specified options configurations.
@@ -25,6 +26,22 @@ namespace Microsoft.Extensions.Options
         public OptionsManager(IOptionsFactory<TOptions> factory)
         {
             _factory = factory;
+        }
+
+        /// <summary>
+        /// Initializes a new instance with the specified options factory and shared validated cache.
+        /// </summary>
+        /// <param name="factory">The factory to use to create options.</param>
+        /// <param name="validatedCache">The shared cache holding options instances validated during startup.</param>
+        public OptionsManager(IOptionsFactory<TOptions> factory, IOptionsMonitorCache<TOptions> validatedCache)
+            : this(factory)
+        {
+            // Only consult the shared validated cache for types that have an asynchronous validator.
+            // Sync-only types keep the existing per-scope behavior of creating and validating synchronously.
+            if (factory is OptionsFactory<TOptions> optionsFactory && optionsFactory.HasAsyncValidators)
+            {
+                _validatedCache = validatedCache;
+            }
         }
 
         /// <summary>
@@ -48,10 +65,24 @@ namespace Microsoft.Extensions.Options
                 // Store the options in our instance cache. Avoid closure on fast path by storing state into scoped locals.
                 IOptionsFactory<TOptions> localFactory = _factory;
                 string localName = name;
-                options = _cache.GetOrAdd(name, () => localFactory.Create(localName));
+                IOptionsMonitorCache<TOptions>? localValidatedCache = _validatedCache;
+                options = _cache.GetOrAdd(name, () => CreateValue(localFactory, localName, localValidatedCache));
             }
 
             return options;
+        }
+
+        private static TOptions CreateValue(IOptionsFactory<TOptions> factory, string name, IOptionsMonitorCache<TOptions>? validatedCache)
+        {
+            // For an async-validated type, prefer the value validated during startup (seeded into the shared cache) so a
+            // synchronous snapshot returns the last validated value instead of re-running the throwing synchronous Validate.
+            // If nothing has been validated yet, fall back to Create, which fails fast with an actionable message.
+            if (validatedCache is OptionsCache<TOptions> optionsCache && optionsCache.TryGetValue(name, out TOptions? validated))
+            {
+                return validated;
+            }
+
+            return factory.Create(name);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsManager.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsManager.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Extensions.Options
     {
         private readonly IOptionsFactory<TOptions> _factory;
         private readonly OptionsCache<TOptions> _cache = new OptionsCache<TOptions>(); // Note: this is a private cache
-        private readonly IOptionsMonitorCache<TOptions>? _validatedCache;
 
         /// <summary>
         /// Initializes a new instance with the specified options configurations.
@@ -26,22 +25,6 @@ namespace Microsoft.Extensions.Options
         public OptionsManager(IOptionsFactory<TOptions> factory)
         {
             _factory = factory;
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the specified options factory and shared validated cache.
-        /// </summary>
-        /// <param name="factory">The factory to use to create options.</param>
-        /// <param name="validatedCache">The shared cache holding options instances validated during startup.</param>
-        public OptionsManager(IOptionsFactory<TOptions> factory, IOptionsMonitorCache<TOptions> validatedCache)
-            : this(factory)
-        {
-            // Only consult the shared validated cache for types that have an asynchronous validator.
-            // Sync-only types keep the existing per-scope behavior of creating and validating synchronously.
-            if (factory is OptionsFactory<TOptions> optionsFactory && optionsFactory.HasAsyncValidators)
-            {
-                _validatedCache = validatedCache;
-            }
         }
 
         /// <summary>
@@ -65,24 +48,10 @@ namespace Microsoft.Extensions.Options
                 // Store the options in our instance cache. Avoid closure on fast path by storing state into scoped locals.
                 IOptionsFactory<TOptions> localFactory = _factory;
                 string localName = name;
-                IOptionsMonitorCache<TOptions>? localValidatedCache = _validatedCache;
-                options = _cache.GetOrAdd(name, () => CreateValue(localFactory, localName, localValidatedCache));
+                options = _cache.GetOrAdd(name, () => localFactory.Create(localName));
             }
 
             return options;
-        }
-
-        private static TOptions CreateValue(IOptionsFactory<TOptions> factory, string name, IOptionsMonitorCache<TOptions>? validatedCache)
-        {
-            // For an async-validated type, prefer the value validated during startup (seeded into the shared cache) so a
-            // synchronous snapshot returns the last validated value instead of re-running the throwing synchronous Validate.
-            // If nothing has been validated yet, fall back to Create, which fails fast with an actionable message.
-            if (validatedCache is OptionsCache<TOptions> optionsCache && optionsCache.TryGetValue(name, out TOptions? validated))
-            {
-                return validated;
-            }
-
-            return factory.Create(name);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Extensions.Options
 
         private async Task RefreshAsync(string name, ReloadValidationConfiguration<TOptions> config, EagerReloadState state, int generation, CancellationToken cancellationToken)
         {
+            TOptions? published = null;
             try
             {
                 TOptions validated = _factory is OptionsFactory<TOptions> asyncFactory
@@ -150,13 +151,14 @@ namespace Microsoft.Extensions.Options
                         _cache.TryRemove(name);
                         _cache.TryAdd(name, validated);
                     }
-                }
 
-                _onChange?.Invoke(validated, name);
+                    published = validated;
+                }
             }
             catch (OperationCanceledException)
             {
                 // Superseded by a newer reload (or disposal); nothing to publish.
+                return;
             }
             catch (Exception ex)
             {
@@ -174,7 +176,21 @@ namespace Microsoft.Extensions.Options
                     }
                 }
 
-                config.OnError?.Invoke(name, ex);
+                try
+                {
+                    config.OnError?.Invoke(name, ex);
+                }
+                catch
+                {
+                    // The error callback is user code. We catch here to prevent an unobserved task exception.
+                }
+
+                return;
+            }
+
+            if (published is not null)
+            {
+                _onChange?.Invoke(published, name);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
@@ -176,6 +176,10 @@ namespace Microsoft.Extensions.Options
                     }
                 }
 
+                // Always surface the failure through the event source so a reload failure is observable even when no
+                // error callback was supplied. This is independent of the user callback below.
+                OptionsEventSource.Log.ReloadValidationFailed(name, typeof(TOptions), ex);
+
                 try
                 {
                     config.OnError?.Invoke(name, ex);

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Options
@@ -20,6 +23,8 @@ namespace Microsoft.Extensions.Options
         private readonly IOptionsMonitorCache<TOptions> _cache;
         private readonly IOptionsFactory<TOptions> _factory;
         private readonly List<IDisposable> _registrations = new List<IDisposable>();
+        private readonly Dictionary<string, ReloadValidationConfiguration<TOptions>>? _reloadConfigs;
+        private readonly ConcurrentDictionary<string, EagerReloadState>? _eagerStates;
         internal event Action<TOptions, string>? _onChange;
 
         /// <summary>
@@ -29,9 +34,32 @@ namespace Microsoft.Extensions.Options
         /// <param name="sources">The sources used to listen for changes to the options instance.</param>
         /// <param name="cache">The cache used to store options.</param>
         public OptionsMonitor(IOptionsFactory<TOptions> factory, IEnumerable<IOptionsChangeTokenSource<TOptions>> sources, IOptionsMonitorCache<TOptions> cache)
+            : this(factory, sources, cache, reloadValidationConfigs: Array.Empty<ReloadValidationConfiguration<TOptions>>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="OptionsMonitor{TOptions}"/> with the specified factory, sources, cache, and reload-validation opt-ins.
+        /// </summary>
+        /// <param name="factory">The factory to use to create options.</param>
+        /// <param name="sources">The sources used to listen for changes to the options instance.</param>
+        /// <param name="cache">The cache used to store options.</param>
+        /// <param name="reloadValidationConfigs">The reload-validation opt-ins registered through the <c>ValidateOnChange</c> options-builder extension.</param>
+        public OptionsMonitor(IOptionsFactory<TOptions> factory, IEnumerable<IOptionsChangeTokenSource<TOptions>> sources, IOptionsMonitorCache<TOptions> cache, IEnumerable<ReloadValidationConfiguration<TOptions>> reloadValidationConfigs)
         {
             _factory = factory;
             _cache = cache;
+
+            foreach (ReloadValidationConfiguration<TOptions> config in reloadValidationConfigs)
+            {
+                // The last opt-in for a given name wins, mirroring the "greediest configuration wins" behavior elsewhere.
+                (_reloadConfigs ??= new Dictionary<string, ReloadValidationConfiguration<TOptions>>(StringComparer.Ordinal))[config.Name] = config;
+            }
+
+            if (_reloadConfigs is not null)
+            {
+                _eagerStates = new ConcurrentDictionary<string, EagerReloadState>(StringComparer.Ordinal);
+            }
 
             void RegisterSource(IOptionsChangeTokenSource<TOptions> source)
             {
@@ -64,9 +92,90 @@ namespace Microsoft.Extensions.Options
         private void InvokeChanged(string? name)
         {
             name ??= Options.DefaultName;
+
+            if (_reloadConfigs is not null && _reloadConfigs.TryGetValue(name, out ReloadValidationConfiguration<TOptions>? config))
+            {
+                // Eager revalidation: keep serving the last validated value while the reloaded configuration is
+                // re-created and validated in the background, then swap it in only if validation succeeds.
+                InvokeEagerReload(name, config);
+                return;
+            }
+
             _cache.TryRemove(name);
             TOptions options = Get(name);
             _onChange?.Invoke(options, name);
+        }
+
+        private void InvokeEagerReload(string name, ReloadValidationConfiguration<TOptions> config)
+        {
+            EagerReloadState state = _eagerStates!.GetOrAdd(name, static _ => new EagerReloadState());
+
+            int generation;
+            CancellationToken cancellationToken;
+            lock (state)
+            {
+                // Latest-wins: supersede any in-flight refresh for this name so only the newest reload publishes.
+                state.Cancel();
+                state.Cts = new CancellationTokenSource();
+                cancellationToken = state.Cts.Token;
+                generation = ++state.Generation;
+            }
+
+            _ = RefreshAsync(name, config, state, generation, cancellationToken);
+        }
+
+        private async Task RefreshAsync(string name, ReloadValidationConfiguration<TOptions> config, EagerReloadState state, int generation, CancellationToken cancellationToken)
+        {
+            try
+            {
+                TOptions validated = _factory is OptionsFactory<TOptions> asyncFactory
+                    ? await asyncFactory.CreateAsync(name, cancellationToken).ConfigureAwait(false)
+                    : _factory.Create(name);
+
+                lock (state)
+                {
+                    // Re-check under the lock and publish atomically so a superseded reload can never overwrite a newer
+                    // published value (the generation check and the cache write must not be interleaved with another reload).
+                    if (state.Generation != generation)
+                    {
+                        return;
+                    }
+
+                    if (_cache is OptionsCache<TOptions> optionsCache)
+                    {
+                        optionsCache.AddOrReplace(name, validated);
+                    }
+                    else
+                    {
+                        _cache.TryRemove(name);
+                        _cache.TryAdd(name, validated);
+                    }
+                }
+
+                _onChange?.Invoke(validated, name);
+            }
+            catch (OperationCanceledException)
+            {
+                // Superseded by a newer reload (or disposal); nothing to publish.
+            }
+            catch (Exception ex)
+            {
+                lock (state)
+                {
+                    if (state.Generation != generation)
+                    {
+                        return;
+                    }
+
+                    if (config.Behavior == OptionsReloadValidationBehavior.FailReads)
+                    {
+                        // Drop the cached value so the next read re-creates and surfaces the failure.
+                        _cache.TryRemove(name);
+                    }
+                }
+
+                config.OnError?.Invoke(name, ex);
+            }
         }
 
         /// <summary>
@@ -125,6 +234,35 @@ namespace Microsoft.Extensions.Options
             }
 
             _registrations.Clear();
+
+            if (_eagerStates is not null)
+            {
+                // Cancel any in-flight eager revalidation so a superseded refresh does not publish after disposal.
+                foreach (EagerReloadState state in _eagerStates.Values)
+                {
+                    lock (state)
+                    {
+                        state.Cancel();
+                    }
+                }
+            }
+        }
+
+        private sealed class EagerReloadState
+        {
+            public int Generation;
+            public CancellationTokenSource? Cts;
+
+            public void Cancel()
+            {
+                CancellationTokenSource? cts = Cts;
+                if (cts is not null)
+                {
+                    cts.Cancel();
+                    cts.Dispose();
+                    Cts = null;
+                }
+            }
         }
 
         internal sealed class ChangeTrackerDisposable : IDisposable

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
@@ -155,9 +155,11 @@ namespace Microsoft.Extensions.Options
                     published = validated;
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                // Superseded by a newer reload (or disposal); nothing to publish.
+                // Our token was canceled: superseded by a newer reload (or disposal).
+                // A cancellation that does not originate from our token (e.g. a validator's own timeout) falls
+                // through to the general handler below and is treated as a genuine reload failure.
                 return;
             }
             catch (Exception ex)
@@ -194,7 +196,17 @@ namespace Microsoft.Extensions.Options
 
             if (published is not null)
             {
-                _onChange?.Invoke(published, name);
+                try
+                {
+                    _onChange?.Invoke(published, name);
+                }
+                catch
+                {
+                    // Change listeners are user code. RefreshAsync runs as a fire-and-forget task, so a throwing
+                    // listener must be swallowed here to avoid faulting that task (an unobserved task exception).
+                    // A listener throwing is a listener bug and is not a reload failure, so it is not surfaced
+                    // through the failure channels above.
+                }
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
@@ -269,12 +269,14 @@ namespace Microsoft.Extensions.Options
 
             if (_eagerStates is not null)
             {
-                // Cancel any in-flight eager revalidation so a superseded refresh does not publish after disposal.
+                // Cancel any in-flight eager revalidation and bump the generation so a refresh that ignores the
+                // cancellation token still fails the generation check and does not publish after disposal.
                 foreach (EagerReloadState state in _eagerStates.Values)
                 {
                     lock (state)
                     {
                         state.Cancel();
+                        state.Generation++;
                     }
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsReloadValidationBehavior.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsReloadValidationBehavior.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Controls how an <see cref="IOptionsMonitor{TOptions}"/> serves values when asynchronous revalidation of a
+    /// reloaded configuration fails, for options that opted in through the <c>ValidateOnChange</c> options-builder extension.
+    /// </summary>
+    public enum OptionsReloadValidationBehavior
+    {
+        /// <summary>
+        /// Keeps serving the last successfully validated value and reports the failure through the error callback.
+        /// </summary>
+        KeepLastGood,
+
+        /// <summary>
+        /// Clears the cached value so the next read re-creates and validates it, surfacing the failure to the reader.
+        /// </summary>
+        FailReads,
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsReloadValidationBehavior.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsReloadValidationBehavior.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Extensions.Options
     public enum OptionsReloadValidationBehavior
     {
         /// <summary>
-        /// Keeps serving the last successfully validated value and reports the failure through the error callback.
+        /// Keeps serving the last successfully validated value.
+        /// The failure is reported to the <c>Microsoft-Extensions-Options</c> event source
+        /// and, if one was supplied, to the error callback.
         /// </summary>
         KeepLastGood,
 

--- a/src/libraries/Microsoft.Extensions.Options/src/ReloadValidationConfiguration.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/ReloadValidationConfiguration.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Represents a single opt-in to eager asynchronous revalidation on configuration reload for a named
+    /// <typeparamref name="TOptions"/> instance, as registered by the <c>ValidateOnChange</c> options-builder extension.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type this registration applies to.</typeparam>
+    public sealed class ReloadValidationConfiguration<TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReloadValidationConfiguration{TOptions}"/> class.
+        /// </summary>
+        /// <param name="name">The name of the options instance to revalidate on reload.</param>
+        /// <param name="behavior">How reads are served when revalidation of a reloaded configuration fails.</param>
+        /// <param name="onError">An optional callback invoked with the options name and the exception when revalidation of a reloaded configuration fails.</param>
+        public ReloadValidationConfiguration(string name, OptionsReloadValidationBehavior behavior, Action<string?, Exception>? onError)
+        {
+            Name = name;
+            Behavior = behavior;
+            OnError = onError;
+        }
+
+        /// <summary>
+        /// Gets the name of the options instance to revalidate on reload.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets a value that indicates how reads are served when revalidation of a reloaded configuration fails.
+        /// </summary>
+        public OptionsReloadValidationBehavior Behavior { get; }
+
+        /// <summary>
+        /// Gets the callback invoked with the options name and the exception when revalidation of a reloaded configuration fails.
+        /// </summary>
+        public Action<string?, Exception>? OnError { get; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Options/src/ReloadValidationConfiguration.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/ReloadValidationConfiguration.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Extensions.Options
         /// <param name="onError">An optional callback invoked with the options name and the exception when revalidation of a reloaded configuration fails.</param>
         public ReloadValidationConfiguration(string name, OptionsReloadValidationBehavior behavior, Action<string?, Exception>? onError)
         {
+            ArgumentNullException.ThrowIfNull(name);
+
             Name = name;
             Behavior = behavior;
             OnError = onError;

--- a/src/libraries/Microsoft.Extensions.Options/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/src/Resources/Strings.resx
@@ -139,6 +139,6 @@
     <value>Options instance of type '{0}' is validated by an asynchronous validator that cannot run during synchronous validation. Validate these options asynchronously before accessing them synchronously.</value>
   </data>
   <data name="AsyncOnlyValidatorRegistration" xml:space="preserve">
-    <value>A validator for options type '{0}' is registered only as 'IAsyncValidateOptions&lt;TOptions&gt;'. Register it as 'IValidateOptions&lt;TOptions&gt;' instead.</value>
+    <value>A validator for options type '{0}' is registered as 'IAsyncValidateOptions&lt;TOptions&gt;'. Register it as 'IValidateOptions&lt;TOptions&gt;' instead.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/src/Resources/Strings.resx
@@ -135,4 +135,7 @@
   <data name="Error_NoConfigurationServicesAndAction" xml:space="preserve">
     <value>No IConfigureOptions&lt;&gt;, IPostConfigureOptions&lt;&gt;, or IValidateOptions&lt;&gt; implementations were found, did you mean to call Configure&lt;&gt; or PostConfigure&lt;&gt;?</value>
   </data>
+  <data name="AsyncValidatorSyncValidationUnsupported" xml:space="preserve">
+    <value>Options instance of type '{0}' is validated by an asynchronous validator that cannot run during synchronous validation. Validate these options asynchronously before accessing them synchronously.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/src/Resources/Strings.resx
@@ -138,4 +138,7 @@
   <data name="AsyncValidatorSyncValidationUnsupported" xml:space="preserve">
     <value>Options instance of type '{0}' is validated by an asynchronous validator that cannot run during synchronous validation. Validate these options asynchronously before accessing them synchronously.</value>
   </data>
+  <data name="AsyncOnlyValidatorRegistration" xml:space="preserve">
+    <value>A validator for options type '{0}' is registered only as 'IAsyncValidateOptions&lt;TOptions&gt;'. Register it as 'IValidateOptions&lt;TOptions&gt;' instead.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/src/StartupValidatorOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/StartupValidatorOptions.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Extensions.Options
         // Maps each pair of a) options type and b) options name to a method that forces its evaluation, e.g. IOptionsMonitor<TOptions>.Get(name)
         public Dictionary<(Type, string), Action> _validators { get; } = new Dictionary<(Type, string), Action>();
 
-        // Maps each pair of a) options type and b) options name to an async method that forces evaluation and runs async validators
+        // Maps each pair of a) options type and b) options name to an async method that runs the complete
+        // validation (synchronous and asynchronous validators) and seeds the monitor cache with the result
         public Dictionary<(Type, string), Func<CancellationToken, Task>> _asyncValidators { get; } = new Dictionary<(Type, string), Func<CancellationToken, Task>>();
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/UnnamedOptionsManager.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/UnnamedOptionsManager.cs
@@ -11,10 +11,23 @@ namespace Microsoft.Extensions.Options
         where TOptions : class
     {
         private readonly IOptionsFactory<TOptions> _factory;
+        private readonly IOptionsMonitorCache<TOptions>? _validatedCache;
         private object? _syncObj;
         private volatile TOptions? _value;
 
         public UnnamedOptionsManager(IOptionsFactory<TOptions> factory) => _factory = factory;
+
+        public UnnamedOptionsManager(IOptionsFactory<TOptions> factory, IOptionsMonitorCache<TOptions> cache)
+        {
+            _factory = factory;
+
+            // Only consult the shared validated cache for types that have an asynchronous validator; sync-only types
+            // keep the existing behavior of creating and validating synchronously.
+            if (factory is OptionsFactory<TOptions> optionsFactory && optionsFactory.HasAsyncValidators)
+            {
+                _validatedCache = cache;
+            }
+        }
 
         public TOptions Value
         {
@@ -27,9 +40,23 @@ namespace Microsoft.Extensions.Options
 
                 lock (_syncObj ?? Interlocked.CompareExchange(ref _syncObj, new object(), null) ?? _syncObj)
                 {
-                    return _value ??= _factory.Create(Options.DefaultName);
+                    return _value ??= CreateValue();
                 }
             }
+        }
+
+        private TOptions CreateValue()
+        {
+            // For an async-validated type, prefer the value validated during startup (seeded into the shared cache) so a
+            // synchronous access returns the last validated value instead of re-running the throwing synchronous Validate.
+            // If nothing has been validated yet (no host, pre-startup, or no ValidateOnStart), fall back to Create, which
+            // fails fast with an actionable message.
+            if (_validatedCache is OptionsCache<TOptions> optionsCache && optionsCache.TryGetValue(Options.DefaultName, out TOptions? validated))
+            {
+                return validated;
+            }
+
+            return _factory.Create(Options.DefaultName);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/ValidateOnStart.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/ValidateOnStart.cs
@@ -55,8 +55,6 @@ namespace Microsoft.Extensions.Options
 
         public async Task ValidateAsync(CancellationToken cancellationToken = default)
         {
-            // Async validators only — sync validation is handled separately by
-            // IStartupValidator.Validate() in Host.StartAsync() (two-stage orchestration).
             List<Exception>? exceptions = null;
 
             foreach (Func<CancellationToken, Task> asyncValidator in _validatorOptions._asyncValidators.Values)

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -300,6 +300,62 @@ namespace Microsoft.Extensions.Options.Tests
             Assert.False(spy.SyncCalled);
         }
 
+        [Fact]
+        public void MisregisteredAsyncOnlyValidator_ThrowsClearErrorOnSyncAccess()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>();
+            // Misregistration: registered only as the IAsyncValidateOptions<T> capability interface.
+            services.AddSingleton<IAsyncValidateOptions<FakeOptions>>(
+                new AsyncValidateOptions<FakeOptions>(null, (o, ct) => Task.FromResult(false), "async fail"));
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => sp.GetRequiredService<IOptions<FakeOptions>>().Value);
+
+            Assert.Contains(nameof(FakeOptions), ex.Message);
+            Assert.Contains(nameof(IValidateOptions<FakeOptions>), ex.Message);
+        }
+
+        [Fact]
+        public async Task MisregisteredAsyncOnlyValidator_ThrowsClearErrorOnStartup()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>().ValidateOnStart();
+            services.AddSingleton<IAsyncValidateOptions<FakeOptions>>(
+                new AsyncValidateOptions<FakeOptions>(null, (o, ct) => Task.FromResult(false), "async fail"));
+            using ServiceProvider sp = services.BuildServiceProvider();
+            IAsyncStartupValidator validator = GetAsyncStartupValidator(sp);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => validator.ValidateAsync(CancellationToken.None));
+        }
+
+        [Fact]
+        public void CorrectlyRegisteredAsyncValidator_DoesNotThrowMisregistrationError()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>().Configure(o => o.Message = "ok");
+            // Correct: an async-capable validator registered through IValidateOptions<T>.
+            services.AddSingleton<IValidateOptions<FakeOptions>>(new CapabilitySpyValidator());
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            FakeOptions value = sp.GetRequiredService<IOptions<FakeOptions>>().Value;
+
+            Assert.Equal("ok", value.Message);
+        }
+
+        [Fact]
+        public void NoAsyncValidators_DoesNotThrowMisregistrationError()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>().Configure(o => o.Message = "ok");
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            FakeOptions value = sp.GetRequiredService<IOptions<FakeOptions>>().Value;
+
+            Assert.Equal("ok", value.Message);
+        }
+
         private class CustomSyncOnlyValidator : IStartupValidator
         {
             public void Validate() { }

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Microsoft.Extensions.Options.Tests
@@ -354,6 +355,217 @@ namespace Microsoft.Extensions.Options.Tests
             FakeOptions value = sp.GetRequiredService<IOptions<FakeOptions>>().Value;
 
             Assert.Equal("ok", value.Message);
+        }
+
+        // ---- Phase 8: opt-in async reload revalidation (ValidateOnChange) ----
+
+        [Fact]
+        public void Phase8_ValidReload_PublishesNewValidatedValueAndNotifies()
+        {
+            var source = new ReloadSource();
+            var validator = new ReloadTestValidator();
+            int configureCount = 0;
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = $"v{Interlocked.Increment(ref configureCount)}")
+                .ValidateOnChange();
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "seed");
+            IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+            Assert.Equal("seed", monitor.CurrentValue.Message);
+
+            using var changed = new ManualResetEventSlim();
+            string? notified = null;
+            using IDisposable _ = monitor.OnChange((o, n) => { notified = o.Message; changed.Set(); });
+
+            source.Trigger();
+
+            Assert.True(changed.Wait(TimeSpan.FromSeconds(30)), "The change notification was not raised.");
+            Assert.NotEqual("seed", monitor.CurrentValue.Message);
+            Assert.Equal(monitor.CurrentValue.Message, notified);
+        }
+
+        [Fact]
+        public void Phase8_InvalidReload_KeepLastGood_ServesLastGoodAndReportsError()
+        {
+            var source = new ReloadSource();
+            var validator = new ReloadTestValidator { Fail = true };
+            var services = new ServiceCollection();
+            using var errored = new ManualResetEventSlim();
+            Exception? reportedError = null;
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "reloaded")
+                .ValidateOnChange(OptionsReloadValidationBehavior.KeepLastGood, (name, ex) => { reportedError = ex; errored.Set(); });
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "good");
+            IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            bool changeFired = false;
+            using IDisposable _ = monitor.OnChange((o, n) => changeFired = true);
+
+            source.Trigger();
+
+            Assert.True(errored.Wait(TimeSpan.FromSeconds(30)), "The error callback was not invoked.");
+            Assert.IsType<OptionsValidationException>(reportedError);
+            // The last validated value keeps being served, and no change notification is raised for a failed reload.
+            Assert.Equal("good", monitor.CurrentValue.Message);
+            Assert.False(changeFired);
+        }
+
+        [Fact]
+        public void Phase8_InvalidReload_FailReads_NextReadThrows()
+        {
+            var source = new ReloadSource();
+            var validator = new ReloadTestValidator { Fail = true };
+            var services = new ServiceCollection();
+            using var errored = new ManualResetEventSlim();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "reloaded")
+                .ValidateOnChange(OptionsReloadValidationBehavior.FailReads, (name, ex) => errored.Set());
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "good");
+            IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            source.Trigger();
+
+            Assert.True(errored.Wait(TimeSpan.FromSeconds(30)), "The error callback was not invoked.");
+            // FailReads dropped the cached value, so the next read re-creates and surfaces the failure.
+            Assert.Throws<OptionsValidationException>(() => monitor.CurrentValue);
+        }
+
+        [Fact]
+        public void Phase8_DefaultMonitorWithoutOptIn_UsesLazyRevalidation()
+        {
+            var source = new ReloadSource();
+            int configureCount = 0;
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = $"v{Interlocked.Increment(ref configureCount)}");
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+            IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            Assert.Equal("v1", monitor.CurrentValue.Message);
+
+            // Without ValidateOnChange the default lazy behavior clears the cache and re-creates on the next read.
+            source.Trigger();
+            Assert.Equal("v2", monitor.CurrentValue.Message);
+        }
+
+        [Fact]
+        public void Phase8_RapidReloads_LatestWins()
+        {
+            var source = new ReloadSource();
+            var validator = new ReloadTestValidator();
+            var firstGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            validator.Gate = firstGate.Task;
+            int configureCount = 0;
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = $"v{Interlocked.Increment(ref configureCount)}")
+                .ValidateOnChange();
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "seed");
+            IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            using var secondChanged = new ManualResetEventSlim();
+            string? lastNotified = null;
+            using IDisposable _ = monitor.OnChange((o, n) => { lastNotified = o.Message; secondChanged.Set(); });
+
+            // First reload blocks in ValidateAsync on the gate.
+            source.Trigger();
+            // Second reload supersedes the first and completes (its gate was cleared before it started).
+            validator.Gate = null;
+            source.Trigger();
+
+            Assert.True(secondChanged.Wait(TimeSpan.FromSeconds(30)), "The superseding reload did not publish.");
+            string published = monitor.CurrentValue.Message;
+
+            // Release the superseded first reload; it must not overwrite the newer published value.
+            firstGate.SetResult(true);
+            Thread.Sleep(200);
+
+            Assert.Equal(published, monitor.CurrentValue.Message);
+            Assert.Equal(published, lastNotified);
+        }
+
+        [Fact]
+        public void Phase8_DisposeCancelsInFlightReload()
+        {
+            var source = new ReloadSource();
+            var validator = new ReloadTestValidator();
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            validator.Gate = gate.Task;
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "reloaded")
+                .ValidateOnChange();
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "seed");
+            var monitor = (OptionsMonitor<FakeOptions>)sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            source.Trigger();          // starts a background reload blocked on the gate
+            monitor.Dispose();         // cancels the in-flight reload
+            gate.SetResult(true);      // release; the canceled reload must not publish
+            Thread.Sleep(200);
+
+            var cache = (OptionsCache<FakeOptions>)sp.GetRequiredService<IOptionsMonitorCache<FakeOptions>>();
+            Assert.True(cache.TryGetValue(Options.DefaultName, out FakeOptions? value));
+            Assert.Equal("seed", value!.Message);
+        }
+
+        private static void SeedCache(IServiceProvider sp, string message)
+        {
+            var cache = (OptionsCache<FakeOptions>)sp.GetRequiredService<IOptionsMonitorCache<FakeOptions>>();
+            cache.AddOrReplace(Options.DefaultName, new FakeOptions { Message = message });
+        }
+
+        private sealed class ReloadSource : IOptionsChangeTokenSource<FakeOptions>
+        {
+            private readonly FakeChangeToken _token = new FakeChangeToken();
+            public string? Name => null;
+            public IChangeToken GetChangeToken() => _token;
+            public void Trigger() => _token.InvokeChangeCallback();
+        }
+
+        private sealed class ReloadTestValidator : IValidateOptions<FakeOptions>, IAsyncValidateOptions<FakeOptions>
+        {
+            public bool Fail { get; set; }
+            public Task? Gate { get; set; }
+
+            public ValidateOptionsResult Validate(string? name, FakeOptions options)
+                => ValidateOptionsResult.Fail("Synchronous validation is not supported.");
+
+            public async Task<ValidateOptionsResult> ValidateAsync(string? name, FakeOptions options, CancellationToken cancellationToken)
+            {
+                Task? gate = Gate;
+                if (gate is not null)
+                {
+                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    using (cancellationToken.Register(static s => ((TaskCompletionSource<bool>)s!).TrySetCanceled(), tcs))
+                    {
+                        await Task.WhenAny(gate, tcs.Task).ConfigureAwait(false);
+                    }
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                return Fail ? ValidateOptionsResult.Fail("async validation failed") : ValidateOptionsResult.Success;
+            }
         }
 
         private class CustomSyncOnlyValidator : IStartupValidator

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Threading;
@@ -461,6 +462,64 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
+        public void ValidateOnChange_ThrowingChangeListener_DoesNotFaultBackgroundRefresh()
+        {
+            var unobserved = new List<Exception>();
+            void OnUnobserved(object? sender, UnobservedTaskExceptionEventArgs e)
+            {
+                lock (unobserved)
+                {
+                    unobserved.Add(e.Exception);
+                }
+            }
+
+            TaskScheduler.UnobservedTaskException += OnUnobserved;
+            try
+            {
+                var source = new ReloadSource();
+                var validator = new ReloadTestValidator();
+                var services = new ServiceCollection();
+                services.AddOptions<FakeOptions>()
+                    .Configure(o => o.Message = "reloaded")
+                    .ValidateOnChange();
+                services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+                services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+                using ServiceProvider sp = services.BuildServiceProvider();
+
+                SeedCache(sp, "seed");
+                IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+                using var listenerRan = new ManualResetEventSlim();
+                using IDisposable _ = monitor.OnChange((o, n) =>
+                {
+                    listenerRan.Set();
+                    throw new InvalidOperationException("listener boom");
+                });
+
+                source.Trigger();
+                Assert.True(listenerRan.Wait(TimeSpan.FromSeconds(30)), "The change listener did not run.");
+                Thread.Sleep(200);
+
+                // Force finalization so a faulted, unobserved fire-and-forget refresh task would raise
+                // UnobservedTaskException. With the listener guarded, the task completes without faulting.
+                for (int i = 0; i < 3; i++)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                }
+
+                lock (unobserved)
+                {
+                    Assert.DoesNotContain(unobserved, e => e.ToString().Contains("listener boom"));
+                }
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= OnUnobserved;
+            }
+        }
+
+        [Fact]
         public void ValidateOnChange_ThrowingOnErrorCallback_DoesNotFaultBackgroundRefresh()
         {
             var source = new ReloadSource();
@@ -540,6 +599,32 @@ namespace Microsoft.Extensions.Options.Tests
 
             Assert.True(listener.FailureReported.Wait(TimeSpan.FromSeconds(30)), "The reload failure was not reported to the event source.");
             // The failure is observable through the event source even though no onError callback was supplied.
+            Assert.Equal("good", monitor.CurrentValue.Message);
+        }
+
+        [Fact]
+        public void ValidateOnChange_ReloadValidatorThrowsOwnCancellation_ReportsError()
+        {
+            var source = new ReloadSource();
+            var validator = new ReloadTestValidator { ThrowOwnCancellation = true };
+            var services = new ServiceCollection();
+            using var errored = new ManualResetEventSlim();
+            Exception? reportedError = null;
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "reloaded")
+                .ValidateOnChange(OptionsReloadValidationBehavior.KeepLastGood, (name, ex) => { reportedError = ex; errored.Set(); });
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "good");
+            IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            source.Trigger();
+
+            Assert.True(errored.Wait(TimeSpan.FromSeconds(30)), "A validator-originated cancellation was not reported as a failure.");
+            // A cancellation that does not originate from the monitor's own token is a genuine failure, not a supersession.
+            Assert.IsType<OperationCanceledException>(reportedError);
             Assert.Equal("good", monitor.CurrentValue.Message);
         }
 
@@ -671,6 +756,7 @@ namespace Microsoft.Extensions.Options.Tests
         private sealed class ReloadTestValidator : IValidateOptions<FakeOptions>, IAsyncValidateOptions<FakeOptions>
         {
             public bool Fail { get; set; }
+            public bool ThrowOwnCancellation { get; set; }
             public Task? Gate { get; set; }
 
             public ValidateOptionsResult Validate(string? name, FakeOptions options)
@@ -687,6 +773,13 @@ namespace Microsoft.Extensions.Options.Tests
                         await Task.WhenAny(gate, tcs.Task).ConfigureAwait(false);
                     }
                     cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                if (ThrowOwnCancellation)
+                {
+                    // Simulate a validator that cancels for its own reasons (e.g. an internal timeout) using a token
+                    // unrelated to the monitor's reload token.
+                    throw new OperationCanceledException(new CancellationToken(canceled: true));
                 }
 
                 return Fail ? ValidateOptionsResult.Fail("async validation failed") : ValidateOptionsResult.Success;

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -357,6 +357,46 @@ namespace Microsoft.Extensions.Options.Tests
             Assert.Equal("ok", value.Message);
         }
 
+        // ---- Phase 9: sync-accessor validated-value caching ----
+
+        [Fact]
+        public async Task Phase9_AsyncValidatedType_SyncAccessorsReturnStartupValidatedValue()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "validated")
+                .Validate(async (FakeOptions o, CancellationToken ct) => await Task.FromResult(true), "async fail")
+                .ValidateOnStart();
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            // Before startup nothing has been validated, so synchronous access fails fast rather than silently skipping.
+            Assert.Throws<OptionsValidationException>(() => sp.GetRequiredService<IOptions<FakeOptions>>().Value);
+
+            await GetAsyncStartupValidator(sp).ValidateAsync(CancellationToken.None);
+
+            // After startup seeds the shared cache, synchronous IOptions<T>.Value returns the validated value.
+            Assert.Equal("validated", sp.GetRequiredService<IOptions<FakeOptions>>().Value.Message);
+
+            // IOptionsSnapshot<T>.Get (scoped) also serves the startup-validated value instead of re-validating synchronously.
+            using IServiceScope scope = sp.CreateScope();
+            Assert.Equal("validated", scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get(null).Message);
+        }
+
+        [Fact]
+        public void Phase9_SyncOnlyType_SyncAccessorsBehaviorUnchanged()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "sync")
+                .Validate(o => o.Message == "sync", "sync fail");
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            // A sync-only type is not async-capable, so the accessors create and validate synchronously as before.
+            Assert.Equal("sync", sp.GetRequiredService<IOptions<FakeOptions>>().Value.Message);
+            using IServiceScope scope = sp.CreateScope();
+            Assert.Equal("sync", scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get(null).Message);
+        }
+
         // ---- Phase 8: opt-in async reload revalidation (ValidateOnChange) ----
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -208,6 +208,50 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
+        public void ValidateOnStart_RegistersBuiltInValidatorAsBothInterfaces()
+        {
+            var services = new ServiceCollection();
+
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "test")
+                .Validate(o => true)
+                .ValidateOnStart();
+
+            ServiceProvider sp = services.BuildServiceProvider();
+
+            IStartupValidator sync = sp.GetRequiredService<IStartupValidator>();
+            Assert.IsType<IAsyncStartupValidator>(sync, exactMatch: false);
+            Assert.Single(sp.GetServices<IAsyncStartupValidator>());
+        }
+
+        [Fact]
+        public void ValidateOnStart_CalledMultipleTimes_RegistersSingleAsyncStartupValidator()
+        {
+            var services = new ServiceCollection();
+
+            services.AddOptions<FakeOptions>("a").Configure(o => o.Message = "a").Validate(o => true).ValidateOnStart();
+            services.AddOptions<FakeOptions>("b").Configure(o => o.Message = "b").Validate(o => true).ValidateOnStart();
+
+            ServiceProvider sp = services.BuildServiceProvider();
+
+            Assert.Single(sp.GetServices<IAsyncStartupValidator>());
+        }
+
+        [Fact]
+        public void ValidateOnStart_CustomAsyncStartupValidator_CoexistsWithBuiltInInEnumerable()
+        {
+            var services = new ServiceCollection();
+
+            services.AddSingleton<IAsyncStartupValidator>(new TrackingAsyncStartupValidator());
+            services.AddOptions<FakeOptions>().Configure(o => o.Message = "test").Validate(o => true).ValidateOnStart();
+
+            ServiceProvider sp = services.BuildServiceProvider();
+
+            // A custom async startup validator (a different implementation type) coexists with the built-in one.
+            Assert.Equal(2, sp.GetServices<IAsyncStartupValidator>().Count());
+        }
+
+        [Fact]
         public async Task StartupValidator_ValidateAsync_CancellationTokenPropagated()
         {
             var services = new ServiceCollection();
@@ -853,6 +897,17 @@ namespace Microsoft.Extensions.Options.Tests
         private class CustomSyncOnlyValidator : IStartupValidator
         {
             public void Validate() { }
+        }
+
+        private sealed class TrackingAsyncStartupValidator : IAsyncStartupValidator
+        {
+            public bool Validated { get; private set; }
+
+            public Task ValidateAsync(CancellationToken cancellationToken = default)
+            {
+                Validated = true;
+                return Task.CompletedTask;
+            }
         }
 
         private sealed class SyncCapableAsyncValidator : IValidateOptions<FakeOptions>, IAsyncValidateOptions<FakeOptions>

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -739,6 +739,33 @@ namespace Microsoft.Extensions.Options.Tests
             Assert.Equal("seed", value!.Message);
         }
 
+        [Fact]
+        public void ValidateOnChange_DisposeMonitor_NonCooperativeValidatorDoesNotPublishAfterDispose()
+        {
+            var source = new ReloadSource();
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var validator = new ReloadTestValidator { Gate = gate.Task, IgnoreCancellation = true };
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "reloaded")
+                .ValidateOnChange();
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "seed");
+            var monitor = (OptionsMonitor<FakeOptions>)sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            source.Trigger();          // starts a background reload blocked on the gate, ignoring cancellation
+            monitor.Dispose();         // cancels (ignored) and bumps the generation
+            gate.SetResult(true);      // release; the completed reload must not publish after disposal
+            Thread.Sleep(200);
+
+            var cache = (OptionsCache<FakeOptions>)sp.GetRequiredService<IOptionsMonitorCache<FakeOptions>>();
+            Assert.True(cache.TryGetValue(Options.DefaultName, out FakeOptions? value));
+            Assert.Equal("seed", value!.Message);
+        }
+
         private static void SeedCache(IServiceProvider sp, string message)
         {
             var cache = (OptionsCache<FakeOptions>)sp.GetRequiredService<IOptionsMonitorCache<FakeOptions>>();
@@ -757,6 +784,7 @@ namespace Microsoft.Extensions.Options.Tests
         {
             public bool Fail { get; set; }
             public bool ThrowOwnCancellation { get; set; }
+            public bool IgnoreCancellation { get; set; }
             public Task? Gate { get; set; }
 
             public ValidateOptionsResult Validate(string? name, FakeOptions options)
@@ -767,12 +795,20 @@ namespace Microsoft.Extensions.Options.Tests
                 Task? gate = Gate;
                 if (gate is not null)
                 {
-                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    using (cancellationToken.Register(static s => ((TaskCompletionSource<bool>)s!).TrySetCanceled(), tcs))
+                    if (IgnoreCancellation)
                     {
-                        await Task.WhenAny(gate, tcs.Task).ConfigureAwait(false);
+                        // Simulate a validator that does not observe the cancellation token.
+                        await gate.ConfigureAwait(false);
                     }
-                    cancellationToken.ThrowIfCancellationRequested();
+                    else
+                    {
+                        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        using (cancellationToken.Register(static s => ((TaskCompletionSource<bool>)s!).TrySetCanceled(), tcs))
+                        {
+                            await Task.WhenAny(gate, tcs.Task).ConfigureAwait(false);
+                        }
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
                 }
 
                 if (ThrowOwnCancellation)

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -357,10 +357,8 @@ namespace Microsoft.Extensions.Options.Tests
             Assert.Equal("ok", value.Message);
         }
 
-        // ---- Phase 9: sync-accessor validated-value caching ----
-
         [Fact]
-        public async Task Phase9_AsyncValidatedType_SyncAccessorsReturnStartupValidatedValue()
+        public async Task AsyncValidatedOptions_SyncAccessorsReturnStartupValidatedValue()
         {
             var services = new ServiceCollection();
             services.AddOptions<FakeOptions>()
@@ -383,7 +381,7 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
-        public void Phase9_SyncOnlyType_SyncAccessorsBehaviorUnchanged()
+        public void SyncOnlyValidatedOptions_SyncAccessorsBehaviorUnchanged()
         {
             var services = new ServiceCollection();
             services.AddOptions<FakeOptions>()
@@ -397,10 +395,8 @@ namespace Microsoft.Extensions.Options.Tests
             Assert.Equal("sync", scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get(null).Message);
         }
 
-        // ---- Phase 8: opt-in async reload revalidation (ValidateOnChange) ----
-
         [Fact]
-        public void Phase8_ValidReload_PublishesNewValidatedValueAndNotifies()
+        public void ValidateOnChange_ValidReload_PublishesNewValidatedValueAndNotifies()
         {
             var source = new ReloadSource();
             var validator = new ReloadTestValidator();
@@ -429,7 +425,71 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
-        public void Phase8_InvalidReload_KeepLastGood_ServesLastGoodAndReportsError()
+        public void ValidateOnChange_ThrowingChangeListener_DoesNotEvictPublishedValueOrReportError()
+        {
+            var source = new ReloadSource();
+            var validator = new ReloadTestValidator();
+            var services = new ServiceCollection();
+            bool errorReported = false;
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "reloaded")
+                .ValidateOnChange(OptionsReloadValidationBehavior.FailReads, (name, ex) => errorReported = true);
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "seed");
+            IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            using var listenerRan = new ManualResetEventSlim();
+            using IDisposable _ = monitor.OnChange((o, n) =>
+            {
+                listenerRan.Set();
+                throw new InvalidOperationException("listener boom");
+            });
+
+            source.Trigger();
+
+            Assert.True(listenerRan.Wait(TimeSpan.FromSeconds(30)), "The change listener did not run.");
+            Thread.Sleep(200);
+
+            // A throwing listener runs after a successful reload; it must not be treated as a reload failure: the
+            // published value is served (not evicted by FailReads) and the error callback is not invoked.
+            Assert.Equal("reloaded", monitor.CurrentValue.Message);
+            Assert.False(errorReported);
+        }
+
+        [Fact]
+        public void ValidateOnChange_ThrowingOnErrorCallback_DoesNotFaultBackgroundRefresh()
+        {
+            var source = new ReloadSource();
+            var validator = new ReloadTestValidator { Fail = true };
+            var services = new ServiceCollection();
+            using var errored = new ManualResetEventSlim();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "reloaded")
+                .ValidateOnChange(OptionsReloadValidationBehavior.KeepLastGood, (name, ex) =>
+                {
+                    errored.Set();
+                    throw new InvalidOperationException("onError boom");
+                });
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "good");
+            IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            source.Trigger();
+
+            // A throwing OnError must be swallowed by the background refresh (no unobserved task fault); the last good
+            // value keeps being served.
+            Assert.True(errored.Wait(TimeSpan.FromSeconds(30)), "The error callback was not invoked.");
+            Assert.Equal("good", monitor.CurrentValue.Message);
+        }
+
+        [Fact]
+        public void ValidateOnChange_InvalidReload_KeepLastGood_ServesLastGoodAndReportsError()
         {
             var source = new ReloadSource();
             var validator = new ReloadTestValidator { Fail = true };
@@ -459,7 +519,7 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
-        public void Phase8_InvalidReload_FailReads_NextReadThrows()
+        public void ValidateOnChange_InvalidReload_FailReads_NextReadThrows()
         {
             var source = new ReloadSource();
             var validator = new ReloadTestValidator { Fail = true };
@@ -483,7 +543,7 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
-        public void Phase8_DefaultMonitorWithoutOptIn_UsesLazyRevalidation()
+        public void ValidateOnChange_NotOptedIn_MonitorUsesLazyRevalidation()
         {
             var source = new ReloadSource();
             int configureCount = 0;
@@ -502,7 +562,7 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
-        public void Phase8_RapidReloads_LatestWins()
+        public void ValidateOnChange_RapidReloads_LatestWins()
         {
             var source = new ReloadSource();
             var validator = new ReloadTestValidator();
@@ -542,7 +602,7 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
-        public void Phase8_DisposeCancelsInFlightReload()
+        public void ValidateOnChange_DisposeMonitor_CancelsInFlightReload()
         {
             var source = new ReloadSource();
             var validator = new ReloadTestValidator();

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Extensions.Options.Tests
 {
     public class AsyncOptionsValidationTests
     {
+        private static IAsyncStartupValidator GetAsyncStartupValidator(IServiceProvider sp) =>
+            Assert.IsAssignableFrom<IAsyncStartupValidator>(sp.GetRequiredService<IStartupValidator>());
+
         [Fact]
         public async Task AsyncValidateOptions_SkipsWhenNameDoesNotMatch()
         {
@@ -68,7 +71,7 @@ namespace Microsoft.Extensions.Options.Tests
                 .ValidateOnStart();
 
             ServiceProvider sp = services.BuildServiceProvider();
-            var validator = sp.GetRequiredService<IAsyncStartupValidator>();
+            IAsyncStartupValidator validator = GetAsyncStartupValidator(sp);
 
             await validator.ValidateAsync(CancellationToken.None);
 
@@ -76,7 +79,7 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
-        public async Task StartupValidator_TwoStage_RunsBothSyncAndAsyncValidators()
+        public async Task StartupValidator_SinglePath_RunsBothSyncAndAsyncValidators()
         {
             var services = new ServiceCollection();
             bool syncRan = false;
@@ -94,18 +97,17 @@ namespace Microsoft.Extensions.Options.Tests
 
             ServiceProvider sp = services.BuildServiceProvider();
 
-            // Two-stage orchestration: Host.cs calls Validate() then ValidateAsync() independently
-            var syncValidator = sp.GetRequiredService<IStartupValidator>();
-            syncValidator.Validate();
-            Assert.True(syncRan);
+            // Single-path orchestration: one ValidateAsync runs every validator (sync and async) for the type,
+            // dispatching each by capability.
+            IAsyncStartupValidator validator = GetAsyncStartupValidator(sp);
+            await validator.ValidateAsync(CancellationToken.None);
 
-            var asyncValidator = sp.GetRequiredService<IAsyncStartupValidator>();
-            await asyncValidator.ValidateAsync(CancellationToken.None);
+            Assert.True(syncRan);
             Assert.True(asyncRan);
         }
 
         [Fact]
-        public async Task StartupValidator_TwoStage_SyncFailureSkipsAsyncValidators()
+        public async Task StartupValidator_SinglePath_AggregatesSyncAndAsyncFailures()
         {
             var services = new ServiceCollection();
             bool asyncRan = false;
@@ -116,19 +118,21 @@ namespace Microsoft.Extensions.Options.Tests
                 .Validate(async (FakeOptions o, CancellationToken ct) =>
                 {
                     asyncRan = true;
-                    return await Task.FromResult(true);
-                }, "async")
+                    return await Task.FromResult(false);
+                }, "async validation failed")
                 .ValidateOnStart();
 
             ServiceProvider sp = services.BuildServiceProvider();
+            IAsyncStartupValidator validator = GetAsyncStartupValidator(sp);
 
-            // Stage 1: Sync throws — in Host.cs, this prevents reaching Stage 2
-            var syncValidator = sp.GetRequiredService<IStartupValidator>();
-            Assert.Throws<OptionsValidationException>(() => syncValidator.Validate());
+            // The single path does not short-circuit on the first failure: every validator runs and
+            // all failures are aggregated into one OptionsValidationException.
+            OptionsValidationException ex = await Assert.ThrowsAsync<OptionsValidationException>(
+                () => validator.ValidateAsync(CancellationToken.None));
 
-            // Stage 2 is never reached because the exception propagates.
-            // Verify async didn't run (simulating Host.cs short-circuit behavior).
-            Assert.False(asyncRan);
+            Assert.True(asyncRan);
+            Assert.Contains("sync validation failed", ex.Failures);
+            Assert.Contains("async validation failed", ex.Failures);
         }
 
         [Fact]
@@ -147,7 +151,7 @@ namespace Microsoft.Extensions.Options.Tests
                 .ValidateOnStart();
 
             ServiceProvider sp = services.BuildServiceProvider();
-            var validator = sp.GetRequiredService<IAsyncStartupValidator>();
+            IAsyncStartupValidator validator = GetAsyncStartupValidator(sp);
 
             await validator.ValidateAsync(CancellationToken.None);
 
@@ -169,7 +173,7 @@ namespace Microsoft.Extensions.Options.Tests
                 .ValidateOnStart();
 
             ServiceProvider sp = services.BuildServiceProvider();
-            var validator = sp.GetRequiredService<IAsyncStartupValidator>();
+            IAsyncStartupValidator validator = GetAsyncStartupValidator(sp);
 
             OptionsValidationException ex = await Assert.ThrowsAsync<OptionsValidationException>(
                 () => validator.ValidateAsync(CancellationToken.None));
@@ -177,11 +181,12 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
-        public async Task ValidateOnStart_CustomSyncOnlyValidator_DoesNotThrowInvalidCast()
+        public void ValidateOnStart_CustomSyncOnlyValidator_UsesSyncPath()
         {
             var services = new ServiceCollection();
 
-            // Register a custom IStartupValidator that does NOT implement IAsyncStartupValidator
+            // A custom sync-only IStartupValidator registered before ValidateOnStart wins the
+            // TryAddTransient, so it is the resolved IStartupValidator.
             services.AddSingleton<IStartupValidator>(new CustomSyncOnlyValidator());
 
             services.AddOptions<FakeOptions>()
@@ -191,9 +196,12 @@ namespace Microsoft.Extensions.Options.Tests
 
             ServiceProvider sp = services.BuildServiceProvider();
 
-            // Should NOT throw InvalidCastException — IAsyncStartupValidator gets its own StartupValidator instance
-            var asyncValidator = sp.GetRequiredService<IAsyncStartupValidator>();
-            await asyncValidator.ValidateAsync(CancellationToken.None);
+            // The custom validator is not async-capable, so the host falls back to the sync path
+            // (validator.Validate()) — no InvalidCastException and no async validation.
+            IStartupValidator validator = sp.GetRequiredService<IStartupValidator>();
+            Assert.IsType<CustomSyncOnlyValidator>(validator);
+            Assert.False(validator is IAsyncStartupValidator);
+            validator.Validate();
         }
 
         [Fact]
@@ -212,7 +220,7 @@ namespace Microsoft.Extensions.Options.Tests
                 .ValidateOnStart();
 
             ServiceProvider sp = services.BuildServiceProvider();
-            var validator = sp.GetRequiredService<IAsyncStartupValidator>();
+            IAsyncStartupValidator validator = GetAsyncStartupValidator(sp);
 
             cts.Cancel();
             await Assert.ThrowsAsync<OperationCanceledException>(() => validator.ValidateAsync(cts.Token));
@@ -264,16 +272,55 @@ namespace Microsoft.Extensions.Options.Tests
                 .ValidateOnStart();
 
             using ServiceProvider sp = services.BuildServiceProvider();
-            var validator = sp.GetRequiredService<IAsyncStartupValidator>();
+            IAsyncStartupValidator validator = GetAsyncStartupValidator(sp);
 
             AggregateException ex = await Assert.ThrowsAsync<AggregateException>(() => validator.ValidateAsync());
             Assert.Equal(2, ex.InnerExceptions.Count);
             Assert.All(ex.InnerExceptions, e => Assert.IsType<OptionsValidationException>(e));
         }
 
+        [Fact]
+        public async Task StartupValidator_ValidatorImplementingBoth_DispatchesToAsync()
+        {
+            var spy = new CapabilitySpyValidator();
+            var services = new ServiceCollection();
+
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "test")
+                .ValidateOnStart();
+            services.AddSingleton<IValidateOptions<FakeOptions>>(spy);
+
+            ServiceProvider sp = services.BuildServiceProvider();
+            IAsyncStartupValidator validator = GetAsyncStartupValidator(sp);
+
+            await validator.ValidateAsync(CancellationToken.None);
+
+            // A validator that implements both contracts is dispatched through ValidateAsync only.
+            Assert.True(spy.AsyncCalled);
+            Assert.False(spy.SyncCalled);
+        }
+
         private class CustomSyncOnlyValidator : IStartupValidator
         {
             public void Validate() { }
+        }
+
+        private sealed class CapabilitySpyValidator : IValidateOptions<FakeOptions>, IAsyncValidateOptions<FakeOptions>
+        {
+            public bool SyncCalled { get; private set; }
+            public bool AsyncCalled { get; private set; }
+
+            public ValidateOptionsResult Validate(string? name, FakeOptions options)
+            {
+                SyncCalled = true;
+                return ValidateOptionsResult.Success;
+            }
+
+            public Task<ValidateOptionsResult> ValidateAsync(string? name, FakeOptions options, CancellationToken cancellationToken = default)
+            {
+                AsyncCalled = true;
+                return Task.FromResult(ValidateOptionsResult.Success);
+            }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -199,8 +199,8 @@ namespace Microsoft.Extensions.Options.Tests
 
             ServiceProvider sp = services.BuildServiceProvider();
 
-            // The custom validator is not async-capable, so the host falls back to the sync path
-            // (validator.Validate()) — no InvalidCastException and no async validation.
+            // The custom validator is not async-capable, so the host falls back to the sync path (validator.Validate())
+            // This means no InvalidCastException and no async validation.
             IStartupValidator validator = sp.GetRequiredService<IStartupValidator>();
             Assert.IsType<CustomSyncOnlyValidator>(validator);
             Assert.False(validator is IAsyncStartupValidator);
@@ -374,12 +374,40 @@ namespace Microsoft.Extensions.Options.Tests
 
             await GetAsyncStartupValidator(sp).ValidateAsync(CancellationToken.None);
 
-            // After startup seeds the shared cache, synchronous IOptions<T>.Value returns the validated value.
+            // After startup seeds the shared cache, the singleton IOptions<T>.Value returns the validated value.
             Assert.Equal("validated", sp.GetRequiredService<IOptions<FakeOptions>>().Value.Message);
 
-            // IOptionsSnapshot<T>.Get (scoped) also serves the startup-validated value instead of re-validating synchronously.
+            // IOptionsSnapshot<T> is scoped and creates per scope; it does not consult the shared validated cache, so
+            // for an async-only validator (whose synchronous Validate cannot run) a scoped access fails fast.
             using IServiceScope scope = sp.CreateScope();
-            Assert.Equal("validated", scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get(null).Message);
+            Assert.Throws<OptionsValidationException>(
+                () => scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get(null));
+        }
+
+        [Fact]
+        public void AsyncValidatedOptions_SyncCapableValidator_SnapshotIsPerScope()
+        {
+            int configureCount = 0;
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = $"v{Interlocked.Increment(ref configureCount)}")
+                .ValidateOnStart();
+            services.AddSingleton<IValidateOptions<FakeOptions>>(new SyncCapableAsyncValidator());
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            FakeOptions first, second;
+            using (IServiceScope scope = sp.CreateScope())
+            {
+                first = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get(null);
+            }
+            using (IServiceScope scope = sp.CreateScope())
+            {
+                second = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get(null);
+            }
+
+            // A validator that is async-capable but whose synchronous Validate works keeps the per-scope IOptionsSnapshot
+            // semantics: each scope creates and validates a fresh instance rather than sharing the startup-validated one.
+            Assert.NotSame(first, second);
         }
 
         [Fact]
@@ -825,6 +853,14 @@ namespace Microsoft.Extensions.Options.Tests
         private class CustomSyncOnlyValidator : IStartupValidator
         {
             public void Validate() { }
+        }
+
+        private sealed class SyncCapableAsyncValidator : IValidateOptions<FakeOptions>, IAsyncValidateOptions<FakeOptions>
+        {
+            public ValidateOptionsResult Validate(string? name, FakeOptions options) => ValidateOptionsResult.Success;
+
+            public Task<ValidateOptionsResult> ValidateAsync(string? name, FakeOptions options, CancellationToken cancellationToken = default)
+                => Task.FromResult(ValidateOptionsResult.Success);
         }
 
         private sealed class OptionsEventSourceListener : EventListener

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/AsyncOptionsValidationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -519,6 +520,30 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
+        public void ValidateOnChange_InvalidReload_WithoutErrorCallback_EmitsEventSourceFailure()
+        {
+            using var listener = new OptionsEventSourceListener();
+            var source = new ReloadSource();
+            var validator = new ReloadTestValidator { Fail = true };
+            var services = new ServiceCollection();
+            services.AddOptions<FakeOptions>()
+                .Configure(o => o.Message = "reloaded")
+                .ValidateOnChange();
+            services.AddSingleton<IValidateOptions<FakeOptions>>(validator);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(source);
+            using ServiceProvider sp = services.BuildServiceProvider();
+
+            SeedCache(sp, "good");
+            IOptionsMonitor<FakeOptions> monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+
+            source.Trigger();
+
+            Assert.True(listener.FailureReported.Wait(TimeSpan.FromSeconds(30)), "The reload failure was not reported to the event source.");
+            // The failure is observable through the event source even though no onError callback was supplied.
+            Assert.Equal("good", monitor.CurrentValue.Message);
+        }
+
+        [Fact]
         public void ValidateOnChange_InvalidReload_FailReads_NextReadThrows()
         {
             var source = new ReloadSource();
@@ -671,6 +696,33 @@ namespace Microsoft.Extensions.Options.Tests
         private class CustomSyncOnlyValidator : IStartupValidator
         {
             public void Validate() { }
+        }
+
+        private sealed class OptionsEventSourceListener : EventListener
+        {
+            public ManualResetEventSlim FailureReported { get; } = new ManualResetEventSlim();
+
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                if (eventSource.Name == "Microsoft-Extensions-Options")
+                {
+                    EnableEvents(eventSource, EventLevel.Error);
+                }
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                if (eventData.EventName == "ReloadValidationFailed")
+                {
+                    FailureReported.Set();
+                }
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                FailureReported.Dispose();
+            }
         }
 
         private sealed class CapabilitySpyValidator : IValidateOptions<FakeOptions>, IAsyncValidateOptions<FakeOptions>

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/Microsoft.Extensions.Options.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/Microsoft.Extensions.Options.Tests.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
     <!-- https://github.com/dotnet/runtime/issues/126862 -->
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.Options.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration\src\Microsoft.Extensions.Configuration.csproj"/>
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection\src\Microsoft.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Hosting\src\Microsoft.Extensions.Hosting.csproj"/>

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsBuilderTest.cs
@@ -1046,7 +1046,7 @@ namespace Microsoft.Extensions.Options.Tests
                 .ValidateOnStart();
 
             using ServiceProvider sp = services.BuildServiceProvider();
-            var asyncValidator = sp.GetRequiredService<IAsyncStartupValidator>();
+            var asyncValidator = (IAsyncStartupValidator)sp.GetRequiredService<Microsoft.Extensions.Options.IStartupValidator>();
             await asyncValidator.ValidateAsync(CancellationToken.None);
         }
 

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
@@ -422,6 +422,73 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
+        public void AddOrReplace_AddsWhenAbsentAndReplacesWhenPresent()
+        {
+            var cache = new OptionsCache<FakeOptions>();
+
+            cache.AddOrReplace("name", new FakeOptions { Message = "first" });
+            Assert.True(cache.TryGetValue("name", out FakeOptions? added));
+            Assert.Equal("first", added!.Message);
+
+            // Unlike TryAdd, AddOrReplace overwrites an existing entry.
+            cache.AddOrReplace("name", new FakeOptions { Message = "second" });
+            Assert.True(cache.TryGetValue("name", out FakeOptions? replaced));
+            Assert.Equal("second", replaced!.Message);
+
+            // TryAdd still reports the name already exists after a replace.
+            Assert.False(cache.TryAdd("name", new FakeOptions { Message = "third" }));
+        }
+
+        [Fact]
+        public void AddOrReplace_NullNameUsesDefaultName()
+        {
+            var cache = new OptionsCache<FakeOptions>();
+
+            cache.AddOrReplace(null, new FakeOptions { Message = "value" });
+
+            Assert.True(cache.TryGetValue(Options.DefaultName, out FakeOptions? byDefault));
+            Assert.Equal("value", byDefault!.Message);
+            Assert.True(cache.TryGetValue(null, out FakeOptions? byNull));
+            Assert.Equal("value", byNull!.Message);
+        }
+
+        [Fact]
+        public void AddOrReplace_DerivedCacheRoutesThroughVirtualMembers()
+        {
+            var cache = new CountingOptionsCache();
+
+            // First call: no existing entry, so only TryAdd runs.
+            cache.AddOrReplace("name", new FakeOptions { Message = "first" });
+            Assert.Equal(1, cache.TryRemoveCalls);
+            Assert.Equal(1, cache.TryAddCalls);
+
+            // Second call replaces: TryRemove then TryAdd both run through the overrides.
+            cache.AddOrReplace("name", new FakeOptions { Message = "second" });
+            Assert.Equal(2, cache.TryRemoveCalls);
+            Assert.Equal(2, cache.TryAddCalls);
+            Assert.True(cache.TryGetValue("name", out FakeOptions? replaced));
+            Assert.Equal("second", replaced!.Message);
+        }
+
+        private sealed class CountingOptionsCache : OptionsCache<FakeOptions>
+        {
+            public int TryAddCalls { get; private set; }
+            public int TryRemoveCalls { get; private set; }
+
+            public override bool TryAdd(string? name, FakeOptions options)
+            {
+                TryAddCalls++;
+                return base.TryAdd(name, options);
+            }
+
+            public override bool TryRemove(string? name)
+            {
+                TryRemoveCalls++;
+                return base.TryRemove(name);
+            }
+        }
+
+        [Fact]
         public void CallsPublicGetOrAddForCustomOptionsCache()
         {
             DerivedOptionsCache derivedOptionsCache = new();

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -513,6 +513,28 @@ public class EmitterTests
     }
 
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
+    public async Task AlreadyImplementedAsync()
+    {
+        var (diagnostics, _) = await RunGenerator(@"
+            public class FirstModel
+            {
+                [Required]
+                public string One { get; set; } = string.Empty;
+            }
+
+            [OptionsValidator]
+            public partial class FirstValidator : IAsyncValidateOptions<FirstModel>
+            {
+                public System.Threading.Tasks.Task<ValidateOptionsResult> ValidateAsync(string? name, FirstModel options, System.Threading.CancellationToken cancellationToken = default)
+                    => System.Threading.Tasks.Task.FromResult(ValidateOptionsResult.Success);
+            }
+        ");
+
+        _ = Assert.Single(diagnostics);
+        Assert.Equal(DiagDescriptors.AlreadyImplementsValidateAsyncMethod.Id, diagnostics[0].Id);
+    }
+
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
     public async Task ShouldNotProduceInfoWhenTheClassHasABaseClass()
     {
         var (diagnostics, _) = await RunGenerator(@"

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -534,6 +534,69 @@ public class EmitterTests
         Assert.Equal(DiagDescriptors.AlreadyImplementsValidateAsyncMethod.Id, diagnostics[0].Id);
     }
 
+#if NET
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
+    public async Task AsyncValidateMethodWithNoAwaitedWorkIsNotAsync()
+    {
+        // The model validates only synchronously (IValidatableObject, no attributes, no async children) but is validated
+        // by an IAsyncValidateOptions<T> validator, so the generated ValidateAsync body contains no await and must be
+        // emitted as a non-async method returning Task.FromResult(...) (avoids CS1998).
+        var (diagnostics, generatedSources) = await RunGenerator(@"
+            using System.Collections.Generic;
+
+            public class SyncSelfModel : IValidatableObject
+            {
+                public string? Name { get; set; }
+                public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+                {
+                    yield break;
+                }
+            }
+
+            [OptionsValidator]
+            public partial class SyncSelfModelValidator : IAsyncValidateOptions<SyncSelfModel>
+            {
+            }
+        ");
+
+        Assert.Empty(diagnostics);
+        _ = Assert.Single(generatedSources);
+        string emitted = generatedSources[0].SourceText.ToString();
+
+        // Task.FromResult(...) is emitted only on the no-await branch; the awaited branch returns builder.Build() directly.
+        Assert.Contains("global::System.Threading.Tasks.Task.FromResult", emitted);
+        // A non-async ValidateAsync contains neither the async modifier nor any await.
+        Assert.DoesNotContain("await ", emitted);
+    }
+#endif // NET
+
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
+    public async Task AsyncValidationRequiresNet11Diagnostic()
+    {
+        // A validator implementing IAsyncValidateOptions<T> (available on every TFM) needs the async DataAnnotations
+        // APIs (IAsyncValidatableObject / Validator.TryValidateValueAsync), which are only present on .NET 11+.
+        var (diagnostics, _) = await RunGenerator(@"
+            public class FirstModel
+            {
+                [Required]
+                public string One { get; set; } = string.Empty;
+            }
+
+            [OptionsValidator]
+            public partial class FirstValidator : IAsyncValidateOptions<FirstModel>
+            {
+            }
+        ");
+
+#if NET
+        // .NET 11+: the async symbols are available, so no downlevel diagnostic is produced.
+        Assert.DoesNotContain(diagnostics, d => d.Id == DiagDescriptors.AsyncValidationRequiresNet11.Id);
+#else
+        // Downlevel (async symbols absent): the generator reports SYSLIB1218 instead of emitting code that fails to compile.
+        Assert.Contains(diagnostics, d => d.Id == DiagDescriptors.AsyncValidationRequiresNet11.Id);
+#endif // NET
+    }
+
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
     public async Task ShouldNotProduceInfoWhenTheClassHasABaseClass()
     {

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -534,6 +534,28 @@ public class EmitterTests
         Assert.Equal(DiagDescriptors.AlreadyImplementsValidateAsyncMethod.Id, diagnostics[0].Id);
     }
 
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
+    public async Task AlreadyImplementedAsyncExplicitInterface()
+    {
+        var (diagnostics, _) = await RunGenerator(@"
+            public class FirstModel
+            {
+                [Required]
+                public string One { get; set; } = string.Empty;
+            }
+
+            [OptionsValidator]
+            public partial class FirstValidator : IAsyncValidateOptions<FirstModel>
+            {
+                System.Threading.Tasks.Task<ValidateOptionsResult> IAsyncValidateOptions<FirstModel>.ValidateAsync(string? name, FirstModel options, System.Threading.CancellationToken cancellationToken)
+                    => System.Threading.Tasks.Task.FromResult(ValidateOptionsResult.Success);
+            }
+        ");
+
+        _ = Assert.Single(diagnostics);
+        Assert.Equal(DiagDescriptors.AlreadyImplementsValidateAsyncMethod.Id, diagnostics[0].Id);
+    }
+
 #if NET
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
     public async Task AsyncValidateMethodWithNoAwaitedWorkIsNotAsync()

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
@@ -512,6 +512,29 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
 
             ValidateOptionsResult syncResult = new SyncRootReusingNestedOptionsValidator().Validate("SyncRoot", syncOptions);
             Assert.True(syncResult.Succeeded);
+
+            // Finding 3 regression: AsyncNestedOptions self-validates asynchronously. The async root must run that
+            // nested async self-validation, while the synchronous root sharing the same nested model type must not.
+            // Keying synthesized validators by model type alone would let the async root reuse a synchronous-only
+            // child (depending on discovery order) and silently skip nested async self-validation.
+            AsyncOptions asyncSelfValidating = new()
+            {
+                Name = "Valid",
+                Age = 30,
+                Nested = new() { Level = 5, Id = "trigger-async", Children = new() { new AsyncChildOptions { Name = "C1" } } }
+            };
+
+            ValidateOptionsResult nestedAsyncResult = await new AsyncOptionsValidator().ValidateAsync("AsyncOptions", asyncSelfValidating, default);
+            Assert.True(nestedAsyncResult.Failed);
+            Assert.Contains("Nested async self-validation failed.", nestedAsyncResult.Failures);
+
+            SyncRootReusingNestedOptions syncSelfValidating = new()
+            {
+                Nested = new() { Level = 5, Id = "trigger-async", Children = new() { new AsyncChildOptions { Name = "C1" } } }
+            };
+
+            ValidateOptionsResult syncNestedResult = new SyncRootReusingNestedOptionsValidator().Validate("SyncRoot", syncSelfValidating);
+            Assert.True(syncNestedResult.Succeeded);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
@@ -752,7 +775,7 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
         public string? Name { get; set; }
     }
 
-    public class AsyncNestedOptions
+    public class AsyncNestedOptions : IAsyncValidatableObject
     {
         [Range(0, 10)]
         public int Level { get; set; }
@@ -762,6 +785,22 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
 
         [ValidateEnumeratedItems]
         public List<AsyncChildOptions>? Children { get; set; }
+
+        public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+            ValidationContext validationContext,
+            [global::System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            if (Id == "trigger-async")
+            {
+                yield return new ValidationResult("Nested async self-validation failed.");
+            }
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            yield break;
+        }
     }
 
     public class AsyncOptions : IAsyncValidatableObject
@@ -801,10 +840,11 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
     }
 
     // Regression: a synchronous validator that nests the same type (AsyncNestedOptions) as the async
-    // AsyncOptionsValidator. A synthesized child validator is cached by model type only, so the same
-    // AsyncNestedOptions validator is shared between the synchronous and asynchronous roots. This guards against the
-    // async root emitting "await child.ValidateAsync(...)" against a synthesized child that was generated without a
-    // ValidateAsync method; the whole test assembly failing to compile is the regression signal.
+    // AsyncOptionsValidator. Synthesized child validators are cached per model type and per capability
+    // (synchronous vs asynchronous), so the async root gets an async-capable child and the synchronous root gets a
+    // synchronous one regardless of discovery order. This guards against the async root emitting
+    // "await child.ValidateAsync(...)" against a synthesized child generated without a ValidateAsync method, and
+    // against the async root silently falling back to the synchronous child's Validate path.
     public class SyncRootReusingNestedOptions
     {
         [ValidateObjectMembers]

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
@@ -417,6 +417,113 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
                     Assert.True(result.Succeeded);
                 }, TaskCreationOptions.LongRunning)).ToArray());
         }
+
+#if NET
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        public async Task TestAsyncValidationSucceeds()
+        {
+            AsyncOptions options = new()
+            {
+                Name = "Valid",
+                Age = 30,
+                Nested = new()
+                {
+                    Level = 5,
+                    Id = "1",
+                    Children = new() { new AsyncChildOptions { Name = "C1" } }
+                }
+            };
+
+            AsyncOptionsValidator validator = new();
+
+            ValidateOptionsResult asyncResult = await validator.ValidateAsync("AsyncOptions", options, default);
+            Assert.True(asyncResult.Succeeded);
+
+            // The generated ValidateAsync must agree with the synchronous Validate for the same input.
+            ValidateOptionsResult syncResult = validator.Validate("AsyncOptions", options);
+            Assert.True(syncResult.Succeeded);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        public async Task TestAsyncValidationFailures()
+        {
+            AsyncOptions options = new()
+            {
+                Name = "Invalid", // trips self-validation
+                Age = 0,          // out of [Range(1, 100)]
+                Nested = new()
+                {
+                    Level = 50,   // out of [Range(0, 10)]
+                    Id = null,    // [Required]
+                    Children = new() { new AsyncChildOptions { Name = null } } // [Required] on enumerated item
+                }
+            };
+
+            AsyncOptionsValidator validator = new();
+
+            ValidateOptionsResult asyncResult = await validator.ValidateAsync("AsyncOptions", options, default);
+            Assert.True(asyncResult.Failed);
+
+            // Attribute, nested object-member, enumerated-item failures, plus the async self-validation failure,
+            // are all surfaced. The self-validation entry ("Async self-validation failed.") proves the generated
+            // ValidateAsync dispatches to IAsyncValidatableObject.ValidateAsync (await foreach) rather than the
+            // synchronous IValidatableObject.Validate path.
+            Assert.Equal(new List<string>
+                        {
+                            "Age: The field AsyncOptions.Age must be between 1 and 100.",
+                            "Level: The field AsyncOptions.Nested.Level must be between 0 and 10.",
+                            "Id: The AsyncOptions.Nested.Id field is required.",
+                            "Name: The AsyncOptions.Nested.Children[0].Name field is required.",
+                            "Async self-validation failed.",
+                        },
+                        asyncResult.Failures);
+
+            // The synchronous Validate path uses the synchronous self-validation instead, confirming the two code
+            // paths are genuinely distinct and the async test would not pass if ValidateAsync silently ran the sync path.
+            ValidateOptionsResult syncResult = validator.Validate("AsyncOptions", options);
+            Assert.True(syncResult.Failed);
+            Assert.Contains("Sync self-validation failed.", syncResult.Failures);
+            Assert.DoesNotContain("Async self-validation failed.", syncResult.Failures);
+            Assert.DoesNotContain("Sync self-validation failed.", asyncResult.Failures);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        public async Task TestAsyncValidationWithSharedSynthesizedValidator()
+        {
+            // The async AsyncOptionsValidator and the synchronous SyncRootReusingNestedOptionsValidator both nest
+            // AsyncNestedOptions, so they share a single synthesized child validator. Exercise both roots to confirm the
+            // shared child validates correctly from an async caller and a sync caller alike.
+            AsyncOptions asyncOptions = new()
+            {
+                Name = "Valid",
+                Age = 30,
+                Nested = new() { Level = 50, Id = null, Children = new() { new AsyncChildOptions { Name = "C1" } } }
+            };
+
+            ValidateOptionsResult asyncResult = await new AsyncOptionsValidator().ValidateAsync("AsyncOptions", asyncOptions, default);
+            Assert.True(asyncResult.Failed);
+            Assert.Contains("Level: The field AsyncOptions.Nested.Level must be between 0 and 10.", asyncResult.Failures);
+            Assert.Contains("Id: The AsyncOptions.Nested.Id field is required.", asyncResult.Failures);
+
+            SyncRootReusingNestedOptions syncOptions = new()
+            {
+                Nested = new() { Level = 5, Id = "1", Children = new() { new AsyncChildOptions { Name = "C1" } } }
+            };
+
+            ValidateOptionsResult syncResult = new SyncRootReusingNestedOptionsValidator().Validate("SyncRoot", syncOptions);
+            Assert.True(syncResult.Succeeded);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        public async Task TestManualValidateAsyncIsNotOverwritten()
+        {
+            // The generator must not emit a ValidateAsync for ManualAsyncOptionsValidator (that would be a duplicate
+            // member); the hand-written implementation is the one invoked.
+            ValidateOptionsResult result = await new ManualAsyncOptionsValidator().ValidateAsync("ManualAsyncOptions", new ManualAsyncOptions { Name = "Valid" }, default);
+            Assert.True(result.Failed);
+            Assert.Contains("Manual ValidateAsync invoked.", result.Failures);
+        }
+#endif // NET
     }
 
     public class FakeCount(int count) { public int Count { get { return count; } } }
@@ -637,4 +744,91 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
     public partial class TimeSpanRangeAttributeValidator : IValidateOptions<OptionsWithTimeSpanRangeAttribute>
     {
     }
+
+#if NET
+    public class AsyncChildOptions
+    {
+        [Required]
+        public string? Name { get; set; }
+    }
+
+    public class AsyncNestedOptions
+    {
+        [Range(0, 10)]
+        public int Level { get; set; }
+
+        [Required]
+        public string? Id { get; set; }
+
+        [ValidateEnumeratedItems]
+        public List<AsyncChildOptions>? Children { get; set; }
+    }
+
+    public class AsyncOptions : IAsyncValidatableObject
+    {
+        [Required]
+        public string? Name { get; set; }
+
+        [Range(1, 100)]
+        public int Age { get; set; }
+
+        [ValidateObjectMembers]
+        public AsyncNestedOptions? Nested { get; set; }
+
+        public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+            ValidationContext validationContext,
+            [global::System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            if (Name == "Invalid")
+            {
+                yield return new ValidationResult("Async self-validation failed.");
+            }
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (Name == "Invalid")
+            {
+                yield return new ValidationResult("Sync self-validation failed.");
+            }
+        }
+    }
+
+    [OptionsValidator]
+    public partial class AsyncOptionsValidator : IValidateOptions<AsyncOptions>, IAsyncValidateOptions<AsyncOptions>
+    {
+    }
+
+    // Regression: a synchronous validator that nests the same type (AsyncNestedOptions) as the async
+    // AsyncOptionsValidator. A synthesized child validator is cached by model type only, so the same
+    // AsyncNestedOptions validator is shared between the synchronous and asynchronous roots. This guards against the
+    // async root emitting "await child.ValidateAsync(...)" against a synthesized child that was generated without a
+    // ValidateAsync method; the whole test assembly failing to compile is the regression signal.
+    public class SyncRootReusingNestedOptions
+    {
+        [ValidateObjectMembers]
+        public AsyncNestedOptions? Nested { get; set; }
+    }
+
+    [OptionsValidator]
+    public partial class SyncRootReusingNestedOptionsValidator : IValidateOptions<SyncRootReusingNestedOptions>
+    {
+    }
+
+    public class ManualAsyncOptions
+    {
+        [Required]
+        public string? Name { get; set; }
+    }
+
+    // Regression: the validator implements IAsyncValidateOptions<T> but supplies its own ValidateAsync. The generator
+    // must skip emitting ValidateAsync to avoid a duplicate-member compile error, and the hand-written method must win.
+    [OptionsValidator]
+    public partial class ManualAsyncOptionsValidator : IValidateOptions<ManualAsyncOptions>, IAsyncValidateOptions<ManualAsyncOptions>
+    {
+        public Task<ValidateOptionsResult> ValidateAsync(string? name, ManualAsyncOptions options, CancellationToken cancellationToken = default)
+            => Task.FromResult(ValidateOptionsResult.Fail("Manual ValidateAsync invoked."));
+    }
+#endif // NET
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
@@ -536,16 +536,6 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
             ValidateOptionsResult syncNestedResult = new SyncRootReusingNestedOptionsValidator().Validate("SyncRoot", syncSelfValidating);
             Assert.True(syncNestedResult.Succeeded);
         }
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        public async Task TestManualValidateAsyncIsNotOverwritten()
-        {
-            // The generator must not emit a ValidateAsync for ManualAsyncOptionsValidator (that would be a duplicate
-            // member); the hand-written implementation is the one invoked.
-            ValidateOptionsResult result = await new ManualAsyncOptionsValidator().ValidateAsync("ManualAsyncOptions", new ManualAsyncOptions { Name = "Valid" }, default);
-            Assert.True(result.Failed);
-            Assert.Contains("Manual ValidateAsync invoked.", result.Failures);
-        }
 #endif // NET
     }
 
@@ -854,21 +844,6 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
     [OptionsValidator]
     public partial class SyncRootReusingNestedOptionsValidator : IValidateOptions<SyncRootReusingNestedOptions>
     {
-    }
-
-    public class ManualAsyncOptions
-    {
-        [Required]
-        public string? Name { get; set; }
-    }
-
-    // Regression: the validator implements IAsyncValidateOptions<T> but supplies its own ValidateAsync. The generator
-    // must skip emitting ValidateAsync to avoid a duplicate-member compile error, and the hand-written method must win.
-    [OptionsValidator]
-    public partial class ManualAsyncOptionsValidator : IValidateOptions<ManualAsyncOptions>, IAsyncValidateOptions<ManualAsyncOptions>
-    {
-        public Task<ValidateOptionsResult> ValidateAsync(string? name, ManualAsyncOptions options, CancellationToken cancellationToken = default)
-            => Task.FromResult(ValidateOptionsResult.Fail("Manual ValidateAsync invoked."));
     }
 #endif // NET
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
@@ -536,6 +536,25 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
             ValidateOptionsResult syncNestedResult = new SyncRootReusingNestedOptionsValidator().Validate("SyncRoot", syncSelfValidating);
             Assert.True(syncNestedResult.Succeeded);
         }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        public async Task TestExplicitTypeTransitiveAndEnumeratedAsyncValidatorsAreAwaited()
+        {
+            // Both the explicit-type transitive validator ([ValidateObjectMembers(typeof(...))]) and the explicit-type
+            // enumerated-items validator ([ValidateEnumeratedItems(typeof(...))]) implement IAsyncValidateOptions<T>, so
+            // the async parent must await their ValidateAsync. AsyncNestedOptions only self-validates asynchronously, so
+            // if either child were dispatched through its synchronous Validate the failure would be silently skipped.
+            var options = new ExplicitAsyncRootOptions
+            {
+                Nested = new AsyncNestedOptions { Level = 5, Id = "trigger-async" },
+                Items = new() { new AsyncNestedOptions { Level = 5, Id = "trigger-async" } }
+            };
+
+            ValidateOptionsResult result = await new ExplicitAsyncRootOptionsValidator().ValidateAsync("Root", options, default);
+
+            Assert.True(result.Failed);
+            Assert.Equal(2, result.Failures.Count(f => f.Contains("Nested async self-validation failed.")));
+        }
 #endif // NET
     }
 
@@ -843,6 +862,28 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
 
     [OptionsValidator]
     public partial class SyncRootReusingNestedOptionsValidator : IValidateOptions<SyncRootReusingNestedOptions>
+    {
+    }
+
+    // An explicitly specified transitive/enumerated validator (typeof(...)) that implements
+    // IAsyncValidateOptions<T> must be dispatched through ValidateAsync by an async parent. Otherwise the parent calls
+    // the child's synchronous Validate and silently skips the child's async-only validation.
+    public class ExplicitAsyncRootOptions
+    {
+        [ValidateObjectMembers(typeof(ExplicitAsyncNestedValidator))]
+        public AsyncNestedOptions? Nested { get; set; }
+
+        [ValidateEnumeratedItems(typeof(ExplicitAsyncNestedValidator))]
+        public List<AsyncNestedOptions>? Items { get; set; }
+    }
+
+    [OptionsValidator]
+    public partial class ExplicitAsyncNestedValidator : IAsyncValidateOptions<AsyncNestedOptions>
+    {
+    }
+
+    [OptionsValidator]
+    public partial class ExplicitAsyncRootOptionsValidator : IAsyncValidateOptions<ExplicitAsyncRootOptions>
     {
     }
 #endif // NET

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
@@ -555,6 +555,74 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
             Assert.True(result.Failed);
             Assert.Equal(2, result.Failures.Count(f => f.Contains("Nested async self-validation failed.")));
         }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        public async Task TestGeneratedValidateAsyncPropagatesCancellationToken()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var validator = new CancellationObservingOptionsValidator();
+
+            // The generated ValidateAsync threads its CancellationToken into the validation sinks; with an already
+            // canceled token, validation observes it and throws. A future emitter change that dropped the token would
+            // make this complete normally.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => validator.ValidateAsync("opt", new CancellationObservingOptions { Name = "valid" }, cts.Token));
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        public async Task TestGeneratedValidateAsyncNoAwaitPathRunsSynchronously()
+        {
+            var validator = new SyncSelfValidatingOptionsValidator();
+
+            // The generated ValidateAsync for this model contains no await (non-async, returns Task.FromResult(...)).
+            // Its mere presence in this compiled assembly proves it compiles (no CS1998); assert it also runs correctly.
+            Task<ValidateOptionsResult> successTask = validator.ValidateAsync("opt", new SyncSelfValidatingOptions { Name = "ok" }, default);
+            Assert.True(successTask.IsCompletedSuccessfully);
+            Assert.True((await successTask).Succeeded);
+
+            ValidateOptionsResult failure = await validator.ValidateAsync("opt", new SyncSelfValidatingOptions { Name = "bad" }, default);
+            Assert.True(failure.Failed);
+            Assert.Contains(failure.Failures, f => f.Contains("Sync self-validation failed."));
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        public async Task TestGeneratedValidateAsyncMatchesValidatorParity()
+        {
+            var validator = new AsyncParityOptionsValidator();
+
+            var valid = new AsyncParityOptions { Name = "ok", Age = 30 };
+            var validResults = new List<ValidationResult>();
+            bool validatorValid = await Validator.TryValidateObjectAsync(valid, new ValidationContext(valid), validResults, validateAllProperties: true);
+            ValidateOptionsResult generatedValid = await validator.ValidateAsync("AsyncParityOptions", valid, default);
+            Assert.True(validatorValid);
+            Assert.True(generatedValid.Succeeded);
+            Assert.Empty(validResults);
+
+            // Attribute-only failure (Age out of range, name is valid and not reserved). Note: Validator.TryValidateObjectAsync
+            // skips IAsyncValidatableObject.ValidateAsync once property validation fails, whereas the generated method always
+            // runs it; the two agree here only because the self-validation yields nothing for this input, so we deliberately
+            // avoid combining an attribute failure with a self-validation failure in one instance.
+            var attributeFailure = new AsyncParityOptions { Name = "ok", Age = 0 };
+            var attributeResults = new List<ValidationResult>();
+            bool validatorAttr = await Validator.TryValidateObjectAsync(attributeFailure, new ValidationContext(attributeFailure), attributeResults, validateAllProperties: true);
+            ValidateOptionsResult generatedAttr = await validator.ValidateAsync("AsyncParityOptions", attributeFailure, default);
+            Assert.False(validatorAttr);
+            Assert.True(generatedAttr.Failed);
+            Assert.Equal(attributeResults.Count, generatedAttr.Failures.Count());
+
+            // Self-validation-only failure (attributes pass, reserved name). Validator runs the async self-validation because
+            // property validation succeeds, so both report the same single failure.
+            var selfFailure = new AsyncParityOptions { Name = "reserved", Age = 30 };
+            var selfResults = new List<ValidationResult>();
+            bool validatorSelf = await Validator.TryValidateObjectAsync(selfFailure, new ValidationContext(selfFailure), selfResults, validateAllProperties: true);
+            ValidateOptionsResult generatedSelf = await validator.ValidateAsync("AsyncParityOptions", selfFailure, default);
+            Assert.False(validatorSelf);
+            Assert.True(generatedSelf.Failed);
+            Assert.Equal(selfResults.Count, generatedSelf.Failures.Count());
+            Assert.Contains(generatedSelf.Failures, f => f.Contains("Name is reserved."));
+        }
 #endif // NET
     }
 
@@ -884,6 +952,86 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
 
     [OptionsValidator]
     public partial class ExplicitAsyncRootOptionsValidator : IAsyncValidateOptions<ExplicitAsyncRootOptions>
+    {
+    }
+
+    // Flat model whose async self-validation observes the cancellation token, used to prove the generated ValidateAsync
+    // threads its CancellationToken into the validation sinks (TryValidateValueAsync / IAsyncValidatableObject.ValidateAsync).
+    public class CancellationObservingOptions : IAsyncValidatableObject
+    {
+        [Required]
+        public string? Name { get; set; }
+
+        public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+            ValidationContext validationContext,
+            [global::System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield break;
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            yield break;
+        }
+    }
+
+    [OptionsValidator]
+    public partial class CancellationObservingOptionsValidator : IAsyncValidateOptions<CancellationObservingOptions>
+    {
+    }
+
+    // Model that validates only synchronously (IValidatableObject, no attributes, no async children) but is validated by
+    // an async validator, so the generated ValidateAsync body contains no await and must be emitted as a non-async
+    // method returning Task.FromResult(...) (avoids CS1998).
+    public class SyncSelfValidatingOptions : IValidatableObject
+    {
+        public string? Name { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (Name == "bad")
+            {
+                yield return new ValidationResult("Sync self-validation failed.", new[] { nameof(Name) });
+            }
+        }
+    }
+
+    [OptionsValidator]
+    public partial class SyncSelfValidatingOptionsValidator : IAsyncValidateOptions<SyncSelfValidatingOptions>
+    {
+    }
+
+    // Flat model (attributes + async self-validation, no nested members) so the generated ValidateAsync can be compared
+    // for parity against Validator.TryValidateObjectAsync, which does not recurse into nested members.
+    public class AsyncParityOptions : IAsyncValidatableObject
+    {
+        [Required]
+        public string? Name { get; set; }
+
+        [Range(1, 100)]
+        public int Age { get; set; }
+
+        public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+            ValidationContext validationContext,
+            [global::System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            if (Name == "reserved")
+            {
+                yield return new ValidationResult("Name is reserved.", new[] { nameof(Name) });
+            }
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            yield break;
+        }
+    }
+
+    [OptionsValidator]
+    public partial class AsyncParityOptionsValidator : IAsyncValidateOptions<AsyncParityOptions>
     {
     }
 #endif // NET

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
@@ -189,6 +189,18 @@
   <data name="AlreadyImplementsValidateMethodMessage" xml:space="preserve">
     <value>Type {0} already implements the Validate method.</value>
   </data>
+  <data name="AlreadyImplementsValidateAsyncMethodTitle" xml:space="preserve">
+    <value>A type already includes an implementation of the 'ValidateAsync' method.</value>
+  </data>
+  <data name="AlreadyImplementsValidateAsyncMethodMessage" xml:space="preserve">
+    <value>Type {0} already implements the ValidateAsync method.</value>
+  </data>
+  <data name="AsyncValidationRequiresNet11Title" xml:space="preserve">
+    <value>Asynchronous options validation requires targeting .NET 11 or later.</value>
+  </data>
+  <data name="AsyncValidationRequiresNet11Message" xml:space="preserve">
+    <value>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</value>
+  </data>
   <data name="CantBeStaticClassTitle" xml:space="preserve">
     <value>'OptionsValidatorAttribute' can't be applied to a static class.</value>
   </data>

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
@@ -189,6 +189,18 @@
   <data name="AlreadyImplementsValidateMethodMessage" xml:space="preserve">
     <value>Type {0} already implements the Validate method.</value>
   </data>
+  <data name="AlreadyImplementsValidateAsyncMethodTitle" xml:space="preserve">
+    <value>A type already includes an implementation of the 'ValidateAsync' method.</value>
+  </data>
+  <data name="AlreadyImplementsValidateAsyncMethodMessage" xml:space="preserve">
+    <value>Type {0} already implements the ValidateAsync method.</value>
+  </data>
+  <data name="AsyncValidationRequiresNet11Title" xml:space="preserve">
+    <value>Asynchronous options validation requires targeting .NET 11 or later.</value>
+  </data>
+  <data name="AsyncValidationRequiresNet11Message" xml:space="preserve">
+    <value>Type {0} requires asynchronous options validation, which is only supported when targeting .NET 11 or later.</value>
+  </data>
   <data name="CantBeStaticClassTitle" xml:space="preserve">
     <value>'OptionsValidatorAttribute' can't be applied to a static class.</value>
   </data>


### PR DESCRIPTION
Implements API proposal #130719. Builds on top of #130263 and addresses its review feedback.

Currently, this is a prototype implementation used for exploring the proposed design change.

## Contract unification

- `IAsyncValidateOptions<T>` now **extends `IValidateOptions<T>`** and is invariant (was standalone `IAsyncValidateOptions<in TOptions>`).
- `IAsyncStartupValidator` now **extends `IStartupValidator`**.
- Built-in delegate `AsyncValidateOptions<…>` (all 6 arities) gain a **conservative synchronous `Validate`** that returns `Skip` for non-matching names, and fails for matching names (never sync-over-async).
- **Single validator collection**: all validators are registered as `IValidateOptions<T>`, async is a capability checked at runtime. `Create` always runs `Validate`, `CreateAsync` prefers `ValidateAsync` when the validator also implements `IAsyncValidateOptions<T>` (never both). Registration order preserved.
- **Misregistration detection**: a validator registered as `IAsyncValidateOptions<T>` instead of `IValidateOptions<T>` produces an `InvalidOperationException` the **first time the options value is created**.

## Startup validation changes

- **Single startup path**: `Host.StartAsync` resolves one `IStartupValidator`, calls `ValidateAsync` when it's also `IAsyncStartupValidator`, and runs it **before** hosted-service construction in order to seed the options cache before potential synchronous access (e.g., an `IOptions<T>.Value` read during service startup).
- **Sync accessors serve the startup-validated value** for async-validated types. Once startup validation has seeded a validated instance, `IOptions<T>.Value` returns it instead of re-creating and validating synchronously (which would fail).

## Opt-in async revalidation on config reload

- **`ValidateOnChange`** options-builder extension that enables eager async revalidation on configuration reload (default reload stays lazy).  Each reload re-creates and re-validates the options **in the background**, keeps serving the last valid value until the new config passes, then swaps it in atomically.
- Users can specify **behavior on failure**: either `KeepLastGood` (keep the old value) or `FailReads` (next read throws).
- **Failure observability**: Users can optionally provide an `onError` callback (e.g., for logging via `ILogger`). Failures are also emitted to a new `EventSource`.

## Source generator changes (addressing feedback from #130263)

- **Always emits synchronous `Validate`** in addition to optional `ValidateAsync`.
- New **diagnostics**: `SYSLIB1218` (async validation requested but target < net11) and `SYSLIB1219` (type already implements `ValidateAsync`).
- More precise **signature matching** which also handles explicit interface implementations of `Validate`/`ValidateAsync`.
