### PR TITLE
Use WriteFourDigits for UInt64 formatting

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -2314,8 +2314,16 @@ namespace System
 #else
             if (value >= 10)
             {
-                // Handle all values >= 100 two-digits at a time so as to avoid expensive integer division operations.
-                while (value >= 100)
+                // Handle all values >= 10000 four-digits at a time so as to avoid expensive integer division operations.
+                while (value >= 10_000)
+                {
+                    bufferEnd -= 4;
+                    (value, ulong remainder) = Math.DivRem(value, 10_000);
+                    WriteFourDigits((uint)remainder, bufferEnd);
+                }
+
+                // If there are at least three digits remaining, store two of them.
+                if (value >= 100)
                 {
                     bufferEnd -= 2;
                     (value, ulong remainder) = Math.DivRem(value, 100);
@@ -2353,7 +2361,15 @@ namespace System
             return UInt32ToDecChars(bufferEnd, (uint)value, digits);
 #else
             ulong remainder;
-            while (value >= 100)
+            while (value >= 10_000)
+            {
+                bufferEnd -= 4;
+                digits -= 4;
+                (value, remainder) = Math.DivRem(value, 10_000);
+                WriteFourDigits((uint)remainder, bufferEnd);
+            }
+
+            if (value >= 100)
             {
                 bufferEnd -= 2;
                 digits -= 2;


### PR DESCRIPTION
## Summary

- Process `UInt64` values four digits at a time on 64-bit targets.
- Use the existing `WriteFourDigits` helper in both `UInt64ToDecChars` overloads.
- Retain the existing two- and one-digit handling for the remaining digits.

## Testing

- Checked CoreLib, native CoreLib, and library testhost build
- `System.Runtime.Tests`: 68,746 passed, 0 failed

Performance will be measured with EgorBot after opening the PR.

> [!NOTE]
> GitHub Copilot helped create this PR.