### PR TITLE
Defer CBOR writer map key uniqueness tracking allocation

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
@@ -94,15 +94,21 @@ namespace System.Formats.Cbor
 
         private void HandleMapKeyWritten()
         {
-            Debug.Assert(_currentKeyOffset != null && _currentValueOffset == null);
+            Debug.Assert(_currentKeyOffset != null);
 
             if (CborConformanceModeHelpers.RequiresUniqueKeys(ConformanceMode))
             {
-                HashSet<(int Offset, int Length)> keyEncodingRanges = GetKeyEncodingRanges();
-
                 (int Offset, int Length) currentKey = (_currentKeyOffset.Value, _offset - _currentKeyOffset.Value);
+                HashSet<(int Offset, int Length)>? keyEncodingRanges = _keyEncodingRanges;
 
-                if (!keyEncodingRanges.Add(currentKey))
+                if (keyEncodingRanges is null && _currentValueOffset is not null)
+                {
+                    keyEncodingRanges = GetKeyEncodingRanges();
+                    var firstKey = (_frameOffset, _currentValueOffset.Value - _frameOffset);
+                    keyEncodingRanges.Add(firstKey);
+                }
+
+                if (keyEncodingRanges is not null && !keyEncodingRanges.Add(currentKey))
                 {
                     // reset writer state to right before the offending key write
                     _buffer.AsSpan(currentKey.Offset, _offset).Clear();
@@ -144,7 +150,10 @@ namespace System.Formats.Cbor
 
             // update offset state to the next key
             _currentKeyOffset = _offset;
-            _currentValueOffset = null;
+            if (_itemsWritten != 1 || !CborConformanceModeHelpers.RequiresUniqueKeys(ConformanceMode))
+            {
+                _currentValueOffset = null;
+            }
         }
 
         private void CompleteMapWrite()


### PR DESCRIPTION
## Summary

`CborWriter` allocates a `HashSet<(int Offset, int Length)>` to enforce key uniqueness for **every** map written in a unique-key conformance mode (Strict — the default — plus Canonical and Ctap2Canonical). A single-entry map can never contain a duplicate key, so that allocation is pure overhead in the common single-entry case.

This change defers the `HashSet` allocation until a map receives its **second** key. Single-entry maps in unique-key modes now allocate no tracking set. When a second key arrives, the set is lazily created and the first key's encoding range — reconstructed from `_frameOffset` and the preserved `_currentValueOffset` — is added before the second key is checked, so duplicate detection and the recoverable-error contract are unchanged.

## Change

Touches only `CborWriter.Map.cs`:

- `HandleMapValueWritten` keeps `_currentValueOffset` non-null after the first value when the map requires unique keys, so the first key's `(offset, length)` range can be reconstructed later.
- `HandleMapKeyWritten` lazily allocates the set on the second key and backfills the first key before adding the second.

No public API or wire-format change. Lax mode (no unique-key requirement) is untouched.

## Tests

Full `System.Formats.Cbor` suite passes (1921/1921), including the duplicate-key strict/recoverable, nested-map, and conformance-sorting cases that exercise the deferred-add path.

## Local allocation measurement (before/after)

`MemoryDiagnoser`, Apple M5 Pro, .NET 11 preview. Baseline vs final built from the same harness with the assembly swapped in-place (verified by MVID). Headline metric is allocated bytes/op.

| Method | Base B | Final B | Δ |
|---|---:|---:|---:|
| `OnePair_Strict_Fresh` (primary) | 1784 | 1496 | **−288 B** |
| `OnePair_Canonical` | 1976 | 1688 | −288 B |
| `Nested_Strict` (3 single-entry maps) | 2320 | 1504 | −816 B |
| `OnePair_Strict_Reused` (control) | 32 | 32 | 0 |
| `Larger_Strict` (control, ≥2 keys) | 3240 | 3240 | 0 |
| `DuplicateRecovery_Strict` (control) | 2280 | 2280 | 0 |

Single-entry unique-key maps drop the 288 B `HashSet`; multi-key and reused-writer paths are unaffected. Authoritative cross-platform Release timings requested from EgorBot below.

> [!NOTE]
> This PR was prepared with assistance from GitHub Copilot.
