### PR TITLE
[cDAC] Implement IsThreadSuspendedOrHijacked for cDAC

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -4175,7 +4175,30 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
     }
 
     public int IsThreadSuspendedOrHijacked(ulong vmThread, Interop.BOOL* pResult)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.IsThreadSuspendedOrHijacked(vmThread, pResult) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            Contracts.ThreadState threadState = _target.Contracts.Thread.GetThreadData(vmThread).State;
+            *pResult = (threadState & (Contracts.ThreadState.DebugSyncSuspended | Contracts.ThreadState.Hijacked)) != 0
+                        ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            Interop.BOOL pResultLocal;
+            int hrLocal = _legacy.IsThreadSuspendedOrHijacked(vmThread, &pResultLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+                Debug.Assert(*pResult == pResultLocal);
+        }
+#endif
+        return hr;
+    }
 
     public int CreateHeapWalk(nuint* pHandle)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -4179,6 +4179,10 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         int hr = HResults.S_OK;
         try
         {
+            if (pResult is null)
+                throw new NullReferenceException();
+
+            *pResult = Interop.BOOL.FALSE;
             Contracts.ThreadState threadState = _target.Contracts.Thread.GetThreadData(vmThread).State;
             *pResult = (threadState & (Contracts.ThreadState.DebugSyncSuspended | Contracts.ThreadState.Hijacked)) != 0
                         ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
@@ -4190,11 +4194,12 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
 #if DEBUG
         if (_legacy is not null)
         {
-            Interop.BOOL pResultLocal;
-            int hrLocal = _legacy.IsThreadSuspendedOrHijacked(vmThread, &pResultLocal);
+            Interop.BOOL resultLocal = Interop.BOOL.FALSE;
+            Interop.BOOL* resultLocalPtr = pResult is null ? null : &resultLocal;
+            int hrLocal = _legacy.IsThreadSuspendedOrHijacked(vmThread, resultLocalPtr);
             Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
-                Debug.Assert(*pResult == pResultLocal);
+                Debug.Assert(*pResult == resultLocal);
         }
 #endif
         return hr;

--- a/src/native/managed/cdac/tests/DumpTests/DacDbi/DacDbiThreadDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DacDbi/DacDbiThreadDumpTests.cs
@@ -83,6 +83,31 @@ public class DacDbiThreadDumpTests : DumpTestBase
 
     [ConditionalTheory]
     [MemberData(nameof(TestConfigurations))]
+    public unsafe void IsThreadSuspendedOrHijacked_CrossValidateWithContract(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        DacDbiImpl dbi = CreateDacDbi();
+
+        IThread threadContract = Target.Contracts.Thread;
+        ThreadStoreData storeData = threadContract.GetThreadStoreData();
+
+        TargetPointer current = storeData.FirstThread;
+        while (current != TargetPointer.Null)
+        {
+            Interop.BOOL isSuspendedOrHijacked;
+            int hr = dbi.IsThreadSuspendedOrHijacked(current, &isSuspendedOrHijacked);
+            Assert.Equal(System.HResults.S_OK, hr);
+
+            ThreadData data = threadContract.GetThreadData(current);
+            bool contractSaysSuspendedOrHijacked = (data.State & (Contracts.ThreadState.DebugSyncSuspended | Contracts.ThreadState.Hijacked)) != 0;
+            Assert.Equal(contractSaysSuspendedOrHijacked, isSuspendedOrHijacked == Interop.BOOL.TRUE);
+
+            current = data.NextThread;
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
     public unsafe void TryGetVolatileOSThreadID_MatchesContract(TestConfiguration config)
     {
         InitializeDumpTest(config);

--- a/src/native/managed/cdac/tests/UnitTests/DacDbiImplTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/DacDbiImplTests.cs
@@ -37,6 +37,43 @@ public unsafe class DacDbiImplTests
         return (dacDbi, target);
     }
 
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void IsThreadSuspendedOrHijacked_NullOutput_ReturnsEPointer(MockTarget.Architecture arch)
+    {
+        var mockThread = new Mock<IThread>();
+        TestPlaceholderTarget target = new TestPlaceholderTarget.Builder(arch)
+            .AddMockContract(mockThread)
+            .Build();
+        DacDbiImpl dacDbi = new(target, legacyObj: null);
+
+        int hr = dacDbi.IsThreadSuspendedOrHijacked(0, null);
+
+        Assert.Equal(System.HResults.E_POINTER, hr);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void IsThreadSuspendedOrHijacked_ContractFailure_InitializesOutput(MockTarget.Architecture arch)
+    {
+        const ulong ThreadAddress = 0x1000;
+        InvalidOperationException exception = new();
+        var mockThread = new Mock<IThread>();
+        mockThread
+            .Setup(t => t.GetThreadData(new TargetPointer(ThreadAddress)))
+            .Throws(exception);
+        TestPlaceholderTarget target = new TestPlaceholderTarget.Builder(arch)
+            .AddMockContract(mockThread)
+            .Build();
+        DacDbiImpl dacDbi = new(target, legacyObj: null);
+        Interop.BOOL result = Interop.BOOL.TRUE;
+
+        int hr = dacDbi.IsThreadSuspendedOrHijacked(ThreadAddress, &result);
+
+        Assert.Equal(exception.HResult, hr);
+        Assert.Equal(Interop.BOOL.FALSE, result);
+    }
+
     [Fact]
     public void DacSetTargetConsistencyChecks_Standalone_ReturnsSuccess()
     {


### PR DESCRIPTION
### Summary
Implement `IsThreadSuspendedOrHijacked` for cDAC.

### Changes
- `DacDbiImpl.cs` - Implement `IsThreadSuspendedOrHijacked`.
- `DacDbiThreadDumpTests.cs` - Add a test cross-validating the result against the thread contract.