### PR TITLE
Defer CBOR reader strict-map key tracking until second key

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
@@ -160,7 +160,18 @@ namespace System.Formats.Cbor
         {
             Debug.Assert(_currentKeyOffset != null);
 
-            HashSet<(int Offset, int Length)> keyEncodingRanges = GetKeyEncodingRanges();
+            HashSet<(int Offset, int Length)>? keyEncodingRanges = _keyEncodingRanges;
+            if (keyEncodingRanges is null)
+            {
+                if (_previousKeyEncodingRange is null)
+                {
+                    _previousKeyEncodingRange = currentKeyEncodingRange;
+                    return;
+                }
+
+                keyEncodingRanges = GetKeyEncodingRanges();
+                keyEncodingRanges.Add(_previousKeyEncodingRange.Value);
+            }
 
             if (!keyEncodingRanges.Add(currentKeyEncodingRange))
             {


### PR DESCRIPTION
Defers the `HashSet<(int,int)>` allocation used for strict-mode map key-uniqueness validation until a **second** key is actually encountered. Single-pair strict maps (a common shape) no longer allocate the set at all.

## What changed

`CborReader.ValidateKeyUniqueness` previously allocated (or rented) the key-encoding `HashSet` on the very first key of every strict-mode map. Now the first key's encoding range is stashed in the existing `_previousKeyEncodingRange` slot; the set is only allocated on the second key, seeded with the stashed first range before the duplicate check proceeds. Behavior is otherwise identical — duplicate detection, buffer reset on throw, checkpoint rollback, and nested/pooled state are all unchanged.

The `_previousKeyEncodingRange` field already exists and is used by the canonical-mode sorted-key path. Strict and canonical validation are mutually exclusive for a given reader (fixed by `ConformanceMode`), so the two never share the slot concurrently.

## Results

Local BenchmarkDotNet A/B (macOS arm64, .NET 11.0.0, BDN 0.14.0, `[MemoryDiagnoser]`), same source except this one file:

| Method | Baseline Alloc | This PR Alloc |
|---|---:|---:|
| `OnePair_Strict_Fresh` | 712 B | **424 B** |
| `OnePair_Strict_Reused` | 0 B | 0 B |
| `Larger_Strict` (32 pairs) | 2088 B | 2088 B |
| `Canonical_Sorted` | 424 B | 424 B |
| `Nested_Strict` | 1240 B | 1240 B |
| `Duplicate_Strict` | 1288 B | 1288 B |
| `Rollback_Strict` | 1312 B | 1312 B |

One-pair strict maps drop from 712 B → 424 B (−40%), now matching the canonical path that never needed the set. All multi-key/canonical/nested/duplicate/rollback controls are byte-identical (no regression); the pooled reused-reader path stays at 0 B.

Full System.Formats.Cbor test suite passes locally (1921 total, 0 failed, 0 skipped).

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot.
