### PR TITLE
Fix in-proc crash reporter frame assert.

### DIFF
--- a/src/coreclr/vm/crashreportstackwalker.cpp
+++ b/src/coreclr/vm/crashreportstackwalker.cpp
@@ -260,7 +260,7 @@ FrameCallbackAdapter(
 
     Module* pModule = pMD->GetModule();
 
-    uint32_t nativeOffset = pCF->HasFaulted() ? 0 : pCF->GetRelOffset();
+    uint32_t nativeOffset = (pCF->HasFaulted() || !pCF->IsFrameless()) ? 0 : pCF->GetRelOffset();
     uint32_t ilOffset = 0;
     PCODE ip = (PCODE)0;
     TADDR stackPointer = (TADDR)0;


### PR DESCRIPTION
Stackwalk callback in in-proc crash reporter didn't check if a CrawlFrame was FrameLess before calling its GetRelOffset, something that method asserts, triggering an abort in debug builds.