### PR TITLE
[mono][wasm] Fix UnmanagedCallersOnly exports with more than 8 arguments

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -479,5 +479,35 @@ namespace Wasm.Build.Tests
             Assert.DoesNotContain("Conflict.A.Managed8\u4F60Func(123) -> 123", result.TestOutput);
             Assert.Contains("ManagedFunc returned 42", result.TestOutput);
         }
+
+        [Theory]
+        [BuildAndRun(aot: false)]
+        public async Task UnmanagedCallbackWithManyArgs(Configuration config, bool aot)
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/109338:
+            // [UnmanagedCallersOnly] exports with more than MAX_INTERP_ENTRY_ARGS (8)
+            // arguments trapped with "null function or function signature mismatch"
+            // when invoked from native code.
+            var extraProperties = "<AllowUnsafeBlocks>true</AllowUnsafeBlocks>";
+            var extraItems = @"<NativeFileReference Include=""local.c"" />";
+            ProjectInfo info = CopyTestAsset(config, aot, TestAsset.WasmBasicTestApp, "uco_manyargs", extraItems: extraItems, extraProperties: extraProperties);
+            ReplaceFile(Path.Combine("Common", "Program.cs"), Path.Combine(BuildEnvironment.TestAssetsPath, "EntryPoints", "PInvoke", "UnmanagedCallbackManyArgs.cs"));
+            File.Copy(Path.Combine(BuildEnvironment.TestAssetsPath, "native-libs", "local_manyargs.c"), Path.Combine(_projectDir, "local.c"));
+            // The test program does not use JS interop, so the JS interop assembly would be
+            // linked away by the trimmer and the template main.js (which calls
+            // getAssemblyExports) would fail at startup.
+            ReplaceMainJsWithMinimalRunMain();
+
+            PublishProject(info, config, new PublishOptions(AOT: aot), isNativeBuild: true);
+            RunResult result = await RunForPublishWithWebServer(new BrowserRunOptions(
+                config,
+                TestScenario: "DotnetRun",
+                ExpectedExitCode: 42
+            ));
+            Assert.Contains("ManagedSum8 returned 36", result.TestOutput);
+            Assert.Contains("ManagedSum9 returned 45", result.TestOutput);
+            Assert.Contains("ManagedSum16 returned 136", result.TestOutput);
+            Assert.Contains("ManagedVoid12 stored 78", result.TestOutput);
+        }
     }
 }

--- a/src/mono/wasm/testassets/EntryPoints/PInvoke/UnmanagedCallbackManyArgs.cs
+++ b/src/mono/wasm/testassets/EntryPoints/PInvoke/UnmanagedCallbackManyArgs.cs
@@ -9,6 +9,14 @@ public unsafe partial class Test
     public unsafe static int Main(string[] args)
     {
         Console.WriteLine($"main: {args.Length}");
+
+        // Take the addresses of the [UnmanagedCallersOnly] methods so the trimmer keeps them
+        // and their native export symbols are generated (they are only referenced from native code).
+        GC.KeepAlive((IntPtr)(delegate* unmanaged<int, int, int, int, int, int, int, int, int>)&Sum8);
+        GC.KeepAlive((IntPtr)(delegate* unmanaged<int, int, int, int, int, int, int, int, int, int>)&Sum9);
+        GC.KeepAlive((IntPtr)(delegate* unmanaged<long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long>)&Sum16);
+        GC.KeepAlive((IntPtr)(delegate* unmanaged<int, int, int, int, int, int, int, int, int, int, int, int, void>)&Void12);
+
         Console.WriteLine($"TestOutput -> ManagedSum8 returned {CallSum8()}");
         Console.WriteLine($"TestOutput -> ManagedSum9 returned {CallSum9()}");
         Console.WriteLine($"TestOutput -> ManagedSum16 returned {CallSum16()}");

--- a/src/mono/wasm/testassets/EntryPoints/PInvoke/UnmanagedCallbackManyArgs.cs
+++ b/src/mono/wasm/testassets/EntryPoints/PInvoke/UnmanagedCallbackManyArgs.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+public unsafe partial class Test
+{
+    public unsafe static int Main(string[] args)
+    {
+        Console.WriteLine($"main: {args.Length}");
+        Console.WriteLine($"TestOutput -> ManagedSum8 returned {CallSum8()}");
+        Console.WriteLine($"TestOutput -> ManagedSum9 returned {CallSum9()}");
+        Console.WriteLine($"TestOutput -> ManagedSum16 returned {CallSum16()}");
+        CallVoid12();
+        Console.WriteLine($"TestOutput -> ManagedVoid12 stored {s_void12}");
+        return 42;
+    }
+
+    private static int s_void12;
+
+    // 8 args: exercises the specialized (<= MAX_INTERP_ENTRY_ARGS) entry path
+    [UnmanagedCallersOnly(EntryPoint = "ManagedSum8")]
+    public static int Sum8(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8)
+        => a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8;
+
+    // 9 args: exercises the generic interp_entry_general path (> MAX_INTERP_ENTRY_ARGS)
+    [UnmanagedCallersOnly(EntryPoint = "ManagedSum9")]
+    public static int Sum9(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9)
+        => a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9;
+
+    // 16 args with a 64-bit return, further stressing the many-args path
+    [UnmanagedCallersOnly(EntryPoint = "ManagedSum16")]
+    public static long Sum16(long a1, long a2, long a3, long a4, long a5, long a6, long a7, long a8,
+                             long a9, long a10, long a11, long a12, long a13, long a14, long a15, long a16)
+        => a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15 + a16;
+
+    // void return with > 8 args
+    [UnmanagedCallersOnly(EntryPoint = "ManagedVoid12")]
+    public static void Void12(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12)
+        => s_void12 = a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12;
+
+    [DllImport("local", EntryPoint = "call_sum8")]
+    public static extern int CallSum8();
+
+    [DllImport("local", EntryPoint = "call_sum9")]
+    public static extern int CallSum9();
+
+    [DllImport("local", EntryPoint = "call_sum16")]
+    public static extern long CallSum16();
+
+    [DllImport("local", EntryPoint = "call_void12")]
+    public static extern void CallVoid12();
+}

--- a/src/mono/wasm/testassets/native-libs/local_manyargs.c
+++ b/src/mono/wasm/testassets/native-libs/local_manyargs.c
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+int ManagedSum8(int, int, int, int, int, int, int, int);
+int ManagedSum9(int, int, int, int, int, int, int, int, int);
+long long ManagedSum16(long long, long long, long long, long long, long long, long long, long long, long long,
+                       long long, long long, long long, long long, long long, long long, long long, long long);
+void ManagedVoid12(int, int, int, int, int, int, int, int, int, int, int, int);
+
+int call_sum8(void) { return ManagedSum8(1, 2, 3, 4, 5, 6, 7, 8); }
+int call_sum9(void) { return ManagedSum9(1, 2, 3, 4, 5, 6, 7, 8, 9); }
+long long call_sum16(void) { return ManagedSum16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16); }
+void call_void12(void) { ManagedVoid12(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12); }

--- a/src/tasks/WasmAppBuilder/mono/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/mono/PInvokeTableGenerator.cs
@@ -367,6 +367,47 @@ internal sealed class PInvokeTableGenerator
             entryArgs.AddRange(cb.Parameters.Select((_, i) => $"(int*)&arg{i}"));
             entryArgs.Add($"(int*)wasm_native_to_interp_ftndescs [{cb_index}].arg");
 
+            // Methods with at most MAX_INTERP_ENTRY_ARGS (8) arguments use a specialized
+            // interp entry function that receives the arguments individually. Methods with
+            // more arguments use the generic interp_entry_general entry point, which takes
+            // the arguments as a pointer array:
+            //   void interp_entry_general (void *this_arg, void *res, void **args, void *rmethod)
+            // The runtime already installs interp_entry_general as the ftndesc target for these
+            // methods, but there is no per-signature wrapper to adapt the individual-argument
+            // calling convention (generating one would require runtime JIT, which is unavailable
+            // on wasm). So for the high-argument-count case, build the argument pointer array here
+            // and call the general entry point directly with the matching signature. Keep this in
+            // sync with MAX_INTERP_ENTRY_ARGS in src/mono/mono/mini/interp/interp.h.
+            const int MaxInterpEntryArgs = 8;
+            if (cb.Parameters.Length > MaxInterpEntryArgs)
+            {
+                string argArray = string.Join(", ", cb.Parameters.Select((_, i) => $"(void*)&arg{i}"));
+                string resArg = cb.IsVoid ? "(void*)0" : "(void*)&result";
+                w.Write(
+                    $$"""
+
+                    {{(cb.IsExport ?
+                    $"__attribute__((export_name(\"{EscapeLiteral(cb.EntryPoint!)}\"))){w.NewLine}" : "")}}{{
+                    MapType(cb.ReturnType)}}
+                    {{cb.EntrySymbol}} ({{cb.Parameters.Join(", ", (info, i) => $"{MapType(info.ParameterType)} arg{i}")}}) {{{
+                        (!cb.IsVoid ? $"{w.NewLine}    {MapType(cb.ReturnType)} result;" : "")}}
+                        void *wasm_interp_args{{cb_index}} [{{cb.Parameters.Length}}] = { {{argArray}} };
+
+                        if (!wasm_native_to_interp_ftndescs [{{cb_index}}].func) {{{
+                            (cb.IsExport && _isLibraryMode ? $"initialize_runtime();{w.NewLine}" : "")}}
+                            mono_wasm_marshal_get_managed_wrapper ("{{EscapeLiteral(cb.AssemblyName)}}", "{{EscapeLiteral(cb.Namespace)}}", "{{EscapeLiteral(cb.TypeName)}}", "{{EscapeLiteral(cb.MethodName)}}", {{cb.Token}}, {{cb.Parameters.Length}});
+                        }
+
+                        typedef void (*InterpEntryGeneral_T{{cb_index}}) (void*, void*, void**, void*);
+                        ((InterpEntryGeneral_T{{cb_index}})wasm_native_to_interp_ftndescs [{{cb_index}}].func) ((void*)0, {{resArg}}, wasm_interp_args{{cb_index}}, wasm_native_to_interp_ftndescs [{{cb_index}}].arg);{{
+                        (!cb.IsVoid ?  $"{w.NewLine}    return result;" : "")}}
+                    }
+
+                    """);
+                cb_index++;
+                continue;
+            }
+
             w.Write(
                 $$"""
 


### PR DESCRIPTION
## Summary

Invoking a `[UnmanagedCallersOnly]` (or `[MonoPInvokeCallback]`) export with **more than 8 arguments** from native code traps at runtime with:

```
RuntimeError: null function or function signature mismatch
    at dotnet.native.wasm.<export>
```

Exports with 8 or fewer arguments work; the failure begins at 9. Fixes #109338.

## Root cause

The native→interp entry for an exported method is dispatched through an interp entry function that the runtime installs as the target of the generated C thunk's ftndesc:

- **≤ `MAX_INTERP_ENTRY_ARGS` (8) args** → a specialized entry (`interp_entry_static_N`) that receives the arguments **individually**.
- **> 8 args** → the generic `interp_entry_general`, whose signature takes the arguments as a **pointer array**:
  ```c
  void interp_entry_general (void *this_arg, void *res, void **args, void *rmethod)
  ```

The runtime already installs `interp_entry_general` for the high-arg-count case (`interp_create_method_pointer`, `HOST_WASM` path). But the C thunk emitted by the **mono** `PInvokeTableGenerator` always called the entry point using the *individual-argument* convention, regardless of arg count. For >8 args this mismatches the actual `interp_entry_general` signature, so the `call_indirect` fails with a signature mismatch.

There is no per-signature adapter wrapper for this case (the `interp_in` wrapper) available in the image — generating one at runtime would require JIT compilation, which is unavailable on wasm. The interpreter itself has no arg-count limit (`interp_entry_general` handles any count); it's purely a calling-convention mismatch in the generated glue.

## Fix

In the mono `PInvokeTableGenerator`, for methods with more than `MAX_INTERP_ENTRY_ARGS` arguments, build a local argument-pointer array and call `interp_entry_general` directly with the matching signature, instead of the individual-argument convention. The ≤8 path is unchanged.

The CoreCLR-wasm generator already dispatches through an argument array (`ExecuteInterpretedMethodFromUnmanaged`), so it never had this bug and is unchanged.

## Validation

Verified against a local browser-wasm interpreter build (native C calling the exports):

| export | args | result | expected |
| --- | --- | --- | --- |
| `ManagedSum8` | 8 (int) | 36 | 36 |
| `ManagedSum9` | 9 (int) | 45 | 45 |
| `ManagedSum16` | 16 (long, long return) | 136 | 136 |
| `ManagedVoid12` | 12 (void return) | 78 | 78 |

Before the fix, the 9/16/void12 cases trap with `null function or function signature mismatch`; the 8-arg case works either way.

Adds a `Wasm.Build.Tests` regression test (`UnmanagedCallbackWithManyArgs`) exercising the 8/9/16-argument and void 12-argument exports end-to-end.

> [!NOTE]
> This PR was created with the assistance of GitHub Copilot.
