### PR TITLE
Fix up core count detection logic on android

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -143,8 +143,18 @@ bool GCToOSInterface::Initialize()
 
     g_pageSizeUnixInl = uint32_t((pageSize > 0) ? pageSize : 0x1000);
 
-    // Calculate and cache the number of processors on this machine
+#ifdef TARGET_ANDROID
+	// Android tries really hard to save power by powering off CPUs on SMP phones which
+	// means the normal way to query cpu count can underestimate the number of available CPUs.
+    int cpuCount = minipal_get_cpu_present_count();
+    if (cpuCount == -1)
+    {
+        cpuCount = sysconf(SYSCONF_GET_NUMPROCS);
+    }
+#else
     int cpuCount = sysconf(SYSCONF_GET_NUMPROCS);
+#endif
+
     if (cpuCount == -1)
     {
         return false;
@@ -171,7 +181,7 @@ bool GCToOSInterface::Initialize()
 
     InitializeCGroup();
 
-#if HAVE_SCHED_GETAFFINITY
+#if HAVE_SCHED_GETAFFINITY && !defined(TARGET_ANDROID)
 
     {
         // Use a dynamically allocated cpu_set_t to support systems with more than CPU_SETSIZE (typically 1024) CPUs.

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -144,8 +144,8 @@ bool GCToOSInterface::Initialize()
     g_pageSizeUnixInl = uint32_t((pageSize > 0) ? pageSize : 0x1000);
 
 #ifdef TARGET_ANDROID
-	// Android tries really hard to save power by powering off CPUs on SMP phones which
-	// means the normal way to query cpu count can underestimate the number of available CPUs.
+    // Android tries really hard to save power by powering off CPUs on SMP phones which
+    // means the normal way to query cpu count can underestimate the number of available CPUs.
     int cpuCount = minipal_get_cpu_present_count();
     if (cpuCount == -1)
     {

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -181,7 +181,7 @@ bool GCToOSInterface::Initialize()
 
     InitializeCGroup();
 
-#if HAVE_SCHED_GETAFFINITY && !defined(TARGET_ANDROID)
+#if HAVE_SCHED_GETAFFINITY
 
     {
         // Use a dynamically allocated cpu_set_t to support systems with more than CPU_SETSIZE (typically 1024) CPUs.

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -464,6 +464,10 @@ void InitializeCurrentProcessCpuCount()
     else if ((cpuPresentCount = minipal_get_cpu_present_count()) > 0)
     {
         count = cpuPresentCount;
+
+        uint32_t cpuLimit;
+        if (GetCpuLimit(&cpuLimit) && cpuLimit < count)
+            count = cpuLimit;
     }
 #endif
     else

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -459,8 +459,8 @@ void InitializeCurrentProcessCpuCount()
         count = configValue;
     }
 #ifdef HOST_ANDROID
-	// Android tries really hard to save power by powering off CPUs on SMP phones which
-	// means the normal way to query cpu count can underestimate the number of available CPUs.
+    // Android tries really hard to save power by powering off CPUs on SMP phones which
+    // means the normal way to query cpu count can underestimate the number of available CPUs.
     else if ((cpuPresentCount = minipal_get_cpu_present_count()) > 0)
     {
         count = cpuPresentCount;

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -451,12 +451,21 @@ void InitializeCurrentProcessCpuCount()
 
     const unsigned int MAX_PROCESSOR_COUNT = 0xffff;
     uint64_t configValue;
+    int cpuPresentCount;
 
     if (g_pRhConfig->ReadConfigValue("PROCESSOR_COUNT", &configValue, true /* decimal */) &&
         0 < configValue && configValue <= MAX_PROCESSOR_COUNT)
     {
         count = configValue;
     }
+#ifdef HOST_ANDROID
+	// Android tries really hard to save power by powering off CPUs on SMP phones which
+	// means the normal way to query cpu count can underestimate the number of available CPUs.
+    else if ((cpuPresentCount = minipal_get_cpu_present_count()) > 0)
+    {
+        count = cpuPresentCount;
+    }
+#endif
     else
     {
 #if HAVE_SCHED_GETAFFINITY

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -447,7 +447,7 @@ void InitializeCurrentProcessCpuCount()
     uint32_t count = 0;
 
     // If the configuration value has been set, it takes precedence. Otherwise, take into account
-    // process affinity and CPU quota limit.
+    // process affinity and CPU quota limit, except for Android (explained below).
 
     const unsigned int MAX_PROCESSOR_COUNT = 0xffff;
     uint64_t configValue;

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -154,7 +154,13 @@ PAL_GetLogicalCpuCountFromOS()
 {
     static int nrcpus = -1;
 
-    if (nrcpus == -1)
+	// Android tries really hard to save power by powering off CPUs on SMP phones which
+	// means the normal way to query cpu count can underestimate the number of available CPUs.
+#if defined(HOST_ANDROID)
+    nrcpus = minipal_get_cpu_present_count();
+#endif
+
+    if (nrcpus <= 0)
     {
 #if HAVE_SCHED_GETAFFINITY
 

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -154,8 +154,8 @@ PAL_GetLogicalCpuCountFromOS()
 {
     static int nrcpus = -1;
 
-	// Android tries really hard to save power by powering off CPUs on SMP phones which
-	// means the normal way to query cpu count can underestimate the number of available CPUs.
+    // Android tries really hard to save power by powering off CPUs on SMP phones which
+    // means the normal way to query cpu count can underestimate the number of available CPUs.
 #if defined(HOST_ANDROID)
     if (nrcpus <= 0)
     {

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -157,7 +157,10 @@ PAL_GetLogicalCpuCountFromOS()
 	// Android tries really hard to save power by powering off CPUs on SMP phones which
 	// means the normal way to query cpu count can underestimate the number of available CPUs.
 #if defined(HOST_ANDROID)
-    nrcpus = minipal_get_cpu_present_count();
+    if (nrcpus <= 0)
+    {
+        nrcpus = minipal_get_cpu_present_count();
+    }
 #endif
 
     if (nrcpus <= 0)

--- a/src/mono/mono/utils/mono-proclib.c
+++ b/src/mono/mono/utils/mono-proclib.c
@@ -80,21 +80,53 @@ mono_cpu_count (void)
 	/* Android tries really hard to save power by powering off CPUs on SMP phones which
 	 * means the normal way to query cpu count returns a wrong value with userspace API.
 	 * Instead we use /sys entries to query the actual hardware CPU count.
+	 *
+	 * The /sys entry is a cpulist: a comma-separated list of CPU indexes and ranges,
+	 * e.g. "0", "0-7" or "0-3,5-7".
 	 */
 	int count = 0;
-	char buffer[8] = {'\0'};
+	int parse_success = 0;
+	char buffer[32];
 	int present = open ("/sys/devices/system/cpu/present", O_RDONLY);
-	/* Format of the /sys entry is a cpulist of indexes which in the case
-	 * of present is always of the form "0-(n-1)" when there is more than
-	 * 1 core, n being the number of CPU cores in the system. Otherwise
-	 * the value is simply 0
-	 */
-	if (present != -1 && read (present, (char*)buffer, sizeof (buffer)) > 3)
-		count = strtol (((char*)buffer) + 2, NULL, 10);
-	if (present != -1)
+	if (present != -1) {
+		int nread = read (present, buffer, sizeof (buffer) - 1);
 		close (present);
-	if (count > 0)
-		return count + 1;
+		if (nread > 0 && (nread < sizeof (buffer) - 1 || buffer [nread - 1] == '\n')) {
+			buffer[nread] = '\0';
+			char *p = buffer;
+			while (*p) {
+				char *endp = NULL;
+				errno = 0;
+				int lo = (int) strtol (p, &endp, 10);
+				if (endp == p || errno != 0)
+					break; /* no digits parsed, stop */
+				int hi = lo;
+				p = endp;
+				if (*p == '-') {
+					p++;
+					errno = 0;
+					hi = (int) strtol (p, &endp, 10);
+					if (endp == p || errno != 0)
+						break;
+					p = endp;
+				}
+				if (hi < lo)
+					break;
+				count += hi - lo + 1;
+
+				if (*p == ',')
+					p++;
+				else if (*p == '\n' || *p == '\0') {
+					parse_success = 1;
+					break;
+				}
+				else
+					break;
+			}
+		}
+	}
+	if (parse_success && count > 0)
+		return count;
 #endif
 
 #if defined(HOST_ARM) || defined (HOST_ARM64)

--- a/src/mono/mono/utils/mono-proclib.c
+++ b/src/mono/mono/utils/mono-proclib.c
@@ -7,6 +7,7 @@
 
 #include "config.h"
 #include <mono/utils/mono-proclib.h>
+#include <minipal/cpucount.h>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -78,55 +79,14 @@ mono_cpu_count (void)
 #else
 #ifdef HOST_ANDROID
 	/* Android tries really hard to save power by powering off CPUs on SMP phones which
-	 * means the normal way to query cpu count returns a wrong value with userspace API.
+	 * means the normal way to query cpu count can underestimate the number of available CPUs.
 	 * Instead we use /sys entries to query the actual hardware CPU count.
-	 *
-	 * The /sys entry is a cpulist: a comma-separated list of CPU indexes and ranges,
-	 * e.g. "0", "0-7" or "0-3,5-7".
 	 */
-	int count = 0;
-	int parse_success = 0;
-	char buffer[32];
-	int present = open ("/sys/devices/system/cpu/present", O_RDONLY);
-	if (present != -1) {
-		int nread = read (present, buffer, sizeof (buffer) - 1);
-		close (present);
-		if (nread > 0 && (nread < sizeof (buffer) - 1 || buffer [nread - 1] == '\n')) {
-			buffer[nread] = '\0';
-			char *p = buffer;
-			while (*p) {
-				char *endp = NULL;
-				errno = 0;
-				int lo = (int) strtol (p, &endp, 10);
-				if (endp == p || errno != 0)
-					break; /* no digits parsed, stop */
-				int hi = lo;
-				p = endp;
-				if (*p == '-') {
-					p++;
-					errno = 0;
-					hi = (int) strtol (p, &endp, 10);
-					if (endp == p || errno != 0)
-						break;
-					p = endp;
-				}
-				if (hi < lo)
-					break;
-				count += hi - lo + 1;
-
-				if (*p == ',')
-					p++;
-				else if (*p == '\n' || *p == '\0') {
-					parse_success = 1;
-					break;
-				}
-				else
-					break;
-			}
-		}
+	{
+		int count = minipal_get_cpu_present_count ();
+		if (count > 0)
+			return count;
 	}
-	if (parse_success && count > 0)
-		return count;
 #endif
 
 #if defined(HOST_ARM) || defined (HOST_ARM64)

--- a/src/native/minipal/cpucount.c
+++ b/src/native/minipal/cpucount.c
@@ -73,7 +73,7 @@ static int parse_cpulist_file(const char* path, int* outCount, int* outMaxIndex)
         if (outCount) *outCount = count;
         if (outMaxIndex) *outMaxIndex = maxIndex;
     }
-    return parseSuccess;
+    return parseSuccess && count > 0;
 }
 #endif
 

--- a/src/native/minipal/cpucount.c
+++ b/src/native/minipal/cpucount.c
@@ -6,44 +6,97 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#if defined(__linux__)
+// Parses a kernel cpulist file (comma-separated ranges like "0-3,5-7").
+// Sets *outCount to total CPU count and *outMaxIndex to highest index on success.
+static int parse_cpulist_file(const char* path, int* outCount, int* outMaxIndex)
+{
+    FILE* f = fopen(path, "r");
+    if (f == NULL)
+    {
+        return 0;
+    }
+
+    int count = 0;
+    int maxIndex = -1;
+    int parseSuccess = 0;
+    for (;;)
+    {
+        int lo, hi;
+        int matched = fscanf(f, "%d-%d", &lo, &hi);
+        if (matched == 1)
+        {
+            hi = lo;
+        }
+        else if (matched != 2)
+        {
+            // Unexpected format, discard
+            count = 0;
+            break;
+        }
+
+        if (hi < lo)
+        {
+            // Invalid range, discard
+            count = 0;
+            break;
+        }
+
+        count += hi - lo + 1;
+        if (hi > maxIndex)
+        {
+            maxIndex = hi;
+        }
+
+        int ch = fgetc(f);
+        if (ch == ',')
+        {
+            continue;
+        }
+        else if (ch == '\n' || ch == EOF)
+        {
+            parseSuccess = 1;
+            break;
+        }
+        else
+        {
+            // Unexpected character, discard
+            count = 0;
+            break;
+        }
+    }
+
+    fclose(f);
+
+    if (parseSuccess && count > 0)
+    {
+        if (outCount) *outCount = count;
+        if (outMaxIndex) *outMaxIndex = maxIndex;
+    }
+    return parseSuccess;
+}
+#endif
+
 int minipal_get_cpu_max_possible_count(void)
 {
 #if defined(__linux__)
-    FILE* f = fopen("/sys/devices/system/cpu/possible", "r");
-    if (f != NULL)
+    int maxIndex;
+    if (parse_cpulist_file("/sys/devices/system/cpu/possible", NULL, &maxIndex))
     {
-        int maxCpu = -1;
-        for (;;)
-        {
-            int lo, hi;
-            int matched = fscanf(f, "%d-%d", &lo, &hi);
-            if (matched == 1)
-            {
-                hi = lo;
-            }
-            else if (matched != 2)
-            {
-                break;
-            }
-
-            if (maxCpu < hi)
-            {
-                maxCpu = hi;
-            }
-
-            int ch = fgetc(f);
-            if (ch == EOF || ch != ',')
-            {
-                break;
-            }
-        }
-        fclose(f);
-        if (maxCpu != -1)
-        {
-            return maxCpu + 1;
-        }
+        return maxIndex + 1;
     }
 #endif
-
     return (int)sysconf(_SC_NPROCESSORS_CONF);
+}
+
+int minipal_get_cpu_present_count(void)
+{
+#if defined(__linux__)
+    int count;
+    if (parse_cpulist_file("/sys/devices/system/cpu/present", &count, NULL))
+    {
+        return count;
+    }
+#endif
+    return -1;
 }

--- a/src/native/minipal/cpucount.h
+++ b/src/native/minipal/cpucount.h
@@ -17,6 +17,13 @@ extern "C"
 // Falls back to sysconf(_SC_NPROCESSORS_CONF) if the sysfs file is unavailable.
 int minipal_get_cpu_max_possible_count(void);
 
+// Returns the number of CPUs physically present in the system, regardless of
+// whether they are currently online or offline. It's the number of cores the process
+// could potentially use if they were all online.
+//
+// On Linux, this reads /sys/devices/system/cpu/present.
+int minipal_get_cpu_present_count(void);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/src/native/minipal/cpucount.h
+++ b/src/native/minipal/cpucount.h
@@ -18,8 +18,8 @@ extern "C"
 int minipal_get_cpu_max_possible_count(void);
 
 // Returns the number of CPUs physically present in the system, regardless of
-// whether they are currently online or offline or -1 if unavailable. It's the
-// number of cores the process could potentially use if they were all online.
+// whether they are currently online or offline or -1 if unavailable. This is the
+// system core count and does not account for per-process affinity / cgroup limits.
 //
 // On Linux, this reads /sys/devices/system/cpu/present.
 int minipal_get_cpu_present_count(void);

--- a/src/native/minipal/cpucount.h
+++ b/src/native/minipal/cpucount.h
@@ -18,8 +18,8 @@ extern "C"
 int minipal_get_cpu_max_possible_count(void);
 
 // Returns the number of CPUs physically present in the system, regardless of
-// whether they are currently online or offline. It's the number of cores the process
-// could potentially use if they were all online.
+// whether they are currently online or offline or -1 if unavailable. It's the
+// number of cores the process could potentially use if they were all online.
 //
 // On Linux, this reads /sys/devices/system/cpu/present.
 int minipal_get_cpu_present_count(void);


### PR DESCRIPTION
Parse `/sys/devices/system/cpu/present` as a comma-separated cpulist (single indices and ranges) rather than assuming a single 0-(n-1) range. Extends the Mono logic to get the core count on android to CoreCLR and Native AOT too.

Closes #126417.