### PR TITLE
Throw PNSE for Extended Protection on unsupported platforms

### DIFF
--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -311,6 +311,9 @@
   <data name="security_ExtendedProtectionPolicy_NoEmptyServiceNameCollection" xml:space="preserve">
     <value>The ServiceNameCollection must contain at least one service name.</value>
   </data>
+  <data name="net_extprotection_not_supported" xml:space="preserve">
+    <value>Extended Protection is not supported on this platform.</value>
+  </data>
   <data name="net_allocate_ssl_context_failed" xml:space="preserve">
     <value>Failed to allocate SSL/TLS context, OpenSSL error - {0}.</value>
   </data>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateAuthentication.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateAuthentication.cs
@@ -51,6 +51,12 @@ namespace System.Net.Security
         {
             ArgumentNullException.ThrowIfNull(serverOptions);
 
+            if (serverOptions.Policy?.PolicyEnforcement == PolicyEnforcement.Always &&
+                !ExtendedProtectionPolicy.OSSupportsExtendedProtection)
+            {
+                throw new PlatformNotSupportedException(SR.net_extprotection_not_supported);
+            }
+
             _isServer = true;
             _requestedPackage = serverOptions.Package;
             _requiredImpersonationLevel = serverOptions.RequiredImpersonationLevel;

--- a/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Security;
 using System.Net.Test.Common;
+using System.Security.Authentication.ExtendedProtection;
 using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
@@ -529,6 +530,13 @@ namespace System.Net.Security.Tests
             byte[]? response = ntAuth.GetOutgoingBlob(malformed, out statusCode);
             Assert.Equal(NegotiateAuthenticationStatusCode.InvalidToken, statusCode);
             Assert.Null(response);
+        }
+
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.Windows)]
+        public void ExtendedProtectionPolicy_NotSupportedOnUnix()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => new NegotiateAuthentication(new NegotiateAuthenticationServerOptions { Policy = new ExtendedProtectionPolicy(PolicyEnforcement.Always) }));
         }
     }
 }


### PR DESCRIPTION
Implement a check that throws a `PlatformNotSupportedException` when Extended Protection is enforced on platforms that do not support it. Add a corresponding error message for clarity. Include a test to verify this behavior on non-Windows platforms.

