### PR TITLE
[mobile] Skip publishing tests ignored by CI

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -151,7 +151,7 @@
   <Import Project="$(MSBuildThisFileDirectory)workloads-testing.targets" Condition="'$(SkipWorkloadsTestingTargetsImport)' == 'true'" />
 
   <Target Name="PublishTestAsSelfContained"
-          Condition="'$(IsCrossTargetingBuild)' != 'true'"
+          Condition="'$(IsCrossTargetingBuild)' != 'true' and '$(IgnoreForCI)' != 'true'"
           AfterTargets="$(PublishTestAsSelfContainedAfterTargets)"
           DependsOnTargets="$(PublishTestAsSelfContainedDependsOn);$(BundleTestAppTargets);ArchiveTests" />
 


### PR DESCRIPTION
## Description

Skip `PublishTestAsSelfContained` when `IgnoreForCI` evaluates to `true`. Mobile builds currently skip archiving these projects but still publish them after `Build`, which runs aggressive trimming for tests that are not supported on the target platform. This prevents the Apple mobile CoreCLR leg from invoking `ILLink` for `System.Text.Json.SourceGeneration.Roslyn4.4.Tests`. Failure log https://dev.azure.com/dnceng-public/public/_build/results?buildId=1516430&view=logs&j=fbbe6d24-ec94-5563-68e4-47df2fb4f886&t=fd24ffdb-b6c4-50de-7ee2-f1794d18b0a7