### PR TITLE
Optimize Half comparison operators and CompareTo

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
 
 namespace System
 {
@@ -157,6 +158,12 @@ namespace System
         /// <inheritdoc cref="IComparisonOperators{TSelf, TOther, TResult}.op_LessThan(TSelf, TOther)" />
         public static bool operator <(Half left, Half right)
         {
+            if (Avx2.IsSupported)
+            {
+                // (float)Half lowers to a hardware conversion here, so comparing as float is cheaper.
+                return (float)left < (float)right;
+            }
+
             if (IsNaN(left) || IsNaN(right))
             {
                 // IEEE defines that NaN is unordered with respect to everything, including itself.
@@ -185,6 +192,12 @@ namespace System
         /// <inheritdoc cref="IComparisonOperators{TSelf, TOther, TResult}.op_LessThanOrEqual(TSelf, TOther)" />
         public static bool operator <=(Half left, Half right)
         {
+            if (Avx2.IsSupported)
+            {
+                // (float)Half lowers to a hardware conversion here, so comparing as float is cheaper.
+                return (float)left <= (float)right;
+            }
+
             if (IsNaN(left) || IsNaN(right))
             {
                 // IEEE defines that NaN is unordered with respect to everything, including itself.
@@ -437,19 +450,10 @@ namespace System
         /// <returns>A value less than zero if this is less than <paramref name="other"/>, zero if this is equal to <paramref name="other"/>, or a value greater than zero if this is greater than <paramref name="other"/>.</returns>
         public int CompareTo(Half other)
         {
-            if (this < other)
+            if (Avx2.IsSupported)
             {
-                return -1;
-            }
-
-            if (this > other)
-            {
-                return 1;
-            }
-
-            if (this == other)
-            {
-                return 0;
+                // (float)Half lowers to a hardware conversion here, so comparing as float is cheaper.
+                return ((float)this).CompareTo((float)other);
             }
 
             if (IsNaN(this))
@@ -457,8 +461,20 @@ namespace System
                 return IsNaN(other) ? 0 : -1;
             }
 
-            Debug.Assert(IsNaN(other));
-            return 1;
+            if (IsNaN(other))
+            {
+                return 1;
+            }
+
+            // Neither value is NaN, so map the sign-magnitude bits to a monotonic ordering.
+            return GetCompareKey(_value) - GetCompareKey(other._value);
+        }
+
+        private static int GetCompareKey(ushort bits)
+        {
+            // Positive maps to 0x8000 + bits and negative maps to 0x8000 - magnitude, so both zeros
+            // collapse to 0x8000 while the ordering stays monotonic across the finite and infinite range.
+            return ((bits & SignMask) == 0) ? (SignMask + bits) : (SignMask - (bits & ~SignMask));
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
@@ -341,6 +341,12 @@ namespace System.Tests
             yield return new object[] { (Half)(-180f), (Half)(180f), -1};
             yield return new object[] { (Half)(180f), (Half)(-180f), 1};
             yield return new object[] { (Half)(-65535), (object)null, 1};
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0000), BitConverter.UInt16BitsToHalf(0x8000), 0 }; // +0 vs -0
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), BitConverter.UInt16BitsToHalf(0x0000), 0 }; // -0 vs +0
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8001), Half.Epsilon, -1 }; // -subnormal vs +subnormal
+            yield return new object[] { Half.NaN, Half.PositiveInfinity, -1 };
+            yield return new object[] { Half.PositiveInfinity, Half.NaN, 1 };
+            yield return new object[] { Half.NaN, Half.NegativeInfinity, -1 };
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #43117.

`Half.CompareTo(Half)` previously delegated to `this < other`, `this > other`, and `this == other`. Since those operators were rewritten to handle signed values and zeros, each is now a full managed method with its own NaN/sign/zero handling -- so the common non-NaN path ran roughly six `IsNaN` checks plus redundant sign/zero work before falling into a bit comparison it could have done directly.

This rewrites `CompareTo` to handle NaN once and then compare a monotonic sign-magnitude ordering key derived directly from the bits (both zeros collapse to the same key, preserving `+0 == -0`).

----------

It also adds an AVX2 fast path to `CompareTo`, `operator <`, and `operator <=` that compares via `(float)Half`. On `TARGET_XARCH` + AVX2 the `Half`->`float` conversion lowers to a hardware `vcvtph2ps`, so comparing as `float` is materially cheaper. `operator >` / `operator >=` are thin `right < left` / `right <= left` wrappers and inherit the fast path automatically, and the existing `Min`/`Max`/`*Magnitude*` helpers already delegate through `float`/relational operators, so they benefit as well. `Avx2.IsSupported` is a JIT-time constant, so the non-taken branch is eliminated and there's no overhead on other targets; the bit-based logic remains as the hardware-independent fallback.

The equality operators (`==`, `!=`, `Equals`) are intentionally left on the bit logic -- converting to `float` there measured slower, since the bit equality check is nearly free and doesn't justify two conversions.

`Half`->`float` is lossless and order-preserving (NaN and signed-zero semantics preserved), so all fast paths match the existing bit semantics exactly.

----------

**Measurements** (local, AVX2 machine; 4096 comparisons/op; in-process BenchmarkDotNet)

CompareTo, mixed data:

| Impl | Time | ns/cmp |
|---|---|---|
| Old (operator-chained) | 13.06 us | ~3.19 |
| Bit-key only | 7.10 us | ~1.73 |
| Bit-key + AVX2 float path | **3.47 us** | ~0.85 |

`operator <`: 4.76 us -> **2.41 us** (~2x).

With AVX2 disabled the change is still a win over the old code (`CompareTo` 12.25 -> 7.06 us via the bit-key fallback), and the equality path measured slower as `float` (2.16 -> 3.20 us), which is why it was left alone.

Tests: extended `HalfTests.CompareTo_TestData` with signed-zero, subnormal-sign, and NaN/infinity ordering cases. Full `HalfTests` (1629 cases) pass both with AVX2 enabled and with `DOTNET_EnableAVX2=0` exercising the fallback.

> [!NOTE]
> This PR description and the code changes were drafted with the assistance of GitHub Copilot.
