### PR TITLE
[mono] Root concrete gsharedvt method dependencies

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -419,6 +419,8 @@ typedef struct MonoAotCompile {
 	GHashTable *blob_hash;
 	/* Maps MonoMethod*->GPtrArray* */
 	GHashTable *gshared_instances;
+	/* Maps gsharedvt MonoMethod*->GPtrArray<MonoRuntimeGenericContextInfoTemplate*>* */
+	GHashTable *gsharedvt_method_dependencies;
 	/* Hash of gshared methods where specific instances are preferred */
 	GHashTable *prefer_instances;
 	GPtrArray *exported_methods;
@@ -459,6 +461,8 @@ static MonoAotCompile *current_acfg;
 static MonoAssembly *dedup_assembly;
 static GHashTable *dedup_methods;
 static GPtrArray *dedup_methods_list;
+static GHashTable *dedup_gshared_instances;
+static GHashTable *dedup_gsharedvt_method_dependencies;
 
 /* Cache of decoded method external icall symbol names. */
 /* Owned by acfg, but kept in this static as well since it is */
@@ -4436,6 +4440,36 @@ is_open_method (MonoMethod *method)
 }
 
 static void
+record_gshared_instance (MonoAotCompile *acfg, MonoMethod *gshared_method, MonoMethod *instance, gboolean gsharedvt)
+{
+	if (is_open_method (instance) || (!gsharedvt && mono_method_is_generic_sharable_full (instance, TRUE, FALSE, FALSE)))
+		return;
+
+	gboolean use_dedup_tables = gsharedvt && (acfg->dedup_phase == DEDUP_COLLECT || acfg->dedup_phase == DEDUP_EMIT);
+	GHashTable *instances_hash = use_dedup_tables ? dedup_gshared_instances : acfg->gshared_instances;
+	GPtrArray *instances = (GPtrArray *)g_hash_table_lookup (instances_hash, gshared_method);
+	if (!instances) {
+		instances = g_ptr_array_new ();
+		g_hash_table_insert (instances_hash, gshared_method, instances);
+	}
+	if (!g_ptr_array_find (instances, instance, NULL))
+		g_ptr_array_add (instances, instance);
+}
+
+static void
+record_gshared_instance_for_method (MonoAotCompile *acfg, MonoMethod *instance)
+{
+	ERROR_DECL (error);
+	MonoMethod *gshared_method = mini_get_shared_method_full (instance, SHARE_MODE_GSHAREDVT, error);
+	if (!is_ok (error)) {
+		mono_error_cleanup (error);
+		return;
+	}
+
+	record_gshared_instance (acfg, gshared_method, instance, TRUE);
+}
+
+static void
 add_extra_method_full (MonoAotCompile *acfg, MonoMethod *method, gboolean prefer_gshared, int depth)
 {
 	ERROR_DECL (error);
@@ -4468,14 +4502,7 @@ add_extra_method_full (MonoAotCompile *acfg, MonoMethod *method, gboolean prefer
 		if (acfg->aot_opts.profile_only && g_hash_table_lookup (acfg->profile_methods, orig))
 			g_hash_table_insert (acfg->profile_methods, method, method);
 
-		if (!is_open_method (orig) && !mono_method_is_generic_sharable_full (orig, TRUE, FALSE, FALSE)) {
-			GPtrArray *instances = g_hash_table_lookup (acfg->gshared_instances, method);
-			if (!instances) {
-				instances = g_ptr_array_new ();
-				g_hash_table_insert (acfg->gshared_instances, method, instances);
-			}
-			g_ptr_array_add (instances, orig);
-		}
+		record_gshared_instance (acfg, method, orig, FALSE);
 	} else if ((acfg->jit_opts & MONO_OPT_GSHAREDVT) && prefer_gshared && prefer_gsharedvt_method (acfg, method) && mono_method_is_generic_sharable_full (method, FALSE, FALSE, TRUE)) {
 		/* Use the gsharedvt version */
 		method = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);
@@ -5802,6 +5829,8 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 
 		if (mono_method_is_generic_sharable_full (method, FALSE, FALSE, use_gsharedvt)) {
 			/* Already added */
+			if (acfg->aot_opts.llvm_only && use_gsharedvt)
+				record_gshared_instance_for_method (acfg, method);
 			add_types_from_method_header (acfg, method);
 			continue;
 		}
@@ -6008,6 +6037,8 @@ add_types_from_method_header (MonoAotCompile *acfg, MonoMethod *method)
 	sig = mono_method_signature_internal (method);
 
 	if (sig) {
+		if (sig->ret->type == MONO_TYPE_GENERICINST)
+			add_generic_class_with_depth (acfg, mono_class_from_mono_type_internal (sig->ret), depth + 1, "ret");
 		for (j = 0; j < sig->param_count; ++j)
 			if (sig->params [j]->type == MONO_TYPE_GENERICINST)
 				add_generic_class_with_depth (acfg, mono_class_from_mono_type_internal (sig->params [j]), depth + 1, "arg");
@@ -9377,6 +9408,93 @@ add_gsharedvt_wrappers (MonoAotCompile *acfg, MonoMethodSignature *sig, gboolean
 }
 
 static void
+record_gsharedvt_method_dependencies (MonoAotCompile *acfg, MonoMethod *method,
+									  MonoRuntimeGenericContextInfoTemplate *entries, int num_entries)
+{
+	for (int i = 0; i < num_entries; ++i) {
+		MonoRuntimeGenericContextInfoTemplate *entry = &entries [i];
+		if (!mini_rgctx_info_is_method_dependency (entry->info_type))
+			continue;
+
+		gboolean use_dedup_tables = acfg->dedup_phase == DEDUP_COLLECT || acfg->dedup_phase == DEDUP_EMIT;
+		GHashTable *dependencies_hash = use_dedup_tables ?
+			dedup_gsharedvt_method_dependencies : acfg->gsharedvt_method_dependencies;
+		GPtrArray *recorded_dependencies = (GPtrArray *)g_hash_table_lookup (dependencies_hash, method);
+		if (!recorded_dependencies) {
+			recorded_dependencies = g_ptr_array_new ();
+			g_hash_table_insert (dependencies_hash, method, recorded_dependencies);
+		}
+
+		gboolean already_recorded = FALSE;
+		for (guint j = 0; j < recorded_dependencies->len; ++j) {
+			MonoRuntimeGenericContextInfoTemplate *recorded_entry =
+				(MonoRuntimeGenericContextInfoTemplate *)g_ptr_array_index (recorded_dependencies, j);
+			if (recorded_entry->info_type == entry->info_type && recorded_entry->data == entry->data) {
+				already_recorded = TRUE;
+				break;
+			}
+		}
+		if (already_recorded)
+			continue;
+
+		MonoRuntimeGenericContextInfoTemplate *recorded_entry = acfg->dedup_phase == DEDUP_COLLECT ?
+			g_new (MonoRuntimeGenericContextInfoTemplate, 1) :
+			(MonoRuntimeGenericContextInfoTemplate *)mono_mempool_alloc (acfg->mempool, sizeof (MonoRuntimeGenericContextInfoTemplate));
+		*recorded_entry = *entry;
+		g_ptr_array_add (recorded_dependencies, recorded_entry);
+	}
+}
+
+static void
+add_gsharedvt_method_dependencies_range (MonoAotCompile *acfg, MonoMethod *instance, GPtrArray *dependencies,
+										 guint dep_start, guint dep_end, int depth)
+{
+	MonoGenericContext *context = mono_method_get_context (instance);
+	if (!context)
+		return;
+
+	for (guint j = dep_start; j < dep_end; ++j) {
+		ERROR_DECL (error);
+		MonoMethod *dependency = mini_rgctx_info_get_method_dependency (
+			(MonoRuntimeGenericContextInfoTemplate *)g_ptr_array_index (dependencies, j), context, instance->klass, error);
+		if (!is_ok (error)) {
+			mono_error_cleanup (error);
+			continue;
+		}
+		if (!dependency || method_has_type_vars (dependency))
+			continue;
+
+		add_extra_method_full (acfg, dependency, FALSE, depth + 1);
+		add_gsharedvt_wrappers (acfg, mono_method_signature_internal (dependency), FALSE, TRUE, FALSE);
+	}
+}
+
+static void
+add_gsharedvt_method_dependencies (MonoAotCompile *acfg, GHashTable *instances_hash, MonoMethod *method, GPtrArray *dependencies,
+								   GHashTable *processed_dependency_counts, GHashTable *processed_instance_counts, int depth)
+{
+	GPtrArray *instances = (GPtrArray *)g_hash_table_lookup (instances_hash, method);
+	if (!instances)
+		return;
+
+	guint processed_deps = GPOINTER_TO_UINT (g_hash_table_lookup (processed_dependency_counts, method));
+	guint processed_instances = GPOINTER_TO_UINT (g_hash_table_lookup (processed_instance_counts, method));
+	guint total_deps = dependencies->len;
+	guint total_instances = instances->len;
+
+	for (guint i = 0; i < total_instances; ++i)
+		add_gsharedvt_method_dependencies_range (acfg, (MonoMethod *)g_ptr_array_index (instances, i), dependencies,
+												 processed_deps, total_deps, depth);
+
+	for (guint i = processed_instances; i < total_instances; ++i)
+		add_gsharedvt_method_dependencies_range (acfg, (MonoMethod *)g_ptr_array_index (instances, i), dependencies,
+												 0, processed_deps, depth);
+
+	g_hash_table_insert (processed_dependency_counts, method, GUINT_TO_POINTER (total_deps));
+	g_hash_table_insert (processed_instance_counts, method, GUINT_TO_POINTER (total_instances));
+}
+
+static void
 add_referenced_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, int depth)
 {
 	switch (patch_info->type) {
@@ -9728,6 +9846,11 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	 * The depth is used to avoid infinite loops when generic virtual recursion is
 	 * encountered.
 	 */
+	if (acfg->aot_opts.llvm_only) {
+		if (cfg->gsharedvt_info)
+			record_gsharedvt_method_dependencies (acfg, cfg->method, cfg->gsharedvt_info->entries, cfg->gsharedvt_info->num_entries);
+	}
+
 	depth = GPOINTER_TO_UINT (g_hash_table_lookup (acfg->method_depth, method));
 	if (!acfg->aot_opts.no_instances && depth < 32 && (mono_aot_mode_is_full (&acfg->aot_opts) || mono_aot_mode_is_hybrid (&acfg->aot_opts))) {
 		for (patch_info = cfg->patch_info; patch_info; patch_info = patch_info->next)
@@ -13216,6 +13339,29 @@ compile_methods (MonoAotCompile *acfg)
 		compile_method (acfg, (MonoMethod *)g_ptr_array_index (acfg->methods, i));
 	}
 
+	if (!acfg->aot_opts.no_instances && (mono_aot_mode_is_full (&acfg->aot_opts) || mono_aot_mode_is_hybrid (&acfg->aot_opts))) {
+		GHashTable *dependencies_hash = acfg->dedup_phase == DEDUP_EMIT ?
+			dedup_gsharedvt_method_dependencies : acfg->gsharedvt_method_dependencies;
+		GHashTable *instances_hash = acfg->dedup_phase == DEDUP_EMIT ?
+			dedup_gshared_instances : acfg->gshared_instances;
+		GHashTable *processed_dependency_counts = g_hash_table_new (NULL, NULL);
+		GHashTable *processed_instance_counts = g_hash_table_new (NULL, NULL);
+		do {
+			methods_len = acfg->methods->len;
+			GHashTableIter iter;
+			gpointer method, dependencies;
+			g_hash_table_iter_init (&iter, dependencies_hash);
+			while (g_hash_table_iter_next (&iter, &method, &dependencies))
+				add_gsharedvt_method_dependencies (acfg, instances_hash, (MonoMethod *)method, (GPtrArray *)dependencies,
+												   processed_dependency_counts, processed_instance_counts,
+												   GPOINTER_TO_UINT (g_hash_table_lookup (acfg->method_depth, method)));
+			for (guint i = methods_len; i < acfg->methods->len; ++i)
+				compile_method (acfg, (MonoMethod *)g_ptr_array_index (acfg->methods, i));
+		} while (methods_len != acfg->methods->len);
+		g_hash_table_destroy (processed_dependency_counts);
+		g_hash_table_destroy (processed_instance_counts);
+	}
+
 #ifdef ENABLE_LLVM
 	if (acfg->llvm)
 		mono_llvm_fixup_aot_module ();
@@ -14296,6 +14442,7 @@ acfg_create (MonoAssembly *ass, guint32 jit_opts)
 	acfg->gsharedvt_out_signatures = g_hash_table_new ((GHashFunc)mono_signature_hash, (GEqualFunc)mono_metadata_signature_equal);
 	acfg->profile_methods = g_hash_table_new (NULL, NULL);
 	acfg->gshared_instances = g_hash_table_new (NULL, NULL);
+	acfg->gsharedvt_method_dependencies = g_hash_table_new (NULL, NULL);
 	acfg->prefer_instances = g_hash_table_new (NULL, NULL);
 	acfg->exported_methods = g_ptr_array_new ();
 	acfg->dedup_phase = DEDUP_NONE;
@@ -15872,6 +16019,8 @@ mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 jit_opt
 
 		dedup_methods = g_hash_table_new (NULL, NULL);
 		dedup_methods_list = g_ptr_array_new ();
+		dedup_gshared_instances = g_hash_table_new (NULL, NULL);
+		dedup_gsharedvt_method_dependencies = g_hash_table_new (NULL, NULL);
 	}
 
 	if (aot_opts.trimming_eligible_methods_outfile) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4443,13 +4443,11 @@ is_open_method (MonoMethod *method)
 }
 
 static void
-record_gshared_instance (MonoAotCompile *acfg, MonoMethod *gshared_method, MonoMethod *instance, gboolean gsharedvt)
+record_gshared_instance_in_hash (GHashTable *instances_hash, MonoMethod *gshared_method, MonoMethod *instance, gboolean gsharedvt)
 {
 	if (is_open_method (instance) || (!gsharedvt && mono_method_is_generic_sharable_full (instance, TRUE, FALSE, FALSE)))
 		return;
 
-	gboolean use_dedup_tables = gsharedvt && (acfg->dedup_phase == DEDUP_COLLECT || acfg->dedup_phase == DEDUP_EMIT);
-	GHashTable *instances_hash = use_dedup_tables ? dedup_gshared_instances : acfg->gshared_instances;
 	GPtrArray *instances = (GPtrArray *)g_hash_table_lookup (instances_hash, gshared_method);
 	if (!instances) {
 		instances = g_ptr_array_new ();
@@ -4457,6 +4455,14 @@ record_gshared_instance (MonoAotCompile *acfg, MonoMethod *gshared_method, MonoM
 	}
 	if (!g_ptr_array_find (instances, instance, NULL))
 		g_ptr_array_add (instances, instance);
+}
+
+static void
+record_gshared_instance (MonoAotCompile *acfg, MonoMethod *gshared_method, MonoMethod *instance, gboolean gsharedvt)
+{
+	gboolean use_dedup_tables = gsharedvt && (acfg->dedup_phase == DEDUP_COLLECT || acfg->dedup_phase == DEDUP_EMIT);
+	GHashTable *instances_hash = use_dedup_tables ? dedup_gshared_instances : acfg->gshared_instances;
+	record_gshared_instance_in_hash (instances_hash, gshared_method, instance, gsharedvt);
 }
 
 static void
@@ -4513,8 +4519,10 @@ add_extra_method_full (MonoAotCompile *acfg, MonoMethod *method, gboolean prefer
 		record_gshared_instance (acfg, method, orig, FALSE);
 	} else if ((acfg->jit_opts & MONO_OPT_GSHAREDVT) && prefer_gshared && prefer_gsharedvt_method (acfg, method) && mono_method_is_generic_sharable_full (method, FALSE, FALSE, TRUE)) {
 		/* Use the gsharedvt version */
+		MonoMethod *orig = method;
 		method = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);
 		mono_error_assert_ok (error);
+		record_gshared_instance (acfg, method, orig, TRUE);
 	}
 
 	if (collect_dedup_method (acfg, method))
@@ -9449,7 +9457,7 @@ record_gsharedvt_method_dependencies (MonoAotCompile *acfg, MonoMethod *method,
 		if (already_recorded)
 			continue;
 
-		MonoRuntimeGenericContextInfoTemplate *recorded_entry = acfg->dedup_phase == DEDUP_COLLECT ?
+		MonoRuntimeGenericContextInfoTemplate *recorded_entry = use_dedup_tables ?
 			g_new (MonoRuntimeGenericContextInfoTemplate, 1) :
 			(MonoRuntimeGenericContextInfoTemplate *)mono_mempool_alloc (acfg->mempool, sizeof (MonoRuntimeGenericContextInfoTemplate));
 		*recorded_entry = *entry;
@@ -9482,8 +9490,8 @@ add_gsharedvt_method_dependencies_range (MonoAotCompile *acfg, MonoMethod *insta
 }
 
 static void
-add_gsharedvt_method_instances (MonoAotCompile *acfg, GHashTable *instances_hash, GHashTable *classes_hash,
-								MonoMethod *method, GHashTable *processed_class_counts)
+add_gsharedvt_method_instances (GHashTable *instances_hash, GHashTable *classes_hash, MonoMethod *method,
+								GHashTable *processed_class_counts)
 {
 	MonoClass *gshared_container = mono_class_is_ginst (method->klass) ?
 		mono_class_get_generic_class (method->klass)->container_class : method->klass;
@@ -9509,7 +9517,7 @@ add_gsharedvt_method_instances (MonoAotCompile *acfg, GHashTable *instances_hash
 			continue;
 		}
 		if (gshared_method == method)
-			record_gshared_instance (acfg, method, instance, TRUE);
+			record_gshared_instance_in_hash (instances_hash, method, instance, TRUE);
 	}
 
 	g_hash_table_insert (processed_class_counts, method, GUINT_TO_POINTER (classes->len));
@@ -9520,7 +9528,7 @@ add_gsharedvt_method_dependencies (MonoAotCompile *acfg, GHashTable *instances_h
 								   MonoMethod *method, GPtrArray *dependencies, GHashTable *processed_class_counts,
 								   GHashTable *processed_dependency_counts, GHashTable *processed_instance_counts, int depth)
 {
-	add_gsharedvt_method_instances (acfg, instances_hash, classes_hash, method, processed_class_counts);
+	add_gsharedvt_method_instances (instances_hash, classes_hash, method, processed_class_counts);
 
 	GPtrArray *instances = (GPtrArray *)g_hash_table_lookup (instances_hash, method);
 	if (!instances)

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -419,6 +419,8 @@ typedef struct MonoAotCompile {
 	GHashTable *blob_hash;
 	/* Maps MonoMethod*->GPtrArray* */
 	GHashTable *gshared_instances;
+	/* Maps generic type definitions to their concrete gsharedvt MonoClass* instances. */
+	GHashTable *gsharedvt_classes;
 	/* Maps gsharedvt MonoMethod*->GPtrArray<MonoRuntimeGenericContextInfoTemplate*>* */
 	GHashTable *gsharedvt_method_dependencies;
 	/* Hash of gshared methods where specific instances are preferred */
@@ -462,6 +464,7 @@ static MonoAssembly *dedup_assembly;
 static GHashTable *dedup_methods;
 static GPtrArray *dedup_methods_list;
 static GHashTable *dedup_gshared_instances;
+static GHashTable *dedup_gsharedvt_classes;
 static GHashTable *dedup_gsharedvt_method_dependencies;
 
 /* Cache of decoded method external icall symbol names. */
@@ -4457,16 +4460,21 @@ record_gshared_instance (MonoAotCompile *acfg, MonoMethod *gshared_method, MonoM
 }
 
 static void
-record_gshared_instance_for_method (MonoAotCompile *acfg, MonoMethod *instance)
+record_gsharedvt_class (MonoAotCompile *acfg, MonoClass *klass)
 {
-	ERROR_DECL (error);
-	MonoMethod *gshared_method = mini_get_shared_method_full (instance, SHARE_MODE_GSHAREDVT, error);
-	if (!is_ok (error)) {
-		mono_error_cleanup (error);
+	if (!mono_class_is_ginst (klass) || mono_class_get_generic_class (klass)->context.class_inst->is_open)
 		return;
-	}
 
-	record_gshared_instance (acfg, gshared_method, instance, TRUE);
+	gboolean use_dedup_classes = acfg->dedup_phase == DEDUP_COLLECT || acfg->dedup_phase == DEDUP_EMIT;
+	GHashTable *classes_hash = use_dedup_classes ? dedup_gsharedvt_classes : acfg->gsharedvt_classes;
+	MonoClass *container = mono_class_get_generic_class (klass)->container_class;
+	GPtrArray *classes = (GPtrArray *)g_hash_table_lookup (classes_hash, container);
+	if (!classes) {
+		classes = g_ptr_array_new ();
+		g_hash_table_insert (classes_hash, container, classes);
+	}
+	if (!g_ptr_array_find (classes, klass, NULL))
+		g_ptr_array_add (classes, klass);
 }
 
 static void
@@ -5818,6 +5826,9 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 	}
 #endif
 
+	if (acfg->aot_opts.llvm_only && use_gsharedvt)
+		record_gsharedvt_class (acfg, klass);
+
 	iter = NULL;
 	while ((method = mono_class_get_methods (klass, &iter))) {
 		if ((acfg->jit_opts & MONO_OPT_GSHAREDVT) && method->is_inflated && mono_method_get_context (method)->method_inst) {
@@ -5829,8 +5840,11 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 
 		if (mono_method_is_generic_sharable_full (method, FALSE, FALSE, use_gsharedvt)) {
 			/* Already added */
-			if (acfg->aot_opts.llvm_only && use_gsharedvt)
-				record_gshared_instance_for_method (acfg, method);
+			if (acfg->aot_opts.llvm_only && use_gsharedvt) {
+				MonoMethodSignature *sig = mono_method_signature_internal (method);
+				if (sig && sig->ret->type == MONO_TYPE_GENERICINST)
+					record_gsharedvt_class (acfg, mono_class_from_mono_type_internal (sig->ret));
+			}
 			add_types_from_method_header (acfg, method);
 			continue;
 		}
@@ -6037,8 +6051,6 @@ add_types_from_method_header (MonoAotCompile *acfg, MonoMethod *method)
 	sig = mono_method_signature_internal (method);
 
 	if (sig) {
-		if (sig->ret->type == MONO_TYPE_GENERICINST)
-			add_generic_class_with_depth (acfg, mono_class_from_mono_type_internal (sig->ret), depth + 1, "ret");
 		for (j = 0; j < sig->param_count; ++j)
 			if (sig->params [j]->type == MONO_TYPE_GENERICINST)
 				add_generic_class_with_depth (acfg, mono_class_from_mono_type_internal (sig->params [j]), depth + 1, "arg");
@@ -9470,9 +9482,46 @@ add_gsharedvt_method_dependencies_range (MonoAotCompile *acfg, MonoMethod *insta
 }
 
 static void
-add_gsharedvt_method_dependencies (MonoAotCompile *acfg, GHashTable *instances_hash, MonoMethod *method, GPtrArray *dependencies,
+add_gsharedvt_method_instances (MonoAotCompile *acfg, GHashTable *instances_hash, GHashTable *classes_hash,
+								MonoMethod *method, GHashTable *processed_class_counts)
+{
+	MonoClass *gshared_container = mono_class_is_ginst (method->klass) ?
+		mono_class_get_generic_class (method->klass)->container_class : method->klass;
+	GPtrArray *classes = (GPtrArray *)g_hash_table_lookup (classes_hash, gshared_container);
+	if (!classes)
+		return;
+
+	guint processed_classes = GPOINTER_TO_UINT (g_hash_table_lookup (processed_class_counts, method));
+	for (guint i = processed_classes; i < classes->len; ++i) {
+		ERROR_DECL (error);
+		MonoClass *klass = (MonoClass *)g_ptr_array_index (classes, i);
+		MonoMethod *instance = mono_class_get_method_generic (klass, method, error);
+		if (!is_ok (error)) {
+			mono_error_cleanup (error);
+			continue;
+		}
+		if (!instance || is_open_method (instance))
+			continue;
+
+		MonoMethod *gshared_method = mini_get_shared_method_full (instance, SHARE_MODE_GSHAREDVT, error);
+		if (!is_ok (error)) {
+			mono_error_cleanup (error);
+			continue;
+		}
+		if (gshared_method == method)
+			record_gshared_instance (acfg, method, instance, TRUE);
+	}
+
+	g_hash_table_insert (processed_class_counts, method, GUINT_TO_POINTER (classes->len));
+}
+
+static void
+add_gsharedvt_method_dependencies (MonoAotCompile *acfg, GHashTable *instances_hash, GHashTable *classes_hash,
+								   MonoMethod *method, GPtrArray *dependencies, GHashTable *processed_class_counts,
 								   GHashTable *processed_dependency_counts, GHashTable *processed_instance_counts, int depth)
 {
+	add_gsharedvt_method_instances (acfg, instances_hash, classes_hash, method, processed_class_counts);
+
 	GPtrArray *instances = (GPtrArray *)g_hash_table_lookup (instances_hash, method);
 	if (!instances)
 		return;
@@ -13344,6 +13393,9 @@ compile_methods (MonoAotCompile *acfg)
 			dedup_gsharedvt_method_dependencies : acfg->gsharedvt_method_dependencies;
 		GHashTable *instances_hash = acfg->dedup_phase == DEDUP_EMIT ?
 			dedup_gshared_instances : acfg->gshared_instances;
+		GHashTable *classes_hash = acfg->dedup_phase == DEDUP_EMIT ?
+			dedup_gsharedvt_classes : acfg->gsharedvt_classes;
+		GHashTable *processed_class_counts = g_hash_table_new (NULL, NULL);
 		GHashTable *processed_dependency_counts = g_hash_table_new (NULL, NULL);
 		GHashTable *processed_instance_counts = g_hash_table_new (NULL, NULL);
 		do {
@@ -13352,12 +13404,13 @@ compile_methods (MonoAotCompile *acfg)
 			gpointer method, dependencies;
 			g_hash_table_iter_init (&iter, dependencies_hash);
 			while (g_hash_table_iter_next (&iter, &method, &dependencies))
-				add_gsharedvt_method_dependencies (acfg, instances_hash, (MonoMethod *)method, (GPtrArray *)dependencies,
-												   processed_dependency_counts, processed_instance_counts,
+				add_gsharedvt_method_dependencies (acfg, instances_hash, classes_hash, (MonoMethod *)method, (GPtrArray *)dependencies,
+												   processed_class_counts, processed_dependency_counts, processed_instance_counts,
 												   GPOINTER_TO_UINT (g_hash_table_lookup (acfg->method_depth, method)));
 			for (guint i = methods_len; i < acfg->methods->len; ++i)
 				compile_method (acfg, (MonoMethod *)g_ptr_array_index (acfg->methods, i));
 		} while (methods_len != acfg->methods->len);
+		g_hash_table_destroy (processed_class_counts);
 		g_hash_table_destroy (processed_dependency_counts);
 		g_hash_table_destroy (processed_instance_counts);
 	}
@@ -14442,6 +14495,7 @@ acfg_create (MonoAssembly *ass, guint32 jit_opts)
 	acfg->gsharedvt_out_signatures = g_hash_table_new ((GHashFunc)mono_signature_hash, (GEqualFunc)mono_metadata_signature_equal);
 	acfg->profile_methods = g_hash_table_new (NULL, NULL);
 	acfg->gshared_instances = g_hash_table_new (NULL, NULL);
+	acfg->gsharedvt_classes = g_hash_table_new (NULL, NULL);
 	acfg->gsharedvt_method_dependencies = g_hash_table_new (NULL, NULL);
 	acfg->prefer_instances = g_hash_table_new (NULL, NULL);
 	acfg->exported_methods = g_ptr_array_new ();
@@ -16020,6 +16074,7 @@ mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 jit_opt
 		dedup_methods = g_hash_table_new (NULL, NULL);
 		dedup_methods_list = g_ptr_array_new ();
 		dedup_gshared_instances = g_hash_table_new (NULL, NULL);
+		dedup_gsharedvt_classes = g_hash_table_new (NULL, NULL);
 		dedup_gsharedvt_method_dependencies = g_hash_table_new (NULL, NULL);
 	}
 

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -929,6 +929,19 @@ get_method_nofail (MonoClass *klass, const char *method_name, int num_params, in
 	return method;
 }
 
+static MonoMethod*
+class_get_rgctx_method_dependency (MonoClass *klass, MonoRgctxInfoType info_type, MonoError *error)
+{
+	if (!mono_class_is_nullable (klass))
+		return NULL;
+
+	if (info_type == MONO_RGCTX_INFO_NULLABLE_CLASS_BOX)
+		return mono_class_get_method_from_name_checked (klass, "Box", 1, 0, error);
+	if (info_type == MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX)
+		return mono_class_get_method_from_name_checked (klass, "Unbox", 1, 0, error);
+	return NULL;
+}
+
 static gpointer
 class_type_info (MonoMemoryManager *mem_manager, MonoClass *klass, MonoRgctxInfoType info_type, MonoError *error)
 {
@@ -1059,11 +1072,7 @@ class_type_info (MonoMemoryManager *mem_manager, MonoClass *klass, MonoRgctxInfo
 			/* This can happen since all the entries in MonoGSharedVtMethodInfo are inflated, even those which are not used */
 			return NULL;
 
-		if (info_type == MONO_RGCTX_INFO_NULLABLE_CLASS_BOX)
-			method = mono_class_get_method_from_name_checked (klass, "Box", 1, 0, error);
-		else
-			method = mono_class_get_method_from_name_checked (klass, "Unbox", 1, 0, error);
-
+		method = class_get_rgctx_method_dependency (klass, info_type, error);
 		return_val_if_nok (error, NULL);
 
 		addr = mono_jit_compile_method (method, error);
@@ -1107,6 +1116,41 @@ class_type_info (MonoMemoryManager *mem_manager, MonoClass *klass, MonoRgctxInfo
 	}
 	/* Not reached */
 	return NULL;
+}
+
+MonoMethod*
+mini_rgctx_info_get_method_dependency (MonoRuntimeGenericContextInfoTemplate *oti,
+										MonoGenericContext *context, MonoClass *klass, MonoError *error)
+{
+	error_init (error);
+
+	if (!oti->data)
+		return NULL;
+
+	if (oti->info_type == MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER) {
+		return (MonoMethod *)inflate_info (NULL, oti, context, klass, TRUE);
+	}
+
+	if (oti->info_type == MONO_RGCTX_INFO_NULLABLE_CLASS_BOX || oti->info_type == MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX) {
+		MonoType *inflated_type = mono_class_inflate_generic_type_checked ((MonoType *)oti->data, context, error);
+		return_val_if_nok (error, NULL);
+
+		MonoClass *inflated_class = mono_class_from_mono_type_internal (inflated_type);
+		mono_metadata_free_type (inflated_type);
+		if (!inflated_class)
+			return NULL;
+		return class_get_rgctx_method_dependency (inflated_class, oti->info_type, error);
+	}
+
+	return NULL;
+}
+
+gboolean
+mini_rgctx_info_is_method_dependency (MonoRgctxInfoType info_type)
+{
+	return info_type == MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER ||
+		info_type == MONO_RGCTX_INFO_NULLABLE_CLASS_BOX ||
+		info_type == MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX;
 }
 
 static gboolean

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2882,6 +2882,9 @@ MonoMethod* mini_get_gsharedvt_in_sig_wrapper (MonoMethodSignature *sig);
 MonoMethod* mini_get_gsharedvt_out_sig_wrapper (MonoMethodSignature *sig);
 MonoMethodSignature* mini_get_gsharedvt_out_sig_wrapper_signature (gboolean has_this, gboolean has_ret, int param_count);
 gboolean mini_gsharedvt_runtime_invoke_supported (MonoMethodSignature *sig);
+gboolean mini_rgctx_info_is_method_dependency (MonoRgctxInfoType info_type);
+MonoMethod* mini_rgctx_info_get_method_dependency (MonoRuntimeGenericContextInfoTemplate *oti,
+													MonoGenericContext *context, MonoClass *klass, MonoError *error);
 gpointer mini_instantiate_gshared_info (MonoRuntimeGenericContextInfoTemplate *oti,
 										MonoGenericContext *context, MonoClass *klass);
 

--- a/src/mono/wasm/Wasm.Build.Tests/WasmBuildAppTest.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmBuildAppTest.cs
@@ -137,8 +137,8 @@ namespace Wasm.Build.Tests
         [Theory]
         [BuildAndRun(config: Configuration.Release, aot: true)]
         [TestCategory("native-mono")]
-        public async Task GSharedVtConcreteMethodDependencies(Configuration config, bool aot)
-            => await TestMain("gsharedvt_concrete_method_dependencies", """
+        public async Task GSharedVtNullableBoxWrapper(Configuration config, bool aot)
+            => await TestMain("gsharedvt_nullable_box_wrapper", """
                 using System;
                 using System.Collections;
                 using System.Collections.Generic;

--- a/src/mono/wasm/Wasm.Build.Tests/WasmBuildAppTest.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmBuildAppTest.cs
@@ -135,6 +135,30 @@ namespace Wasm.Build.Tests
                         isNativeBuild: true);
 
         [Theory]
+        [BuildAndRun(config: Configuration.Release, aot: true)]
+        [TestCategory("native-mono")]
+        public async Task GSharedVtConcreteMethodDependencies(Configuration config, bool aot)
+            => await TestMain("gsharedvt_concrete_method_dependencies", """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+
+                public static class Program
+                {
+                    public static int Main()
+                    {
+                        Queue queue = new(new List<Int128?> { 42, null });
+                        bool passed = queue.Count == 2 &&
+                            Equals(queue.Dequeue(), (Int128)42) &&
+                            queue.Dequeue() is null;
+
+                        Console.WriteLine(passed ? "PASS" : "FAIL");
+                        return passed ? 42 : 1;
+                    }
+                }
+                """, config, aot, expectedOutput: "PASS");
+
+        [Theory]
         [BuildAndRun]
         public async Task PropertiesFromRuntimeConfigJson(Configuration config, bool aot)
             => await TestMain("runtime_config_json",


### PR DESCRIPTION
## Summary

Prototype a dependency-driven mechanism for Mono llvmonly/minimal-gsharedvt AOT to root concrete callees and required gsharedvt out wrappers.

The motivating wasm AOT failure is `List<Int128?>.Enumerator.System.Collections.IEnumerator.get_Current`: its compiled gsharedvt body resolves Nullable boxing through RGCTX, but the concrete `Nullable<Int128>.Box` dependency and required out wrapper were not retained. The resulting llvmonly execution hit the `mini-generic-sharing.c` assertion instead of boxing the enumerator value.

## Design

- Record only method-producing RGCTX entries emitted by compiled gsharedvt methods.
- Pair those dependency templates with concrete caller contexts already known to static AOT collection.
- Root the inflated concrete callees and their required gsharedvt out wrappers to a fixed point.
- Match concrete generic classes lazily, by generic type definition, only for shared methods that actually published dependencies.
- Preserve complete class and method contexts when AOT explicitly selects a gsharedvt body.
- Keep dedup dependency entries process-owned when stored in cross-assembly static tables.

This avoids blanket signature generation and broad rooting of every generic method or return type.

## Why draft

Only the Nullable boxing path currently has a demonstrated failing regression. `MONO_R?GCTX_INFO_GSHAREDVT_OUT_WRAPPER` is general infrastructure, but its broader non-Nullable behavior and cross-assembly dedup paths need maintainer feedback and additional coverage before this should be considered production-ready.

Concrete instantiations created only through reflection, and otherwise absent from metadata, profiles, or AOT instance collection, remain outside static AOT knowledge.

PR #131049 is the immediate narrow fix. This draft explores a possible broader long-term dependency mechanism rather than proposing to replace that targeted change yet.

## Validation

- Confirmed the dependency-disabled baseline fails the exact `List<Int128?>` wasm AOT/llvmonly workload with the `mini-generic-sharing.c` assertion.
- Confirmed the final standalone workload prints `PASS`.
- Built `./build.sh mono+libs`.
- Built browser Mono Release with `./build.sh mono+libs -os browser -c Release`.
- Built `Wasm.Build.Tests.csproj` successfully.
- The filtered xUnit test was not executed locally because the provisioned SDK lacks the `wasm-tools` workload; the equivalent standalone in-tree wasm AOT workload was executed directly.
- Multi-model review completed with no remaining errors or warnings.

## AOT impact

Controlled same-environment comparison of the final refined implementation on the representative `List<Int128?>` workload:

| Variant | Native wasm | Publish time |
| --- | ---: | ---: |
| Dependency-disabled baseline | 7,727,752 bytes | 22.38 s |
| Final prototype | 7,727,752 bytes | 21.99 s |

The output-size delta is **0 bytes** and the timing difference is noise. An earlier apparent +93 KB comparison was caused by differing runtime/tool build states and is not an implementation cost.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.