### PR TITLE
Update ad-hoc signing in HostModel for changed `codesign` behaviour (code directory page size) in macOS 26+

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/MachO/BinaryFormat/Blobs/CodeDirectoryBlob.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/MachO/BinaryFormat/Blobs/CodeDirectoryBlob.cs
@@ -69,8 +69,12 @@ internal sealed class CodeDirectoryBlob : IBlob
         HashType hashType,
         ExecutableSegmentFlags execSegmentFlags,
         byte[][] specialSlotHashes,
-        byte[][] codeHashes)
+        byte[][] codeHashes,
+        uint pageSize)
     {
+        // The CodeDirectory stores log2 of the page size. codesign only uses a 4 KB or 16 KB code directory page.
+        Debug.Assert(pageSize is MachObjectFile.DefaultCodeDirectoryPageSize or MachObjectFile.Arm64CodeDirectoryPageSize);
+        byte log2PageSize = pageSize == MachObjectFile.Arm64CodeDirectoryPageSize ? (byte)14 : (byte)12;
         // Always assume the executable length is the entire file size / signature start.
         _cdHeader = new CodeDirectoryHeader(
             identifier,
@@ -82,7 +86,8 @@ internal sealed class CodeDirectoryBlob : IBlob
             signatureStart,
             0,
             signatureStart,
-            execSegmentFlags);
+            execSegmentFlags,
+            log2PageSize);
         _identifier = identifier;
         _specialSlotHashes = specialSlotHashes;
         _codeHashes = codeHashes;
@@ -120,7 +125,7 @@ internal sealed class CodeDirectoryBlob : IBlob
         string identifier,
         RequirementsBlob requirementsBlob,
         HashType hashType = HashType.SHA256,
-        uint pageSize = MachObjectFile.DefaultPageSize)
+        uint pageSize = MachObjectFile.DefaultCodeDirectoryPageSize)
     {
         uint codeSlotCount = GetCodeSlotCount((uint)signatureStart, pageSize);
         uint specialCodeSlotCount = (uint)CodeDirectorySpecialSlot.Requirements;
@@ -171,7 +176,8 @@ internal sealed class CodeDirectoryBlob : IBlob
             hashType,
             ExecutableSegmentFlags.MainBinary,
             specialSlotHashes,
-            codeHashes);
+            codeHashes,
+            pageSize);
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -217,7 +223,7 @@ internal sealed class CodeDirectoryBlob : IBlob
 
         private static unsafe uint GetSize() => (uint)sizeof(CodeDirectoryHeader);
 
-        public CodeDirectoryHeader(string identifier, uint codeSlotCount, uint specialCodeSlotCount, uint executableLength, byte hashSize, HashType hashType, ulong signatureStart, ulong execSegmentBase, ulong execSegmentLimit, ExecutableSegmentFlags execSegmentFlags)
+        public CodeDirectoryHeader(string identifier, uint codeSlotCount, uint specialCodeSlotCount, uint executableLength, byte hashSize, HashType hashType, ulong signatureStart, ulong execSegmentBase, ulong execSegmentLimit, ExecutableSegmentFlags execSegmentFlags, byte log2PageSize)
         {
             HashSize = hashSize;
             _version = (CodeDirectoryVersion)((uint)CodeDirectoryVersion.HighestVersion).ConvertToBigEndian();
@@ -229,7 +235,7 @@ internal sealed class CodeDirectoryBlob : IBlob
             _executableLength = executableLength.ConvertToBigEndian();
             HashType = hashType;
             Platform = 0;
-            Log2PageSize = 12; // 4K page size
+            Log2PageSize = log2PageSize;
             _codeLimit64 = (signatureStart >= uint.MaxValue ? signatureStart : 0).ConvertToBigEndian();
             _execSegmentBase = execSegmentBase.ConvertToBigEndian();
             _execSegmentLimit = execSegmentLimit.ConvertToBigEndian();
@@ -288,7 +294,7 @@ internal sealed class CodeDirectoryBlob : IBlob
         return (uint)(Encoding.UTF8.GetByteCount(identifier) + 1);
     }
 
-    internal static uint GetCodeSlotCount(uint signatureStart, uint pageSize = MachObjectFile.DefaultPageSize)
+    internal static uint GetCodeSlotCount(uint signatureStart, uint pageSize = MachObjectFile.DefaultCodeDirectoryPageSize)
     {
         return (signatureStart + pageSize - 1) / pageSize;
     }

--- a/src/installer/managed/Microsoft.NET.HostModel/MachO/BinaryFormat/Blobs/CodeDirectoryBlob.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/MachO/BinaryFormat/Blobs/CodeDirectoryBlob.cs
@@ -124,8 +124,8 @@ internal sealed class CodeDirectoryBlob : IBlob
         long signatureStart,
         string identifier,
         RequirementsBlob requirementsBlob,
-        HashType hashType = HashType.SHA256,
-        uint pageSize = MachObjectFile.DefaultCodeDirectoryPageSize)
+        uint pageSize,
+        HashType hashType = HashType.SHA256)
     {
         uint codeSlotCount = GetCodeSlotCount((uint)signatureStart, pageSize);
         uint specialCodeSlotCount = (uint)CodeDirectorySpecialSlot.Requirements;
@@ -294,7 +294,7 @@ internal sealed class CodeDirectoryBlob : IBlob
         return (uint)(Encoding.UTF8.GetByteCount(identifier) + 1);
     }
 
-    internal static uint GetCodeSlotCount(uint signatureStart, uint pageSize = MachObjectFile.DefaultCodeDirectoryPageSize)
+    internal static uint GetCodeSlotCount(uint signatureStart, uint pageSize)
     {
         return (signatureStart + pageSize - 1) / pageSize;
     }

--- a/src/installer/managed/Microsoft.NET.HostModel/MachO/BinaryFormat/Blobs/EmbeddedSignatureBlob.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/MachO/BinaryFormat/Blobs/EmbeddedSignatureBlob.cs
@@ -111,7 +111,8 @@ internal sealed class EmbeddedSignatureBlob : IBlob
         size += sizeof(uint); // Blob size
         size += sizeof(CodeDirectoryBlob.CodeDirectoryHeader); // CodeDirectory header
         size += CodeDirectoryBlob.GetIdentifierLength(identifier); // Identifier
-        size += (long)CodeDirectoryBlob.GetCodeSlotCount(fileSize) * usedHashSize; // Code hashes
+        // Uses the smallest code directory page size (4 KiB) so the code slot count is the maximum possible for any architecture.
+        size += (long)CodeDirectoryBlob.GetCodeSlotCount(fileSize, MachObjectFile.DefaultCodeDirectoryPageSize) * usedHashSize; // Code hashes
         size += (long)(uint)CodeDirectorySpecialSlot.Requirements * usedHashSize; // Special code hashes
 
         size += RequirementsBlob.Empty.Size; // Requirements is always written as an empty blob
@@ -123,7 +124,7 @@ internal sealed class EmbeddedSignatureBlob : IBlob
     /// Returns the size of a signature used to replace an existing one.
     /// If the existing signature is null, it will assume sizing using the default signature, which includes the Requirements and CMS blobs.
     /// </summary>
-    internal static unsafe long GetSignatureSize(uint fileSize, string identifier, byte? hashSize = null)
+    internal static unsafe long GetSignatureSize(uint fileSize, string identifier, uint pageSize, byte? hashSize = null)
     {
         byte usedHashSize = hashSize ?? CodeDirectoryBlob.DefaultHashType.GetHashSize();
         uint specialCodeSlotCount = (uint)CodeDirectorySpecialSlot.Requirements;
@@ -142,7 +143,7 @@ internal sealed class EmbeddedSignatureBlob : IBlob
         size += sizeof(CodeDirectoryBlob.CodeDirectoryHeader); // CodeDirectory header
         size += CodeDirectoryBlob.GetIdentifierLength(identifier); // Identifier
         size += specialCodeSlotCount * usedHashSize; // Special code hashes
-        size += CodeDirectoryBlob.GetCodeSlotCount(fileSize) * usedHashSize; // Code hashes
+        size += CodeDirectoryBlob.GetCodeSlotCount(fileSize, pageSize) * usedHashSize; // Code hashes
         // RequirementsBlob
         size += RequirementsBlob.Empty.Size;
         // CmsWrapperBlob

--- a/src/installer/managed/Microsoft.NET.HostModel/MachO/Enums/MachCpuType.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/MachO/Enums/MachCpuType.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.HostModel.MachO;
+
+/// <summary>
+/// See https://github.com/apple-oss-distributions/xnu/blob/xnu-11215.1.10/osfmk/mach/machine.h#L131-L156
+/// </summary>
+internal enum MachCpuType : uint
+{
+    // Architecture mask bits.
+    Abi64 = 0x01000000,       // CPU_ARCH_ABI64: 64-bit ABI
+    Abi64_32 = 0x02000000,    // CPU_ARCH_ABI64_32: ABI for 64-bit hardware with 32-bit types
+
+    // Base CPU type.
+    Arm = 12,                 // CPU_TYPE_ARM
+
+    // Combined CPU types.
+    Arm64 = Arm | Abi64,      // CPU_TYPE_ARM64
+    Arm64_32 = Arm | Abi64_32, // CPU_TYPE_ARM64_32
+}

--- a/src/installer/managed/Microsoft.NET.HostModel/MachO/MachObjectFile.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/MachO/MachObjectFile.cs
@@ -19,6 +19,13 @@ namespace Microsoft.NET.HostModel.MachO;
 internal unsafe partial class MachObjectFile
 {
     internal const uint DefaultPageSize = 0x1000;
+    // The default code directory page size codesign uses to hash the code slots (4 KiB).
+    // https://github.com/apple-oss-distributions/Security/blob/Security-61901.0.87.0.1/OSX/libsecurity_codesigning/lib/diskrep.h#L158-L160
+    internal const uint DefaultCodeDirectoryPageSize = 0x1000;
+    // The code directory page size codesign uses to hash the code slots of arm64/arm64_32 objects (16 KiB).
+    // https://github.com/apple-oss-distributions/Security/blob/Security-61901.0.87.0.1/OSX/libsecurity_codesigning/lib/machorep.cpp#L574-L591
+    // https://github.com/apple-oss-distributions/Security/blob/Security-61901.0.87.0.1/OSX/libsecurity_codesigning/lib/diskrep.h#L158-L160
+    internal const uint Arm64CodeDirectoryPageSize = 0x4000;
     private const uint CodeSignatureAlignment = 0x10;
     private MachHeader _header;
     private (LinkEditLoadCommand Command, long FileOffset) _codeSignatureLoadCommand;
@@ -133,11 +140,21 @@ internal unsafe partial class MachObjectFile
         uint signatureStart = machObject._codeSignatureLoadCommand.Command.GetDataOffset(machObject._header);
         RequirementsBlob requirementsBlob = RequirementsBlob.Empty;
         CmsWrapperBlob cmsWrapperBlob = CmsWrapperBlob.Empty;
+
+        // Match codesign behavior on macOS 26+:
+        //   16 KiB code directory page size for arm64/arm64_32
+        //   4 KiB otherwise
+        // Before macOS 26, it used 4 KiB for every architecture.
+        // A 16 KiB code directory page is valid on older arm64 macOS versions.
+        uint pageSize = (MachCpuType)machObject._header.CpuType is MachCpuType.Arm64 or MachCpuType.Arm64_32
+            ? Arm64CodeDirectoryPageSize
+            : DefaultCodeDirectoryPageSize;
         var codeDirectory = CodeDirectoryBlob.Create(
             file,
             signatureStart,
             identifier,
-            requirementsBlob);
+            requirementsBlob,
+            pageSize: pageSize);
 
         return new EmbeddedSignatureBlob(
             codeDirectoryBlob: codeDirectory,

--- a/src/installer/managed/Microsoft.NET.HostModel/MachO/MachObjectFile.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/MachO/MachObjectFile.cs
@@ -19,12 +19,10 @@ namespace Microsoft.NET.HostModel.MachO;
 internal unsafe partial class MachObjectFile
 {
     internal const uint DefaultPageSize = 0x1000;
-    // The default code directory page size codesign uses to hash the code slots (4 KiB).
+    // Code directory page size codesign uses to hash the code slots
     // https://github.com/apple-oss-distributions/Security/blob/Security-61901.0.87.0.1/OSX/libsecurity_codesigning/lib/diskrep.h#L158-L160
-    internal const uint DefaultCodeDirectoryPageSize = 0x1000;
-    // The code directory page size codesign uses to hash the code slots of arm64/arm64_32 objects (16 KiB).
     // https://github.com/apple-oss-distributions/Security/blob/Security-61901.0.87.0.1/OSX/libsecurity_codesigning/lib/machorep.cpp#L574-L591
-    // https://github.com/apple-oss-distributions/Security/blob/Security-61901.0.87.0.1/OSX/libsecurity_codesigning/lib/diskrep.h#L158-L160
+    internal const uint DefaultCodeDirectoryPageSize = 0x1000;
     internal const uint Arm64CodeDirectoryPageSize = 0x4000;
     private const uint CodeSignatureAlignment = 0x10;
     private MachHeader _header;
@@ -46,6 +44,17 @@ internal unsafe partial class MachObjectFile
     internal EmbeddedSignatureBlob? EmbeddedSignatureBlob => _codeSignatureBlob;
 
     internal MachHeader Header => _header;
+
+    // Match codesign behavior on macOS 26+:
+    //   16 KiB code directory page size for arm64/arm64_32
+    //   4 KiB otherwise
+    // Before macOS 26, it used 4 KiB for every architecture.
+    // HostModel always uses the macOS 26 value so signing is deterministic and independent of the build
+    // machine's OS; a 16 KiB code directory page is valid on older arm64 macOS versions.
+    private uint CodeDirectoryPageSize
+        => (MachCpuType)_header.CpuType is MachCpuType.Arm64 or MachCpuType.Arm64_32
+            ? Arm64CodeDirectoryPageSize
+            : DefaultCodeDirectoryPageSize;
 
     private MachObjectFile(
         MachHeader header,
@@ -141,20 +150,12 @@ internal unsafe partial class MachObjectFile
         RequirementsBlob requirementsBlob = RequirementsBlob.Empty;
         CmsWrapperBlob cmsWrapperBlob = CmsWrapperBlob.Empty;
 
-        // Match codesign behavior on macOS 26+:
-        //   16 KiB code directory page size for arm64/arm64_32
-        //   4 KiB otherwise
-        // Before macOS 26, it used 4 KiB for every architecture.
-        // A 16 KiB code directory page is valid on older arm64 macOS versions.
-        uint pageSize = (MachCpuType)machObject._header.CpuType is MachCpuType.Arm64 or MachCpuType.Arm64_32
-            ? Arm64CodeDirectoryPageSize
-            : DefaultCodeDirectoryPageSize;
         var codeDirectory = CodeDirectoryBlob.Create(
             file,
             signatureStart,
             identifier,
             requirementsBlob,
-            pageSize: pageSize);
+            machObject.CodeDirectoryPageSize);
 
         return new EmbeddedSignatureBlob(
             codeDirectoryBlob: codeDirectory,
@@ -443,7 +444,7 @@ internal unsafe partial class MachObjectFile
     {
         uint csOffset = GetSignatureStart();
         uint csPtr = (uint)(_codeSignatureLoadCommand.Command.IsDefault ? NextLoadCommandOffset : _codeSignatureLoadCommand.FileOffset);
-        uint csSize = (uint)EmbeddedSignatureBlob.GetSignatureSize(csOffset, identifier);
+        uint csSize = (uint)EmbeddedSignatureBlob.GetSignatureSize(csOffset, identifier, CodeDirectoryPageSize);
 
         if (_codeSignatureLoadCommand.Command.IsDefault)
         {

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/SigningTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/SigningTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.NET.HostModel.MachO.CodeSign.Tests
             Assert.True(IsSigned(managedSignedPath + ".resigned"), $"Failed to resign {filePath}");
         }
 
-        [Theory(Skip = "Temporarily disabled due to macOS 26 codesign behavior change - only hashing __TEXT segment")]
+        [Theory]
         [PlatformSpecific(TestPlatforms.OSX)]
         [MemberData(nameof(GetTestFilePaths), nameof(MatchesCodesignOutput))]
         public void MatchesCodesignOutput(string filePath, TestArtifact _)
@@ -88,6 +88,12 @@ namespace Microsoft.NET.HostModel.MachO.CodeSign.Tests
             string originalFilePath = filePath;
             string codesignFilePath = filePath + ".codesigned";
             string managedSignedPath = filePath + ".signed";
+
+            // codesign's default arm64 code directory page size only matches HostModel's (16 KiB) on macOS 26+.
+            // On older macOS, codesign defaults to 4 KiB for arm64, so there is nothing meaningful to compare.
+            Assert.SkipWhen(
+                !OperatingSystem.IsMacOSVersionAtLeast(26) && IsArm64File(originalFilePath),
+                "codesign uses a different default code directory page size for arm64 before macOS 26.");
 
             // Codesigned file
             File.Copy(filePath, codesignFilePath);
@@ -189,6 +195,15 @@ namespace Microsoft.NET.HostModel.MachO.CodeSign.Tests
             {
                 SelfContainedApp.Dispose();
             }
+        }
+
+        static bool IsArm64File(string filePath)
+        {
+            using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1);
+            using var mmapFile = MemoryMappedFile.CreateFromFile(fileStream, null, 0, MemoryMappedFileAccess.Read, HandleInheritability.None, true);
+            using var accessor = mmapFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.CopyOnWrite);
+            var cpuType = (MachCpuType)MachObjectFile.Create(new MemoryMappedMachOViewAccessor(accessor)).Header.CpuType;
+            return cpuType is MachCpuType.Arm64 or MachCpuType.Arm64_32;
         }
 
         static void AssertMachFilesAreEquivalent(string codesignedPath, string managedSignedPath, string fileName)

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/SigningTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/SigningTests.cs
@@ -202,7 +202,11 @@ namespace Microsoft.NET.HostModel.MachO.CodeSign.Tests
             using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1);
             using var mmapFile = MemoryMappedFile.CreateFromFile(fileStream, null, 0, MemoryMappedFileAccess.Read, HandleInheritability.None, true);
             using var accessor = mmapFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.CopyOnWrite);
-            var cpuType = (MachCpuType)MachObjectFile.Create(new MemoryMappedMachOViewAccessor(accessor)).Header.CpuType;
+
+            var file = new MemoryMappedMachOViewAccessor(accessor);
+            file.Read(0, out MachHeader header);
+
+            var cpuType = (MachCpuType)header.CpuType;
             return cpuType is MachCpuType.Arm64 or MachCpuType.Arm64_32;
         }
 


### PR DESCRIPTION
macOS 26 changed `codesign` to hash arm64/arm64_32 Mach-O objects with a 16 KiB code directory page size instead of 4 KiB, so HostModel's managed ad-hoc signer  no longer matched `codesign` on arm64. This change uses the Mach-O CPU type to determine the code directory page size, matching `codesign` on macOS 26+. The larger page size should still work on older arm64 macOS versions.

Also validated by manually kicking off a run for the host tests on the osx.15.arm64 queue.

Fixes #121825 