### PR TITLE
Remove larger test length for Iri_ExpandingContents_TestData

### DIFF
--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -564,7 +564,7 @@ namespace System.PrivateUri.Tests
         {
             get
             {
-                foreach (int length in new[] { 1, 64_000, 66_000, 1_000_000 })
+                foreach (int length in new[] { 1, 64_000, 66_000 })
                 {
                     yield return new object[] { @"test://" + new string('a', length) + new string('\uD800', 2) + "@8.8.8.8" }; // Userinfo
                     yield return new object[] { @"test://8.8.8.8?" + new string('a', length) + new string('\uD800', 2) }; // Query


### PR DESCRIPTION
Closes #130786

The 1 million length test will end up allocating a ~9 million character string for `ToString`.
Together with all the other properties we're allocating and various buffers, this could reach some ~100 MB.

The test case was added when I removed the length restriction on Uris. The 66k case should already give us coverage for the important "longer than ushort" scenarios.