### PR TITLE
Fix non-monotonic GC.GetTotalAllocatedBytes under DATAS (Server GC)

### DIFF
--- a/src/coreclr/gc/interface.cpp
+++ b/src/coreclr/gc/interface.cpp
@@ -2023,7 +2023,7 @@ uint64_t GCHeap::GetTotalAllocatedBytes()
 {
 #ifdef MULTIPLE_HEAPS
     uint64_t total_alloc_bytes = 0;
-    for (int i = 0; i < gc_heap::n_heaps; i++)
+    for (int i = 0; i < gc_heap::n_max_heaps; i++)
     {
         gc_heap* hp = gc_heap::g_heaps[i];
         total_alloc_bytes += hp->total_alloc_bytes_soh;

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
@@ -31,8 +31,6 @@ using Xunit;
 
 public class GetTotalAllocatedBytesServerGC
 {
-    private static volatile object s_sink;
-
     [Fact]
     public static void TestEntryPoint()
     {

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Regression test for a Server GC accounting bug in GC.GetTotalAllocatedBytes().
+//
+// GCHeap::GetTotalAllocatedBytes() summed each heap's cumulative total_alloc_bytes
+// over the *currently-active* heaps [0, n_heaps). Under DATAS (Dynamic Adaptation To
+// Application Sizes, default-on for Server GC) the active heap count grows and shrinks
+// at run time as load changes. Because a decommissioned heap keeps its (real, frozen)
+// total_alloc_bytes, excluding it from the sum made the returned value DROP whenever the
+// heap count shrank -- i.e. GC.GetTotalAllocatedBytes() became non-monotonic. The
+// precise overload has no smoothing, so it exposed the drop directly (surfacing as random
+// zero / hallucinated allocation deltas in tools that difference two reads).
+//
+// This test drives Server GC with an oscillating allocation load (bursts grow the heap
+// count, quiet periods let DATAS shrink it) while forcing frequent blocking gen2 GCs --
+// the points at which DATAS re-evaluates and decommissions heaps -- and repeatedly reads
+// the precise cumulative total. Because the value is a cumulative counter, it must never
+// decrease. A shrink-induced drop equals an entire heap's cumulative allocation, which is
+// far larger than the small, by-design fluctuation of the precise value (per-thread unused
+// allocation-context bytes); the tolerance below absorbs the latter while catching the bug.
+//
+// Only meaningful under Server GC (the .csproj sets DOTNET_gcServer=1). Under Workstation
+// GC there is a single heap and no heap-count oscillation, so the check is a trivial pass.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Xunit;
+
+public class GetTotalAllocatedBytesServerGC
+{
+    private static volatile object s_sink;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        TimeSpan budget = TimeSpan.FromSeconds(20);
+
+        // The precise total legitimately fluctuates by a small amount (it subtracts each
+        // thread's currently-unused allocation-context bytes). The bug drops a whole heap's
+        // cumulative counter, which is orders of magnitude larger. Allow generous slack for
+        // the benign fluctuation so the test cannot false-fail on a correct runtime.
+        const long Tolerance = 64L * 1024 * 1024;
+
+        int burstThreads = Math.Max(2, Environment.ProcessorCount);
+        using var cts = new CancellationTokenSource();
+        CancellationToken token = cts.Token;
+
+        // Load controller: alternate a heavy BURST (many allocators -> DATAS grows the heap
+        // count) with a QUIET period (near-zero allocation -> DATAS shrinks it).
+        var controller = new Thread(() =>
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var burst = new List<Thread>();
+                using var burstCts = new CancellationTokenSource();
+                for (int i = 0; i < burstThreads; i++)
+                {
+                    var t = new Thread(() =>
+                    {
+                        var rnd = new Random(Environment.CurrentManagedThreadId);
+                        object local = null;
+                        while (!burstCts.IsCancellationRequested)
+                        {
+                            for (int j = 0; j < 2000; j++)
+                                local = new byte[rnd.Next(16, 4096)];
+                        }
+                        GC.KeepAlive(local);
+                    })
+                    { IsBackground = true };
+                    t.Start();
+                    burst.Add(t);
+                }
+
+                if (token.WaitHandle.WaitOne(1500)) { burstCts.Cancel(); break; }
+                burstCts.Cancel();
+                foreach (var t in burst)
+                    t.Join(2000);
+
+                // QUIET: near-zero allocation so DATAS decides to shrink the heap count.
+                if (token.WaitHandle.WaitOne(3000))
+                    break;
+            }
+        })
+        { IsBackground = true, Name = "load-controller" };
+        controller.Start();
+
+        long maxDrop = 0;
+        long prevInitial = 0, prevFinal = 0;
+        long prev = GC.GetTotalAllocatedBytes(precise: true);
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            while (sw.Elapsed < budget)
+            {
+                // A blocking gen2 GC is where DATAS re-evaluates (and can decommission) heaps.
+                GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+                long cur = GC.GetTotalAllocatedBytes(precise: true);
+                if (cur < prev)
+                {
+                    long drop = prev - cur;
+                    if (drop > maxDrop)
+                    {
+                        maxDrop = drop;
+                        prevInitial = prev;
+                        prevFinal = cur;
+                    }
+                }
+                prev = cur;
+            }
+        }
+        finally
+        {
+            cts.Cancel();
+            controller.Join(3000);
+        }
+
+        Assert.True(
+            maxDrop <= Tolerance,
+            $"GC.GetTotalAllocatedBytes(precise: true) is a cumulative counter and must not " +
+            $"decrease, but it dropped by {maxDrop:N0} bytes (from {prevInitial:N0} to {prevFinal:N0}), " +
+            $"exceeding the {Tolerance:N0} byte tolerance. Server GC = {System.Runtime.GCSettings.IsServerGC}, " +
+            $"processors = {Environment.ProcessorCount}.");
+    }
+}

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
@@ -72,10 +72,16 @@ public class GetTotalAllocatedBytesServerGC
                     burst.Add(t);
                 }
 
-                if (token.WaitHandle.WaitOne(1500)) { burstCts.Cancel(); break; }
+                bool cancelled = token.WaitHandle.WaitOne(1500);
+
+                // Always cancel and join the burst threads so no allocator outlives the
+                // BURST -- this guarantees the following QUIET period is truly allocation-free.
                 burstCts.Cancel();
                 foreach (var t in burst)
                     t.Join(2000);
+
+                if (cancelled)
+                    break;
 
                 // QUIET: near-zero allocation so DATAS decides to shrink the heap count.
                 if (token.WaitHandle.WaitOne(3000))

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
@@ -34,6 +34,11 @@ public class GetTotalAllocatedBytesServerGC
     [Fact]
     public static void TestEntryPoint()
     {
+        if (!System.Runtime.GCSettings.IsServerGC)
+        {
+            throw new Exception("ERROR: Requires server GC.");
+        }
+
         TimeSpan budget = TimeSpan.FromSeconds(20);
 
         // The precise total legitimately fluctuates by a small amount (it subtracts each

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
@@ -47,7 +47,11 @@ public class GetTotalAllocatedBytesServerGC
         // the benign fluctuation so the test cannot false-fail on a correct runtime.
         const long Tolerance = 64L * 1024 * 1024;
 
-        int burstThreads = Math.Max(2, Environment.ProcessorCount);
+        // Cap the allocator count: we only need enough parallel allocators to drive DATAS
+        // heap-count oscillation, not one per core. Scaling 1:1 with ProcessorCount would spawn
+        // hundreds of threads on high-core machines, oversubscribing the box and making the test
+        // needlessly heavy and flaky without improving repro reliability.
+        int burstThreads = Math.Clamp(Environment.ProcessorCount, 2, 16);
         using var cts = new CancellationTokenSource();
         CancellationToken token = cts.Token;
 

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
@@ -116,6 +116,11 @@ public class GetTotalAllocatedBytesServerGC
                         prevInitial = prev;
                         prevFinal = cur;
                     }
+
+                    if (maxDrop > Tolerance)
+                    {
+                        break;
+                    }
                 }
                 prev = cur;
             }

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.cs
@@ -59,13 +59,14 @@ public class GetTotalAllocatedBytesServerGC
             {
                 var burst = new List<Thread>();
                 using var burstCts = new CancellationTokenSource();
+                CancellationToken burstToken = burstCts.Token;
                 for (int i = 0; i < burstThreads; i++)
                 {
                     var t = new Thread(() =>
                     {
                         var rnd = new Random(Environment.CurrentManagedThreadId);
                         object local = null;
-                        while (!burstCts.IsCancellationRequested)
+                        while (!burstToken.IsCancellationRequested)
                         {
                             for (int j = 0; j < 2000; j++)
                                 local = new byte[rnd.Next(16, 4096)];

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.csproj
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable and GCStressIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <CLRTestPriority>1</CLRTestPriority>
+    <!-- DATAS heap-count adaptation is a CoreCLR Server GC behavior -->
+    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <!-- Timing-sensitive probe: its window won't behave under GCStress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GetTotalAllocatedBytesServerGC.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Multiple heaps + DATAS heap-count oscillation only happen under Server GC -->
+    <CLRTestEnvironmentVariable Include="DOTNET_gcServer" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_GCDynamicAdaptationMode" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

`GCHeap::GetTotalAllocatedBytes()` summed each heap's `total_alloc_bytes` only over the
**currently-active** heaps `[0, n_heaps)`. Under DATAS (Dynamic Adaptation To Application Sizes,
default-on for Server GC in .NET 9+), the active heap count shrinks and grows at run time, so the
returned value could **drop** when heaps were decommissioned (and jump back when re-added), making
`GC.GetTotalAllocatedBytes()` **non-monotonic**.

Fix: sum over **all heaps that have ever existed** `[0, n_max_heaps)`.

```diff
-    for (int i = 0; i < gc_heap::n_heaps; i++)
+    for (int i = 0; i < gc_heap::n_max_heaps; i++)
```

## Root cause

- Per-heap `total_alloc_bytes_soh/uoh` is a durable accumulator: it only ever increases while a
  heap is active, is **frozen** (not reset) while decommissioned, and is never absorbed onto another
  heap. `decommission_heap()`, `recommission_heap()`, and `change_heap_count()` deliberately leave it
  untouched (the only reset is per-heap init at startup).
- Allocation only happens on active heaps, and all `n_max_heaps` heaps are created once at startup
  (`g_heaps` is sized to `n_max_heaps`; `n_max_heaps` is set once and never reduced; the runtime
  already walks `[n_heaps, n_max_heaps)`, e.g. `check_decommissioned_heap`).
- Therefore `Σ[0, n_max_heaps)` is the true, monotonic cumulative total. The old `Σ[0, n_heaps)`
  excluded decommissioned heaps' frozen bytes, so it under-reported by that amount whenever the
  heap count was below its maximum — i.e. it dropped on every DATAS shrink. When DATAS is off,
  `n_heaps == n_max_heaps`, so behavior is unchanged.

## Impact on the two public APIs

Both `GC.GetTotalAllocatedBytes(precise: false)` and `(precise: true)` call this function.
- **Precise** path has no smoothing → exposed the drops directly (BenchmarkDotNet MemoryDiagnoser
  reported random `0 B` and hallucinated-high per-op numbers — issue #118826).
- **Non-precise** (default) path has a `high_watermark` clamp that never returns less than before →
  the drops were masked into a **stuck plateau** at the last (higher, more-correct) peak until real
  allocation climbed back past it (issue #122299).

This fix makes the raw value monotonic at the source, resolving both surfaces.

## Validation (A/B, private Release CoreCLR)

Server GC + regions + DATAS (defaults). Identical workload; only `coreclr.dll` swapped
(hash-verified live before each run). Harness drives oscillating load + per-iteration forced
blocking gen2 GC and counts contamination-proof `final < initial` decreases.

| Variant   | Runs | Result                                                  |
|-----------|------|---------------------------------------------------------|
| unfixed   | 5    | ALL reproduce: 5–12 drops/run, max drop ~64–94 GB       |
| fixed     | 4    | ALL clean: 0 drops (also 1.13M-probe monotonic loop)    |

## Regression test

Adds `src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.{cs,csproj}` (priority 1, Server GC via
`DOTNET_gcServer=1` + `DOTNET_GCDynamicAdaptationMode=1`, `GCStressIncompatible`). It drives an
oscillating allocation load with frequent forced blocking gen2 GCs and asserts the precise
cumulative total never decreases (beyond a 64 MB tolerance for the by-design per-thread
allocation-context jitter). Proven fail→pass on Release: unfixed exits 101 (observed a 22.5 GB
drop), fixed exits 100 (pass, stable across repeated runs).

## Related

- Fixes #118826
- Should also address #122299 (same root cause; the non-precise `high_watermark` clamp surfaces it
  as a stuck/constant value instead of a drop).

---

> [!NOTE]
> This pull request was generated with the assistance of AI (GitHub Copilot).
