### PR TITLE
Return CBOR ranges after failed string reads

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.String.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.String.cs
@@ -357,6 +357,7 @@ namespace System.Formats.Cbor
             if (concatenatedBufferSize > destination.Length)
             {
                 bytesWritten = 0;
+                ReturnIndefiniteLengthStringRangeList(ranges);
                 return false;
             }
 
@@ -426,6 +427,7 @@ namespace System.Formats.Cbor
             if (concatenatedStringSize > destination.Length)
             {
                 charsWritten = 0;
+                ReturnIndefiniteLengthStringRangeList(ranges);
                 return false;
             }
 


### PR DESCRIPTION
## Summary

The indefinite-length concatenated paths of `TryReadByteString`/`TryReadTextString` leaked the pooled range list when the destination buffer was too small.

`CborReader` caches a single `List<(int Offset, int Length)>` in `_indefiniteLengthStringRangeAllocation` and hands it out via `Interlocked.Exchange(..., null)`. On the "destination too small → `false`" path the list was acquired (field set to `null`) but never returned, so the next call — the caller's retry with a correctly sized buffer — had to allocate a fresh list. The idiomatic "call once to size the buffer, then read" pattern paid a `List` allocation every time.

## Fix

Call `ReturnIndefiniteLengthStringRangeList(ranges)` before returning `false`, matching the success path and the non-`Try` `Read…Concatenated` methods. Two lines, one per method; no behavioral change other than restored pool reuse.

## Validation

- Full `System.Formats.Cbor` test suite: **1921 passed, 0 failed, 0 skipped**.

### Executed BenchmarkDotNet results (baseline vs final)

Allocated bytes/op — **baseline → final** — over small / 1 KiB / 64 KiB indefinite-length payloads (8-byte chunks). The fix eliminates the per-op range-`List` allocation on every fail/retry/state path; the `Success` true-path control is 0 in both:

| Method | 64 B | 1 KiB | 64 KiB |
| --- | --- | --- | --- |
| `ByteString_Undersized_Fail` | 176 → **0** | 2,192 → **0** | 131,360 → **0** |
| `TextString_Undersized_Fail` | 176 → **0** | 2,192 → **0** | 131,360 → **0** |
| `ByteString_Retry` | 176 → **0** | 2,192 → **0** | 131,360 → **0** |
| `TextString_Retry` | 176 → **0** | 2,192 → **0** | 131,360 → **0** |
| `ByteString_ReaderState_Unadvanced` | 176 → **0** | 2,192 → **0** | 131,360 → **0** |
| `TextString_ReaderState_Unadvanced` | 176 → **0** | 2,192 → **0** | 131,360 → **0** |
| `ByteString_Success` *(control)* | 0 → 0 | 0 → 0 | 0 → 0 |
| `TextString_Success` *(control)* | 0 → 0 | 0 → 0 | 0 → 0 |

Mean time also improves (64 KiB, baseline → final): `ByteString_Undersized_Fail` 20,213 → 16,955 ns; `TextString_Undersized_Fail` 42,937 → 38,683 ns; `ByteString_Retry` 53,273 → 51,506 ns. The two arms run as separate processes, so the untouched `Success` control drifts by a comparable small magnitude/sign (`ByteString_Success` 33,560 → 32,359 ns) — i.e. part of the ns delta is cross-run/thermal variation, not a true-path change. The definitive, reproducible result is **allocated B/op → 0** on every fail/retry/state path.

**Provenance.** Exact A/B of parent `5ba65ff0b5c~1` (= `7aa830a0359`) vs this PR `5ba65ff0b5c`. Both arms ran the **byte-identical** compiled harness (`CborBench`, source/config SHA-256 `256e7958…8d51`); only the referenced `System.Formats.Cbor.dll` differed. Real (non-`Dry`) BDN — `InProcessEmitToolchain`, `[MemoryDiagnoser]`, Warmup=3, Iterations=6 — so the assembly location + MVID each arm printed at startup is provably the one measured:

- baseline (parent) — MVID `33b104eb-5c32-450c-8b5f-64c5e774b718`, SHA-256 `77b1ddee…1ec7`
- final (PR) — MVID `c0416dd9-9e15-479a-95bd-f33095b75ad4`, SHA-256 `f1d4448b…0c3b`
- Command per arm: `dotnet run -c Release -p:CborDll=<arm>/System.Formats.Cbor.dll`
- Env: BenchmarkDotNet v0.15.8 · .NET 11.0.0-preview.6.26352.110 Arm64 RyuJIT · macOS 26.5.2 · Apple M5 Pro.

Range count scales with payload (8-byte chunks): 64 B → 8 ranges, 1 KiB → 128, 64 KiB → 8192; the leaked `List` (+ its backing `(int,int)[]`) grows with it, which is why the reclaimed allocation scales 176 B → 131,360 B.

<details><summary>Full ns/op and B/op, both arms with Δ (24 cases)</summary>

| Method | Payload | Base ns | Final ns | Δ ns | Base B | Final B |
| --- | --- | --- | --- | --- | --- | --- |
| ByteString_Undersized_Fail | 64 | 35.80 | 21.37 | −14 | 176 | 0 |
| TextString_Undersized_Fail | 64 | 60.61 | 45.27 | −15 | 176 | 0 |
| ByteString_Retry | 64 | 74.16 | 61.76 | −12 | 176 | 0 |
| TextString_Retry | 64 | 139.35 | 121.99 | −17 | 176 | 0 |
| ByteString_Success *(ctrl)* | 64 | 43.03 | 40.41 | −3 | 0 | 0 |
| TextString_Success *(ctrl)* | 64 | 78.10 | 77.51 | −1 | 0 | 0 |
| ByteString_ReaderState_Unadvanced | 64 | 35.49 | 23.00 | −12 | 176 | 0 |
| TextString_ReaderState_Unadvanced | 64 | 60.33 | 45.56 | −15 | 176 | 0 |
| ByteString_Undersized_Fail | 1024 | 420.70 | 346.27 | −74 | 2,192 | 0 |
| TextString_Undersized_Fail | 1024 | 759.80 | 697.65 | −62 | 2,192 | 0 |
| ByteString_Retry | 1024 | 1,033.35 | 1,020.54 | −13 | 2,192 | 0 |
| TextString_Retry | 1024 | 1,987.50 | 1,873.97 | −114 | 2,192 | 0 |
| ByteString_Success *(ctrl)* | 1024 | 619.74 | 582.99 | −37 | 0 | 0 |
| TextString_Success *(ctrl)* | 1024 | 1,184.92 | 1,170.96 | −14 | 0 | 0 |
| ByteString_ReaderState_Unadvanced | 1024 | 437.33 | 357.40 | −80 | 2,192 | 0 |
| TextString_ReaderState_Unadvanced | 1024 | 760.16 | 690.07 | −70 | 2,192 | 0 |
| ByteString_Undersized_Fail | 65536 | 20,212.98 | 16,955.11 | −3,258 | 131,360 | 0 |
| TextString_Undersized_Fail | 65536 | 42,937.44 | 38,683.40 | −4,254 | 131,360 | 0 |
| ByteString_Retry | 65536 | 53,273.10 | 51,506.41 | −1,767 | 131,360 | 0 |
| TextString_Retry | 65536 | 113,833.25 | 107,665.80 | −6,167 | 131,360 | 0 |
| ByteString_Success *(ctrl)* | 65536 | 33,559.78 | 32,359.09 | −1,201 | 0 | 0 |
| TextString_Success *(ctrl)* | 65536 | 69,935.81 | 68,984.16 | −952 | 0 | 0 |
| ByteString_ReaderState_Unadvanced | 65536 | 20,908.74 | 17,302.57 | −3,606 | 131,360 | 0 |
| TextString_ReaderState_Unadvanced | 65536 | 43,116.02 | 38,643.74 | −4,472 | 131,360 | 0 |

The `Success` controls also shift negative here (the final arm's process ran slightly faster overall), so the ns Δ partly reflects cross-run variation between the two separate launches — not overstated as a true-path speedup. The definitive, reproducible result is **B/op → 0** on every fail/retry/state path.

</details>

Cross-machine allocation confirmation (`@EgorBot -amd -osx_arm64`) is pending.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.
