### PR TITLE
Fill WASM SIMD gaps: Base64 vectorization and byte/ushort LeadingZeroCount

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.LeadingZeroCount.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.LeadingZeroCount.cs
@@ -29,9 +29,12 @@ namespace System.Numerics.Tensors
         internal readonly unsafe struct LeadingZeroCountOperator<T> : IUnaryOperator<T, T> where T : IBinaryInteger<T>
         {
             public static bool Vectorizable =>
-                (Avx512CD.VL.IsSupported && (sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8)) ||
-                (Avx512Vbmi.VL.IsSupported && sizeof(T) == 1) ||
-                (AdvSimd.IsSupported && (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4));
+                // byte/ushort: the software fallback (bit-smear + PopCount) is a measured win at these widths.
+                // uint/ulong: a serial smear chain over only 2-4 lanes doesn't beat a single-instruction scalar
+                // clz (x86 lzcnt, wasm i32/i64.clz), so we only vectorize them with a hardware vector clz.
+                (sizeof(T) == 1 || sizeof(T) == 2) ||
+                (Avx512CD.VL.IsSupported && (sizeof(T) == 4 || sizeof(T) == 8)) ||
+                (AdvSimd.IsSupported && sizeof(T) == 4);
 
             public static T Invoke(T x) => T.LeadingZeroCount(x);
 
@@ -77,13 +80,36 @@ namespace System.Numerics.Tensors
                     }
                 }
 
-                Debug.Assert(AdvSimd.IsSupported);
+                if (AdvSimd.IsSupported)
                 {
                     if (sizeof(T) == 1) return AdvSimd.LeadingZeroCount(x.AsByte()).As<byte, T>();
                     if (sizeof(T) == 2) return AdvSimd.LeadingZeroCount(x.AsUInt16()).As<ushort, T>();
 
                     Debug.Assert(sizeof(T) == 4);
                     return AdvSimd.LeadingZeroCount(x.AsUInt32()).As<uint, T>();
+                }
+
+                // Software fallback (byte/ushort only): smear the most-significant set bit down so every
+                // lower bit is set, then LeadingZeroCount == bitWidth - PopCount(smeared).
+                if (sizeof(T) == 1)
+                {
+                    // Byte shifts are unavailable on some ISAs, so shift as 16-bit and mask off the
+                    // bits that bleed in from the adjacent higher byte.
+                    Vector128<byte> v = x.AsByte();
+                    v |= (v.AsUInt16() >> 1).AsByte() & Vector128.Create((byte)0x7F);
+                    v |= (v.AsUInt16() >> 2).AsByte() & Vector128.Create((byte)0x3F);
+                    v |= (v.AsUInt16() >> 4).AsByte() & Vector128.Create((byte)0x0F);
+                    return (Vector128.Create((byte)8) - PopCountOperator<byte>.Invoke(v)).As<byte, T>();
+                }
+
+                Debug.Assert(sizeof(T) == 2);
+                {
+                    Vector128<ushort> v = x.AsUInt16();
+                    v |= v >> 1;
+                    v |= v >> 2;
+                    v |= v >> 4;
+                    v |= v >> 8;
+                    return (Vector128.Create((ushort)16) - PopCountOperator<ushort>.Invoke(v)).As<ushort, T>();
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 
 #if NET
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 using System.Runtime.Intrinsics;
 #endif
@@ -966,13 +967,18 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         internal static Vector128<byte> SimdShuffle(Vector128<byte> left, Vector128<byte> right, Vector128<byte> mask8F)
         {
-            Debug.Assert((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian);
+            Debug.Assert((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) && BitConverter.IsLittleEndian);
 
             if (Ssse3.IsSupported)
             {
                 return Ssse3.Shuffle(left, right);
+            }
+            else if (PackedSimd.IsSupported)
+            {
+                return PackedSimd.Swizzle(left, right & mask8F);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
@@ -89,7 +89,7 @@ namespace System.Buffers.Text
                     }
 
                     end = srcMax - 24;
-                    if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian && (end >= src))
+                    if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) && BitConverter.IsLittleEndian && (end >= src))
                     {
                         Vector128Decode(decoder, ref src, ref dest, end, maxSrcLength, destLength, srcBytes, destBytes);
 
@@ -1129,11 +1129,12 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static unsafe void Vector128Decode<TBase64Decoder, T>(TBase64Decoder decoder, ref T* srcBytes, ref byte* destBytes, T* srcEnd, int sourceLength, int destLength, T* srcStart, byte* destStart)
             where TBase64Decoder : IBase64Decoder<T>
             where T : unmanaged
         {
-            Debug.Assert((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian);
+            Debug.Assert((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) && BitConverter.IsLittleEndian);
 
             // If we have Vector128 support, pick off 16 bytes at a time for as long as we can,
             // but make sure that we quit before seeing any == markers at the end of the
@@ -1254,6 +1255,14 @@ namespace System.Buffers.Text
                     Vector128<ushort> odds = AdvSimd.Arm64.TransposeOdd(str, Vector128<byte>.Zero).AsUInt16();
                     merge_ab_and_bc = Vector128.Add(evens, odds).AsInt16();
                 }
+                else if (PackedSimd.IsSupported)
+                {
+                    // MultiplyAddAdjacent by {64,1,...} is the even byte (low of each u16 lane) times 64 plus the odd byte.
+                    Vector128<ushort> u = str.AsUInt16();
+                    Vector128<ushort> evens = Vector128.ShiftLeft(u & Vector128.Create((ushort)0x00FF), 6);
+                    Vector128<ushort> odds = Vector128.ShiftRightLogical(u, 8);
+                    merge_ab_and_bc = (evens + odds).AsInt16();
+                }
                 else
                 {
                     // We explicitly recheck each IsSupported query to ensure that the trimmer can see which paths are live/dead
@@ -1275,6 +1284,14 @@ namespace System.Buffers.Text
                     Vector128<int> ievens = AdvSimd.ShiftLeftLogicalWideningLower(AdvSimd.Arm64.UnzipEven(merge_ab_and_bc, one.AsInt16()).GetLower(), 12);
                     Vector128<int> iodds = AdvSimd.Arm64.TransposeOdd(merge_ab_and_bc, Vector128<short>.Zero).AsInt32();
                     output = Vector128.Add(ievens, iodds).AsInt32();
+                }
+                else if (PackedSimd.IsSupported)
+                {
+                    // MultiplyAddAdjacent by {4096,1,...} is the even i16 (low of each i32 lane) times 4096 plus the odd i16.
+                    Vector128<uint> m = merge_ab_and_bc.AsUInt32();
+                    Vector128<uint> ievens = Vector128.ShiftLeft(m & Vector128.Create(0x0000FFFFu), 12);
+                    Vector128<uint> iodds = Vector128.ShiftRightLogical(m, 16);
+                    output = (ievens + iodds).AsInt32();
                 }
                 else
                 {
@@ -1422,6 +1439,7 @@ namespace System.Buffers.Text
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
             [CompExactlyDependsOn(typeof(Ssse3))]
+            [CompExactlyDependsOn(typeof(PackedSimd))]
             public bool TryDecode128Core(
                 Vector128<byte> str,
                 Vector128<byte> hiNibbles,
@@ -1643,6 +1661,7 @@ namespace System.Buffers.Text
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
             [CompExactlyDependsOn(typeof(Ssse3))]
+            [CompExactlyDependsOn(typeof(PackedSimd))]
             public bool TryDecode128Core(Vector128<byte> str, Vector128<byte> hiNibbles, Vector128<byte> maskSlashOrUnderscore, Vector128<byte> mask8F,
                 Vector128<byte> lutLow, Vector128<byte> lutHigh, Vector128<sbyte> lutShift, Vector128<byte> shiftForUnderscore, out Vector128<byte> result) =>
                 default(Base64DecoderByte).TryDecode128Core(str, hiNibbles, maskSlashOrUnderscore, mask8F, lutLow, lutHigh, lutShift, shiftForUnderscore, out result);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64EncoderHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64EncoderHelper.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 #if NET
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -71,7 +72,7 @@ namespace System.Buffers.Text
                     }
 
                     end = srcMax - 16;
-                    if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian && (end >= src))
+                    if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) && BitConverter.IsLittleEndian && (end >= src))
                     {
                         Vector128Encode(encoder, ref src, ref dest, end, maxSrcLength, destLength, srcBytes, destBytes);
 
@@ -441,6 +442,7 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         private static unsafe void Vector128Encode<TBase64Encoder, T>(TBase64Encoder encoder, ref byte* srcBytes, ref T* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, T* destStart)
             where TBase64Encoder : IBase64Encoder<T>
             where T : unmanaged
@@ -504,6 +506,13 @@ namespace System.Buffers.Text
                     Vector128<ushort> even = Vector128.ShiftRightLogical(AdvSimd.Arm64.UnzipEven(t0.AsUInt16(), t0.AsUInt16()), 10);
                     t1 = AdvSimd.Arm64.ZipLow(even, odd);
                 }
+                else if (PackedSimd.IsSupported)
+                {
+                    // MultiplyHigh by {2^6, 2^10} is a right shift of the even u16 lanes by 10 and the odd lanes by 6.
+                    Vector128<ushort> shr6 = Vector128.ShiftRightLogical(t0.AsUInt16(), 6);
+                    Vector128<ushort> shr10 = Vector128.ShiftRightLogical(t0.AsUInt16(), 10);
+                    t1 = Vector128.ConditionalSelect(Vector128.Create(0x0000FFFFu).AsUInt16(), shr10, shr6);
+                }
                 else
                 {
                     // We explicitly recheck each IsSupported query to ensure that the trimmer can see which paths are live/dead
@@ -547,6 +556,10 @@ namespace System.Buffers.Text
                 else if (AdvSimd.IsSupported)
                 {
                     indices = AdvSimd.SubtractSaturate(str.AsByte(), const51);
+                }
+                else if (PackedSimd.IsSupported)
+                {
+                    indices = PackedSimd.SubtractSaturate(str.AsByte(), const51);
                 }
                 else
                 {


### PR DESCRIPTION
This is the first, low-risk slice of an audit of the vectorized libraries code (`Vector<T>`, `Vector128/256/512<T>`, `System.Runtime.Intrinsics.*`) for WebAssembly SIMD (`PackedSimd`) coverage. It fixes the genuine WASM gaps found so far and leaves the broader audit tracked for follow-ups.

The audit is grounded on the **RyuJIT WASM backend**, not Mono+LLVM. RyuJIT auto-lowers cross-platform `Vector128`/`Vector<T>` into `PackedSimd` during import/lowering, so xplat code is already WASM-accelerated. A genuine WASM gap therefore exists only where code uses **raw `Sse*`/`Avx*`/`AdvSimd` intrinsics with no xplat fallback** (so WASM drops to scalar), and the operation has a WASM equivalent.

----------

## Base64 encode/decode (`Base64EncoderHelper.cs`, `Base64DecoderHelper.cs`)

The `Vector128` encode/decode loops were gated on `Ssse3 || AdvSimd.Arm64` with no cross-platform fallback, so WASM fell all the way back to the scalar path. These are the only true "vector cliffs" the audit found. Both helpers are shared by `Base64` and `Base64Url`, so this covers all four public surfaces.

The gate is widened to include `PackedSimd`, and the handful of x86/Arm-specific primitives are given `PackedSimd` branches:

- `SimdShuffle` → `PackedSimd.Swizzle` (matches `Ssse3.Shuffle`'s high-bit-clears-lane semantics via `mask8F`).
- `SubtractSaturate` → `PackedSimd.SubtractSaturate`.
- The `pmaddubsw`/`pmaddwd`/`MultiplyHigh` reshuffles are emulated with per-lane logical shifts, exact for the 6-/10-/12-bit intermediates (e.g. `pmaddubsw` by `{64,1,…}` is `(even_byte << 6) + odd_byte`).

The emulations were validated bit-identical against the `Sse2`/`Ssse3` intrinsics over random inputs. All new branches constant-fold away off-WASM (`PackedSimd.IsSupported` is a JIT constant), so there's no change to x86/Arm codegen.

----------

## byte/ushort `LeadingZeroCount` software fallback (`TensorPrimitives.LeadingZeroCount.cs`)

`LeadingZeroCount` previously vectorized only via a **hardware** vector clz — `Avx512CD`/`Avx512Vbmi` on x86, `AdvSimd` on Arm. WASM has no vector clz opcode, so it ran fully scalar; x86-without-AVX512 also ran scalar for `byte`/`ushort`.

This adds a table-free software fallback for **`byte`/`ushort` only**: smear the most-significant set bit down so every lower bit is set, then `LeadingZeroCount == bitWidth - PopCount(smeared)`, reusing the existing `PopCountOperator` (the same idiom `TrailingZeroCount` already uses). Hardware paths keep priority; the fallback only fills the gap on platforms lacking a vector clz for these widths (WASM, x86-SSE).

### Why byte/ushort only

The smear is a serial dependency chain of `O(log bitWidth)` instructions **independent of lane count**, so it only pays off with enough lanes to amortize the chain. Measured on an AVX2 box with `Avx512CD.VL` disabled to force the software path, comparing the actual `TensorPrimitives.LeadingZeroCount<T>` path before/after (best-of-N, warmed):

| width | lanes / V128 | vec vs scalar |
|---|---|---|
| `byte`   | 16 | **3.27x** |
| `ushort` |  8 | **1.45x** |
| `uint`   |  4 | ~1.0x (break-even) |
| `ulong`  |  2 | regresses |

So `uint`/`ulong` keep their existing hardware-vector-clz gates and stay scalar where no vector clz exists — a single-instruction scalar clz (`x86 lzcnt`, `wasm i32/i64.clz`) beats a serial smear over only 2–4 lanes.

I also checked whether widening to `Vector256` would flip `uint`/`ulong` to a win (more lanes amortizing the same chain, plus wider loads for memory-bound inputs). It doesn't hold up — `uint` only wins at the L1-resident (1.21x) and truly DRAM-bound (1.18x) extremes but loses ~2x across the L2/L3 middle where most inputs land; `ulong` never breaks even (0.54–0.75x). The scalar loop sustains higher memory-level parallelism than the long dependency chain, so the wide-vector version is left out.

----------

## Audit coverage (for reviewer context)

~68 vectorized files were reviewed. Breakdown:

- **Already WASM-explicit (24):** carry a `PackedSimd` branch alongside x86/Arm (e.g. `HexConverter`, `Guid`, `Matrix4x4`, the ASCII/UTF8/Teddy/Probabilistic `SearchValues`).
- **Already xplat-covered (20):** the internal ISA branch is an AVX2 *wider-than-128* fast path or a hardware clz/round lightup; the `Vector128`/`Vector<T>` fallback is what RyuJIT lowers on WASM, so no cliff (e.g. `SpanHelpers.Byte/Char`, `Ascii.*`, `Math`/`MathF`, `TrailingZeroCount`, Latin1 narrowing).
- **Scalar by nature (13):** CRC (carryless-multiply tables), FMA, and similar — no WASM vector equivalent, or inherently scalar.
- **Fixed here (4):** the Base64/Base64Url helpers above.
- **Intentionally left as an x86-only optimization (7):** the packed `SearchValues` family (`SpanHelpers.Packed.cs` + `Any*CharPacked*`). Its throughput win rests on a *cheap* movemask + saturating narrow. Those are cheap when a WASM engine runs on an x86 host but lower to the same expensive emulation on an Arm host — which is exactly why native Arm (`AdvSimd`) is deliberately excluded there. Since we can't condition on the host ISA from within WASM, enabling it risks the Arm worst-case regression, so `PackedIndexOfIsSupported` stays x86-only. WASM already uses the non-packed (still vector-accelerated) searcher.

> [!NOTE]
> This PR description and the code changes were authored with GitHub Copilot.
