### PR TITLE
[wasm] Emit terminal `end` for EH funclets ending in a no-return call

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -229,6 +229,7 @@ protected:
     void                       genEmitBeginBlock(WasmValueType blockType = WasmValueType::Invalid);
     void                       genEmitEndBlock();
     void                       genEmitFunctionEnd(bool emitTerminalUnreachable = true);
+    bool                       genIsLastBlockOfCurrentFunc(BasicBlock* block);
 #endif
 
     void genEmitStartBlock(BasicBlock* block);

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -808,7 +808,7 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
             // At function/funclet end, close open intervals and emit `end`
             // (we've already emitted the terminating `unreachable` above).
             //
-            if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+            if (genIsLastBlockOfCurrentFunc(block))
             {
                 genEmitFunctionEnd(/* emitTerminalUnreachable */ false);
             }
@@ -910,7 +910,7 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
             // (e.g., backedge of an infinite loop), close any still-open
             // wasm intervals and emit the function-body terminator.
             //
-            if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+            if (genIsLastBlockOfCurrentFunc(block))
             {
                 genEmitFunctionEnd();
             }

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -472,6 +472,35 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
 }
 
 //------------------------------------------------------------------------
+// genIsLastBlockOfCurrentFunc: determine whether `block` is the last block of the
+//   wasm function or funclet currently being generated -- i.e. the block after
+//   which the function body's terminal `end` opcode must be emitted.
+//
+// Arguments:
+//   block - the block being generated
+//
+// Return Value:
+//   true if `block` is the current func/funclet's last block.
+//
+// Notes:
+//   A wasm function body is structurally required to end in `end`, even when its
+//   last block is a no-return call (e.g. a throw-helper tail). `block->Next()`
+//   walks the GLOBAL block order (bbNext), in which a funclet's last block can be
+//   followed by an interspersed root throw-helper block (`fgIsThrowHlpBlk`, no
+//   handler index) that is not a funclet begin, so `bbIsFuncletBeg(block->Next())`
+//   fails to recognize the funclet boundary. Codegen iterates per-funclet
+//   (`genCodeForFunclet` over `funcInfo->Blocks()`), so also compare against the
+//   current func/funclet's authoritative last block (`FuncInfoDsc::GetLastBlock`:
+//   `ebdHndLast` for handlers, `BBFilterLast` for filters, and
+//   `fgLastBBInMainFunction` for the root).
+//
+bool CodeGen::genIsLastBlockOfCurrentFunc(BasicBlock* block)
+{
+    return block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()) ||
+           (block == m_compiler->funCurrentFunc()->GetLastBlock(m_compiler));
+}
+
+//------------------------------------------------------------------------
 // genFuncletEpilog: codegen for funclet epilogs.
 //
 // Arguments:
@@ -479,7 +508,10 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
 //
 void CodeGen::genFuncletEpilog(BasicBlock* block)
 {
-    if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+    // Emit the function-body terminator (`end`) when this epilog block is the last
+    // block of the funclet; otherwise emit `return` to unwind to the caller.
+    //
+    if (genIsLastBlockOfCurrentFunc(block))
     {
         instGen(INS_end);
     }
@@ -3781,7 +3813,7 @@ void CodeGen::genCallFinally(BasicBlock* block)
         // A retless BBJ_CALLFINALLY can be the last block of a wasm function/funclet;
         // every wasm function body must end with `end`.
         //
-        if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+        if (genIsLastBlockOfCurrentFunc(block))
         {
             GetEmitter()->emitIns(INS_end);
         }


### PR DESCRIPTION
## Summary
When crossgen2 compiles managed methods to WebAssembly (wasm32) R2R, it emits a malformed wasm function body for certain exception-handling (EH) funclets: the required terminal `end` opcode (`0x0b`) is **dropped**. The resulting module fails validation — both V8 and `wasm-tools validate` reject it with `function body must end with end opcode`. A wasm function body is *structurally required* to end in `end` regardless of whether the last instruction is reachable, so dropping it produces invalid wasm.

The defect is in the shared `TARGET_WASM` codegen path (no OS-specific branching), so it reproduces identically for both `--targetos:browser` and `--targetos:wasi`, and the fix benefits both.

## Repro / observed
Compiling `System.Data.Common.dll` to wasm R2R produces **two** malformed EH funclets, both property setters:

| method | funclet |
|--------|---------|
| `System.Data.DataColumn.set_Expression` | 4 |
| `System.Data.DataTable.set_Locale` | 3 |

Both are EH funclets (they have an `exnref` local — `try_table`/`catch_ref` EH) whose last block ends in a no-return tail (`call_indirect (no-return)` + `unreachable`), after which the terminal `0x0b` is missing. This is **not** SIMD-related: the two funclets contain zero `0xfd`-prefixed opcodes, and the composite is byte-identical whether SIMD is forced on or bailed (`--codegenopt:JitWasmSimdNyiToR2RUnsupported=0` vs `=1`). It reproduces identically on browser and WASI (same funclet, same byte offset), confirming it is OS-agnostic.

## Root cause
The wasm end-emission guard `block->IsLast() || bbIsFuncletBeg(block->Next())` uses the **global** block order (`bbNext`), in which a funclet's last block can be followed by an interspersed root throw-helper block (`fgIsThrowHlpBlk`, no handler index) that is **not** a funclet begin. Codegen iterates **per funclet** (`genCodeForFunclet` over `funcInfo->Blocks()`), so the guard fails to recognize the funclet boundary and the terminal `end` is never emitted.

This same unsound predicate was duplicated across **four** wasm end-emission sites:
- the `BBJ_THROW` and `BBJ_ALWAYS` arms of `genEmitEndBlock` (`codegenlinear.cpp`),
- the retless `BBJ_CALLFINALLY` path in `genCallFinally` (`codegenwasm.cpp`, added by #129449), and
- the `end`/`return` discriminator in `genFuncletEpilog` (`codegenwasm.cpp`).

The copy-paste drift across these sites is what let this gap — and the incompleteness of the prior fix #129335 — arise.

## Fix
Consolidate the predicate into a single wasm helper `CodeGen::genIsLastBlockOfCurrentFunc` that also compares against the current func/funclet's *authoritative* last block (`funCurrentFunc()->GetLastBlock()`), and route all four end-emission sites through it:

```cpp
bool CodeGen::genIsLastBlockOfCurrentFunc(BasicBlock* block)
{
    return block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()) ||
           (block == m_compiler->funCurrentFunc()->GetLastBlock(m_compiler));
}
```

**Correct across every funclet kind, by construction.** `FuncInfoDsc::GetLastBlock` resolves to `fgLastBBInMainFunction()` for `FUNC_ROOT`, `ehDsc->BBFilterLast()` for `FUNC_FILTER`, and `ehDsc->ebdHndLast` for `FUNC_HANDLER` (which covers catch/finally/fault handlers alike). Crucially, it is the exact upper bound of the per-funclet codegen iteration range — `FuncInfoDsc::Blocks()` is defined as `BasicBlockRangeList(GetStartBlock(comp), GetLastBlock(comp))` — so the new term recognizes precisely the last block codegen will process for the current func/funclet, for *every* kind, not just the two `BBJ_THROW` cases the repro exercises.

The added term is an **additive OR**, so each block still emits at most one terminal `end` (no double-`end` regression on the `BBJ_RETURN` / funclet-epilog paths), and because it is authoritative it cannot false-positive on mid-funclet blocks. Routing all four sites through one predicate removes the drift that caused this class of bug.

This is **not** a mirror of the non-wasm `DOES_NOT_RETURN` else-clause (which emits an `INS_BREAKPOINT` for GC liveness) — on wasm the correct behavior is to still emit the function body's terminal `end`.

## Validation
Recrossgenned standalone `System.Data.Common` → wasm R2R:
- Both funclets now emit their terminal `end`.
- `wasm-tools validate`: **passes** (was failing at func 597 pre-fix).
- No double-`end` regression — validation rules out both a missing `end` ("control frames remain") and an extra `end` across all functions in the module.
- The change is a pure predicate consolidation: the emitted module is byte-identical across rebuilds.
- Confirmed on **both** `--targetos:browser` and `--targetos:wasi`: unfixed crossgen2 fails validation at the same funclet (func 597, offset `0xdb1ae`) on both targets; the fixed build passes `wasm-tools validate` on both.
- Independently confirmed against a second, separately-built standalone `System.Data.Common` fixture (same func 597).

## Related sibling defect (separate root cause, tracked separately)
The same wasm crossgen surfaces a second, independent EH-funclet codegen defect this PR does **not** address, tracked as #131252: `CodeGen::findTargetDepth` (`codegenwasm.cpp`) asserts in `DEBUG` when a branch target isn't found in the control-flow stack, but **release** falls through to `return ~0;`, shipping `0xFFFFFFFF` as a branch depth (e.g. V8: `invalid branch depth: 4294967295`). Observed on `System.Threading.Tasks.Parallel.Invoke_0` funclet 1. Distinct root cause (branch-target resolution, not end-emission) and not fixable by the same predicate; both share the pattern of an EH-funclet codegen gap caught only by a checked-only assert that is compiled out in release.

## Related issues
- #129335 — incomplete predecessor (same defect class, does not cover the EH-funclet-with-no-return-tail shape).
- #129449 — added the `genCallFinally` site that shares this predicate.
- #131252 — sibling wasm EH-funclet defect (invalid branch depth), separate root cause.

> [!NOTE]
> This PR was created with the help of GitHub Copilot.