### PR TITLE
Remove unused args from specifier-less JITDUMP calls

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -12502,8 +12502,7 @@ GenTree* Compiler::impArrayAccessIntrinsic(
         if (varTypeIsStruct(elemType))
         {
             JITDUMP("impArrayAccessIntrinsic: rejecting SET array intrinsic because elemType is TYP_STRUCT"
-                    " (implementation limitation)\n",
-                    arrayElemSize);
+                    " (implementation limitation)\n");
             return nullptr;
         }
 

--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -474,7 +474,7 @@ GenTree* Compiler::impUtf16StringComparison(StringComparisonKind kind, CORINFO_S
     {
         // check for fake "" first
         cnsLength = 0;
-        JITDUMP("Trying to unroll String.Equals|StartsWith|EndsWith(op1, \"\")...\n", str)
+        JITDUMP("Trying to unroll String.Equals|StartsWith|EndsWith(op1, \"\")...\n")
     }
     else
     {

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -751,7 +751,7 @@ void Compiler::optReplaceWidenedIV(unsigned lclNum, unsigned ssaNum, unsigned ne
     {
         gtSetStmtInfo(stmt);
         fgSetStmtSeq(stmt);
-        JITDUMP("New tree:\n", dspTreeID(stmt->GetRootNode()));
+        JITDUMP("New tree:\n");
         DISPTREE(stmt->GetRootNode());
         JITDUMP("\n");
     }
@@ -2784,7 +2784,7 @@ bool Compiler::optRemoveUnusedIVs(FlowGraphNaturalLoop* loop, PerLoopInfo* loopI
             continue;
         }
 
-        JITDUMP(" has no essential uses and will be removed\n", lclNum);
+        JITDUMP(" has no essential uses and will be removed\n");
         auto remove = [=](BasicBlock* block, Statement* stmt) {
             JITDUMP("  Removing " FMT_STMT "\n", stmt->GetID());
             fgRemoveStmt(block, stmt);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1843,7 +1843,7 @@ void Lowering::SplitArgumentBetweenRegistersAndStack(GenTreeCall* call, CallArg*
     {
         assert(arg->OperIsLocalRead());
 
-        JITDUMP("Argument is a local\n", numRegs, stackSeg.Size);
+        JITDUMP("Argument is a local\n");
 
         GenTreeLclVarCommon* lcl = arg->AsLclVarCommon();
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6083,7 +6083,7 @@ PhaseStatus Compiler::optVNBasedDeadStoreRemoval()
                     // the implicit "live-in" one, which is not guaranteed, but very likely.
                     if ((defIndex == 1) && !varDsc->TypeIs(TYP_STRUCT))
                     {
-                        JITDUMP(" -- no; first explicit def of a non-STRUCT local\n", lclNum);
+                        JITDUMP(" -- no; first explicit def of a non-STRUCT local\n");
                         continue;
                     }
 

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -2446,7 +2446,7 @@ Range RangeCheck::GetRangeWorker(BasicBlock* block, GenTree* expr, bool monIncre
         JITDUMP("[RangeCheck::GetRangeWorker] " FMT_BB " ", block->bbNum);
         m_compiler->gtDispTree(expr);
         Indent(indent);
-        JITDUMP("{\n", expr);
+        JITDUMP("{\n");
     }
 #endif
 
@@ -2461,7 +2461,7 @@ Range RangeCheck::GetRangeWorker(BasicBlock* block, GenTree* expr, bool monIncre
         JITDUMP("   %s Range [%06d] => %s\n", (pRange == nullptr) ? "Computed" : "Cached", Compiler::dspTreeID(expr),
                 range.ToString(m_compiler));
         Indent(indent);
-        JITDUMP("}\n", expr);
+        JITDUMP("}\n");
     }
 #endif
     return range;


### PR DESCRIPTION
Follow-up to #130837.

Several `JITDUMP` calls pass a trailing argument to a format string that has no corresponding `%` specifier, so the argument is silently ignored. This removes those leftover args. All are `DEBUG`-only and behavior is unchanged.

- `lower.cpp` -- `JITDUMP("Argument is a local\n", numRegs, stackSeg.Size)` (the one called out in #130837)
- `importercalls.cpp` -- `arrayElemSize`
- `importervectorization.cpp` -- `str`
- `inductionvariableopts.cpp` -- `dspTreeID(...)` (redundant; the following `DISPTREE` already dumps the tree) and `lclNum`
- `optimizer.cpp` -- `lclNum`
- `rangecheck.cpp` -- `expr` (two sites)

Found by scanning every `.cpp` under `src/coreclr/jit` for literal format strings with no conversion but a trailing argument; these were the only hits.

> [!NOTE]
> This PR description and the changes were drafted with GitHub Copilot.
