### PR TITLE
Fix Windows case sensitive zip extraction

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -226,9 +226,19 @@ namespace System.IO.Compression
                 destinationDirectoryFullPath = string.Concat(destinationDirectoryFullPath, new ReadOnlySpan<char>(in sep));
             }
 
-            fileDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectoryFullPath, ArchivingUtils.SanitizeEntryFilePath(source.FullName)));
+            string sanitizedEntryPath = ArchivingUtils.SanitizeEntryFilePath(source.FullName);
 
-            if (!fileDestinationPath.StartsWith(destinationDirectoryFullPath, PathInternal.StringComparison))
+            fileDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectoryFullPath, sanitizedEntryPath));
+
+            // Verify the resolved path stays within the destination root. On case-insensitive platforms
+            // (Windows, macOS, iOS, tvOS) the comparison below is OrdinalIgnoreCase, which alone cannot
+            // detect a ".." segment that pops the root's final segment and re-descends into a
+            // differently-cased sibling directory (e.g. "../dest/pwn.txt" extracted into a root named
+            // "Dest"). Path.GetFullPath never re-cases the segments we supplied, so a prefix that matches
+            // only case-insensitively is the signature of exactly that escape. Require an ordinal match of
+            // the root prefix on those platforms to reject it, while still allowing benign in-root "..".
+            if (!fileDestinationPath.StartsWith(destinationDirectoryFullPath, PathInternal.StringComparison) ||
+                (!PathInternal.IsCaseSensitive && !fileDestinationPath.StartsWith(destinationDirectoryFullPath, StringComparison.Ordinal)))
             {
                 throw new IOException(SR.IO_ExtractingResultsInOutside);
             }

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -224,10 +224,18 @@ namespace System.IO.Compression
             string sanitizedEntryPath = ArchivingUtils.SanitizeEntryFilePath(source.FullName);
             fileDestinationPath = Path.GetFullPath(Path.Combine(fullDestination, sanitizedEntryPath));
 
-            // Ensure the path stays within the destination directory boundary
-            if (!fileDestinationPath.StartsWith(fullDestination, StringComparison.Ordinal) ||
-                fileDestinationPath.Length <= fullDestination.Length ||
-                fileDestinationPath[fullDestination.Length] != Path.DirectorySeparatorChar)
+            // Build a destination prefix that always ends in a separator, so that the comparison below
+            // doesn't produce false positives for roots (e.g. "C:\" or "\\server\share\") that already end
+            // in a separator, and doesn't allow a sibling directory with a matching prefix (e.g. "Dest" vs
+            // "Destinations") to be treated as being inside the destination.
+            string destinationPrefix = fullDestination.EndsWith(Path.DirectorySeparatorChar)
+                ? fullDestination
+                : fullDestination + Path.DirectorySeparatorChar;
+
+            // Ensure the path stays within the destination directory boundary. The path is allowed to be
+            // exactly equal to the destination itself (e.g. for an entry named "." or "subdir/..").
+            if (!fileDestinationPath.Equals(fullDestination, StringComparison.Ordinal) &&
+                !fileDestinationPath.StartsWith(destinationPrefix, StringComparison.Ordinal))
             {
                 throw new IOException(SR.IO_ExtractingResultsInOutside);
             }

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -232,10 +232,8 @@ namespace System.IO.Compression
                 ? fullDestination
                 : fullDestination + Path.DirectorySeparatorChar;
 
-            // Ensure the path stays within the destination directory boundary. The path is allowed to be
-            // exactly equal to the destination itself (e.g. for an entry named "." or "subdir/..").
-            if (!fileDestinationPath.Equals(fullDestination, StringComparison.Ordinal) &&
-                !fileDestinationPath.StartsWith(destinationPrefix, StringComparison.Ordinal))
+            // Ensure the path stays within the destination directory boundary.
+            if (!fileDestinationPath.StartsWith(destinationPrefix, StringComparison.Ordinal))
             {
                 throw new IOException(SR.IO_ExtractingResultsInOutside);
             }

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -219,26 +219,15 @@ namespace System.IO.Compression
 
             // Note that this will give us a good DirectoryInfo even if destinationDirectoryName exists:
             DirectoryInfo di = Directory.CreateDirectory(destinationDirectoryName);
-            string destinationDirectoryFullPath = di.FullName;
-            if (!destinationDirectoryFullPath.EndsWith(Path.DirectorySeparatorChar))
-            {
-                char sep = Path.DirectorySeparatorChar;
-                destinationDirectoryFullPath = string.Concat(destinationDirectoryFullPath, new ReadOnlySpan<char>(in sep));
-            }
+            string fullDestination = Path.GetFullPath(di.FullName);
 
             string sanitizedEntryPath = ArchivingUtils.SanitizeEntryFilePath(source.FullName);
+            fileDestinationPath = Path.GetFullPath(Path.Combine(fullDestination, sanitizedEntryPath));
 
-            fileDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectoryFullPath, sanitizedEntryPath));
-
-            // Reject entries that resolve outside the destination root. GetFullPath collapses "." and ".."
-            // but never re-cases the segments it keeps. The root is combined in verbatim with a trailing
-            // separator. That means a resolved path that shares the root's exact casing never climbed above the root;
-            // one that matches the root only case-insensitively did climb out and re-descend under a
-            // different spelling (e.g. "../dest/x" into root "Dest"), which is a distinct directory on a
-            // case-sensitive volume. The two terms below together require that ordinal match. Symlinks and
-            // junctions are not resolved here, so a reparse point inside the root is a separate concern.
-            if (!fileDestinationPath.StartsWith(destinationDirectoryFullPath, PathInternal.StringComparison) ||
-                (!PathInternal.IsCaseSensitive && !fileDestinationPath.StartsWith(destinationDirectoryFullPath, StringComparison.Ordinal)))
+            // Ensure the path stays within the destination directory boundary
+            if (!fileDestinationPath.StartsWith(fullDestination, StringComparison.Ordinal) ||
+                fileDestinationPath.Length <= fullDestination.Length ||
+                fileDestinationPath[fullDestination.Length] != Path.DirectorySeparatorChar)
             {
                 throw new IOException(SR.IO_ExtractingResultsInOutside);
             }

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -230,13 +230,13 @@ namespace System.IO.Compression
 
             fileDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectoryFullPath, sanitizedEntryPath));
 
-            // Verify the resolved path stays within the destination root. On case-insensitive platforms
-            // (Windows, macOS, iOS, tvOS) the comparison below is OrdinalIgnoreCase, which alone cannot
-            // detect a ".." segment that pops the root's final segment and re-descends into a
-            // differently-cased sibling directory (e.g. "../dest/pwn.txt" extracted into a root named
-            // "Dest"). Path.GetFullPath never re-cases the segments we supplied, so a prefix that matches
-            // only case-insensitively is the signature of exactly that escape. Require an ordinal match of
-            // the root prefix on those platforms to reject it, while still allowing benign in-root "..".
+            // Reject entries that resolve outside the destination root. GetFullPath collapses "." and ".."
+            // but never re-cases the segments it keeps. The root is combined in verbatim with a trailing
+            // separator. That means a resolved path that shares the root's exact casing never climbed above the root;
+            // one that matches the root only case-insensitively did climb out and re-descend under a
+            // different spelling (e.g. "../dest/x" into root "Dest"), which is a distinct directory on a
+            // case-sensitive volume. The two terms below together require that ordinal match. Symlinks and
+            // junctions are not resolved here, so a reparse point inside the root is a separate concern.
             if (!fileDestinationPath.StartsWith(destinationDirectoryFullPath, PathInternal.StringComparison) ||
                 (!PathInternal.IsCaseSensitive && !fileDestinationPath.StartsWith(destinationDirectoryFullPath, StringComparison.Ordinal)))
             {

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -98,6 +98,75 @@ namespace System.IO.Compression.Tests
             await Assert.ThrowsAsync<IOException>(() => ZipFile.ExtractToDirectoryAsync(archivePath, destination.FullName));
         }
 
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task ExtractOutOfRoot_CaseInsensitiveSiblingDirectory(bool async)
+        {
+            // An entry that normalizes into a differently-cased sibling of the destination root must be
+            // rejected. On case-insensitive platforms (Windows, macOS, iOS, tvOS) the destination-root
+            // prefix check is case-insensitive, so extracting "../dest/pwn.txt" into a root named "Dest"
+            // would otherwise be treated as staying inside the root even though the file system can keep
+            // "Dest" and "dest" as distinct directories.
+            string root = GetTestFilePath();
+            DirectoryInfo destination = Directory.CreateDirectory(Path.Combine(root, "Dest"));
+
+            string archivePath = GetTestFilePath();
+            ZipArchive archive = await CallZipFileOpen(async, archivePath, ZipArchiveMode.Create);
+            archive.CreateEntry("../dest/pwn.txt");
+            await DisposeZipArchive(async, archive);
+
+            await Assert.ThrowsAsync<IOException>(() => CallZipFileExtractToDirectory(async, archivePath, destination.FullName));
+
+            Assert.False(File.Exists(Path.Combine(root, "dest", "pwn.txt")));
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task ExtractToDirectory_InRootParentSegment_Allowed(bool async)
+        {
+            // A ".." segment that resolves back inside the destination root is benign and must still
+            // extract. Only a ".." that re-descends into a differently-cased sibling of the root (which
+            // would match the root case-insensitively but not ordinally) is rejected.
+            string archivePath = GetTestFilePath();
+            ZipArchive archive = await CallZipFileOpen(async, archivePath, ZipArchiveMode.Create);
+            ZipArchiveEntry entry = archive.CreateEntry("subdir/../readme.txt", CompressionLevel.Optimal);
+            Stream entryStream = await OpenEntryStream(async, entry);
+            using (StreamWriter writer = new StreamWriter(entryStream))
+            {
+                writer.Write("This is a test.");
+            }
+            await DisposeStream(async, entryStream);
+            await DisposeZipArchive(async, archive);
+
+            string destination = GetTestFilePath();
+            await CallZipFileExtractToDirectory(async, archivePath, destination);
+
+            Assert.True(File.Exists(Path.Combine(destination, "readme.txt")));
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task ExtractToDirectory_CurrentDirectorySegment_Allowed(bool async)
+        {
+            // "." (current-directory) segments are harmless and appear in real archives; they must still
+            // extract successfully rather than being treated as a traversal attempt.
+            string archivePath = GetTestFilePath();
+            ZipArchive archive = await CallZipFileOpen(async, archivePath, ZipArchiveMode.Create);
+            ZipArchiveEntry entry = archive.CreateEntry("subdir/./readme.txt", CompressionLevel.Optimal);
+            Stream entryStream = await OpenEntryStream(async, entry);
+            using (StreamWriter writer = new StreamWriter(entryStream))
+            {
+                writer.Write("This is a test.");
+            }
+            await DisposeStream(async, entryStream);
+            await DisposeZipArchive(async, archive);
+
+            string destination = GetTestFilePath();
+            await CallZipFileExtractToDirectory(async, archivePath, destination);
+
+            Assert.True(File.Exists(Path.Combine(destination, "subdir", "readme.txt")));
+        }
+
         /// <summary>
         /// This test ensures that a zipfile with path names that are invalid to this OS will throw errors
         /// when an attempt is made to extract them.


### PR DESCRIPTION
Fixes #131066

Update checks for zip extraction to better protect case sensitive environments.