### PR TITLE
Fix ParamName in guard of `Base64.GetMaxEncodedToUtf8Length`

### DIFF
--- a/src/libraries/System.Memory/tests/Base64/Base64EncoderUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64EncoderUnitTests.cs
@@ -253,12 +253,12 @@ namespace System.Buffers.Text.Tests
             }
 
             // integer overflow
-            Assert.Throws<ArgumentOutOfRangeException>(() => Base64.GetMaxEncodedToUtf8Length(1610612734));
-            Assert.Throws<ArgumentOutOfRangeException>(() => Base64.GetMaxEncodedToUtf8Length(int.MaxValue));
+            Assert.Throws<ArgumentOutOfRangeException>("bytesLength", () => Base64.GetMaxEncodedToUtf8Length(1610612734));
+            Assert.Throws<ArgumentOutOfRangeException>("bytesLength", () => Base64.GetMaxEncodedToUtf8Length(int.MaxValue));
 
             // negative input
-            Assert.Throws<ArgumentOutOfRangeException>(() => Base64.GetMaxEncodedToUtf8Length(-1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => Base64.GetMaxEncodedToUtf8Length(int.MinValue));
+            Assert.Throws<ArgumentOutOfRangeException>("bytesLength", () => Base64.GetMaxEncodedToUtf8Length(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("bytesLength", () => Base64.GetMaxEncodedToUtf8Length(int.MinValue));
         }
 
         [Fact]

--- a/src/libraries/System.Memory/tests/Base64Url/Base64UrlEncoderUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64Url/Base64UrlEncoderUnitTests.cs
@@ -250,12 +250,12 @@ namespace System.Buffers.Text.Tests
             }
 
             // integer overflow
-            Assert.Throws<ArgumentOutOfRangeException>(() => Base64Url.GetEncodedLength(1610612734));
-            Assert.Throws<ArgumentOutOfRangeException>(() => Base64Url.GetEncodedLength(int.MaxValue));
+            Assert.Throws<ArgumentOutOfRangeException>("bytesLength", () => Base64Url.GetEncodedLength(1610612734));
+            Assert.Throws<ArgumentOutOfRangeException>("bytesLength", () => Base64Url.GetEncodedLength(int.MaxValue));
 
             // negative input
-            Assert.Throws<ArgumentOutOfRangeException>(() => Base64Url.GetEncodedLength(-1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => Base64Url.GetEncodedLength(int.MinValue));
+            Assert.Throws<ArgumentOutOfRangeException>("bytesLength", () => Base64Url.GetEncodedLength(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("bytesLength", () => Base64Url.GetEncodedLength(int.MinValue));
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -27,7 +27,7 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetEncodedLength(int bytesLength)
         {
-            ArgumentOutOfRangeException.ThrowIfGreaterThan<uint>((uint)bytesLength, MaximumEncodeLength);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan<uint>((uint)bytesLength, MaximumEncodeLength, nameof(bytesLength));
 
             return ((bytesLength + 2) / 3) * 4;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlEncoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlEncoder.cs
@@ -40,7 +40,7 @@ namespace System.Buffers.Text
         public static int GetEncodedLength(int bytesLength)
         {
 #if NET
-            ArgumentOutOfRangeException.ThrowIfGreaterThan<uint>((uint)bytesLength, MaximumEncodeLength);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan<uint>((uint)bytesLength, MaximumEncodeLength, nameof(bytesLength));
 
             (uint whole, uint remainder) = uint.DivRem((uint)bytesLength, 3);
 


### PR DESCRIPTION
Without fix `ParamName` of the exception was `(uint)bytesLength`

Also fix same issue for `Base64Url.GetEncodedLength`