### PR TITLE
[mono][wasm][AOT] Generate gsharedvt out-sig wrappers for Nullable<T>.Box/Unbox

### DIFF
--- a/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
@@ -411,13 +411,9 @@ namespace System.Text.Json.Serialization.Tests
                 await RunAsCollectionElementTest(JsonNumberTestData.NullableDoubles);
                 await RunAsCollectionElementTest(JsonNumberTestData.NullableDecimals);
 #if NET
-                // https://github.com/dotnet/runtime/issues/119143
-                if (!PlatformDetection.IsBrowser)
-                {
-                    await RunAsCollectionElementTest(JsonNumberTestData.NullableInt128s);
-                    await RunAsCollectionElementTest(JsonNumberTestData.NullableUInt128s);
-                    await RunAsCollectionElementTest(JsonNumberTestData.NullableHalfs);
-                }
+                await RunAsCollectionElementTest(JsonNumberTestData.NullableInt128s);
+                await RunAsCollectionElementTest(JsonNumberTestData.NullableUInt128s);
+                await RunAsCollectionElementTest(JsonNumberTestData.NullableHalfs);
 #endif
             }
         }

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -5818,41 +5818,42 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 	}
 
 	/*
-	 * Nullable<T>.Box/Unbox (defined in Nullable.Mono.cs) are private static
-	 * methods that are only ever invoked by the JIT: from the box/unbox IL
-	 * lowering (see handle_unbox_nullable / MONO_TYPE_ISNULLABLE handling in
-	 * method-to-ir.c) and from the MONO_RGCTX_INFO_NULLABLE_CLASS_BOX/UNBOX
-	 * rgctx entries. Because nothing in the normal managed call graph references
-	 * them, they are never pulled into the AOT compile set: the method-iteration
-	 * loop above treats them as generic-sharable and skips them ("already added"),
-	 * but the shared Nullable<gsharedvt>.Box/Unbox is likewise never referenced,
-	 * so it is not compiled either (unlike Equals/GetHashCode/ToString, which are
-	 * reached from normal code and do get their shared version).
+	 * Minimal gsharedvt (llvmonly only; see cfg->gsharedvt_min in mini.c) cannot
+	 * compile a method whose signature contains a variable-length gsharedvt type.
+	 * Nullable<T>.Box/Unbox (private static helpers in Nullable.Mono.cs) take/return
+	 * Nullable<T> by value, so for a variable (struct) T their shared gsharedvt
+	 * instantiation is rejected and never emitted.
 	 *
-	 * When a Nullable<T> (T a struct) is boxed through a non-generic interface
-	 * under gsharedvt in llvmonly mode, class_type_info's NULLABLE_CLASS_BOX case
-	 * compiles the concrete Nullable<T>.Box and, because the caller uses the
-	 * gsharedvt calling convention while the resolved callee is concrete, needs
-	 * the object(Nullable<T>) gsharedvt out-sig wrapper (and Nullable<T>(object)
-	 * for Unbox). That wrapper is only emitted as a side effect of AOT-compiling
-	 * the concrete Box/Unbox method (via the add_gsharedvt_wrappers call driven by
-	 * compiled method signatures). Compiling only the shared gsharedvt version is
-	 * not sufficient: at runtime mono_jit_compile_method resolves the concrete
-	 * instantiation through a static rgctx trampoline, so the box path still
-	 * requires the concrete out-sig wrapper.
+	 * The box/unbox IL lowering resolves these helpers through the rgctx at runtime
+	 * (MONO_RGCTX_INFO_NULLABLE_CLASS_BOX/UNBOX, mini-generic-sharing.c). With no
+	 * shared version available, the resolved callee is the *concrete* instantiation,
+	 * so the gsharedvt caller needs a gsharedvt->concrete out-sig wrapper
+	 * (llvmonly-runtime.c mini_llvmonly_add_method_wrappers: caller_gsharedvt &&
+	 * !callee_gsharedvt). That wrapper only exists as a side effect of AOT-compiling
+	 * the concrete method (add_gsharedvt_wrappers in compile_method).
 	 *
-	 * Add the concrete Box/Unbox for every Nullable<T> instantiation so the
-	 * required wrappers are emitted. This mirrors what already happens for
-	 * Nullable<primitive>/Nullable<enum> (whose concrete Box is compiled via other
-	 * paths); without it, boxing a Nullable<vtype> traps at runtime
-	 * ("null function or function signature mismatch") because the wrapper cannot
-	 * be JIT-compiled in aot-only mode.
+	 * Unlike ordinary generic methods, Box/Unbox are JIT-internal helpers that are
+	 * never referenced from IL, so nothing in the managed call graph collects their
+	 * concrete instantiation (Equals/GetHashCode/ToString, by contrast, are reached
+	 * from normal code and do get their shared version). Without this, neither the
+	 * concrete method nor its wrapper is emitted and boxing a Nullable<vtype> traps
+	 * at runtime with "null function or function signature mismatch". Add the
+	 * concrete Box/Unbox so the wrapper is generated.
+	 *
+	 * Only minimal gsharedvt needs this: with full gsharedvt (non-llvmonly) the
+	 * shared Box/Unbox is emitted and handles every T, so no concrete method or
+	 * wrapper is required -- hence the llvm_only guard.
 	 */
-	if (mono_class_is_nullable (klass)) {
+	if (acfg->aot_opts.llvm_only && mono_class_is_nullable (klass)) {
 		MonoMethod *box = try_get_method_nofail (klass, "Box", 1, 0);
 		if (box)
 			add_extra_method_with_depth (acfg, box, depth + 1);
-		MonoMethod *unbox = try_get_method_nofail (klass, "Unbox", 1, 0);
+		/*
+		 * Enum-backed Nullable<T> unboxes via UnboxExact (exact type check),
+		 * everything else via Unbox -- mirrors handle_unbox_nullable.
+		 */
+		const char *unbox_name = m_class_is_enumtype (mono_class_get_nullable_param_internal (klass)) ? "UnboxExact" : "Unbox";
+		MonoMethod *unbox = try_get_method_nofail (klass, unbox_name, 1, 0);
 		if (unbox)
 			add_extra_method_with_depth (acfg, unbox, depth + 1);
 	}

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -5818,18 +5818,35 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 	}
 
 	/*
-	 * Nullable<T>.Box/Unbox are runtime-synthesized methods (not part of the
-	 * type's regular method list) that are requested by the
-	 * MONO_RGCTX_INFO_NULLABLE_CLASS_BOX/UNBOX rgctx entries when a Nullable<T>
-	 * is boxed/unboxed through a non-generic interface under gsharedvt sharing.
-	 * In llvmonly mode the caller uses the gsharedvt calling convention and needs
-	 * the object(Nullable<T>) / Nullable<T>(object) gsharedvt out-sig wrappers.
-	 * Those wrappers are only emitted when the Box/Unbox methods themselves are
-	 * AOT-compiled (see the add_gsharedvt_wrappers call driven by compiled method
-	 * signatures). Since the method-iteration loop above never sees these synthetic
-	 * methods, add them explicitly here for every Nullable<T> instantiation,
-	 * otherwise boxing a Nullable<vtype> traps ("function signature mismatch")
-	 * at runtime because JIT compilation is unavailable in aot-only mode.
+	 * Nullable<T>.Box/Unbox (defined in Nullable.Mono.cs) are private static
+	 * methods that are only ever invoked by the JIT: from the box/unbox IL
+	 * lowering (see handle_unbox_nullable / MONO_TYPE_ISNULLABLE handling in
+	 * method-to-ir.c) and from the MONO_RGCTX_INFO_NULLABLE_CLASS_BOX/UNBOX
+	 * rgctx entries. Because nothing in the normal managed call graph references
+	 * them, they are never pulled into the AOT compile set: the method-iteration
+	 * loop above treats them as generic-sharable and skips them ("already added"),
+	 * but the shared Nullable<gsharedvt>.Box/Unbox is likewise never referenced,
+	 * so it is not compiled either (unlike Equals/GetHashCode/ToString, which are
+	 * reached from normal code and do get their shared version).
+	 *
+	 * When a Nullable<T> (T a struct) is boxed through a non-generic interface
+	 * under gsharedvt in llvmonly mode, class_type_info's NULLABLE_CLASS_BOX case
+	 * compiles the concrete Nullable<T>.Box and, because the caller uses the
+	 * gsharedvt calling convention while the resolved callee is concrete, needs
+	 * the object(Nullable<T>) gsharedvt out-sig wrapper (and Nullable<T>(object)
+	 * for Unbox). That wrapper is only emitted as a side effect of AOT-compiling
+	 * the concrete Box/Unbox method (via the add_gsharedvt_wrappers call driven by
+	 * compiled method signatures). Compiling only the shared gsharedvt version is
+	 * not sufficient: at runtime mono_jit_compile_method resolves the concrete
+	 * instantiation through a static rgctx trampoline, so the box path still
+	 * requires the concrete out-sig wrapper.
+	 *
+	 * Add the concrete Box/Unbox for every Nullable<T> instantiation so the
+	 * required wrappers are emitted. This mirrors what already happens for
+	 * Nullable<primitive>/Nullable<enum> (whose concrete Box is compiled via other
+	 * paths); without it, boxing a Nullable<vtype> traps at runtime
+	 * ("null function or function signature mismatch") because the wrapper cannot
+	 * be JIT-compiled in aot-only mode.
 	 */
 	if (mono_class_is_nullable (klass)) {
 		MonoMethod *box = try_get_method_nofail (klass, "Box", 1, 0);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -5817,6 +5817,29 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 		add_extra_method_with_depth (acfg, method, depth + 1);
 	}
 
+	/*
+	 * Nullable<T>.Box/Unbox are runtime-synthesized methods (not part of the
+	 * type's regular method list) that are requested by the
+	 * MONO_RGCTX_INFO_NULLABLE_CLASS_BOX/UNBOX rgctx entries when a Nullable<T>
+	 * is boxed/unboxed through a non-generic interface under gsharedvt sharing.
+	 * In llvmonly mode the caller uses the gsharedvt calling convention and needs
+	 * the object(Nullable<T>) / Nullable<T>(object) gsharedvt out-sig wrappers.
+	 * Those wrappers are only emitted when the Box/Unbox methods themselves are
+	 * AOT-compiled (see the add_gsharedvt_wrappers call driven by compiled method
+	 * signatures). Since the method-iteration loop above never sees these synthetic
+	 * methods, add them explicitly here for every Nullable<T> instantiation,
+	 * otherwise boxing a Nullable<vtype> traps ("function signature mismatch")
+	 * at runtime because JIT compilation is unavailable in aot-only mode.
+	 */
+	if (mono_class_is_nullable (klass)) {
+		MonoMethod *box = try_get_method_nofail (klass, "Box", 1, 0);
+		if (box)
+			add_extra_method_with_depth (acfg, box, depth + 1);
+		MonoMethod *unbox = try_get_method_nofail (klass, "Unbox", 1, 0);
+		if (unbox)
+			add_extra_method_with_depth (acfg, unbox, depth + 1);
+	}
+
 	iter = NULL;
 	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->type == MONO_TYPE_GENERICINST)

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -5818,44 +5818,33 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 	}
 
 	/*
-	 * Minimal gsharedvt (llvmonly only; see cfg->gsharedvt_min in mini.c) cannot
-	 * compile a method whose signature contains a variable-length gsharedvt type.
-	 * Nullable<T>.Box/Unbox (private static helpers in Nullable.Mono.cs) take/return
-	 * Nullable<T> by value, so for a variable (struct) T their shared gsharedvt
-	 * instantiation is rejected and never emitted.
+	 * Minimal gsharedvt used by llvmonly cannot compile shared methods whose
+	 * signatures contain variable-size value types. Nullable<T>.Box/Unbox have
+	 * such signatures, so their shared implementations are unavailable.
 	 *
-	 * The box/unbox IL lowering resolves these helpers through the rgctx at runtime
-	 * (MONO_RGCTX_INFO_NULLABLE_CLASS_BOX/UNBOX, mini-generic-sharing.c). With no
-	 * shared version available, the resolved callee is the *concrete* instantiation,
-	 * so the gsharedvt caller needs a gsharedvt->concrete out-sig wrapper
-	 * (llvmonly-runtime.c mini_llvmonly_add_method_wrappers: caller_gsharedvt &&
-	 * !callee_gsharedvt). That wrapper only exists as a side effect of AOT-compiling
-	 * the concrete method (add_gsharedvt_wrappers in compile_method).
+	 * The runtime consequently resolves these helpers to concrete methods and
+	 * adapts gsharedvt callers with out wrappers. Those wrappers are generated
+	 * when the concrete methods are AOT-compiled, while the generic-class scan
+	 * normally skips these methods because they are otherwise sharable.
+	 * Explicitly add the concrete helpers to cover this llvmonly-specific gap.
 	 *
-	 * Unlike ordinary generic methods, Box/Unbox are JIT-internal helpers that are
-	 * never referenced from IL, so nothing in the managed call graph collects their
-	 * concrete instantiation (Equals/GetHashCode/ToString, by contrast, are reached
-	 * from normal code and do get their shared version). Without this, neither the
-	 * concrete method nor its wrapper is emitted and boxing a Nullable<vtype> traps
-	 * at runtime with "null function or function signature mismatch". Add the
-	 * concrete Box/Unbox so the wrapper is generated.
-	 *
-	 * Only minimal gsharedvt needs this: with full gsharedvt (non-llvmonly) the
-	 * shared Box/Unbox is emitted and handles every T, so no concrete method or
-	 * wrapper is required -- hence the llvm_only guard.
+	 * The rgctx unbox entry (MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX) always resolves
+	 * Unbox, so add Box and Unbox unconditionally; enum-backed Nullable<T> is
+	 * additionally unboxed via UnboxExact from the statically-typed IL lowering
+	 * (handle_unbox_nullable), so add that too.
 	 */
 	if (acfg->aot_opts.llvm_only && mono_class_is_nullable (klass)) {
 		MonoMethod *box = try_get_method_nofail (klass, "Box", 1, 0);
 		if (box)
 			add_extra_method_with_depth (acfg, box, depth + 1);
-		/*
-		 * Enum-backed Nullable<T> unboxes via UnboxExact (exact type check),
-		 * everything else via Unbox -- mirrors handle_unbox_nullable.
-		 */
-		const char *unbox_name = m_class_is_enumtype (mono_class_get_nullable_param_internal (klass)) ? "UnboxExact" : "Unbox";
-		MonoMethod *unbox = try_get_method_nofail (klass, unbox_name, 1, 0);
+		MonoMethod *unbox = try_get_method_nofail (klass, "Unbox", 1, 0);
 		if (unbox)
 			add_extra_method_with_depth (acfg, unbox, depth + 1);
+		if (m_class_is_enumtype (mono_class_get_nullable_param_internal (klass))) {
+			MonoMethod *unbox_exact = try_get_method_nofail (klass, "UnboxExact", 1, 0);
+			if (unbox_exact)
+				add_extra_method_with_depth (acfg, unbox_exact, depth + 1);
+		}
 	}
 
 	iter = NULL;


### PR DESCRIPTION
## Summary

Boxing a `Nullable<T>` (where `T` is a non-primitive struct) through a **non-generic** interface (e.g. `IEnumerator.Current` → `object`) under **wasm AOT (llvmonly)** traps at runtime with `MONO_WASM: null function or function signature mismatch`, or — in an asserts build — aborts with:

```
Attempting to JIT compile method
'(wrapper other) object:gsharedvt_out_sig (intptr,System.ValueTuple`2<byte,...>&,intptr)'
while running in aot-only mode.
```

Fixes #119143.

## Root cause

`Nullable<T>.Box` / `Nullable<T>.Unbox` are runtime-synthesized methods (obtained via `mono_class_get_method_from_name(klass, "Box"/"Unbox", 1, 0)`), **not** part of the type's regular method list. The AOT compiler's `add_generic_class` method-iteration loop therefore never sees them, so they are never AOT-compiled.

In llvmonly mode the `MONO_RGCTX_INFO_NULLABLE_CLASS_BOX`/`UNBOX` rgctx entries request the `object(Nullable<T>)` / `Nullable<T>(object)` **gsharedvt out-sig wrappers** (the caller uses the gsharedvt calling convention). Those wrappers are only emitted as a side effect of a method with that signature being AOT-compiled (see the `add_gsharedvt_wrappers` call driven by compiled method signatures in `compile_method`). Because `Nullable<T>.Box`/`Unbox` were never compiled, the wrapper is absent, cannot be JIT-created in aot-only mode, and the indirect call traps.

The wrappers *were* generated for a few `Nullable<T>` only when the canonical struct shape happened to collide with another compiled signature; novel struct payloads (`Int128`, `Guid`, `decimal`, `DateTime`, `Vector128<byte>`, …) were never covered.

## Fix

In `add_generic_class_with_depth`, explicitly add `Nullable<T>.Box` and `Nullable<T>.Unbox` to the compile set for every concrete `Nullable<T>` instantiation (reached via the TYPESPEC table), mirroring the existing `Comparer<T>`/`EqualityComparer<T>` special-cases in the same function. The per-compiled-method gsharedvt wrapper emission then generates the required out-sig wrappers deterministically.

## Verification

Static (nesm wasm inspection of the AOT'd `dotnet.native.wasm`):

| Nullable shape | Box `obj(...)` wrapper | Unbox `...(obj)` wrapper |
| --- | --- | --- |
| `Nullable<Int128>` (`ValueTuple<byte,(long,long)>`) — **before** | ❌ absent | ❌ absent |
| `Nullable<Int128>` — **after** | ✅ present | ✅ present |

The missing `gsharedvt_out_sig_obj_cl4c_...ValueTuple<byte,(long,long)>` symbol named in the #119143 crash stack is exactly the one now emitted.

Functional (Mono wasm AOT, run under node): a 17-case matrix boxing each value type through a non-generic `IEnumerable` now passes for every previously-failing `Nullable<struct>` (`Int128`, `Guid`, `decimal`, `DateTime`, `Vector128<byte>`, `Pixel4`, 2×`long`) while all previously-working cases (primitives, bare structs, `Nullable<primitive>`) remain green.

Re-enables the `NullableInt128s` / `NullableUInt128s` / `NullableHalfs` cases of `System.Text.Json`'s `Number_AsCollectionElement_RoundTrip` on Browser (previously skipped via `!PlatformDetection.IsBrowser`).

## Scope / related

This is the **tractable `Nullable` subset** of a broader family where the AOT compiler doesn't pre-generate gsharedvt out-sig wrappers for every struct signature reachable at runtime. Distinct, *not* addressed here:
- #130545 — `PixelOperations<Rgba32>` via static-abstract `TPixel.FromRgba32` (different dispatch).
- #117557 (closed KBE) — `SymbolicRegexBuilder.NodeCacheKey<object>&` by-ref struct.
- #101481 — `Nullable<int>` under MT (primitive nullable; already works here).

> [!NOTE]
> This PR was created with the assistance of GitHub Copilot.
