### PR TITLE
JIT: recognize generic Vector128 intrinsics on wasm

### DIFF
--- a/src/coreclr/jit/hwintrinsicwasm.cpp
+++ b/src/coreclr/jit/hwintrinsicwasm.cpp
@@ -25,7 +25,7 @@ CORINFO_InstructionSet Compiler::lookupInstructionSet(const char* className)
     {
         return InstructionSet_PackedSimd;
     }
-    else if (strcmp(className, "Vector128") == 0)
+    else if ((strcmp(className, "Vector128") == 0) || (strcmp(className, "Vector128`1") == 0))
     {
         return InstructionSet_Vector128;
     }


### PR DESCRIPTION
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 760f2e57-f8d3-478b-a9cb-de67d71c9452