### PR TITLE
Fix issues flagged by compiling `clr.aot` with clang on Windows

### DIFF
--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -4186,7 +4186,7 @@ public:
             return;
         }
 
-        if (strBufferSize > bufferSize)
+        if (static_cast<size_t>(strBufferSize) > bufferSize)
         {
             m_pBuffer = new WCHAR[strBufferSize];
         }

--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
@@ -49,7 +49,7 @@ public:
                           PTR_VOID pvManagedCodeStartRange, uint32_t cbManagedCodeRange,
                           PTR_RUNTIME_FUNCTION pRuntimeFunctionTable, uint32_t nRuntimeFunctionTable,
                           PTR_PTR_VOID pClasslibFunctions, uint32_t nClasslibFunctions);
-    ~CoffNativeCodeManager();
+    virtual ~CoffNativeCodeManager();
 
     //
     // Code manager methods

--- a/src/coreclr/nativeaot/Runtime/windows/PalMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalMinWin.cpp
@@ -8,7 +8,6 @@
 
 #include "holder.h"
 
-#define _T(s) L##s
 #include "RhConfig.h"
 
 #include "gcenv.h"
@@ -18,7 +17,7 @@
 #include "thread.h"
 #include "threadstore.h"
 
-#include "nativecontext.h"
+#include "NativeContext.h"
 
 #ifdef FEATURE_SPECIAL_USER_MODE_APC
 #include <versionhelpers.h>

--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -65,6 +65,7 @@ static void DECLSPEC_NORETURN FailFastOnAssert()
     CreateCrashDumpIfEnabled();
 #endif
     RaiseFailFastException(NULL, NULL, 0);
+    UNREACHABLE();
 }
 
 #ifdef _DEBUG

--- a/src/coreclr/utilcode/pedecoder.cpp
+++ b/src/coreclr/utilcode/pedecoder.cpp
@@ -978,7 +978,7 @@ inline PTR_STORAGESTREAM NextStorageStream(PTR_STORAGESTREAM pSS)
 
     SUPPORTS_DAC;
     TADDR pc = dac_cast<TADDR>(pSS);
-    pc += (sizeof(STORAGESTREAM) - 32 /*sizeof(STORAGESTREAM::rcName)*/ + strlen(pSS->rcName)+1+3)&~3;
+    pc += (sizeof(STORAGESTREAM) - 32 /*sizeof(STORAGESTREAM::rcName)*/ + strlen((const char*)pSS->rcName)+1+3)&~3;
     return PTR_STORAGESTREAM(pc);
 }
 //-------------------------------------------------------------------------------

--- a/src/coreclr/utilcode/stacktrace.cpp
+++ b/src/coreclr/utilcode/stacktrace.cpp
@@ -425,7 +425,7 @@ void MagicInit()
     //
     // Try to get the API entrypoints in imagehlp.dll
     //
-    for (int i = 0; i < ARRAY_SIZE(ailFuncList); i++)
+    for (size_t i = 0; i < ARRAY_SIZE(ailFuncList); i++)
     {
         *(ailFuncList[i].ppvfn) = GetProcAddress(
                 g_hinstImageHlp,

--- a/src/native/minipal/guid.c
+++ b/src/native/minipal/guid.c
@@ -69,7 +69,7 @@ void minipal_guid_as_string(GUID guid, char* guidString, uint32_t len)
     assert(len >= MINIPAL_GUID_BUFFER_LEN);
 
     int32_t nBytes = snprintf(guidString, len, "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-        guid.Data1, guid.Data2, guid.Data3,
+        (unsigned int)guid.Data1, guid.Data2, guid.Data3,
         guid.Data4[0], guid.Data4[1],
         guid.Data4[2], guid.Data4[3],
         guid.Data4[4], guid.Data4[5],

--- a/src/native/minipal/xoshiro128pp.c
+++ b/src/native/minipal/xoshiro128pp.c
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include <minipal/xoshiro128pp.h>
+#include <stddef.h>
 
 // This code is a slightly modified version of the xoshiro128++ generator from http://prng.di.unimi.it/xoshiro128plusplus.c
 
@@ -29,7 +30,7 @@ static void jump(struct minipal_xoshiro128pp* pState) {
 	uint32_t s1 = 0;
 	uint32_t s2 = 0;
 	uint32_t s3 = 0;
-	for (int i = 0; i < sizeof JUMP / sizeof * JUMP; i++)
+	for (size_t i = 0; i < sizeof JUMP / sizeof * JUMP; i++)
 		for (int b = 0; b < 32; b++) {
 			if (JUMP[i] & UINT32_C(1) << b) {
 				s0 ^= s[0];
@@ -77,5 +78,4 @@ uint32_t minipal_xoshiro128pp_next(struct minipal_xoshiro128pp* pState) {
 
 	return result;
 }
-
 


### PR DESCRIPTION
Out of curiosity I let copilot build clr.aot with clang. Most are signed/unsigned comparison mismatches that we treat as errors on Windows (`/we4018`) and copilot matched it with `-Wsign-compare`.