### PR TITLE
JIT: Fix WASM scalar extraction from SIMD parameters

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -9289,7 +9289,23 @@ void Lowering::FindInducedParameterRegisterLocals()
 
         GenTree* value = m_compiler->gtNewLclVarNode(remappedLclNum);
 
+#ifdef TARGET_WASM
+        if (varTypeIsSIMD(value) && !varTypeIsSIMD(fld))
+        {
+            // Unlike native targets, wasm cannot reinterpret a v128 local access as a scalar.
+            const unsigned laneOffset = fld->GetLclOffs() - regSegment->Offset;
+            const unsigned scalarSize = genTypeSize(fld);
+            assert((laneOffset % scalarSize) == 0);
+
+            const unsigned laneIndex = laneOffset / scalarSize;
+            value                    = m_compiler->gtNewSimdGetElementNode(fld->TypeGet(), value,
+                                                                           m_compiler->gtNewIconNode(static_cast<ssize_t>(laneIndex)),
+                                                                           fld->TypeGet(), genTypeSize(value));
+        }
+        else if (varTypeUsesFloatReg(value))
+#else
         if (varTypeUsesFloatReg(value))
+#endif // TARGET_WASM
         {
             assert(fld->GetLclOffs() == regSegment->Offset);
 


### PR DESCRIPTION
## Summary

Fixes a WASM codegen bug where extracting a scalar field from a SIMD-register parameter leaks a `v128` where a scalar (`f64`/`f32`/...) is expected, producing invalid WASM:

```
type mismatch: expected f64, found v128
```

`Lowering::FindInducedParameterRegisterLocals` maps a scalar field of an unenregisterable parameter to the local created for the containing register segment. Native targets can read the overlapping low scalar value by retyping that local access, but WASM has distinct `v128` and scalar value-stack types and cannot reinterpret them implicitly.

This is the floating-point `ToScalar` / SIMD-to-scalar `var_type` transition at ABI boundaries noted as deferred in #130444.

## Fix

When the mapped incoming register local is SIMD and the field is scalar, use `gtNewSimdGetElementNode` under `TARGET_WASM`. For lane zero this becomes `ToScalar`, which WASM lowers to the appropriate `extract_lane` operation rather than retyping a `v128` local or spilling through memory.

The byte offset is required to be scalar-lane aligned before deriving the lane index. Every non-WASM target retains the existing path unchanged.

## Validation

- `./build.sh clr.jit -rc Debug`
- `PATH="/opt/homebrew/bin:$PATH" ./build.sh -os browser -c Debug -subset clr+libs`
  - Confirmed `lower.cpp` compiled into the WASM JIT.
- `python3 src/coreclr/scripts/jitformat.py -r . -o osx -a arm64`

There is currently no WASM R2R validation leg in CI suitable for a focused regression test. The existing generalized extraction tests from #131174 were intentionally not included in this narrowly scoped WASM correctness fix.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.