### PR TITLE
Fall back to NTLM in managed SPNEGO when Kerberos credentials are missing on Unix

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedSpnego.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedSpnego.cs
@@ -186,13 +186,14 @@ namespace System.Net
                                                 // When an optimistic mechanism (e.g. Kerberos) is unavailable, fall
                                                 // back to the next offered mechanism (NTLM) instead of failing the
                                                 // whole exchange. NTLM is always the last mechanism, so a fallback is
-                                                // only attempted when another mechanism follows. On OpenBSD the GSS-API
-                                                // (Heimdal) reports a missing Kerberos TGT as UnknownCredentials rather
-                                                // than Unsupported, so that status is also treated as recoverable there.
+                                                // only attempted when another mechanism follows. A missing Kerberos
+                                                // KDC/TGT is reported by the GSS-API as UnknownCredentials
+                                                // (GSS_S_NO_CRED) - on MIT krb5 (Linux) as well as Heimdal (OpenBSD) -
+                                                // so that status is also treated as recoverable.
                                                 bool canFallBackToNextMechanism = packageAndOid.Key != NegotiationInfoClass.NTLM;
                                                 bool isRecoverableOptimisticFailure =
                                                     statusCode == NegotiateAuthenticationStatusCode.Unsupported ||
-                                                    (LocalAppContextSwitches.IsOpenBsd && statusCode == NegotiateAuthenticationStatusCode.UnknownCredentials);
+                                                    statusCode == NegotiateAuthenticationStatusCode.UnknownCredentials;
                                                 if (!canFallBackToNextMechanism || !isRecoverableOptimisticFailure)
                                                 {
                                                     return null;


### PR DESCRIPTION
## Summary

Fixes #122895.

When the **managed** Negotiate (SPNEGO) implementation offers Kerberos as the optimistic mechanism and no usable KDC/TGT is available, the GSS-API reports `GSS_S_NO_CRED`, which maps to `NegotiateAuthenticationStatusCode.UnknownCredentials`. Previously this status was only treated as a *recoverable* optimistic failure on **OpenBSD** (Heimdal). On **Linux (MIT krb5)** the same condition aborted the whole exchange instead of falling back to NTLM, so managed NTLM over HTTP (e.g. EWS/Exchange with `AppContext.SetSwitch("System.Net.Security.UseManagedNtlm", true)`) failed with **401** whenever a Kerberos mechanism was advertised but no KDC was reachable — the exact scenario in #122895 on the Ubuntu Noble .NET 10 image with `gss-ntlmssp` installed.

This change treats `UnknownCredentials` as a recoverable optimistic failure on **all Unix** platforms, so SPNEGO falls back from Kerberos to NTLM. NTLM remains the last offered mechanism and is guarded by `canFallBackToNextMechanism`, so a genuine `UnknownCredentials` originating from NTLM itself (e.g. missing default credentials, see #91160) still propagates unchanged.

## Why the previously merged change (#123003) was not enough

#123003 made `HasSystemNetSecurityNative` (and thus `supportKerberos`) `true` whenever the native GSS-API library loads. That does **not** address the reporter's configuration (with `gss-ntlmssp` installed, `supportKerberos` was already `true`), and on its own it *regresses* the `gss-ntlmssp`-absent configuration, because Kerberos then starts being offered optimistically and hits the same missing-fallback path. The real fix is the fallback change here; combined with #123003 both configurations work.

## Empirical validation

Because a full test host could not be built in the dev environment (an unrelated clang internal compiler crash), the fix was validated by building real `System.Net.Security.dll` variants and running an NTLM/Negotiate HTTP handshake against a reference server on a private copy of the 10.0.9 shared framework:

| Variant | `UseManagedNtlm=true`, gss-ntlmssp **absent** | `UseManagedNtlm=true`, gss-ntlmssp **present** (reporter) |
|---|---|---|
| baseline (no fix) | 200 | **401 (bug)** |
| #123003 only | **401 (regression)** | 401 |
| **fallback fix (this PR)** | 200 | **200** |
| #123003 + fallback fix | 200 | 200 |

## Notes

- The managed unit test `DefaultNetworkCredentials_NTLM_DoesNotThrow` (which asserts `UnknownCredentials` for the direct `NTLM` package) is unaffected: this change only alters non-NTLM optimistic mechanisms in the SPNEGO path.
- Consider backporting to `release/10.0` together with #123003.

> [!NOTE]
> This pull request was authored by GitHub Copilot (CLI).
