### PR TITLE
Fix EH - throw from catch in UnmanagedCallersOnly

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -4123,7 +4123,7 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
     // Check for reverse pinvoke or CallDescrWorkerInternal.
     if (isNativeTransition)
     {
-        CLR_BOOL isPropagatingToNativeCode = FALSE;
+        bool isPropagatingToNativeCode = false;
         EECodeInfo codeInfo(preUnwindControlPC);
         // If we are unwinding from a funclet, we don't care about the reverse pinvoke frame of the parent method
         // that we would get from the GC info. It applies to the parent method only. The funclet itself cannot be
@@ -4182,12 +4182,12 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
             if (IsCallDescrWorkerInternalReturnAddress(GetIP(pThis->m_crawl.GetRegisterSet()->pCurrentContext)))
             {
                 EH_LOG((LL_INFO100, "SfiNext: the native frame is CallDescrWorkerInternal\n"));
-                isPropagatingToNativeCode = TRUE;
+                isPropagatingToNativeCode = true;
             }
             else if (doingFuncletUnwind && codeInfo.GetJitManager()->IsFilterFunclet(&codeInfo))
             {
                 EH_LOG((LL_INFO100, "SfiNext: current frame is filter funclet\n"));
-                isPropagatingToNativeCode = TRUE;
+                isPropagatingToNativeCode = true;
             }
         }
 

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -4123,15 +4123,19 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
     // Check for reverse pinvoke or CallDescrWorkerInternal.
     if (isNativeTransition)
     {
+        CLR_BOOL isPropagatingToNativeCode = FALSE;
         EECodeInfo codeInfo(preUnwindControlPC);
+        if (!doingFuncletUnwind)
+        {
 #ifdef USE_GC_INFO_DECODER
-        GcInfoDecoder gcInfoDecoder(codeInfo.GetGCInfoToken(), DECODE_REVERSE_PINVOKE_VAR);
-        CLR_BOOL isPropagatingToNativeCode = gcInfoDecoder.GetReversePInvokeFrameStackSlot() != NO_REVERSE_PINVOKE_FRAME;
+            GcInfoDecoder gcInfoDecoder(codeInfo.GetGCInfoToken(), DECODE_REVERSE_PINVOKE_VAR);
+            isPropagatingToNativeCode = gcInfoDecoder.GetReversePInvokeFrameStackSlot() != NO_REVERSE_PINVOKE_FRAME;
 #else // USE_GC_INFO_DECODER
-        hdrInfo *hdrInfoBody;
-        codeInfo.DecodeGCHdrInfo(&hdrInfoBody);
-        CLR_BOOL isPropagatingToNativeCode = hdrInfoBody->revPInvokeOffset != INVALID_REV_PINVOKE_OFFSET;
+            hdrInfo *hdrInfoBody;
+            codeInfo.DecodeGCHdrInfo(&hdrInfoBody);
+            isPropagatingToNativeCode = hdrInfoBody->revPInvokeOffset != INVALID_REV_PINVOKE_OFFSET;
 #endif // USE_GC_INFO_DECODER
+        }
         bool isPropagatingToExternalNativeCode = false;
 
         EH_LOG((LL_INFO100, "SfiNext: reached native frame at IP=%p, SP=%p, isPropagatingToNativeCode=%d\n",

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -4125,6 +4125,9 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
     {
         CLR_BOOL isPropagatingToNativeCode = FALSE;
         EECodeInfo codeInfo(preUnwindControlPC);
+        // If we are unwinding from a funclet, we don't care about the reverse pinvoke frame of the parent method
+        // that we would get from the GC info. It applies to the parent method only. The funclet itself cannot be
+        // invoked via a reverse pinvoke.
         if (!doingFuncletUnwind)
         {
 #ifdef USE_GC_INFO_DECODER

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
@@ -21,6 +21,9 @@ internal unsafe static class ExceptionInteropNative
 
 public unsafe static class ExceptionInterop
 {
+    private static int s_nativeExceptionFromCatchCount;
+    private static int s_managedExceptionFromCatchCount;
+
     [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     public static void ThrowNativeExceptionAndCatchInFrame()
     {
@@ -169,6 +172,46 @@ public unsafe static class ExceptionInterop
         }
     }
 
+    [UnmanagedCallersOnly]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void ThrowNativeExceptionFromCatchInUnmanagedCallersOnly()
+    {
+        try
+        {
+            throw new Exception("This one is handled");
+        }
+        catch
+        {
+            s_nativeExceptionFromCatchCount++;
+            if (s_nativeExceptionFromCatchCount > 1)
+            {
+                return;
+            }
+
+            ThrowException();
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void ThrowManagedExceptionFromCatchInUnmanagedCallersOnly()
+    {
+        try
+        {
+            throw new Exception("This one is handled");
+        }
+        catch
+        {
+            s_managedExceptionFromCatchCount++;
+            if (s_managedExceptionFromCatchCount > 1)
+            {
+                return;
+            }
+
+            throw new ApplicationException();
+        }
+    }
+
     [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     public static void PropagateAndRethrowCppException()
     {
@@ -199,5 +242,43 @@ public unsafe static class ExceptionInterop
         InvokeCallbackOnNewThread(&CallPInvoke);
         AppDomain.CurrentDomain.UnhandledException -= handler;
         Assert.False(reportedUnhandledException, "Exception should not be reported as unhandled");
+    }
+
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
+    public static void ThrowNativeExceptionFromCatchInUnmanagedCallersOnlyCallback()
+    {
+        s_nativeExceptionFromCatchCount = 0;
+
+        Exception exception = null;
+        try
+        {
+            CallCallback(&ThrowNativeExceptionFromCatchInUnmanagedCallersOnly);
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        Assert.Equal(1, s_nativeExceptionFromCatchCount);
+        Assert.NotNull(exception);
+    }
+
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
+    public static void ThrowManagedExceptionFromCatchInUnmanagedCallersOnlyCallback()
+    {
+        s_managedExceptionFromCatchCount = 0;
+
+        Exception exception = null;
+        try
+        {
+            CallCallback(&ThrowManagedExceptionFromCatchInUnmanagedCallersOnly);
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        Assert.Equal(1, s_managedExceptionFromCatchCount);
+        Assert.IsType<ApplicationException>(exception);
     }
 }

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
@@ -260,7 +260,7 @@ public unsafe static class ExceptionInterop
         }
 
         Assert.Equal(1, s_nativeExceptionFromCatchCount);
-        Assert.NotNull(exception);
+        Assert.IsType<SEHException>(exception);
     }
 
     [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]


### PR DESCRIPTION
There is an issue when an exception is thrown from catch in a method marked as `UnmanagedCallersOnly` on Windows. When such exception escapes the catch, it is not detected as going into CallEHFunclet, but it is thought to be escaping the `UnmanagedCallersOnly` method itself, thus going through a reverse pinvoke transition. That results in an incorrect handling of that exception. We don't detect the unwind is colliding with previous exception and we end up calling the same catch again. This results in an infinite loop and a stack overflow after a while.

Close #123579