### PR TITLE
Fix incorrect result for pow(x, 1) on ARM/ARM64

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10342,7 +10342,14 @@ ValueNum ValueNumStore::EvalMathFuncBinary(var_types typ, NamedIntrinsic gtMathF
                 {
                     assert(typ == TypeOfVN(arg1VN));
                     double arg1Val = GetConstantDouble(arg1VN);
-                    res            = pow(arg0Val, arg1Val);
+#if defined(TARGET_ARM) || defined(TARGET_ARM64)
+                    // The ARM/ARM64 CRT `pow` returns `0` rather than `arg0Val` for subnormal
+                    // `arg0Val` when `arg1Val` is exactly `1`; match the runtime helper fixup
+                    // https://github.com/dotnet/runtime/issues/12139
+                    res = (arg1Val == 1.0) ? arg0Val : pow(arg0Val, arg1Val);
+#else
+                    res = pow(arg0Val, arg1Val);
+#endif
                     break;
                 }
 
@@ -10430,7 +10437,14 @@ ValueNum ValueNumStore::EvalMathFuncBinary(var_types typ, NamedIntrinsic gtMathF
                 {
                     assert(typ == TypeOfVN(arg1VN));
                     float arg1Val = GetConstantSingle(arg1VN);
-                    res           = powf(arg0Val, arg1Val);
+#if defined(TARGET_ARM) || defined(TARGET_ARM64)
+                    // The ARM/ARM64 CRT `powf` returns `0` rather than `arg0Val` for subnormal
+                    // `arg0Val` when `arg1Val` is exactly `1`; match the runtime helper fixup
+                    // https://github.com/dotnet/runtime/issues/12139
+                    res = (arg1Val == 1.0f) ? arg0Val : powf(arg0Val, arg1Val);
+#else
+                    res = powf(arg0Val, arg1Val);
+#endif
                     break;
                 }
 

--- a/src/coreclr/vm/floatdouble.cpp
+++ b/src/coreclr/vm/floatdouble.cpp
@@ -232,6 +232,16 @@ FCIMPLEND
 FCIMPL2_VV(double, COMDouble::Pow, double x, double y)
     FCALL_CONTRACT;
 
+#if defined(TARGET_ARM) || defined(TARGET_ARM64)
+    // The ARM/ARM64 CRT implementation of `pow` returns `0` rather than `x` for
+    // subnormal `x` when `y` is exactly `1`; `pow(x, 1)` is `x` for all `x`
+    // https://github.com/dotnet/runtime/issues/12139
+    if (y == 1.0)
+    {
+        return x;
+    }
+#endif
+
     return pow(x, y);
 FCIMPLEND
 

--- a/src/coreclr/vm/floatsingle.cpp
+++ b/src/coreclr/vm/floatsingle.cpp
@@ -207,6 +207,16 @@ FCIMPLEND
 FCIMPL2_VV(float, COMSingle::Pow, float x, float y)
     FCALL_CONTRACT;
 
+#if defined(TARGET_ARM) || defined(TARGET_ARM64)
+    // The ARM/ARM64 CRT implementation of `powf` returns `0` rather than `x` for
+    // subnormal `x` when `y` is exactly `1`; `powf(x, 1)` is `x` for all `x`
+    // https://github.com/dotnet/runtime/issues/12139
+    if (y == 1.0f)
+    {
+        return x;
+    }
+#endif
+
     return powf(x, y);
 FCIMPLEND
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Math.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Math.cs
@@ -1035,6 +1035,7 @@ namespace System.Tests
                 yield return new object[] { 0.0, 2.0, 0.0, 0.0 };
                 yield return new object[] { 0.0, 3.0, 0.0, 0.0 };
                 yield return new object[] { 0.0, double.PositiveInfinity, 0.0, 0.0 };
+                yield return new object[] { double.Epsilon, 1.0, double.Epsilon, 0.0 };
                 yield return new object[] { 1.0, double.NegativeInfinity, 1.0, CrossPlatformMachineEpsilon * 10 };
                 yield return new object[] { 1.0, -1.0, 1.0, CrossPlatformMachineEpsilon * 10 };
                 yield return new object[] { 1.0, -0.0, 1.0, CrossPlatformMachineEpsilon * 10 };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/MathF.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/MathF.cs
@@ -998,6 +998,7 @@ namespace System.Tests
         [InlineData(0.0f, 2.0f, 0.0f, 0.0f)]
         [InlineData(0.0f, 3.0f, 0.0f, 0.0f)]
         [InlineData(0.0f, float.PositiveInfinity, 0.0f, 0.0f)]
+        [InlineData(float.Epsilon, 1.0f, float.Epsilon, 0.0f)]
         [InlineData(1.0f, float.NegativeInfinity, 1.0f, CrossPlatformMachineEpsilon * 10)]
         [InlineData(1.0f, -1.0f, 1.0f, CrossPlatformMachineEpsilon * 10)]
         [InlineData(1.0f, -0.0f, 1.0f, CrossPlatformMachineEpsilon * 10)]


### PR DESCRIPTION
Fixes #12139.

ARM/ARM64 return `0` for `Math.Pow(double.Epsilon, 1)` (and `MathF.Pow(float.Epsilon, 1)`) when they should return the input. The ARM/ARM64 CRT computes `pow` via `exp(y * log(x))`, which underflows a subnormal `x` to `0` when `y` is exactly `1`. `pow(x, 1)` is `x` for all `x` (including NaN, +/-inf, +/-0), so an exact `y == 1` early return is correct.

- Add an ARM-guarded `y == 1` fast path returning `x` to the `Math.Pow`/`MathF.Pow` runtime helpers in `floatdouble.cpp`/`floatsingle.cpp`.

----------

- Mirror the fixup in the JIT value-number constant folding (`EvalMathFuncBinary`). Folding `Math.Pow(const, 1)` uses the same buggy host `pow` when the JIT itself runs natively on ARM, which would otherwise defeat the helper fix and diverge from runtime behavior.

----------

- Add subnormal-`x`, `y == 1` regression cases to the existing `Math.Pow`/`MathF.Pow` theory data.

The ARM `#if` branches can't be compiled or exercised on the x64 dev host; the expected test values were verified on x64 (`Math.Pow(double.Epsilon, 1) == double.Epsilon` and the `float` equivalent both hold), so the added cases pass on x64 and would fail on unfixed ARM. CI ARM legs will provide the real validation.

> [!NOTE]
> This PR description and the code changes were drafted with GitHub Copilot.
