### PR TITLE
Fix tar tests

### DIFF
--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -453,8 +453,17 @@ namespace System.Formats.Tar.Tests
 
             if (OperatingSystem.IsWindows())
             {
-                // Windows only creates file symlinks and trying to process a directory symlink will throw UnauthorizedAccessException instead of IOException
-                Assert.Throws<UnauthorizedAccessException>(() => TarFile.ExtractToDirectory(tarPath, destDir, overwriteFiles: true));
+                // Windows always creates file symlinks (FileInfo.CreateAsSymbolicLink), so entry "a/b" becomes a
+                // *file* symlink whose target (".") is a *directory*. Processing the nested entries forces the
+                // extractor to resolve/descend through that type-mismatched reparse point, which Windows rejects,
+                // but the surfaced exception depends on the OS build:
+                //   - Some builds throw UnauthorizedAccessException while resolving the link (FileInfo.ResolveLinkTarget
+                //     during the traversal-safety walk in FilePathEscapesDirectory).
+                //   - Others resolve the link successfully, then fail creating a directory where the file symlink
+                //     already exists, throwing IOException ("a file or directory with the same name already exists").
+                // Either way the archive is rejected and nothing escapes (verified below), so accept both.
+                Exception ex = Assert.ThrowsAny<Exception>(() => TarFile.ExtractToDirectory(tarPath, destDir, overwriteFiles: true));
+                Assert.True(ex is IOException or UnauthorizedAccessException, $"Unexpected exception type: {ex}");
             }
             else
             {

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -46,7 +46,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void SetsLastModifiedTimeOnExtractedFiles()
         {
             using TempDirectory root = new TempDirectory();
@@ -74,7 +73,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void SetsLastModifiedTimeOnExtractedDirectories()
         {
             using TempDirectory root = new TempDirectory();
@@ -211,7 +209,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void ExtractArchiveWithEntriesThatStartWithSlashDotPrefix()
         {
             using TempDirectory root = new TempDirectory();
@@ -237,7 +234,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void UnixFileModes(bool overwrite)
         {
             using TempDirectory source = new TempDirectory();
@@ -306,7 +302,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void UnixFileModes_RestrictiveParentDir(bool overwrite)
         {
             using TempDirectory source = new TempDirectory();
@@ -347,7 +342,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void LinkBeforeTarget()
         {
             using TempDirectory source = new TempDirectory();
@@ -377,7 +371,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void ExtractToDirectory_RejectsSymlinkDirectoryTraversal_WithNestedFile()
         {
             using TempDirectory root = new TempDirectory();

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -76,7 +76,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(TarEntryType.SymbolicLink)]
         [InlineData(TarEntryType.HardLink)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void Extract_LinkEntry_TargetOutsideDirectory(TarEntryType entryType)
         {
             using MemoryStream archive = new MemoryStream();
@@ -99,25 +98,21 @@ namespace System.Formats.Tar.Tests
         [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void Extract_SymbolicLinkEntry_TargetInsideDirectory(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.SymbolicLink, format, null);
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsHardLinkCreation))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void Extract_HardLinkEntry_TargetInsideDirectory(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.HardLink, format, null);
 
         [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void Extract_SymbolicLinkEntry_TargetInsideDirectory_LongBaseDir(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.SymbolicLink, format, new string('a', 99));
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsHardLinkCreation))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void Extract_HardLinkEntry_TargetInsideDirectory_LongBaseDir(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal(TarEntryType.HardLink, format, new string('a', 99));
 
         // This test would not pass for the V7 and Ustar formats in some OSs like MacCatalyst, tvOSSimulator and OSX, because the TempDirectory gets created in
@@ -157,7 +152,6 @@ namespace System.Formats.Tar.Tests
         [InlineData(512)]
         [InlineData(512 + 1)]
         [InlineData(512 + 512 - 1)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void Extract_UnseekableStream_BlockAlignmentPadding_DoesNotAffectNextEntries(int contentSize)
         {
             byte[] fileContents = new byte[contentSize];
@@ -214,7 +208,6 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(GetTestTarFormats))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public void UnseekableStreams_RoundTrip(TestTarFormat testFormat)
         {
             using TempDirectory root = new();

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -57,7 +57,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public async Task SetsLastModifiedTimeOnExtractedFiles()
         {
             using TempDirectory root = new TempDirectory();
@@ -85,7 +84,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public async Task SetsLastModifiedTimeOnExtractedDirectories()
         {
             using TempDirectory root = new TempDirectory();
@@ -238,7 +236,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public async Task ExtractArchiveWithEntriesThatStartWithSlashDotPrefix_Async()
         {
             using (TempDirectory root = new TempDirectory())
@@ -267,7 +264,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public async Task UnixFileModes_Async(bool overwrite)
         {
             using TempDirectory source = new TempDirectory();
@@ -334,7 +330,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public async Task UnixFileModes_RestrictiveParentDir_Async()
         {
             using TempDirectory source = new TempDirectory();
@@ -368,7 +363,6 @@ namespace System.Formats.Tar.Tests
         }
 
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public async Task LinkBeforeTargetAsync()
         {
             using TempDirectory source = new TempDirectory();

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -136,7 +136,6 @@ namespace System.Formats.Tar.Tests
         [Theory]
         [InlineData(TarEntryType.SymbolicLink)]
         [InlineData(TarEntryType.HardLink)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public async Task Extract_LinkEntry_TargetOutsideDirectory_Async(TarEntryType entryType)
         {
             await using (MemoryStream archive = new MemoryStream())
@@ -161,25 +160,21 @@ namespace System.Formats.Tar.Tests
         [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public Task Extract_SymbolicLinkEntry_TargetInsideDirectory_Async(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal_Async(TarEntryType.SymbolicLink, format, null);
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsHardLinkCreation))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public Task Extract_HardLinkEntry_TargetInsideDirectory_Async(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal_Async(TarEntryType.HardLink, format, null);
 
         [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public Task Extract_SymbolicLinkEntry_TargetInsideDirectory_LongBaseDir_Async(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal_Async(TarEntryType.SymbolicLink, format, new string('a', 99));
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsHardLinkCreation))]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public Task Extract_HardLinkEntry_TargetInsideDirectory_LongBaseDir_Async(TarEntryFormat format) => Extract_LinkEntry_TargetInsideDirectory_Internal_Async(TarEntryType.HardLink, format, new string('a', 99));
 
         // This test would not pass for the V7 and Ustar formats in some OSs like MacCatalyst, tvOSSimulator and OSX, because the TempDirectory gets created in
@@ -222,7 +217,6 @@ namespace System.Formats.Tar.Tests
         [InlineData(512)]
         [InlineData(512 + 1)]
         [InlineData(512 + 512 - 1)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public async Task Extract_UnseekableStream_BlockAlignmentPadding_DoesNotAffectNextEntries_Async(int contentSize)
         {
             byte[] fileContents = new byte[contentSize];
@@ -279,7 +273,6 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(GetTestTarFormats))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/129227", TestPlatforms.OSX)]
         public async Task UnseekableStreams_RoundTrip_Async(TestTarFormat testFormat)
         {
             using TempDirectory root = new();


### PR DESCRIPTION
Windows always creates file symlinks, not directories. Based on the build, the exception can be thrown either when creating the symlink or when parsing it. We are now dealing with both cases.