### PR TITLE
Add an experimental option to avoid partitioning the connection pool by SNI

### DIFF
--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -4,5 +4,9 @@
       <!-- called through reflection by System.Net.HttpWebRequest -->
       <method name="get_Settings" />
     </type>
+    <type fullname="System.Net.Http.HttpRequestMessage">
+      <!-- called through UnsafeAccessor by System.Net.Http tests -->
+      <method name="ExperimentalDangerousDoNotPartitionConnectionPoolBySni" />
+    </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -22,6 +22,7 @@ namespace System.Net.Http
             Disposed = 4,
             AuthDisabled = 8,
             ConnectionIdSet = 16,
+            DoNotPartitionConnectionPoolBySni = 32,
         }
 
         private MessageFlags _flags;
@@ -244,6 +245,12 @@ namespace System.Net.Http
         internal void DisableAuth() => _flags |= MessageFlags.AuthDisabled;
 
         internal bool IsAuthDisabled() => _flags.HasFlag(MessageFlags.AuthDisabled);
+
+        internal bool IsConnectionPoolPartitioningBySniDisabled() => _flags.HasFlag(MessageFlags.DoNotPartitionConnectionPoolBySni);
+
+        // Experimental opt-in accessed via UnsafeAccessor from System.Net.Http tests. There is no product code path
+        // that sets this flag today, so it is preserved from the trimmer via ILLink.Descriptors.LibraryBuild.xml.
+        internal void ExperimentalDangerousDoNotPartitionConnectionPoolBySni() => _flags |= MessageFlags.DoNotPartitionConnectionPoolBySni;
 
         private bool Disposed
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -349,10 +349,21 @@ namespace System.Net.Http
         {
             HttpConnectionKey key = GetConnectionKey(request, proxyUri, isProxyConnect);
 
+            string? sslHostName = key.SslHostName;
+
+            if (sslHostName is not null && request.IsConnectionPoolPartitioningBySniDisabled())
+            {
+                // The request is using HTTPS, but has opted out of partitioning the connection pool by SNI.
+                // The connection pool will be shared by requests to the same Uri Host, regardless of the Host header.
+                // This enables requests where the Uri is set to an IP of shared infrastructure to share connections even if the host names differ.
+                // This is a dangerous opt-in where the caller is responsible for ensuring that the server certificate is acceptable for all requests to a given IP.
+                key = new HttpConnectionKey(key.Kind, key.Host, key.Port, sslHostName: null, key.ProxyUri, key.Identity);
+            }
+
             HttpConnectionPool? pool;
             while (!_pools.TryGetValue(key, out pool))
             {
-                pool = new HttpConnectionPool(this, key.Kind, key.Host, key.Port, key.SslHostName, key.ProxyUri, GetTelemetryServerAddress(request, key));
+                pool = new HttpConnectionPool(this, key.Kind, key.Host, key.Port, sslHostName, key.ProxyUri, GetTelemetryServerAddress(request, key));
 
                 if (_cleaningTimer == null)
                 {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.IO.Pipes;
 using System.Linq;
 using System.Net.Http.Headers;
+using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -5105,6 +5106,192 @@ namespace System.Net.Http.Functional.Tests
                 },
                 new LoopbackServer.Options { UseSsl = true });
         }
+    }
+
+    public abstract class SocketsHttpHandler_ConnectionPoolPartitioning_Test : HttpClientHandlerTestBase
+    {
+        public SocketsHttpHandler_ConnectionPoolPartitioning_Test(ITestOutputHelper output) : base(output) { }
+
+        private string AuthorityHeaderName => UseVersion == HttpVersion.Version11 ? "Host" : ":authority";
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DoNotPartitionConnectionPoolBySni_SharesConnectionAcrossSslHostNames(bool doNotPartitionBySni)
+        {
+            var sniValues = new List<string>();
+            var options = new GenericLoopbackOptions { UseSsl = true };
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClientHandler handler = CreateHttpClientHandler();
+                    ConfigureSniCallback(handler, sniValues);
+
+                    using HttpClient client = CreateHttpClient(handler);
+
+                    // Both requests target the same URI (same scheme/host/port) but set a different Host header,
+                    // which by default partitions the connection pool by the Host header (used as SNI / SslHostName).
+                    HttpRequestMessage request1 = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    request1.Headers.Host = "host1.test";
+
+                    HttpRequestMessage request2 = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    request2.Headers.Host = "host2.test";
+
+                    if (doNotPartitionBySni)
+                    {
+                        ExperimentalDangerousDoNotPartitionConnectionPoolBySni(request1);
+                        ExperimentalDangerousDoNotPartitionConnectionPoolBySni(request2);
+                    }
+
+                    using (HttpResponseMessage response1 = await client.SendAsync(request1))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+                    }
+
+                    using (HttpResponseMessage response2 = await client.SendAsync(request2))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+                    }
+
+                    if (doNotPartitionBySni)
+                    {
+                        // A single TLS handshake should have occurred and been reused for both requests.
+                        Assert.Equal(new[] { "host1.test" }, sniValues);
+                    }
+                    else
+                    {
+                        // Each request established its own TLS session with its own SNI value.
+                        Assert.Equal(new[] { "host1.test", "host2.test" }, sniValues);
+                    }
+                },
+                async server =>
+                {
+                    if (server is Http2LoopbackServer http2Server)
+                    {
+                        http2Server.AllowMultipleConnections = true;
+                    }
+
+                    await using GenericLoopbackConnection connection1 = await server.EstablishGenericConnectionAsync();
+                    HttpRequestData firstRequest = await connection1.ReadRequestDataAsync(readBody: false);
+                    await connection1.SendResponseAsync();
+
+                    Assert.Equal("host1.test", firstRequest.GetSingleHeaderValue(AuthorityHeaderName));
+
+                    if (doNotPartitionBySni)
+                    {
+                        // Second request should reuse the existing connection because partitioning by SNI is disabled.
+                        HttpRequestData secondRequest = await connection1.ReadRequestDataAsync(readBody: false);
+                        await connection1.SendResponseAsync();
+                        Assert.Equal("host2.test", secondRequest.GetSingleHeaderValue(AuthorityHeaderName));
+                    }
+                    else
+                    {
+                        // Without the opt-in, the second request goes to a separate pool and opens a new connection.
+                        await using GenericLoopbackConnection connection2 = await server.EstablishGenericConnectionAsync();
+                        HttpRequestData secondRequest = await connection2.ReadRequestDataAsync(readBody: false);
+                        await connection2.SendResponseAsync();
+                        Assert.Equal("host2.test", secondRequest.GetSingleHeaderValue(AuthorityHeaderName));
+                    }
+                },
+                options: options);
+        }
+
+        [Fact]
+        public async Task DoNotPartitionConnectionPoolBySni_DoesNotShareConnectionWithRequestsThatDidNotOptIn()
+        {
+            // A request opted into the unpartitioned pool (sslHostName = null) and a request that did not opt in
+            // (sslHostName = "host1.test") have different connection pool keys even for the same host, so they
+            // must not share a connection.
+            var sniValues = new List<string>();
+            var options = new GenericLoopbackOptions { UseSsl = true };
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClientHandler handler = CreateHttpClientHandler();
+                    ConfigureSniCallback(handler, sniValues);
+
+                    using HttpClient client = CreateHttpClient(handler);
+
+                    HttpRequestMessage request1 = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    request1.Headers.Host = "host1.test";
+                    ExperimentalDangerousDoNotPartitionConnectionPoolBySni(request1);
+
+                    HttpRequestMessage request2 = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    request2.Headers.Host = "host1.test";
+
+                    using (HttpResponseMessage response1 = await client.SendAsync(request1))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+                    }
+
+                    using (HttpResponseMessage response2 = await client.SendAsync(request2))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+                    }
+
+                    // Two separate TLS handshakes were performed - one per connection.
+                    Assert.Equal(new[] { "host1.test", "host1.test" }, sniValues);
+                },
+                async server =>
+                {
+                    if (server is Http2LoopbackServer http2Server)
+                    {
+                        http2Server.AllowMultipleConnections = true;
+                    }
+
+                    await using GenericLoopbackConnection connection1 = await server.EstablishGenericConnectionAsync();
+                    HttpRequestData firstRequest = await connection1.ReadRequestDataAsync(readBody: false);
+                    await connection1.SendResponseAsync();
+                    Assert.Equal("host1.test", firstRequest.GetSingleHeaderValue(AuthorityHeaderName));
+
+                    await using GenericLoopbackConnection connection2 = await server.EstablishGenericConnectionAsync();
+                    HttpRequestData secondRequest = await connection2.ReadRequestDataAsync(readBody: false);
+                    await connection2.SendResponseAsync();
+                    Assert.Equal("host1.test", secondRequest.GetSingleHeaderValue(AuthorityHeaderName));
+                },
+                options: options);
+        }
+
+        private static void ConfigureSniCallback(HttpClientHandler handler, List<string> sniValues)
+        {
+            GetUnderlyingSocketsHttpHandler(handler).SslOptions.RemoteCertificateValidationCallback = (sender, _, _, _) =>
+            {
+                string sni = sender switch
+                {
+                    SslStream s => s.TargetHostName,
+                    QuicConnection q => q.TargetHostName,
+                    _ => null
+                };
+                sniValues.Add(sni);
+                return true;
+            };
+        }
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method)]
+        private static extern void ExperimentalDangerousDoNotPartitionConnectionPoolBySni(HttpRequestMessage request);
+    }
+
+    [ConditionalClass(typeof(SocketsHttpHandler), nameof(SocketsHttpHandler.IsSupported))]
+    public sealed class SocketsHttpHandler_ConnectionPoolPartitioning_Http11_Test : SocketsHttpHandler_ConnectionPoolPartitioning_Test
+    {
+        public SocketsHttpHandler_ConnectionPoolPartitioning_Http11_Test(ITestOutputHelper output) : base(output) { }
+        protected override Version UseVersion => HttpVersion.Version11;
+    }
+
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+    public sealed class SocketsHttpHandler_ConnectionPoolPartitioning_Http2_Test : SocketsHttpHandler_ConnectionPoolPartitioning_Test
+    {
+        public SocketsHttpHandler_ConnectionPoolPartitioning_Http2_Test(ITestOutputHelper output) : base(output) { }
+        protected override Version UseVersion => HttpVersion.Version20;
+    }
+
+    [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsHttp3Supported))]
+    public sealed class SocketsHttpHandler_ConnectionPoolPartitioning_Http3_Test : SocketsHttpHandler_ConnectionPoolPartitioning_Test
+    {
+        public SocketsHttpHandler_ConnectionPoolPartitioning_Http3_Test(ITestOutputHelper output) : base(output) { }
+        protected override Version UseVersion => HttpVersion.Version30;
     }
 
     [SkipOnPlatform(TestPlatforms.Wasi, "SocketsHttpHandler is not supported on WASI")]


### PR DESCRIPTION
Replaces https://github.com/dotnet/runtime/pull/128653

This adds a way to opt-in requests into sharing connections regardless of SNI, potentially sharing connections with TLS established to a different host.
In practice it'd be used when you know you're talking with shared infrastructure that uses different hosts, and you know you can share connections to the same IP.

It's not exposed as public API for now, we can think about that for .NET 12 if it proves valuable enough.
```c#
[UnsafeAccessor(UnsafeAccessorKind.Method)]
private static extern void ExperimentalDangerousDoNotPartitionConnectionPoolBySni(HttpRequestMessage request);
```