### PR TITLE
Emit SupportedOSPlatform("browser") on generated JSImport partials

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Constants.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Constants.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Interop.JavaScript
         public const string JSExportAttribute = "System.Runtime.InteropServices.JavaScript.JSExportAttribute";
         public const string JavaScriptMarshal = "System.Runtime.InteropServices.JavaScript.JavaScriptMarshal";
         public const string DebuggerNonUserCodeAttribute = "global::System.Diagnostics.DebuggerNonUserCode";
+        public const string SupportedOSPlatformAttribute = "global::System.Runtime.Versioning.SupportedOSPlatform";
+        public const string BrowserPlatform = "browser";
 
         public const string JSFunctionSignatureGlobal = "global::System.Runtime.InteropServices.JavaScript.JSFunctionBinding";
         public const string JSMarshalerArgumentGlobal = "global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument";

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.cs
@@ -93,6 +93,10 @@ namespace Microsoft.Interop.JavaScript
                 .AddAttributeLists(stub.SignatureContext.AdditionalAttributes.ToArray())
                 .WithAttributeLists(SingletonList(AttributeList(SingletonSeparatedList(
                     Attribute(IdentifierName(Constants.DebuggerNonUserCodeAttribute))))))
+                .AddAttributeLists(AttributeList(SingletonSeparatedList(
+                    Attribute(IdentifierName(Constants.SupportedOSPlatformAttribute))
+                        .AddArgumentListArguments(AttributeArgument(LiteralExpression(
+                            SyntaxKind.StringLiteralExpression, Literal(Constants.BrowserPlatform)))))))
                 .WithModifiers(StripTriviaFromModifiers(userDeclaredMethod.Modifiers))
                 .WithParameterList(ParameterList(SeparatedList(stub.SignatureContext.StubParameters)))
                 .WithBody(stubCode);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.cs
@@ -90,13 +90,15 @@ namespace Microsoft.Interop.JavaScript
         {
             // Create stub function
             MethodDeclarationSyntax stubMethod = MethodDeclaration(stub.SignatureContext.StubReturnType, userDeclaredMethod.Identifier)
-                .AddAttributeLists(stub.SignatureContext.AdditionalAttributes.ToArray())
-                .WithAttributeLists(SingletonList(AttributeList(SingletonSeparatedList(
-                    Attribute(IdentifierName(Constants.DebuggerNonUserCodeAttribute))))))
-                .AddAttributeLists(AttributeList(SingletonSeparatedList(
-                    Attribute(IdentifierName(Constants.SupportedOSPlatformAttribute))
-                        .AddArgumentListArguments(AttributeArgument(LiteralExpression(
-                            SyntaxKind.StringLiteralExpression, Literal(Constants.BrowserPlatform)))))))
+                .WithAttributeLists(List(new[]
+                {
+                    AttributeList(SingletonSeparatedList(
+                        Attribute(ParseName(Constants.DebuggerNonUserCodeAttribute)))),
+                    AttributeList(SingletonSeparatedList(
+                        Attribute(ParseName(Constants.SupportedOSPlatformAttribute))
+                            .AddArgumentListArguments(AttributeArgument(LiteralExpression(
+                                SyntaxKind.StringLiteralExpression, Literal(Constants.BrowserPlatform)))))),
+                }))
                 .WithModifiers(StripTriviaFromModifiers(userDeclaredMethod.Modifiers))
                 .WithParameterList(ParameterList(SeparatedList(stub.SignatureContext.StubParameters)))
                 .WithBody(stubCode);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/JSImportGenerator.UnitTest/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/JSImportGenerator.UnitTest/Compiles.cs
@@ -67,6 +67,7 @@ namespace JSImportGenerator.Unit.Tests
                             unsafe partial class Basic
                             {
                                 [global::System.Diagnostics.DebuggerNonUserCode]
+                                [global::System.Runtime.Versioning.SupportedOSPlatform("browser")]
                                 internal static partial void Annotated(object a1, long a2, long a3, global::System.Action a4, global::System.Func<int> a5, global::System.Span<byte> a6, global::System.ArraySegment<byte> a7, global::System.Threading.Tasks.Task<object> a8, object[] a9, global::System.DateTime a10, global::System.DateTimeOffset a11, global::System.Threading.Tasks.Task<global::System.DateTime> a12, global::System.Threading.Tasks.Task<global::System.DateTimeOffset> a13, global::System.Threading.Tasks.Task<long> a14, global::System.Threading.Tasks.Task<long> a15, global::System.ArraySegment<float> a16)
                                 {
                                     if (__signature_Annotated_2034238666 == null)
@@ -291,6 +292,7 @@ namespace JSImportGenerator.Unit.Tests
                             unsafe partial class Basic
                             {
                                 [global::System.Diagnostics.DebuggerNonUserCode]
+                                [global::System.Runtime.Versioning.SupportedOSPlatform("browser")]
                                 public static partial global::System.Threading.Tasks.Task<int> Import1()
                                 {
                                     if (__signature_Import1_622134597 == null)


### PR DESCRIPTION
Fixes #121165.

## Problem

`JSImportAttribute` carries `[SupportedOSPlatform("browser")]`, but placing that attribute on the *attribute type* has no effect on the methods it annotates. As a result, `CA1416` never fires when a `JSImport` method is called from code that is reachable on non-browser platforms — the platform guidance the attribute was meant to convey is silently lost.

## Fix

Have the JSImport source generator apply `[SupportedOSPlatform("browser")]` to the generated **partial method implementation** instead. Partial-method attribute merging then makes the combined method browser-only, so the platform-compatibility analyzer reports `CA1416` as expected when the method is used from non-browser code.

## Notes

- **JSExport is intentionally not changed.** `JSExportAttribute` has the same ineffective class-level `[SupportedOSPlatform("browser")]`, but `JSExport` is applied to a user-authored *non-partial* method — the generator only emits wrapper/registration code, not the method itself, so there is no generated declaration to decorate.
- The class-level `[SupportedOSPlatform("browser")]` on `JSImportAttribute`/`JSExportAttribute` was left in place. It is ineffective for the annotated-method scenario but harmless, and removing it would churn the public ref surface. Happy to remove it if preferred.

## Testing

- Baseline `clr+libs` build succeeded.
- `JSImportGenerator.Unit.Tests`: 22/22 pass, including the two generated-source verification snapshots (`Annotated`, `Import1`) updated to include the new attribute.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.