### PR TITLE
Re-enable foreground shutdown test

### DIFF
--- a/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.cs
+++ b/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.cs
@@ -16,7 +16,6 @@ using TestLibrary;
 
 public class Test_foreground_shutdown
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/83658", TestRuntimes.CoreCLR)]
     [Fact]
     public static int TestEntryPoint()
     {


### PR DESCRIPTION
I think the original issue #84006 could have been resolved by #103877. I couldn't reproduce the issue locally.

Closes #84006.