### PR TITLE
Make AiaCompletionHasLimits handle Windows variance

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
@@ -221,10 +221,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         public static void AiaCompletionHasLimits()
         {
             const int IntermediateCount = 8;
+            int iteration = 0;
 
             RetryHelper.Execute(
                 () =>
                 {
+                    iteration++;
+
                     CertificateAuthority.BuildPrivatePki(
                         PkiOptions.AllRevocation,
                         out RevocationResponder responder,
@@ -233,7 +236,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                         out X509Certificate2 endEntity,
                         intermediateAuthorityCount: IntermediateCount,
                         pkiOptionsInSubject: false,
-                        testName: nameof(AiaCompletionHasLimits));
+                        testName: $"{nameof(AiaCompletionHasLimits)}_{iteration}");
 
                     using (responder)
                     using (root)

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
@@ -327,9 +327,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                         }
                         finally
                         {
-                            foreach (CertificateAuthority intermediate in intermediates)
+                            if (intermediates is not null)
                             {
-                                intermediate.Dispose();
+                                foreach (CertificateAuthority intermediate in intermediates)
+                                {
+                                    intermediate.Dispose();
+                                }
                             }
                         }
                     }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
@@ -222,24 +222,24 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         {
             const int IntermediateCount = 8;
 
-            CertificateAuthority.BuildPrivatePki(
-                PkiOptions.AllRevocation,
-                out RevocationResponder responder,
-                out CertificateAuthority root,
-                out CertificateAuthority[] intermediates,
-                out X509Certificate2 endEntity,
-                intermediateAuthorityCount: IntermediateCount,
-                pkiOptionsInSubject: false,
-                testName: nameof(AiaCompletionHasLimits));
-
-            using (responder)
-            using (root)
-            using (endEntity)
-            {
-                try
+            RetryHelper.Execute(
+                () =>
                 {
-                    RetryHelper.Execute(
-                        () =>
+                    CertificateAuthority.BuildPrivatePki(
+                        PkiOptions.AllRevocation,
+                        out RevocationResponder responder,
+                        out CertificateAuthority root,
+                        out CertificateAuthority[] intermediates,
+                        out X509Certificate2 endEntity,
+                        intermediateAuthorityCount: IntermediateCount,
+                        pkiOptionsInSubject: false,
+                        testName: nameof(AiaCompletionHasLimits));
+
+                    using (responder)
+                    using (root)
+                    using (endEntity)
+                    {
+                        try
                         {
                             using (ChainHolder holder = new ChainHolder())
                             {
@@ -324,22 +324,22 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                                     }
                                 }
                             }
-                        });
-                }
-                finally
-                {
-                    foreach (CertificateAuthority intermediate in intermediates)
-                    {
-                        intermediate.Dispose();
+                        }
+                        finally
+                        {
+                            foreach (CertificateAuthority intermediate in intermediates)
+                            {
+                                intermediate.Dispose();
+                            }
+                        }
                     }
-                }
+                });
 
-                static void CloneIntoExtraStore(X509Chain chain, int index)
-                {
-                    ReadOnlySpan<byte> source = chain.ChainElements[index].Certificate.RawDataMemory.Span;
-                    X509Certificate2 cert = X509CertificateLoader.LoadCertificate(source);
-                    chain.ChainPolicy.ExtraStore.Add(cert);
-                }
+            static void CloneIntoExtraStore(X509Chain chain, int index)
+            {
+                ReadOnlySpan<byte> source = chain.ChainElements[index].Certificate.RawDataMemory.Span;
+                X509Certificate2 cert = X509CertificateLoader.LoadCertificate(source);
+                chain.ChainPolicy.ExtraStore.Add(cert);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/AiaTests.cs
@@ -220,7 +220,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         [Fact]
         public static void AiaCompletionHasLimits()
         {
-            const int IntermediateCount = 6;
+            const int IntermediateCount = 8;
 
             CertificateAuthority.BuildPrivatePki(
                 PkiOptions.AllRevocation,
@@ -260,25 +260,60 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                                     // EE, intermediate0 (AIA), intermediate1 (ExtraStore), intermediate2 (AIA).
                                     AssertExtensions.TrueExpression(chain.Build(endEntity));
-                                    Assert.Equal(4, chain.ChainElements.Count);
-                                    AssertExtensions.HasFlag(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
 
-                                    CloneIntoExtraStore(chain, 1);
-                                    CloneIntoExtraStore(chain, 3);
-                                    holder.DisposeChainElements();
+                                    // Current Windows only allows 2, by black box testing, but 3 does seem to happen
+                                    // on some builds.  So, variant test for it being over-sized
+                                    if (chain.ChainElements.Count == 5)
+                                    {
+                                        // The ones described above, plus intermediate3(AIA).
+                                        AssertExtensions.HasFlag(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
 
-                                    // Previous 4 plus intermediate3 and intermediate4.
+                                        CloneIntoExtraStore(chain, 1);
+                                        CloneIntoExtraStore(chain, 3);
+                                        CloneIntoExtraStore(chain, 4);
+                                        holder.DisposeChainElements();
+
+                                        // Previous 5 plus intermediate4, intermediate5, and intermediate6.
+                                        AssertExtensions.TrueExpression(chain.Build(endEntity));
+                                        Assert.Equal(8, chain.ChainElements.Count);
+                                        AssertExtensions.HasFlag(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
+
+                                        CloneIntoExtraStore(chain, 5);
+                                        CloneIntoExtraStore(chain, 6);
+                                        CloneIntoExtraStore(chain, 7);
+                                        holder.DisposeChainElements();
+                                    }
+                                    else
+                                    {
+                                        Assert.Equal(4, chain.ChainElements.Count);
+                                        AssertExtensions.HasFlag(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
+
+                                        CloneIntoExtraStore(chain, 1);
+                                        CloneIntoExtraStore(chain, 3);
+                                        holder.DisposeChainElements();
+
+                                        // Previous 4 plus intermediate3 and intermediate4.
+                                        AssertExtensions.TrueExpression(chain.Build(endEntity));
+                                        Assert.Equal(6, chain.ChainElements.Count);
+                                        AssertExtensions.HasFlag(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
+
+                                        CloneIntoExtraStore(chain, 4);
+                                        CloneIntoExtraStore(chain, 5);
+                                        holder.DisposeChainElements();
+
+                                        // Previous 6 plus intermediate5 and intermediate6.
+                                        AssertExtensions.TrueExpression(chain.Build(endEntity));
+                                        Assert.Equal(8, chain.ChainElements.Count);
+                                        AssertExtensions.HasFlag(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
+
+                                        CloneIntoExtraStore(chain, 6);
+                                        CloneIntoExtraStore(chain, 7);
+                                        holder.DisposeChainElements();
+                                    }
+
+                                    // AIA fetches intermediate7 and root, chain finishes.
                                     AssertExtensions.TrueExpression(chain.Build(endEntity));
-                                    Assert.Equal(6, chain.ChainElements.Count);
-                                    AssertExtensions.HasFlag(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
-
-                                    CloneIntoExtraStore(chain, 4);
-                                    CloneIntoExtraStore(chain, 5);
-                                    holder.DisposeChainElements();
-
-                                    // AIA fetches intermediate5 and root, chain finishes.
-                                    AssertExtensions.TrueExpression(chain.Build(endEntity));
-                                    Assert.Equal(8, chain.ChainElements.Count);
+                                    Assert.Equal(10, chain.ChainElements.Count);
                                     Assert.Equal(X509ChainStatusFlags.UntrustedRoot, chain.AllStatusFlags());
                                 }
                                 finally


### PR DESCRIPTION
Fixes #130947 (theoretically)

I've run this on Windows 11 25H2 26200.8893 both with a registry override to force 3 (by setting the limit to 4) and in the default behavior (which wincrypt.h says is 3, but black box says is 2).

This should definitely eliminate failures from getting 5 on the first answer.  But, along the fix development path it appears that Windows is squirrelling away the previous AIA fetches, and so RetryHelper might take a problem and amplify it.  (Since I don't see the certs ending up in persisted stores, I'm going to guess they don't count AIA fetches if they're in memory in the Windows version of the AIA fetch cache)