### PR TITLE
Disable FullPdbThrower test in ilasm round trip testing

### DIFF
--- a/src/tests/baseservices/exceptions/fullpdbstacktrace/FullPdbThrower.csproj
+++ b/src/tests/baseservices/exceptions/fullpdbstacktrace/FullPdbThrower.csproj
@@ -5,8 +5,10 @@
     <DebugType Condition="'$(TargetOS)' == 'windows'">Full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
-    <!-- Needed for StackTraceLineNumberSupport -->
+    <!-- Needed for StackTraceLineNumberSupport, IlasmRoundTripIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- ilasm does not support full PDBs -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- DIA isn't used under Native AOT at runtime, but ensure that ILC does create
      line number blobs from full PDB that can be used in runtime stack traces. -->
     <StackTraceLineNumberSupport>true</StackTraceLineNumberSupport>


### PR DESCRIPTION
ilasm only supports portable pdbs