### PR TITLE
Add on-demand in-proc crash report generation.

### DIFF
--- a/src/coreclr/debug/crashreport/inproccrashreporter.cpp
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.cpp
@@ -313,8 +313,7 @@ class CrashReportOutputContext
 {
 public:
     CrashReportOutputContext()
-        : m_fd(-1),
-          m_writeFailed(false)
+        : m_fd(-1)
     {
     }
 
@@ -327,12 +326,10 @@ public:
     CrashReportOutputContext& operator=(const CrashReportOutputContext&) = delete;
 
     int Fd() const { return m_fd; }
-    bool WriteFailed() const { return m_writeFailed; }
 
     void Init(int fd)
     {
         m_fd = fd;
-        m_writeFailed = false;
     }
 
     static bool ChunkCallback(const char* buffer, size_t len, void* ctx);
@@ -341,7 +338,6 @@ private:
     bool HandleChunk(const char* buffer, size_t len);
 
     int m_fd;
-    bool m_writeFailed;
 };
 
 class InProcCrashReporter
@@ -403,10 +399,10 @@ private:
         void* context);
 
     void BeginConsoleReport(int signal);
-    void EndConsoleReport();
+    bool EndConsoleReport();
 
     void BeginJsonReport();
-    void EndJsonReport(
+    bool EndJsonReport(
         int signal,
         bool finalizeReportFile);
 
@@ -628,9 +624,10 @@ InProcCrashReporter::CreateReport(
     BeginConsoleReport(signal);
     BeginJsonReport();
     EmitThreads(crashKind, context);
-    EndJsonReport(signal, /*finalizeReportFile*/ jsonEnabled);
-    EndConsoleReport();
-    return true;
+    bool jsonSucceeded = EndJsonReport(signal, /*finalizeReportFile*/ jsonEnabled);
+    bool consoleSucceeded = EndConsoleReport();
+
+    return jsonSucceeded && consoleSucceeded;
 }
 
 bool
@@ -642,6 +639,12 @@ InProcCrashReporter::CreateReport(
     void* callbackContext)
 {
     if (outputCallback == nullptr)
+    {
+        return false;
+    }
+
+    if (outputFormat != InProcCrashReportOutputFormat::Json &&
+        outputFormat != InProcCrashReportOutputFormat::Log)
     {
         return false;
     }
@@ -672,15 +675,17 @@ InProcCrashReporter::CreateReport(
     BeginConsoleReport(signal);
     BeginJsonReport();
     EmitThreads(crashKind, context);
-    EndJsonReport(signal, /*finalizeReportFile*/ false);
-    EndConsoleReport();
+    bool jsonSucceeded = EndJsonReport(signal, /*finalizeReportFile*/ false);
+    bool consoleSucceeded = EndConsoleReport();
+
+    bool reportSucceeded = jsonSucceeded && consoleSucceeded;
 
     m_consoleWriter.SetOutputSink(SignalSafeConsoleWriter::PlatformConsoleOutputSink());
     m_jsonWriter.SetOutputSink(SignalSafeJsonWriter::DropAllOutputSink());
     m_moduleTable.Reset();
 
     InterlockedExchange(&m_reportInFlight, ReportNotInFlight);
-    return true;
+    return reportSucceeded;
 }
 
 void
@@ -1062,13 +1067,7 @@ CrashReportOutputContext::HandleChunk(
         return false;
     }
 
-    if (!CrashReportHelpers::WriteToFile(m_fd, buffer, len))
-    {
-        m_writeFailed = true;
-        return false;
-    }
-
-    return true;
+    return CrashReportHelpers::WriteToFile(m_fd, buffer, len);
 }
 
 bool
@@ -2147,7 +2146,7 @@ InProcCrashReporter::BeginConsoleReport(int signal)
     m_consoleWriter.EndLine();
 }
 
-void
+bool
 InProcCrashReporter::EndConsoleReport()
 {
     if (m_moduleTable.Count() != 0)
@@ -2178,6 +2177,7 @@ InProcCrashReporter::EndConsoleReport()
     }
 
     m_consoleWriter.WriteSeparator();
+    return !m_consoleWriter.HasWriteFailed();
 }
 
 // --- InProcCrashReporter: JSON report lifecycle ----------------------------
@@ -2203,7 +2203,7 @@ InProcCrashReporter::BeginJsonReport()
     m_jsonWriter.WriteDecimalAsString("pid", static_cast<uint64_t>(GetCurrentProcessId()));
 }
 
-void
+bool
 InProcCrashReporter::EndJsonReport(
     int signal,
     bool finalizeReportFile)
@@ -2231,18 +2231,12 @@ InProcCrashReporter::EndJsonReport(
     {
         int fd = m_outputContext.Fd();
         bool finishSucceeded = m_jsonWriter.Finish();
-        bool writeFailed = m_outputContext.WriteFailed();
-        if (!CrashReportHelpers::WriteToFile(fd, "\n", 1))
-        {
-            writeFailed = true;
-        }
-
+        bool newlineSucceeded = CrashReportHelpers::WriteToFile(fd, "\n", 1);
         bool closeSucceeded = close(fd) == 0;
-        bool reportSucceeded = finishSucceeded && !writeFailed && closeSucceeded;
+        bool reportSucceeded = finishSucceeded && newlineSucceeded && closeSucceeded;
         m_lifecycle.FinishReportFile(reportSucceeded, m_reportFilePath);
+        return reportSucceeded;
     }
-    else
-    {
-        (void)m_jsonWriter.Finish();
-    }
+
+    return m_jsonWriter.Finish();
 }

--- a/src/coreclr/debug/crashreport/inproccrashreporter.cpp
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.cpp
@@ -167,7 +167,6 @@ public:
 
     int Count() const { return m_count; }
     const void* ModuleHandle(int i) const { return m_moduleHandles[i]; }
-
     void Reset() { m_count = 0; }
 private:
     const void* m_moduleHandles[MAX_MODULES_IN_TABLE];
@@ -352,31 +351,21 @@ public:
     static bool InitializeInstance(const InProcCrashReporterSettings& settings);
 
     // Capture the VM callbacks and process identity. Must run before the instance
-    // is published to the PAL signal-handler path. Does not arm the crash-dump
-    // behavior (watchdog / lifecycle); see InitializeServices.
+    // is published to the PAL signal-handler path.
     void Initialize(const InProcCrashReporterSettings& settings);
 
     // Initialize the env-gated crash-dump services (watchdog + lifecycle/file
-    // management) after the reporter has been initialized. Separated from
-    // Initialize so the reporter can be brought up with only its VM callbacks
-    // (making on-demand reports possible) independently of the crash-dump
-    // configuration, and so the services are started on the single configuration
-    // pass.
+    // management) after the reporter has been initialized.
     void InitializeServices(const InProcCrashReporterServicesSettings& settings);
 
     // Signal-path report generation, invoked by the PAL fatal-signal dispatcher.
-    // Returns true if the report was generated, or false if it was skipped because
-    // another report (a nested fatal signal, or an in-flight on-demand report) is
-    // already using the shared reporter state.
     bool CreateReport(
         int signal,
         void* context);
 
     // On-demand report generation. Runs the same emit core as the signal path
     // but without the watchdog or lifecycle/file management, routing the selected
-    // output format to `outputCallback`. Re-runnable (sequentially); rejects
-    // reentrant/concurrent use. Returns false if `outputCallback` is null or the
-    // call is reentered.
+    // output format to `outputCallback`.
     bool CreateReport(
         InProcCrashReportOutputFormat outputFormat,
         int signal,
@@ -397,19 +386,6 @@ private:
     InProcCrashReporter(const InProcCrashReporter&) = delete;
     InProcCrashReporter& operator=(const InProcCrashReporter&) = delete;
 
-    // State of m_reportInFlight, the single guard shared by the signal-handler and
-    // on-demand CreateReport paths. The two paths are mutually exclusive: they
-    // contend for the same signal-safe writers, module table, thread context, and
-    // the process-global ThreadSuspend machinery (SuspendEE), none of which is safe
-    // to drive from two reports at once. At most one report runs at a time on a
-    // first-come-first-served basis:
-    //   * Whichever path observes an idle guard claims it and generates its report.
-    //   * Any other report - a nested fatal signal, or a signal arriving while an
-    //     on-demand report driven by a user fatal-error handler is in flight - finds
-    //     the guard held and aborts without generating. The in-flight report (or,
-    //     for the signal case, the imminent process termination) takes over.
-    // The on-demand path releases the guard when done so it stays re-runnable; the
-    // signal path never releases it, because a fatal signal terminates the process.
     enum ReportInFlightState : LONG
     {
         ReportNotInFlight = 0,
@@ -613,13 +589,6 @@ InProcCrashReporter::CreateReport(
     int signal,
     void* context)
 {
-    // Claim the shared guard. The signal path and the on-demand path are mutually
-    // exclusive over the shared writers, module table, and the process-global
-    // ThreadSuspend machinery, so at most one report runs at a time. If a report
-    // is already in flight - an on-demand report driven by a user fatal-error
-    // handler, or a nested fatal signal - abort without generating: the in-flight
-    // report, or the imminent process termination, takes over from here. The
-    // signal path never releases the guard: a fatal signal terminates the process.
     if (InterlockedCompareExchange(&m_reportInFlight, ReportInFlight, ReportNotInFlight) != ReportNotInFlight)
     {
         return false;
@@ -653,8 +622,6 @@ InProcCrashReporter::CreateReport(
     }
     else
     {
-        // Compact-log-only mode: route the JSON emitter to the drop-all sink so
-        // it keeps its bookkeeping consistent without emitting bytes.
         m_jsonWriter.SetOutputSink(SignalSafeJsonWriter::DropAllOutputSink());
     }
 
@@ -679,10 +646,6 @@ InProcCrashReporter::CreateReport(
         return false;
     }
 
-    // Acquire the shared guard only from the idle state: yield (return false) to
-    // any report already in flight - another on-demand report, or the signal-path
-    // crash report. Mutual exclusion keeps the two paths off the shared writers
-    // and the process-global ThreadSuspend machinery at the same time.
     if (InterlockedCompareExchange(&m_reportInFlight, ReportInFlight, ReportNotInFlight) != ReportNotInFlight)
     {
         return false;
@@ -712,16 +675,10 @@ InProcCrashReporter::CreateReport(
     EndJsonReport(signal, /*finalizeReportFile*/ false);
     EndConsoleReport();
 
-    // Leave the writers and module table in a clean default state for the next
-    // run (platform console sink and drop-all JSON sink).
     m_consoleWriter.SetOutputSink(SignalSafeConsoleWriter::PlatformConsoleOutputSink());
     m_jsonWriter.SetOutputSink(SignalSafeJsonWriter::DropAllOutputSink());
     m_moduleTable.Reset();
 
-    // Release the guard so a later report (on-demand or signal) can run. This
-    // report is the sole owner while it runs: a signal that arrived in the
-    // meantime aborted without touching the guard, and other on-demand callers
-    // yielded, so a plain reset to idle is safe.
     InterlockedExchange(&m_reportInFlight, ReportNotInFlight);
     return true;
 }
@@ -953,8 +910,6 @@ InProcCrashReportInitializeServices(const InProcCrashReporterServicesSettings& s
         return;
     }
 
-    // Requires the reporter to have been initialized first (see
-    // InProcCrashReportInitialize); nothing to arm otherwise.
     InProcCrashReporter* reporter = InProcCrashReporter::GetInstance();
     if (reporter == nullptr)
     {

--- a/src/coreclr/debug/crashreport/inproccrashreporter.cpp
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.cpp
@@ -131,8 +131,9 @@ static void CacheSysctlString(const char* sysctlName, char* buffer, size_t buffe
 // ``(in <name>) `` so the frame stays self-describing — overflow is lossless,
 // just less compact for that frame.
 //
-// Single-instance because CreateReport is one-shot per process (guarded by
-// the ``s_generating`` InterlockedCompareExchange in CreateReport).
+// Single-instance because at most one report (signal-path or on-demand) runs at
+// a time, enforced by the m_reportInFlight guard in CreateReport. It is Reset()
+// at the start of each report so on-demand reports stay re-runnable.
 
 static constexpr int MAX_MODULES_IN_TABLE = 256;
 
@@ -166,6 +167,8 @@ public:
 
     int Count() const { return m_count; }
     const void* ModuleHandle(int i) const { return m_moduleHandles[i]; }
+
+    void Reset() { m_count = 0; }
 private:
     const void* m_moduleHandles[MAX_MODULES_IN_TABLE];
     int m_count = 0;
@@ -348,13 +351,38 @@ public:
     static InProcCrashReporter* GetInstance();
     static bool InitializeInstance(const InProcCrashReporterSettings& settings);
 
-    // Capture configuration and the crash-report template path. Must run before
-    // the instance is published to the PAL signal-handler path.
+    // Capture the VM callbacks and process identity. Must run before the instance
+    // is published to the PAL signal-handler path. Does not arm the crash-dump
+    // behavior (watchdog / lifecycle); see InitializeServices.
     void Initialize(const InProcCrashReporterSettings& settings);
 
-    void CreateReport(
+    // Initialize the env-gated crash-dump services (watchdog + lifecycle/file
+    // management) after the reporter has been initialized. Separated from
+    // Initialize so the reporter can be brought up with only its VM callbacks
+    // (making on-demand reports possible) independently of the crash-dump
+    // configuration, and so the services are started on the single configuration
+    // pass.
+    void InitializeServices(const InProcCrashReporterServicesSettings& settings);
+
+    // Signal-path report generation, invoked by the PAL fatal-signal dispatcher.
+    // Returns true if the report was generated, or false if it was skipped because
+    // another report (a nested fatal signal, or an in-flight on-demand report) is
+    // already using the shared reporter state.
+    bool CreateReport(
         int signal,
         void* context);
+
+    // On-demand report generation. Runs the same emit core as the signal path
+    // but without the watchdog or lifecycle/file management, routing the selected
+    // output format to `outputCallback`. Re-runnable (sequentially); rejects
+    // reentrant/concurrent use. Returns false if `outputCallback` is null or the
+    // call is reentered.
+    bool CreateReport(
+        InProcCrashReportOutputFormat outputFormat,
+        int signal,
+        void* context,
+        InProcCrashReportOutputCallback outputCallback,
+        void* callbackContext);
 
     void SetCrashKind(InProcCrashReportCrashKind crashKind);
     void BeginStackOverflowTrace(uint64_t crashingTid, uint32_t totalFrameCount);
@@ -368,6 +396,25 @@ private:
     InProcCrashReporter() = default;
     InProcCrashReporter(const InProcCrashReporter&) = delete;
     InProcCrashReporter& operator=(const InProcCrashReporter&) = delete;
+
+    // State of m_reportInFlight, the single guard shared by the signal-handler and
+    // on-demand CreateReport paths. The two paths are mutually exclusive: they
+    // contend for the same signal-safe writers, module table, thread context, and
+    // the process-global ThreadSuspend machinery (SuspendEE), none of which is safe
+    // to drive from two reports at once. At most one report runs at a time on a
+    // first-come-first-served basis:
+    //   * Whichever path observes an idle guard claims it and generates its report.
+    //   * Any other report - a nested fatal signal, or a signal arriving while an
+    //     on-demand report driven by a user fatal-error handler is in flight - finds
+    //     the guard held and aborts without generating. The in-flight report (or,
+    //     for the signal case, the imminent process termination) takes over.
+    // The on-demand path releases the guard when done so it stays re-runnable; the
+    // signal path never releases it, because a fatal signal terminates the process.
+    enum ReportInFlightState : LONG
+    {
+        ReportNotInFlight = 0,
+        ReportInFlight = 1,
+    };
 
     void EmitSynthesizedCrashThread(
         void* context,
@@ -385,8 +432,7 @@ private:
     void BeginJsonReport();
     void EndJsonReport(
         int signal,
-        bool jsonEnabled,
-        int fd);
+        bool finalizeReportFile);
 
     static const char* GetSignalNameAscii(int signal);
 
@@ -402,6 +448,7 @@ private:
     InProcCrashReportEnumerateThreadsCallback m_enumerateThreadsCallback = nullptr;
     InProcCrashReportModuleInfoCallback m_moduleInfoCallback = nullptr;
     volatile LONG m_crashKind = static_cast<LONG>(InProcCrashReportCrashKind::Unknown);
+    volatile LONG m_reportInFlight = ReportNotInFlight;
     uint32_t m_frameLimitPerThread = 0;
     InProcCrashReportLifecycle m_lifecycle;
     char m_reportFilePath[CRASHREPORT_PATH_BUFFER_SIZE];
@@ -559,31 +606,35 @@ public:
         const char* buffer,
         size_t len);
 
-    // SignalSafeJsonWriter callback that drops everything: used when the
-    // crash report is running in compact-log-only mode (no managed report
-    // directory configured) so the JSON formatter still keeps its bookkeeping
-    // consistent without emitting bytes anywhere.
-    static bool DiscardOutputCallback(const char* buffer, size_t len, void* ctx);
-
 };
 
-void
+bool
 InProcCrashReporter::CreateReport(
     int signal,
     void* context)
 {
-    static LONG s_generating = 0;
-    if (InterlockedCompareExchange(&s_generating, 1, 0) != 0)
+    // Claim the shared guard. The signal path and the on-demand path are mutually
+    // exclusive over the shared writers, module table, and the process-global
+    // ThreadSuspend machinery, so at most one report runs at a time. If a report
+    // is already in flight - an on-demand report driven by a user fatal-error
+    // handler, or a nested fatal signal - abort without generating: the in-flight
+    // report, or the imminent process termination, takes over from here. The
+    // signal path never releases the guard: a fatal signal terminates the process.
+    if (InterlockedCompareExchange(&m_reportInFlight, ReportInFlight, ReportNotInFlight) != ReportNotInFlight)
     {
-        return;
+        return false;
     }
+
     CrashReportWatchdogScope watchdogScope;
+
+    m_moduleTable.Reset();
+    m_consoleWriter.SetOutputSink(SignalSafeConsoleWriter::PlatformConsoleOutputSink());
 
     m_reportFilePath[0] = '\0';
     // The JSON file sink is enabled only by lifecycle-managed output. Otherwise
     // the crash report runs in compact-log-only mode: the JSON emitter still
-    // executes (so it can keep its bookkeeping consistent) but writes go to a
-    // no-op DiscardOutputCallback instead of an open fd.
+    // executes (so it can keep its bookkeeping consistent) but writes go to the
+    // writer's drop-all default sink instead of an open fd.
     int fd = -1;
     bool jsonEnabled = m_lifecycle.IsReportFileOutputEnabled() &&
         m_lifecycle.PrepareReportFile(&m_formatter, m_reportFilePath, sizeof(m_reportFilePath), &fd);
@@ -593,24 +644,86 @@ InProcCrashReporter::CreateReport(
         jsonEnabled = false;
     }
 
-    InProcCrashReportCrashKind crashKind = static_cast<InProcCrashReportCrashKind>(
-        InterlockedExchange(&m_crashKind, static_cast<LONG>(InProcCrashReportCrashKind::Unknown)));
+    InProcCrashReportCrashKind crashKind = static_cast<InProcCrashReportCrashKind>(VolatileLoad(&m_crashKind));
 
     m_outputContext.Init(fd);
     if (jsonEnabled)
     {
-        m_jsonWriter.Init(&CrashReportOutputContext::ChunkCallback, &m_outputContext);
+        m_jsonWriter.SetOutputSink(SignalSafeJsonOutputSink(&CrashReportOutputContext::ChunkCallback, &m_outputContext));
     }
     else
     {
-        m_jsonWriter.Init(&CrashReportHelpers::DiscardOutputCallback, nullptr);
+        // Compact-log-only mode: route the JSON emitter to the drop-all sink so
+        // it keeps its bookkeeping consistent without emitting bytes.
+        m_jsonWriter.SetOutputSink(SignalSafeJsonWriter::DropAllOutputSink());
     }
 
     BeginConsoleReport(signal);
     BeginJsonReport();
     EmitThreads(crashKind, context);
-    EndJsonReport(signal, jsonEnabled, fd);
+    EndJsonReport(signal, /*finalizeReportFile*/ jsonEnabled);
     EndConsoleReport();
+    return true;
+}
+
+bool
+InProcCrashReporter::CreateReport(
+    InProcCrashReportOutputFormat outputFormat,
+    int signal,
+    void* context,
+    InProcCrashReportOutputCallback outputCallback,
+    void* callbackContext)
+{
+    if (outputCallback == nullptr)
+    {
+        return false;
+    }
+
+    // Acquire the shared guard only from the idle state: yield (return false) to
+    // any report already in flight - another on-demand report, or the signal-path
+    // crash report. Mutual exclusion keeps the two paths off the shared writers
+    // and the process-global ThreadSuspend machinery at the same time.
+    if (InterlockedCompareExchange(&m_reportInFlight, ReportInFlight, ReportNotInFlight) != ReportNotInFlight)
+    {
+        return false;
+    }
+
+    m_moduleTable.Reset();
+
+    if (outputFormat == InProcCrashReportOutputFormat::Json)
+    {
+        m_jsonWriter.SetOutputSink(SignalSafeJsonOutputSink(outputCallback, callbackContext));
+        m_consoleWriter.SetOutputSink(SignalSafeConsoleWriter::DropAllOutputSink());
+    }
+    else
+    {
+        m_jsonWriter.SetOutputSink(SignalSafeJsonWriter::DropAllOutputSink());
+        m_consoleWriter.SetOutputSink(SignalSafeConsoleOutputSink(outputCallback, callbackContext, /*appendNewline*/ true));
+    }
+
+    uint64_t crashingTid = static_cast<uint64_t>(minipal_get_current_thread_id());
+    InProcCrashReportCrashKind crashKind = (VolatileLoad(&m_stackOverflowTrace.available) != 0 && m_stackOverflowTrace.crashingTid == crashingTid)
+        ? InProcCrashReportCrashKind::StackOverflow
+        : InProcCrashReportCrashKind::Unknown;
+
+    BeginConsoleReport(signal);
+    BeginJsonReport();
+    EmitThreads(crashKind, context);
+    EndJsonReport(signal, /*finalizeReportFile*/ false);
+    EndConsoleReport();
+
+    // Leave the writers and module table in a clean default state for the next
+    // run (platform console sink and drop-all JSON sink).
+    m_consoleWriter.SetOutputSink(SignalSafeConsoleWriter::PlatformConsoleOutputSink());
+    m_jsonWriter.SetOutputSink(SignalSafeJsonWriter::DropAllOutputSink());
+    m_moduleTable.Reset();
+
+    // Release the guard so a later report (on-demand or signal) can run. This
+    // report is the sole owner while it runs: a signal that arrived in the
+    // meantime aborted without touching the guard, and other on-demand callers
+    // yielded, so a plain reset to idle is safe.
+    InterlockedExchange(&m_reportInFlight, ReportNotInFlight);
+    return true;
 }
 
 void
@@ -712,8 +825,6 @@ InProcCrashReporter::Initialize(
     m_stackOverflowTrace.available = 0;
     m_reportFilePath[0] = '\0';
 
-    (void)CrashReportWatchdog::TryInitialize(settings.timeoutSeconds);
-
     m_processName[0] = '\0';
 #if defined(__ANDROID__)
     // On Android every app forks from the Zygote, so /proc/self/exe always
@@ -741,20 +852,30 @@ InProcCrashReporter::Initialize(
         }
     }
 
-    // File output is produced only through the lifecycle-managed report
-    // directory. When no root is configured the reporter still runs, emitting
-    // compact console logs without writing a JSON report file.
-    if (settings.reportRootPath != nullptr && settings.reportRootPath[0] != '\0')
-    {
-        m_lifecycle.Initialize(settings.reportRootPath, settings.maxFileCount);
-    }
-
 #if defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
     // Cache sysctl values at Initialize because sysctl/sysctlbyname is not on POSIX's
     // async-signal-safe list; CreateReport reads these from the signal-handler path.
     CacheSysctlString("kern.osproductversion", m_osVersion, sizeof(m_osVersion));
     CacheSysctlString("hw.model", m_systemModel, sizeof(m_systemModel));
 #endif
+}
+
+void
+InProcCrashReporter::InitializeServices(const InProcCrashReporterServicesSettings& settings)
+{
+    if (settings.enableWatchdog)
+    {
+        (void)CrashReportWatchdog::TryInitialize(settings.timeoutSeconds);
+    }
+
+    // File output is produced only through the lifecycle-managed report
+    // directory, and only when both enabled and given a root path. When the
+    // lifecycle is disabled the reporter still runs, emitting compact console
+    // logs without writing a JSON report file.
+    if (settings.enableLifecycle && settings.reportRootPath != nullptr && settings.reportRootPath[0] != '\0')
+    {
+        m_lifecycle.Initialize(settings.reportRootPath, settings.maxFileCount);
+    }
 }
 
 void
@@ -821,15 +942,58 @@ InProcCrashReportSignalDispatcher(int signal, void* siginfo, void* context)
 void
 InProcCrashReportInitialize(const InProcCrashReporterSettings& settings)
 {
-    if (!InProcCrashReporter::InitializeInstance(settings))
+    (void)InProcCrashReporter::InitializeInstance(settings);
+}
+
+void
+InProcCrashReportInitializeServices(const InProcCrashReporterServicesSettings& settings)
+{
+    if (!settings.enableCreateCrashDump)
     {
         return;
     }
+
+    // Requires the reporter to have been initialized first (see
+    // InProcCrashReportInitialize); nothing to arm otherwise.
+    InProcCrashReporter* reporter = InProcCrashReporter::GetInstance();
+    if (reporter == nullptr)
+    {
+        return;
+    }
+
+    static LONG s_servicesInitialized = 0;
+    if (InterlockedCompareExchange(&s_servicesInitialized, 1, 0) != 0)
+    {
+        return;
+    }
+
+    reporter->InitializeServices(settings);
 
     // Register last so PAL only observes the dispatcher after the reporter
     // singleton is fully populated (mirrors the publication ordering used by
     // PAL_SetLogManagedCallstackForSignalCallback).
     PAL_SetInProcCrashReportCallback(&InProcCrashReportSignalDispatcher);
+}
+
+bool
+InProcCrashReportCreateReport(
+    InProcCrashReportOutputFormat outputFormat,
+    int signal,
+    void* context,
+    InProcCrashReportOutputCallback outputCallback,
+    void* callbackContext)
+{
+    InProcCrashReporter* reporter = InProcCrashReporter::GetInstance();
+    if (reporter == nullptr)
+    {
+        return false;
+    }
+
+    // Preserve the interrupted context's errno before the crash reporter uses syscalls.
+    int savedErrno = errno;
+    bool generated = reporter->CreateReport(outputFormat, signal, context, outputCallback, callbackContext);
+    errno = savedErrno;
+    return generated;
 }
 
 void
@@ -930,15 +1094,6 @@ CrashReportHelpers::WriteToFile(
         return false;
     }
 
-    return true;
-}
-
-bool
-CrashReportHelpers::DiscardOutputCallback(
-    const char* /*buffer*/,
-    size_t /*len*/,
-    void* /*ctx*/)
-{
     return true;
 }
 
@@ -2096,8 +2251,7 @@ InProcCrashReporter::BeginJsonReport()
 void
 InProcCrashReporter::EndJsonReport(
     int signal,
-    bool jsonEnabled,
-    int fd)
+    bool finalizeReportFile)
 {
     m_jsonWriter.CloseObject(); // payload
 
@@ -2118,8 +2272,9 @@ InProcCrashReporter::EndJsonReport(
 
     m_jsonWriter.CloseObject(); // root
 
-    if (jsonEnabled)
+    if (finalizeReportFile)
     {
+        int fd = m_outputContext.Fd();
         bool finishSucceeded = m_jsonWriter.Finish();
         bool writeFailed = m_outputContext.WriteFailed();
         if (!CrashReportHelpers::WriteToFile(fd, "\n", 1))

--- a/src/coreclr/debug/crashreport/inproccrashreporter.h
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.h
@@ -70,24 +70,73 @@ using InProcCrashReportModuleInfoCallback = bool (*)(
     const char** moduleName,
     GUID* moduleGuid);
 
+// Output format for an on-demand report (see InProcCrashReportCreateReport).
+enum class InProcCrashReportOutputFormat : uint32_t
+{
+    Json = 0,
+    Log = 1,
+};
+
+// Receives on-demand report bytes as they are produced: raw JSON document chunks
+// for the Json format, newline-delimited lines for the Log format. Returns false
+// on write failure. Must be async-signal-safe when invoked from a crash context.
+using InProcCrashReportOutputCallback = bool (*)(const char* buffer, size_t length, void* context);
+
 struct InProcCrashReporterSettings
 {
-    const char* reportRootPath;
-    int timeoutSeconds;
     InProcCrashReportIsManagedThreadCallback isManagedThreadCallback;
     InProcCrashReportWalkStackCallback walkStackCallback;
     InProcCrashReportEnumerateThreadsCallback enumerateThreadsCallback;
     InProcCrashReportModuleInfoCallback moduleInfoCallback;
     uint32_t frameLimitPerThread;
-    int32_t maxFileCount;
 };
 
-// Free-function entry point used by the runtime to wire the in-proc crash
-// reporter into the PAL signal-handler path. Captures `settings` into an
-// init-time allocated reporter and registers a signal-safe dispatcher with PAL
-// via PAL_SetInProcCrashReportCallback. PAL has no direct dependency on the
-// reporter; the only coupling is through this registered callback.
+struct InProcCrashReporterServicesSettings
+{
+    const char* reportRootPath;
+    int timeoutSeconds;
+    int32_t maxFileCount;
+    bool enableCreateCrashDump;
+    bool enableWatchdog;
+    bool enableLifecycle;
+};
+
+// Free-function entry points used by the runtime to bring up the in-proc crash
+// reporter. InProcCrashReportInitialize captures `settings` into an init-time
+// allocated reporter (VM callbacks only) and is idempotent, so it can be called
+// both from the runtime's startup configuration and from a fatal-error-handler
+// setup path; the reporter is then available for on-demand reports regardless of
+// crash-dump configuration.
 void InProcCrashReportInitialize(const InProcCrashReporterSettings& settings);
+
+// InProcCrashReportInitializeServices starts the env-gated crash-dump services:
+// when settings.enableCreateCrashDump is true it starts configured services like
+// the watchdog / lifecycle and registers a signal-safe dispatcher with PAL via
+// PAL_SetInProcCrashReportCallback so the default reporter runs on a fatal
+// signal. Requires the reporter to have been initialized first via
+// InProcCrashReportInitialize (it is a no-op otherwise) and starts the services
+// exactly once. PAL has no direct dependency on the reporter; the only coupling is
+// through the optionally-registered callback.
+void InProcCrashReportInitializeServices(const InProcCrashReporterServicesSettings& settings);
+
+// Generates a crash report on demand, independent of the fatal-signal path.
+// Runs the reporter's emit core over the current process without the watchdog
+// or lifecycle/file management, streaming the selected `outputFormat` to
+// `outputCallback` (called with `callbackContext`). `signal` and `context`
+// describe the crash site: `context` is the platform machine context used to
+// walk the crashing (calling) thread's stack, or null to defer to the
+// registered stack-walk callback's default. Intended for a user fatal-error
+// handler to drive report generation while the runtime is still up.
+//
+// Re-runnable sequentially, but yields to any report already in flight: returns
+// false if the reporter is not initialized, `outputCallback` is null, or a
+// signal-handler / on-demand report is currently being generated.
+bool InProcCrashReportCreateReport(
+    InProcCrashReportOutputFormat outputFormat,
+    int signal,
+    void* context,
+    InProcCrashReportOutputCallback outputCallback,
+    void* callbackContext);
 
 // Emits initialization failures before crash-report storage exists.
 void InProcCrashReportLogInitializationFailure(const char* message);

--- a/src/coreclr/debug/crashreport/inproccrashreporter.h
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.h
@@ -70,16 +70,12 @@ using InProcCrashReportModuleInfoCallback = bool (*)(
     const char** moduleName,
     GUID* moduleGuid);
 
-// Output format for an on-demand report (see InProcCrashReportCreateReport).
 enum class InProcCrashReportOutputFormat : uint32_t
 {
     Json = 0,
     Log = 1,
 };
 
-// Receives on-demand report bytes as they are produced: raw JSON document chunks
-// for the Json format, newline-delimited lines for the Log format. Returns false
-// on write failure. Must be async-signal-safe when invoked from a crash context.
 using InProcCrashReportOutputCallback = bool (*)(const char* buffer, size_t length, void* context);
 
 struct InProcCrashReporterSettings
@@ -101,36 +97,19 @@ struct InProcCrashReporterServicesSettings
     bool enableLifecycle;
 };
 
-// Free-function entry points used by the runtime to bring up the in-proc crash
-// reporter. InProcCrashReportInitialize captures `settings` into an init-time
-// allocated reporter (VM callbacks only) and is idempotent, so it can be called
-// both from the runtime's startup configuration and from a fatal-error-handler
-// setup path; the reporter is then available for on-demand reports regardless of
-// crash-dump configuration.
+// Initialize the in-proc crash reporter. InProcCrashReportInitialize captures `settings`
+// into an init-time allocated reporter (VM callbacks only). It can be called both from
+// the runtime's startup configuration and from a fatal-error-handler setup path; the
+// reporter is then available for on-demand reports.
 void InProcCrashReportInitialize(const InProcCrashReporterSettings& settings);
 
-// InProcCrashReportInitializeServices starts the env-gated crash-dump services:
-// when settings.enableCreateCrashDump is true it starts configured services like
-// the watchdog / lifecycle and registers a signal-safe dispatcher with PAL via
-// PAL_SetInProcCrashReportCallback so the default reporter runs on a fatal
-// signal. Requires the reporter to have been initialized first via
-// InProcCrashReportInitialize (it is a no-op otherwise) and starts the services
-// exactly once. PAL has no direct dependency on the reporter; the only coupling is
-// through the optionally-registered callback.
+// Initialize the env-gated crash-dump services like the watchdog / lifecycle
+// and register a signal-safe dispatcher with PAL via PAL_SetInProcCrashReportCallback
+// so the default reporter runs on a fatal signal. Requires the reporter to have been
+// initialized first via InProcCrashReportInitialize and starts the services exactly once.
 void InProcCrashReportInitializeServices(const InProcCrashReporterServicesSettings& settings);
 
-// Generates a crash report on demand, independent of the fatal-signal path.
-// Runs the reporter's emit core over the current process without the watchdog
-// or lifecycle/file management, streaming the selected `outputFormat` to
-// `outputCallback` (called with `callbackContext`). `signal` and `context`
-// describe the crash site: `context` is the platform machine context used to
-// walk the crashing (calling) thread's stack, or null to defer to the
-// registered stack-walk callback's default. Intended for a user fatal-error
-// handler to drive report generation while the runtime is still up.
-//
-// Re-runnable sequentially, but yields to any report already in flight: returns
-// false if the reporter is not initialized, `outputCallback` is null, or a
-// signal-handler / on-demand report is currently being generated.
+// Generates an on-demand crash report.
 bool InProcCrashReportCreateReport(
     InProcCrashReportOutputFormat outputFormat,
     int signal,

--- a/src/coreclr/debug/crashreport/inproccrashreporter.h
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.h
@@ -76,6 +76,7 @@ enum class InProcCrashReportOutputFormat : uint32_t
     Log = 1,
 };
 
+// Receives report bytes; consumers must honor `length` (Json chunks are not NUL-terminated).
 using InProcCrashReportOutputCallback = bool (*)(const char* buffer, size_t length, void* context);
 
 struct InProcCrashReporterSettings

--- a/src/coreclr/debug/crashreport/signalsafeconsolewriter.cpp
+++ b/src/coreclr/debug/crashreport/signalsafeconsolewriter.cpp
@@ -56,13 +56,14 @@ SignalSafeConsoleWriter::SetOutputSink(const SignalSafeConsoleOutputSink& sink)
 {
     m_sink = sink;
     m_pos = 0;
+    m_writeFailed = false;
     m_buffer[0] = '\0';
 }
 
 void
 SignalSafeConsoleWriter::AppendStr(const char* s)
 {
-    if (s == nullptr || m_pos + 1 >= sizeof(m_buffer))
+    if (m_writeFailed || s == nullptr || m_pos + 1 >= sizeof(m_buffer))
     {
         return;
     }
@@ -79,7 +80,7 @@ SignalSafeConsoleWriter::AppendStr(const char* s)
 void
 SignalSafeConsoleWriter::AppendChar(char c)
 {
-    if (m_pos + 1 < sizeof(m_buffer))
+    if (!m_writeFailed && m_pos + 1 < sizeof(m_buffer))
     {
         m_buffer[m_pos++] = c;
     }
@@ -113,6 +114,11 @@ SignalSafeConsoleWriter::AppendSignedDecimal(int64_t v)
 void
 SignalSafeConsoleWriter::EndLine()
 {
+    if (m_writeFailed)
+    {
+        return;
+    }
+
     // Sinks that supply their own line discipline (e.g. Android logcat) opt out
     // of the trailing '\n'; every other sink expects newline-delimited lines.
     if (m_sink.AppendNewline())
@@ -164,10 +170,20 @@ SignalSafeConsoleWriter::WriteSeparator()
 void
 SignalSafeConsoleWriter::Flush()
 {
+    if (m_writeFailed)
+    {
+        m_pos = 0;
+        m_buffer[0] = '\0';
+        return;
+    }
+
     size_t len = (m_pos < sizeof(m_buffer)) ? m_pos : sizeof(m_buffer) - 1;
     m_buffer[len] = '\0';
 
-    m_sink.Write(m_buffer, len);
+    if (!m_sink.Write(m_buffer, len))
+    {
+        m_writeFailed = true;
+    }
 
     m_pos = 0;
     m_buffer[0] = '\0';

--- a/src/coreclr/debug/crashreport/signalsafeconsolewriter.cpp
+++ b/src/coreclr/debug/crashreport/signalsafeconsolewriter.cpp
@@ -164,17 +164,10 @@ SignalSafeConsoleWriter::WriteSeparator()
 void
 SignalSafeConsoleWriter::Flush()
 {
-    // Always null-terminate so sinks that expect a C string (e.g. logcat) see one.
-    if (m_pos < sizeof(m_buffer))
-    {
-        m_buffer[m_pos] = '\0';
-    }
-    else
-    {
-        m_buffer[sizeof(m_buffer) - 1] = '\0';
-    }
+    size_t len = (m_pos < sizeof(m_buffer)) ? m_pos : sizeof(m_buffer) - 1;
+    m_buffer[len] = '\0';
 
-    m_sink.Write(m_buffer, m_pos);
+    m_sink.Write(m_buffer, len);
 
     m_pos = 0;
     m_buffer[0] = '\0';

--- a/src/coreclr/debug/crashreport/signalsafeconsolewriter.cpp
+++ b/src/coreclr/debug/crashreport/signalsafeconsolewriter.cpp
@@ -13,6 +13,52 @@
 
 static const char CRASHREPORT_LINE_SEPARATOR[] = "*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***";
 
+static bool
+PlatformConsoleWrite(const char* buffer, size_t /*len*/, void* /*context*/)
+{
+#if defined(__ANDROID__)
+    // __android_log_write expects a tag + null-terminated message; it adds its
+    // own line discipline (hence appendNewline == false for this sink). Each
+    // call becomes one logcat entry, which is what makes per-line filtering useful.
+    __android_log_write(ANDROID_LOG_FATAL, CRASHREPORT_LOG_TAG, buffer);
+#else
+    minipal_log_write_error(buffer);
+#endif
+    return true;
+}
+
+const SignalSafeConsoleOutputSink&
+SignalSafeConsoleWriter::PlatformConsoleOutputSink()
+{
+    // Android logcat provides its own line discipline, so the platform sink does
+    // not append '\n'; every other platform (stderr) does.
+    static const SignalSafeConsoleOutputSink s_platformSink(
+        &PlatformConsoleWrite,
+        nullptr,
+#if defined(__ANDROID__)
+        /*appendNewline*/ false);
+#else
+        /*appendNewline*/ true);
+#endif
+    return s_platformSink;
+}
+
+const SignalSafeConsoleOutputSink&
+SignalSafeConsoleWriter::DropAllOutputSink()
+{
+    // A null callback discards output and reports success.
+    static const SignalSafeConsoleOutputSink s_dropAllSink(nullptr, nullptr, /*appendNewline*/ false);
+    return s_dropAllSink;
+}
+
+void
+SignalSafeConsoleWriter::SetOutputSink(const SignalSafeConsoleOutputSink& sink)
+{
+    m_sink = sink;
+    m_pos = 0;
+    m_buffer[0] = '\0';
+}
+
 void
 SignalSafeConsoleWriter::AppendStr(const char* s)
 {
@@ -67,19 +113,20 @@ SignalSafeConsoleWriter::AppendSignedDecimal(int64_t v)
 void
 SignalSafeConsoleWriter::EndLine()
 {
-    // On Android, __android_log_write in Flush() adds its own line discipline.
-    // For other platforms, we still need to add a newline.
-#if !defined(__ANDROID__)
-    if (m_pos + 1 < sizeof(m_buffer))
+    // Sinks that supply their own line discipline (e.g. Android logcat) opt out
+    // of the trailing '\n'; every other sink expects newline-delimited lines.
+    if (m_sink.AppendNewline())
     {
-        m_buffer[m_pos++] = '\n';
+        if (m_pos + 1 < sizeof(m_buffer))
+        {
+            m_buffer[m_pos++] = '\n';
+        }
+        else
+        {
+            m_buffer[sizeof(m_buffer) - 2] = '\n';
+            m_pos = sizeof(m_buffer) - 1;
+        }
     }
-    else
-    {
-        m_buffer[sizeof(m_buffer) - 2] = '\n';
-        m_pos = sizeof(m_buffer) - 1;
-    }
-#endif // !__ANDROID__
     Flush();
 }
 
@@ -117,7 +164,7 @@ SignalSafeConsoleWriter::WriteSeparator()
 void
 SignalSafeConsoleWriter::Flush()
 {
-    // Always null-terminate so the platform write APIs see a proper C string.
+    // Always null-terminate so sinks that expect a C string (e.g. logcat) see one.
     if (m_pos < sizeof(m_buffer))
     {
         m_buffer[m_pos] = '\0';
@@ -127,14 +174,7 @@ SignalSafeConsoleWriter::Flush()
         m_buffer[sizeof(m_buffer) - 1] = '\0';
     }
 
-#if defined(__ANDROID__)
-    // __android_log_write expects a tag + null-terminated message; it adds its
-    // own line discipline so we deliberately do not append '\n'. Each call
-    // becomes one logcat entry, which is what makes per-line filtering useful.
-    __android_log_write(ANDROID_LOG_FATAL, CRASHREPORT_LOG_TAG, m_buffer);
-#else
-    minipal_log_write_error(m_buffer);
-#endif
+    m_sink.Write(m_buffer, m_pos);
 
     m_pos = 0;
     m_buffer[0] = '\0';

--- a/src/coreclr/debug/crashreport/signalsafeconsolewriter.h
+++ b/src/coreclr/debug/crashreport/signalsafeconsolewriter.h
@@ -41,19 +41,9 @@
 
 static constexpr size_t SIGNAL_SAFE_CONSOLE_BUFFER_SIZE = 512;
 
-// Value type describing where flushed lines go and whether the writer appends a
-// '\n' before handing the line to the callback. Sinks that provide their own
-// line discipline (e.g. Android logcat) set appendNewline to false;
-// newline-delimited sinks (stderr, caller-supplied callbacks) set it to true.
-// Copyable so it can be assigned into the writer's internal sink.
 class SignalSafeConsoleOutputSink
 {
 public:
-    // Sink for a single flushed line. Receives the null-terminated line buffer
-    // and its byte size (excluding the terminator). Returns false on write failure.
-    // Shares the bool-returning shape of SignalSafeJsonOutputSink::Callback so a
-    // single caller-supplied callback type can drive either writer. Must be
-    // async-signal-safe.
     using Callback = bool(*)(const char* buffer, size_t len, void* context);
 
     SignalSafeConsoleOutputSink(Callback callback, void* context, bool appendNewline)
@@ -83,8 +73,6 @@ private:
 class SignalSafeConsoleWriter
 {
 public:
-    // Default-constructed writers emit to the platform console (Android logcat
-    // under CRASHREPORT_LOG_TAG, stderr on Apple mobile platforms).
     SignalSafeConsoleWriter()
         : m_pos(0)
         , m_sink(PlatformConsoleOutputSink())
@@ -92,7 +80,6 @@ public:
         m_buffer[0] = '\0';
     }
 
-    // Routes output to a caller-supplied sink.
     explicit SignalSafeConsoleWriter(const SignalSafeConsoleOutputSink& sink)
         : m_pos(0)
         , m_sink(sink)
@@ -103,15 +90,8 @@ public:
     SignalSafeConsoleWriter(const SignalSafeConsoleWriter&) = delete;
     SignalSafeConsoleWriter& operator=(const SignalSafeConsoleWriter&) = delete;
 
-    // Re-points the sink for reuse across reports and drops any partially
-    // buffered line. Pass PlatformConsoleOutputSink() to emit to the platform
-    // console or DropAllOutputSink() to suppress output.
     void SetOutputSink(const SignalSafeConsoleOutputSink& sink);
-
-    // The default platform console sink (Android logcat / stderr).
     static const SignalSafeConsoleOutputSink& PlatformConsoleOutputSink();
-
-    // A drop-all sink that discards output and reports success.
     static const SignalSafeConsoleOutputSink& DropAllOutputSink();
 
     void AppendStr(const char* s);

--- a/src/coreclr/debug/crashreport/signalsafeconsolewriter.h
+++ b/src/coreclr/debug/crashreport/signalsafeconsolewriter.h
@@ -41,17 +41,78 @@
 
 static constexpr size_t SIGNAL_SAFE_CONSOLE_BUFFER_SIZE = 512;
 
+// Value type describing where flushed lines go and whether the writer appends a
+// '\n' before handing the line to the callback. Sinks that provide their own
+// line discipline (e.g. Android logcat) set appendNewline to false;
+// newline-delimited sinks (stderr, caller-supplied callbacks) set it to true.
+// Copyable so it can be assigned into the writer's internal sink.
+class SignalSafeConsoleOutputSink
+{
+public:
+    // Sink for a single flushed line. Receives the null-terminated line buffer
+    // and its byte size (excluding the terminator). Returns false on write failure.
+    // Shares the bool-returning shape of SignalSafeJsonOutputSink::Callback so a
+    // single caller-supplied callback type can drive either writer. Must be
+    // async-signal-safe.
+    using Callback = bool(*)(const char* buffer, size_t len, void* context);
+
+    SignalSafeConsoleOutputSink(Callback callback, void* context, bool appendNewline)
+        : m_callback(callback)
+        , m_context(context)
+        , m_appendNewline(appendNewline)
+    {
+    }
+
+    SignalSafeConsoleOutputSink(const SignalSafeConsoleOutputSink&) = default;
+    SignalSafeConsoleOutputSink& operator=(const SignalSafeConsoleOutputSink&) = default;
+
+    bool AppendNewline() const { return m_appendNewline; }
+
+    // A null callback drops output and reports success.
+    bool Write(const char* buffer, size_t len) const
+    {
+        return m_callback == nullptr || m_callback(buffer, len, m_context);
+    }
+
+private:
+    Callback m_callback;
+    void* m_context;
+    bool m_appendNewline;
+};
+
 class SignalSafeConsoleWriter
 {
 public:
+    // Default-constructed writers emit to the platform console (Android logcat
+    // under CRASHREPORT_LOG_TAG, stderr on Apple mobile platforms).
     SignalSafeConsoleWriter()
         : m_pos(0)
+        , m_sink(PlatformConsoleOutputSink())
+    {
+        m_buffer[0] = '\0';
+    }
+
+    // Routes output to a caller-supplied sink.
+    explicit SignalSafeConsoleWriter(const SignalSafeConsoleOutputSink& sink)
+        : m_pos(0)
+        , m_sink(sink)
     {
         m_buffer[0] = '\0';
     }
 
     SignalSafeConsoleWriter(const SignalSafeConsoleWriter&) = delete;
     SignalSafeConsoleWriter& operator=(const SignalSafeConsoleWriter&) = delete;
+
+    // Re-points the sink for reuse across reports and drops any partially
+    // buffered line. Pass PlatformConsoleOutputSink() to emit to the platform
+    // console or DropAllOutputSink() to suppress output.
+    void SetOutputSink(const SignalSafeConsoleOutputSink& sink);
+
+    // The default platform console sink (Android logcat / stderr).
+    static const SignalSafeConsoleOutputSink& PlatformConsoleOutputSink();
+
+    // A drop-all sink that discards output and reports success.
+    static const SignalSafeConsoleOutputSink& DropAllOutputSink();
 
     void AppendStr(const char* s);
     void AppendChar(char c);
@@ -75,4 +136,5 @@ private:
     SignalSafeFormatter m_formatter;
     char m_buffer[SIGNAL_SAFE_CONSOLE_BUFFER_SIZE];
     size_t m_pos;
+    SignalSafeConsoleOutputSink m_sink;
 };

--- a/src/coreclr/debug/crashreport/signalsafeconsolewriter.h
+++ b/src/coreclr/debug/crashreport/signalsafeconsolewriter.h
@@ -75,6 +75,7 @@ class SignalSafeConsoleWriter
 public:
     SignalSafeConsoleWriter()
         : m_pos(0)
+        , m_writeFailed(false)
         , m_sink(PlatformConsoleOutputSink())
     {
         m_buffer[0] = '\0';
@@ -82,6 +83,7 @@ public:
 
     explicit SignalSafeConsoleWriter(const SignalSafeConsoleOutputSink& sink)
         : m_pos(0)
+        , m_writeFailed(false)
         , m_sink(sink)
     {
         m_buffer[0] = '\0';
@@ -110,11 +112,14 @@ public:
     void WriteSeparator();
     void WriteBlank() { WriteLine(""); }
 
+    bool HasWriteFailed() const { return m_writeFailed; }
+
 private:
     void Flush();
 
     SignalSafeFormatter m_formatter;
     char m_buffer[SIGNAL_SAFE_CONSOLE_BUFFER_SIZE];
     size_t m_pos;
+    bool m_writeFailed;
     SignalSafeConsoleOutputSink m_sink;
 };

--- a/src/coreclr/debug/crashreport/signalsafejsonwriter.cpp
+++ b/src/coreclr/debug/crashreport/signalsafejsonwriter.cpp
@@ -14,15 +14,21 @@ ToHexChar(unsigned value)
 }
 
 void
-SignalSafeJsonWriter::Init(
-    SignalSafeJsonOutputCallback outputCallback,
-    void* outputContext)
+SignalSafeJsonWriter::SetOutputSink(
+    const SignalSafeJsonOutputSink& sink)
 {
     m_pos = 0;
     m_commaNeeded = false;
     m_writeFailed = false;
-    m_outputCallback = outputCallback;
-    m_outputContext = outputContext;
+    m_sink = sink;
+}
+
+const SignalSafeJsonOutputSink&
+SignalSafeJsonWriter::DropAllOutputSink()
+{
+    // A null callback discards output and reports success.
+    static const SignalSafeJsonOutputSink s_dropAllSink(nullptr, nullptr);
+    return s_dropAllSink;
 }
 
 bool
@@ -114,7 +120,7 @@ SignalSafeJsonWriter::Flush()
         return true;
     }
 
-    if (m_outputCallback != nullptr && !m_outputCallback(m_buffer, m_pos, m_outputContext))
+    if (!m_sink.Write(m_buffer, m_pos))
     {
         m_writeFailed = true;
         return false;

--- a/src/coreclr/debug/crashreport/signalsafejsonwriter.h
+++ b/src/coreclr/debug/crashreport/signalsafejsonwriter.h
@@ -14,26 +14,61 @@
 
 #include "signalsafeformatter.h"
 
-using SignalSafeJsonOutputCallback = bool (*)(const char* buffer, size_t len, void* ctx);
+// Value type describing where the JSON writer flushes buffered document chunks.
+// Mirrors SignalSafeConsoleOutputSink so both signal-safe writers share the same
+// bool-returning callback shape. Copyable so it can be assigned into the writer.
+class SignalSafeJsonOutputSink
+{
+public:
+    // Sink for a buffered document chunk. Returns false on write failure, which
+    // the writer latches to make subsequent writes no-ops. Must be
+    // async-signal-safe.
+    using Callback = bool (*)(const char* buffer, size_t len, void* context);
+
+    SignalSafeJsonOutputSink(Callback callback, void* context)
+        : m_callback(callback)
+        , m_context(context)
+    {
+    }
+
+    SignalSafeJsonOutputSink(const SignalSafeJsonOutputSink&) = default;
+    SignalSafeJsonOutputSink& operator=(const SignalSafeJsonOutputSink&) = default;
+
+    // A null callback drops output and reports success.
+    bool Write(const char* buffer, size_t len) const
+    {
+        return m_callback == nullptr || m_callback(buffer, len, m_context);
+    }
+
+private:
+    Callback m_callback;
+    void* m_context;
+};
 
 static constexpr size_t SIGNAL_SAFE_JSON_BUFFER_SIZE = 4 * 1024;
 
 class SignalSafeJsonWriter
 {
 public:
+    // Default-constructed writers drop all output (the drop-all default sink).
     SignalSafeJsonWriter()
         : m_pos(0),
           m_commaNeeded(false),
           m_writeFailed(false),
-          m_outputCallback(nullptr),
-          m_outputContext(nullptr)
+          m_sink(DropAllOutputSink())
     {
     }
 
     SignalSafeJsonWriter(const SignalSafeJsonWriter&) = delete;
     SignalSafeJsonWriter& operator=(const SignalSafeJsonWriter&) = delete;
 
-    void Init(SignalSafeJsonOutputCallback outputCallback, void* outputContext);
+    // Re-points the sink and resets writer state for a fresh document. Pass
+    // DropAllOutputSink() to suppress output.
+    void SetOutputSink(const SignalSafeJsonOutputSink& sink);
+
+    // A drop-all sink that discards output and reports success.
+    static const SignalSafeJsonOutputSink& DropAllOutputSink();
+
     bool OpenObject(const char* key);
     bool OpenObject();
     bool CloseObject();
@@ -59,6 +94,5 @@ private:
     size_t m_pos;
     bool m_commaNeeded;
     bool m_writeFailed;
-    SignalSafeJsonOutputCallback m_outputCallback;
-    void* m_outputContext;
+    SignalSafeJsonOutputSink m_sink;
 };

--- a/src/coreclr/debug/crashreport/signalsafejsonwriter.h
+++ b/src/coreclr/debug/crashreport/signalsafejsonwriter.h
@@ -14,15 +14,9 @@
 
 #include "signalsafeformatter.h"
 
-// Value type describing where the JSON writer flushes buffered document chunks.
-// Mirrors SignalSafeConsoleOutputSink so both signal-safe writers share the same
-// bool-returning callback shape. Copyable so it can be assigned into the writer.
 class SignalSafeJsonOutputSink
 {
 public:
-    // Sink for a buffered document chunk. Returns false on write failure, which
-    // the writer latches to make subsequent writes no-ops. Must be
-    // async-signal-safe.
     using Callback = bool (*)(const char* buffer, size_t len, void* context);
 
     SignalSafeJsonOutputSink(Callback callback, void* context)
@@ -34,7 +28,6 @@ public:
     SignalSafeJsonOutputSink(const SignalSafeJsonOutputSink&) = default;
     SignalSafeJsonOutputSink& operator=(const SignalSafeJsonOutputSink&) = default;
 
-    // A null callback drops output and reports success.
     bool Write(const char* buffer, size_t len) const
     {
         return m_callback == nullptr || m_callback(buffer, len, m_context);
@@ -50,7 +43,6 @@ static constexpr size_t SIGNAL_SAFE_JSON_BUFFER_SIZE = 4 * 1024;
 class SignalSafeJsonWriter
 {
 public:
-    // Default-constructed writers drop all output (the drop-all default sink).
     SignalSafeJsonWriter()
         : m_pos(0),
           m_commaNeeded(false),
@@ -62,11 +54,7 @@ public:
     SignalSafeJsonWriter(const SignalSafeJsonWriter&) = delete;
     SignalSafeJsonWriter& operator=(const SignalSafeJsonWriter&) = delete;
 
-    // Re-points the sink and resets writer state for a fresh document. Pass
-    // DropAllOutputSink() to suppress output.
     void SetOutputSink(const SignalSafeJsonOutputSink& sink);
-
-    // A drop-all sink that discards output and reports success.
     static const SignalSafeJsonOutputSink& DropAllOutputSink();
 
     bool OpenObject(const char* key);

--- a/src/coreclr/vm/crashreportstackwalker.cpp
+++ b/src/coreclr/vm/crashreportstackwalker.cpp
@@ -711,8 +711,6 @@ CrashReportInitialize()
 void
 CrashReportConfigure()
 {
-    CrashReportInitialize();
-
     // Read crash report configuration here rather than in PROCAbortInitialize
     // because on Android the DOTNET_* environment variables are set via JNI
     // after PAL_Initialize has already run.
@@ -724,23 +722,30 @@ CrashReportConfigure()
     DWORD reportOnlyEnabled = 0;
     bool enableCrashReportOnly = enabledReportOnlyCfg.IsSet() && enabledReportOnlyCfg.TryAsInteger(10, reportOnlyEnabled) && reportOnlyEnabled == 1;
 
+    // Nothing configured: leave the reporter uninitialized so startup allocates
+    // nothing. The reporter is brought up on demand (e.g. from a fatal-error-handler
+    // setup path) via CrashReportInitialize when it is actually needed.
+    if (!enableCrashReport && !enableCrashReportOnly)
+    {
+        return;
+    }
+
+    CrashReportInitialize();
+
     CLRConfigNoCache crashReportRootPathCfg = CLRConfigNoCache::Get("CrashReportRootPath", /*noprefix*/ false, &getenv);
     const char* crashReportRootPath = crashReportRootPathCfg.IsSet() ? crashReportRootPathCfg.AsString() : nullptr;
 
     InProcCrashReporterServicesSettings settings = {};
-    settings.enableCreateCrashDump = enableCrashReport || enableCrashReportOnly;
-    if (settings.enableCreateCrashDump)
+    settings.enableCreateCrashDump = true;
+    if (crashReportRootPath != nullptr && crashReportRootPath[0] != '\0')
     {
-        if (crashReportRootPath != nullptr && crashReportRootPath[0] != '\0')
-        {
-            settings.enableLifecycle = true;
-            settings.reportRootPath = crashReportRootPath;
-            settings.maxFileCount = GetCrashReportMaxFileCount();
-        }
-
-        settings.enableWatchdog = true;
-        settings.timeoutSeconds = GetCrashReportTimeoutSeconds();
+        settings.enableLifecycle = true;
+        settings.reportRootPath = crashReportRootPath;
+        settings.maxFileCount = GetCrashReportMaxFileCount();
     }
+
+    settings.enableWatchdog = true;
+    settings.timeoutSeconds = GetCrashReportTimeoutSeconds();
 
     // Start the crash-dump services and register the PAL signal-path callback last
     // so PAL only observes the reporter after all VM callbacks are wired in.

--- a/src/coreclr/vm/crashreportstackwalker.cpp
+++ b/src/coreclr/vm/crashreportstackwalker.cpp
@@ -722,9 +722,6 @@ CrashReportConfigure()
     DWORD reportOnlyEnabled = 0;
     bool enableCrashReportOnly = enabledReportOnlyCfg.IsSet() && enabledReportOnlyCfg.TryAsInteger(10, reportOnlyEnabled) && reportOnlyEnabled == 1;
 
-    // Nothing configured: leave the reporter uninitialized so startup allocates
-    // nothing. The reporter is brought up on demand (e.g. from a fatal-error-handler
-    // setup path) via CrashReportInitialize when it is actually needed.
     if (!enableCrashReport && !enableCrashReportOnly)
     {
         return;

--- a/src/coreclr/vm/crashreportstackwalker.cpp
+++ b/src/coreclr/vm/crashreportstackwalker.cpp
@@ -683,9 +683,36 @@ GetCrashReportTimeoutSeconds()
     return timeoutSeconds;
 }
 
+static InProcCrashReporterSettings
+GetDefaultInProcCrashReporterSettings()
+{
+    InProcCrashReporterSettings settings = {};
+    settings.isManagedThreadCallback = CrashReportIsCurrentThreadManaged;
+    settings.walkStackCallback = CrashReportWalkStack;
+    settings.enumerateThreadsCallback = CrashReportEnumerateThreads;
+    settings.moduleInfoCallback = CrashReportGetModuleInfo;
+    settings.frameLimitPerThread = GetCrashReportFrameLimitPerThread();
+    return settings;
+}
+
+void
+CrashReportInitialize()
+{
+    if (!EnsureCrashReportStackWalkerState())
+    {
+        InProcCrashReportLogInitializationFailure(".NET crash report disabled: failed to allocate stack walker storage");
+        return;
+    }
+
+    InProcCrashReporterSettings settings = GetDefaultInProcCrashReporterSettings();
+    InProcCrashReportInitialize(settings);
+}
+
 void
 CrashReportConfigure()
 {
+    CrashReportInitialize();
+
     // Read crash report configuration here rather than in PROCAbortInitialize
     // because on Android the DOTNET_* environment variables are set via JNI
     // after PAL_Initialize has already run.
@@ -697,38 +724,27 @@ CrashReportConfigure()
     DWORD reportOnlyEnabled = 0;
     bool enableCrashReportOnly = enabledReportOnlyCfg.IsSet() && enabledReportOnlyCfg.TryAsInteger(10, reportOnlyEnabled) && reportOnlyEnabled == 1;
 
-    if (!enableCrashReport && !enableCrashReportOnly)
-    {
-        return;
-    }
-
-    if (!EnsureCrashReportStackWalkerState())
-    {
-        InProcCrashReportLogInitializationFailure(".NET crash report disabled: failed to allocate stack walker storage");
-        return;
-    }
-
     CLRConfigNoCache crashReportRootPathCfg = CLRConfigNoCache::Get("CrashReportRootPath", /*noprefix*/ false, &getenv);
     const char* crashReportRootPath = crashReportRootPathCfg.IsSet() ? crashReportRootPathCfg.AsString() : nullptr;
-    bool rootConfigured = crashReportRootPath != nullptr && crashReportRootPath[0] != '\0';
 
-    InProcCrashReporterSettings settings = {};
-    if (rootConfigured)
+    InProcCrashReporterServicesSettings settings = {};
+    settings.enableCreateCrashDump = enableCrashReport || enableCrashReportOnly;
+    if (settings.enableCreateCrashDump)
     {
-        settings.reportRootPath = crashReportRootPath;
-        settings.maxFileCount = GetCrashReportMaxFileCount();
+        if (crashReportRootPath != nullptr && crashReportRootPath[0] != '\0')
+        {
+            settings.enableLifecycle = true;
+            settings.reportRootPath = crashReportRootPath;
+            settings.maxFileCount = GetCrashReportMaxFileCount();
+        }
+
+        settings.enableWatchdog = true;
+        settings.timeoutSeconds = GetCrashReportTimeoutSeconds();
     }
 
-    settings.timeoutSeconds = GetCrashReportTimeoutSeconds();
-    settings.isManagedThreadCallback = CrashReportIsCurrentThreadManaged;
-    settings.walkStackCallback = CrashReportWalkStack;
-    settings.enumerateThreadsCallback = CrashReportEnumerateThreads;
-    settings.moduleInfoCallback = CrashReportGetModuleInfo;
-    settings.frameLimitPerThread = GetCrashReportFrameLimitPerThread();
-
-    // Initialize the reporter and register the PAL signal-path callback last
+    // Start the crash-dump services and register the PAL signal-path callback last
     // so PAL only observes the reporter after all VM callbacks are wired in.
-    InProcCrashReportInitialize(settings);
+    InProcCrashReportInitializeServices(settings);
 }
 
 #endif // FEATURE_INPROC_CRASHREPORT

--- a/src/coreclr/vm/crashreportstackwalker.h
+++ b/src/coreclr/vm/crashreportstackwalker.h
@@ -10,9 +10,10 @@
 // reports are possible independently of the env-gated crash-dump configuration.
 void CrashReportInitialize();
 
-// Initialize the reporter (via CrashReportInitialize) and, based on the DOTNET_*
-// crash-report configuration, start its crash-dump services and register the PAL
-// signal-path dispatcher. Intended to run once at runtime startup.
+// Based on the DOTNET_* crash-report configuration, initialize the reporter (via
+// CrashReportInitialize), start its crash-dump services, and register the PAL
+// signal-path dispatcher. A no-op that allocates nothing when crash reporting is
+// not configured. Intended to run once at runtime startup.
 void CrashReportConfigure();
 
 #endif // FEATURE_INPROC_CRASHREPORT

--- a/src/coreclr/vm/crashreportstackwalker.h
+++ b/src/coreclr/vm/crashreportstackwalker.h
@@ -6,6 +6,13 @@
 
 #ifdef FEATURE_INPROC_CRASHREPORT
 
+// Bring up the in-proc crash reporter with only its VM callbacks so on-demand
+// reports are possible independently of the env-gated crash-dump configuration.
+void CrashReportInitialize();
+
+// Initialize the reporter (via CrashReportInitialize) and, based on the DOTNET_*
+// crash-report configuration, start its crash-dump services and register the PAL
+// signal-path dispatcher. Intended to run once at runtime startup.
 void CrashReportConfigure();
 
 #endif // FEATURE_INPROC_CRASHREPORT

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -165,6 +165,7 @@ class CallStackLogger
     PEXCEPTION_POINTERS m_pExceptionInfo;
     // MethodDescs of the stack frames, the TOS is at index 0
     CDynArray<MethodDesc*> m_frames;
+    bool m_captureStackOverflowTrace;
 
     StackWalkAction LogCallstackForLogCallbackWorker(CrawlFrame *pCF)
     {
@@ -214,7 +215,10 @@ class CallStackLogger
         TypeString::AppendMethodInternal(frame, pMD, TypeString::FormatNamespace|TypeString::FormatFullInst|TypeString::FormatSignature);
 
 #ifdef FEATURE_INPROC_CRASHREPORT
-        InProcCrashReportAddStackOverflowTraceFrame(frame.GetUTF8(), repeatCount, repeatSequenceLength);
+        if (m_captureStackOverflowTrace)
+        {
+            InProcCrashReportAddStackOverflowTraceFrame(frame.GetUTF8(), repeatCount, repeatSequenceLength);
+        }
 #endif // FEATURE_INPROC_CRASHREPORT
 
         SString str(pWordAt);
@@ -226,11 +230,12 @@ class CallStackLogger
 
 public:
 
-    CallStackLogger(PEXCEPTION_POINTERS pExceptionInfo)
+    CallStackLogger(PEXCEPTION_POINTERS pExceptionInfo, bool captureStackOverflowTrace)
     {
         WRAPPER_NO_CONTRACT;
 
         m_pExceptionInfo = pExceptionInfo;
+        m_captureStackOverflowTrace = captureStackOverflowTrace;
     }
 
     // Callback called by the stack walker for each frame on the stack
@@ -317,7 +322,10 @@ public:
         }
 
 #ifdef FEATURE_INPROC_CRASHREPORT
-        InProcCrashReportBeginStackOverflowTrace(crashingTid, static_cast<uint32_t>(m_frames.Count()));
+        if (m_captureStackOverflowTrace)
+        {
+            InProcCrashReportBeginStackOverflowTrace(crashingTid, static_cast<uint32_t>(m_frames.Count()));
+        }
 #endif // FEATURE_INPROC_CRASHREPORT
 
         for (int i = 0; i < largestCommonStartOffset; i++)
@@ -349,7 +357,10 @@ public:
         }
 
 #ifdef FEATURE_INPROC_CRASHREPORT
-        InProcCrashReportEndStackOverflowTrace();
+        if (m_captureStackOverflowTrace)
+        {
+            InProcCrashReportEndStackOverflowTrace();
+        }
 #endif // FEATURE_INPROC_CRASHREPORT
     }
 };
@@ -370,7 +381,7 @@ static bool g_LogStackOverflowExit = false;
 // Return Value:
 //    None
 //
-inline void LogCallstackForLogWorker(Thread* pThread, PEXCEPTION_POINTERS pExceptionInfo)
+inline void LogCallstackForLogWorker(Thread* pThread, PEXCEPTION_POINTERS pExceptionInfo, bool captureStackOverflowTrace)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -386,7 +397,7 @@ inline void LogCallstackForLogWorker(Thread* pThread, PEXCEPTION_POINTERS pExcep
     }
     WordAt.Append(W(" "));
 
-    CallStackLogger logger(pExceptionInfo);
+    CallStackLogger logger(pExceptionInfo, captureStackOverflowTrace);
 
     pThread->StackWalkFrames(&CallStackLogger::LogCallstackForLogCallback, &logger, QUICKUNWIND | FUNCTIONSONLY | ALLOW_ASYNC_STACK_WALK);
 
@@ -477,7 +488,7 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, PEXCEPTION_POINTERS
         Thread* pThread = GetThreadNULLOk();
         if (pThread && errorSource == NULL)
         {
-            LogCallstackForLogWorker(pThread, pExceptionInfo);
+            LogCallstackForLogWorker(pThread, pExceptionInfo, /*captureStackOverflowTrace*/ false);
 
             if (argExceptionString != NULL) {
                 PrintToStdErrW(argExceptionString);
@@ -677,7 +688,7 @@ void DisplayStackOverflowException()
 
 DWORD LogStackOverflowStackTraceThread(void* arg)
 {
-    LogCallstackForLogWorker((Thread*)arg, NULL);
+    LogCallstackForLogWorker((Thread*)arg, NULL, /*captureStackOverflowTrace*/ true);
 
     return 0;
 }


### PR DESCRIPTION
## Summary

Adds an on-demand entry point to the in-proc crash reporter so a report can be generated programmatically while the runtime is still running, independent of the fatal-signal path. This is the reporting mechanism that a user-registered native
fatal-error handler (proposed in #129543) can call to produce a crash report.

## Motivation

The in-proc crash reporter can currently only run from the PAL fatal-signal dispatcher. The fatal-error-handler proposal (#129543) needs a way to invoke just the reporting mechanism on demand, formatting the report to a caller-supplied sink,
without the watchdog/lifecycle/file-management that the signal path performs.

## What's in this PR

- **On-demand report API** — `InProcCrashReportCreateReport(outputFormat, signal, context, outputCallback, callbackContext)`. Emits the same report as the signal path but streams the selected format (`Json` or `Log`) to a caller-supplied callback, with no watchdog or file output. Re-runnable; yields to any report already in flight.
- **Shared in-flight guard** — the signal-path and on-demand `CreateReport` paths are made mutually exclusive over the shared signal-safe writers, module table, and process-global thread-suspension machinery via a single `m_reportInFlight` guard. The on-demand path releases the guard on completion; the signal path never does (the process is terminating).
- **Init / services split** — reporter bring-up is split into `CrashReportInitialize` (VM callbacks only, so on-demand reports are possible) and `InProcCrashReportInitializeServices` (env-gated watchdog + lifecycle + PAL dispatcher registration). This lets the reporter be initialized from either the runtime startup path or a future fatal-error-handler setup path, without arming the signal-path crash-dump behavior.
- **Output sink refactor** — `SignalSafeConsoleWriter` and `SignalSafeJsonWriter` gain a small copyable sink abstraction so a single caller-supplied callback shape can drive either writer (platform console / drop-all / caller callback).
- **Stack-overflow classification fix** — the in-proc SO stack trace is now captured only on the real stack-overflow path. Previously a `FailFast` (which funnels through the same fatal-error callstack logger) populated the SO-trace latch, causing an on-demand report to misclassify a `FailFast` as a `StackOverflow`. Gating capture to the real-SO path makes the latch authoritative for classification.

## Behavior notes

- No behavior changes when crash reporting is disabled: startup allocates nothing.
- No behavior changes when crash reporting is enabled: allocates and configure signal-based in-proc crash reporter.

## Testing

- In-proc crash reporter lacks automatic tests, on-demand can be tested through #129543 tests when integrated.
- Manually ran FailFast and StackOverflow paths on Android arm64 emulator.
- All tests in https://github.com/mdh1418/runtime/blob/inproc_crashreport_tests/src/tests/FunctionalTests/Android/Device_Emulator/InProcCrashReport/OVERVIEW.md pass on Android arm64 emulator.

## Follow-ups

- Wiring the on-demand entry point into the fatal-error handler once #129543 lands.