### PR TITLE
[mono][wasm][AOT] Promote variable-signature methods to full gsharedvt instead of failing

### DIFF
--- a/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
@@ -411,13 +411,9 @@ namespace System.Text.Json.Serialization.Tests
                 await RunAsCollectionElementTest(JsonNumberTestData.NullableDoubles);
                 await RunAsCollectionElementTest(JsonNumberTestData.NullableDecimals);
 #if NET
-                // https://github.com/dotnet/runtime/issues/119143
-                if (!PlatformDetection.IsBrowser)
-                {
-                    await RunAsCollectionElementTest(JsonNumberTestData.NullableInt128s);
-                    await RunAsCollectionElementTest(JsonNumberTestData.NullableUInt128s);
-                    await RunAsCollectionElementTest(JsonNumberTestData.NullableHalfs);
-                }
+                await RunAsCollectionElementTest(JsonNumberTestData.NullableInt128s);
+                await RunAsCollectionElementTest(JsonNumberTestData.NullableUInt128s);
+                await RunAsCollectionElementTest(JsonNumberTestData.NullableHalfs);
 #endif
             }
         }

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7048,13 +7048,35 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	}
 
 	if (cfg->gsharedvt_min) {
-		if (mini_is_gsharedvt_variable_signature (sig))
-			GSHAREDVT_FAILURE (*cfg->cil_start);
-
-		for (int i = 0; i < header->num_locals; ++i) {
+		/*
+		 * Minimal gsharedvt (used for llvmonly, see mini_method_compile) only
+		 * supports methods whose signature and locals have no variable-length
+		 * (gsharedvt-variable) types; historically it bailed out with
+		 * GSHAREDVT_FAILURE otherwise, which skips the shared method and forces
+		 * per-instantiation concrete compilation. For value types that are only
+		 * reached through the shared/rgctx path (e.g. Nullable<T>.Box/Unbox for a
+		 * struct T, boxed through a non-generic interface) the concrete out-sig
+		 * wrapper is not AOT-generated, so boxing traps at runtime with a
+		 * "null function or function signature mismatch".
+		 *
+		 * The LLVM backend already implements the full variable calling
+		 * convention for llvmonly (all args by-ref, return via vret), keyed off
+		 * the signature in get_llvm_call_info / mono_llvm_create_vars
+		 * (LLVMArgGsharedvtVariable) - it never consults gsharedvt_min. So rather
+		 * than failing, promote this method to full gsharedvt by clearing
+		 * gsharedvt_min. This happens in the method preamble, before any body IR
+		 * is emitted, so every gsharedvt_min check below sees a consistent value.
+		 * Methods that don't depend on their variable-length arguments (the common
+		 * minimal-gsharedvt case, e.g. List<T>.get_Count) have non-variable
+		 * signatures/locals and are unaffected.
+		 */
+		gboolean needs_full = mini_is_gsharedvt_variable_signature (sig);
+		for (int i = 0; !needs_full && i < header->num_locals; ++i) {
 			if (mini_is_gsharedvt_variable_type (header->locals [i]))
-				GSHAREDVT_FAILURE (*cfg->cil_start);
+				needs_full = TRUE;
 		}
+		if (needs_full)
+			cfg->gsharedvt_min = FALSE;
 	}
 
 	/* we use a spare stack slot in SWITCH and NEWOBJ and others */

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7047,7 +7047,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		g_assert (bb);
 	}
 
-	if (cfg->gsharedvt_min) {
+	if (cfg->gsharedvt_min && cfg->method == method) {
 		/*
 		 * Minimal gsharedvt (used for llvmonly, see mini_method_compile) only
 		 * supports methods whose signature and locals have no variable-length
@@ -7069,6 +7069,11 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		 * Methods that don't depend on their variable-length arguments (the common
 		 * minimal-gsharedvt case, e.g. List<T>.get_Count) have non-variable
 		 * signatures/locals and are unaffected.
+		 *
+		 * gsharedvt_min is compile-wide and mono_method_to_ir runs recursively for
+		 * inlinees, so only promote when compiling the root method (cfg->method ==
+		 * method); otherwise the cleared flag would leak into the outer method even
+		 * if the inline is aborted.
 		 */
 		gboolean needs_full = mini_is_gsharedvt_variable_signature (sig);
 		for (int i = 0; !needs_full && i < header->num_locals; ++i) {

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7047,7 +7047,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		g_assert (bb);
 	}
 
-	if (cfg->gsharedvt_min && cfg->method == method) {
+	if (cfg->gsharedvt_min) {
 		/*
 		 * Minimal gsharedvt (used for llvmonly, see mini_method_compile) only
 		 * supports methods whose signature and locals have no variable-length
@@ -7071,17 +7071,23 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		 * signatures/locals and are unaffected.
 		 *
 		 * gsharedvt_min is compile-wide and mono_method_to_ir runs recursively for
-		 * inlinees, so only promote when compiling the root method (cfg->method ==
-		 * method); otherwise the cleared flag would leak into the outer method even
-		 * if the inline is aborted.
+		 * inlinees. Only the root method (cfg->method == method) is promoted;
+		 * clearing the flag for an inlinee would leak into the outer method's
+		 * compilation. For inlinees the historical bailout is preserved so a
+		 * variable-signature callee is never inlined into a minimal-gsharedvt
+		 * method (keeping the minimal-gsharedvt invariants intact).
 		 */
 		gboolean needs_full = mini_is_gsharedvt_variable_signature (sig);
 		for (int i = 0; !needs_full && i < header->num_locals; ++i) {
 			if (mini_is_gsharedvt_variable_type (header->locals [i]))
 				needs_full = TRUE;
 		}
-		if (needs_full)
-			cfg->gsharedvt_min = FALSE;
+		if (needs_full) {
+			if (cfg->method == method)
+				cfg->gsharedvt_min = FALSE;
+			else
+				GSHAREDVT_FAILURE (*cfg->cil_start);
+		}
 	}
 
 	/* we use a spare stack slot in SWITCH and NEWOBJ and others */


### PR DESCRIPTION
## Summary

Draft / RFC. Alternative approach to #131049 (and the broader value-type-through-gsharedvt AOT trap family, e.g. #119143).

In `llvm_only` mode Mono uses **minimal gsharedvt**, which only supports methods whose signature and locals contain no variable-length (gsharedvt-variable) types. Methods that don't qualify previously bailed out with `GSHAREDVT_FAILURE`, which **skips the shared method** and forces per-instantiation concrete compilation.

For value types reached *only* through the shared/rgctx path — e.g. `Nullable<T>.Box`/`Unbox` for a struct `T` boxed through a non-generic interface — the required concrete out-sig wrapper is not AOT-generated, so boxing traps at runtime with `null function or function signature mismatch` (#119143).

The LLVM backend **already implements** the full variable calling convention for `llvm_only` (all args by-ref, return via vret), keyed off the *signature* in `get_llvm_call_info` / `mono_llvm_create_vars` (`LLVMArgGsharedvtVariable`) — it never consults `gsharedvt_min`. So instead of failing, this change **promotes** the method to full gsharedvt by clearing `gsharedvt_min` in the method preamble (before any body IR is emitted, so every subsequent `gsharedvt_min` check sees a consistent value).

## Why this is interesting

Unlike the targeted `Nullable<T>` wrapper fix in #131049, this is **generic**: it should retire the whole "value-type reached only through gsharedvt has no AOT wrapper → runtime trap" family (Nullable box/unbox, and plausibly static-abstract-interface and by-ref-struct dispatch cases) with one change, rather than enumerating each family in the AOT driver.

The branch only fires for methods that **minimal gsharedvt cannot run anyway** (variable signature/locals). Methods that benefit from minimal gsharedvt (`List<T>.get_Count`, etc.) have non-variable signatures and are untouched — so there is no fast minimal path being displaced. These methods **currently fail-and-fallback to concrete**, so we are not disturbing a working fast path, only adding a single shared copy per generic *definition* (not per instantiation).

## Validation

Locally AOT-published a wasm app that boxes `Nullable<struct>` through a non-generic `IEnumerable` (the #119143 repro shape) across six element types, run under node:

```
Int128: SUCCESS count=3      decimal: SUCCESS count=3     Vector128: SUCCESS count=2
Guid: SUCCESS count=2        DateTime: SUCCESS count=2    DayOfWeek: SUCCESS count=3   (enum → UnboxExact path)
NBOX_RESULT: ALL_SUCCESS  EXIT_CODE=0
```

All pass with correct element counts, with **no** AOT-driver workaround — the gate relaxation alone is sufficient.

## Open questions (why this is a draft)

1. **Build-artifact size.** Expected to be minimal (shared = one copy per generic definition, and the affected set is cold — otherwise we'd already see widespread traps or bloat), but it needs measuring. This draft exists so CI can produce before/after size numbers.
2. **Regression surface.** Minimal gsharedvt was shipped deliberately (#70867) partly for perf and partly to avoid chasing full-path edge cases. This change needs the full browser-wasm test suite to shake out any variable-signature IR pattern the original authors punted on.
3. **Scope of promotion.** Should we promote *all* variable-signature methods (as here), or gate it more narrowly? Input from the Mono AOT owners (@BrzVlad, @vargaz) welcome.

cc @lewing

> [!NOTE]
> This PR description was drafted with GitHub Copilot.
