### PR TITLE
Remove unnecessary layers of indirection in `PreallocatedOverlapped`.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.Portable.cs
@@ -11,25 +11,6 @@ namespace System.Threading
     {
         internal ThreadPoolBoundHandleOverlapped? _overlappedPortableCore;
 
-        private static PreAllocatedOverlapped UnsafeCreatePortableCore(IOCompletionCallback callback, object? state, object? pinData) =>
-            new PreAllocatedOverlapped(callback, state, pinData, flowExecutionContext: false);
-
-        private bool AddRefPortableCore()
-        {
-            return _lifetime.AddRef();
-        }
-
-        private void ReleasePortableCore()
-        {
-            _lifetime.Release(this);
-        }
-
-        private void DisposePortableCore()
-        {
-            _lifetime.Dispose(this);
-            GC.SuppressFinalize(this);
-        }
-
         private unsafe void IDeferredDisposableOnFinalReleasePortableCore(bool disposed)
         {
             if (_overlappedPortableCore != null) // protect against ctor throwing exception and leaving field uninitialized

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.Windows.cs
@@ -90,7 +90,7 @@ namespace System.Threading
         /// </exception>
         [CLSCompliant(false)]
         public static PreAllocatedOverlapped UnsafeCreate(IOCompletionCallback callback, object? state, object? pinData) =>
-            ThreadPool.UseWindowsThreadPool ? UnsafeCreateWindowsThreadPool(callback, state, pinData) : UnsafeCreatePortableCore(callback, state, pinData);
+            new(callback, state, pinData, flowExecutionContext: false);
 
         private unsafe PreAllocatedOverlapped(IOCompletionCallback callback, object? state, object? pinData, bool flowExecutionContext)
         {
@@ -110,33 +110,17 @@ namespace System.Threading
             }
         }
 
-        internal bool AddRef() => ThreadPool.UseWindowsThreadPool ? AddRefWindowsThreadPool() : AddRefPortableCore();
+        internal bool AddRef() => _lifetime.AddRef();
 
-        internal void Release()
-        {
-            if (ThreadPool.UseWindowsThreadPool)
-            {
-                ReleaseWindowsThreadPool();
-            }
-            else
-            {
-                ReleasePortableCore();
-            }
-        }
+        internal void Release() => _lifetime.Release(this);
 
         /// <summary>
         /// Frees the resources associated with this <see cref="PreAllocatedOverlapped"/> instance.
         /// </summary>
         public void Dispose()
         {
-            if (ThreadPool.UseWindowsThreadPool)
-            {
-                DisposeWindowsThreadPool();
-            }
-            else
-            {
-                DisposePortableCore();
-            }
+            _lifetime.Dispose(this);
+            GC.SuppressFinalize(this);
         }
 
         ~PreAllocatedOverlapped()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.WindowsThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.WindowsThreadPool.cs
@@ -9,26 +9,7 @@ namespace System.Threading
     {
         internal readonly unsafe Win32ThreadPoolNativeOverlapped* _overlappedWindowsThreadPool;
 
-        private static PreAllocatedOverlapped UnsafeCreateWindowsThreadPool(IOCompletionCallback callback, object? state, object? pinData) =>
-            new PreAllocatedOverlapped(callback, state, pinData, flowExecutionContext: false);
-
-        private bool AddRefWindowsThreadPool()
-        {
-            return _lifetime.AddRef();
-        }
-
-        private void ReleaseWindowsThreadPool()
-        {
-            _lifetime.Release(this);
-        }
-
         internal unsafe bool IsUserObject(byte[]? buffer) => _overlappedWindowsThreadPool->IsUserObject(buffer);
-
-        private void DisposeWindowsThreadPool()
-        {
-            _lifetime.Dispose(this);
-            GC.SuppressFinalize(this);
-        }
 
         private unsafe void IDeferredDisposableOnFinalReleaseWindowsThreadPool(bool disposed)
         {


### PR DESCRIPTION
Several of the class' methods have three editions each; one for the portable thread pool, one for the Windows thread pool, and the external-facing entry point that routes to one of the above. However, for four of the families of methods, both thread pool editions are identical, and were folded into one method each.