### PR TITLE
[wasm] Emit the 'V' thunk signature-key char for Vector128<T>/Vector<T> args

### DIFF
--- a/docs/design/coreclr/botr/readytorun-format.md
+++ b/docs/design/coreclr/botr/readytorun-format.md
@@ -1059,6 +1059,7 @@ The string format is:
 | `l` | returns `i64` |
 | `f` | returns `f32` |
 | `d` | returns `f64` |
+| `V` | returns `v128` (a `Vector128<T>`, or a 16-byte `Vector<T>`) |
 | `S<N>` | struct return via hidden buffer, `N` is the struct size in bytes |
 
 **This pointer** (if the method has a `this` parameter):
@@ -1085,6 +1086,7 @@ it knows a hidden retbuf pointer argument is present in the Wasm parameter list.
 | `l` | `i64` parameter |
 | `f` | `f32` parameter |
 | `d` | `f64` parameter |
+| `V` | `v128` parameter (a `Vector128<T>`, or a 16-byte `Vector<T>`, passed by value) |
 | `S<N>` | struct parameter passed by reference, `<N>` is the struct size in bytes |
 | `e` | empty struct parameter — elided from Wasm args but present in the string |
 

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -1033,18 +1033,21 @@ namespace
         }
 
         MethodTable* pMT = th.AsMethodTable();
-        PTR_MethodTable pVector128MT = CoreLibBinder::GetClassIfExist(CLASS__VECTOR128T);
-        PTR_MethodTable pVectorTMT = CoreLibBinder::GetClassIfExist(CLASS__VECTORT);
 
         bool isSupportedVectorBaseType =
             pMT->IsIntrinsicType() &&
             (pMT->GetNumGenericArgs() == 1) &&
             CorIsNumericalType(pMT->GetInstantiation()[0].GetSignatureCorElementType());
-        if (isSupportedVectorBaseType &&
-            ((pVector128MT != nullptr && pMT->HasSameTypeDefAs(pVector128MT)) ||
-             ((size == 16) && (pVectorTMT != nullptr) && pMT->HasSameTypeDefAs(pVectorTMT))))
+        if (isSupportedVectorBaseType)
         {
-            return { ConvertType::ToV128, 0 };
+            PTR_MethodTable pVector128MT = CoreLibBinder::GetClassIfExist(CLASS__VECTOR128T);
+            PTR_MethodTable pVectorTMT = CoreLibBinder::GetClassIfExist(CLASS__VECTORT);
+
+            if ((pVector128MT != nullptr && pMT->HasSameTypeDefAs(pVector128MT)) ||
+                ((size == 16) && (pVectorTMT != nullptr) && pMT->HasSameTypeDefAs(pVectorTMT)))
+            {
+                return { ConvertType::ToV128, 0 };
+            }
         }
 
         uint32_t numInstanceFields = pMT->GetNumInstanceFields();

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -1033,13 +1033,16 @@ namespace
         }
 
         MethodTable* pMT = th.AsMethodTable();
+        PTR_MethodTable pVector128MT = CoreLibBinder::GetClassIfExist(CLASS__VECTOR128T);
+        PTR_MethodTable pVectorTMT = CoreLibBinder::GetClassIfExist(CLASS__VECTORT);
+
         bool isSupportedVectorBaseType =
             pMT->IsIntrinsicType() &&
             (pMT->GetNumGenericArgs() == 1) &&
             CorIsNumericalType(pMT->GetInstantiation()[0].GetSignatureCorElementType());
         if (isSupportedVectorBaseType &&
-            (pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR128T)) ||
-             ((size == 16) && pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTORT)))))
+            ((pVector128MT != NULL && pMT->HasSameTypeDefAs(pVector128MT)) ||
+             ((size == 16) && (pVectorTMT != NULL) && pMT->HasSameTypeDefAs(pVectorTMT))))
         {
             return { ConvertType::ToV128, 0 };
         }

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -989,6 +989,7 @@ namespace
         ToI64,
         ToF32,
         ToF64,
+        ToV128,
         ToStruct,   // S<N> — multi-field struct passed by pointer, structSize holds the size
         ToEmpty,    // e — empty struct, takes no wasm argument
     };
@@ -1032,6 +1033,17 @@ namespace
         }
 
         MethodTable* pMT = th.AsMethodTable();
+        bool isSupportedVectorBaseType =
+            pMT->IsIntrinsicType() &&
+            (pMT->GetNumGenericArgs() == 1) &&
+            CorIsNumericalType(pMT->GetInstantiation()[0].GetSignatureCorElementType());
+        if (isSupportedVectorBaseType &&
+            (pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR128T)) ||
+             ((size == 16) && pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTORT)))))
+        {
+            return { ConvertType::ToV128, 0 };
+        }
+
         uint32_t numInstanceFields = pMT->GetNumInstanceFields();
 
         // WASM-TODO: Empty structs should return ToEmpty once .NET
@@ -1107,6 +1119,7 @@ namespace
             case ConvertType::ToI64:       c = 'l'; break;
             case ConvertType::ToF32:       c = 'f'; break;
             case ConvertType::ToF64:       c = 'd'; break;
+            case ConvertType::ToV128:      c = 'V'; break;
             case ConvertType::ToEmpty:     c = 'e'; break;
             case ConvertType::ToStruct:
             {

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -1041,8 +1041,8 @@ namespace
             (pMT->GetNumGenericArgs() == 1) &&
             CorIsNumericalType(pMT->GetInstantiation()[0].GetSignatureCorElementType());
         if (isSupportedVectorBaseType &&
-            ((pVector128MT != NULL && pMT->HasSameTypeDefAs(pVector128MT)) ||
-             ((size == 16) && (pVectorTMT != NULL) && pMT->HasSameTypeDefAs(pVectorTMT))))
+            ((pVector128MT != nullptr && pMT->HasSameTypeDefAs(pVector128MT)) ||
+             ((size == 16) && (pVectorTMT != nullptr) && pMT->HasSameTypeDefAs(pVectorTMT))))
         {
             return { ConvertType::ToV128, 0 };
         }


### PR DESCRIPTION
## Summary

The interp↔R2R thunk ABI encodes a wasm `v128` argument as the signature-key char `'V'`. crossgen2 (`WasmLowering`) already generates interp→R2R thunks that encode a supported `Vector128<T>` / 16-byte `Vector<T>` parameter as `v128` → `'V'` (`WasmValueType.V128 => 'V'`, predicate `IsWasmV128Type`).

But the VM-side signature-key builder in `src/coreclr/vm/wasm/helpers.cpp` classified such a 16-byte vector as a generic by-ref struct (`ToStruct` → `'S16'`), so at runtime the VM built a key that did **not** match the crossgen2-generated `'V'` thunk:

```
crossgen2 thunk key:  …V…
VM runtime lookup:    …S16…   → LookupThunk returns NULL
                              → "WASM calli missing for key" (missing thunk)
```

for any interp→R2R call passing a `Vector128<T>` (or a 16-byte `Vector<T>`) by value.

## Fix

Classify a supported vector base type — an intrinsic type with a single numeric generic argument that is `Vector128<T>`, or a 16-byte `Vector<T>` — as the new `ConvertType::ToV128`, emitted as `'V'`, matching `WasmLowering`'s v128 encoding so the runtime resolves the correct v128-passing thunk. Single-field structs wrapping a v128 recurse through the existing single-field unwrap path and land on `ToV128` as well, matching crossgen2. Mirrors the JIT's `TYP_SIMD16` recognition and `WasmLowering.IsWasmV128Type`.

## Validation

- WASI CoreCLR build (`clr -os wasi -c Release`): 0W/0E; `helpers.cpp` object recompiles clean.
- Validated against the `System.Runtime.CompilerServices.Unsafe` library suite under R2R (128/128), which exercises `Vector128` interp↔R2R boundaries (previously failed with a missing thunk).

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.
