### PR TITLE
Make XsdDataContractExporter export consistent for ctor-less collections

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -58,17 +58,17 @@ namespace System.Runtime.Serialization.DataContracts
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal static DataContract GetDataContract(Type type)
+        internal static DataContract GetDataContract(Type type, bool verifyConstructor = true)
         {
-            return GetDataContract(type.TypeHandle);
+            return GetDataContract(type.TypeHandle, verifyConstructor);
         }
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal static DataContract GetDataContract(RuntimeTypeHandle typeHandle)
+        internal static DataContract GetDataContract(RuntimeTypeHandle typeHandle, bool verifyConstructor = true)
         {
             int id = GetId(typeHandle);
-            DataContract dataContract = GetDataContractSkipValidation(id, typeHandle, null);
+            DataContract dataContract = GetDataContractSkipValidation(id, typeHandle, null, verifyConstructor);
             return dataContract.GetValidContract();
         }
 
@@ -82,9 +82,9 @@ namespace System.Runtime.Serialization.DataContracts
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal static DataContract GetDataContractSkipValidation(int id, RuntimeTypeHandle typeHandle, Type? type)
+        internal static DataContract GetDataContractSkipValidation(int id, RuntimeTypeHandle typeHandle, Type? type, bool verifyConstructor = true)
         {
-            return DataContractCriticalHelper.GetDataContractSkipValidation(id, typeHandle, type);
+            return DataContractCriticalHelper.GetDataContractSkipValidation(id, typeHandle, type, verifyConstructor);
         }
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
@@ -350,7 +350,7 @@ namespace System.Runtime.Serialization.DataContracts
 
             [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
             [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-            internal static DataContract GetDataContractSkipValidation(int id, RuntimeTypeHandle typeHandle, Type? type)
+            internal static DataContract GetDataContractSkipValidation(int id, RuntimeTypeHandle typeHandle, Type? type, bool verifyConstructor = true)
             {
                 DataContract? dataContract = s_dataContractCache.GetItem(id);
                 if (dataContract == null)
@@ -359,7 +359,7 @@ namespace System.Runtime.Serialization.DataContracts
                 }
                 else
                 {
-                    return dataContract.GetValidContract(verifyConstructor: true);
+                    return dataContract.GetValidContract(verifyConstructor);
                 }
                 return dataContract;
             }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSet.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSet.cs
@@ -78,7 +78,7 @@ namespace System.Runtime.Serialization.DataContracts
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         internal void Add(Type type)
         {
-            DataContract dataContract = GetDataContract(type);
+            DataContract dataContract = GetDataContract(type, verifyConstructor: false);
             EnsureTypeNotGeneric(dataContract.UnderlyingType);
             Add(dataContract);
         }
@@ -224,17 +224,17 @@ namespace System.Runtime.Serialization.DataContracts
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public DataContract GetDataContract(Type type)
+        public DataContract GetDataContract(Type type, bool verifyConstructor = true)
         {
             if (_surrogateProvider == null)
-                return DataContract.GetDataContract(type);
+                return DataContract.GetDataContract(type, verifyConstructor);
 
             DataContract? dataContract = DataContract.GetBuiltInDataContract(type);
             if (dataContract != null)
                 return dataContract;
 
             Type dcType = DataContractSurrogateCaller.GetDataContractType(_surrogateProvider, type);
-            dataContract = DataContract.GetDataContract(dcType);
+            dataContract = DataContract.GetDataContract(dcType, verifyConstructor);
             if (_extendedSurrogateProvider != null && !SurrogateData.Contains(dataContract))
             {
                 object? customData = DataContractSurrogateCaller.GetCustomDataToExport(_extendedSurrogateProvider, type, dcType);
@@ -281,7 +281,7 @@ namespace System.Runtime.Serialization.DataContracts
                 }
                 else
                 {
-                    return GetDataContract(dataMemberType);
+                    return GetDataContract(dataMemberType, verifyConstructor: false);
                 }
             }
             return dataMember.MemberTypeContract;
@@ -292,7 +292,7 @@ namespace System.Runtime.Serialization.DataContracts
         internal DataContract GetItemTypeDataContract(CollectionDataContract collectionContract)
         {
             if (collectionContract.ItemType != null)
-                return GetDataContract(collectionContract.ItemType);
+                return GetDataContract(collectionContract.ItemType, verifyConstructor: false);
             return collectionContract.ItemContract;
         }
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSet.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSet.cs
@@ -224,7 +224,14 @@ namespace System.Runtime.Serialization.DataContracts
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public DataContract GetDataContract(Type type, bool verifyConstructor = true)
+        public DataContract GetDataContract(Type type)
+        {
+            return GetDataContract(type, verifyConstructor: true);
+        }
+
+        [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
+        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
+        private DataContract GetDataContract(Type type, bool verifyConstructor)
         {
             if (_surrogateProvider == null)
                 return DataContract.GetDataContract(type, verifyConstructor);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XsdDataContractExporter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XsdDataContractExporter.cs
@@ -191,7 +191,7 @@ namespace System.Runtime.Serialization
             ArgumentNullException.ThrowIfNull(type);
 
             type = GetSurrogatedType(type);
-            DataContract dataContract = DataContract.GetDataContract(type);
+            DataContract dataContract = DataContract.GetDataContract(type, verifyConstructor: false);
             EnsureTypeNotGeneric(dataContract.UnderlyingType);
             if (dataContract is XmlDataContract xmlDataContract && xmlDataContract.IsAnonymous)
                 return XmlQualifiedName.Empty;
@@ -210,7 +210,7 @@ namespace System.Runtime.Serialization
             ArgumentNullException.ThrowIfNull(type);
 
             type = GetSurrogatedType(type);
-            DataContract dataContract = DataContract.GetDataContract(type);
+            DataContract dataContract = DataContract.GetDataContract(type, verifyConstructor: false);
             EnsureTypeNotGeneric(dataContract.UnderlyingType);
             if (dataContract is XmlDataContract xmlDataContract && xmlDataContract.IsAnonymous)
                 return xmlDataContract.XsdType;
@@ -229,7 +229,7 @@ namespace System.Runtime.Serialization
             ArgumentNullException.ThrowIfNull(type);
 
             type = GetSurrogatedType(type);
-            DataContract dataContract = DataContract.GetDataContract(type);
+            DataContract dataContract = DataContract.GetDataContract(type, verifyConstructor: false);
             EnsureTypeNotGeneric(dataContract.UnderlyingType);
             if (dataContract is not XmlDataContract xdc || xdc.HasRoot) // All non-XmlDataContracts "have root".
             {

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XsdDataContractExporterTests/ExporterTypesTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XsdDataContractExporterTests/ExporterTypesTests.cs
@@ -76,16 +76,6 @@ namespace System.Runtime.Serialization.Xml.XsdDataContractExporterTests
             SchemaUtils.OrderedContains(@"<xs:schema xmlns:tns=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" elementFormDefault=""qualified"" targetNamespace=""http://schemas.microsoft.com/2003/10/Serialization/Arrays"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">", ref schemas);
         }
 
-        public static IEnumerable<object[]> GetDynamicallyVersionedTypesTestNegativeData()
-        {
-            // Need this case in a member data because inline data only accepts constant expressions
-            yield return new object[] {
-                typeof(TypeWithReadWriteCollectionAndNoCtorOnCollection),
-                typeof(InvalidDataContractException),
-                $@"System.Runtime.Serialization.Xml.XsdDataContractExporterTests.ExporterTypesTests+CollectionWithoutParameterlessCtor`1[[System.Runtime.Serialization.Xml.XsdDataContractExporterTests.ExporterTypesTests+Person, System.Runtime.Serialization.Xml.Tests, Version={Reflection.Assembly.GetExecutingAssembly().GetName().Version.Major}.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51]] does not have a default constructor."
-            };
-        }
-
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.DataSetXmlSerializationIsSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/82967", TestPlatforms.Browser | TestPlatforms.Wasi)]
         [InlineData(typeof(NoDataContractWithoutParameterlessConstructor), typeof(InvalidDataContractException), @"Type 'System.Runtime.Serialization.Xml.XsdDataContractExporterTests.ExporterTypesTests+NoDataContractWithoutParameterlessConstructor' cannot be serialized. Consider marking it with the DataContractAttribute attribute, and marking all of its members you want serialized with the DataMemberAttribute attribute. Alternatively, you can ensure that the type is public and has a parameterless constructor - all public members of the type will then be serialized, and no attributes will be required.")]
@@ -95,13 +85,51 @@ namespace System.Runtime.Serialization.Xml.XsdDataContractExporterTests
         [InlineData(typeof(ArrayContainer), typeof(InvalidOperationException), @"DataContract for type 'System.Runtime.Serialization.Xml.XsdDataContractExporterTests.ExporterTypesTests+ArrayB' cannot be added to DataContractSet since type 'System.Runtime.Serialization.Xml.XsdDataContractExporterTests.ExporterTypesTests+ArrayA' with the same data contract name 'Array' in namespace 'http://schemas.datacontract.org/2004/07/System.Runtime.Serialization.Xml.XsdDataContractExporterTests' is already present and the contracts are not equivalent.")]
         [InlineData(typeof(KeyValueNameSame), typeof(InvalidDataContractException), @"The collection data contract type 'System.Runtime.Serialization.Xml.XsdDataContractExporterTests.ExporterTypesTests+KeyValueNameSame' specifies the same value 'MyName' for both the KeyName and the ValueName properties. This is not allowed. Consider changing either the KeyName or the ValueName property.")]
         [InlineData(typeof(AnyWithRoot), typeof(InvalidDataContractException), @"Type 'System.Runtime.Serialization.Xml.XsdDataContractExporterTests.ExporterTypesTests+AnyWithRoot' cannot specify an XmlRootAttribute attribute because its IsAny setting is 'true'. This type must write all its contents including the root element. Verify that the IXmlSerializable implementation is correct.")]
-        [MemberData(nameof(GetDynamicallyVersionedTypesTestNegativeData))]
         public void TypesTest_Negative(Type badType, Type exType, string exMsg = null)
         {
             XsdDataContractExporter exporter = new XsdDataContractExporter();
             var ex = Assert.Throws(exType, () => exporter.Export(badType));
             if (exMsg != null)
                 Assert.Equal(exMsg, ex.Message);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.DataSetXmlSerializationIsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/82967", TestPlatforms.Browser | TestPlatforms.Wasi)]
+        // Unprimed: a collection type seen cold (read-write first) caches the "read-only contract" shape.
+        [InlineData(false, typeof(TypeWithReadWriteColdCollectionAndNoCtorOnCollection), "ArrayOfExporterTypesTests.ColdPerson")]
+        // Primed: a collection type first seen through a get-only member caches the "constructor-check" shape.
+        [InlineData(true, typeof(TypeWithReadWriteCollectionAndNoCtorOnCollection), "ArrayOfExporterTypesTests.Person")]
+        public void ReadWriteCollectionWithoutParameterlessConstructor_ExportsConsistently(bool primeGetOnlyContractFirst, Type containerType, string collectionSchemaName)
+        {
+            // A schema describes the shape of data, not whether an instance of a type can be
+            // constructed, so a collection type that lacks a parameterless constructor is still fully
+            // describable. Depending on whether such a collection is first seen through a get-only
+            // member or through a read-write reference, its DataContract is cached in one of two shapes
+            // in the process-global cache (first-write-wins). Exporting a read-write reference used to
+            // throw only when the get-only shape had been cached first - a purely cache-order-dependent
+            // difference, since a cold export of the identical type emitted schema without throwing.
+            // Export must now behave the same regardless of which shape was cached first.
+            //
+            // Because the cache keeps whichever shape it sees first, the two orderings use different
+            // collection types (keyed by their distinct item types) so both shapes can be produced
+            // deterministically in a single process: the primed case forces the get-only shape by
+            // exporting a get-only holder first; the unprimed case exports a read-write reference to a
+            // collection type that nothing else ever touches get-only, so it is always seen cold. Both
+            // must emit schema; neither may throw. The constructibility requirement is unchanged and is
+            // still enforced by the serializer at (de)serialization time.
+            if (primeGetOnlyContractFirst)
+            {
+                // Referencing the collection through a get-only member first caches its DataContract with
+                // the constructor-check flag set - the state that used to make the later read-write export throw.
+                new XsdDataContractExporter().Export(typeof(ReadOnlyCollectionWithoutCtorHolder));
+            }
+
+            XsdDataContractExporter exporter = new XsdDataContractExporter();
+            exporter.Export(containerType);
+
+            string schemas = SchemaUtils.DumpSchema(exporter.Schemas);
+            _output.WriteLine(schemas);
+            Assert.Contains($@"<xs:complexType name=""{collectionSchemaName}"">", schemas);
         }
 
         [Theory]
@@ -499,6 +527,24 @@ namespace System.Runtime.Serialization.Xml.XsdDataContractExporterTests
             }
         }
 
+        // Priming helper for ReadWriteCollectionWithoutParameterlessConstructor_ExportsConsistently.
+        // Referencing CollectionWithoutParameterlessCtor<Person> through a get-only member registers
+        // its DataContract in the process-global cache with the constructor-check flag set, without
+        // throwing - the cache state that historically made a later read-write reference throw.
+        public class ReadOnlyCollectionWithoutCtorHolder
+        {
+            private CollectionWithoutParameterlessCtor<Person> friends;
+
+            public CollectionWithoutParameterlessCtor<Person> Friends
+            {
+                get
+                {
+                    friends = friends ?? new CollectionWithoutParameterlessCtor<Person>(2);
+                    return friends;
+                }
+            }
+        }
+
         public class TypeWithReadWriteCollectionAndNoCtorOnCollection
         {
             private double[] potentialSalaries;
@@ -532,6 +578,35 @@ namespace System.Runtime.Serialization.Xml.XsdDataContractExporterTests
                 get
                 {
                     friends = friends ?? new CollectionWithoutParameterlessCtor<Person>(2);
+                    return friends;
+                }
+                set
+                {
+                    friends = value;
+                }
+            }
+        }
+
+        // Dedicated to the unprimed (cold) case of
+        // ReadWriteCollectionWithoutParameterlessConstructor_ExportsConsistently. ColdPerson exists only
+        // so CollectionWithoutParameterlessCtor<ColdPerson> is a distinct cache key that is seen exclusively
+        // through a read-write reference. Do NOT reference that collection through a get-only member
+        // anywhere, or the cold cache shape this case relies on will no longer be produced.
+        [Serializable]
+        public class ColdPerson
+        {
+            string name = "Jane Doe";
+        }
+
+        public class TypeWithReadWriteColdCollectionAndNoCtorOnCollection
+        {
+            CollectionWithoutParameterlessCtor<ColdPerson> friends;
+
+            public CollectionWithoutParameterlessCtor<ColdPerson> Friends
+            {
+                get
+                {
+                    friends = friends ?? new CollectionWithoutParameterlessCtor<ColdPerson>(2);
                     return friends;
                 }
                 set

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XsdDataContractExporterTests/ExporterTypesTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XsdDataContractExporterTests/ExporterTypesTests.cs
@@ -95,41 +95,61 @@ namespace System.Runtime.Serialization.Xml.XsdDataContractExporterTests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.DataSetXmlSerializationIsSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/82967", TestPlatforms.Browser | TestPlatforms.Wasi)]
-        // Unprimed: a collection type seen cold (read-write first) caches the "read-only contract" shape.
-        [InlineData(false, typeof(TypeWithReadWriteColdCollectionAndNoCtorOnCollection), "ArrayOfExporterTypesTests.ColdPerson")]
-        // Primed: a collection type first seen through a get-only member caches the "constructor-check" shape.
-        [InlineData(true, typeof(TypeWithReadWriteCollectionAndNoCtorOnCollection), "ArrayOfExporterTypesTests.Person")]
-        public void ReadWriteCollectionWithoutParameterlessConstructor_ExportsConsistently(bool primeGetOnlyContractFirst, Type containerType, string collectionSchemaName)
+        // Full-schema export - unprimed: a collection seen cold (read-write first) caches the plain collection shape (no constructor check).
+        [InlineData(typeof(Admin), "ArrayOfExporterTypesTests.Admin", false, false)]
+        // Full-schema export - primed: a collection first seen through a get-only member caches the "constructor-check" shape.
+        [InlineData(typeof(Engineer), "ArrayOfExporterTypesTests.Engineer", true, false)]
+        // Name-only export - unprimed (cold) collection.
+        [InlineData(typeof(Employee), "ArrayOfExporterTypesTests.Employee", false, true)]
+        // Name-only export - primed (get-only-first) collection.
+        [InlineData(typeof(Architect), "ArrayOfExporterTypesTests.Architect", true, true)]
+        public void ReadWriteCollectionWithoutParameterlessConstructor_ExportsConsistently(Type itemType, string collectionSchemaName, bool primeGetOnlyContractFirst, bool nameOnlyExport)
         {
             // A schema describes the shape of data, not whether an instance of a type can be
             // constructed, so a collection type that lacks a parameterless constructor is still fully
             // describable. Depending on whether such a collection is first seen through a get-only
             // member or through a read-write reference, its DataContract is cached in one of two shapes
-            // in the process-global cache (first-write-wins). Exporting a read-write reference used to
-            // throw only when the get-only shape had been cached first - a purely cache-order-dependent
-            // difference, since a cold export of the identical type emitted schema without throwing.
-            // Export must now behave the same regardless of which shape was cached first.
+            // in the process-global cache (first-write-wins). Exporting used to throw only when the
+            // get-only shape had been cached first - a purely cache-order-dependent difference, since a
+            // cold export of the identical type emitted schema without throwing. Export must now behave
+            // the same regardless of which shape was cached first, across both the full-schema surface
+            // and the name-only entry points (which bypass the DataContractSet walk).
             //
             // Because the cache keeps whichever shape it sees first, the two orderings use different
             // collection types (keyed by their distinct item types) so both shapes can be produced
-            // deterministically in a single process: the primed case forces the get-only shape by
-            // exporting a get-only holder first; the unprimed case exports a read-write reference to a
-            // collection type that nothing else ever touches get-only, so it is always seen cold. Both
-            // must emit schema; neither may throw. The constructibility requirement is unchanged and is
-            // still enforced by the serializer at (de)serialization time.
+            // deterministically in a single process: the primed cases force the get-only shape by
+            // exporting a get-only holder first; the unprimed cases only ever reference a collection type
+            // that nothing else touches get-only, so it is always seen cold. Neither may throw. The
+            // constructibility requirement is unchanged and is still enforced by the serializer at
+            // (de)serialization time.
             if (primeGetOnlyContractFirst)
             {
                 // Referencing the collection through a get-only member first caches its DataContract with
-                // the constructor-check flag set - the state that used to make the later read-write export throw.
-                new XsdDataContractExporter().Export(typeof(ReadOnlyCollectionWithoutCtorHolder));
+                // the constructor-check flag set - the state that used to make the later export throw.
+                new XsdDataContractExporter().Export(typeof(TypeWithGetOnlyCollectionWithoutCtor<>).MakeGenericType(itemType));
             }
 
             XsdDataContractExporter exporter = new XsdDataContractExporter();
-            exporter.Export(containerType);
 
-            string schemas = SchemaUtils.DumpSchema(exporter.Schemas);
-            _output.WriteLine(schemas);
-            Assert.Contains($@"<xs:complexType name=""{collectionSchemaName}"">", schemas);
+            if (!nameOnlyExport)
+            {
+                // Export a container that references the collection through a read-write member; the
+                // collection's complexType is emitted as part of the container's schema.
+                exporter.Export(typeof(TypeWithReadWriteCollectionAndNoCtorOnCollection<>).MakeGenericType(itemType));
+
+                string schemas = SchemaUtils.DumpSchema(exporter.Schemas);
+                _output.WriteLine(schemas);
+                Assert.Contains($@"<xs:complexType name=""{collectionSchemaName}"">", schemas);
+            }
+            else
+            {
+                // The name-only entry points are queried against the collection type itself - the type
+                // whose cached shape used to make these calls throw - not a container that references it.
+                var collectionType = typeof(CollectionWithoutParameterlessCtor<>).MakeGenericType(itemType);
+                Assert.Equal(collectionSchemaName, exporter.GetSchemaTypeName(collectionType).Name);
+                Assert.Null(exporter.GetSchemaType(collectionType));
+                Assert.Equal(collectionSchemaName, exporter.GetRootElementName(collectionType).Name);
+            }
         }
 
         [Theory]
@@ -527,29 +547,25 @@ namespace System.Runtime.Serialization.Xml.XsdDataContractExporterTests
             }
         }
 
-        // Priming helper for ReadWriteCollectionWithoutParameterlessConstructor_ExportsConsistently.
-        // Referencing CollectionWithoutParameterlessCtor<Person> through a get-only member registers
-        // its DataContract in the process-global cache with the constructor-check flag set, without
-        // throwing - the cache state that historically made a later read-write reference throw.
-        public class ReadOnlyCollectionWithoutCtorHolder
+        public class TypeWithGetOnlyCollectionWithoutCtor<T>
         {
-            private CollectionWithoutParameterlessCtor<Person> friends;
+            private CollectionWithoutParameterlessCtor<T> friends;
 
-            public CollectionWithoutParameterlessCtor<Person> Friends
+            public CollectionWithoutParameterlessCtor<T> Friends
             {
                 get
                 {
-                    friends = friends ?? new CollectionWithoutParameterlessCtor<Person>(2);
+                    friends = friends ?? new CollectionWithoutParameterlessCtor<T>(2);
                     return friends;
                 }
             }
         }
 
-        public class TypeWithReadWriteCollectionAndNoCtorOnCollection
+        public class TypeWithReadWriteCollectionAndNoCtorOnCollection<T>
         {
             private double[] potentialSalaries;
             private double[] potentialExpenditures;
-            CollectionWithoutParameterlessCtor<Person> friends;
+            CollectionWithoutParameterlessCtor<T> friends;
 
             public double[] PotentialSalaries
             {
@@ -573,40 +589,11 @@ namespace System.Runtime.Serialization.Xml.XsdDataContractExporterTests
             }
 
 
-            public CollectionWithoutParameterlessCtor<Person> Friends
+            public CollectionWithoutParameterlessCtor<T> Friends
             {
                 get
                 {
-                    friends = friends ?? new CollectionWithoutParameterlessCtor<Person>(2);
-                    return friends;
-                }
-                set
-                {
-                    friends = value;
-                }
-            }
-        }
-
-        // Dedicated to the unprimed (cold) case of
-        // ReadWriteCollectionWithoutParameterlessConstructor_ExportsConsistently. ColdPerson exists only
-        // so CollectionWithoutParameterlessCtor<ColdPerson> is a distinct cache key that is seen exclusively
-        // through a read-write reference. Do NOT reference that collection through a get-only member
-        // anywhere, or the cold cache shape this case relies on will no longer be produced.
-        [Serializable]
-        public class ColdPerson
-        {
-            string name = "Jane Doe";
-        }
-
-        public class TypeWithReadWriteColdCollectionAndNoCtorOnCollection
-        {
-            CollectionWithoutParameterlessCtor<ColdPerson> friends;
-
-            public CollectionWithoutParameterlessCtor<ColdPerson> Friends
-            {
-                get
-                {
-                    friends = friends ?? new CollectionWithoutParameterlessCtor<ColdPerson>(2);
+                    friends = friends ?? new CollectionWithoutParameterlessCtor<T>(2);
                     return friends;
                 }
                 set


### PR DESCRIPTION
A collection type lacking a parameterless constructor is fully describable by a schema, yet XsdDataContractExporter's behavior depended on the order in which the type's DataContract was first cached in the process-global cache. When the contract was first cached through a get-only member (setting its constructor-check flag), a later export of a read-write reference threw InvalidDataContractException; a cold export of the identical type instead emitted schema without throwing. The normal outcome is to emit schema, so this made export throw only in a cache-order-dependent corner case.

Scope the constructor check to (de)serialization by threading an optional verifyConstructor flag through the DataContract acquisition chain and passing false from the three DataContractSet export-walk sites (Add(Type), the GetMemberTypeDataContract else-branch, and GetItemTypeDataContract). The runtime serializer still acquires contracts with verification enabled, so serialization and deserialization continue to enforce constructibility - only schema export is affected, and only in the previously inconsistent case.

Rework the exporter test to exercise both cache orderings in-process using two distinct collection cache keys (one primed get-only first, one seen cold via a read-write reference) and assert both emit schema, locking in the consistency.

**Why this breaking change is justified and low-impact**

It removes an inconsistency, not a guarantee. Today the same collection type produces two different export outcomes purely based on the order in which the process-global  DataContract  cache was first populated: a cold/root-first export emits  ArrayOf…  schema and defers, while an export that happens after the type was first seen through a get-only member throws  InvalidDataContractException . That is not a designed contract — it's an accident of caching. No documentation ever promised export-time constructor validation, and the "normal" (cold) path already doesn't throw. We're making the noisy, order-dependent case behave like the already-blessed common case, so the change collapses two behaviors into the correct one rather than removing a feature.

The real enforcement point is unchanged. A read-only collection still cannot round-trip, and that is still enforced exactly where it matters — at serialization and deserialization — by code paths this change never touches. Export only describes the shape of the data; whether a live instance can be constructed is irrelevant to the XSD, which is why a read-only  MyColl<int>  and a  List<int>  both export as  ArrayOfint . We are moving a redundant, early, unreliable failure to the single reliable failure point that was always the source of truth.

The blast radius is tiny and the compat risk is asymmetric. The only behavior that changes is the primed-export-throws path — and because that throw was cache-order-dependent, anyone who relied on it had an inherently fragile setup that could already flip to success depending on unrelated code running first. In practice the eager failure has for 15+ years steered people away from this scenario, so it's very unlikely anyone depends on export throwing here; and if a caller genuinely wants to reject non-constructible types, they still get the exception the moment they actually (de)serialize. The safe direction was specifically "never throw at export" (Direction B) rather than "always throw," which would have been a genuinely high-risk change. This is also strictly a schema-tooling change: the runtime serializer's cache acquisition is byte-for-byte unchanged

Fixes: #125411