### PR TITLE
[HTTP] High cardinality metrics to observable

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -19,25 +19,22 @@ namespace System.Net.Http.Metrics
         public readonly string? Scheme;
         public readonly string? Host;
         public readonly int Port;
-        public readonly bool HasUriTags;
         public readonly string Method;
         private readonly int _hashCode;
 
-        public ActiveRequestsTagKey(string? scheme, string? host, int port, bool hasUriTags, string method)
+        public ActiveRequestsTagKey(string? scheme, string? host, int port, string method)
         {
             Scheme = scheme;
             Host = host;
             Port = port;
-            HasUriTags = hasUriTags;
             Method = method;
-            _hashCode = HashCode.Combine(scheme, host, port, hasUriTags, method);
+            _hashCode = HashCode.Combine(scheme, host, port, method);
         }
 
         public bool Equals(ActiveRequestsTagKey other) =>
             Scheme == other.Scheme &&
             Host == other.Host &&
             Port == other.Port &&
-            HasUriTags == other.HasUriTags &&
             Method == other.Method;
 
         public override bool Equals(object? obj) => obj is ActiveRequestsTagKey other && Equals(other);
@@ -47,7 +44,7 @@ namespace System.Net.Http.Metrics
         public TagList ToTagList()
         {
             TagList tags = default;
-            if (HasUriTags)
+            if (Scheme is not null)
             {
                 tags.Add("url.scheme", Scheme);
                 tags.Add("server.address", Host);
@@ -56,6 +53,9 @@ namespace System.Net.Http.Metrics
             tags.Add("http.request.method", Method);
             return tags;
         }
+
+        public override string ToString() =>
+            $"{Method}{(Scheme is not null ? $" {Scheme}://{Host}:{Port}" : "")}";
     }
 
     /// <summary>
@@ -87,6 +87,7 @@ namespace System.Net.Http.Metrics
                 {
                     // Key doesn't exist, nothing to decrement.
                     // This shouldn't happen in normal operation but we handle it gracefully.
+                    Debug.Fail($"Decrement for non-existing request {key}");
                     return;
                 }
 
@@ -218,8 +219,6 @@ namespace System.Net.Http.Metrics
 
         private void RequestStop(HttpRequestMessage request, HttpResponseMessage? response, Exception? exception, long startTimestamp, bool recordCurrentRequests)
         {
-            TagList tags = InitializeCommonTags(request);
-
             if (recordCurrentRequests)
             {
                 _activeRequestsTracker.Decrement(CreateActiveRequestsTagKey(request));
@@ -230,6 +229,7 @@ namespace System.Net.Http.Metrics
                 return;
             }
 
+            TagList tags = InitializeCommonTags(request);
             if (response is not null)
             {
                 tags.Add("http.response.status_code", DiagnosticsHelper.GetBoxedInt32((int)response.StatusCode));
@@ -274,19 +274,17 @@ namespace System.Net.Http.Metrics
             string? scheme = null;
             string? host = null;
             int port = 0;
-            bool hasUriTags = false;
 
             if (request.RequestUri is Uri requestUri && requestUri.IsAbsoluteUri)
             {
                 scheme = requestUri.Scheme;
                 host = DiagnosticsHelper.GetServerAddress(request, _proxy);
                 port = requestUri.Port;
-                hasUriTags = true;
             }
 
             string method = (string)DiagnosticsHelper.GetMethodTag(request.Method, out _).Value!;
 
-            return new ActiveRequestsTagKey(scheme, host, port, hasUriTags, method);
+            return new ActiveRequestsTagKey(scheme, host, port, method);
         }
 
         private sealed class SharedMeter : Meter

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -10,10 +11,124 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http.Metrics
 {
+    /// <summary>
+    /// Represents a unique combination of tags for tracking active requests.
+    /// </summary>
+    internal readonly struct ActiveRequestsTagKey : IEquatable<ActiveRequestsTagKey>
+    {
+        public readonly string? Scheme;
+        public readonly string? Host;
+        public readonly int Port;
+        public readonly bool HasUriTags;
+        public readonly string Method;
+        private readonly int _hashCode;
+
+        public ActiveRequestsTagKey(string? scheme, string? host, int port, bool hasUriTags, string method)
+        {
+            Scheme = scheme;
+            Host = host;
+            Port = port;
+            HasUriTags = hasUriTags;
+            Method = method;
+            _hashCode = HashCode.Combine(scheme, host, port, hasUriTags, method);
+        }
+
+        public bool Equals(ActiveRequestsTagKey other) =>
+            Scheme == other.Scheme &&
+            Host == other.Host &&
+            Port == other.Port &&
+            HasUriTags == other.HasUriTags &&
+            Method == other.Method;
+
+        public override bool Equals(object? obj) => obj is ActiveRequestsTagKey other && Equals(other);
+
+        public override int GetHashCode() => _hashCode;
+
+        public TagList ToTagList()
+        {
+            TagList tags = default;
+            if (HasUriTags)
+            {
+                tags.Add("url.scheme", Scheme);
+                tags.Add("server.address", Host);
+                tags.Add("server.port", DiagnosticsHelper.GetBoxedInt32(Port));
+            }
+            tags.Add("http.request.method", Method);
+            return tags;
+        }
+    }
+
+    /// <summary>
+    /// Thread-safe tracker for active request counts by tag combination.
+    /// </summary>
+    internal sealed class ActiveRequestsTracker
+    {
+        private readonly ConcurrentDictionary<ActiveRequestsTagKey, long> _counts = new();
+
+        /// <summary>
+        /// Increments the count for the specified tag combination.
+        /// </summary>
+        public void Increment(in ActiveRequestsTagKey key)
+        {
+            _counts.AddOrUpdate(key, 1, static (_, currentValue) => currentValue + 1);
+        }
+
+        /// <summary>
+        /// Decrements the count for the specified tag combination.
+        /// Removes the entry if the count reaches zero.
+        /// </summary>
+        public void Decrement(in ActiveRequestsTagKey key)
+        {
+            // We need to atomically decrement and remove if zero.
+            // Use a spin loop with TryGetValue/TryUpdate/TryRemove to handle this safely.
+            while (true)
+            {
+                if (!_counts.TryGetValue(key, out long currentValue))
+                {
+                    // Key doesn't exist, nothing to decrement.
+                    // This shouldn't happen in normal operation but we handle it gracefully.
+                    return;
+                }
+
+                if (currentValue <= 1)
+                {
+                    // Try to remove the entry since it will become zero.
+                    // Use the overload that checks the current value to ensure atomicity.
+                    if (_counts.TryRemove(new KeyValuePair<ActiveRequestsTagKey, long>(key, currentValue)))
+                    {
+                        return;
+                    }
+                    // Another thread modified the value, retry.
+                }
+                else
+                {
+                    // Try to decrement the value.
+                    if (_counts.TryUpdate(key, currentValue - 1, currentValue))
+                    {
+                        return;
+                    }
+                    // Another thread modified the value, retry.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns measurements for all tag combinations with non-zero counts.
+        /// </summary>
+        public IEnumerable<Measurement<long>> GetMeasurements()
+        {
+            foreach (KeyValuePair<ActiveRequestsTagKey, long> entry in _counts)
+            {
+                yield return new Measurement<long>(entry.Value, entry.Key.ToTagList());
+            }
+        }
+    }
+
     internal sealed class MetricsHandler : HttpMessageHandlerStage
     {
         private readonly HttpMessageHandler _innerHandler;
-        private readonly UpDownCounter<long> _activeRequests;
+        private readonly ActiveRequestsTracker _activeRequestsTracker = new();
+        private readonly ObservableUpDownCounter<long> _activeRequests;
         private readonly Histogram<double> _requestsDuration;
         private readonly IWebProxy? _proxy;
 
@@ -27,8 +142,9 @@ namespace System.Net.Http.Metrics
             meter = meterFactory?.Create("System.Net.Http") ?? SharedMeter.Instance;
 
             // Meter has a cache for the instruments it owns
-            _activeRequests = meter.CreateUpDownCounter<long>(
+            _activeRequests = meter.CreateObservableUpDownCounter<long>(
                 "http.client.active_requests",
+                observeValues: _activeRequestsTracker.GetMeasurements,
                 unit: "{request}",
                 description: "Number of outbound HTTP requests that are currently active on the client.");
             _requestsDuration = meter.CreateHistogram<double>(
@@ -94,8 +210,7 @@ namespace System.Net.Http.Metrics
 
             if (recordCurrentRequests)
             {
-                TagList tags = InitializeCommonTags(request);
-                _activeRequests.Add(1, tags);
+                _activeRequestsTracker.Increment(CreateActiveRequestsTagKey(request));
             }
 
             return (startTimestamp, recordCurrentRequests);
@@ -107,7 +222,7 @@ namespace System.Net.Http.Metrics
 
             if (recordCurrentRequests)
             {
-                _activeRequests.Add(-1, tags);
+                _activeRequestsTracker.Decrement(CreateActiveRequestsTagKey(request));
             }
 
             if (!_requestsDuration.Enabled)
@@ -152,6 +267,26 @@ namespace System.Net.Http.Metrics
             tags.Add(DiagnosticsHelper.GetMethodTag(request.Method, out _));
 
             return tags;
+        }
+
+        private ActiveRequestsTagKey CreateActiveRequestsTagKey(HttpRequestMessage request)
+        {
+            string? scheme = null;
+            string? host = null;
+            int port = 0;
+            bool hasUriTags = false;
+
+            if (request.RequestUri is Uri requestUri && requestUri.IsAbsoluteUri)
+            {
+                scheme = requestUri.Scheme;
+                host = DiagnosticsHelper.GetServerAddress(request, _proxy);
+                port = requestUri.Port;
+                hasUriTags = true;
+            }
+
+            string method = (string)DiagnosticsHelper.GetMethodTag(request.Method, out _).Value!;
+
+            return new ActiveRequestsTagKey(scheme, host, port, hasUriTags, method);
         }
 
         private sealed class SharedMeter : Meter

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -173,7 +173,7 @@ namespace System.Net.Http.Metrics
         {
             Debug.Assert(GlobalHttpSettings.MetricsHandler.IsGloballyEnabled);
 
-            (long startTimestamp, bool recordCurrentRequests) = RequestStart(request);
+            (long startTimestamp, bool recordCurrentRequests, ActiveRequestsTagKey requestTagKey) = RequestStart(request);
             HttpResponseMessage? response = null;
             Exception? exception = null;
             try
@@ -190,7 +190,7 @@ namespace System.Net.Http.Metrics
             }
             finally
             {
-                RequestStop(request, response, exception, startTimestamp, recordCurrentRequests);
+                RequestStop(request, response, exception, startTimestamp, recordCurrentRequests, requestTagKey);
             }
         }
 
@@ -204,24 +204,25 @@ namespace System.Net.Http.Metrics
             base.Dispose(disposing);
         }
 
-        private (long StartTimestamp, bool RecordCurrentRequests) RequestStart(HttpRequestMessage request)
+        private (long StartTimestamp, bool RecordCurrentRequests, ActiveRequestsTagKey RequestTagKey) RequestStart(HttpRequestMessage request)
         {
             bool recordCurrentRequests = _activeRequests.Enabled;
             long startTimestamp = Stopwatch.GetTimestamp();
 
+            ActiveRequestsTagKey requestTagKey = CreateActiveRequestsTagKey(request);
             if (recordCurrentRequests)
             {
-                _activeRequestsTracker.Increment(CreateActiveRequestsTagKey(request));
+                _activeRequestsTracker.Increment(requestTagKey);
             }
 
-            return (startTimestamp, recordCurrentRequests);
+            return (startTimestamp, recordCurrentRequests, requestTagKey);
         }
 
-        private void RequestStop(HttpRequestMessage request, HttpResponseMessage? response, Exception? exception, long startTimestamp, bool recordCurrentRequests)
+        private void RequestStop(HttpRequestMessage request, HttpResponseMessage? response, Exception? exception, long startTimestamp, bool recordCurrentRequests, ActiveRequestsTagKey requestTagKey)
         {
             if (recordCurrentRequests)
             {
-                _activeRequestsTracker.Decrement(CreateActiveRequestsTagKey(request));
+                _activeRequestsTracker.Decrement(requestTagKey);
             }
 
             if (!_requestsDuration.Enabled)
@@ -229,7 +230,7 @@ namespace System.Net.Http.Metrics
                 return;
             }
 
-            TagList tags = InitializeCommonTags(request);
+            TagList tags = requestTagKey.ToTagList();
             if (response is not null)
             {
                 tags.Add("http.response.status_code", DiagnosticsHelper.GetBoxedInt32((int)response.StatusCode));
@@ -252,21 +253,6 @@ namespace System.Net.Http.Metrics
             {
                 HttpMetricsEnrichmentContext.RecordDurationWithEnrichment(callbacks, request, response, exception, durationTime, tags, _requestsDuration);
             }
-        }
-
-        private TagList InitializeCommonTags(HttpRequestMessage request)
-        {
-            TagList tags = default;
-
-            if (request.RequestUri is Uri requestUri && requestUri.IsAbsoluteUri)
-            {
-                tags.Add("url.scheme", requestUri.Scheme);
-                tags.Add("server.address", DiagnosticsHelper.GetServerAddress(request, _proxy));
-                tags.Add("server.port", DiagnosticsHelper.GetBoxedInt32(requestUri.Port));
-            }
-            tags.Add(DiagnosticsHelper.GetMethodTag(request.Method, out _));
-
-            return tags;
         }
 
         private ActiveRequestsTagKey CreateActiveRequestsTagKey(HttpRequestMessage request)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -457,14 +457,14 @@ namespace System.Net.Http
             {
                 if (_activeRequests.Remove(stream))
                 {
-                    if (ShuttingDown)
-                    {
-                        CheckForShutdown();
-                    }
-
                     if (_activeRequests.Count == 0)
                     {
                         MarkConnectionAsIdle();
+                    }
+
+                    if (ShuttingDown)
+                    {
+                        CheckForShutdown();
                     }
                 }
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
@@ -53,23 +53,27 @@ namespace System.Net.Http.Metrics
         {
             if (_openConnectionsEnabled)
             {
-                _currentlyIdle = true;
-                _metrics.OpenConnectionsTracker.Increment(CreateTagKey(idle: true));
+                lock (this)
+                {
+                    _currentlyIdle = true;
+                    _metrics.OpenConnectionsTracker.Increment(CreateTagKey(idle: true));
+                }
             }
         }
 
         public void ConnectionClosed(long durationMs)
         {
-            TagList tags = GetTags();
-
             if (_metrics.ConnectionDuration.Enabled)
             {
-                _metrics.ConnectionDuration.Record(durationMs / 1000d, tags);
+                _metrics.ConnectionDuration.Record(durationMs / 1000d, GetTags());
             }
 
             if (_openConnectionsEnabled)
             {
-                _metrics.OpenConnectionsTracker.Decrement(CreateTagKey(idle: _currentlyIdle));
+                lock (this)
+                {
+                    _metrics.OpenConnectionsTracker.Decrement(CreateTagKey(idle: _currentlyIdle));
+                }
             }
         }
 
@@ -77,9 +81,12 @@ namespace System.Net.Http.Metrics
         {
             if (_openConnectionsEnabled && _currentlyIdle != idle)
             {
-                _currentlyIdle = idle;
-                _metrics.OpenConnectionsTracker.Decrement(CreateTagKey(idle: !idle));
-                _metrics.OpenConnectionsTracker.Increment(CreateTagKey(idle: idle));
+                lock (this)
+                {
+                    _currentlyIdle = idle;
+                    _metrics.OpenConnectionsTracker.Decrement(CreateTagKey(idle: !idle));
+                    _metrics.OpenConnectionsTracker.Increment(CreateTagKey(idle: idle));
+                }
             }
         }
     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
@@ -10,11 +10,11 @@ namespace System.Net.Http.Metrics
     {
         private readonly SocketsHttpHandlerMetrics _metrics;
         private readonly bool _openConnectionsEnabled;
-        private readonly object _protocolVersionTag;
-        private readonly object _schemeTag;
-        private readonly object _hostTag;
-        private readonly object _portTag;
-        private readonly object? _peerAddressTag;
+        private readonly string _protocolVersionTag;
+        private readonly string _schemeTag;
+        private readonly string _hostTag;
+        private readonly int _portTag;
+        private readonly string? _peerAddressTag;
         private bool _currentlyIdle;
 
         public ConnectionMetrics(SocketsHttpHandlerMetrics metrics, string protocolVersion, string scheme, string host, int port, string? peerAddress)
@@ -24,7 +24,7 @@ namespace System.Net.Http.Metrics
             _protocolVersionTag = protocolVersion;
             _schemeTag = scheme;
             _hostTag = host;
-            _portTag = DiagnosticsHelper.GetBoxedInt32(port);
+            _portTag = port;
             _peerAddressTag = peerAddress;
         }
 
@@ -36,7 +36,7 @@ namespace System.Net.Http.Metrics
             tags.Add("network.protocol.version", _protocolVersionTag);
             tags.Add("url.scheme", _schemeTag);
             tags.Add("server.address", _hostTag);
-            tags.Add("server.port", _portTag);
+            tags.Add("server.port", DiagnosticsHelper.GetBoxedInt32(_portTag));
 
             if (_peerAddressTag is not null)
             {
@@ -46,16 +46,15 @@ namespace System.Net.Http.Metrics
             return tags;
         }
 
-        private static KeyValuePair<string, object?> GetStateTag(bool idle) => new KeyValuePair<string, object?>("http.connection.state", idle ? "idle" : "active");
+        private OpenConnectionsTagKey CreateTagKey(bool idle) =>
+            new OpenConnectionsTagKey(_protocolVersionTag, _schemeTag, _hostTag, _portTag, idle, _peerAddressTag);
 
         public void ConnectionEstablished()
         {
             if (_openConnectionsEnabled)
             {
                 _currentlyIdle = true;
-                TagList tags = GetTags();
-                tags.Add(GetStateTag(idle: true));
-                _metrics.OpenConnections.Add(1, tags);
+                _metrics.OpenConnectionsTracker.Increment(CreateTagKey(idle: true));
             }
         }
 
@@ -70,8 +69,7 @@ namespace System.Net.Http.Metrics
 
             if (_openConnectionsEnabled)
             {
-                tags.Add(GetStateTag(idle: _currentlyIdle));
-                _metrics.OpenConnections.Add(-1, tags);
+                _metrics.OpenConnectionsTracker.Decrement(CreateTagKey(idle: _currentlyIdle));
             }
         }
 
@@ -80,11 +78,8 @@ namespace System.Net.Http.Metrics
             if (_openConnectionsEnabled && _currentlyIdle != idle)
             {
                 _currentlyIdle = idle;
-                TagList tags = GetTags();
-                tags.Add(GetStateTag(idle: !idle));
-                _metrics.OpenConnections.Add(-1, tags);
-                tags[tags.Count - 1] = GetStateTag(idle: idle);
-                _metrics.OpenConnections.Add(1, tags);
+                _metrics.OpenConnectionsTracker.Decrement(CreateTagKey(idle: !idle));
+                _metrics.OpenConnectionsTracker.Increment(CreateTagKey(idle: idle));
             }
         }
     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
@@ -58,6 +58,9 @@ namespace System.Net.Http.Metrics
             }
             return tags;
         }
+
+        public override string ToString() =>
+            $"HTTP/{ProtocolVersion} {Scheme}://{Host}:{Port} {(IsIdle ? "idle" : "active")}{(PeerAddress is not null ? $" {PeerAddress}" : "")}";
     }
 
     /// <summary>
@@ -89,6 +92,7 @@ namespace System.Net.Http.Metrics
                 {
                     // Key doesn't exist, nothing to decrement.
                     // This shouldn't happen in normal operation but we handle it gracefully.
+                    Debug.Fail($"Decrement for non-existing connection {key}");
                     return;
                 }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Threading;
 
 namespace System.Net.Http.Metrics
 {
@@ -30,7 +29,7 @@ namespace System.Net.Http.Metrics
             Port = port;
             IsIdle = isIdle;
             PeerAddress = peerAddress;
-            _hashCode = HashCode.Combine(protocolVersion, scheme, host, port, isIdle);
+            _hashCode = HashCode.Combine(protocolVersion, scheme, host, port, isIdle, peerAddress);
         }
 
         public bool Equals(OpenConnectionsTagKey other) =>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
@@ -1,33 +1,166 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Threading;
 
 namespace System.Net.Http.Metrics
 {
-    internal sealed class SocketsHttpHandlerMetrics(Meter meter)
+    /// <summary>
+    /// Represents a unique combination of tags for tracking open connections.
+    /// </summary>
+    internal readonly struct OpenConnectionsTagKey : IEquatable<OpenConnectionsTagKey>
     {
-        public readonly UpDownCounter<long> OpenConnections = meter.CreateUpDownCounter<long>(
-            name: "http.client.open_connections",
-            unit: "{connection}",
-            description: "Number of outbound HTTP connections that are currently active or idle on the client.");
+        public readonly string ProtocolVersion;
+        public readonly string Scheme;
+        public readonly string Host;
+        public readonly int Port;
+        public readonly bool IsIdle;
+        public readonly string? PeerAddress;
+        private readonly int _hashCode;
 
-        public readonly Histogram<double> ConnectionDuration = meter.CreateHistogram<double>(
-            name: "http.client.connection.duration",
-            unit: "s",
-            description: "The duration of successfully established outbound HTTP connections.",
-            advice: new InstrumentAdvice<double>()
+        public OpenConnectionsTagKey(string protocolVersion, string scheme, string host, int port, bool isIdle, string? peerAddress)
+        {
+            ProtocolVersion = protocolVersion;
+            Scheme = scheme;
+            Host = host;
+            Port = port;
+            IsIdle = isIdle;
+            PeerAddress = peerAddress;
+            _hashCode = HashCode.Combine(protocolVersion, scheme, host, port, isIdle);
+        }
+
+        public bool Equals(OpenConnectionsTagKey other) =>
+            ProtocolVersion == other.ProtocolVersion &&
+            Scheme == other.Scheme &&
+            Host == other.Host &&
+            Port == other.Port &&
+            IsIdle == other.IsIdle &&
+            PeerAddress == other.PeerAddress;
+
+        public override bool Equals(object? obj) => obj is OpenConnectionsTagKey other && Equals(other);
+
+        public override int GetHashCode() => _hashCode;
+
+        public TagList ToTagList()
+        {
+            TagList tags = default;
+            tags.Add("network.protocol.version", ProtocolVersion);
+            tags.Add("url.scheme", Scheme);
+            tags.Add("server.address", Host);
+            tags.Add("server.port", DiagnosticsHelper.GetBoxedInt32(Port));
+            tags.Add("http.connection.state", IsIdle ? "idle" : "active");
+            if (PeerAddress is not null)
             {
-                // These values are not based on a standard and may change in the future.
-                HistogramBucketBoundaries = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300]
-            });
+                tags.Add("network.peer.address", PeerAddress);
+            }
+            return tags;
+        }
+    }
 
-        public readonly Histogram<double> RequestsQueueDuration = meter.CreateHistogram<double>(
-            name: "http.client.request.time_in_queue",
-            unit: "s",
-            description: "The amount of time requests spent on a queue waiting for an available connection.",
-            advice: DiagnosticsHelper.ShortHistogramAdvice);
+    /// <summary>
+    /// Thread-safe tracker for open connection counts by tag combination.
+    /// </summary>
+    internal sealed class OpenConnectionsTracker
+    {
+        private readonly ConcurrentDictionary<OpenConnectionsTagKey, long> _counts = new();
+
+        /// <summary>
+        /// Increments the count for the specified tag combination.
+        /// </summary>
+        public void Increment(in OpenConnectionsTagKey key)
+        {
+            _counts.AddOrUpdate(key, 1, static (_, currentValue) => currentValue + 1);
+        }
+
+        /// <summary>
+        /// Decrements the count for the specified tag combination.
+        /// Removes the entry if the count reaches zero.
+        /// </summary>
+        public void Decrement(in OpenConnectionsTagKey key)
+        {
+            // We need to atomically decrement and remove if zero.
+            // Use a spin loop with TryGetValue/TryUpdate/TryRemove to handle this safely.
+            while (true)
+            {
+                if (!_counts.TryGetValue(key, out long currentValue))
+                {
+                    // Key doesn't exist, nothing to decrement.
+                    // This shouldn't happen in normal operation but we handle it gracefully.
+                    return;
+                }
+
+                if (currentValue <= 1)
+                {
+                    // Try to remove the entry since it will become zero.
+                    // Use the overload that checks the current value to ensure atomicity.
+                    if (_counts.TryRemove(new KeyValuePair<OpenConnectionsTagKey, long>(key, currentValue)))
+                    {
+                        return;
+                    }
+                    // Another thread modified the value, retry.
+                }
+                else
+                {
+                    // Try to decrement the value.
+                    if (_counts.TryUpdate(key, currentValue - 1, currentValue))
+                    {
+                        return;
+                    }
+                    // Another thread modified the value, retry.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns measurements for all tag combinations with non-zero counts.
+        /// </summary>
+        public IEnumerable<Measurement<long>> GetMeasurements()
+        {
+            foreach (KeyValuePair<OpenConnectionsTagKey, long> entry in _counts)
+            {
+                yield return new Measurement<long>(entry.Value, entry.Key.ToTagList());
+            }
+        }
+    }
+
+    internal sealed class SocketsHttpHandlerMetrics
+    {
+        public readonly OpenConnectionsTracker OpenConnectionsTracker = new();
+
+        public readonly ObservableUpDownCounter<long> OpenConnections;
+
+        public readonly Histogram<double> ConnectionDuration;
+
+        public readonly Histogram<double> RequestsQueueDuration;
+
+        public SocketsHttpHandlerMetrics(Meter meter)
+        {
+            OpenConnections = meter.CreateObservableUpDownCounter<long>(
+                name: "http.client.open_connections",
+                observeValues: OpenConnectionsTracker.GetMeasurements,
+                unit: "{connection}",
+                description: "Number of outbound HTTP connections that are currently active or idle on the client.");
+
+            ConnectionDuration = meter.CreateHistogram<double>(
+                name: "http.client.connection.duration",
+                unit: "s",
+                description: "The duration of successfully established outbound HTTP connections.",
+                advice: new InstrumentAdvice<double>()
+                {
+                    // These values are not based on a standard and may change in the future.
+                    HistogramBucketBoundaries = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300]
+                });
+
+            RequestsQueueDuration = meter.CreateHistogram<double>(
+                name: "http.client.request.time_in_queue",
+                unit: "s",
+                description: "The amount of time requests spent on a queue waiting for an available connection.",
+                advice: DiagnosticsHelper.ShortHistogramAdvice);
+        }
 
         public void RequestLeftQueue(HttpRequestMessage request, HttpConnectionPool pool, TimeSpan duration, int versionMajor)
         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -407,9 +407,9 @@ namespace System.Net.Http.Functional.Tests
             using (HttpMessageInvoker client = CreateHttpMessageInvoker())
             {
                 using HttpRequestMessage request = new(HttpMethod.Get, uri) { Version = UseVersion };
-                request.Headers.ConnectionClose = true;
                 using HttpResponseMessage response = await SendAsync(client, request);
                 await response.Content.LoadIntoBufferAsync();
+                openConnectionsRecorder.RecordObservableInstruments();
                 await WaitForEnvironmentTicksToAdvance();
             }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -294,21 +294,33 @@ namespace System.Net.Http.Functional.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/129223", TestPlatforms.Wasi)]
         public Task ActiveRequests_Success_Recorded()
         {
+            var serverTcs = new TaskCompletionSource();
+            var clientTcs = new TaskCompletionSource();
+
             return LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 using HttpMessageInvoker client = CreateHttpMessageInvoker();
                 using InstrumentRecorder<long> recorder = SetupInstrumentRecorder<long>(InstrumentNames.ActiveRequests);
                 using HttpRequestMessage request = new(HttpMethod.Get, uri) { Version = UseVersion };
 
-                HttpResponseMessage response = await SendAsync(client, request);
+                var requestTask = SendAsync(client, request);
+                await serverTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                recorder.RecordObservableInstruments();
+                clientTcs.SetResult();
+                var response = await requestTask;
                 response.Dispose(); // Make sure disposal doesn't interfere with recording by enforcing early disposal.
 
                 Assert.Collection(recorder.GetMeasurements(),
-                    m => VerifyActiveRequests(m, 1, uri),
-                    m => VerifyActiveRequests(m, -1, uri));
+                    m => VerifyActiveRequests(m, 1, uri));
             }, async server =>
             {
-                await server.AcceptConnectionSendResponseAndCloseAsync();
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    var requestData = await connection.ReadRequestDataAsync();
+                    serverTcs.SetResult();
+                    await clientTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    await connection.SendResponseAsync();
+                });
             });
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -221,6 +221,7 @@ namespace System.Net.Http.Functional.Tests
                 }
             }
 
+            public void RecordObservableInstruments() => _meterListener.RecordObservableInstruments();
             public IReadOnlyList<Measurement<T>> GetMeasurements() => _values.ToArray();
             public void Dispose() => _meterListener.Dispose();
         }
@@ -272,6 +273,7 @@ namespace System.Net.Http.Functional.Tests
                 _meterListener.Start();
             }
 
+            public void RecordObservableInstruments() => _meterListener.RecordObservableInstruments();
             public IReadOnlyList<RecordedCounter> GetMeasurements() => _values.ToArray();
             public void Dispose() => _meterListener.Dispose();
         }
@@ -752,6 +754,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task AllSocketsHttpHandlerCounters_Success_Recorded()
         {
             TaskCompletionSource clientWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource serverWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TaskCompletionSource clientDisposedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
@@ -764,32 +767,19 @@ namespace System.Net.Http.Functional.Tests
 
                     using HttpRequestMessage request = new(HttpMethod.Get, uri) { Version = UseVersion };
                     Task<HttpResponseMessage> sendAsyncTask = SendAsync(invoker, request);
+                    await serverWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    recorder.RecordObservableInstruments();
                     clientWaitingTcs.SetResult();
-                    using HttpResponseMessage response = await sendAsyncTask;
+                    recorder.RecordObservableInstruments();
+                    await serverWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    HttpResponseMessage response = await sendAsyncTask;
+                    response.Dispose();
 
                     await WaitForEnvironmentTicksToAdvance();
+                    recorder.RecordObservableInstruments();
                 }
 
                 clientDisposedTcs.SetResult();
-
-                Action<RecordedCounter> requestsQueueDuration = m =>
-                    VerifyTimeInQueue(m.InstrumentName, m.Value, m.Tags, uri, UseVersion);
-                Action<RecordedCounter> connectionNoLongerIdle = m =>
-                    VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, -1, uri, UseVersion, "idle");
-                Action<RecordedCounter> connectionIsActive = m =>
-                    VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, UseVersion, "active");
-
-                Action<RecordedCounter> check1 = requestsQueueDuration;
-                Action<RecordedCounter> check2 = connectionNoLongerIdle;
-                Action<RecordedCounter> check3 = connectionIsActive;
-
-                if (UseVersion.Major > 2)
-                {
-                    // With HTTP/3, the idle state change is emitted before RequestsQueueDuration.
-                    check1 = connectionNoLongerIdle;
-                    check2 = connectionIsActive;
-                    check3 = requestsQueueDuration;
-                }
 
                 IReadOnlyList<RecordedCounter> measurements = recorder.GetMeasurements();
                 foreach (RecordedCounter m in measurements)
@@ -799,26 +789,22 @@ namespace System.Net.Http.Functional.Tests
 
                 Assert.Collection(measurements,
                     m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, 1, uri),
-                    m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, UseVersion, "idle"),
-                    check1, // requestsQueueDuration, connectionNoLongerIdle, connectionIsActive in the appropriate order.
-                    check2,
-                    check3,
-                    m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, -1, uri, UseVersion, "active"),
-                    m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, UseVersion, "idle"),
-
+                    m => VerifyTimeInQueue(m.InstrumentName, m.Value, m.Tags, uri, UseVersion),
+                    m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, UseVersion, "active"),
                     m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, -1, uri),
                     m => VerifyRequestDuration(m.InstrumentName, (double)m.Value, m.Tags, uri, UseVersion, 200),
-                    m => VerifyConnectionDuration(m.InstrumentName, m.Value, m.Tags, uri, UseVersion),
-                    m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, -1, uri, UseVersion, "idle"));
+                    m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, UseVersion, "idle"),
+                    m => VerifyConnectionDuration(m.InstrumentName, m.Value, m.Tags, uri, UseVersion));
             },
             async server =>
             {
-                await clientWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
-
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestDataAsync();
-                    await connection.SendResponseAsync();
+                    await clientWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    serverWaitingTcs.SetResult();
+                    await clientWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    await connection.SendResponseAsync(content: new string('a', 10*1024));
                     await clientDisposedTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
                 });
             });
@@ -1528,6 +1514,7 @@ namespace System.Net.Http.Functional.Tests
             await RemoteExecutor.Invoke(static async Task () =>
             {
                 TaskCompletionSource clientWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                TaskCompletionSource serverWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 using HttpMetricsTest_DefaultMeter test = new(null);
                 await test.LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
@@ -1538,27 +1525,25 @@ namespace System.Net.Http.Functional.Tests
                     {
                         using HttpRequestMessage request = new(HttpMethod.Get, uri) { Version = test.UseVersion };
                         Task<HttpResponseMessage> sendAsyncTask = client.SendAsync(request);
+                        await serverWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                        recorder.RecordObservableInstruments();
                         clientWaitingTcs.SetResult();
-                        using HttpResponseMessage response = await sendAsyncTask;
+                        HttpResponseMessage response = await sendAsyncTask;
+                        response.Dispose();
 
                         await WaitForEnvironmentTicksToAdvance();
+                        recorder.RecordObservableInstruments();
                     }
 
                     Version version = HttpVersion.Version11;
                     Assert.Collection(recorder.GetMeasurements(),
                         m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, 1, uri),
-                        m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, version, "idle"),
                         m => VerifyTimeInQueue(m.InstrumentName, m.Value, m.Tags, uri, version),
-
-                        m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, -1, uri, version, "idle"),
                         m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, version, "active"),
-                        m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, -1, uri, version, "active"),
-                        m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, version, "idle"),
-
                         m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, -1, uri),
                         m => VerifyRequestDuration(m.InstrumentName, (double)m.Value, m.Tags, uri, version, 200),
-                        m => VerifyConnectionDuration(m.InstrumentName, m.Value, m.Tags, uri, version),
-                        m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, -1, uri, version, "idle"));
+                        m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, version, "idle"),
+                        m => VerifyConnectionDuration(m.InstrumentName, m.Value, m.Tags, uri, version));
                 },
                 async server =>
                 {
@@ -1567,6 +1552,8 @@ namespace System.Net.Http.Functional.Tests
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         await connection.ReadRequestDataAsync();
+                        serverWaitingTcs.SetResult();
+                        await clientWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
                         await connection.SendResponseAsync(isFinal: false);
                         await connection.WaitForCloseAsync(CancellationToken.None);
                     });

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -785,8 +785,8 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(typeof(SocketsHttpHandler), nameof(SocketsHttpHandler.IsSupported))]
         public async Task AllSocketsHttpHandlerCounters_Success_Recorded()
         {
-            TaskCompletionSource clientWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            TaskCompletionSource serverWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource clientTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource serverTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TaskCompletionSource clientDisposedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
@@ -799,31 +799,21 @@ namespace System.Net.Http.Functional.Tests
 
                     using HttpRequestMessage request = new(HttpMethod.Get, uri) { Version = UseVersion };
                     Task<HttpResponseMessage> sendAsyncTask = SendAsync(invoker, request);
-                    await serverWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    await serverTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
                     recorder.RecordObservableInstruments();
-                    clientWaitingTcs.SetResult();
-                    recorder.RecordObservableInstruments();
-                    await serverWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    clientTcs.SetResult();
                     HttpResponseMessage response = await sendAsyncTask;
                     response.Dispose();
 
                     await WaitForEnvironmentTicksToAdvance();
                     recorder.RecordObservableInstruments();
                 }
-
                 clientDisposedTcs.SetResult();
 
-                IReadOnlyList<RecordedCounter> measurements = recorder.GetMeasurements();
-                foreach (RecordedCounter m in measurements)
-                {
-                    _output.WriteLine(m.ToString());
-                }
-
-                Assert.Collection(measurements,
-                    m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, 1, uri),
+                Assert.Collection(recorder.GetMeasurements(),
                     m => VerifyTimeInQueue(m.InstrumentName, m.Value, m.Tags, uri, UseVersion),
+                    m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, 1, uri),
                     m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, UseVersion, "active"),
-                    m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, -1, uri),
                     m => VerifyRequestDuration(m.InstrumentName, (double)m.Value, m.Tags, uri, UseVersion, 200),
                     m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, UseVersion, "idle"),
                     m => VerifyConnectionDuration(m.InstrumentName, m.Value, m.Tags, uri, UseVersion));
@@ -833,10 +823,9 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestDataAsync();
-                    await clientWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
-                    serverWaitingTcs.SetResult();
-                    await clientWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
-                    await connection.SendResponseAsync(content: new string('a', 10*1024));
+                    serverTcs.SetResult();
+                    await clientTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    await connection.SendResponseAsync(isFinal: true);
                     await clientDisposedTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
                 });
             });
@@ -1518,6 +1507,9 @@ namespace System.Net.Http.Functional.Tests
         {
             await RemoteExecutor.Invoke(static async Task () =>
             {
+                var serverTcs = new TaskCompletionSource();
+                var clientTcs = new TaskCompletionSource();
+
                 using HttpMetricsTest_DefaultMeter test = new(null);
                 await test.LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
                 {
@@ -1525,15 +1517,24 @@ namespace System.Net.Http.Functional.Tests
                     using InstrumentRecorder<long> recorder = new InstrumentRecorder<long>(InstrumentNames.ActiveRequests);
                     using HttpRequestMessage request = new(HttpMethod.Get, uri) { Version = test.UseVersion };
 
-                    HttpResponseMessage response = await client.SendAsync(request);
+                    var requestTask = client.SendAsync(request);
+                    await serverTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    recorder.RecordObservableInstruments();
+                    clientTcs.SetResult();
+                    var response = await requestTask;
                     response.Dispose(); // Make sure disposal doesn't interfere with recording by enforcing early disposal.
 
                     Assert.Collection(recorder.GetMeasurements(),
-                        m => VerifyActiveRequests(m, 1, uri),
-                        m => VerifyActiveRequests(m, -1, uri));
+                        m => VerifyActiveRequests(m, 1, uri));
                 }, async server =>
                 {
-                    await server.AcceptConnectionSendResponseAndCloseAsync();
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        var requestData = await connection.ReadRequestDataAsync();
+                        serverTcs.SetResult();
+                        await clientTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                        await connection.SendResponseAsync();
+                    });
                 });
             }).DisposeAsync();
         }
@@ -1545,8 +1546,9 @@ namespace System.Net.Http.Functional.Tests
         {
             await RemoteExecutor.Invoke(static async Task () =>
             {
-                TaskCompletionSource clientWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-                TaskCompletionSource serverWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                TaskCompletionSource clientTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                TaskCompletionSource serverTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                TaskCompletionSource clientDisposedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 using HttpMetricsTest_DefaultMeter test = new(null);
                 await test.LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
@@ -1557,37 +1559,35 @@ namespace System.Net.Http.Functional.Tests
                     {
                         using HttpRequestMessage request = new(HttpMethod.Get, uri) { Version = test.UseVersion };
                         Task<HttpResponseMessage> sendAsyncTask = client.SendAsync(request);
-                        await serverWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                        await serverTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
                         recorder.RecordObservableInstruments();
-                        clientWaitingTcs.SetResult();
+                        clientTcs.SetResult();
                         HttpResponseMessage response = await sendAsyncTask;
                         response.Dispose();
 
                         await WaitForEnvironmentTicksToAdvance();
                         recorder.RecordObservableInstruments();
                     }
+                    clientDisposedTcs.SetResult();
 
                     Version version = HttpVersion.Version11;
                     Assert.Collection(recorder.GetMeasurements(),
-                        m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, 1, uri),
                         m => VerifyTimeInQueue(m.InstrumentName, m.Value, m.Tags, uri, version),
+                        m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, 1, uri),
                         m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, version, "active"),
-                        m => VerifyActiveRequests(m.InstrumentName, (long)m.Value, m.Tags, -1, uri),
                         m => VerifyRequestDuration(m.InstrumentName, (double)m.Value, m.Tags, uri, version, 200),
                         m => VerifyOpenConnections(m.InstrumentName, m.Value, m.Tags, 1, uri, version, "idle"),
                         m => VerifyConnectionDuration(m.InstrumentName, m.Value, m.Tags, uri, version));
                 },
                 async server =>
                 {
-                    await clientWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
-
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         await connection.ReadRequestDataAsync();
-                        serverWaitingTcs.SetResult();
-                        await clientWaitingTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                        serverTcs.SetResult();
+                        await clientTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
                         await connection.SendResponseAsync(isFinal: false);
-                        await connection.WaitForCloseAsync(CancellationToken.None);
+                        await clientDisposedTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
                     });
                 });
             }).DisposeAsync();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -316,7 +316,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 await server.AcceptConnectionAsync(async connection =>
                 {
-                    var requestData = await connection.ReadRequestDataAsync();
+                    await connection.ReadRequestDataAsync();
                     serverTcs.SetResult();
                     await clientTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
                     await connection.SendResponseAsync();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -687,6 +687,11 @@ namespace System.Net.Http.Functional.Tests
                 Handler.Credentials = credentialsMode == 1 ? new CredentialCache() : new CustomCredentials();
             }
 
+            var originalServerTcs = new TaskCompletionSource();
+            var redirectServerTcs = new TaskCompletionSource();
+            var clientTcs1 = new TaskCompletionSource();
+            var clientTcs2 = new TaskCompletionSource();
+
             return LoopbackServerFactory.CreateServerAsync((originalServer, originalUri) =>
             {
                 return LoopbackServerFactory.CreateServerAsync(async (redirectServer, redirectUri) =>
@@ -696,21 +701,36 @@ namespace System.Net.Http.Functional.Tests
                     using HttpRequestMessage request = new(HttpMethod.Get, originalUri) { Version = UseVersion };
 
                     Task clientTask = SendAsync(client, request);
-                    Task serverTask = originalServer.HandleRequestAsync(HttpStatusCode.Redirect, new[] { new HttpHeaderData("Location", redirectUri.AbsoluteUri) });
-
+                    var serverTask = originalServer.AcceptConnectionAsync(async connection =>
+                    {
+                        var requestData = await connection.ReadRequestDataAsync();
+                        originalServerTcs.SetResult();
+                        await clientTcs1.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                        await connection.SendResponseAsync(HttpStatusCode.Redirect, new[] { new HttpHeaderData("Location", redirectUri.AbsoluteUri) });
+                    });
+                    await originalServerTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    recorder.RecordObservableInstruments();
+                    clientTcs1.SetResult();
                     await Task.WhenAny(clientTask, serverTask);
                     Assert.False(clientTask.IsCompleted, $"{clientTask.Status}: {clientTask.Exception}");
                     await serverTask;
 
-                    serverTask = redirectServer.HandleRequestAsync();
+                    serverTask = redirectServer.AcceptConnectionAsync(async connection =>
+                    {
+                        var requestData = await connection.ReadRequestDataAsync();
+                        redirectServerTcs.SetResult();
+                        await clientTcs2.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                        await connection.SendResponseAsync();
+                    });
+                    await redirectServerTcs.Task.WaitAsync(TestHelper.PassingTestTimeout);
+                    recorder.RecordObservableInstruments();
+                    clientTcs2.SetResult();
                     await TestHelper.WhenAllCompletedOrAnyFailed(clientTask, serverTask);
                     await clientTask;
 
                     Assert.Collection(recorder.GetMeasurements(),
                         m => VerifyActiveRequests(m, 1, originalUri),
-                        m => VerifyActiveRequests(m, -1, originalUri),
-                        m => VerifyActiveRequests(m, 1, redirectUri),
-                        m => VerifyActiveRequests(m, -1, redirectUri));
+                        m => VerifyActiveRequests(m, 1, redirectUri));
                 });
             });
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -294,8 +294,8 @@ namespace System.Net.Http.Functional.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/129223", TestPlatforms.Wasi)]
         public Task ActiveRequests_Success_Recorded()
         {
-            var serverTcs = new TaskCompletionSource();
-            var clientTcs = new TaskCompletionSource();
+            var serverTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             return LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
@@ -687,10 +687,10 @@ namespace System.Net.Http.Functional.Tests
                 Handler.Credentials = credentialsMode == 1 ? new CredentialCache() : new CustomCredentials();
             }
 
-            var originalServerTcs = new TaskCompletionSource();
-            var redirectServerTcs = new TaskCompletionSource();
-            var clientTcs1 = new TaskCompletionSource();
-            var clientTcs2 = new TaskCompletionSource();
+            var originalServerTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var redirectServerTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientTcs2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             return LoopbackServerFactory.CreateServerAsync((originalServer, originalUri) =>
             {
@@ -1507,8 +1507,8 @@ namespace System.Net.Http.Functional.Tests
         {
             await RemoteExecutor.Invoke(static async Task () =>
             {
-                var serverTcs = new TaskCompletionSource();
-                var clientTcs = new TaskCompletionSource();
+                var serverTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 using HttpMetricsTest_DefaultMeter test = new(null);
                 await test.LoopbackServerFactory.CreateClientAndServerAsync(async uri =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -717,7 +717,7 @@ namespace System.Net.Http.Functional.Tests
 
                     serverTask = redirectServer.AcceptConnectionAsync(async connection =>
                     {
-                        var requestData = await connection.ReadRequestDataAsync();
+                        await connection.ReadRequestDataAsync();
                         redirectServerTcs.SetResult();
                         await clientTcs2.Task.WaitAsync(TestHelper.PassingTestTimeout);
                         await connection.SendResponseAsync();


### PR DESCRIPTION
The open_connections and active_requests up down counters both use peer address in their tags and suffer from accumulation of data at the monitoring side. This PR changes them to their observable counterpart that counts the values and reports them only when asked. 

This does not solve the underlying issue, this just somewhat mitigates the biggest pain points for customers. Eventually, this change should be reverted when the issue is solved on OpenTelemtry side, see https://github.com/open-telemetry/semantic-conventions/issues/3279.

**Unintentianal side effect is that if someone is directly using `MeterListener` this change will be breaking for them.** They also need to start using `RecordObservableInstruments` to get the values now, see changes in our metrics tests.

Fixes #122752