### PR TITLE
Use stable names for perf sample-app binlog artifacts

### DIFF
--- a/eng/pipelines/performance/templates/build-perf-sample-apps.yml
+++ b/eng/pipelines/performance/templates/build-perf-sample-apps.yml
@@ -12,11 +12,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=Mono
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
-          artifactName:  AndroidMonoArm64BuildLog_Attempt$(System.JobAttempt)
+          artifactName:  AndroidMonoArm64BuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/AppBundle/bin/HelloAndroid.apk
@@ -35,11 +35,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=Mono AOT=true
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
-          artifactName:  AndroidMonoAOTArm64BuildLog_Attempt$(System.JobAttempt)
+          artifactName:  AndroidMonoAOTArm64BuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/AppBundle/bin/HelloAndroid.apk
@@ -59,11 +59,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=CoreCLR
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
-          artifactName:  AndroidCoreCLRArm64BuildLog_Attempt$(System.JobAttempt)
+          artifactName:  AndroidCoreCLRArm64BuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/AppBundle/bin/HelloAndroid.apk
@@ -82,11 +82,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=CoreCLR STATIC_LINKING=true
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
-          artifactName:  AndroidCoreCLRArm64StaticLinkingBuildLog_Attempt$(System.JobAttempt)
+          artifactName:  AndroidCoreCLRArm64StaticLinkingBuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/AppBundle/bin/HelloAndroid.apk
@@ -105,11 +105,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=CoreCLR R2R=true
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
-          artifactName:  AndroidCoreCLRR2RArm64BuildLog_Attempt$(System.JobAttempt)
+          artifactName:  AndroidCoreCLRR2RArm64BuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/AppBundle/bin/HelloAndroid.apk
@@ -133,11 +133,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
         displayName: Build HelloiOS Mono FullAOT sample app LLVM=False STRIP_SYMBOLS=True
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-          artifactName:  iOSMonoFullAOTArm64NoLLVMStripSymbolsBuildLog_Attempt$(System.JobAttempt)
+          artifactName:  iOSMonoFullAOTArm64NoLLVMStripSymbolsBuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
@@ -157,11 +157,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
         displayName: Build HelloiOS Mono FullAOT sample app LLVM=True STRIP_SYMBOLS=True
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-          artifactName: iOSMonoFullAOTArm64LLVMStripSymbolsBuildLog_Attempt$(System.JobAttempt)
+          artifactName: iOSMonoFullAOTArm64LLVMStripSymbolsBuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
@@ -182,11 +182,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
         displayName: Build HelloiOS CoreCLR Interpreter sample app STRIP_SYMBOLS=True
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-          artifactName:  iOSCoreCLRInterpreterArm64StripSymbolsBuildLog_Attempt$(System.JobAttempt)
+          artifactName:  iOSCoreCLRInterpreterArm64StripSymbolsBuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
@@ -206,11 +206,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
         displayName: Build HelloiOS CoreCLR R2R sample app STRIP_SYMBOLS=True
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-          artifactName:  iOSCoreCLRR2RArm64StripSymbolsBuildLog_Attempt$(System.JobAttempt)
+          artifactName:  iOSCoreCLRR2RArm64StripSymbolsBuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
@@ -231,11 +231,11 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT
         displayName: Build HelloiOS NativeAOT sample app STRIP_SYMBOLS=True
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: 'Publish binlog'
         inputs:
           targetPath: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/msbuild.binlog
-          artifactName: iOSNativeAOTArm64StripSymbolsBuildLog_Attempt$(System.JobAttempt)
+          artifactName: iOSNativeAOTArm64StripSymbolsBuildLog
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
           rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app


### PR DESCRIPTION
These 10 binlog artifacts are consumed downstream by the dotnet/performance runtime-perf-job.yml "Download binlog files" steps, which reference stable base names. PR #128498 classified them as diagnostic artifacts and appended _Attempt$(System.JobAttempt), breaking those cross-repo downloads. Per #128498's own naming strategy, downstream-consumed artifacts should use stable names and publish on succeeded(), matching the sibling APK uploads.


Copilot-Session: 6f47a24b-d0d8-4286-afcc-a1f3d96552c5