### PR TITLE
Disable new test on clr interpreter

### DIFF
--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -750,9 +750,14 @@ namespace System.Diagnostics.Tests
             yield return new object[] { () => V2Methods.Quuux(), MethodExceptionStrings["Quuux"] };
             yield return new object[] { () => V2Methods.Bux(), MethodExceptionStrings["Bux"] };
             yield return new object[] { () => V2Methods.ThrowsSoon(), MethodExceptionStrings["ThrowsSoon"] };
-            yield return new object[] { () => V2Methods.ThrowsSoonValueTaskSource(), MethodExceptionStrings["ThrowsSoonValueTaskSource"] };
             yield return new object[] { () => V1Methods.EdiOuter(), MethodExceptionStrings["EdiOuter"] };
         }
+
+        // Move test case back into Ctor_Async_TestData once enabled.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/131123", typeof(PlatformDetection), nameof(PlatformDetection.IsCoreClrInterpreter))]
+        public Task ToString_Async_ThrowsSoonValueTaskSource() =>
+            ToString_Async(V2Methods.ThrowsSoonValueTaskSource, MethodExceptionStrings["ThrowsSoonValueTaskSource"]);
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsRuntimeAsyncSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]


### PR DESCRIPTION
Test added in https://github.com/dotnet/runtime/pull/130777.

For code like the one below, where the `GetResult` of the value task source throws, the correct stacktrace should point to the await as the source of the throw. However, on interpreter, it is pointing to the new instruction. 
```
public static async Task ThrowsSoonValueTaskSource()
{
    ValueTask vt = new ValueTask(new ThrowsSoonValueTaskSourceImpl(), 0);
    await vt;
}
```

The cause of this seems to be that we only report IL->native offsets for locations where the IL stack is empty, therefore we don't have a location at the await. This seems to be easily fixable via https://github.com/BrzVlad/runtime/commit/460eae9b05f8f1fabdbb5318d573d1c00fcb5b1a. The problem with the fix is that it is a partial revert of https://github.com/dotnet/runtime/pull/127469 so it has a good chance to lead to regressions on other diagnostic tests.
