### PR TITLE
Fix Dragon4 shortest formatting for exact powers of two

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
@@ -33,7 +33,7 @@ namespace System
             if ((mantissa >> TNumber.DenormalMantissaBits) != 0)
             {
                 mantissaHighBitIdx = TNumber.DenormalMantissaBits;
-                hasUnequalMargins = (mantissa == (1U << TNumber.DenormalMantissaBits));
+                hasUnequalMargins = (mantissa == (1UL << TNumber.DenormalMantissaBits));
             }
             else
             {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.cs
@@ -1051,6 +1051,23 @@ namespace System.Tests
             Assert.Equal(expected, d.ToString(format, NumberFormatInfo.InvariantInfo));
         }
 
+        [Theory]
+        // Exact powers of two have unequal rounding margins, so the shortest round-trippable
+        // string needs all 17 significant digits. Dropping the last one parses back to the
+        // adjacent lower value.
+        [InlineData(0x3E60000000000000, "2.9802322387695312E-08")]   // +2^-25
+        [InlineData(0xBE60000000000000, "-2.9802322387695312E-08")]  // -2^-25
+        [InlineData(0x0410000000000000, "4.1045368012983762E-289")]  // +2^-958
+        [InlineData(0x8410000000000000, "-4.1045368012983762E-289")] // -2^-958
+        public static void ToString_ExactPowerOfTwo_Roundtrips(ulong bits, string expected)
+        {
+            double d = BitConverter.UInt64BitsToDouble(bits);
+
+            Assert.Equal(expected, d.ToString("R", CultureInfo.InvariantCulture));
+            Assert.Equal(expected, d.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal(d, double.Parse(expected, CultureInfo.InvariantCulture));
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))] // Requires a lot of memory
         [OuterLoop("Takes a long time, allocates a lot of memory")]
         [SkipOnMono("Frequently throws OOM on Mono")]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.cs
@@ -1052,8 +1052,8 @@ namespace System.Tests
         }
 
         [Theory]
-        // Exact powers of two have unequal rounding margins, so the shortest round-trippable
-        // string needs all 17 significant digits. Dropping the last one parses back to the
+        // These exact powers of two have unequal rounding margins; their shortest round-trippable
+        // string needs all 17 significant digits, and dropping the last one parses back to the
         // adjacent lower value.
         [InlineData(0x3E60000000000000, "2.9802322387695312E-08")]   // +2^-25
         [InlineData(0xBE60000000000000, "-2.9802322387695312E-08")]  // -2^-25


### PR DESCRIPTION
## Summary

`Number.Dragon4` computed `hasUnequalMargins` by comparing the extracted mantissa against `1U << TNumber.DenormalMantissaBits`. `1U` is 32-bit, and C# masks the shift count to 5 bits for a 32-bit operand, so for `double` (`DenormalMantissaBits == 52`) this evaluates to `1U << (52 & 31)` == `1U << 20`, not `1UL << 52`.

As a result `hasUnequalMargins` was wrongly `false` for every exact power of two in `double`, so Dragon4 used equal rounding margins and produced a non-round-trippable shortest string for cases like `2^-25` and `2^-958`:

| Value | Before | After |
| --- | --- | --- |
| `2^-25` | `2.980232238769531E-08` | `2.9802322387695312E-08` |
| `2^-958` | `4.104536801298376E-289` | `4.1045368012983762E-289` |

The "before" strings parse back to the adjacent lower-magnitude `double`.

The fix widens the shift to `1UL`, which is correct for all supported types (`float` 23, `double` 52, `Half` 10, `BFloat16` 7 � all `< 64`).

----------

This is a regression from #102683, which merged the per-type `double`/`float`/`Half` paths into one generic method. The pre-refactor `double` path used `1UL << DiyFp.DoubleImplicitBitIndex`; the merge kept `Half`'s `1U`, which silently truncates for `double`. `ExtractFractionAndBiasedExponent` and `DiyFp.GetBoundaries` were unaffected (both already use `1UL`).

## Testing

- Added `DoubleTests.ToString_ExactPowerOfTwo_Roundtrips` covering �`2^-25` and �`2^-958`. It fails without the fix and passes with it.
- Existing `double`/`float`/`Half`/`BFloat16` `ToString` tests pass (checked runtime).
- Exhaustive power-of-two sweep (2098 values) and ~10M randomized `float`/`double` round-trips, plus exhaustive `Half`, all pass.

> [!NOTE]
> GitHub Copilot helped create this PR.
