### PR TITLE
Support IEEE 754 decimals in TotalOrderIeee754Comparer and fast-path the built-in types

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -158,6 +158,7 @@ namespace System
         static abstract int NumberBitsSignificand { get; }
         static abstract TValue NaNMask { get; }
         static abstract TValue SNaNMask { get; }
+        static abstract TValue NaNPayloadMask { get; }
         static abstract TValue SignMask { get; }
         static abstract TValue G0G1Mask { get; }
         static abstract TValue G0ToGwPlus1ExponentMask { get; } //G0 to G(w+1)

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal128.cs
@@ -51,6 +51,7 @@ namespace System.Numerics
         private static UInt128 PiValue => new UInt128(0x2FFE_9AE4_7957_96A7, 0xBABE_5564_E6F3_9F8F);  // +3.141592653589793238462643383279503
         private static UInt128 TauValue => new UInt128(0x2FFF_35C8_F2AF_2D4F, 0x757C_AAC9_CDE7_3F1E); // +6.283185307179586476925286766559006
         private static UInt128 QuietNaNValue => new UInt128(0xFC00_0000_0000_0000, 0);
+        private static UInt128 NaNPayloadMask => new UInt128(0x0000_3FFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF);
 
         private const ulong SignMaskUpper = 0x8000_0000_0000_0000;
         private const ulong NaNMaskUpper = 0x7C00_0000_0000_0000;
@@ -1254,7 +1255,7 @@ namespace System.Numerics
         static int INumberBase<Decimal128>.Radix => 10;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
-        static bool INumberBase<Decimal128>.IsCanonical(Decimal128 value) => Number.IsCanonicalDecimalIeee754<Decimal128, UInt128>(new UInt128(value._upper, value._lower), nanReservedMask: new UInt128(0x01FF_C000_0000_0000, 0x0000_0000_0000_0000), nanPayloadMask: new UInt128(0x0000_3FFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), maxNaNPayload: new UInt128(0x0000_314D_C644_8D93, 0x38C1_5B09_FFFF_FFFF));
+        static bool INumberBase<Decimal128>.IsCanonical(Decimal128 value) => Number.IsCanonicalDecimalIeee754<Decimal128, UInt128>(new UInt128(value._upper, value._lower), nanReservedMask: new UInt128(0x01FF_C000_0000_0000, 0x0000_0000_0000_0000), nanPayloadMask: NaNPayloadMask, maxNaNPayload: new UInt128(0x0000_314D_C644_8D93, 0x38C1_5B09_FFFF_FFFF));
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
         static bool INumberBase<Decimal128>.IsComplexNumber(Decimal128 value) => false;
@@ -1792,6 +1793,8 @@ namespace System.Numerics
         static UInt128 IDecimalIeee754ParseAndFormatInfo<Decimal128, UInt128>.NaNMask => new UInt128(NaNMaskUpper, 0);
 
         static UInt128 IDecimalIeee754ParseAndFormatInfo<Decimal128, UInt128>.SNaNMask => new UInt128(SNaNMaskUpper, 0);
+
+        static UInt128 IDecimalIeee754ParseAndFormatInfo<Decimal128, UInt128>.NaNPayloadMask => NaNPayloadMask;
 
         static UInt128 IDecimalIeee754ParseAndFormatInfo<Decimal128, UInt128>.SignMask => new UInt128(SignMaskUpper, 0);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal32.cs
@@ -57,6 +57,7 @@ namespace System.Numerics
         private const uint MostSignificantBitOfSignificandMask = 0x0080_0000;
         private const uint NaNMask = 0x7C00_0000;
         private const uint SNaNMask = 0x7E00_0000;
+        private const uint NaNPayloadMask = 0x000F_FFFF;
         private const uint InfinityMask = 0x7800_0000;
         private const uint MaxSignificand = 9_999_999;
         private const uint MaxInternalValue = 0x77F8_967F; // +9.999_999 * 10^96; aka +9_999_999 * 10^90
@@ -1277,7 +1278,7 @@ namespace System.Numerics
         static int INumberBase<Decimal32>.Radix => 10;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
-        static bool INumberBase<Decimal32>.IsCanonical(Decimal32 value) => Number.IsCanonicalDecimalIeee754<Decimal32, uint>(value._value, nanReservedMask: 0x01F0_0000, nanPayloadMask: 0x000F_FFFF, maxNaNPayload: 999_999);
+        static bool INumberBase<Decimal32>.IsCanonical(Decimal32 value) => Number.IsCanonicalDecimalIeee754<Decimal32, uint>(value._value, nanReservedMask: 0x01F0_0000, nanPayloadMask: NaNPayloadMask, maxNaNPayload: 999_999);
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
         static bool INumberBase<Decimal32>.IsComplexNumber(Decimal32 value) => false;
@@ -1772,6 +1773,8 @@ namespace System.Numerics
         static uint IDecimalIeee754ParseAndFormatInfo<Decimal32, uint>.NaNMask => NaNMask;
 
         static uint IDecimalIeee754ParseAndFormatInfo<Decimal32, uint>.SNaNMask => SNaNMask;
+
+        static uint IDecimalIeee754ParseAndFormatInfo<Decimal32, uint>.NaNPayloadMask => NaNPayloadMask;
 
         static uint IDecimalIeee754ParseAndFormatInfo<Decimal32, uint>.SignMask => SignMask;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Decimal64.cs
@@ -50,6 +50,7 @@ namespace System.Numerics
         private const ulong MostSignificantBitOfSignificandMask = 0x0020_0000_0000_0000;
         private const ulong NaNMask = 0x7C00_0000_0000_0000;
         private const ulong SNaNMask = 0x7E00_0000_0000_0000;
+        private const ulong NaNPayloadMask = 0x0003_FFFF_FFFF_FFFF;
         private const ulong InfinityMask = 0x7800_0000_0000_0000;
         private const ulong MaxSignificand = 9_999_999_999_999_999;
         private const ulong MaxInternalValue = 0x77FB_86F2_6FC0_FFFF; // 9.999_999_999_999_999 * 10^384; aka 9_999_999_999_999_999 * 10^369
@@ -1268,7 +1269,7 @@ namespace System.Numerics
         static int INumberBase<Decimal64>.Radix => 10;
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsCanonical(TSelf)" />
-        static bool INumberBase<Decimal64>.IsCanonical(Decimal64 value) => Number.IsCanonicalDecimalIeee754<Decimal64, ulong>(value._value, nanReservedMask: 0x01FC_0000_0000_0000, nanPayloadMask: 0x0003_FFFF_FFFF_FFFF, maxNaNPayload: 999_999_999_999_999);
+        static bool INumberBase<Decimal64>.IsCanonical(Decimal64 value) => Number.IsCanonicalDecimalIeee754<Decimal64, ulong>(value._value, nanReservedMask: 0x01FC_0000_0000_0000, nanPayloadMask: NaNPayloadMask, maxNaNPayload: 999_999_999_999_999);
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsComplexNumber(TSelf)" />
         static bool INumberBase<Decimal64>.IsComplexNumber(Decimal64 value) => false;
@@ -1764,6 +1765,8 @@ namespace System.Numerics
         static ulong IDecimalIeee754ParseAndFormatInfo<Decimal64, ulong>.NaNMask => NaNMask;
 
         static ulong IDecimalIeee754ParseAndFormatInfo<Decimal64, ulong>.SNaNMask => SNaNMask;
+
+        static ulong IDecimalIeee754ParseAndFormatInfo<Decimal64, ulong>.NaNPayloadMask => NaNPayloadMask;
 
         static ulong IDecimalIeee754ParseAndFormatInfo<Decimal64, ulong>.SignMask => SignMask;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
@@ -264,12 +264,14 @@ namespace System.Numerics
                         return xIsNegative ? -1 : 1;
                     }
 
-                    // Same-signed NaNs are ordered by their decoded significand (payload), matching the
-                    // significand comparison the generic path uses.
-                    TValue xSignificand = Number.UnpackDecimalIeee754<TDecimal, TValue>(xBits).Significand;
-                    TValue ySignificand = Number.UnpackDecimalIeee754<TDecimal, TValue>(yBits).Significand;
+                    // Same-signed NaNs are ordered by their raw payload, mirroring how the binary
+                    // formats order NaNs by their significand bits. The payload is used directly
+                    // rather than the decoded coefficient so every width (including Decimal128, whose
+                    // NaN coefficient decode is non-canonical) orders consistently.
+                    TValue xPayload = xBits & TDecimal.NaNPayloadMask;
+                    TValue yPayload = yBits & TDecimal.NaNPayloadMask;
 
-                    int payload = xSignificand.CompareTo(ySignificand);
+                    int payload = xPayload.CompareTo(yPayload);
                     return xIsNegative ? -payload : payload;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Numerics
 {
@@ -62,6 +63,28 @@ namespace System.Numerics
             {
                 return CompareIntegerSemantic(BitConverter.HalfToInt16Bits((Half)(object)x!), BitConverter.HalfToInt16Bits((Half)(object)y!));
             }
+            else if (typeof(T) == typeof(BFloat16))
+            {
+                return CompareIntegerSemantic(Unsafe.BitCast<BFloat16, short>((BFloat16)(object)x!), Unsafe.BitCast<BFloat16, short>((BFloat16)(object)y!));
+            }
+            else if (typeof(T) == typeof(NFloat))
+            {
+                return CompareIntegerSemantic(Unsafe.BitCast<NFloat, nint>((NFloat)(object)x!), Unsafe.BitCast<NFloat, nint>((NFloat)(object)y!));
+            }
+            else if (typeof(T) == typeof(Decimal32))
+            {
+                return CompareDecimal<Decimal32, uint>(((Decimal32)(object)x!)._value, ((Decimal32)(object)y!)._value);
+            }
+            else if (typeof(T) == typeof(Decimal64))
+            {
+                return CompareDecimal<Decimal64, ulong>(((Decimal64)(object)x!)._value, ((Decimal64)(object)y!)._value);
+            }
+            else if (typeof(T) == typeof(Decimal128))
+            {
+                Decimal128 xValue = (Decimal128)(object)x!;
+                Decimal128 yValue = (Decimal128)(object)y!;
+                return CompareDecimal<Decimal128, UInt128>(new UInt128(xValue._upper, xValue._lower), new UInt128(yValue._upper, yValue._lower));
+            }
             else
             {
                 return CompareGeneric(x, y);
@@ -97,6 +120,32 @@ namespace System.Numerics
                     return 1;
                 }
 
+                static int CompareExponent(T x, T y)
+                {
+                    // Equal values with differing representations only differ by their exponent, so the
+                    // unbiased (quantum) exponents are read and compared using signed semantics. For a
+                    // given type both exponents share the same byte count.
+
+                    // Prevent stack overflow for huge numbers
+                    const int StackAllocThreshold = 256;
+
+                    int xExponentLength = x!.GetExponentByteCount();
+                    int yExponentLength = y!.GetExponentByteCount();
+
+                    Span<byte> exponentX = (uint)xExponentLength <= StackAllocThreshold ? stackalloc byte[xExponentLength] : new byte[xExponentLength];
+                    Span<byte> exponentY = (uint)yExponentLength <= StackAllocThreshold ? stackalloc byte[yExponentLength] : new byte[yExponentLength];
+
+                    x.WriteExponentBigEndian(exponentX);
+                    y.WriteExponentBigEndian(exponentY);
+
+                    // The exponents are two's complement big-endian. Flipping the sign bit of the most
+                    // significant byte maps the signed ordering onto an unsigned byte-wise comparison.
+                    exponentX[0] ^= 0x80;
+                    exponentY[0] ^= 0x80;
+
+                    return exponentX.SequenceCompareTo(exponentY);
+                }
+
                 // If < or > returns true, the result satisfies definition of totalOrder too
 
                 if (x < y)
@@ -109,27 +158,20 @@ namespace System.Numerics
                 }
                 else if (x == y)
                 {
-                    if (T.IsZero(x)) // only zeros are equal to zeros
+                    // Only zeros are equal to zeros, and totalOrder places -0 before +0.
+                    if (T.IsZero(x) && (T.IsNegative(x) != T.IsNegative(y)))
                     {
-                        // IEEE 754 numbers are either positive or negative. Skip check for the opposite.
-
-                        if (T.IsNegative(x))
-                        {
-                            return T.IsNegative(y) ? 0 : -1;
-                        }
-                        else
-                        {
-                            return T.IsPositive(y) ? 0 : 1;
-                        }
+                        return T.IsNegative(x) ? -1 : 1;
                     }
-                    else
-                    {
-                        // Equivalant values are compared by their exponent parts,
-                        // and the value with smaller exponent is considered closer to zero.
 
-                        // This only applies to IEEE 754 decimals. Consider to add support if decimals are added into .NET.
-                        return 0;
-                    }
+                    // Values that are equal but have differing representations are IEEE 754 decimal cohort
+                    // members (e.g. 1.0 and 1.00, or same-signed zeros with differing exponents). These are
+                    // ordered by exponent: the value with the smaller exponent is closer to zero for positive
+                    // values, and the ordering is reversed for negative values. Binary types have a unique
+                    // representation per value, so their exponents already match and this returns 0.
+
+                    int exponentComparison = CompareExponent(x, y);
+                    return T.IsNegative(x) ? -exponentComparison : exponentComparison;
                 }
                 else
                 {
@@ -140,7 +182,6 @@ namespace System.Numerics
                     {
                         // IEEE 754 totalOrder only defines the order of NaN type bit (the first bit of significand)
                         // To match the integer semantic comparison above, here we compare all the significand bits
-                        // Revisit this if decimals are added
 
                         // Leave the space for custom floating-point type that has variable significand length
 
@@ -199,6 +240,69 @@ namespace System.Numerics
                     }
                 }
             }
+        }
+
+        // Fast path for the built-in IEEE 754 decimal types. Decimal bit patterns are not monotonic
+        // in totalOrder (unlike binary formats), so this replicates the generic totalOrder while
+        // unpacking each operand at most twice instead of the four-plus unpacks the generic path incurs.
+        private static int CompareDecimal<TDecimal, TValue>(TValue xBits, TValue yBits)
+            where TDecimal : unmanaged, IDecimalIeee754ParseAndFormatInfo<TDecimal, TValue>
+            where TValue : unmanaged, IBinaryInteger<TValue>
+        {
+            bool xIsNaN = TDecimal.IsNaN(xBits);
+            bool yIsNaN = TDecimal.IsNaN(yBits);
+
+            if (xIsNaN || yIsNaN)
+            {
+                // totalOrder places NaNs at the extremes ordered by sign: -qNaN < -sNaN < finite < +sNaN < +qNaN.
+                bool xIsNegative = TDecimal.IsNegative(xBits);
+
+                if (xIsNaN && yIsNaN)
+                {
+                    if (xIsNegative != TDecimal.IsNegative(yBits))
+                    {
+                        return xIsNegative ? -1 : 1;
+                    }
+
+                    // Same-signed NaNs are ordered by their decoded significand (payload), matching the
+                    // significand comparison the generic path uses.
+                    TValue xSignificand = Number.UnpackDecimalIeee754<TDecimal, TValue>(xBits).Significand;
+                    TValue ySignificand = Number.UnpackDecimalIeee754<TDecimal, TValue>(yBits).Significand;
+
+                    int payload = xSignificand.CompareTo(ySignificand);
+                    return xIsNegative ? -payload : payload;
+                }
+
+                if (xIsNaN)
+                {
+                    return xIsNegative ? -1 : 1;
+                }
+
+                return TDecimal.IsNegative(yBits) ? 1 : -1;
+            }
+
+            int result = Number.CompareDecimalIeee754<TDecimal, TValue>(xBits, yBits);
+
+            if (result != 0)
+            {
+                return result;
+            }
+
+            // The values are numerically equal but may have differing representations (decimal cohort
+            // members such as 1.0 and 1.00, or same-signed zeros with differing exponents).
+            Number.DecodedDecimalIeee754<TValue> x = Number.UnpackDecimalIeee754<TDecimal, TValue>(xBits);
+            Number.DecodedDecimalIeee754<TValue> y = Number.UnpackDecimalIeee754<TDecimal, TValue>(yBits);
+
+            // totalOrder places -0 before +0.
+            if ((x.Significand == TValue.Zero) && (x.Signed != y.Signed))
+            {
+                return x.Signed ? -1 : 1;
+            }
+
+            // Cohort members differ only by exponent: the value with the smaller exponent is closer to
+            // zero for positive values, and the ordering is reversed for negative values.
+            int exponentComparison = x.UnbiasedExponent.CompareTo(y.UnbiasedExponent);
+            return x.Signed ? -exponentComparison : exponentComparison;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
@@ -264,14 +264,17 @@ namespace System.Numerics
                         return xIsNegative ? -1 : 1;
                     }
 
-                    // Same-signed NaNs are ordered by their raw payload, mirroring how the binary
-                    // formats order NaNs by their significand bits. The payload is used directly
-                    // rather than the decoded coefficient so every width (including Decimal128, whose
-                    // NaN coefficient decode is non-canonical) orders consistently.
-                    TValue xPayload = xBits & TDecimal.NaNPayloadMask;
-                    TValue yPayload = yBits & TDecimal.NaNPayloadMask;
+                    // Same-signed NaNs follow totalOrder's +sNaN < +qNaN ordering, then break ties on
+                    // the raw payload. The binary formats get this for free because their quiet bit is
+                    // the significand's most significant bit; the decimal signaling bit sits above the
+                    // payload but is set for signaling (not quiet), so it is folded in inverted to rank
+                    // quiet above signaling. Using the raw payload rather than the decoded coefficient
+                    // keeps every width consistent (including Decimal128, whose NaN decode is non-canonical).
+                    TValue signalingMask = TDecimal.SNaNMask ^ TDecimal.NaNMask;
+                    TValue xKey = (xBits & TDecimal.NaNPayloadMask) | ((xBits & signalingMask) ^ signalingMask);
+                    TValue yKey = (yBits & TDecimal.NaNPayloadMask) | ((yBits & signalingMask) ^ signalingMask);
 
-                    int payload = xPayload.CompareTo(yPayload);
+                    int payload = xKey.CompareTo(yKey);
                     return xIsNegative ? -payload : payload;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/TotalOrderIeee754Comparer.cs
@@ -254,7 +254,8 @@ namespace System.Numerics
 
             if (xIsNaN || yIsNaN)
             {
-                // totalOrder places NaNs at the extremes ordered by sign: -qNaN < -sNaN < finite < +sNaN < +qNaN.
+                // totalOrder places NaNs at the extremes ordered by sign:
+                // -qNaN < -sNaN < -infinite < -finite < -0 < +0 < +finite < +infinite < +sNaN < +qNaN.
                 bool xIsNegative = TDecimal.IsNegative(xBits);
 
                 if (xIsNaN && yIsNaN)
@@ -264,12 +265,13 @@ namespace System.Numerics
                         return xIsNegative ? -1 : 1;
                     }
 
-                    // Same-signed NaNs follow totalOrder's +sNaN < +qNaN ordering, then break ties on
-                    // the raw payload. The binary formats get this for free because their quiet bit is
-                    // the significand's most significant bit; the decimal signaling bit sits above the
-                    // payload but is set for signaling (not quiet), so it is folded in inverted to rank
-                    // quiet above signaling. Using the raw payload rather than the decoded coefficient
-                    // keeps every width consistent (including Decimal128, whose NaN decode is non-canonical).
+                    // totalOrder only fixes the sign and the signaling-before-quiet ordering for NaNs;
+                    // the payload order is implementation-defined, so there is no need to canonicalize.
+                    // The raw payload bits are compared directly (including non-canonical payloads), which
+                    // is cheaper and more deterministic than decoding the coefficient and stays consistent
+                    // across every width (notably Decimal128, whose NaN coefficient decode is non-canonical).
+                    // The signaling bit sits just above the payload but is set for signaling rather than
+                    // quiet, so it is folded in inverted to rank quiet above signaling with a single compare.
                     TValue signalingMask = TDecimal.SNaNMask ^ TDecimal.NaNMask;
                     TValue xKey = (xBits & TDecimal.NaNPayloadMask) | ((xBits & signalingMask) ^ signalingMask);
                     TValue yKey = (yBits & TDecimal.NaNPayloadMask) | ((yBits & signalingMask) ^ signalingMask);

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
@@ -111,6 +111,7 @@ namespace System.Runtime.Tests
                 yield return new object[] { -BFloat16.NaN, BFloat16.PositiveInfinity, 1 };
                 yield return new object[] { BFloat16.NaN, BFloat16.NaN, 0 };
                 yield return new object[] { BFloat16.NaN, -BFloat16.NaN, -1 };
+                yield return new object[] { Unsafe.BitCast<ushort, BFloat16>(0x7FC0), Unsafe.BitCast<ushort, BFloat16>(0x7FC1), -1 }; // implementation defined, not part of IEEE 754 totalOrder
             }
         }
 
@@ -181,6 +182,9 @@ namespace System.Runtime.Tests
                 // Same-signed NaNs are ordered by payload (implementation defined, not part of IEEE 754 totalOrder)
                 yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x7C00_0000), Unsafe.BitCast<uint, Decimal32>(0x7C00_0001), -1 };
                 yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xFC00_0000), Unsafe.BitCast<uint, Decimal32>(0xFC00_0001), 1 };
+                // Signaling NaNs order before quiet NaNs of the same sign (+sNaN < +qNaN)
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x7E00_0000), Unsafe.BitCast<uint, Decimal32>(0x7C00_0000), -1 };
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xFE00_0000), Unsafe.BitCast<uint, Decimal32>(0xFC00_0000), 1 };
                 // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
                 yield return new object[] { Decimal32.Parse("1.00", CultureInfo.InvariantCulture), Decimal32.Parse("1.0", CultureInfo.InvariantCulture), -1 };
                 yield return new object[] { Decimal32.Parse("1.0", CultureInfo.InvariantCulture), Decimal32.Parse("1.00", CultureInfo.InvariantCulture), 1 };
@@ -219,6 +223,9 @@ namespace System.Runtime.Tests
                 // Same-signed NaNs are ordered by payload (implementation defined, not part of IEEE 754 totalOrder)
                 yield return new object[] { Unsafe.BitCast<ulong, Decimal64>(0x7C00_0000_0000_0000), Unsafe.BitCast<ulong, Decimal64>(0x7C00_0000_0000_0001), -1 };
                 yield return new object[] { Unsafe.BitCast<ulong, Decimal64>(0xFC00_0000_0000_0000), Unsafe.BitCast<ulong, Decimal64>(0xFC00_0000_0000_0001), 1 };
+                // Signaling NaNs order before quiet NaNs of the same sign (+sNaN < +qNaN)
+                yield return new object[] { Unsafe.BitCast<ulong, Decimal64>(0x7E00_0000_0000_0000), Unsafe.BitCast<ulong, Decimal64>(0x7C00_0000_0000_0000), -1 };
+                yield return new object[] { Unsafe.BitCast<ulong, Decimal64>(0xFE00_0000_0000_0000), Unsafe.BitCast<ulong, Decimal64>(0xFC00_0000_0000_0000), 1 };
                 // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
                 yield return new object[] { Decimal64.Parse("1.00", CultureInfo.InvariantCulture), Decimal64.Parse("1.0", CultureInfo.InvariantCulture), -1 };
                 yield return new object[] { Decimal64.Parse("1.0", CultureInfo.InvariantCulture), Decimal64.Parse("1.00", CultureInfo.InvariantCulture), 1 };
@@ -258,6 +265,9 @@ namespace System.Runtime.Tests
                 // The payload here lives entirely in the low bits, which the coefficient decode would discard.
                 yield return new object[] { Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0x7C00_0000_0000_0000, 0x0000_0000_0000_0000)), Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0x7C00_0000_0000_0000, 0x0000_0000_0000_0001)), -1 };
                 yield return new object[] { Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0xFC00_0000_0000_0000, 0x0000_0000_0000_0000)), Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0xFC00_0000_0000_0000, 0x0000_0000_0000_0001)), 1 };
+                // Signaling NaNs order before quiet NaNs of the same sign (+sNaN < +qNaN)
+                yield return new object[] { Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0x7E00_0000_0000_0000, 0x0000_0000_0000_0000)), Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0x7C00_0000_0000_0000, 0x0000_0000_0000_0000)), -1 };
+                yield return new object[] { Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0xFE00_0000_0000_0000, 0x0000_0000_0000_0000)), Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0xFC00_0000_0000_0000, 0x0000_0000_0000_0000)), 1 };
                 // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
                 yield return new object[] { Decimal128.Parse("1.00", CultureInfo.InvariantCulture), Decimal128.Parse("1.0", CultureInfo.InvariantCulture), -1 };
                 yield return new object[] { Decimal128.Parse("1.0", CultureInfo.InvariantCulture), Decimal128.Parse("1.00", CultureInfo.InvariantCulture), 1 };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -94,6 +94,33 @@ namespace System.Runtime.Tests
             Assert.Equal(result, Math.Sign(comparer.Compare(x, y)));
         }
 
+        public static IEnumerable<object[]> BFloat16TestData
+        {
+            get
+            {
+                yield return new object[] { (BFloat16)0.0f, (BFloat16)0.0f, 0 };
+                yield return new object[] { (BFloat16)(-0.0f), (BFloat16)(-0.0f), 0 };
+                yield return new object[] { (BFloat16)0.0f, (BFloat16)(-0.0f), 1 };
+                yield return new object[] { (BFloat16)(-0.0f), (BFloat16)0.0f, -1 };
+                yield return new object[] { (BFloat16)0.0f, (BFloat16)1.0f, -1 };
+                yield return new object[] { BFloat16.PositiveInfinity, (BFloat16)1.0f, 1 };
+                yield return new object[] { BFloat16.NaN, BFloat16.NegativeInfinity, -1 };
+                yield return new object[] { BFloat16.NaN, (BFloat16)(-1.0f), -1 };
+                yield return new object[] { -BFloat16.NaN, (BFloat16)1.0f, 1 };
+                yield return new object[] { -BFloat16.NaN, BFloat16.PositiveInfinity, 1 };
+                yield return new object[] { BFloat16.NaN, BFloat16.NaN, 0 };
+                yield return new object[] { BFloat16.NaN, -BFloat16.NaN, -1 };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(BFloat16TestData))]
+        public void TotalOrderTestBFloat16(BFloat16 x, BFloat16 y, int result)
+        {
+            var comparer = new TotalOrderIeee754Comparer<BFloat16>();
+            Assert.Equal(result, Math.Sign(comparer.Compare(x, y)));
+        }
+
         public static IEnumerable<object[]> NFloatTestData
         {
             get
@@ -131,6 +158,111 @@ namespace System.Runtime.Tests
         public void TotalOrderTestNFloat(NFloat x, NFloat y, int result)
         {
             var comparer = new TotalOrderIeee754Comparer<NFloat>();
+            Assert.Equal(result, Math.Sign(comparer.Compare(x, y)));
+        }
+
+        public static IEnumerable<object[]> Decimal32TestData
+        {
+            get
+            {
+                yield return new object[] { Decimal32.Parse("0"), Decimal32.Parse("0"), 0 };
+                yield return new object[] { Decimal32.NegativeZero, Decimal32.NegativeZero, 0 };
+                yield return new object[] { Decimal32.Parse("0"), Decimal32.NegativeZero, 1 };
+                yield return new object[] { Decimal32.NegativeZero, Decimal32.Parse("0"), -1 };
+                yield return new object[] { Decimal32.Parse("0"), Decimal32.Parse("1"), -1 };
+                yield return new object[] { Decimal32.PositiveInfinity, Decimal32.Parse("1"), 1 };
+                yield return new object[] { Decimal32.NaN, Decimal32.NegativeInfinity, -1 };
+                yield return new object[] { Decimal32.NaN, Decimal32.Parse("-1"), -1 };
+                yield return new object[] { -Decimal32.NaN, Decimal32.Parse("1"), 1 };
+                yield return new object[] { -Decimal32.NaN, Decimal32.PositiveInfinity, 1 };
+                yield return new object[] { Decimal32.NaN, Decimal32.NaN, 0 };
+                yield return new object[] { Decimal32.NaN, -Decimal32.NaN, -1 };
+                // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
+                yield return new object[] { Decimal32.Parse("1.00"), Decimal32.Parse("1.0"), -1 };
+                yield return new object[] { Decimal32.Parse("1.0"), Decimal32.Parse("1.00"), 1 };
+                yield return new object[] { Decimal32.Parse("1e1"), Decimal32.Parse("10e0"), 1 };
+                yield return new object[] { Decimal32.Parse("-1.00"), Decimal32.Parse("-1.0"), 1 };
+                yield return new object[] { Decimal32.Parse("-1.0"), Decimal32.Parse("-1.00"), -1 };
+                yield return new object[] { Decimal32.Parse("0.00"), Decimal32.Parse("0"), -1 };
+                yield return new object[] { Decimal32.Parse("-0.00"), Decimal32.NegativeZero, 1 };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Decimal32TestData))]
+        public void TotalOrderTestDecimal32(Decimal32 x, Decimal32 y, int result)
+        {
+            var comparer = new TotalOrderIeee754Comparer<Decimal32>();
+            Assert.Equal(result, Math.Sign(comparer.Compare(x, y)));
+        }
+
+        public static IEnumerable<object[]> Decimal64TestData
+        {
+            get
+            {
+                yield return new object[] { Decimal64.Parse("0"), Decimal64.Parse("0"), 0 };
+                yield return new object[] { Decimal64.NegativeZero, Decimal64.NegativeZero, 0 };
+                yield return new object[] { Decimal64.Parse("0"), Decimal64.NegativeZero, 1 };
+                yield return new object[] { Decimal64.NegativeZero, Decimal64.Parse("0"), -1 };
+                yield return new object[] { Decimal64.Parse("0"), Decimal64.Parse("1"), -1 };
+                yield return new object[] { Decimal64.PositiveInfinity, Decimal64.Parse("1"), 1 };
+                yield return new object[] { Decimal64.NaN, Decimal64.NegativeInfinity, -1 };
+                yield return new object[] { Decimal64.NaN, Decimal64.Parse("-1"), -1 };
+                yield return new object[] { -Decimal64.NaN, Decimal64.Parse("1"), 1 };
+                yield return new object[] { -Decimal64.NaN, Decimal64.PositiveInfinity, 1 };
+                yield return new object[] { Decimal64.NaN, Decimal64.NaN, 0 };
+                yield return new object[] { Decimal64.NaN, -Decimal64.NaN, -1 };
+                // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
+                yield return new object[] { Decimal64.Parse("1.00"), Decimal64.Parse("1.0"), -1 };
+                yield return new object[] { Decimal64.Parse("1.0"), Decimal64.Parse("1.00"), 1 };
+                yield return new object[] { Decimal64.Parse("1e1"), Decimal64.Parse("10e0"), 1 };
+                yield return new object[] { Decimal64.Parse("-1.00"), Decimal64.Parse("-1.0"), 1 };
+                yield return new object[] { Decimal64.Parse("-1.0"), Decimal64.Parse("-1.00"), -1 };
+                yield return new object[] { Decimal64.Parse("0.00"), Decimal64.Parse("0"), -1 };
+                yield return new object[] { Decimal64.Parse("-0.00"), Decimal64.NegativeZero, 1 };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Decimal64TestData))]
+        public void TotalOrderTestDecimal64(Decimal64 x, Decimal64 y, int result)
+        {
+            var comparer = new TotalOrderIeee754Comparer<Decimal64>();
+            Assert.Equal(result, Math.Sign(comparer.Compare(x, y)));
+        }
+
+        public static IEnumerable<object[]> Decimal128TestData
+        {
+            get
+            {
+                yield return new object[] { Decimal128.Parse("0"), Decimal128.Parse("0"), 0 };
+                yield return new object[] { Decimal128.NegativeZero, Decimal128.NegativeZero, 0 };
+                yield return new object[] { Decimal128.Parse("0"), Decimal128.NegativeZero, 1 };
+                yield return new object[] { Decimal128.NegativeZero, Decimal128.Parse("0"), -1 };
+                yield return new object[] { Decimal128.Parse("0"), Decimal128.Parse("1"), -1 };
+                yield return new object[] { Decimal128.PositiveInfinity, Decimal128.Parse("1"), 1 };
+                yield return new object[] { Decimal128.NaN, Decimal128.NegativeInfinity, -1 };
+                yield return new object[] { Decimal128.NaN, Decimal128.Parse("-1"), -1 };
+                yield return new object[] { -Decimal128.NaN, Decimal128.Parse("1"), 1 };
+                yield return new object[] { -Decimal128.NaN, Decimal128.PositiveInfinity, 1 };
+                yield return new object[] { Decimal128.NaN, Decimal128.NaN, 0 };
+                yield return new object[] { Decimal128.NaN, -Decimal128.NaN, -1 };
+                // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
+                yield return new object[] { Decimal128.Parse("1.00"), Decimal128.Parse("1.0"), -1 };
+                yield return new object[] { Decimal128.Parse("1.0"), Decimal128.Parse("1.00"), 1 };
+                yield return new object[] { Decimal128.Parse("1e1"), Decimal128.Parse("10e0"), 1 };
+                yield return new object[] { Decimal128.Parse("-1.00"), Decimal128.Parse("-1.0"), 1 };
+                yield return new object[] { Decimal128.Parse("-1.0"), Decimal128.Parse("-1.00"), -1 };
+                yield return new object[] { Decimal128.Parse("0.00"), Decimal128.Parse("0"), -1 };
+                yield return new object[] { Decimal128.Parse("-0.00"), Decimal128.NegativeZero, 1 };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Decimal128TestData))]
+        public void TotalOrderTestDecimal128(Decimal128 x, Decimal128 y, int result)
+        {
+            var comparer = new TotalOrderIeee754Comparer<Decimal128>();
             Assert.Equal(result, Math.Sign(comparer.Compare(x, y)));
         }
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -177,6 +178,9 @@ namespace System.Runtime.Tests
                 yield return new object[] { -Decimal32.NaN, Decimal32.PositiveInfinity, 1 };
                 yield return new object[] { Decimal32.NaN, Decimal32.NaN, 0 };
                 yield return new object[] { Decimal32.NaN, -Decimal32.NaN, -1 };
+                // Same-signed NaNs are ordered by payload (implementation defined, not part of IEEE 754 totalOrder)
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0x7C00_0000), Unsafe.BitCast<uint, Decimal32>(0x7C00_0001), -1 };
+                yield return new object[] { Unsafe.BitCast<uint, Decimal32>(0xFC00_0000), Unsafe.BitCast<uint, Decimal32>(0xFC00_0001), 1 };
                 // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
                 yield return new object[] { Decimal32.Parse("1.00", CultureInfo.InvariantCulture), Decimal32.Parse("1.0", CultureInfo.InvariantCulture), -1 };
                 yield return new object[] { Decimal32.Parse("1.0", CultureInfo.InvariantCulture), Decimal32.Parse("1.00", CultureInfo.InvariantCulture), 1 };
@@ -212,6 +216,9 @@ namespace System.Runtime.Tests
                 yield return new object[] { -Decimal64.NaN, Decimal64.PositiveInfinity, 1 };
                 yield return new object[] { Decimal64.NaN, Decimal64.NaN, 0 };
                 yield return new object[] { Decimal64.NaN, -Decimal64.NaN, -1 };
+                // Same-signed NaNs are ordered by payload (implementation defined, not part of IEEE 754 totalOrder)
+                yield return new object[] { Unsafe.BitCast<ulong, Decimal64>(0x7C00_0000_0000_0000), Unsafe.BitCast<ulong, Decimal64>(0x7C00_0000_0000_0001), -1 };
+                yield return new object[] { Unsafe.BitCast<ulong, Decimal64>(0xFC00_0000_0000_0000), Unsafe.BitCast<ulong, Decimal64>(0xFC00_0000_0000_0001), 1 };
                 // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
                 yield return new object[] { Decimal64.Parse("1.00", CultureInfo.InvariantCulture), Decimal64.Parse("1.0", CultureInfo.InvariantCulture), -1 };
                 yield return new object[] { Decimal64.Parse("1.0", CultureInfo.InvariantCulture), Decimal64.Parse("1.00", CultureInfo.InvariantCulture), 1 };
@@ -247,6 +254,10 @@ namespace System.Runtime.Tests
                 yield return new object[] { -Decimal128.NaN, Decimal128.PositiveInfinity, 1 };
                 yield return new object[] { Decimal128.NaN, Decimal128.NaN, 0 };
                 yield return new object[] { Decimal128.NaN, -Decimal128.NaN, -1 };
+                // Same-signed NaNs are ordered by payload (implementation defined, not part of IEEE 754 totalOrder).
+                // The payload here lives entirely in the low bits, which the coefficient decode would discard.
+                yield return new object[] { Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0x7C00_0000_0000_0000, 0x0000_0000_0000_0000)), Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0x7C00_0000_0000_0000, 0x0000_0000_0000_0001)), -1 };
+                yield return new object[] { Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0xFC00_0000_0000_0000, 0x0000_0000_0000_0000)), Unsafe.BitCast<UInt128, Decimal128>(new UInt128(0xFC00_0000_0000_0000, 0x0000_0000_0000_0001)), 1 };
                 // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
                 yield return new object[] { Decimal128.Parse("1.00", CultureInfo.InvariantCulture), Decimal128.Parse("1.0", CultureInfo.InvariantCulture), -1 };
                 yield return new object[] { Decimal128.Parse("1.0", CultureInfo.InvariantCulture), Decimal128.Parse("1.00", CultureInfo.InvariantCulture), 1 };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
@@ -165,26 +165,26 @@ namespace System.Runtime.Tests
         {
             get
             {
-                yield return new object[] { Decimal32.Parse("0"), Decimal32.Parse("0"), 0 };
+                yield return new object[] { Decimal32.Parse("0", CultureInfo.InvariantCulture), Decimal32.Parse("0", CultureInfo.InvariantCulture), 0 };
                 yield return new object[] { Decimal32.NegativeZero, Decimal32.NegativeZero, 0 };
-                yield return new object[] { Decimal32.Parse("0"), Decimal32.NegativeZero, 1 };
-                yield return new object[] { Decimal32.NegativeZero, Decimal32.Parse("0"), -1 };
-                yield return new object[] { Decimal32.Parse("0"), Decimal32.Parse("1"), -1 };
-                yield return new object[] { Decimal32.PositiveInfinity, Decimal32.Parse("1"), 1 };
+                yield return new object[] { Decimal32.Parse("0", CultureInfo.InvariantCulture), Decimal32.NegativeZero, 1 };
+                yield return new object[] { Decimal32.NegativeZero, Decimal32.Parse("0", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal32.Parse("0", CultureInfo.InvariantCulture), Decimal32.Parse("1", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal32.PositiveInfinity, Decimal32.Parse("1", CultureInfo.InvariantCulture), 1 };
                 yield return new object[] { Decimal32.NaN, Decimal32.NegativeInfinity, -1 };
-                yield return new object[] { Decimal32.NaN, Decimal32.Parse("-1"), -1 };
-                yield return new object[] { -Decimal32.NaN, Decimal32.Parse("1"), 1 };
+                yield return new object[] { Decimal32.NaN, Decimal32.Parse("-1", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { -Decimal32.NaN, Decimal32.Parse("1", CultureInfo.InvariantCulture), 1 };
                 yield return new object[] { -Decimal32.NaN, Decimal32.PositiveInfinity, 1 };
                 yield return new object[] { Decimal32.NaN, Decimal32.NaN, 0 };
                 yield return new object[] { Decimal32.NaN, -Decimal32.NaN, -1 };
                 // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
-                yield return new object[] { Decimal32.Parse("1.00"), Decimal32.Parse("1.0"), -1 };
-                yield return new object[] { Decimal32.Parse("1.0"), Decimal32.Parse("1.00"), 1 };
-                yield return new object[] { Decimal32.Parse("1e1"), Decimal32.Parse("10e0"), 1 };
-                yield return new object[] { Decimal32.Parse("-1.00"), Decimal32.Parse("-1.0"), 1 };
-                yield return new object[] { Decimal32.Parse("-1.0"), Decimal32.Parse("-1.00"), -1 };
-                yield return new object[] { Decimal32.Parse("0.00"), Decimal32.Parse("0"), -1 };
-                yield return new object[] { Decimal32.Parse("-0.00"), Decimal32.NegativeZero, 1 };
+                yield return new object[] { Decimal32.Parse("1.00", CultureInfo.InvariantCulture), Decimal32.Parse("1.0", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal32.Parse("1.0", CultureInfo.InvariantCulture), Decimal32.Parse("1.00", CultureInfo.InvariantCulture), 1 };
+                yield return new object[] { Decimal32.Parse("1e1", CultureInfo.InvariantCulture), Decimal32.Parse("10e0", CultureInfo.InvariantCulture), 1 };
+                yield return new object[] { Decimal32.Parse("-1.00", CultureInfo.InvariantCulture), Decimal32.Parse("-1.0", CultureInfo.InvariantCulture), 1 };
+                yield return new object[] { Decimal32.Parse("-1.0", CultureInfo.InvariantCulture), Decimal32.Parse("-1.00", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal32.Parse("0.00", CultureInfo.InvariantCulture), Decimal32.Parse("0", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal32.Parse("-0.00", CultureInfo.InvariantCulture), Decimal32.NegativeZero, 1 };
             }
         }
 
@@ -200,26 +200,26 @@ namespace System.Runtime.Tests
         {
             get
             {
-                yield return new object[] { Decimal64.Parse("0"), Decimal64.Parse("0"), 0 };
+                yield return new object[] { Decimal64.Parse("0", CultureInfo.InvariantCulture), Decimal64.Parse("0", CultureInfo.InvariantCulture), 0 };
                 yield return new object[] { Decimal64.NegativeZero, Decimal64.NegativeZero, 0 };
-                yield return new object[] { Decimal64.Parse("0"), Decimal64.NegativeZero, 1 };
-                yield return new object[] { Decimal64.NegativeZero, Decimal64.Parse("0"), -1 };
-                yield return new object[] { Decimal64.Parse("0"), Decimal64.Parse("1"), -1 };
-                yield return new object[] { Decimal64.PositiveInfinity, Decimal64.Parse("1"), 1 };
+                yield return new object[] { Decimal64.Parse("0", CultureInfo.InvariantCulture), Decimal64.NegativeZero, 1 };
+                yield return new object[] { Decimal64.NegativeZero, Decimal64.Parse("0", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal64.Parse("0", CultureInfo.InvariantCulture), Decimal64.Parse("1", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal64.PositiveInfinity, Decimal64.Parse("1", CultureInfo.InvariantCulture), 1 };
                 yield return new object[] { Decimal64.NaN, Decimal64.NegativeInfinity, -1 };
-                yield return new object[] { Decimal64.NaN, Decimal64.Parse("-1"), -1 };
-                yield return new object[] { -Decimal64.NaN, Decimal64.Parse("1"), 1 };
+                yield return new object[] { Decimal64.NaN, Decimal64.Parse("-1", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { -Decimal64.NaN, Decimal64.Parse("1", CultureInfo.InvariantCulture), 1 };
                 yield return new object[] { -Decimal64.NaN, Decimal64.PositiveInfinity, 1 };
                 yield return new object[] { Decimal64.NaN, Decimal64.NaN, 0 };
                 yield return new object[] { Decimal64.NaN, -Decimal64.NaN, -1 };
                 // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
-                yield return new object[] { Decimal64.Parse("1.00"), Decimal64.Parse("1.0"), -1 };
-                yield return new object[] { Decimal64.Parse("1.0"), Decimal64.Parse("1.00"), 1 };
-                yield return new object[] { Decimal64.Parse("1e1"), Decimal64.Parse("10e0"), 1 };
-                yield return new object[] { Decimal64.Parse("-1.00"), Decimal64.Parse("-1.0"), 1 };
-                yield return new object[] { Decimal64.Parse("-1.0"), Decimal64.Parse("-1.00"), -1 };
-                yield return new object[] { Decimal64.Parse("0.00"), Decimal64.Parse("0"), -1 };
-                yield return new object[] { Decimal64.Parse("-0.00"), Decimal64.NegativeZero, 1 };
+                yield return new object[] { Decimal64.Parse("1.00", CultureInfo.InvariantCulture), Decimal64.Parse("1.0", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal64.Parse("1.0", CultureInfo.InvariantCulture), Decimal64.Parse("1.00", CultureInfo.InvariantCulture), 1 };
+                yield return new object[] { Decimal64.Parse("1e1", CultureInfo.InvariantCulture), Decimal64.Parse("10e0", CultureInfo.InvariantCulture), 1 };
+                yield return new object[] { Decimal64.Parse("-1.00", CultureInfo.InvariantCulture), Decimal64.Parse("-1.0", CultureInfo.InvariantCulture), 1 };
+                yield return new object[] { Decimal64.Parse("-1.0", CultureInfo.InvariantCulture), Decimal64.Parse("-1.00", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal64.Parse("0.00", CultureInfo.InvariantCulture), Decimal64.Parse("0", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal64.Parse("-0.00", CultureInfo.InvariantCulture), Decimal64.NegativeZero, 1 };
             }
         }
 
@@ -235,26 +235,26 @@ namespace System.Runtime.Tests
         {
             get
             {
-                yield return new object[] { Decimal128.Parse("0"), Decimal128.Parse("0"), 0 };
+                yield return new object[] { Decimal128.Parse("0", CultureInfo.InvariantCulture), Decimal128.Parse("0", CultureInfo.InvariantCulture), 0 };
                 yield return new object[] { Decimal128.NegativeZero, Decimal128.NegativeZero, 0 };
-                yield return new object[] { Decimal128.Parse("0"), Decimal128.NegativeZero, 1 };
-                yield return new object[] { Decimal128.NegativeZero, Decimal128.Parse("0"), -1 };
-                yield return new object[] { Decimal128.Parse("0"), Decimal128.Parse("1"), -1 };
-                yield return new object[] { Decimal128.PositiveInfinity, Decimal128.Parse("1"), 1 };
+                yield return new object[] { Decimal128.Parse("0", CultureInfo.InvariantCulture), Decimal128.NegativeZero, 1 };
+                yield return new object[] { Decimal128.NegativeZero, Decimal128.Parse("0", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal128.Parse("0", CultureInfo.InvariantCulture), Decimal128.Parse("1", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal128.PositiveInfinity, Decimal128.Parse("1", CultureInfo.InvariantCulture), 1 };
                 yield return new object[] { Decimal128.NaN, Decimal128.NegativeInfinity, -1 };
-                yield return new object[] { Decimal128.NaN, Decimal128.Parse("-1"), -1 };
-                yield return new object[] { -Decimal128.NaN, Decimal128.Parse("1"), 1 };
+                yield return new object[] { Decimal128.NaN, Decimal128.Parse("-1", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { -Decimal128.NaN, Decimal128.Parse("1", CultureInfo.InvariantCulture), 1 };
                 yield return new object[] { -Decimal128.NaN, Decimal128.PositiveInfinity, 1 };
                 yield return new object[] { Decimal128.NaN, Decimal128.NaN, 0 };
                 yield return new object[] { Decimal128.NaN, -Decimal128.NaN, -1 };
                 // Cohort members: equal value, differing quantum exponent (totalOrder orders by exponent)
-                yield return new object[] { Decimal128.Parse("1.00"), Decimal128.Parse("1.0"), -1 };
-                yield return new object[] { Decimal128.Parse("1.0"), Decimal128.Parse("1.00"), 1 };
-                yield return new object[] { Decimal128.Parse("1e1"), Decimal128.Parse("10e0"), 1 };
-                yield return new object[] { Decimal128.Parse("-1.00"), Decimal128.Parse("-1.0"), 1 };
-                yield return new object[] { Decimal128.Parse("-1.0"), Decimal128.Parse("-1.00"), -1 };
-                yield return new object[] { Decimal128.Parse("0.00"), Decimal128.Parse("0"), -1 };
-                yield return new object[] { Decimal128.Parse("-0.00"), Decimal128.NegativeZero, 1 };
+                yield return new object[] { Decimal128.Parse("1.00", CultureInfo.InvariantCulture), Decimal128.Parse("1.0", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal128.Parse("1.0", CultureInfo.InvariantCulture), Decimal128.Parse("1.00", CultureInfo.InvariantCulture), 1 };
+                yield return new object[] { Decimal128.Parse("1e1", CultureInfo.InvariantCulture), Decimal128.Parse("10e0", CultureInfo.InvariantCulture), 1 };
+                yield return new object[] { Decimal128.Parse("-1.00", CultureInfo.InvariantCulture), Decimal128.Parse("-1.0", CultureInfo.InvariantCulture), 1 };
+                yield return new object[] { Decimal128.Parse("-1.0", CultureInfo.InvariantCulture), Decimal128.Parse("-1.00", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal128.Parse("0.00", CultureInfo.InvariantCulture), Decimal128.Parse("0", CultureInfo.InvariantCulture), -1 };
+                yield return new object[] { Decimal128.Parse("-0.00", CultureInfo.InvariantCulture), Decimal128.NegativeZero, 1 };
             }
         }
 


### PR DESCRIPTION
`TotalOrderIeee754Comparer<T>` did not correctly order IEEE 754 decimal (`Decimal32`/`Decimal64`/`Decimal128`) values. The generic path returned `0` for numerically-equal cohort members (e.g. `1.0` vs `1.00`) and for same-signed zeros with differing exponents, where totalOrder requires ordering by the quantum exponent. The equal-value branch now compares the unbiased (quantum) exponents using signed semantics -- the value with the smaller exponent sorts closer to zero for positive values, reversed for negative values. Binary formats have a unique representation per value, so their exponents already match and this remains `0`.

Stale `Revisit this if decimals are added` / `Consider to add support if decimals are added` TODOs are removed now that decimals are handled.

----------

Add `typeof(T)` fast paths for the remaining built-in `IBinaryFloatingPointIeee754<>`/decimal implementers so they skip the generic operator + interface-dispatch path:

- `BFloat16` and `NFloat` reinterpret their bits and reuse the existing sign-magnitude `CompareIntegerSemantic` helper (same shape as the pre-existing `Half` branch).
- `Decimal32`/`Decimal64`/`Decimal128` route through a shared `CompareDecimal<TDecimal, TValue>` helper built on the in-assembly `Number.UnpackDecimalIeee754`/`CompareDecimalIeee754`, unpacking each operand at most twice versus the four-plus unpacks the generic path incurs. It handles NaN placement (`-qNaN < -sNaN < finite < +sNaN < +qNaN`, same-signed NaNs ordered by payload), numeric ordering, and the cohort/`-0`/`+0` exponent tie-breaks.

No new public API -- only a `private static` helper and `typeof(T)` dispatch.

----------

Tests: added per-type theories for the newly fast-pathed built-ins (existing `Single`/`Double`/`Half` shape). The decimal fast path was additionally validated offline against the generic algorithm over 1,000,000 random `Decimal32`/`Decimal64` bit patterns (NaN/Inf/non-canonical included) with 0 mismatches.

> [!NOTE]
> This PR description was drafted by GitHub Copilot.
