### PR TITLE
Re-add retired r2r.yml

### DIFF
--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -1,0 +1,3 @@
+# Keep this file until the corresponding Azure DevOps pipeline is disabled or deleted.
+trigger: none
+pr: none

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -2,6 +2,14 @@
 trigger: none
 pr: none
 
+# schedules:
+# - cron: "0 5 * * *"
+#   displayName: Mon through Sun at 9:00 PM (UTC-8:00)
+#   branches:
+#     include:
+#     - main
+#   always: true
+
 variables:
   - template: /eng/pipelines/common/variables.yml
   - template: /eng/pipelines/helix-platforms.yml

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -1,9 +1,74 @@
-# Keep this file until the corresponding Azure DevOps pipeline is disabled or deleted.
+# This pipeline is a subset of crossgen2-outerloop.yml and is retained for manual runs.
 trigger: none
 pr: none
 
-# Define a minimal job so the YAML remains a valid pipeline definition.
-steps:
-- checkout: none
-- script: echo "Retired pipeline stub. Disable or delete the corresponding Azure DevOps pipeline definition."
-  displayName: Retired pipeline stub
+variables:
+  - template: /eng/pipelines/common/variables.yml
+  - template: /eng/pipelines/helix-platforms.yml
+
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    stages:
+    - stage: Build
+      jobs:
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: checked
+          platforms:
+          - linux_arm
+          - linux_arm64
+          - linux_x64
+          - osx_arm64
+          - windows_arm64
+          - windows_x64
+          - windows_x86
+          jobParameters:
+            buildArgs: -s clr+libs -c $(_BuildConfig) -lc Release
+            postBuildSteps:
+              - template: /eng/pipelines/coreclr/templates/build-native-test-assets-step.yml
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: $(Build.SourcesDirectory)/artifacts/bin
+                  includeRootFolder: false
+                  archiveType: $(archiveType)
+                  archiveExtension: $(archiveExtension)
+                  tarCompression: $(tarCompression)
+                  artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+                  displayName: Build Assets
+            extraVariablesTemplates:
+              - template: /eng/pipelines/common/templates/runtimes/native-test-assets-variables.yml
+                parameters:
+                  testGroup: outerloop
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+          buildConfig: checked
+          platforms:
+          - CoreClrTestBuildHost # Either osx_x64 or linux_x64
+          jobParameters:
+            testGroup: outerloop
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+          buildConfig: checked
+          platforms:
+          - linux_arm
+          - linux_arm64
+          - linux_x64
+          - osx_arm64
+          - windows_arm64
+          - windows_x64
+          - windows_x86
+          helixQueueGroup: ci
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testGroup: outerloop
+            readyToRun: true
+            displayNameArgs: R2R
+            liveLibrariesBuildConfig: Release
+            unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -1,3 +1,9 @@
 # Keep this file until the corresponding Azure DevOps pipeline is disabled or deleted.
 trigger: none
 pr: none
+
+# Define a minimal job so the YAML remains a valid pipeline definition.
+steps:
+- checkout: none
+- script: echo "Retired pipeline stub. Disable or delete the corresponding Azure DevOps pipeline definition."
+  displayName: Retired pipeline stub


### PR DESCRIPTION
The r2r.yml was deleted, but the corresponding AzDO pipeline definition wasn't deleted, and this is causing warnings on AzDO. I don't have permission to delete the definition, so we can add a dummy file in the meantime to avoid those warnings.

Demo run: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1518526&view=results