### PR TITLE
Add XML doc comments for the IEEE 754 decimal types and value properties

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal128.cs
@@ -9,6 +9,10 @@ using System.Runtime.CompilerServices;
 
 namespace System.Numerics
 {
+    /// <summary>
+    /// Represents a decimal floating-point number that uses the IEEE 754 <c>decimal128</c> interchange format, providing 34 decimal digits of precision.
+    /// </summary>
+    /// <remarks>The IEEE 754 standard defines two interchange encodings for decimal floating-point: binary integer decimal (BID) and densely packed decimal (DPD). Which encoding is used is determined by the underlying ABI for the platform and defaults to BID where the ABI does not otherwise specify.</remarks>
     public readonly struct Decimal128
         : IComparable,
           IComparable<Decimal128>,
@@ -52,14 +56,28 @@ namespace System.Numerics
         private const ulong NaNMaskUpper = 0x7C00_0000_0000_0000;
         private const ulong InfinityMaskUpper = 0x7800_0000_0000_0000;
 
+        /// <summary>Gets a value that represents positive <c>infinity</c>.</summary>
         public static Decimal128 PositiveInfinity => new Decimal128(PositiveInfinityValue);
+
+        /// <summary>Gets a value that represents negative <c>infinity</c>.</summary>
         public static Decimal128 NegativeInfinity => new Decimal128(NegativeInfinityValue);
+
+        /// <summary>Gets a value that represents <c>NaN</c>.</summary>
         public static Decimal128 NaN => new Decimal128(QuietNaNValue);
+
+        /// <summary>Gets a value that represents negative <c>zero</c>.</summary>
         public static Decimal128 NegativeZero => new Decimal128(NegativeZeroValue);
+
+        /// <summary>Gets the value <c>0</c> for the type.</summary>
         public static Decimal128 Zero => new Decimal128(ZeroValue);
+
+        /// <summary>Gets the minimum value of the current type.</summary>
         public static Decimal128 MinValue => new Decimal128(upper: 0xDFFF_ED09_BEAD_87C0, lower: 0x378D_8E63_FFFF_FFFF);
+
+        /// <summary>Gets the maximum value of the current type.</summary>
         public static Decimal128 MaxValue => new Decimal128(upper: 0x5FFF_ED09_BEAD_87C0, lower: 0x378D_8E63_FFFF_FFFF);
 
+        /// <summary>Gets the smallest value such that can be added to <c>0</c> that does not result in <c>0</c>.</summary>
         public static Decimal128 Epsilon => new Decimal128(upper: 0x0000_0000_0000_0000, lower: 0x0000_0000_0000_0001); // Smallest positive subnormal value, aka 1 * 10^-6176
 
         internal Decimal128(UInt128 value)

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal32.cs
@@ -10,6 +10,10 @@ using System.Runtime.InteropServices;
 
 namespace System.Numerics
 {
+    /// <summary>
+    /// Represents a decimal floating-point number that uses the IEEE 754 <c>decimal32</c> interchange format, providing 7 decimal digits of precision.
+    /// </summary>
+    /// <remarks>The IEEE 754 standard defines two interchange encodings for decimal floating-point: binary integer decimal (BID) and densely packed decimal (DPD). Which encoding is used is determined by the underlying ABI for the platform and defaults to BID where the ABI does not otherwise specify.</remarks>
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct Decimal32
         : IComparable,
@@ -57,14 +61,28 @@ namespace System.Numerics
         private const uint MaxInternalValue = 0x77F8_967F; // +9.999_999 * 10^96; aka +9_999_999 * 10^90
         private const uint MinInternalValue = 0xF7F8_967F; // -9.999_999 * 10^96; aka -9_999_999 * 10^90
 
+        /// <summary>Gets a value that represents positive <c>infinity</c>.</summary>
         public static Decimal32 PositiveInfinity => new Decimal32(PositiveInfinityValue);
+
+        /// <summary>Gets a value that represents negative <c>infinity</c>.</summary>
         public static Decimal32 NegativeInfinity => new Decimal32(NegativeInfinityValue);
+
+        /// <summary>Gets a value that represents <c>NaN</c>.</summary>
         public static Decimal32 NaN => new Decimal32(QuietNaNValue);
+
+        /// <summary>Gets a value that represents negative <c>zero</c>.</summary>
         public static Decimal32 NegativeZero => new Decimal32(NegativeZeroValue);
+
+        /// <summary>Gets the value <c>0</c> for the type.</summary>
         public static Decimal32 Zero => new Decimal32(ZeroValue);
+
+        /// <summary>Gets the minimum value of the current type.</summary>
         public static Decimal32 MinValue => new Decimal32(MinInternalValue);
+
+        /// <summary>Gets the maximum value of the current type.</summary>
         public static Decimal32 MaxValue => new Decimal32(MaxInternalValue);
 
+        /// <summary>Gets the smallest value such that can be added to <c>0</c> that does not result in <c>0</c>.</summary>
         public static Decimal32 Epsilon => new Decimal32(0x0000_0001); // Smallest positive subnormal value, aka 1 * 10^-101
 
         private static ReadOnlySpan<uint> UInt32Powers10 =>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal64.cs
@@ -9,6 +9,10 @@ using System.Runtime.CompilerServices;
 
 namespace System.Numerics
 {
+    /// <summary>
+    /// Represents a decimal floating-point number that uses the IEEE 754 <c>decimal64</c> interchange format, providing 16 decimal digits of precision.
+    /// </summary>
+    /// <remarks>The IEEE 754 standard defines two interchange encodings for decimal floating-point: binary integer decimal (BID) and densely packed decimal (DPD). Which encoding is used is determined by the underlying ABI for the platform and defaults to BID where the ABI does not otherwise specify.</remarks>
     public readonly struct Decimal64
         : IComparable,
           IComparable<Decimal64>,
@@ -50,14 +54,28 @@ namespace System.Numerics
         private const ulong MaxInternalValue = 0x77FB_86F2_6FC0_FFFF; // 9.999_999_999_999_999 * 10^384; aka 9_999_999_999_999_999 * 10^369
         private const ulong MinInternalValue = 0xF7FB_86F2_6FC0_FFFF; // -9.999_999_999_999_999 * 10^384; aka -9_999_999_999_999_999 * 10^369
 
+        /// <summary>Gets a value that represents positive <c>infinity</c>.</summary>
         public static Decimal64 PositiveInfinity => new Decimal64(PositiveInfinityValue);
+
+        /// <summary>Gets a value that represents negative <c>infinity</c>.</summary>
         public static Decimal64 NegativeInfinity => new Decimal64(NegativeInfinityValue);
+
+        /// <summary>Gets a value that represents <c>NaN</c>.</summary>
         public static Decimal64 NaN => new Decimal64(QuietNaNValue);
+
+        /// <summary>Gets a value that represents negative <c>zero</c>.</summary>
         public static Decimal64 NegativeZero => new Decimal64(NegativeZeroValue);
+
+        /// <summary>Gets the value <c>0</c> for the type.</summary>
         public static Decimal64 Zero => new Decimal64(ZeroValue);
+
+        /// <summary>Gets the minimum value of the current type.</summary>
         public static Decimal64 MinValue => new Decimal64(MinInternalValue);
+
+        /// <summary>Gets the maximum value of the current type.</summary>
         public static Decimal64 MaxValue => new Decimal64(MaxInternalValue);
 
+        /// <summary>Gets the smallest value such that can be added to <c>0</c> that does not result in <c>0</c>.</summary>
         public static Decimal64 Epsilon => new Decimal64(0x0000_0000_0000_0001); // Smallest positive subnormal value, aka 1 * 10^-398
 
         private static ReadOnlySpan<ulong> UInt64Powers10 =>


### PR DESCRIPTION
Fills in the remaining XML doc gaps on the public surface of `Decimal32`, `Decimal64`, and `Decimal128`.

- Documents the three types themselves, calling out that they use the IEEE 754 `decimalN` interchange format with the binary integer decimal (BID) encoding and their respective precision (7, 16, and 34 decimal digits).
- Documents the static value properties `PositiveInfinity`, `NegativeInfinity`, `NaN`, `NegativeZero`, `Zero`, `MinValue`, `MaxValue`, and `Epsilon`. These now correspond to `IFloatingPointIeee754<TSelf>`/`IMinMaxValue<TSelf>`/`INumberBase<TSelf>` members, so the summaries use the interfaces'' canonical wording verbatim, matching the file''s existing convention of literal summaries for `One`/`E`/`Pi`/`Tau`/`NegativeOne`.

The remaining undocumented members are explicit implementations of the `internal` `IDecimalIeee754ParseAndFormatInfo<T, TSignificand>` interface, which aren''t part of the public surface and don''t require docs (consistent with `Half`/`BFloat16`).

Doc-comment-only change.

> [!NOTE]
> This PR description was drafted by Copilot.
