### PR TITLE
Reserve CBOR string buffer capacity in a single call

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Integer.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Integer.cs
@@ -118,6 +118,42 @@ namespace System.Formats.Cbor
             }
         }
 
+        private void WriteUnsignedInteger(CborMajorType type, ulong value, int additionalCapacity)
+        {
+            if (value < (byte)CborAdditionalInfo.Additional8BitData)
+            {
+                EnsureWriteCapacity(checked(1 + additionalCapacity));
+                WriteInitialByte(new CborInitialByte(type, (CborAdditionalInfo)value));
+            }
+            else if (value <= byte.MaxValue)
+            {
+                EnsureWriteCapacity(checked(1 + sizeof(byte) + additionalCapacity));
+                WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Additional8BitData));
+                _buffer[_offset++] = (byte)value;
+            }
+            else if (value <= ushort.MaxValue)
+            {
+                EnsureWriteCapacity(checked(1 + sizeof(ushort) + additionalCapacity));
+                WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Additional16BitData));
+                BinaryPrimitives.WriteUInt16BigEndian(_buffer.AsSpan(_offset), (ushort)value);
+                _offset += sizeof(ushort);
+            }
+            else if (value <= uint.MaxValue)
+            {
+                EnsureWriteCapacity(checked(1 + sizeof(uint) + additionalCapacity));
+                WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Additional32BitData));
+                BinaryPrimitives.WriteUInt32BigEndian(_buffer.AsSpan(_offset), (uint)value);
+                _offset += sizeof(uint);
+            }
+            else
+            {
+                EnsureWriteCapacity(checked(1 + sizeof(ulong) + additionalCapacity));
+                WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Additional64BitData));
+                BinaryPrimitives.WriteUInt64BigEndian(_buffer.AsSpan(_offset), value);
+                _offset += sizeof(ulong);
+            }
+        }
+
         private static int GetIntegerEncodingLength(ulong value)
         {
             if (value < (byte)CborAdditionalInfo.Additional8BitData)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.String.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.String.cs
@@ -38,8 +38,7 @@ namespace System.Formats.Cbor
         /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteByteString(ReadOnlySpan<byte> value)
         {
-            WriteUnsignedInteger(CborMajorType.ByteString, (ulong)value.Length);
-            EnsureWriteCapacity(value.Length);
+            WriteUnsignedInteger(CborMajorType.ByteString, (ulong)value.Length, value.Length);
 
             if (ConvertIndefiniteLengthEncodings && _currentMajorType == CborMajorType.ByteString)
             {
@@ -134,8 +133,7 @@ namespace System.Formats.Cbor
                 throw new ArgumentException(SR.Cbor_Writer_InvalidUtf8String, e);
             }
 
-            WriteUnsignedInteger(CborMajorType.TextString, (ulong)length);
-            EnsureWriteCapacity(length);
+            WriteUnsignedInteger(CborMajorType.TextString, (ulong)length, length);
 
             if (ConvertIndefiniteLengthEncodings && _currentMajorType == CborMajorType.TextString)
             {


### PR DESCRIPTION
## Summary

`CborWriter.WriteByteString` and `CborWriter.WriteTextString` currently reserve
buffer space in two steps: `WriteUnsignedInteger` reserves the length prefix, then a
second `EnsureWriteCapacity(length)` reserves the payload. When the internal buffer
has to grow, this can trigger **two allocations and copies** for a single string write
(e.g. the first write to a fresh `CborWriter`, whose buffer starts empty, is grown to
1024 bytes for the prefix, then grown again for a larger payload).

This change adds a `WriteUnsignedInteger(type, value, additionalCapacity)` overload that
folds the payload size into the length-prefix reservation, so the writer performs **at
most one** `EnsureWriteCapacity` (hence at most one growth) per string write. The final
reserved capacity is identical to before and the encoded output is byte-for-byte identical.

## Details

- New private overload reserves `1 + <intBytes> + additionalCapacity` up front, with
  `checked(...)` guarding against `int` overflow for pathological lengths.
- `WriteByteString(ReadOnlySpan<byte>)` and `WriteTextString(ReadOnlySpan<char>)` now
  pass the payload length as `additionalCapacity` and drop their separate
  `EnsureWriteCapacity` call.
- No public API change.

## Correctness

- Final required capacity is unchanged: `offset + 1 + intBytes + length`.
- `EnsureWriteCapacity` preserves already-written bytes on growth, and the single
  reservation now runs before the header is written, so the header lands in the grown
  buffer.
- The text path copies via `_buffer.AsSpan(_offset, length)`, a bounds-checked slice
  that would throw on any under-reservation — so the passing test suite directly
  validates the new arithmetic.
- Indefinite-length chunk range bookkeeping is unchanged.
- Full `System.Formats.Cbor` test suite passes locally (1921 tests, 0 failed, 0 skipped).

## Performance

Local A/B micro-benchmark (BenchmarkDotNet, `[MemoryDiagnoser]`, in-process; baseline =
`main`, candidate = this change; both compiled Release). Matrix: fresh vs. reused writer
x byte / ASCII text / Unicode text (`é`, 2 UTF-8 bytes/char), medium (256 B) and large
(64 KiB) payloads, plus an `Int64` primitive control that exercises the *unchanged*
`WriteUnsignedInteger` path.

The deterministic win is **one fewer buffer allocation** on a fresh writer once the
payload exceeds the initial 1024-byte growth:

| Scenario (fresh writer)   | Size  | Allocated before | Allocated after | Delta       |
|---------------------------|------:|-----------------:|----------------:|-------------|
| WriteByteString           | 64 KiB| 66,752 B         | 65,704 B        | -1,048 B    |
| WriteTextString (ASCII)   | 64 KiB| 66,752 B         | 65,704 B        | -1,048 B    |
| WriteTextString (Unicode) | 64 KiB| 132,412 B        | 131,364 B       | -1,048 B    |
| WriteByteString / text    | 256 B | 1,184 B          | 1,184 B         | no change   |

- The 64 KiB fresh writes drop exactly the intermediate ~1 KiB array (two allocations
  -> one), with a matching reduction in Gen0 rate (e.g. FreshByteString 7.93 -> 7.81
  Gen0/1k op).
- At 256 B the payload already fits inside the first growth, so both versions allocate
  once — no regression, no change.
- Reused-writer path and the `Int64` control allocate zero in both versions and are
  unchanged (within run-to-run noise).

Local timings are on an Apple M5 Pro (arm64) and are within measurement noise for the
compute-bound cases; the meaningful, deterministic signal here is the allocation
reduction. Cross-platform Release before/after via EgorBot below.

<!-- EgorBot results will appear here -->

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
