### PR TITLE
Implement correct totalOrder for IEEE decimals

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
@@ -62,6 +62,10 @@ namespace System.Numerics
             {
                 return CompareIntegerSemantic(BitConverter.HalfToInt16Bits((Half)(object)x!), BitConverter.HalfToInt16Bits((Half)(object)y!));
             }
+            else if (typeof(T) == typeof(BFloat16))
+            {
+                return CompareIntegerSemantic(BitConverter.BFloat16ToInt16Bits((BFloat16)(object)x!), BitConverter.BFloat16ToInt16Bits((BFloat16)(object)y!));
+            }
             else
             {
                 return CompareGeneric(x, y);

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
@@ -113,17 +113,45 @@ namespace System.Numerics
                 }
                 else if (x == y)
                 {
-                    if (T.IsZero(x)) // only zeros are equal to zeros
+                    static unsafe int CompareExponent(T x, T y)
                     {
-                        // IEEE 754 numbers are either positive or negative. Skip check for the opposite.
+                        int xExponentBits = x!.GetExponentShortestBitLength();
+                        int yExponentBits = y!.GetExponentShortestBitLength();
 
-                        if (T.IsNegative(x))
+                        if (xExponentBits == yExponentBits)
                         {
-                            return T.IsNegative(y) ? 0 : -1;
+                            // Prevent stack overflow for huge numbers
+                            const int StackAllocThreshold = 256;
+
+                            int xExponentLength = x.GetExponentByteCount();
+                            int yExponentLength = y.GetExponentByteCount();
+
+                            Span<byte> significandX = (uint)xExponentLength <= StackAllocThreshold ? stackalloc byte[xExponentLength] : new byte[xExponentLength];
+                            Span<byte> significandY = (uint)yExponentLength <= StackAllocThreshold ? stackalloc byte[yExponentLength] : new byte[yExponentLength];
+
+                            x.WriteExponentBigEndian(significandX);
+                            y.WriteExponentBigEndian(significandY);
+
+                            return significandX.SequenceCompareTo(significandY);
                         }
                         else
                         {
-                            return T.IsPositive(y) ? 0 : 1;
+                            return xExponentBits.CompareTo(yExponentBits);
+                        }
+                    }
+
+                    if (T.IsZero(x)) // only zeros are equal to zeros
+                    {
+                        // IEEE 754 numbers are either positive or negative. Skip check for the opposite.
+                        // Decimals can have zeros with different exponents.
+
+                        if (T.IsNegative(x))
+                        {
+                            return T.IsNegative(y) ? -CompareExponent(x, y) : -1;
+                        }
+                        else
+                        {
+                            return T.IsPositive(y) ? CompareExponent(x, y) : 1;
                         }
                     }
                     else
@@ -131,8 +159,8 @@ namespace System.Numerics
                         // Equivalant values are compared by their exponent parts,
                         // and the value with smaller exponent is considered closer to zero.
 
-                        // This only applies to IEEE 754 decimals. Consider to add support if decimals are added into .NET.
-                        return 0;
+                        // This only applies to IEEE 754 decimals.
+                        return T.IsNegative(x) ? CompareExponent(x, y) : -CompareExponent(x, y);
                     }
                 }
                 else
@@ -224,6 +252,8 @@ namespace System.Numerics
         /// <returns>A hash code for the specified number.</returns>
         public int GetHashCode([DisallowNull] T obj)
         {
+            // GetHashCode contract requires comparison equality => hash code equality
+            // Given totalOrder equality guarantees normal value equality, thus satisfies hash code equality
             ArgumentNullException.ThrowIfNull(obj);
             return obj.GetHashCode();
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
@@ -147,7 +147,7 @@ namespace System.Numerics
 
                         if (T.IsNegative(x))
                         {
-                            return T.IsNegative(y) ? -CompareExponent(x, y) : -1;
+                            return T.IsNegative(y) ? CompareExponent(y, x) : -1;
                         }
                         else
                         {
@@ -160,7 +160,7 @@ namespace System.Numerics
                         // and the value with smaller exponent is considered closer to zero.
 
                         // This only applies to IEEE 754 decimals.
-                        return T.IsNegative(x) ? CompareExponent(x, y) : -CompareExponent(x, y);
+                        return T.IsNegative(x) ? CompareExponent(x, y) : CompareExponent(y, x);
                     }
                 }
                 else

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
@@ -147,11 +147,11 @@ namespace System.Numerics
 
                         if (T.IsNegative(x))
                         {
-                            return T.IsNegative(y) ? CompareExponent(y, x) : -1;
+                            return T.IsNegative(y) ? CompareExponent(x, y) : -1;
                         }
                         else
                         {
-                            return T.IsPositive(y) ? CompareExponent(x, y) : 1;
+                            return T.IsPositive(y) ? CompareExponent(y, x) : 1;
                         }
                     }
                     else

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
@@ -76,7 +76,7 @@ namespace System.Numerics
                 // This also satisfies totalOrder definition which is +x < +Inf < +sNaN < +qNaN
 
                 // The order of NaNs of same category and same sign is implementation defined,
-                // here we define it as the order of exponent bits to simplify comparison
+                // here we define it as the order of significand bits to simplify comparison
 
                 // Negative values are represented in sign-magnitude, instead of two's complement like integers
                 // Just negating the comparison result when both numbers are negative is enough

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
@@ -398,8 +398,10 @@ namespace System.Runtime.Tests
                 // Decimal specific
                 yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x3300_0001), Unsafe.BitCast<uint, Decimal32>(0x3280_000A), -1 }; // 1e1 < 10e0
                 yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x3300_0001), Unsafe.BitCast<uint, Decimal32>(0x3280_0009), 1 }; // 1e1 > 9e0
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x3300_0000), Unsafe.BitCast<uint, Decimal32>(0x3280_0000), -1 }; // 0e1 < 0e0
                 yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xB300_0001), Unsafe.BitCast<uint, Decimal32>(0xB280_000A), 1 }; // -1e1 > -10e0
                 yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xB300_0001), Unsafe.BitCast<uint, Decimal32>(0xB280_0009), -1 }; // -1e1 < -9e0
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xB300_0000), Unsafe.BitCast<uint, Decimal32>(0xB280_0000), 1 }; // -0e1 > -0e0
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -66,6 +67,7 @@ namespace System.Runtime.Tests
             var comparer = new TotalOrderIeee754Comparer<double>();
             Assert.Equal(result, Math.Sign(comparer.Compare(x, y)));
         }
+
         public static IEnumerable<object[]> HalfTestData
         {
             get
@@ -373,6 +375,38 @@ namespace System.Runtime.Tests
             public static bool operator >(StubFloatingPointIeee754 left, StubFloatingPointIeee754 right) => false;
             public static bool operator <=(StubFloatingPointIeee754 left, StubFloatingPointIeee754 right) => false;
             public static bool operator >=(StubFloatingPointIeee754 left, StubFloatingPointIeee754 right) => false;
+        }
+
+        public static IEnumerable<object[]> Decimal32TestData
+        {
+            get
+            {
+                yield return new object[] { Decimal32.Zero, Decimal32.Zero, 0 };
+                yield return new object[] { Decimal32.NegativeZero, Decimal32.NegativeZero, 0 };
+                yield return new object[] { Decimal32.Zero, Decimal32.NegativeZero, 1 };
+                yield return new object[] { Decimal32.NegativeZero, Decimal32.Zero, -1 };
+                yield return new object[] { Decimal32.Zero, Decimal32.One, -1 };
+                yield return new object[] { Decimal32.PositiveInfinity, Decimal32.One, 1 };
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xFC00_0000), Decimal32.NegativeInfinity, -1 };
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xFC00_0000), Decimal32.NegativeOne, -1 };
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x7C00_0000), Decimal32.One, 1 };
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x7C00_0000), Decimal32.PositiveInfinity, 1 };
+                yield return new object[] { Decimal32.NaN, Decimal32.NaN, 0 };
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xFC00_0000), Unsafe.BitCast<uint, Decimal32>(0x7C00_0000), -1 };
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x7C00_0000), Unsafe.BitCast<uint, Decimal32>(0x7C00_0001), -1 }; // implementation defined, not part of IEEE 754 totalOrder
+
+                // Decimal specific
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x3300_0001), Unsafe.BitCast<uint, Decimal32>(0x3280_000A), -1 }; // 1e1 < 10e0
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x3300_0001), Unsafe.BitCast<uint, Decimal32>(0x3280_0009), 1 }; // 1e1 > 9e0
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Decimal32TestData))]
+        public void TotalOrderTestDecimal32(Decimal32 x, Decimal32 y, int result)
+        {
+            var comparer = new TotalOrderIeee754Comparer<Decimal32>();
+            Assert.Equal(result, Math.Sign(comparer.Compare(x, y)));
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
@@ -398,6 +398,8 @@ namespace System.Runtime.Tests
                 // Decimal specific
                 yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x3300_0001), Unsafe.BitCast<uint, Decimal32>(0x3280_000A), -1 }; // 1e1 < 10e0
                 yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x3300_0001), Unsafe.BitCast<uint, Decimal32>(0x3280_0009), 1 }; // 1e1 > 9e0
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xB300_0001), Unsafe.BitCast<uint, Decimal32>(0xB280_000A), 1 }; // -1e1 > -10e0
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xB300_0001), Unsafe.BitCast<uint, Decimal32>(0xB280_0009), -1 }; // -1e1 < -9e0
             }
         }
 


### PR DESCRIPTION
Minimal implementation via the fallback generic path, to ensure correct semantic of the operator. Optimizations can be introduced in the future, since it's not as simple as binary formats.

Also add optimization for BFloat16.