### PR TITLE
[wasm] Export cDAC contract descriptor getter on non-emscripten wasm (wasi-sdk)

### DIFF
--- a/src/coreclr/debug/datadescriptor-shared/contract-descriptor.c.in
+++ b/src/coreclr/debug/datadescriptor-shared/contract-descriptor.c.in
@@ -30,13 +30,26 @@ struct ContractDescriptor CONTRACT_NAME = {
 // Due to linking order, the export may also need to be added to
 // the EXPORTED_FUNCTIONS setting for emcc.
 // See https://emscripten.org/docs/getting_started/FAQ.html#why-do-functions-in-my-c-c-source-code-vanish-when-i-compile-to-webassembly
+#define _GETTER_NAME(exportname) Get ## exportname
+#define GETTER_NAME(exportname) _GETTER_NAME(exportname)
+#define _GETTER_NAME_STR(exportname) "Get" #exportname
+#define GETTER_NAME_STR(exportname) _GETTER_NAME_STR(exportname)
+
 #if defined(EXPORT_CONTRACT) && defined(__EMSCRIPTEN__)
 #include <emscripten.h>
 
-#define _GETTER_NAME(exportname) Get ## exportname
-#define GETTER_NAME(exportname) _GETTER_NAME(exportname)
 extern void* EMSCRIPTEN_KEEPALIVE GETTER_NAME(CONTRACT_NAME)()
 {
     return (void*)&CONTRACT_NAME;
 }
-#endif // EXPORT_CONTRACT && __EMSCRIPTEN__
+#elif defined(EXPORT_CONTRACT) && defined(__wasm__)
+// Non-emscripten wasm (e.g. wasi-sdk): export the getter with an explicit export name so the
+// descriptor symbol is both reachable by a native host and, critically, kept alive by the linker.
+// Without an export rooting it, --gc-sections removes the descriptor from the final module (the
+// emscripten path above relies on EMSCRIPTEN_KEEPALIVE for the same reason).
+__attribute__((export_name(GETTER_NAME_STR(CONTRACT_NAME))))
+void* GETTER_NAME(CONTRACT_NAME)()
+{
+    return (void*)&CONTRACT_NAME;
+}
+#endif // EXPORT_CONTRACT && (__EMSCRIPTEN__ || __wasm__)

--- a/src/coreclr/debug/datadescriptor-shared/contract-descriptor.c.in
+++ b/src/coreclr/debug/datadescriptor-shared/contract-descriptor.c.in
@@ -42,7 +42,7 @@ extern void* EMSCRIPTEN_KEEPALIVE GETTER_NAME(CONTRACT_NAME)()
 {
     return (void*)&CONTRACT_NAME;
 }
-#elif defined(EXPORT_CONTRACT) && defined(__wasm__)
+#elif defined(EXPORT_CONTRACT) && defined(TARGET_WASM)
 // Non-emscripten wasm (e.g. wasi-sdk): export the getter with an explicit export name so the
 // descriptor symbol is both reachable by a native host and, critically, kept alive by the linker.
 // Without an export rooting it, --gc-sections removes the descriptor from the final module (the
@@ -52,4 +52,4 @@ void* GETTER_NAME(CONTRACT_NAME)()
 {
     return (void*)&CONTRACT_NAME;
 }
-#endif // EXPORT_CONTRACT && (__EMSCRIPTEN__ || __wasm__)
+#endif // EXPORT_CONTRACT && (__EMSCRIPTEN__ || TARGET_WASM)

--- a/src/coreclr/debug/datadescriptor-shared/contract-descriptor.c.in
+++ b/src/coreclr/debug/datadescriptor-shared/contract-descriptor.c.in
@@ -42,14 +42,21 @@ extern void* EMSCRIPTEN_KEEPALIVE GETTER_NAME(CONTRACT_NAME)()
 {
     return (void*)&CONTRACT_NAME;
 }
-#elif defined(EXPORT_CONTRACT) && defined(TARGET_WASM)
+#elif defined(EXPORT_CONTRACT) && defined(__wasm__)
 // Non-emscripten wasm (e.g. wasi-sdk): export the getter with an explicit export name so the
 // descriptor symbol is both reachable by a native host and, critically, kept alive by the linker.
 // Without an export rooting it, --gc-sections removes the descriptor from the final module (the
 // emscripten path above relies on EMSCRIPTEN_KEEPALIVE for the same reason).
+//
+// This intentionally keys on the compiler-provided __wasm__ rather than the CoreCLR TARGET_WASM
+// define. datadescriptor-shared is compiled by multiple consumers and TARGET_WASM (set only by
+// CoreCLR's configurecompiler.cmake, and gated on IGNORE_DEFAULT_TARGET_ARCH) is not guaranteed to
+// reach every one of them. Since the whole point of this branch is to keep the descriptor alive on
+// any wasm toolchain, it must depend on a macro that is always defined when targeting wasm; __wasm__
+// is set by the compiler itself for exactly that.
 __attribute__((export_name(GETTER_NAME_STR(CONTRACT_NAME))))
 void* GETTER_NAME(CONTRACT_NAME)()
 {
     return (void*)&CONTRACT_NAME;
 }
-#endif // EXPORT_CONTRACT && (__EMSCRIPTEN__ || TARGET_WASM)
+#endif // EXPORT_CONTRACT && (__EMSCRIPTEN__ || __wasm__)


### PR DESCRIPTION
## Summary

On non-emscripten wasm (wasi-sdk), the cDAC contract descriptor getter `GetDotNetRuntimeContractDescriptor` is not exported, so `--gc-sections` strips the descriptor from the final module. This prevents a native host / the cDAC reader from discovering the runtime data-contract descriptor on WASI.

The emscripten path already handles this via `EMSCRIPTEN_KEEPALIVE`, which both exports the getter and keeps the descriptor alive. There was no equivalent for the wasi-sdk (`__wasm__`, non-emscripten) toolchain.

## Fix

Add an `#elif defined(EXPORT_CONTRACT) && defined(__wasm__)` branch that emits the getter with `__attribute__((export_name("Get" #CONTRACT_NAME)))`. The explicit wasm export both makes the symbol reachable by a native host and roots it so `--gc-sections` does not remove the descriptor — mirroring what `EMSCRIPTEN_KEEPALIVE` does on the emscripten path.

The `GETTER_NAME` token-paste macros are hoisted above the `#if` (shared by both branches) and a `GETTER_NAME_STR` stringize pair is added to produce the literal export name `"GetDotNetRuntimeContractDescriptor"`.

## Validation

- WASI CoreCLR build (`clr -os wasi -c Release`): compiles clean (0W/0E).
- Confirmed the compiled object exports `GetDotNetRuntimeContractDescriptor` with the `no_strip` flag, so it survives `--gc-sections`.

This unblocks live cDAC discovery on WASI (non-emscripten) — the runtime-side counterpart to the cDAC-wasm validation work (#131161). Fixture-based cDAC tests do not depend on it.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.
