### PR TITLE
Re-enable Half modulus negative-zero tests

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.GenericMath.cs
@@ -800,18 +800,12 @@ namespace System.Tests
         public static void op_ModulusTest()
         {
             AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NegativeInfinity, Two));
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MinValue, PositiveTwo));
-
+            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MinValue, Two));
             AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeOne, Two));
             AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MinNormal, Two));
             AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MaxSubnormal, Two));
             AssertBitwiseEqual(-Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-Half.Epsilon, Two)); ;
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeZero, PositiveTwo));
-
+            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeZero, Two));
             AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NaN, Two));
             AssertBitwiseEqual(Zero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Zero, Two));
             AssertBitwiseEqual(Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.Epsilon, Two));


### PR DESCRIPTION
Closes #67993.

The two disabled cases in `HalfTests.op_ModulusTest` (`Half.MinValue % 2` and `-0 % 2`, both expected to be `-0`) were a workaround for a non-deterministic sign-of-zero loss in `float` remainder observed on a single `coreclr windows x64 Debug` CI leg back in 2022. The equivalent `float`, `double`, and `NFloat` assertions have been enabled and green the whole time.

Investigation of the current state:

- The JIT compile-time paths are correct: `gtFoldExprBinaryConstDbl` doesn''t fold `GT_MOD`, and VN `FpRem` computes `(TFp)fmod((double)-0, (double)2)` -> `-0`.
- The runtime helper (`CORINFO_HELP_FLTREM` -> `fmodf`) returns `-0` for `fmod(-0, 2)` on the current MSVC toolset, including the debug CRT (`/MDd`, `/MTd`).
- The `float`->`Half` cast preserves the sign bit (`0x8000`).
- A repro on .NET 10 returns `0x8000` for both cases in Debug and Release.

Root cause was an environmental toolset/CRT defect that no longer reproduces, so the assertions are safe to re-enable. Also fixes the stale `PositiveTwo` helper reference (the file defines `Two`).

----------

Validated behavior against the shipping .NET 10 runtime and the current MSVC CRT directly. Local repo test suite was not run (no baseline build in this environment); CI covers `System.Runtime.Tests`.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.
