### PR TITLE
Fix config binding source generator duplicating collection items bound through a constructor parameter

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -260,9 +260,16 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             private void EmitBindCoreMethod(ComplexTypeSpec type)
             {
                 string objParameterExpression = $"ref {type.TypeRef.FullyQualifiedName} {Identifier.instance}";
-                EmitStartBlock(@$"public static void {nameof(MethodsToGen_CoreBindingHelper.BindCore)}({Identifier.IConfiguration} {Identifier.configuration}, {objParameterExpression}, bool defaultValueIfNotFound, {Identifier.BinderOptions}? {Identifier.binderOptions})");
-
                 ComplexTypeSpec effectiveType = (ComplexTypeSpec)_typeIndex.GetEffectiveTypeSpec(type);
+
+                // Objects created through a parameterized constructor need an extra parameter that tells BindCore
+                // whether the instance was created through that constructor. When it was, properties that are bound
+                // by a matching constructor parameter must not be bound again (see EmitBindCoreImplForObject).
+                string boundThroughConstructorParam = ShouldEmitBoundThroughConstructorParameter(effectiveType)
+                    ? $", bool {Identifier.boundThroughConstructor} = false"
+                    : string.Empty;
+
+                EmitStartBlock(@$"public static void {nameof(MethodsToGen_CoreBindingHelper.BindCore)}({Identifier.IConfiguration} {Identifier.configuration}, {objParameterExpression}, bool defaultValueIfNotFound, {Identifier.BinderOptions}? {Identifier.binderOptions}{boundThroughConstructorParam})");
 
                 switch (effectiveType)
                 {
@@ -859,19 +866,87 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 string validateMethodCallExpr = $"{Identifier.ValidateConfigurationKeys}(typeof({type.TypeRef.FullyQualifiedName}), {keyCacheFieldName}, {Identifier.configuration}, {Identifier.binderOptions});";
                 _writer.WriteLine(validateMethodCallExpr);
 
+                List<PropertySpec>? ctorMatchedProperties = null;
+
                 foreach (PropertySpec property in type.Properties!)
                 {
-                    if (_typeIndex.ShouldBindTo(property))
+                    if (!_typeIndex.ShouldBindTo(property))
                     {
-                        string containingTypeRef = property.IsStatic ? type.TypeRef.FullyQualifiedName : Identifier.instance;
-                        EmitBindImplForMember(
-                            property,
-                            memberAccessExpr: $"{containingTypeRef}.{property.Name}",
-                            GetSectionPathFromConfigurationExpression(property.ConfigurationKeyName),
-                            canSet: property.CanSet,
-                            canGet: property.CanGet,
-                            InitializationKind.Declaration);
+                        continue;
                     }
+
+                    // A property that is bound through a matching constructor parameter is already populated when the
+                    // instance is created through that constructor. Binding it again here would append to collections
+                    // that the constructor already filled, duplicating their items.
+                    // Defer such properties into a block guarded by !boundThroughConstructor so they are only bound when
+                    // the instance was not created through the constructor (e.g. Bind(existingInstance)), matching the
+                    // reflection binder.
+                    if (property.MatchingCtorParam is not null && IsPropertyReboundInBindCore(property))
+                    {
+                        (ctorMatchedProperties ??= new()).Add(property);
+                        continue;
+                    }
+
+                    EmitBindImplForProperty(property);
+                }
+
+                if (ctorMatchedProperties is not null)
+                {
+                    EmitStartBlock($"if (!{Identifier.boundThroughConstructor})");
+                    foreach (PropertySpec property in ctorMatchedProperties)
+                    {
+                        EmitBindImplForProperty(property);
+                    }
+                    EmitEndBlock();
+                }
+
+                void EmitBindImplForProperty(PropertySpec property)
+                {
+                    string containingTypeRef = property.IsStatic ? type.TypeRef.FullyQualifiedName : Identifier.instance;
+                    EmitBindImplForMember(
+                        property,
+                        memberAccessExpr: $"{containingTypeRef}.{property.Name}",
+                        GetSectionPathFromConfigurationExpression(property.ConfigurationKeyName),
+                        canSet: property.CanSet,
+                        canGet: property.CanGet,
+                        InitializationKind.Declaration);
+                }
+            }
+
+            /// <summary>
+            /// Whether <paramref name="type"/> is an object created through a parameterized constructor that has at
+            /// least one property bound through a matching constructor parameter which would otherwise be re-bound in
+            /// its <c>BindCore</c> method. Such types receive an extra <c>boundThroughConstructor</c> parameter.
+            /// </summary>
+            private bool ShouldEmitBoundThroughConstructorParameter(ComplexTypeSpec type) =>
+                type is ObjectSpec { InstantiationStrategy: ObjectInstantiationStrategy.ParameterizedConstructor, Properties: { } properties } &&
+                properties.Any(property =>
+                    property.MatchingCtorParam is not null &&
+                    _typeIndex.ShouldBindTo(property) &&
+                    IsPropertyReboundInBindCore(property));
+
+            /// <summary>
+            /// Whether binding <paramref name="property"/> in a <c>BindCore</c> method emits code that reads from or
+            /// writes to the property. This mirrors the cases in <see cref="EmitBindImplForMember(MemberSpec, string, string, bool, bool, InitializationKind)"/>
+            /// that actually emit binding logic; get-only value/string properties, for example, are never re-bound.
+            /// </summary>
+            private bool IsPropertyReboundInBindCore(PropertySpec property)
+            {
+                switch (_typeIndex.GetEffectiveTypeSpec(property.TypeRef))
+                {
+                    case ParsableFromStringSpec:
+                        return property.CanGet && property.CanSet;
+                    case ConfigurationSectionSpec:
+                        return property.CanSet;
+                    case ComplexTypeSpec complexType:
+                        // EmitBindImplForMember skips a complex member only when it is a
+                        // parameterized-constructor object with no bindable members. Every other complex member is bound.
+                        return _typeIndex.HasBindableMembers(complexType) ||
+                            complexType.IsValueType ||
+                            complexType is CollectionSpec ||
+                            complexType is not ObjectSpec { InstantiationStrategy: ObjectInstantiationStrategy.ParameterizedConstructor };
+                    default:
+                        return false;
                 }
             }
 
@@ -959,7 +1034,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         {
                             // Early detection of types we cannot bind to and skip it.
                             if (!_typeIndex.HasBindableMembers(complexType) &&
-                                !_typeIndex.GetEffectiveTypeSpec(complexType).IsValueType &&
+                                !complexType.IsValueType &&
                                 complexType is not CollectionSpec &&
                                 ((ObjectSpec)complexType).InstantiationStrategy == ObjectInstantiationStrategy.ParameterizedConstructor)
                             {
@@ -1127,12 +1202,30 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
                 void EmitBindingLogic(string instanceToBindExpr, InitializationKind initKind, string? tempIdentifierStoringExpr = null)
                 {
-                    string bindCoreCall = $@"{nameof(MethodsToGen_CoreBindingHelper.BindCore)}({configArgExpr}, ref {instanceToBindExpr}, defaultValueIfNotFound: {FormatDefaultValueIfNotFound()}, {Identifier.binderOptions});";
+                    string boundThroughConstructorArg = string.Empty;
 
                     if (_typeIndex.CanInstantiate(type))
                     {
                         if (initKind is not InitializationKind.None)
                         {
+                            // The instance is (re)created here. If it goes through a parameterized constructor, tell
+                            // BindCore not to bind the properties that the constructor already bound. For a null-check
+                            // assignment the constructor only runs when the existing value was null, so the decision
+                            // has to be made at run time.
+                            if (ShouldEmitBoundThroughConstructorParameter(type))
+                            {
+                                if (initKind is InitializationKind.AssignmentWithNullCheck)
+                                {
+                                    string wasNullIdentifier = GetIncrementalIdentifier(Identifier.wasNull);
+                                    _writer.WriteLine($"bool {wasNullIdentifier} = {instanceToBindExpr} is null;");
+                                    boundThroughConstructorArg = $", {Identifier.boundThroughConstructor}: {wasNullIdentifier}";
+                                }
+                                else
+                                {
+                                    boundThroughConstructorArg = $", {Identifier.boundThroughConstructor}: true";
+                                }
+                            }
+
                             EmitObjectInit(type, instanceToBindExpr, initKind, configArgExpr);
                         }
 
@@ -1154,6 +1247,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
                     void EmitBindCoreCall()
                     {
+                        string bindCoreCall = $@"{nameof(MethodsToGen_CoreBindingHelper.BindCore)}({configArgExpr}, ref {instanceToBindExpr}, defaultValueIfNotFound: {FormatDefaultValueIfNotFound()}, {Identifier.binderOptions}{boundThroughConstructorArg});";
                         _writer.WriteLine(bindCoreCall);
                         writeOnSuccess?.Invoke(instanceToBindExpr, tempIdentifierStoringExpr);
                     }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -826,11 +826,27 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
                                 if (_typeIndex.CanInstantiate(complexElementType))
                                 {
+                                    // A reference-type element created through a parameterized constructor must not have
+                                    // its constructor-bound properties bound again. Since the element is only constructed
+                                    // when it isn't already present, track that at run time and forward it to BindCore.
+                                    // Value-type elements are always (re)constructed through the InitializationKind.None
+                                    // path below, so they don't need a separate flag.
+                                    string? constructedExpr = null;
+                                    if (!isValueType && ShouldEmitBoundThroughConstructorParameter(complexElementType))
+                                    {
+                                        constructedExpr = GetIncrementalIdentifier(Identifier.boundThroughConstructor);
+                                        _writer.WriteLine($"bool {constructedExpr} = false;");
+                                    }
+
                                     EmitStartBlock($"if (!({conditionToUseExistingElement}))");
                                     EmitObjectInit(complexElementType, Identifier.element, InitializationKind.SimpleAssignment, Identifier.section);
+                                    if (constructedExpr is not null)
+                                    {
+                                        _writer.WriteLine($"{constructedExpr} = true;");
+                                    }
                                     EmitEndBlock();
 
-                                    EmitBindingLogic();
+                                    EmitBindingLogic(constructedExpr);
                                 }
                                 else
                                 {
@@ -839,14 +855,15 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                                     EmitEndBlock();
                                 }
 
-                                void EmitBindingLogic()
+                                void EmitBindingLogic(string? constructedExpr = null)
                                 {
                                     this.EmitBindingLogic(
                                         complexElementType,
                                         Identifier.element,
                                         Identifier.section,
                                         InitializationKind.None,
-                                        ValueDefaulting.None);
+                                        ValueDefaulting.None,
+                                        constructedExpr: constructedExpr);
 
                                     _writer.WriteLine($"{instanceIdentifier}[{parsedKeyExpr}] = {Identifier.element};");
                                 }
@@ -1165,7 +1182,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 string configArgExpr,
                 InitializationKind initKind,
                 ValueDefaulting valueDefaulting,
-                Action<string, string?>? writeOnSuccess = null)
+                Action<string, string?>? writeOnSuccess = null,
+                string? constructedExpr = null)
             {
                 if (!_typeIndex.HasBindableMembers(type))
                 {
@@ -1227,6 +1245,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                             }
 
                             EmitObjectInit(type, instanceToBindExpr, initKind, configArgExpr);
+                        }
+                        else if (constructedExpr is not null)
+                        {
+                            // The caller instantiated the instance separately and provides a run-time flag telling
+                            // whether it was created through its constructor (e.g. dictionary element binding). The
+                            // caller only passes it for types that emit the parameter.
+                            Debug.Assert(ShouldEmitBoundThroughConstructorParameter(type));
+                            boundThroughConstructorArg = $", {Identifier.boundThroughConstructor}: {constructedExpr}";
                         }
 
                         EmitBindCoreCall();

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -1236,6 +1236,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     EmitBindingLogic(memberAccessExpr, initKind);
                 }
 
+                /// <summary>
+                /// Emits the instantiation (when required by <paramref name="initKind"/>) and the <c>BindCore</c> call
+                /// that binds <paramref name="instanceToBindExpr"/>.
+                /// </summary>
+                /// <param name="instanceToBindExpr">The local or member expression the value is bound into.</param>
+                /// <param name="initKind">How (or whether) <paramref name="instanceToBindExpr"/> is instantiated before binding.</param>
+                /// <param name="tempIdentifierStoringExpr">
+                /// An optional statement (emitted verbatim after a successful bind) that assigns the just-bound
+                /// temporary back into the enclosing binding target - the local the caller is binding into. Value-type
+                /// members are bound through a temporary (a value type cannot be bound in place through a property that
+                /// returns a copy), so this propagates the bound value back up the temporary chain; the write into the
+                /// member itself (which invokes its setter) is emitted separately by the caller's <c>writeOnSuccess</c>.
+                /// </param>
                 void EmitBindingLogic(string instanceToBindExpr, InitializationKind initKind, string? tempIdentifierStoringExpr = null)
                 {
                     string boundThroughConstructorArg = string.Empty;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -415,7 +415,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         // Since we're binding to local variables, we can always get and set
                         canSet: true,
                         canGet: true,
-                        InitializationKind.None);
+                        InitializationKind.None,
+                        bindingToLocal: true);
 
                     if (canBindToMember)
                     {
@@ -883,7 +884,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 string validateMethodCallExpr = $"{Identifier.ValidateConfigurationKeys}(typeof({type.TypeRef.FullyQualifiedName}), {keyCacheFieldName}, {Identifier.configuration}, {Identifier.binderOptions});";
                 _writer.WriteLine(validateMethodCallExpr);
 
-                List<PropertySpec>? ctorMatchedProperties = null;
+                List<PropertySpec>? initializeBoundProperties = null;
 
                 foreach (PropertySpec property in type.Properties!)
                 {
@@ -892,25 +893,26 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         continue;
                     }
 
-                    // A property that is bound through a matching constructor parameter is already populated when the
-                    // instance is created through that constructor. Binding it again here would append to collections
-                    // that the constructor already filled, duplicating their items.
+                    // A property that is populated while the instance is created through its Initialize method - either
+                    // through a matching constructor parameter or as a required/init-only property assigned in the object
+                    // initializer - is already bound at that point. Binding it again here would append to collections
+                    // that Initialize already filled, duplicating their items.
                     // Defer such properties into a block guarded by !boundThroughConstructor so they are only bound when
-                    // the instance was not created through the constructor (e.g. Bind(existingInstance)), matching the
+                    // the instance was not created through Initialize (e.g. Bind(existingInstance)), matching the
                     // reflection binder.
-                    if (property.MatchingCtorParam is not null && IsPropertyReboundInBindCore(property))
+                    if (IsBoundInInitialize(type, property) && IsPropertyReboundInBindCore(property))
                     {
-                        (ctorMatchedProperties ??= new()).Add(property);
+                        (initializeBoundProperties ??= new()).Add(property);
                         continue;
                     }
 
                     EmitBindImplForProperty(property);
                 }
 
-                if (ctorMatchedProperties is not null)
+                if (initializeBoundProperties is not null)
                 {
                     EmitStartBlock($"if (!{Identifier.boundThroughConstructor})");
-                    foreach (PropertySpec property in ctorMatchedProperties)
+                    foreach (PropertySpec property in initializeBoundProperties)
                     {
                         EmitBindImplForProperty(property);
                     }
@@ -932,15 +934,26 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             /// <summary>
             /// Whether <paramref name="type"/> is an object created through a parameterized constructor that has at
-            /// least one property bound through a matching constructor parameter which would otherwise be re-bound in
-            /// its <c>BindCore</c> method. Such types receive an extra <c>boundThroughConstructor</c> parameter.
+            /// least one property bound while the instance is created (through its Initialize method) which would
+            /// otherwise be re-bound in its <c>BindCore</c> method. Such types receive an extra
+            /// <c>boundThroughConstructor</c> parameter.
             /// </summary>
             private bool ShouldEmitBoundThroughConstructorParameter(ComplexTypeSpec type) =>
-                type is ObjectSpec { InstantiationStrategy: ObjectInstantiationStrategy.ParameterizedConstructor, Properties: { } properties } &&
+                type is ObjectSpec { Properties: { } properties } objectType &&
                 properties.Any(property =>
-                    property.MatchingCtorParam is not null &&
+                    IsBoundInInitialize(objectType, property) &&
                     _typeIndex.ShouldBindTo(property) &&
                     IsPropertyReboundInBindCore(property));
+
+            /// <summary>
+            /// Whether <paramref name="property"/> is populated while an instance of <paramref name="type"/> is created
+            /// through its Initialize method: either it flows through a matching constructor parameter, or it is a
+            /// required/init-only property assigned in the object initializer. Only parameterized-constructor types have
+            /// an Initialize method; parameterless-constructor types bind all their properties in <c>BindCore</c>.
+            /// </summary>
+            private static bool IsBoundInInitialize(ObjectSpec type, PropertySpec property) =>
+                type.InstantiationStrategy is ObjectInstantiationStrategy.ParameterizedConstructor &&
+                (property.MatchingCtorParam is not null || property.SetOnInit);
 
             /// <summary>
             /// Whether binding <paramref name="property"/> in a <c>BindCore</c> method emits code that reads from or
@@ -973,7 +986,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 string sectionPathExpr,
                 bool canSet,
                 bool canGet,
-                InitializationKind initializationKind)
+                InitializationKind initializationKind,
+                bool bindingToLocal = false)
             {
                 string sectionParseExpr = GetSectionFromConfigurationExpression(member.ConfigurationKeyName);
 
@@ -1066,7 +1080,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                             string sectionIdentifier = GetIncrementalIdentifier(Identifier.section);
 
                             EmitStartBlock($"if ({sectionValidationCall} is {Identifier.IConfigurationSection} {sectionIdentifier})");
-                            EmitBindingLogicForComplexMember(member, memberAccessExpr, sectionIdentifier, canSet);
+                            EmitBindingLogicForComplexMember(member, memberAccessExpr, sectionIdentifier, canSet, bindingToLocal);
                             EmitEndBlock();
 
                             // The current configuration section doesn't have any children, let's check if we are binding to an array and the configuration value is empty string.
@@ -1092,7 +1106,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 MemberSpec member,
                 string memberAccessExpr,
                 string configArgExpr,
-                bool canSet)
+                bool canSet,
+                bool bindingToLocal = false)
             {
 
                 TypeSpec memberType = _typeIndex.GetTypeSpec(member.TypeRef);
@@ -1153,7 +1168,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                                 _writer.WriteLine($"{tempIdentifierStoringExpr}");
                             }
 
-                            if (member.CanGet && _typeIndex.CanInstantiate(effectiveMemberType))
+                            // When the config section is absent, re-assign the member to itself so any value-mutator
+                            // setter runs. This is unnecessary when binding into an Initialize local (no accessor to
+                            // invoke) and would emit a CS1717 self-assignment, so skip it in that case.
+                            if (!bindingToLocal && member.CanGet && _typeIndex.CanInstantiate(effectiveMemberType))
                             {
                                 EmitEndBlock();
                                 EmitStartBlock("else");

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/Helpers.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             private static class Identifier
             {
                 public const string binderOptions = nameof(binderOptions);
+                public const string boundThroughConstructor = nameof(boundThroughConstructor);
                 public const string config = nameof(config);
                 public const string configureBinder = nameof(configureBinder);
                 public const string configureOptions = nameof(configureOptions);
@@ -86,6 +87,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 public const string typedObj = nameof(typedObj);
                 public const string validateKeys = nameof(validateKeys);
                 public const string value = nameof(value);
+                public const string wasNull = nameof(wasNull);
 
                 public const string Add = nameof(Add);
                 public const string AddSingleton = nameof(AddSingleton);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -266,6 +266,22 @@ namespace Microsoft.Extensions
             public List<string> Instances { get; }
         }
 
+        public sealed class SourceWithCollectionCtorParameters
+        {
+            public SourceWithCollectionCtorParameters(string Name, IEnumerable<string> Addresses, IList<int> Ints, string[] Strings)
+            {
+                this.Name = Name;
+                this.Addresses = Addresses;
+                this.Ints = Ints;
+                this.Strings = Strings;
+            }
+
+            public string Name { get; }
+            public IEnumerable<string> Addresses { get; }
+            public IList<int> Ints { get; }
+            public string[] Strings { get; }
+        }
+
         public readonly record struct ReadonlyRecordStructTypeOptions(string Color, int Length);
 
         public class ContainerWithNestedImmutableObject

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -282,6 +282,13 @@ namespace Microsoft.Extensions
             public string[] Strings { get; }
         }
 
+        public sealed class ClassWithInitOnlyCollectionNoCtorParam
+        {
+            public ClassWithInitOnlyCollectionNoCtorParam(int Number) => this.Number = Number;
+            public int Number { get; }
+            public List<string> Items { get; init; }
+        }
+
         public readonly record struct ReadonlyRecordStructTypeOptions(string Color, int Length);
 
         public class ContainerWithNestedImmutableObject

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -260,6 +260,11 @@ namespace Microsoft.Extensions
             public IList<string> Instances { get; }
         }
 
+        public sealed class ContainerWithCtorCollectionChild
+        {
+            public GetterOnlyInterfaceCollectionWithCaseMismatchedCtorParameter Child { get; set; }
+        }
+
         public class ParamsCollectionCtor
         {
             public ParamsCollectionCtor(params List<string> instances) => Instances = instances;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -294,6 +294,18 @@ namespace Microsoft.Extensions
             public List<string> Items { get; init; }
         }
 
+        public sealed class ClassWithInitOnlyComplexNoCtorParam
+        {
+            public ClassWithInitOnlyComplexNoCtorParam(int Number) => this.Number = Number;
+            public int Number { get; }
+            public NestedForInitOnly Child { get; init; }
+        }
+
+        public sealed class NestedForInitOnly
+        {
+            public string Value { get; set; }
+        }
+
         public readonly record struct ReadonlyRecordStructTypeOptions(string Color, int Length);
 
         public class ContainerWithNestedImmutableObject

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1686,12 +1686,12 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         /// <summary>
-        /// When a constructor parameter name differs only by case from a matching collection property,
-        /// the binder must bind the collection once (through the constructor) and must not bind it again
-        /// through the property, which would otherwise duplicate the collection items.
+        /// When a constructor parameter populates a matching collection property, the binder must bind the collection
+        /// once (through the constructor) and must not bind it again through the property, which would otherwise
+        /// duplicate the collection items. This must hold whether the parameter name matches the property name exactly
+        /// or differs only by case. This test checks the different case scenario, the next one the same name scenario.
         /// </summary>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/83803", typeof(TestHelpers), nameof(TestHelpers.SourceGenMode))]
         public void CanBindOnParametersAndProperties_GetterOnlyCollectionWithCaseMismatchedConstructorParameter()
         {
             string json = """
@@ -1707,6 +1707,34 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             Assert.Equal(expected, config.Get<SettableCollectionWithCaseMismatchedCtorParameter>().Instances);
             Assert.Equal(expected, config.Get<GetterOnlyInterfaceCollectionWithCaseMismatchedCtorParameter>().Instances);
             Assert.Equal(expected, config.Get<ParamsCollectionCtor>().Instances);
+        }
+
+        /// <summary>
+        /// A type whose constructor parameters have the same name as the matching collection properties (as in the
+        /// canonical record/primary-constructor pattern) must also bind each collection only once.
+        /// </summary>
+        [Fact]
+        public void CanBindOnParametersAndProperties_CollectionsWithSameCasedConstructorParameters()
+        {
+            string json = """
+            {
+                "source": {
+                    "name": "DemoService",
+                    "addresses": [ "127.0.0.1" ],
+                    "ints": [ 1, 2, 3, 4, 5 ],
+                    "strings": [ "one", "two", "three" ]
+                }
+            }
+            """;
+
+            IConfiguration config = TestHelpers.GetConfigurationFromJsonString(json);
+
+            SourceWithCollectionCtorParameters source = config.GetSection("source").Get<SourceWithCollectionCtorParameters>();
+
+            Assert.Equal("DemoService", source.Name);
+            Assert.Equal(new[] { "127.0.0.1" }, source.Addresses);
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Ints);
+            Assert.Equal(new[] { "one", "two", "three" }, source.Strings);
         }
 
         public static IEnumerable<object[]> Configuration_TestData()

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1737,6 +1737,32 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             Assert.Equal(new[] { "one", "two", "three" }, source.Strings);
         }
 
+        /// <summary>
+        /// A dictionary whose value type is created through a parameterized constructor that populates a collection
+        /// property must bind each element's collection only once, even though dictionary elements are bound through a
+        /// separate code path from top-level and property binding.
+        /// </summary>
+        [Fact]
+        public void CanBindOnParametersAndProperties_DictionaryValueWithCollectionConstructorParameter()
+        {
+            string json = """
+            {
+                "map": {
+                    "first": { "Instances": [ "a", "b" ] },
+                    "second": { "Instances": [ "c" ] }
+                }
+            }
+            """;
+
+            IConfiguration config = TestHelpers.GetConfigurationFromJsonString(json);
+
+            Dictionary<string, GetterOnlyInterfaceCollectionWithCaseMismatchedCtorParameter> map =
+                config.GetSection("map").Get<Dictionary<string, GetterOnlyInterfaceCollectionWithCaseMismatchedCtorParameter>>();
+
+            Assert.Equal(new[] { "a", "b" }, map["first"].Instances);
+            Assert.Equal(new[] { "c" }, map["second"].Instances);
+        }
+
         public static IEnumerable<object[]> Configuration_TestData()
         {
             yield return new object[]

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1764,6 +1764,49 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         /// <summary>
+        /// A nested property whose type has a collection populated through a constructor parameter is bound through the
+        /// null-check assignment (<c>??=</c>) path, where whether the instance was created through its constructor is
+        /// decided at run time. The collection must still be bound only once.
+        /// </summary>
+        [Fact]
+        public void CanBind_NestedTypeWithCollectionConstructorParameter()
+        {
+            string json = """
+            {
+                "Child": { "Instances": [ "a", "b" ] }
+            }
+            """;
+
+            IConfiguration config = TestHelpers.GetConfigurationFromJsonString(json);
+
+            ContainerWithCtorCollectionChild result = config.Get<ContainerWithCtorCollectionChild>();
+
+            Assert.Equal(new[] { "a", "b" }, result.Child.Instances);
+        }
+
+        /// <summary>
+        /// When binding into an existing instance (which is not created through its constructor), a settable collection
+        /// property backed by a constructor parameter must still be bound. This guards against the deferral logic
+        /// over-skipping and silently not binding such properties.
+        /// </summary>
+        [Fact]
+        public void CanBindExistingInstance_BindsCtorMatchedCollection()
+        {
+            string json = """
+            {
+                "Instances": [ "first", "second" ]
+            }
+            """;
+
+            IConfiguration config = TestHelpers.GetConfigurationFromJsonString(json);
+            var instance = new SettableCollectionWithCaseMismatchedCtorParameter(new List<string>());
+
+            config.Bind(instance);
+
+            Assert.Equal(new[] { "first", "second" }, instance.Instances);
+        }
+
+        /// <summary>
         /// An init-only (or required) collection property that is not backed by a constructor parameter is bound in the
         /// generated Initialize method (through the object initializer). It must not be bound again in BindCore when the
         /// instance was created there, or the collection items would be duplicated.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1764,6 +1764,29 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         /// <summary>
+        /// A list whose element type has a collection populated through a constructor parameter must bind each
+        /// element's collection only once. List and array elements are constructed through a separate code path
+        /// (enumerable-with-add) from top-level, property, and dictionary binding.
+        /// </summary>
+        [Fact]
+        public void CanBind_ListOfTypeWithCollectionConstructorParameter()
+        {
+            string json = """
+            {
+                "Items": [ { "Instances": [ "a", "b" ] }, { "Instances": [ "c" ] } ]
+            }
+            """;
+
+            IConfiguration config = TestHelpers.GetConfigurationFromJsonString(json);
+
+            List<GetterOnlyInterfaceCollectionWithCaseMismatchedCtorParameter> result =
+                config.GetSection("Items").Get<List<GetterOnlyInterfaceCollectionWithCaseMismatchedCtorParameter>>();
+
+            Assert.Equal(new[] { "a", "b" }, result[0].Instances);
+            Assert.Equal(new[] { "c" }, result[1].Instances);
+        }
+
+        /// <summary>
         /// A nested property whose type has a collection populated through a constructor parameter is bound through the
         /// null-check assignment (<c>??=</c>) path, where whether the instance was created through its constructor is
         /// decided at run time. The collection must still be bound only once.
@@ -1827,6 +1850,29 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
 
             Assert.Equal(7, result.Number);
             Assert.Equal(new[] { "a", "b" }, result.Items);
+        }
+
+        /// <summary>
+        /// An init-only complex (non-collection) property that is not backed by a constructor parameter is bound in the
+        /// generated Initialize method. The generator must not emit a self-assignment for it (which would produce a
+        /// CS1717 compile error), and the property must still be bound correctly.
+        /// </summary>
+        [Fact]
+        public void CanBindOnParametersAndProperties_InitOnlyComplexPropertyWithoutConstructorParameter()
+        {
+            string json = """
+            {
+                "Number": 7,
+                "Child": { "Value": "hello" }
+            }
+            """;
+
+            IConfiguration config = TestHelpers.GetConfigurationFromJsonString(json);
+
+            ClassWithInitOnlyComplexNoCtorParam result = config.Get<ClassWithInitOnlyComplexNoCtorParam>();
+
+            Assert.Equal(7, result.Number);
+            Assert.Equal("hello", result.Child.Value);
         }
 
         public static IEnumerable<object[]> Configuration_TestData()

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1763,6 +1763,29 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             Assert.Equal(new[] { "c" }, map["second"].Instances);
         }
 
+        /// <summary>
+        /// An init-only (or required) collection property that is not backed by a constructor parameter is bound in the
+        /// generated Initialize method (through the object initializer). It must not be bound again in BindCore when the
+        /// instance was created there, or the collection items would be duplicated.
+        /// </summary>
+        [Fact]
+        public void CanBindOnParametersAndProperties_InitOnlyCollectionWithoutConstructorParameter()
+        {
+            string json = """
+            {
+                "Number": 7,
+                "Items": [ "a", "b" ]
+            }
+            """;
+
+            IConfiguration config = TestHelpers.GetConfigurationFromJsonString(json);
+
+            ClassWithInitOnlyCollectionNoCtorParam result = config.Get<ClassWithInitOnlyCollectionNoCtorParam>();
+
+            Assert.Equal(7, result.Number);
+            Assert.Equal(new[] { "a", "b" }, result.Items);
+        }
+
         public static IEnumerable<object[]> Configuration_TestData()
         {
             yield return new object[]

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2357,12 +2357,8 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             Assert.True(options.WasOtherCodeStringSet);
             Assert.Equal("default", options.PocoWithDefault.Example);
             Assert.Equal(1, options.PocoListWithDefault.Count);
-
-#if !BUILDING_SOURCE_GENERATOR_TESTS
-            // Source generator omits calls to setters for nested objects and collections
             Assert.True(options.WasPocoWithDefaultSet);
             Assert.True(options.WasPocoListWithDefaultSet);
-#endif
 
             // These don't exist in configuration and setters are not called since they are nullable.
             Assert.Equal(0, options.OtherCodeNullable);


### PR DESCRIPTION
## Summary

Fixes #83803.

The Configuration Binding **source generator** duplicated the items of a collection property that is populated while an instance is created, when binding a type with a parameterized constructor. For example, given:

```csharp
internal sealed class Source(string Name, IEnumerable<string> Addresses, IList<int> Ints, string[] Strings)
{
    public string Name { get; } = Name;
    public IEnumerable<string> Addresses { get; } = Addresses;
    public IList<int> Ints { get; } = Ints;
    public string[] Strings { get; } = Strings;
}
```

binding `ints: [1, 2, 3, 4, 5]` produced `1, 2, 3, 4, 5, 1, 2, 3, 4, 5`. Arrays and scalars were unaffected; only additive collections (`IList<T>`, `IEnumerable<T>`, settable collections) duplicated. The reflection binder was already fixed (#106158, #129775); this brings the source generator in line.

## Root cause

For a type with a parameterized constructor, the generated code first calls `Initialize(...)` - which invokes the constructor and populates the members bound during construction - and then calls `BindCore(...)`, which re-bound **every** property. Re-binding a collection property appends to the collection that was already filled, so the items appear twice.

## Fix

The generated `BindCore` method now takes an optional `boundThroughConstructor` parameter, emitted only for parameterized-constructor object types that actually have a re-bindable property bound during construction. Properties bound in `Initialize` are deferred into an `if (!boundThroughConstructor)` block, so they are bound only when the instance was **not** created through `Initialize` (e.g. `config.Bind(existingInstance)`), matching the reflection binder's `BindProperties`/`ResetPropertyValue` behavior.

Call sites pass the flag when the instance is (re)created:
- `true` for unconditional construction (`var x = Initialize(...)`),
- a runtime `wasNull` flag for the `x ??= Initialize(...)` case, since the constructor only runs when the existing value was null,
- a runtime flag tracked by the caller for paths that construct the instance separately from `BindCore` (dictionary elements).

The fix covers every construct-then-bind path: top-level `Get<T>()`, nested properties (`??=`), dictionary values, and list/array elements.

"Bound during construction" means both:
- a property that flows through a matching constructor parameter (records, positional or case-mismatched), and
- a `required`/`init`-only property assigned in the generated object initializer, even when it has no matching constructor parameter.

The latter also fixes a `CS1717` self-assignment (`x = x`) the generator previously emitted for a complex or collection `init`/`required` property in `Initialize`.

No baseline `.generated.txt` changes: the extra parameter/guard only appear for the affected type shapes, none of which are in the baseline suite.

## Out of scope

Two related, pre-existing source-generator issues surfaced during review and are intentionally left for follow-ups:
- #95006 - `CS9035` for a `required` property on a parameterless-constructor type (the generator never emits an object initializer there).
- A non-null preset default on an `init` collection is replaced rather than appended to on the `Get<T>()` path (reflection appends).

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
