### PR TITLE
Route code-review skill to vectorization skill on SIMD diffs

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -45,6 +45,11 @@ Before analyzing anything, collect as much relevant **code** context as you can.
   steps, integrating their results. Do not infer or invent an agent from an instruction file.
 - If the environment lacks sub-agent tooling or no matching agent exists, continue the review
   yourself. Area agents are additions to, not replacements for, the regular review.
+- Some specialist skills are triggered by diff **content**, not path. In particular, if the diff
+  contains `Vector128`/`Vector256`/`Vector512`, `Vector<T>`, or any `System.Runtime.Intrinsics.*`
+  type, also apply the `vectorization` skill's review checklist (correctness vs. the scalar
+  contract, remainder handling, memory safety, cross-platform consistency, and `BoundedMemory`
+  test coverage). This holds regardless of which folder the change lives in.
 
 ### Step 3: Form an Independent Assessment
 
@@ -188,6 +193,7 @@ Load, based on the paths in the diff:
 - **Native files (`*.c` / `*.cpp` / `*.h` / `*.inc` / `*.S` / `*.asm`) changed:** `.github/instructions/review-native.instructions.md` -- C++ style, VM/JIT contracts, GC protection, platform defines, and interop/marshalling rules.
 - **Test files (`**/tests/**`, `src/tests/**`) changed:** `.github/instructions/review-all-tests.instructions.md` -- testing conventions and regression-test requirements.
 - **Area matches:** also load any matching area file under `.github/instructions/` (for example `.github/instructions/review-core-runtime.instructions.md`, `.github/instructions/jit.instructions.md`, `.github/instructions/system-net-*.instructions.md`, `.github/instructions/extensions-*.instructions.md`, `.github/instructions/compression.instructions.md`, `.github/instructions/cdac.instructions.md`). These stack on top of the language rules. An area instruction file does not imply that a corresponding agent exists; invoke an area **agent** under `.github/agents/` only when it actually exists and applies, as described in Step 2.
+- **Content matches (not path-based):** if the diff uses `Vector128`/`Vector256`/`Vector512`, `Vector<T>`, or `System.Runtime.Intrinsics.*` anywhere, apply the `vectorization` skill in addition to the above. SIMD code appears in arbitrary library files, so this trigger is keyed on content, not folder.
 
 If a rule in a more specific file conflicts with a general one, the more specific file
 wins. If any required instruction file cannot be loaded, note it in the review and fall

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -46,8 +46,8 @@ Before analyzing anything, collect as much relevant **code** context as you can.
 - If the environment lacks sub-agent tooling or no matching agent exists, continue the review
   yourself. Area agents are additions to, not replacements for, the regular review.
 - Some specialist skills are triggered by diff **content**, not path. In particular, if the diff
-  contains `Vector128`/`Vector256`/`Vector512`, `Vector<T>`, or any `System.Runtime.Intrinsics.*`
-  type, also apply the `vectorization` skill's review checklist (correctness vs. the scalar
+  contains `Vector64`/`Vector128`/`Vector256`/`Vector512`, `Vector<T>`, or any `System.Runtime.Intrinsics.*`
+  namespace usage, also apply the `vectorization` skill's review checklist (correctness vs. the scalar
   contract, remainder handling, memory safety, cross-platform consistency, and `BoundedMemory`
   test coverage). This holds regardless of which folder the change lives in.
 


### PR DESCRIPTION
Adds a content-based trigger so the `code-review` skill applies the `vectorization` skill whenever a diff uses SIMD types, regardless of which folder the change lives in.

Previously the skill routed to area specialists only by path glob (`.github/instructions/*`) or by an existing agent under `.github/agents/`. `vectorization` has neither a path-scoped instruction file nor an agent, and SIMD code appears in arbitrary library files, so once a review was underway the vectorization checklist was never re-surfaced -- even though `.github/copilot-instructions.md` already calls for it. That file isn''t re-consulted mid-skill.

This adds the trigger in two places in `.github/skills/code-review/SKILL.md`:
- Step 2 (area discovery): note that some specialists are content-triggered, calling out `Vector128`/`Vector256`/`Vector512`, `Vector<T>`, and `System.Runtime.Intrinsics.*`.
- The area-loading list: a "Content matches (not path-based)" bullet routing the same triggers to the `vectorization` skill.

> [!NOTE]
> This PR description was drafted by GitHub Copilot.