### PR TITLE
Vectorize BMP string

### DIFF
--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Text;
 
@@ -273,87 +272,8 @@ namespace System.Formats.Asn1
     // T-REC-X.690-201508 sec 8.23.8 says to see ISO/IEC 10646:2003 section 13.1.
     // ISO/IEC 10646:2003 sec 13.1 says each character is represented by "two octets".
     // ISO/IEC 10646:2003 sec 6.3 says that when serialized as octets to use big endian.
-    internal sealed class BMPEncoding : SpanBasedEncoding
+    internal sealed partial class BMPEncoding : SpanBasedEncoding
     {
-        protected override int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
-        {
-            if (chars.IsEmpty)
-            {
-                return 0;
-            }
-
-            int writeIdx = 0;
-
-            for (int i = 0; i < chars.Length; i++)
-            {
-                char c = chars[i];
-
-                if (char.IsSurrogate(c))
-                {
-                    EncoderFallback.CreateFallbackBuffer().Fallback(c, i);
-
-                    Debug.Fail("Fallback should have thrown");
-                    throw new InvalidOperationException();
-                }
-
-                ushort val16 = c;
-
-                if (write)
-                {
-                    bytes[writeIdx + 1] = (byte)val16;
-                    bytes[writeIdx] = (byte)(val16 >> 8);
-                }
-
-                writeIdx += 2;
-            }
-
-            return writeIdx;
-        }
-
-        protected override int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
-        {
-            if (bytes.IsEmpty)
-            {
-                return 0;
-            }
-
-            if (bytes.Length % 2 != 0)
-            {
-                DecoderFallback.CreateFallbackBuffer().Fallback(
-                    bytes.Slice(bytes.Length - 1).ToArray(),
-                    bytes.Length - 1);
-
-                Debug.Fail("Fallback should have thrown");
-                throw new InvalidOperationException();
-            }
-
-            int writeIdx = 0;
-
-            for (int i = 0; i < bytes.Length; i += 2)
-            {
-                char c = (char)BinaryPrimitives.ReadInt16BigEndian(bytes.Slice(i));
-
-                if (char.IsSurrogate(c))
-                {
-                    DecoderFallback.CreateFallbackBuffer().Fallback(
-                        bytes.Slice(i, 2).ToArray(),
-                        i);
-
-                    Debug.Fail("Fallback should have thrown");
-                    throw new InvalidOperationException();
-                }
-
-                if (write)
-                {
-                    chars[writeIdx] = c;
-                }
-
-                writeIdx++;
-            }
-
-            return writeIdx;
-        }
-
         public override int GetMaxByteCount(int charCount)
         {
             checked

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.downlevel.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.downlevel.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
+using System.Diagnostics;
+
 namespace System.Formats.Asn1
 {
     internal abstract class RestrictedAsciiRangeEncoding : RestrictedAsciiStringEncoding
@@ -8,6 +11,88 @@ namespace System.Formats.Asn1
         protected RestrictedAsciiRangeEncoding(byte minCharAllowed, byte maxCharAllowed)
             : base(minCharAllowed, maxCharAllowed)
         {
+        }
+    }
+
+    internal sealed partial class BMPEncoding
+    {
+        protected override int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
+        {
+            if (chars.IsEmpty)
+            {
+                return 0;
+            }
+
+            int writeIdx = 0;
+
+            for (int i = 0; i < chars.Length; i++)
+            {
+                char c = chars[i];
+
+                if (char.IsSurrogate(c))
+                {
+                    EncoderFallback.CreateFallbackBuffer().Fallback(c, i);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new InvalidOperationException();
+                }
+
+                ushort val16 = c;
+
+                if (write)
+                {
+                    bytes[writeIdx + 1] = (byte)val16;
+                    bytes[writeIdx] = (byte)(val16 >> 8);
+                }
+
+                writeIdx += 2;
+            }
+
+            return writeIdx;
+        }
+
+        protected override int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
+        {
+            if (bytes.IsEmpty)
+            {
+                return 0;
+            }
+
+            if (bytes.Length % 2 != 0)
+            {
+                DecoderFallback.CreateFallbackBuffer().Fallback(
+                    bytes.Slice(bytes.Length - 1).ToArray(),
+                    bytes.Length - 1);
+
+                Debug.Fail("Fallback should have thrown");
+                throw new InvalidOperationException();
+            }
+
+            int writeIdx = 0;
+
+            for (int i = 0; i < bytes.Length; i += 2)
+            {
+                char c = (char)BinaryPrimitives.ReadInt16BigEndian(bytes.Slice(i));
+
+                if (char.IsSurrogate(c))
+                {
+                    DecoderFallback.CreateFallbackBuffer().Fallback(
+                        bytes.Slice(i, 2).ToArray(),
+                        i);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new InvalidOperationException();
+                }
+
+                if (write)
+                {
+                    chars[writeIdx] = c;
+                }
+
+                writeIdx++;
+            }
+
+            return writeIdx;
         }
     }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.net.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.net.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.InteropServices;
@@ -187,5 +188,185 @@ namespace System.Formats.Asn1
             Vector<ushort> offset = value - minCharAllowed;
             return Vector.LessThanOrEqualAll(offset, range);
         }
+    }
+
+    internal sealed partial class BMPEncoding
+    {
+        private const ushort SurrogateStart = 0xD800;
+        private const ushort SurrogateRange = 0xDFFF - SurrogateStart;
+
+        protected override int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
+        {
+            if (chars.IsEmpty)
+            {
+                return 0;
+            }
+
+            int position = 0;
+            int writeIdx = 0;
+
+            if (chars.Length >= Vector<ushort>.Count && Vector.IsHardwareAccelerated)
+            {
+                position = GetBytesVectorized(chars, bytes, write);
+                writeIdx = checked(position * sizeof(ushort));
+            }
+
+            for (; position < chars.Length; position++)
+            {
+                char c = chars[position];
+
+                if (char.IsSurrogate(c))
+                {
+                    EncoderFallback.CreateFallbackBuffer().Fallback(c, position);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new InvalidOperationException();
+                }
+
+                ushort val16 = c;
+
+                if (write)
+                {
+                    bytes[writeIdx + 1] = (byte)val16;
+                    bytes[writeIdx] = (byte)(val16 >> 8);
+                }
+
+                writeIdx += sizeof(ushort);
+            }
+
+            return writeIdx;
+        }
+
+        protected override int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
+        {
+            if (bytes.IsEmpty)
+            {
+                return 0;
+            }
+
+            if (bytes.Length % sizeof(ushort) != 0)
+            {
+                DecoderFallback.CreateFallbackBuffer().Fallback(
+                    bytes.Slice(bytes.Length - 1).ToArray(),
+                    bytes.Length - 1);
+
+                Debug.Fail("Fallback should have thrown");
+                throw new InvalidOperationException();
+            }
+
+            int bytePosition = 0;
+            int writeIdx = 0;
+
+            if (bytes.Length >= Vector<ushort>.Count * sizeof(ushort) && Vector.IsHardwareAccelerated)
+            {
+                writeIdx = GetCharsVectorized(bytes, chars, write);
+                bytePosition = checked(writeIdx * sizeof(ushort));
+            }
+
+            for (int i = bytePosition; i < bytes.Length; i += sizeof(ushort))
+            {
+                char c = (char)BinaryPrimitives.ReadInt16BigEndian(bytes.Slice(i));
+
+                if (char.IsSurrogate(c))
+                {
+                    DecoderFallback.CreateFallbackBuffer().Fallback(
+                        bytes.Slice(i, sizeof(ushort)).ToArray(),
+                        i);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new InvalidOperationException();
+                }
+
+                if (write)
+                {
+                    chars[writeIdx] = c;
+                }
+
+                writeIdx++;
+            }
+
+            return writeIdx;
+        }
+
+        // Keep the vectorization out of GetChars and GetBytes to avoid regressing code size
+        // and register allocation for small inputs.
+        private static int GetBytesVectorized(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
+        {
+            int available = write ? Math.Min(chars.Length, bytes.Length / sizeof(ushort)) : chars.Length;
+            int vectorizedLength = available - (available % Vector<ushort>.Count);
+            int position = 0;
+
+            // Revisit this cast when Vector<char> is supported: https://github.com/dotnet/runtime/issues/127611
+            ReadOnlySpan<ushort> source = MemoryMarshal.Cast<char, ushort>(chars);
+            Span<ushort> destination = write ? MemoryMarshal.Cast<byte, ushort>(bytes) : Span<ushort>.Empty;
+            Vector<ushort> surrogateStart = new Vector<ushort>(SurrogateStart);
+            Vector<ushort> surrogateRange = new Vector<ushort>(SurrogateRange);
+
+            for (; position < vectorizedLength; position += Vector<ushort>.Count)
+            {
+                Vector<ushort> value = new Vector<ushort>(source.Slice(position));
+
+                if (ContainsSurrogate(value, surrogateStart, surrogateRange))
+                {
+                    // Do not advance the position so the scalar path can determine the exact surrogate index.
+                    break;
+                }
+
+                if (write)
+                {
+                    ToBigEndian(value).CopyTo(destination.Slice(position));
+                }
+            }
+
+            return position;
+        }
+
+        private static int GetCharsVectorized(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
+        {
+            int sourceLength = bytes.Length / sizeof(ushort);
+            int available = write ? Math.Min(sourceLength, chars.Length) : sourceLength;
+            int vectorizedLength = available - (available % Vector<ushort>.Count);
+            int position = 0;
+
+            ReadOnlySpan<ushort> source = MemoryMarshal.Cast<byte, ushort>(bytes);
+            Span<ushort> destination = write ? MemoryMarshal.Cast<char, ushort>(chars) : Span<ushort>.Empty;
+            Vector<ushort> surrogateStart = new Vector<ushort>(SurrogateStart);
+            Vector<ushort> surrogateRange = new Vector<ushort>(SurrogateRange);
+
+            for (; position < vectorizedLength; position += Vector<ushort>.Count)
+            {
+                Vector<ushort> value = FromBigEndian(new Vector<ushort>(source.Slice(position)));
+
+                if (ContainsSurrogate(value, surrogateStart, surrogateRange))
+                {
+                    // Do not advance the position so the scalar path can determine the exact surrogate index.
+                    break;
+                }
+
+                if (write)
+                {
+                    value.CopyTo(destination.Slice(position));
+                }
+            }
+
+            return position;
+        }
+
+        private static bool ContainsSurrogate(
+            Vector<ushort> value,
+            Vector<ushort> surrogateStart,
+            Vector<ushort> surrogateRange)
+        {
+            Vector<ushort> offset = value - surrogateStart;
+            return Vector.LessThanOrEqualAny(offset, surrogateRange);
+        }
+
+        private static Vector<ushort> FromBigEndian(Vector<ushort> value) =>
+            BitConverter.IsLittleEndian ? ReverseEndianness(value) : value;
+
+        private static Vector<ushort> ToBigEndian(Vector<ushort> value) =>
+            BitConverter.IsLittleEndian ? ReverseEndianness(value) : value;
+
+        private static Vector<ushort> ReverseEndianness(Vector<ushort> value) => (value << 8) | (value >> 8);
     }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.net.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.net.cs
@@ -99,20 +99,20 @@ namespace System.Formats.Asn1
         private int GetBytesVectorized(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
         {
             int available = write ? Math.Min(chars.Length, bytes.Length) : chars.Length;
-            int vectorizedLength = available - (available % Vector<byte>.Count);
             int position = 0;
 
             Debug.Assert(Vector<byte>.Count == 2 * Vector<ushort>.Count);
 
             // Revisit this cast when Vector<char> is supported: https://github.com/dotnet/runtime/issues/127611
-            ReadOnlySpan<ushort> source = MemoryMarshal.Cast<char, ushort>(chars);
+            ReadOnlySpan<ushort> source = MemoryMarshal.Cast<char, ushort>(chars).Slice(0, available);
+            Span<byte> destination = write ? bytes.Slice(0, available) : Span<byte>.Empty;
             Vector<ushort> minCharAllowed = new Vector<ushort>(_minCharAllowed);
             Vector<ushort> range = new Vector<ushort>(_range);
 
-            for (; position < vectorizedLength; position += Vector<byte>.Count)
+            while (source.Length >= Vector<byte>.Count)
             {
-                Vector<ushort> lower = new Vector<ushort>(source.Slice(position));
-                Vector<ushort> upper = new Vector<ushort>(source.Slice(position + Vector<ushort>.Count));
+                Vector<ushort> lower = new Vector<ushort>(source);
+                Vector<ushort> upper = new Vector<ushort>(source.Slice(Vector<ushort>.Count));
 
                 if (!IsAllowed(lower, minCharAllowed, range) || !IsAllowed(upper, minCharAllowed, range))
                 {
@@ -124,8 +124,12 @@ namespace System.Formats.Asn1
 
                 if (write)
                 {
-                    Vector.Narrow(lower, upper).CopyTo(bytes.Slice(position));
+                    Vector.Narrow(lower, upper).CopyTo(destination);
+                    destination = destination.Slice(Vector<byte>.Count);
                 }
+
+                source = source.Slice(Vector<byte>.Count);
+                position += Vector<byte>.Count;
             }
 
             return position;
@@ -134,21 +138,23 @@ namespace System.Formats.Asn1
         private int GetCharsVectorized(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
         {
             int available = write ? Math.Min(bytes.Length, chars.Length) : bytes.Length;
-            int vectorizedLength = available - (available % Vector<byte>.Count);
             int position = 0;
 
             Debug.Assert(Vector<byte>.Count == 2 * Vector<ushort>.Count);
 
+            ReadOnlySpan<byte> source = bytes.Slice(0, available);
             // Revisit this cast when Vector<char> is supported: https://github.com/dotnet/runtime/issues/127611
-            Span<ushort> destination = write ? MemoryMarshal.Cast<char, ushort>(chars) : Span<ushort>.Empty;
+            Span<ushort> destination = write ?
+                MemoryMarshal.Cast<char, ushort>(chars).Slice(0, available) :
+                Span<ushort>.Empty;
             Vector<byte> minCharAllowed = new Vector<byte>(_minCharAllowed);
             Vector<byte> range = new Vector<byte>(_range);
 
-            for (; position < vectorizedLength; position += Vector<byte>.Count)
+            while (source.Length >= Vector<byte>.Count)
             {
-                Vector<byte> source = new Vector<byte>(bytes.Slice(position));
+                Vector<byte> value = new Vector<byte>(source);
 
-                if (!IsAllowed(source, minCharAllowed, range))
+                if (!IsAllowed(value, minCharAllowed, range))
                 {
                     // If any element in the vector is not allowed, we break out and return the position before the
                     // current vector's width so that it goes down the scalar path. The scalar path will determine the
@@ -158,10 +164,14 @@ namespace System.Formats.Asn1
 
                 if (write)
                 {
-                    Vector.Widen(source, out Vector<ushort> lower, out Vector<ushort> upper);
-                    lower.CopyTo(destination.Slice(position));
-                    upper.CopyTo(destination.Slice(position + Vector<ushort>.Count));
+                    Vector.Widen(value, out Vector<ushort> lower, out Vector<ushort> upper);
+                    lower.CopyTo(destination);
+                    upper.CopyTo(destination.Slice(Vector<ushort>.Count));
+                    destination = destination.Slice(Vector<byte>.Count);
                 }
+
+                source = source.Slice(Vector<byte>.Count);
+                position += Vector<byte>.Count;
             }
 
             return position;
@@ -293,18 +303,19 @@ namespace System.Formats.Asn1
         private static int GetBytesVectorized(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
         {
             int available = write ? Math.Min(chars.Length, bytes.Length / sizeof(ushort)) : chars.Length;
-            int vectorizedLength = available - (available % Vector<ushort>.Count);
             int position = 0;
 
             // Revisit this cast when Vector<char> is supported: https://github.com/dotnet/runtime/issues/127611
-            ReadOnlySpan<ushort> source = MemoryMarshal.Cast<char, ushort>(chars);
-            Span<ushort> destination = write ? MemoryMarshal.Cast<byte, ushort>(bytes) : Span<ushort>.Empty;
+            ReadOnlySpan<ushort> source = MemoryMarshal.Cast<char, ushort>(chars).Slice(0, available);
+            Span<ushort> destination = write ?
+                MemoryMarshal.Cast<byte, ushort>(bytes).Slice(0, available) :
+                Span<ushort>.Empty;
             Vector<ushort> surrogateStart = new Vector<ushort>(SurrogateStart);
             Vector<ushort> surrogateRange = new Vector<ushort>(SurrogateRange);
 
-            for (; position < vectorizedLength; position += Vector<ushort>.Count)
+            while (source.Length >= Vector<ushort>.Count)
             {
-                Vector<ushort> value = new Vector<ushort>(source.Slice(position));
+                Vector<ushort> value = new Vector<ushort>(source);
 
                 if (ContainsSurrogate(value, surrogateStart, surrogateRange))
                 {
@@ -314,8 +325,12 @@ namespace System.Formats.Asn1
 
                 if (write)
                 {
-                    ToBigEndian(value).CopyTo(destination.Slice(position));
+                    ToBigEndian(value).CopyTo(destination);
+                    destination = destination.Slice(Vector<ushort>.Count);
                 }
+
+                source = source.Slice(Vector<ushort>.Count);
+                position += Vector<ushort>.Count;
             }
 
             return position;
@@ -325,17 +340,18 @@ namespace System.Formats.Asn1
         {
             int sourceLength = bytes.Length / sizeof(ushort);
             int available = write ? Math.Min(sourceLength, chars.Length) : sourceLength;
-            int vectorizedLength = available - (available % Vector<ushort>.Count);
             int position = 0;
 
-            ReadOnlySpan<ushort> source = MemoryMarshal.Cast<byte, ushort>(bytes);
-            Span<ushort> destination = write ? MemoryMarshal.Cast<char, ushort>(chars) : Span<ushort>.Empty;
+            ReadOnlySpan<ushort> source = MemoryMarshal.Cast<byte, ushort>(bytes).Slice(0, available);
+            Span<ushort> destination = write ?
+                MemoryMarshal.Cast<char, ushort>(chars).Slice(0, available) :
+                Span<ushort>.Empty;
             Vector<ushort> surrogateStart = new Vector<ushort>(SurrogateStart);
             Vector<ushort> surrogateRange = new Vector<ushort>(SurrogateRange);
 
-            for (; position < vectorizedLength; position += Vector<ushort>.Count)
+            while (source.Length >= Vector<ushort>.Count)
             {
-                Vector<ushort> value = FromBigEndian(new Vector<ushort>(source.Slice(position)));
+                Vector<ushort> value = FromBigEndian(new Vector<ushort>(source));
 
                 if (ContainsSurrogate(value, surrogateStart, surrogateRange))
                 {
@@ -345,8 +361,12 @@ namespace System.Formats.Asn1
 
                 if (write)
                 {
-                    value.CopyTo(destination.Slice(position));
+                    value.CopyTo(destination);
+                    destination = destination.Slice(Vector<ushort>.Count);
                 }
+
+                source = source.Slice(Vector<ushort>.Count);
+                position += Vector<ushort>.Count;
             }
 
             return position;

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadBMPString.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadBMPString.cs
@@ -1,9 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using Test.Cryptography;
 using Xunit;
 
@@ -33,6 +36,16 @@ namespace System.Formats.Asn1.Tests.Reader
 
     public abstract class ReadBMPStringBase
     {
+        public static IEnumerable<object[]> VectorBoundaryLengths
+        {
+            get
+            {
+                yield return new object[] { Vector<ushort>.Count - 1 };
+                yield return new object[] { Vector<ushort>.Count };
+                yield return new object[] { Vector<ushort>.Count + 1 };
+            }
+        }
+
         internal abstract AsnReaderWrapper CreateWrapper(
             ReadOnlyMemory<byte> data,
             AsnEncodingRules ruleSet,
@@ -144,6 +157,74 @@ namespace System.Formats.Asn1.Tests.Reader
                     "Dr. & Mrs. Smith\u2010Jones \uFE60 children",
                 },
             };
+
+        [Theory]
+        [MemberData(nameof(VectorBoundaryLengths))]
+        public void ReadBMPString_DoesNotAccessOutsideBounds(int charCount)
+        {
+            int payloadLength = charCount * sizeof(ushort);
+            AssertExtensions.LessThan(payloadLength, 128);
+
+            using BoundedMemory<byte> encoded = BoundedMemory.Allocate<byte>(payloadLength + 2);
+            using BoundedMemory<char> destination = BoundedMemory.Allocate<char>(charCount);
+
+            encoded.Span[0] = (byte)UniversalTagNumber.BMPString;
+            encoded.Span[1] = (byte)payloadLength;
+
+            for (int i = 0; i < charCount; i++)
+            {
+                char value = i % 2 == 0 ? '\uD7FF' : '\uE000';
+                int byteIndex = 2 + (i * sizeof(ushort));
+                encoded.Span[byteIndex] = (byte)(value >> 8);
+                encoded.Span[byteIndex + 1] = (byte)value;
+            }
+
+            encoded.MakeReadonly();
+
+            AsnReaderWrapper reader = CreateWrapper(encoded.Memory, AsnEncodingRules.DER);
+            Assert.True(reader.TryCopyBMPString(destination.Span, out int charsWritten));
+            Assert.Equal(charCount, charsWritten);
+
+            for (int i = 0; i < charsWritten; i++)
+            {
+                Assert.Equal(i % 2 == 0 ? '\uD7FF' : '\uE000', destination.Span[i]);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, '\uD800')]
+        [InlineData(true, '\uDFFF')]
+        [InlineData(false, '\uD800')]
+        [InlineData(false, '\uDFFF')]
+        public void ReadBMPString_InvalidSurrogateInVectorOrTail(bool invalidInVector, char invalidValue)
+        {
+            int invalidIndex = invalidInVector ? 1 : Vector<ushort>.Count;
+            int charCount = Vector<ushort>.Count + 1;
+            int payloadLength = charCount * sizeof(ushort);
+            AssertExtensions.LessThan(payloadLength, 128);
+
+            byte[] encoded = new byte[payloadLength + 2];
+            encoded[0] = (byte)UniversalTagNumber.BMPString;
+            encoded[1] = (byte)payloadLength;
+
+            for (int i = 2; i < encoded.Length; i += sizeof(ushort))
+            {
+                encoded[i] = 0;
+                encoded[i + 1] = (byte)'A';
+            }
+
+            encoded[2 + (invalidIndex * sizeof(ushort))] = (byte)(invalidValue >> 8);
+            encoded[3 + (invalidIndex * sizeof(ushort))] = (byte)invalidValue;
+
+            AsnContentException exception = Assert.Throws<AsnContentException>(
+                () => AsnDecoder.ReadCharacterString(
+                    encoded,
+                    AsnEncodingRules.DER,
+                    UniversalTagNumber.BMPString,
+                    out _));
+            DecoderFallbackException fallback = Assert.IsType<DecoderFallbackException>(exception.InnerException);
+            Assert.Equal(invalidIndex * sizeof(ushort), fallback.Index);
+        }
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]

--- a/src/libraries/System.Formats.Asn1/tests/Writer/WriteBMPString.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/WriteBMPString.cs
@@ -1,13 +1,26 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
 using Xunit;
 
 namespace System.Formats.Asn1.Tests.Writer
 {
     public class WriteBMPString : WriteCharacterString
     {
+        public static IEnumerable<object[]> VectorBoundaryLengths
+        {
+            get
+            {
+                yield return new object[] { Vector<ushort>.Count - 1 };
+                yield return new object[] { Vector<ushort>.Count };
+                yield return new object[] { Vector<ushort>.Count + 1 };
+            }
+        }
+
         public static IEnumerable<object[]> ShortValidCases { get; } = new object[][]
         {
             new object[]
@@ -74,6 +87,55 @@ namespace System.Formats.Asn1.Tests.Writer
             writer.WriteCharacterString(UniversalTagNumber.BMPString, s, tag);
 
         internal override Asn1Tag StandardTag => new Asn1Tag(UniversalTagNumber.BMPString);
+
+        [Theory]
+        [MemberData(nameof(VectorBoundaryLengths))]
+        public void WriteBMPString_DoesNotAccessOutsideBounds(int charCount)
+        {
+            using BoundedMemory<char> value = BoundedMemory.Allocate<char>(charCount);
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                value.Span[i] = i % 2 == 0 ? '\uD7FF' : '\uE000';
+            }
+
+            value.MakeReadonly();
+
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+            writer.WriteCharacterString(UniversalTagNumber.BMPString, value.Span);
+            byte[] encoded = writer.Encode();
+
+            string decoded = AsnDecoder.ReadCharacterString(
+                encoded,
+                AsnEncodingRules.DER,
+                UniversalTagNumber.BMPString,
+                out int bytesConsumed);
+            Assert.Equal(encoded.Length, bytesConsumed);
+            Assert.Equal(charCount, decoded.Length);
+
+            for (int i = 0; i < decoded.Length; i++)
+            {
+                Assert.Equal(i % 2 == 0 ? '\uD7FF' : '\uE000', decoded[i]);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, '\uD800')]
+        [InlineData(true, '\uDFFF')]
+        [InlineData(false, '\uD800')]
+        [InlineData(false, '\uDFFF')]
+        public void WriteBMPString_InvalidSurrogateInVectorOrTail(bool invalidInVector, char invalidValue)
+        {
+            int invalidIndex = invalidInVector ? 1 : Vector<ushort>.Count;
+            char[] value = new string('A', Vector<ushort>.Count + 1).ToCharArray();
+            value[invalidIndex] = invalidValue;
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+
+            EncoderFallbackException exception = Assert.Throws<EncoderFallbackException>(
+                () => writer.WriteCharacterString(UniversalTagNumber.BMPString, value));
+            Assert.Equal(invalidIndex, exception.Index);
+            Assert.Equal(0, writer.GetEncodedLength());
+        }
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]


### PR DESCRIPTION
As a follow up to https://github.com/dotnet/runtime/pull/131109, this introduces vectorization for the `BMPEncoding`.

BMPEncoding is big-endian UCS-2 encoding. It is a subset of UTF-16-BE, with the exception that it is truly fixed width and only supports plane 0 without the surrogate pairs.

Performance is largely improved across the board. Small inputs, like country codes, regress ~0.5ns simply because the method body itself has slightly more register pressure. Other inputs like common names, etc. see notable performance improvements.

This also incorporates some feedback about making the SIMD more JIT-friendly into the existing IA5 and VisibleString encoding.

<details>
<summary>Performance Benchmarks</summary>

Source: https://gist.github.com/vcsjones/4b91a33bcae337333cb26d46fd087bf9

```

BenchmarkDotNet v0.15.8, macOS Tahoe 26.5.2 (25F84) [Darwin 25.5.0]
Apple M1 Ultra, 1 CPU, 20 logical and 20 physical cores
  [Host] : .NET 11.0.0 (11.0.0-dev, 42.42.42.42424), Arm64 RyuJIT armv8.0-a
  Main   : .NET 11.0.0 (11.0.0-dev, 42.42.42.42424), Arm64 RyuJIT armv8.0-a
  Vector : .NET 11.0.0 (11.0.0-dev, 42.42.42.42424), Arm64 RyuJIT armv8.0-a

Runtime=.NET 10.0  IterationCount=15  WarmupCount=5  

```
| Method    | Job    | Toolchain | Alignment | Input       | Mean        | Error    | StdDev   | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|---------- |------- |---------- |---------- |------------ |------------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
| **Decode**    | **Main**   | **Main**      | **Aligned**   | **CountryCode** |    **14.27 ns** | **0.037 ns** | **0.031 ns** |  **1.00** |    **0.00** | **0.0051** |      **-** |      **32 B** |        **1.00** |
| Decode    | Vector | Vector    | Aligned   | CountryCode |    14.97 ns | 0.031 ns | 0.029 ns |  1.05 |    0.00 | 0.0051 |      - |      32 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Aligned   | CountryCode |    11.34 ns | 0.012 ns | 0.011 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Aligned   | CountryCode |    11.74 ns | 0.007 ns | 0.006 ns |  1.04 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Aligned   | CountryCode |    16.13 ns | 0.043 ns | 0.040 ns |  1.00 |    0.00 | 0.0127 |      - |      80 B |        1.00 |
| Write     | Vector | Vector    | Aligned   | CountryCode |    16.79 ns | 0.044 ns | 0.039 ns |  1.04 |    0.00 | 0.0127 |      - |      80 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Aligned**   | **CommonName**  |    **56.85 ns** | **0.073 ns** | **0.068 ns** |  **1.00** |    **0.00** | **0.0127** |      **-** |      **80 B** |        **1.00** |
| Decode    | Vector | Vector    | Aligned   | CommonName  |    26.71 ns | 0.040 ns | 0.035 ns |  0.47 |    0.00 | 0.0127 |      - |      80 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Aligned   | CommonName  |    52.77 ns | 0.033 ns | 0.029 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Aligned   | CommonName  |    21.71 ns | 0.038 ns | 0.034 ns |  0.41 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Aligned   | CommonName  |    43.31 ns | 0.067 ns | 0.060 ns |  1.00 |    0.00 | 0.0216 |      - |     136 B |        1.00 |
| Write     | Vector | Vector    | Aligned   | CommonName  |    26.72 ns | 0.394 ns | 0.349 ns |  0.62 |    0.01 | 0.0217 |      - |     136 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Aligned**   | **UnicodeName** |    **28.28 ns** | **0.078 ns** | **0.069 ns** |  **1.00** |    **0.00** | **0.0076** |      **-** |      **48 B** |        **1.00** |
| Decode    | Vector | Vector    | Aligned   | UnicodeName |    19.37 ns | 0.037 ns | 0.034 ns |  0.68 |    0.00 | 0.0076 |      - |      48 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Aligned   | UnicodeName |    24.90 ns | 0.039 ns | 0.032 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Aligned   | UnicodeName |    15.75 ns | 0.024 ns | 0.020 ns |  0.63 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Aligned   | UnicodeName |    25.70 ns | 0.397 ns | 0.371 ns |  1.00 |    0.02 | 0.0166 |      - |     104 B |        1.00 |
| Write     | Vector | Vector    | Aligned   | UnicodeName |    20.71 ns | 0.040 ns | 0.037 ns |  0.81 |    0.01 | 0.0166 |      - |     104 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Aligned**   | **Length8**     |    **23.64 ns** | **0.012 ns** | **0.011 ns** |  **1.00** |    **0.00** | **0.0063** |      **-** |      **40 B** |        **1.00** |
| Decode    | Vector | Vector    | Aligned   | Length8     |    14.63 ns | 0.044 ns | 0.041 ns |  0.62 |    0.00 | 0.0063 |      - |      40 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Aligned   | Length8     |    20.37 ns | 0.020 ns | 0.019 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Aligned   | Length8     |    11.74 ns | 0.020 ns | 0.016 ns |  0.58 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Aligned   | Length8     |    22.18 ns | 0.062 ns | 0.058 ns |  1.00 |    0.00 | 0.0153 |      - |      96 B |        1.00 |
| Write     | Vector | Vector    | Aligned   | Length8     |    17.24 ns | 0.064 ns | 0.057 ns |  0.78 |    0.00 | 0.0153 |      - |      96 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Aligned**   | **Length16**    |    **36.07 ns** | **0.010 ns** | **0.008 ns** |  **1.00** |    **0.00** | **0.0089** |      **-** |      **56 B** |        **1.00** |
| Decode    | Vector | Vector    | Aligned   | Length16    |    16.58 ns | 0.027 ns | 0.025 ns |  0.46 |    0.00 | 0.0089 |      - |      56 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Aligned   | Length16    |    32.38 ns | 0.046 ns | 0.043 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Aligned   | Length16    |    13.21 ns | 0.030 ns | 0.025 ns |  0.41 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Aligned   | Length16    |    30.14 ns | 0.054 ns | 0.051 ns |  1.00 |    0.00 | 0.0178 |      - |     112 B |        1.00 |
| Write     | Vector | Vector    | Aligned   | Length16    |    19.41 ns | 0.356 ns | 0.315 ns |  0.64 |    0.01 | 0.0179 |      - |     112 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Aligned**   | **Length32**    |    **61.89 ns** | **0.310 ns** | **0.290 ns** |  **1.00** |    **0.01** | **0.0139** |      **-** |      **88 B** |        **1.00** |
| Decode    | Vector | Vector    | Aligned   | Length32    |    21.06 ns | 0.647 ns | 0.605 ns |  0.34 |    0.01 | 0.0140 |      - |      88 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Aligned   | Length32    |    58.35 ns | 0.375 ns | 0.332 ns |  1.00 |    0.01 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Aligned   | Length32    |    16.27 ns | 0.343 ns | 0.268 ns |  0.28 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Aligned   | Length32    |    47.59 ns | 0.814 ns | 0.680 ns |  1.00 |    0.02 | 0.0229 |      - |     144 B |        1.00 |
| Write     | Vector | Vector    | Aligned   | Length32    |    23.47 ns | 0.717 ns | 0.671 ns |  0.49 |    0.02 | 0.0229 |      - |     144 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Aligned**   | **Length64**    |   **123.09 ns** | **1.822 ns** | **1.704 ns** |  **1.00** |    **0.02** | **0.0241** |      **-** |     **152 B** |        **1.00** |
| Decode    | Vector | Vector    | Aligned   | Length64    |    30.67 ns | 0.297 ns | 0.278 ns |  0.25 |    0.00 | 0.0242 |      - |     152 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Aligned   | Length64    |   117.53 ns | 0.437 ns | 0.409 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Aligned   | Length64    |    23.48 ns | 0.103 ns | 0.091 ns |  0.20 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Aligned   | Length64    |    83.22 ns | 0.652 ns | 0.578 ns |  1.00 |    0.01 | 0.0331 |      - |     208 B |        1.00 |
| Write     | Vector | Vector    | Aligned   | Length64    |    31.31 ns | 0.323 ns | 0.286 ns |  0.38 |    0.00 | 0.0331 |      - |     208 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Aligned**   | **Length256**   |   **460.07 ns** | **0.758 ns** | **0.709 ns** |  **1.00** |    **0.00** | **0.0854** |      **-** |     **536 B** |        **1.00** |
| Decode    | Vector | Vector    | Aligned   | Length256   |    73.86 ns | 0.125 ns | 0.104 ns |  0.16 |    0.00 | 0.0854 |      - |     536 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Aligned   | Length256   |   447.23 ns | 0.333 ns | 0.311 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Aligned   | Length256   |    54.62 ns | 0.059 ns | 0.055 ns |  0.12 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Aligned   | Length256   |   297.00 ns | 0.250 ns | 0.234 ns |  1.00 |    0.00 | 0.0939 |      - |     592 B |        1.00 |
| Write     | Vector | Vector    | Aligned   | Length256   |    71.91 ns | 0.080 ns | 0.071 ns |  0.24 |    0.00 | 0.0943 | 0.0001 |     592 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Aligned**   | **Length1024**  | **1,769.30 ns** | **1.602 ns** | **1.420 ns** |  **1.00** |    **0.00** | **0.3300** |      **-** |    **2072 B** |        **1.00** |
| Decode    | Vector | Vector    | Aligned   | Length1024  |   270.31 ns | 0.690 ns | 0.611 ns |  0.15 |    0.00 | 0.3300 |      - |    2072 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Aligned   | Length1024  | 1,693.69 ns | 1.338 ns | 1.252 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Aligned   | Length1024  |   195.24 ns | 0.092 ns | 0.086 ns |  0.12 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Aligned   | Length1024  | 1,119.74 ns | 1.917 ns | 1.700 ns |  1.00 |    0.00 | 0.3376 | 0.0019 |    2128 B |        1.00 |
| Write     | Vector | Vector    | Aligned   | Length1024  |   250.16 ns | 1.218 ns | 1.080 ns |  0.22 |    0.00 | 0.3390 | 0.0024 |    2128 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Unaligned** | **CountryCode** |    **14.42 ns** | **0.127 ns** | **0.119 ns** |  **1.00** |    **0.01** | **0.0051** |      **-** |      **32 B** |        **1.00** |
| Decode    | Vector | Vector    | Unaligned | CountryCode |    15.08 ns | 0.040 ns | 0.033 ns |  1.05 |    0.01 | 0.0051 |      - |      32 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Unaligned | CountryCode |    11.31 ns | 0.021 ns | 0.018 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Unaligned | CountryCode |    11.63 ns | 0.021 ns | 0.020 ns |  1.03 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Unaligned | CountryCode |    16.89 ns | 0.182 ns | 0.170 ns |  1.00 |    0.01 | 0.0127 |      - |      80 B |        1.00 |
| Write     | Vector | Vector    | Unaligned | CountryCode |    17.38 ns | 0.043 ns | 0.038 ns |  1.03 |    0.01 | 0.0127 |      - |      80 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Unaligned** | **CommonName**  |    **56.72 ns** | **0.067 ns** | **0.056 ns** |  **1.00** |    **0.00** | **0.0127** |      **-** |      **80 B** |        **1.00** |
| Decode    | Vector | Vector    | Unaligned | CommonName  |    26.71 ns | 0.057 ns | 0.053 ns |  0.47 |    0.00 | 0.0127 |      - |      80 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Unaligned | CommonName  |    52.68 ns | 0.068 ns | 0.064 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Unaligned | CommonName  |    21.68 ns | 0.018 ns | 0.017 ns |  0.41 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Unaligned | CommonName  |    43.62 ns | 0.035 ns | 0.033 ns |  1.00 |    0.00 | 0.0216 |      - |     136 B |        1.00 |
| Write     | Vector | Vector    | Unaligned | CommonName  |    26.82 ns | 0.068 ns | 0.064 ns |  0.61 |    0.00 | 0.0217 |      - |     136 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Unaligned** | **UnicodeName** |    **28.22 ns** | **0.061 ns** | **0.057 ns** |  **1.00** |    **0.00** | **0.0076** |      **-** |      **48 B** |        **1.00** |
| Decode    | Vector | Vector    | Unaligned | UnicodeName |    19.32 ns | 0.033 ns | 0.031 ns |  0.68 |    0.00 | 0.0076 |      - |      48 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Unaligned | UnicodeName |    24.74 ns | 0.022 ns | 0.021 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Unaligned | UnicodeName |    15.72 ns | 0.023 ns | 0.022 ns |  0.64 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Unaligned | UnicodeName |    25.81 ns | 0.032 ns | 0.030 ns |  1.00 |    0.00 | 0.0166 |      - |     104 B |        1.00 |
| Write     | Vector | Vector    | Unaligned | UnicodeName |    21.11 ns | 0.033 ns | 0.031 ns |  0.82 |    0.00 | 0.0166 |      - |     104 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Unaligned** | **Length8**     |    **23.47 ns** | **0.032 ns** | **0.030 ns** |  **1.00** |    **0.00** | **0.0063** |      **-** |      **40 B** |        **1.00** |
| Decode    | Vector | Vector    | Unaligned | Length8     |    14.49 ns | 0.036 ns | 0.034 ns |  0.62 |    0.00 | 0.0063 |      - |      40 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Unaligned | Length8     |    20.27 ns | 0.025 ns | 0.022 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Unaligned | Length8     |    11.39 ns | 0.004 ns | 0.003 ns |  0.56 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Unaligned | Length8     |    22.72 ns | 0.080 ns | 0.062 ns |  1.00 |    0.00 | 0.0153 |      - |      96 B |        1.00 |
| Write     | Vector | Vector    | Unaligned | Length8     |    18.17 ns | 0.627 ns | 0.586 ns |  0.80 |    0.03 | 0.0153 |      - |      96 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Unaligned** | **Length16**    |    **36.14 ns** | **0.537 ns** | **0.476 ns** |  **1.00** |    **0.02** | **0.0089** |      **-** |      **56 B** |        **1.00** |
| Decode    | Vector | Vector    | Unaligned | Length16    |    16.50 ns | 0.147 ns | 0.114 ns |  0.46 |    0.01 | 0.0089 |      - |      56 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Unaligned | Length16    |    32.57 ns | 0.478 ns | 0.447 ns |  1.00 |    0.02 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Unaligned | Length16    |    12.89 ns | 0.022 ns | 0.020 ns |  0.40 |    0.01 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Unaligned | Length16    |    31.11 ns | 0.646 ns | 0.604 ns |  1.00 |    0.03 | 0.0178 |      - |     112 B |        1.00 |
| Write     | Vector | Vector    | Unaligned | Length16    |    19.64 ns | 0.068 ns | 0.064 ns |  0.63 |    0.01 | 0.0179 |      - |     112 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Unaligned** | **Length32**    |    **61.77 ns** | **0.095 ns** | **0.084 ns** |  **1.00** |    **0.00** | **0.0139** |      **-** |      **88 B** |        **1.00** |
| Decode    | Vector | Vector    | Unaligned | Length32    |    20.65 ns | 0.032 ns | 0.028 ns |  0.33 |    0.00 | 0.0140 |      - |      88 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Unaligned | Length32    |    57.64 ns | 0.049 ns | 0.046 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Unaligned | Length32    |    15.87 ns | 0.013 ns | 0.012 ns |  0.28 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Unaligned | Length32    |    47.41 ns | 0.314 ns | 0.294 ns |  1.00 |    0.01 | 0.0229 |      - |     144 B |        1.00 |
| Write     | Vector | Vector    | Unaligned | Length32    |    23.44 ns | 0.072 ns | 0.068 ns |  0.49 |    0.00 | 0.0229 |      - |     144 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Unaligned** | **Length64**    |   **123.07 ns** | **0.224 ns** | **0.199 ns** |  **1.00** |    **0.00** | **0.0241** |      **-** |     **152 B** |        **1.00** |
| Decode    | Vector | Vector    | Unaligned | Length64    |    29.79 ns | 0.068 ns | 0.063 ns |  0.24 |    0.00 | 0.0242 |      - |     152 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Unaligned | Length64    |   117.86 ns | 1.290 ns | 1.077 ns |  1.00 |    0.01 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Unaligned | Length64    |    23.68 ns | 0.010 ns | 0.008 ns |  0.20 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Unaligned | Length64    |    85.83 ns | 0.225 ns | 0.211 ns |  1.00 |    0.00 | 0.0331 |      - |     208 B |        1.00 |
| Write     | Vector | Vector    | Unaligned | Length64    |    31.51 ns | 0.062 ns | 0.058 ns |  0.37 |    0.00 | 0.0331 |      - |     208 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Unaligned** | **Length256**   |   **462.01 ns** | **0.529 ns** | **0.495 ns** |  **1.00** |    **0.00** | **0.0854** |      **-** |     **536 B** |        **1.00** |
| Decode    | Vector | Vector    | Unaligned | Length256   |    73.40 ns | 0.129 ns | 0.114 ns |  0.16 |    0.00 | 0.0854 |      - |     536 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Unaligned | Length256   |   436.59 ns | 0.388 ns | 0.344 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Unaligned | Length256   |    53.95 ns | 0.054 ns | 0.051 ns |  0.12 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Unaligned | Length256   |   299.77 ns | 0.426 ns | 0.398 ns |  1.00 |    0.00 | 0.0939 |      - |     592 B |        1.00 |
| Write     | Vector | Vector    | Unaligned | Length256   |    73.73 ns | 0.133 ns | 0.124 ns |  0.25 |    0.00 | 0.0943 | 0.0001 |     592 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| **Decode**    | **Main**   | **Main**      | **Unaligned** | **Length1024**  | **1,770.61 ns** | **1.237 ns** | **1.033 ns** |  **1.00** |    **0.00** | **0.3300** |      **-** |    **2072 B** |        **1.00** |
| Decode    | Vector | Vector    | Unaligned | Length1024  |   269.57 ns | 0.657 ns | 0.583 ns |  0.15 |    0.00 | 0.3300 |      - |    2072 B |        1.00 |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| TryDecode | Main   | Main      | Unaligned | Length1024  | 1,692.96 ns | 1.859 ns | 1.739 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
| TryDecode | Vector | Vector    | Unaligned | Length1024  |   194.38 ns | 0.181 ns | 0.169 ns |  0.11 |    0.00 |      - |      - |         - |          NA |
|           |        |           |           |             |             |          |          |       |         |        |        |           |             |
| Write     | Main   | Main      | Unaligned | Length1024  | 1,127.43 ns | 1.654 ns | 1.548 ns |  1.00 |    0.00 | 0.3376 | 0.0019 |    2128 B |        1.00 |
| Write     | Vector | Vector    | Unaligned | Length1024  |   251.62 ns | 0.766 ns | 0.717 ns |  0.22 |    0.00 | 0.3390 | 0.0024 |    2128 B |        1.00 |
</details>