### PR TITLE
[release/8.0-staging] Skip empty iOS NativeAOT Helix submission

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -124,6 +124,8 @@ jobs:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+            # Remove this iOS exclusion if iOS NativeAOT device tests are re-enabled.
+            condition: ne(variables['osGroup'], 'ios')
 
 #
 # Build the whole product using NativeAOT for iOS/tvOS and run runtime tests with iOS/tvOS devices

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -695,11 +695,14 @@ extends:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
                   extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+                  # Remove this iOS exclusion if iOS NativeAOT device tests are re-enabled.
                   condition: >-
-                    or(
-                    eq(variables['librariesContainsChange'], true),
-                    eq(variables['coreclrContainsChange'], true),
-                    eq(variables['isRollingBuild'], true))
+                    and(
+                      ne(variables['osGroup'], 'ios'),
+                      or(
+                        eq(variables['librariesContainsChange'], true),
+                        eq(variables['coreclrContainsChange'], true),
+                        eq(variables['isRollingBuild'], true)))
 
       #
       # MacCatalyst interp - requires AOT Compilation and Interp flags


### PR DESCRIPTION
Fixes #130860

main PR N/A — servicing-only. `main` has the `Exists(...)` guards (#121927) and its iOS device tests are still enabled.

# Description

#130473 marked the only two test projects this leg selects as `IgnoreForCI`, since the servicing test infra isn't being updated for newer macOS:

- `iOS.Device.Aot.Test`
- `iOS.Device.ExportManagedSymbols.Test`

That suppresses `ArchiveTests`/`_CopyTestArchive`, so the leg no longer produces `artifacts/helix/tests` — and release/8.0's `sendtohelix-mobile.targets:87` enumerates that directory unguarded:

```
error MSB4184: The expression "[System.IO.Directory]::GetDirectories(.../artifacts/helix/tests/, *.app, ...)"
cannot be evaluated. Could not find a part of the path '.../artifacts/helix/tests'
```

This keeps the iOS NativeAOT **build** and skips only its now-empty `Send to Helix` step. tvOS is untouched. Both call sites are updated — `runtime.yml` duplicates the block, so fixing only the extra-platforms template would leave the `runtime` definition red.

Backporting just the `Exists(...)` guard doesn't work: it trades MSB4184 for `No helix work items` at `sendtohelixhelp.proj:304`, since the leg still has nothing to submit.

# Customer Impact

None to customers — CI infrastructure only, no shipping bits change.

The leg currently fails on every rolling build and every PR touching libraries or coreclr, which keeps .NET 8 servicing CI red (`blocking-clean-ci`) and buries real regressions in noise.

# Regression

Yes, from #130473 — which correctly disabled unrunnable device tests but left the Helix submission leg scheduled with nothing to send. CI-only; no shipped code involved.

# Testing

`Send to Helix` step results on this PR:

| Build | Definition | Job | Result |
|---|---|---|---|
| 1541064 | runtime-extra-platforms | `ios-arm64 Release AllSubsets_NativeAOT` | skipped |
| 1541064 | runtime-extra-platforms | `tvos-arm64 Release AllSubsets_NativeAOT` | succeeded |
| 1541066 | runtime | `ios-arm64 Release AllSubsets_NativeAOT` | skipped |
| 1541066 | runtime | `tvos-arm64 Release AllSubsets_NativeAOT` | succeeded |

All four parent jobs succeeded, so iOS build coverage is retained. The tvOS step log confirms a real submission (1 work item, 3.3M payload, Helix job completing with 2 finished work items) — it isn't silently skipping too.

Also verified locally with a harness importing the real `sendtohelix-mobile.targets` at the #130473 commit, which reproduces the MSB4184 and the guard-only follow-on failure. The equivalent leg on release/10.0 is green, so no change is needed elsewhere.

# Risk

Low.

- Pipeline YAML only — no product, package, or test source touched.
- Scoped by `osGroup`, so only the iOS NativeAOT leg changes; verified in CI rather than assumed.
- Existing `librariesContainsChange`/`coreclrContainsChange`/`isRollingBuild` gating is preserved, just wrapped in `and(...)`.
- Uses the existing `condition` hook in `eng/pipelines/libraries/helix.yml` instead of loosening shared Helix behavior for all mobile lanes.
- Worst case: iOS NativeAOT test coverage stays absent — already the status quo, since both tests are disabled.

Both call sites carry a comment to remove the exclusion if these tests are re-enabled.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
