### PR TITLE
XmlSerializer - Fire UnknownAttribute for stray attributes on built-in typed elements

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Expected.SerializableAssembly.XmlSerializers.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Expected.SerializableAssembly.XmlSerializers.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
 
     public class XmlSerializationWriter1 : System.Xml.Serialization.XmlSerializationWriter {
 
-        public void Write124_TypeWithXmlElementProperty(object o) {
+        public void Write126_TypeWithXmlElementProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlElementProperty", @"");
@@ -16,7 +16,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write2_TypeWithXmlElementProperty(@"TypeWithXmlElementProperty", @"", ((global::TypeWithXmlElementProperty)o), true, false);
         }
 
-        public void Write125_TypeWithXmlDocumentProperty(object o) {
+        public void Write127_TypeWithXmlDocumentProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlDocumentProperty", @"");
@@ -26,7 +26,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write3_TypeWithXmlDocumentProperty(@"TypeWithXmlDocumentProperty", @"", ((global::TypeWithXmlDocumentProperty)o), true, false);
         }
 
-        public void Write126_TypeWithBinaryProperty(object o) {
+        public void Write128_TypeWithBinaryProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithBinaryProperty", @"");
@@ -36,7 +36,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write4_TypeWithBinaryProperty(@"TypeWithBinaryProperty", @"", ((global::TypeWithBinaryProperty)o), true, false);
         }
 
-        public void Write127_Item(object o) {
+        public void Write129_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDateTimeOffsetProperties", @"");
@@ -46,7 +46,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write5_Item(@"TypeWithDateTimeOffsetProperties", @"", ((global::TypeWithDateTimeOffsetProperties)o), true, false);
         }
 
-        public void Write128_Item(object o) {
+        public void Write130_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDateAndTimeOnlyProperties", @"");
@@ -56,7 +56,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write6_Item(@"TypeWithDateAndTimeOnlyProperties", @"", ((global::TypeWithDateAndTimeOnlyProperties)o), true, false);
         }
 
-        public void Write129_DateOnlyWrapper(object o) {
+        public void Write131_DateOnlyWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DateOnlyWrapper", @"");
@@ -66,7 +66,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write7_DateOnlyWrapper(@"DateOnlyWrapper", @"", ((global::DateOnlyWrapper)o), true, false);
         }
 
-        public void Write130_TimeOnlyWrapper(object o) {
+        public void Write132_TimeOnlyWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TimeOnlyWrapper", @"");
@@ -76,7 +76,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write8_TimeOnlyWrapper(@"TimeOnlyWrapper", @"", ((global::TimeOnlyWrapper)o), true, false);
         }
 
-        public void Write131_TimeOnlyAsXsdTimeWrapper(object o) {
+        public void Write133_TimeOnlyAsXsdTimeWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TimeOnlyAsXsdTimeWrapper", @"");
@@ -86,7 +86,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write9_TimeOnlyAsXsdTimeWrapper(@"TimeOnlyAsXsdTimeWrapper", @"", ((global::TimeOnlyAsXsdTimeWrapper)o), true, false);
         }
 
-        public void Write132_DateTimeDateWrapper(object o) {
+        public void Write134_DateTimeDateWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DateTimeDateWrapper", @"");
@@ -96,7 +96,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write10_DateTimeDateWrapper(@"DateTimeDateWrapper", @"", ((global::DateTimeDateWrapper)o), true, false);
         }
 
-        public void Write133_DateTimeTimeWrapper(object o) {
+        public void Write135_DateTimeTimeWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DateTimeTimeWrapper", @"");
@@ -106,7 +106,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write11_DateTimeTimeWrapper(@"DateTimeTimeWrapper", @"", ((global::DateTimeTimeWrapper)o), true, false);
         }
 
-        public void Write134_TypeWithTimeSpanProperty(object o) {
+        public void Write136_TypeWithTimeSpanProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithTimeSpanProperty", @"");
@@ -116,7 +116,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write12_TypeWithTimeSpanProperty(@"TypeWithTimeSpanProperty", @"", ((global::TypeWithTimeSpanProperty)o), true, false);
         }
 
-        public void Write135_Item(object o) {
+        public void Write137_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDefaultTimeSpanProperty", @"");
@@ -126,7 +126,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write13_Item(@"TypeWithDefaultTimeSpanProperty", @"", ((global::TypeWithDefaultTimeSpanProperty)o), true, false);
         }
 
-        public void Write136_TypeWithByteProperty(object o) {
+        public void Write138_TypeWithByteProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithByteProperty", @"");
@@ -136,7 +136,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write14_TypeWithByteProperty(@"TypeWithByteProperty", @"", ((global::TypeWithByteProperty)o), true, false);
         }
 
-        public void Write137_TypeWithXmlNodeArrayProperty(object o) {
+        public void Write139_TypeWithXmlNodeArrayProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlNodeArrayProperty", @"");
@@ -146,7 +146,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write15_TypeWithXmlNodeArrayProperty(@"TypeWithXmlNodeArrayProperty", @"", ((global::TypeWithXmlNodeArrayProperty)o), true, false);
         }
 
-        public void Write138_Animal(object o) {
+        public void Write140_Animal(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Animal", @"");
@@ -156,7 +156,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write16_Animal(@"Animal", @"", ((global::Animal)o), true, false);
         }
 
-        public void Write139_Dog(object o) {
+        public void Write141_Dog(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Dog", @"");
@@ -166,7 +166,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write18_Dog(@"Dog", @"", ((global::Dog)o), true, false);
         }
 
-        public void Write140_DogBreed(object o) {
+        public void Write142_DogBreed(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"DogBreed", @"");
@@ -175,7 +175,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteElementString(@"DogBreed", @"", Write17_DogBreed(((global::DogBreed)o)));
         }
 
-        public void Write141_Group(object o) {
+        public void Write143_Group(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Group", @"");
@@ -185,7 +185,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write20_Group(@"Group", @"", ((global::Group)o), true, false);
         }
 
-        public void Write142_Vehicle(object o) {
+        public void Write144_Vehicle(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Vehicle", @"");
@@ -195,7 +195,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write19_Vehicle(@"Vehicle", @"", ((global::Vehicle)o), true, false);
         }
 
-        public void Write143_Employee(object o) {
+        public void Write145_Employee(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Employee", @"");
@@ -205,7 +205,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write21_Employee(@"Employee", @"", ((global::Employee)o), true, false);
         }
 
-        public void Write144_BaseClass(object o) {
+        public void Write146_BaseClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseClass", @"");
@@ -215,7 +215,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write23_BaseClass(@"BaseClass", @"", ((global::BaseClass)o), true, false);
         }
 
-        public void Write145_DerivedClass(object o) {
+        public void Write147_DerivedClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedClass", @"");
@@ -225,7 +225,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write22_DerivedClass(@"DerivedClass", @"", ((global::DerivedClass)o), true, false);
         }
 
-        public void Write146_SimpleBaseClass(object o) {
+        public void Write148_SimpleBaseClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleBaseClass", @"");
@@ -235,7 +235,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write25_SimpleBaseClass(@"SimpleBaseClass", @"", ((global::SimpleBaseClass)o), true, false);
         }
 
-        public void Write147_SimpleDerivedClass(object o) {
+        public void Write149_SimpleDerivedClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleDerivedClass", @"");
@@ -245,7 +245,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write24_SimpleDerivedClass(@"SimpleDerivedClass", @"", ((global::SimpleDerivedClass)o), true, false);
         }
 
-        public void Write148_BaseIXmlSerializable(object o) {
+        public void Write150_BaseIXmlSerializable(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseIXmlSerializable", @"http://example.com/serializer-test-namespace");
@@ -255,7 +255,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::XmlSerializableBaseClass)o), @"BaseIXmlSerializable", @"http://example.com/serializer-test-namespace", true, true);
         }
 
-        public void Write149_DerivedIXmlSerializable(object o) {
+        public void Write151_DerivedIXmlSerializable(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedIXmlSerializable", @"");
@@ -265,7 +265,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::XmlSerializableDerivedClass)o), @"DerivedIXmlSerializable", @"", true, true);
         }
 
-        public void Write150_PurchaseOrder(object o) {
+        public void Write152_PurchaseOrder(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"PurchaseOrder", @"http://www.contoso1.com");
@@ -275,7 +275,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write28_PurchaseOrder(@"PurchaseOrder", @"http://www.contoso1.com", ((global::PurchaseOrder)o), false, false);
         }
 
-        public void Write151_Address(object o) {
+        public void Write153_Address(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Address", @"");
@@ -285,7 +285,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write29_Address(@"Address", @"", ((global::Address)o), true, false);
         }
 
-        public void Write152_OrderedItem(object o) {
+        public void Write154_OrderedItem(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"OrderedItem", @"");
@@ -295,7 +295,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write30_OrderedItem(@"OrderedItem", @"", ((global::OrderedItem)o), true, false);
         }
 
-        public void Write153_AliasedTestType(object o) {
+        public void Write155_AliasedTestType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"AliasedTestType", @"");
@@ -305,7 +305,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write31_AliasedTestType(@"AliasedTestType", @"", ((global::AliasedTestType)o), true, false);
         }
 
-        public void Write154_BaseClass1(object o) {
+        public void Write156_BaseClass1(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseClass1", @"");
@@ -315,7 +315,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write32_BaseClass1(@"BaseClass1", @"", ((global::BaseClass1)o), true, false);
         }
 
-        public void Write155_DerivedClass1(object o) {
+        public void Write157_DerivedClass1(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedClass1", @"");
@@ -325,7 +325,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write33_DerivedClass1(@"DerivedClass1", @"", ((global::DerivedClass1)o), true, false);
         }
 
-        public void Write156_ArrayOfDateTime(object o) {
+        public void Write158_ArrayOfDateTime(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ArrayOfDateTime", @"");
@@ -350,7 +350,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        public void Write157_Orchestra(object o) {
+        public void Write159_Orchestra(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Orchestra", @"");
@@ -360,7 +360,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write35_Orchestra(@"Orchestra", @"", ((global::Orchestra)o), true, false);
         }
 
-        public void Write158_Instrument(object o) {
+        public void Write160_Instrument(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Instrument", @"");
@@ -370,7 +370,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write34_Instrument(@"Instrument", @"", ((global::Instrument)o), true, false);
         }
 
-        public void Write159_Brass(object o) {
+        public void Write161_Brass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Brass", @"");
@@ -380,7 +380,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write36_Brass(@"Brass", @"", ((global::Brass)o), true, false);
         }
 
-        public void Write160_Trumpet(object o) {
+        public void Write162_Trumpet(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Trumpet", @"");
@@ -390,7 +390,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write37_Trumpet(@"Trumpet", @"", ((global::Trumpet)o), true, false);
         }
 
-        public void Write161_Pet(object o) {
+        public void Write163_Pet(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Pet", @"");
@@ -400,7 +400,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write38_Pet(@"Pet", @"", ((global::Pet)o), true, false);
         }
 
-        public void Write162_DefaultValuesSetToNaN(object o) {
+        public void Write164_DefaultValuesSetToNaN(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DefaultValuesSetToNaN", @"");
@@ -410,7 +410,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write39_DefaultValuesSetToNaN(@"DefaultValuesSetToNaN", @"", ((global::DefaultValuesSetToNaN)o), true, false);
         }
 
-        public void Write163_Item(object o) {
+        public void Write165_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DefaultValuesSetToPositiveInfinity", @"");
@@ -420,7 +420,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write40_Item(@"DefaultValuesSetToPositiveInfinity", @"", ((global::DefaultValuesSetToPositiveInfinity)o), true, false);
         }
 
-        public void Write164_Item(object o) {
+        public void Write166_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DefaultValuesSetToNegativeInfinity", @"");
@@ -430,7 +430,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write41_Item(@"DefaultValuesSetToNegativeInfinity", @"", ((global::DefaultValuesSetToNegativeInfinity)o), true, false);
         }
 
-        public void Write165_RootElement(object o) {
+        public void Write167_RootElement(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"RootElement", @"");
@@ -440,7 +440,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write42_Item(@"RootElement", @"", ((global::TypeWithMismatchBetweenAttributeAndPropertyType)o), true, false);
         }
 
-        public void Write166_TypeWithLinkedProperty(object o) {
+        public void Write168_TypeWithLinkedProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithLinkedProperty", @"");
@@ -450,7 +450,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write43_TypeWithLinkedProperty(@"TypeWithLinkedProperty", @"", ((global::TypeWithLinkedProperty)o), true, false);
         }
 
-        public void Write167_Document(object o) {
+        public void Write169_Document(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Document", @"http://example.com");
@@ -460,7 +460,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write44_MsgDocumentType(@"Document", @"http://example.com", ((global::MsgDocumentType)o), true, false);
         }
 
-        public void Write168_RootClass(object o) {
+        public void Write170_RootClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"RootClass", @"");
@@ -470,7 +470,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write47_RootClass(@"RootClass", @"", ((global::RootClass)o), true, false);
         }
 
-        public void Write169_Parameter(object o) {
+        public void Write171_Parameter(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Parameter", @"");
@@ -480,7 +480,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write46_Parameter(@"Parameter", @"", ((global::Parameter)o), true, false);
         }
 
-        public void Write170_XElementWrapper(object o) {
+        public void Write172_XElementWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"XElementWrapper", @"");
@@ -490,7 +490,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write48_XElementWrapper(@"XElementWrapper", @"", ((global::XElementWrapper)o), true, false);
         }
 
-        public void Write171_XElementStruct(object o) {
+        public void Write173_XElementStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"XElementStruct", @"");
@@ -499,7 +499,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write49_XElementStruct(@"XElementStruct", @"", ((global::XElementStruct)o), false);
         }
 
-        public void Write172_XElementArrayWrapper(object o) {
+        public void Write174_XElementArrayWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"XElementArrayWrapper", @"");
@@ -509,7 +509,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write50_XElementArrayWrapper(@"XElementArrayWrapper", @"", ((global::XElementArrayWrapper)o), true, false);
         }
 
-        public void Write173_Item(object o) {
+        public void Write175_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DateTimeOffsetIXmlSerializableContainer", @"");
@@ -519,7 +519,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::DateTimeOffsetIXmlSerializableContainer)o), @"DateTimeOffsetIXmlSerializableContainer", @"", true, true);
         }
 
-        public void Write174_TypeWithDateTimeStringProperty(object o) {
+        public void Write176_TypeWithDateTimeStringProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDateTimeStringProperty", @"");
@@ -529,7 +529,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write51_TypeWithDateTimeStringProperty(@"TypeWithDateTimeStringProperty", @"", ((global::SerializationTypes.TypeWithDateTimeStringProperty)o), true, false);
         }
 
-        public void Write175_SimpleType(object o) {
+        public void Write177_SimpleType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleType", @"");
@@ -539,7 +539,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write52_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)o), true, false);
         }
 
-        public void Write176_TypeWithGetSetArrayMembers(object o) {
+        public void Write178_TypeWithGetSetArrayMembers(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithGetSetArrayMembers", @"");
@@ -549,7 +549,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write53_TypeWithGetSetArrayMembers(@"TypeWithGetSetArrayMembers", @"", ((global::SerializationTypes.TypeWithGetSetArrayMembers)o), true, false);
         }
 
-        public void Write177_TypeWithGetOnlyArrayProperties(object o) {
+        public void Write179_TypeWithGetOnlyArrayProperties(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithGetOnlyArrayProperties", @"");
@@ -559,7 +559,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write54_TypeWithGetOnlyArrayProperties(@"TypeWithGetOnlyArrayProperties", @"", ((global::SerializationTypes.TypeWithGetOnlyArrayProperties)o), true, false);
         }
 
-        public void Write178_TypeWithArraylikeMembers(object o) {
+        public void Write180_TypeWithArraylikeMembers(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithArraylikeMembers", @"");
@@ -569,7 +569,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write55_TypeWithArraylikeMembers(@"TypeWithArraylikeMembers", @"", ((global::SerializationTypes.TypeWithArraylikeMembers)o), true, false);
         }
 
-        public void Write179_StructNotSerializable(object o) {
+        public void Write181_StructNotSerializable(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"StructNotSerializable", @"");
@@ -578,7 +578,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write56_StructNotSerializable(@"StructNotSerializable", @"", ((global::SerializationTypes.StructNotSerializable)o), false);
         }
 
-        public void Write180_TypeWithMyCollectionField(object o) {
+        public void Write182_TypeWithMyCollectionField(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithMyCollectionField", @"");
@@ -588,7 +588,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write57_TypeWithMyCollectionField(@"TypeWithMyCollectionField", @"", ((global::SerializationTypes.TypeWithMyCollectionField)o), true, false);
         }
 
-        public void Write181_Item(object o) {
+        public void Write183_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithReadOnlyMyCollectionProperty", @"");
@@ -598,7 +598,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write58_Item(@"TypeWithReadOnlyMyCollectionProperty", @"", ((global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty)o), true, false);
         }
 
-        public void Write182_ArrayOfAnyType(object o) {
+        public void Write184_ArrayOfAnyType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ArrayOfAnyType", @"");
@@ -620,7 +620,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        public void Write183_MyEnum(object o) {
+        public void Write185_MyEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"MyEnum", @"");
@@ -629,7 +629,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteElementString(@"MyEnum", @"", Write59_MyEnum(((global::SerializationTypes.MyEnum)o)));
         }
 
-        public void Write184_TypeWithEnumMembers(object o) {
+        public void Write186_TypeWithEnumMembers(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithEnumMembers", @"");
@@ -639,7 +639,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write60_TypeWithEnumMembers(@"TypeWithEnumMembers", @"", ((global::SerializationTypes.TypeWithEnumMembers)o), true, false);
         }
 
-        public void Write185_DCStruct(object o) {
+        public void Write187_DCStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"DCStruct", @"");
@@ -648,7 +648,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write61_DCStruct(@"DCStruct", @"", ((global::SerializationTypes.DCStruct)o), false);
         }
 
-        public void Write186_DCClassWithEnumAndStruct(object o) {
+        public void Write188_DCClassWithEnumAndStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DCClassWithEnumAndStruct", @"");
@@ -658,7 +658,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write62_DCClassWithEnumAndStruct(@"DCClassWithEnumAndStruct", @"", ((global::SerializationTypes.DCClassWithEnumAndStruct)o), true, false);
         }
 
-        public void Write187_BuiltInTypes(object o) {
+        public void Write189_BuiltInTypes(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BuiltInTypes", @"");
@@ -668,287 +668,307 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write63_BuiltInTypes(@"BuiltInTypes", @"", ((global::SerializationTypes.BuiltInTypes)o), true, false);
         }
 
-        public void Write188_TypeA(object o) {
+        public void Write190_TypeWithBuiltInTypedMembers(object o) {
+            WriteStartDocument();
+            if (o == null) {
+                WriteNullTagLiteral(@"TypeWithBuiltInTypedMembers", @"");
+                return;
+            }
+            TopLevelElement();
+            Write64_TypeWithBuiltInTypedMembers(@"TypeWithBuiltInTypedMembers", @"", ((global::SerializationTypes.TypeWithBuiltInTypedMembers)o), true, false);
+        }
+
+        public void Write191_Item(object o) {
+            WriteStartDocument();
+            if (o == null) {
+                WriteNullTagLiteral(@"TypeWithNullableBuiltInTypedMembers", @"");
+                return;
+            }
+            TopLevelElement();
+            Write65_Item(@"TypeWithNullableBuiltInTypedMembers", @"", ((global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)o), true, false);
+        }
+
+        public void Write192_TypeA(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeA", @"");
                 return;
             }
             TopLevelElement();
-            Write64_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)o), true, false);
+            Write66_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)o), true, false);
         }
 
-        public void Write189_TypeB(object o) {
+        public void Write193_TypeB(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeB", @"");
                 return;
             }
             TopLevelElement();
-            Write65_TypeB(@"TypeB", @"", ((global::SerializationTypes.TypeB)o), true, false);
+            Write67_TypeB(@"TypeB", @"", ((global::SerializationTypes.TypeB)o), true, false);
         }
 
-        public void Write190_TypeHasArrayOfASerializedAsB(object o) {
+        public void Write194_TypeHasArrayOfASerializedAsB(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeHasArrayOfASerializedAsB", @"");
                 return;
             }
             TopLevelElement();
-            Write66_TypeHasArrayOfASerializedAsB(@"TypeHasArrayOfASerializedAsB", @"", ((global::SerializationTypes.TypeHasArrayOfASerializedAsB)o), true, false);
+            Write68_TypeHasArrayOfASerializedAsB(@"TypeHasArrayOfASerializedAsB", @"", ((global::SerializationTypes.TypeHasArrayOfASerializedAsB)o), true, false);
         }
 
-        public void Write191_Item(object o) {
+        public void Write195_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"__TypeNameWithSpecialCharacters漢ñ", @"");
                 return;
             }
             TopLevelElement();
-            Write67_Item(@"__TypeNameWithSpecialCharacters漢ñ", @"", ((global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)o), true, false);
+            Write69_Item(@"__TypeNameWithSpecialCharacters漢ñ", @"", ((global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)o), true, false);
         }
 
-        public void Write192_BaseClassWithSamePropertyName(object o) {
+        public void Write196_BaseClassWithSamePropertyName(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseClassWithSamePropertyName", @"");
                 return;
             }
             TopLevelElement();
-            Write68_BaseClassWithSamePropertyName(@"BaseClassWithSamePropertyName", @"", ((global::SerializationTypes.BaseClassWithSamePropertyName)o), true, false);
+            Write70_BaseClassWithSamePropertyName(@"BaseClassWithSamePropertyName", @"", ((global::SerializationTypes.BaseClassWithSamePropertyName)o), true, false);
         }
 
-        public void Write193_DerivedClassWithSameProperty(object o) {
+        public void Write197_DerivedClassWithSameProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedClassWithSameProperty", @"");
                 return;
             }
             TopLevelElement();
-            Write69_DerivedClassWithSameProperty(@"DerivedClassWithSameProperty", @"", ((global::SerializationTypes.DerivedClassWithSameProperty)o), true, false);
+            Write71_DerivedClassWithSameProperty(@"DerivedClassWithSameProperty", @"", ((global::SerializationTypes.DerivedClassWithSameProperty)o), true, false);
         }
 
-        public void Write194_DerivedClassWithSameProperty2(object o) {
+        public void Write198_DerivedClassWithSameProperty2(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedClassWithSameProperty2", @"");
                 return;
             }
             TopLevelElement();
-            Write70_DerivedClassWithSameProperty2(@"DerivedClassWithSameProperty2", @"", ((global::SerializationTypes.DerivedClassWithSameProperty2)o), true, false);
+            Write72_DerivedClassWithSameProperty2(@"DerivedClassWithSameProperty2", @"", ((global::SerializationTypes.DerivedClassWithSameProperty2)o), true, false);
         }
 
-        public void Write195_Item(object o) {
+        public void Write199_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDateTimePropertyAsXmlTime", @"");
                 return;
             }
             TopLevelElement();
-            Write71_Item(@"TypeWithDateTimePropertyAsXmlTime", @"", ((global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)o), true, false);
+            Write73_Item(@"TypeWithDateTimePropertyAsXmlTime", @"", ((global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)o), true, false);
         }
 
-        public void Write196_TypeWithByteArrayAsXmlText(object o) {
+        public void Write200_TypeWithByteArrayAsXmlText(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithByteArrayAsXmlText", @"");
                 return;
             }
             TopLevelElement();
-            Write72_TypeWithByteArrayAsXmlText(@"TypeWithByteArrayAsXmlText", @"", ((global::SerializationTypes.TypeWithByteArrayAsXmlText)o), true, false);
+            Write74_TypeWithByteArrayAsXmlText(@"TypeWithByteArrayAsXmlText", @"", ((global::SerializationTypes.TypeWithByteArrayAsXmlText)o), true, false);
         }
 
-        public void Write197_SimpleDC(object o) {
+        public void Write201_SimpleDC(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleDC", @"");
                 return;
             }
             TopLevelElement();
-            Write73_SimpleDC(@"SimpleDC", @"", ((global::SerializationTypes.SimpleDC)o), true, false);
+            Write75_SimpleDC(@"SimpleDC", @"", ((global::SerializationTypes.SimpleDC)o), true, false);
         }
 
-        public void Write198_Item(object o) {
+        public void Write202_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"TypeWithXmlTextAttributeOnArray", @"http://schemas.xmlsoap.org/ws/2005/04/discovery");
                 return;
             }
             TopLevelElement();
-            Write74_Item(@"TypeWithXmlTextAttributeOnArray", @"http://schemas.xmlsoap.org/ws/2005/04/discovery", ((global::SerializationTypes.TypeWithXmlTextAttributeOnArray)o), false, false);
+            Write76_Item(@"TypeWithXmlTextAttributeOnArray", @"http://schemas.xmlsoap.org/ws/2005/04/discovery", ((global::SerializationTypes.TypeWithXmlTextAttributeOnArray)o), false, false);
         }
 
-        public void Write199_EnumFlags(object o) {
+        public void Write203_EnumFlags(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"EnumFlags", @"");
                 return;
             }
-            WriteElementString(@"EnumFlags", @"", Write75_EnumFlags(((global::SerializationTypes.EnumFlags)o)));
+            WriteElementString(@"EnumFlags", @"", Write77_EnumFlags(((global::SerializationTypes.EnumFlags)o)));
         }
 
-        public void Write200_ClassImplementsInterface(object o) {
+        public void Write204_ClassImplementsInterface(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ClassImplementsInterface", @"");
                 return;
             }
             TopLevelElement();
-            Write76_ClassImplementsInterface(@"ClassImplementsInterface", @"", ((global::SerializationTypes.ClassImplementsInterface)o), true, false);
+            Write78_ClassImplementsInterface(@"ClassImplementsInterface", @"", ((global::SerializationTypes.ClassImplementsInterface)o), true, false);
         }
 
-        public void Write201_WithStruct(object o) {
+        public void Write205_WithStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"WithStruct", @"");
                 return;
             }
             TopLevelElement();
-            Write78_WithStruct(@"WithStruct", @"", ((global::SerializationTypes.WithStruct)o), true, false);
+            Write80_WithStruct(@"WithStruct", @"", ((global::SerializationTypes.WithStruct)o), true, false);
         }
 
-        public void Write202_SomeStruct(object o) {
+        public void Write206_SomeStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"SomeStruct", @"");
                 return;
             }
-            Write77_SomeStruct(@"SomeStruct", @"", ((global::SerializationTypes.SomeStruct)o), false);
+            Write79_SomeStruct(@"SomeStruct", @"", ((global::SerializationTypes.SomeStruct)o), false);
         }
 
-        public void Write203_WithEnums(object o) {
+        public void Write207_WithEnums(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"WithEnums", @"");
                 return;
             }
             TopLevelElement();
-            Write81_WithEnums(@"WithEnums", @"", ((global::SerializationTypes.WithEnums)o), true, false);
+            Write83_WithEnums(@"WithEnums", @"", ((global::SerializationTypes.WithEnums)o), true, false);
         }
 
-        public void Write204_WithNullables(object o) {
+        public void Write208_WithNullables(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"WithNullables", @"");
                 return;
             }
             TopLevelElement();
-            Write82_WithNullables(@"WithNullables", @"", ((global::SerializationTypes.WithNullables)o), true, false);
+            Write84_WithNullables(@"WithNullables", @"", ((global::SerializationTypes.WithNullables)o), true, false);
         }
 
-        public void Write205_ByteEnum(object o) {
+        public void Write209_ByteEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"ByteEnum", @"");
                 return;
             }
-            WriteElementString(@"ByteEnum", @"", Write83_ByteEnum(((global::SerializationTypes.ByteEnum)o)));
+            WriteElementString(@"ByteEnum", @"", Write85_ByteEnum(((global::SerializationTypes.ByteEnum)o)));
         }
 
-        public void Write206_SByteEnum(object o) {
+        public void Write210_SByteEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"SByteEnum", @"");
                 return;
             }
-            WriteElementString(@"SByteEnum", @"", Write84_SByteEnum(((global::SerializationTypes.SByteEnum)o)));
+            WriteElementString(@"SByteEnum", @"", Write86_SByteEnum(((global::SerializationTypes.SByteEnum)o)));
         }
 
-        public void Write207_ShortEnum(object o) {
+        public void Write211_ShortEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"ShortEnum", @"");
                 return;
             }
-            WriteElementString(@"ShortEnum", @"", Write80_ShortEnum(((global::SerializationTypes.ShortEnum)o)));
+            WriteElementString(@"ShortEnum", @"", Write82_ShortEnum(((global::SerializationTypes.ShortEnum)o)));
         }
 
-        public void Write208_IntEnum(object o) {
+        public void Write212_IntEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"IntEnum", @"");
                 return;
             }
-            WriteElementString(@"IntEnum", @"", Write79_IntEnum(((global::SerializationTypes.IntEnum)o)));
+            WriteElementString(@"IntEnum", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o)));
         }
 
-        public void Write209_UIntEnum(object o) {
+        public void Write213_UIntEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"UIntEnum", @"");
                 return;
             }
-            WriteElementString(@"UIntEnum", @"", Write85_UIntEnum(((global::SerializationTypes.UIntEnum)o)));
+            WriteElementString(@"UIntEnum", @"", Write87_UIntEnum(((global::SerializationTypes.UIntEnum)o)));
         }
 
-        public void Write210_LongEnum(object o) {
+        public void Write214_LongEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"LongEnum", @"");
                 return;
             }
-            WriteElementString(@"LongEnum", @"", Write86_LongEnum(((global::SerializationTypes.LongEnum)o)));
+            WriteElementString(@"LongEnum", @"", Write88_LongEnum(((global::SerializationTypes.LongEnum)o)));
         }
 
-        public void Write211_ULongEnum(object o) {
+        public void Write215_ULongEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"ULongEnum", @"");
                 return;
             }
-            WriteElementString(@"ULongEnum", @"", Write87_ULongEnum(((global::SerializationTypes.ULongEnum)o)));
+            WriteElementString(@"ULongEnum", @"", Write89_ULongEnum(((global::SerializationTypes.ULongEnum)o)));
         }
 
-        public void Write212_AttributeTesting(object o) {
+        public void Write216_AttributeTesting(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"AttributeTesting", @"");
                 return;
             }
             TopLevelElement();
-            Write89_XmlSerializerAttributes(@"AttributeTesting", @"", ((global::SerializationTypes.XmlSerializerAttributes)o), false, false);
+            Write91_XmlSerializerAttributes(@"AttributeTesting", @"", ((global::SerializationTypes.XmlSerializerAttributes)o), false, false);
         }
 
-        public void Write213_ItemChoiceType(object o) {
+        public void Write217_ItemChoiceType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"ItemChoiceType", @"");
                 return;
             }
-            WriteElementString(@"ItemChoiceType", @"", Write88_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)o)));
+            WriteElementString(@"ItemChoiceType", @"", Write90_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)o)));
         }
 
-        public void Write214_TypeWithAnyAttribute(object o) {
+        public void Write218_TypeWithAnyAttribute(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithAnyAttribute", @"");
                 return;
             }
             TopLevelElement();
-            Write90_TypeWithAnyAttribute(@"TypeWithAnyAttribute", @"", ((global::SerializationTypes.TypeWithAnyAttribute)o), true, false);
+            Write92_TypeWithAnyAttribute(@"TypeWithAnyAttribute", @"", ((global::SerializationTypes.TypeWithAnyAttribute)o), true, false);
         }
 
-        public void Write215_KnownTypesThroughConstructor(object o) {
+        public void Write219_KnownTypesThroughConstructor(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"KnownTypesThroughConstructor", @"");
                 return;
             }
             TopLevelElement();
-            Write91_KnownTypesThroughConstructor(@"KnownTypesThroughConstructor", @"", ((global::SerializationTypes.KnownTypesThroughConstructor)o), true, false);
+            Write93_KnownTypesThroughConstructor(@"KnownTypesThroughConstructor", @"", ((global::SerializationTypes.KnownTypesThroughConstructor)o), true, false);
         }
 
-        public void Write216_SimpleKnownTypeValue(object o) {
+        public void Write220_SimpleKnownTypeValue(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleKnownTypeValue", @"");
                 return;
             }
             TopLevelElement();
-            Write92_SimpleKnownTypeValue(@"SimpleKnownTypeValue", @"", ((global::SerializationTypes.SimpleKnownTypeValue)o), true, false);
+            Write94_SimpleKnownTypeValue(@"SimpleKnownTypeValue", @"", ((global::SerializationTypes.SimpleKnownTypeValue)o), true, false);
         }
 
-        public void Write217_Item(object o) {
+        public void Write221_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ClassImplementingIXmlSerializable", @"");
@@ -958,7 +978,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::SerializationTypes.ClassImplementingIXmlSerializable)o), @"ClassImplementingIXmlSerializable", @"", true, true);
         }
 
-        public void Write218_Item(object o) {
+        public void Write222_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor", @"");
@@ -967,7 +987,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor)o), @"StructImplementingIXmlSerializableWithoutParameterlessConstructor", @"", false, true);
         }
 
-        public void Write219_Item(object o) {
+        public void Write223_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"StructImplementingIXmlSerializableWithParameterlessConstructor", @"");
@@ -976,67 +996,67 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor)o), @"StructImplementingIXmlSerializableWithParameterlessConstructor", @"", false, true);
         }
 
-        public void Write220_TypeWithPropertyNameSpecified(object o) {
+        public void Write224_TypeWithPropertyNameSpecified(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithPropertyNameSpecified", @"");
                 return;
             }
             TopLevelElement();
-            Write93_TypeWithPropertyNameSpecified(@"TypeWithPropertyNameSpecified", @"", ((global::SerializationTypes.TypeWithPropertyNameSpecified)o), true, false);
+            Write95_TypeWithPropertyNameSpecified(@"TypeWithPropertyNameSpecified", @"", ((global::SerializationTypes.TypeWithPropertyNameSpecified)o), true, false);
         }
 
-        public void Write221_TypeWithXmlSchemaFormAttribute(object o) {
+        public void Write225_TypeWithXmlSchemaFormAttribute(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlSchemaFormAttribute", @"");
                 return;
             }
             TopLevelElement();
-            Write94_TypeWithXmlSchemaFormAttribute(@"TypeWithXmlSchemaFormAttribute", @"", ((global::SerializationTypes.TypeWithXmlSchemaFormAttribute)o), true, false);
+            Write96_TypeWithXmlSchemaFormAttribute(@"TypeWithXmlSchemaFormAttribute", @"", ((global::SerializationTypes.TypeWithXmlSchemaFormAttribute)o), true, false);
         }
 
-        public void Write222_MyXmlType(object o) {
+        public void Write226_MyXmlType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"MyXmlType", @"");
                 return;
             }
             TopLevelElement();
-            Write95_Item(@"MyXmlType", @"", ((global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)o), true, false);
+            Write97_Item(@"MyXmlType", @"", ((global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)o), true, false);
         }
 
-        public void Write223_Item(object o) {
+        public void Write227_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithSchemaFormInXmlAttribute", @"");
                 return;
             }
             TopLevelElement();
-            Write96_Item(@"TypeWithSchemaFormInXmlAttribute", @"", ((global::SerializationTypes.TypeWithSchemaFormInXmlAttribute)o), true, false);
+            Write98_Item(@"TypeWithSchemaFormInXmlAttribute", @"", ((global::SerializationTypes.TypeWithSchemaFormInXmlAttribute)o), true, false);
         }
 
-        public void Write224_CustomDocument(object o) {
+        public void Write228_CustomDocument(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"CustomDocument", @"");
                 return;
             }
             TopLevelElement();
-            Write98_CustomDocument(@"CustomDocument", @"", ((global::SerializationTypes.CustomDocument)o), true, false);
+            Write100_CustomDocument(@"CustomDocument", @"", ((global::SerializationTypes.CustomDocument)o), true, false);
         }
 
-        public void Write225_CustomElement(object o) {
+        public void Write229_CustomElement(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"CustomElement", @"");
                 return;
             }
             TopLevelElement();
-            Write97_CustomElement(@"CustomElement", @"", ((global::SerializationTypes.CustomElement)o), true, false);
+            Write99_CustomElement(@"CustomElement", @"", ((global::SerializationTypes.CustomElement)o), true, false);
         }
 
-        public void Write226_Item(object o) {
+        public void Write230_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"", null);
@@ -1051,256 +1071,256 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        public void Write227_Item(object o) {
+        public void Write231_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithNonPublicDefaultConstructor", @"");
                 return;
             }
             TopLevelElement();
-            Write99_Item(@"TypeWithNonPublicDefaultConstructor", @"", ((global::SerializationTypes.TypeWithNonPublicDefaultConstructor)o), true, false);
+            Write101_Item(@"TypeWithNonPublicDefaultConstructor", @"", ((global::SerializationTypes.TypeWithNonPublicDefaultConstructor)o), true, false);
         }
 
-        public void Write228_ServerSettings(object o) {
+        public void Write232_ServerSettings(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ServerSettings", @"");
                 return;
             }
             TopLevelElement();
-            Write100_ServerSettings(@"ServerSettings", @"", ((global::SerializationTypes.ServerSettings)o), true, false);
+            Write102_ServerSettings(@"ServerSettings", @"", ((global::SerializationTypes.ServerSettings)o), true, false);
         }
 
-        public void Write229_TypeWithXmlQualifiedName(object o) {
+        public void Write233_TypeWithXmlQualifiedName(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlQualifiedName", @"");
                 return;
             }
             TopLevelElement();
-            Write101_TypeWithXmlQualifiedName(@"TypeWithXmlQualifiedName", @"", ((global::SerializationTypes.TypeWithXmlQualifiedName)o), true, false);
+            Write103_TypeWithXmlQualifiedName(@"TypeWithXmlQualifiedName", @"", ((global::SerializationTypes.TypeWithXmlQualifiedName)o), true, false);
         }
 
-        public void Write230_TypeWith2DArrayProperty2(object o) {
+        public void Write234_TypeWith2DArrayProperty2(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWith2DArrayProperty2", @"");
                 return;
             }
             TopLevelElement();
-            Write102_TypeWith2DArrayProperty2(@"TypeWith2DArrayProperty2", @"", ((global::SerializationTypes.TypeWith2DArrayProperty2)o), true, false);
+            Write104_TypeWith2DArrayProperty2(@"TypeWith2DArrayProperty2", @"", ((global::SerializationTypes.TypeWith2DArrayProperty2)o), true, false);
         }
 
-        public void Write231_Item(object o) {
+        public void Write235_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithPropertiesHavingDefaultValue", @"");
                 return;
             }
             TopLevelElement();
-            Write103_Item(@"TypeWithPropertiesHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)o), true, false);
+            Write105_Item(@"TypeWithPropertiesHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)o), true, false);
         }
 
-        public void Write232_Item(object o) {
+        public void Write236_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithEnumPropertyHavingDefaultValue", @"");
                 return;
             }
             TopLevelElement();
-            Write104_Item(@"TypeWithEnumPropertyHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)o), true, false);
+            Write106_Item(@"TypeWithEnumPropertyHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)o), true, false);
         }
 
-        public void Write233_Item(object o) {
+        public void Write237_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"");
                 return;
             }
             TopLevelElement();
-            Write105_Item(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)o), true, false);
+            Write107_Item(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)o), true, false);
         }
 
-        public void Write234_TypeWithShouldSerializeMethod(object o) {
+        public void Write238_TypeWithShouldSerializeMethod(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithShouldSerializeMethod", @"");
                 return;
             }
             TopLevelElement();
-            Write106_TypeWithShouldSerializeMethod(@"TypeWithShouldSerializeMethod", @"", ((global::SerializationTypes.TypeWithShouldSerializeMethod)o), true, false);
+            Write108_TypeWithShouldSerializeMethod(@"TypeWithShouldSerializeMethod", @"", ((global::SerializationTypes.TypeWithShouldSerializeMethod)o), true, false);
         }
 
-        public void Write235_Item(object o) {
+        public void Write239_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseTypeWithShouldSerializeMethod", @"");
                 return;
             }
             TopLevelElement();
-            Write107_Item(@"BaseTypeWithShouldSerializeMethod", @"", ((global::SerializationTypes.BaseTypeWithShouldSerializeMethod)o), true, false);
+            Write109_Item(@"BaseTypeWithShouldSerializeMethod", @"", ((global::SerializationTypes.BaseTypeWithShouldSerializeMethod)o), true, false);
         }
 
-        public void Write236_Item(object o) {
+        public void Write240_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedTypeWithInheritedShouldSerialize", @"");
                 return;
             }
             TopLevelElement();
-            Write108_Item(@"DerivedTypeWithInheritedShouldSerialize", @"", ((global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o), true, false);
+            Write110_Item(@"DerivedTypeWithInheritedShouldSerialize", @"", ((global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o), true, false);
         }
 
-        public void Write237_Item(object o) {
+        public void Write241_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithFieldBackedSpecifiedMember", @"");
                 return;
             }
             TopLevelElement();
-            Write109_Item(@"TypeWithFieldBackedSpecifiedMember", @"", ((global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)o), true, false);
+            Write111_Item(@"TypeWithFieldBackedSpecifiedMember", @"", ((global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)o), true, false);
         }
 
-        public void Write238_Item(object o) {
+        public void Write242_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"KnownTypesThroughConstructorWithArrayProperties", @"");
                 return;
             }
             TopLevelElement();
-            Write110_Item(@"KnownTypesThroughConstructorWithArrayProperties", @"", ((global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)o), true, false);
+            Write112_Item(@"KnownTypesThroughConstructorWithArrayProperties", @"", ((global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)o), true, false);
         }
 
-        public void Write239_Item(object o) {
+        public void Write243_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"KnownTypesThroughConstructorWithValue", @"");
                 return;
             }
             TopLevelElement();
-            Write111_Item(@"KnownTypesThroughConstructorWithValue", @"", ((global::SerializationTypes.KnownTypesThroughConstructorWithValue)o), true, false);
+            Write113_Item(@"KnownTypesThroughConstructorWithValue", @"", ((global::SerializationTypes.KnownTypesThroughConstructorWithValue)o), true, false);
         }
 
-        public void Write240_Item(object o) {
+        public void Write244_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithTypesHavingCustomFormatter", @"");
                 return;
             }
             TopLevelElement();
-            Write112_Item(@"TypeWithTypesHavingCustomFormatter", @"", ((global::SerializationTypes.TypeWithTypesHavingCustomFormatter)o), true, false);
+            Write114_Item(@"TypeWithTypesHavingCustomFormatter", @"", ((global::SerializationTypes.TypeWithTypesHavingCustomFormatter)o), true, false);
         }
 
-        public void Write241_Item(object o) {
+        public void Write245_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithArrayPropertyHavingChoice", @"");
                 return;
             }
             TopLevelElement();
-            Write114_Item(@"TypeWithArrayPropertyHavingChoice", @"", ((global::SerializationTypes.TypeWithArrayPropertyHavingChoice)o), true, false);
+            Write116_Item(@"TypeWithArrayPropertyHavingChoice", @"", ((global::SerializationTypes.TypeWithArrayPropertyHavingChoice)o), true, false);
         }
 
-        public void Write242_Item(object o) {
+        public void Write246_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithPropertyHavingComplexChoice", @"");
                 return;
             }
             TopLevelElement();
-            Write117_Item(@"TypeWithPropertyHavingComplexChoice", @"", ((global::SerializationTypes.TypeWithPropertyHavingComplexChoice)o), true, false);
+            Write119_Item(@"TypeWithPropertyHavingComplexChoice", @"", ((global::SerializationTypes.TypeWithPropertyHavingComplexChoice)o), true, false);
         }
 
-        public void Write243_MoreChoices(object o) {
+        public void Write247_MoreChoices(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"MoreChoices", @"");
                 return;
             }
-            WriteElementString(@"MoreChoices", @"", Write113_MoreChoices(((global::SerializationTypes.MoreChoices)o)));
+            WriteElementString(@"MoreChoices", @"", Write115_MoreChoices(((global::SerializationTypes.MoreChoices)o)));
         }
 
-        public void Write244_ComplexChoiceA(object o) {
+        public void Write248_ComplexChoiceA(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ComplexChoiceA", @"");
                 return;
             }
             TopLevelElement();
-            Write116_ComplexChoiceA(@"ComplexChoiceA", @"", ((global::SerializationTypes.ComplexChoiceA)o), true, false);
+            Write118_ComplexChoiceA(@"ComplexChoiceA", @"", ((global::SerializationTypes.ComplexChoiceA)o), true, false);
         }
 
-        public void Write245_ComplexChoiceB(object o) {
+        public void Write249_ComplexChoiceB(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ComplexChoiceB", @"");
                 return;
             }
             TopLevelElement();
-            Write115_ComplexChoiceB(@"ComplexChoiceB", @"", ((global::SerializationTypes.ComplexChoiceB)o), true, false);
+            Write117_ComplexChoiceB(@"ComplexChoiceB", @"", ((global::SerializationTypes.ComplexChoiceB)o), true, false);
         }
 
-        public void Write246_TypeWithFieldsOrdered(object o) {
+        public void Write250_TypeWithFieldsOrdered(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithFieldsOrdered", @"");
                 return;
             }
             TopLevelElement();
-            Write118_TypeWithFieldsOrdered(@"TypeWithFieldsOrdered", @"", ((global::SerializationTypes.TypeWithFieldsOrdered)o), true, false);
+            Write120_TypeWithFieldsOrdered(@"TypeWithFieldsOrdered", @"", ((global::SerializationTypes.TypeWithFieldsOrdered)o), true, false);
         }
 
-        public void Write247_Item(object o) {
+        public void Write251_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName", @"");
                 return;
             }
             TopLevelElement();
-            Write119_Item(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName", @"", ((global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)o), true, false);
+            Write121_Item(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName", @"", ((global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)o), true, false);
         }
 
-        public void Write248_Root(object o) {
+        public void Write252_Root(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Root", @"");
                 return;
             }
             TopLevelElement();
-            Write122_Item(@"Root", @"", ((global::SerializationTypes.NamespaceTypeNameClashContainer)o), true, false);
+            Write124_Item(@"Root", @"", ((global::SerializationTypes.NamespaceTypeNameClashContainer)o), true, false);
         }
 
-        public void Write249_TypeClashB(object o) {
+        public void Write253_TypeClashB(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeClashB", @"");
                 return;
             }
             TopLevelElement();
-            Write121_TypeNameClash(@"TypeClashB", @"", ((global::SerializationTypes.TypeNameClashB.TypeNameClash)o), true, false);
+            Write123_TypeNameClash(@"TypeClashB", @"", ((global::SerializationTypes.TypeNameClashB.TypeNameClash)o), true, false);
         }
 
-        public void Write250_TypeClashA(object o) {
+        public void Write254_TypeClashA(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeClashA", @"");
                 return;
             }
             TopLevelElement();
-            Write120_TypeNameClash(@"TypeClashA", @"", ((global::SerializationTypes.TypeNameClashA.TypeNameClash)o), true, false);
+            Write122_TypeNameClash(@"TypeClashA", @"", ((global::SerializationTypes.TypeNameClashA.TypeNameClash)o), true, false);
         }
 
-        public void Write251_Person(object o) {
+        public void Write255_Person(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Person", @"");
                 return;
             }
             TopLevelElement();
-            Write123_Person(@"Person", @"", ((global::Outer.Person)o), true, false);
+            Write125_Person(@"Person", @"", ((global::Outer.Person)o), true, false);
         }
 
-        void Write123_Person(string n, string ns, global::Outer.Person o, bool isNullable, bool needType) {
+        void Write125_Person(string n, string ns, global::Outer.Person o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1321,7 +1341,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write120_TypeNameClash(string n, string ns, global::SerializationTypes.TypeNameClashA.TypeNameClash o, bool isNullable, bool needType) {
+        void Write122_TypeNameClash(string n, string ns, global::SerializationTypes.TypeNameClashA.TypeNameClash o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1340,7 +1360,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write121_TypeNameClash(string n, string ns, global::SerializationTypes.TypeNameClashB.TypeNameClash o, bool isNullable, bool needType) {
+        void Write123_TypeNameClash(string n, string ns, global::SerializationTypes.TypeNameClashB.TypeNameClash o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1359,7 +1379,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write122_Item(string n, string ns, global::SerializationTypes.NamespaceTypeNameClashContainer o, bool isNullable, bool needType) {
+        void Write124_Item(string n, string ns, global::SerializationTypes.NamespaceTypeNameClashContainer o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1378,7 +1398,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 global::SerializationTypes.TypeNameClashA.TypeNameClash[] a = (global::SerializationTypes.TypeNameClashA.TypeNameClash[])o.@A;
                 if (a != null) {
                     for (int ia = 0; ia < a.Length; ia++) {
-                        Write120_TypeNameClash(@"A", @"", ((global::SerializationTypes.TypeNameClashA.TypeNameClash)a[ia]), false, false);
+                        Write122_TypeNameClash(@"A", @"", ((global::SerializationTypes.TypeNameClashA.TypeNameClash)a[ia]), false, false);
                     }
                 }
             }
@@ -1386,14 +1406,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 global::SerializationTypes.TypeNameClashB.TypeNameClash[] a = (global::SerializationTypes.TypeNameClashB.TypeNameClash[])o.@B;
                 if (a != null) {
                     for (int ia = 0; ia < a.Length; ia++) {
-                        Write121_TypeNameClash(@"B", @"", ((global::SerializationTypes.TypeNameClashB.TypeNameClash)a[ia]), false, false);
+                        Write123_TypeNameClash(@"B", @"", ((global::SerializationTypes.TypeNameClashB.TypeNameClash)a[ia]), false, false);
                     }
                 }
             }
             WriteEndElement(o);
         }
 
-        void Write119_Item(string n, string ns, global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName o, bool isNullable, bool needType) {
+        void Write121_Item(string n, string ns, global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1424,199 +1444,207 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::Outer.Person)) {
-                        Write123_Person(n, ns,(global::Outer.Person)o, isNullable, true);
+                        Write125_Person(n, ns,(global::Outer.Person)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.NamespaceTypeNameClashContainer)) {
-                        Write122_Item(n, ns,(global::SerializationTypes.NamespaceTypeNameClashContainer)o, isNullable, true);
+                        Write124_Item(n, ns,(global::SerializationTypes.NamespaceTypeNameClashContainer)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeNameClashB.TypeNameClash)) {
-                        Write121_TypeNameClash(n, ns,(global::SerializationTypes.TypeNameClashB.TypeNameClash)o, isNullable, true);
+                        Write123_TypeNameClash(n, ns,(global::SerializationTypes.TypeNameClashB.TypeNameClash)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeNameClashA.TypeNameClash)) {
-                        Write120_TypeNameClash(n, ns,(global::SerializationTypes.TypeNameClashA.TypeNameClash)o, isNullable, true);
+                        Write122_TypeNameClash(n, ns,(global::SerializationTypes.TypeNameClashA.TypeNameClash)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)) {
-                        Write119_Item(n, ns,(global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)o, isNullable, true);
+                        Write121_Item(n, ns,(global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithFieldsOrdered)) {
-                        Write118_TypeWithFieldsOrdered(n, ns,(global::SerializationTypes.TypeWithFieldsOrdered)o, isNullable, true);
+                        Write120_TypeWithFieldsOrdered(n, ns,(global::SerializationTypes.TypeWithFieldsOrdered)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithPropertyHavingComplexChoice)) {
-                        Write117_Item(n, ns,(global::SerializationTypes.TypeWithPropertyHavingComplexChoice)o, isNullable, true);
+                        Write119_Item(n, ns,(global::SerializationTypes.TypeWithPropertyHavingComplexChoice)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ComplexChoiceA)) {
-                        Write116_ComplexChoiceA(n, ns,(global::SerializationTypes.ComplexChoiceA)o, isNullable, true);
+                        Write118_ComplexChoiceA(n, ns,(global::SerializationTypes.ComplexChoiceA)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ComplexChoiceB)) {
-                        Write115_ComplexChoiceB(n, ns,(global::SerializationTypes.ComplexChoiceB)o, isNullable, true);
+                        Write117_ComplexChoiceB(n, ns,(global::SerializationTypes.ComplexChoiceB)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithArrayPropertyHavingChoice)) {
-                        Write114_Item(n, ns,(global::SerializationTypes.TypeWithArrayPropertyHavingChoice)o, isNullable, true);
+                        Write116_Item(n, ns,(global::SerializationTypes.TypeWithArrayPropertyHavingChoice)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithTypesHavingCustomFormatter)) {
-                        Write112_Item(n, ns,(global::SerializationTypes.TypeWithTypesHavingCustomFormatter)o, isNullable, true);
+                        Write114_Item(n, ns,(global::SerializationTypes.TypeWithTypesHavingCustomFormatter)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.KnownTypesThroughConstructorWithValue)) {
-                        Write111_Item(n, ns,(global::SerializationTypes.KnownTypesThroughConstructorWithValue)o, isNullable, true);
+                        Write113_Item(n, ns,(global::SerializationTypes.KnownTypesThroughConstructorWithValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)) {
-                        Write110_Item(n, ns,(global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)o, isNullable, true);
+                        Write112_Item(n, ns,(global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)) {
-                        Write109_Item(n, ns,(global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)o, isNullable, true);
+                        Write111_Item(n, ns,(global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.BaseTypeWithShouldSerializeMethod)) {
-                        Write107_Item(n, ns,(global::SerializationTypes.BaseTypeWithShouldSerializeMethod)o, isNullable, true);
+                        Write109_Item(n, ns,(global::SerializationTypes.BaseTypeWithShouldSerializeMethod)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)) {
-                        Write108_Item(n, ns,(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o, isNullable, true);
+                        Write110_Item(n, ns,(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithShouldSerializeMethod)) {
-                        Write106_TypeWithShouldSerializeMethod(n, ns,(global::SerializationTypes.TypeWithShouldSerializeMethod)o, isNullable, true);
+                        Write108_TypeWithShouldSerializeMethod(n, ns,(global::SerializationTypes.TypeWithShouldSerializeMethod)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)) {
-                        Write105_Item(n, ns,(global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)o, isNullable, true);
+                        Write107_Item(n, ns,(global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)) {
-                        Write104_Item(n, ns,(global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)o, isNullable, true);
+                        Write106_Item(n, ns,(global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)) {
-                        Write103_Item(n, ns,(global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)o, isNullable, true);
+                        Write105_Item(n, ns,(global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWith2DArrayProperty2)) {
-                        Write102_TypeWith2DArrayProperty2(n, ns,(global::SerializationTypes.TypeWith2DArrayProperty2)o, isNullable, true);
+                        Write104_TypeWith2DArrayProperty2(n, ns,(global::SerializationTypes.TypeWith2DArrayProperty2)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithXmlQualifiedName)) {
-                        Write101_TypeWithXmlQualifiedName(n, ns,(global::SerializationTypes.TypeWithXmlQualifiedName)o, isNullable, true);
+                        Write103_TypeWithXmlQualifiedName(n, ns,(global::SerializationTypes.TypeWithXmlQualifiedName)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ServerSettings)) {
-                        Write100_ServerSettings(n, ns,(global::SerializationTypes.ServerSettings)o, isNullable, true);
+                        Write102_ServerSettings(n, ns,(global::SerializationTypes.ServerSettings)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithNonPublicDefaultConstructor)) {
-                        Write99_Item(n, ns,(global::SerializationTypes.TypeWithNonPublicDefaultConstructor)o, isNullable, true);
+                        Write101_Item(n, ns,(global::SerializationTypes.TypeWithNonPublicDefaultConstructor)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.CustomDocument)) {
-                        Write98_CustomDocument(n, ns,(global::SerializationTypes.CustomDocument)o, isNullable, true);
+                        Write100_CustomDocument(n, ns,(global::SerializationTypes.CustomDocument)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.CustomElement)) {
-                        Write97_CustomElement(n, ns,(global::SerializationTypes.CustomElement)o, isNullable, true);
+                        Write99_CustomElement(n, ns,(global::SerializationTypes.CustomElement)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)) {
-                        Write95_Item(n, ns,(global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)o, isNullable, true);
+                        Write97_Item(n, ns,(global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithXmlSchemaFormAttribute)) {
-                        Write94_TypeWithXmlSchemaFormAttribute(n, ns,(global::SerializationTypes.TypeWithXmlSchemaFormAttribute)o, isNullable, true);
+                        Write96_TypeWithXmlSchemaFormAttribute(n, ns,(global::SerializationTypes.TypeWithXmlSchemaFormAttribute)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithPropertyNameSpecified)) {
-                        Write93_TypeWithPropertyNameSpecified(n, ns,(global::SerializationTypes.TypeWithPropertyNameSpecified)o, isNullable, true);
+                        Write95_TypeWithPropertyNameSpecified(n, ns,(global::SerializationTypes.TypeWithPropertyNameSpecified)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.SimpleKnownTypeValue)) {
-                        Write92_SimpleKnownTypeValue(n, ns,(global::SerializationTypes.SimpleKnownTypeValue)o, isNullable, true);
+                        Write94_SimpleKnownTypeValue(n, ns,(global::SerializationTypes.SimpleKnownTypeValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.KnownTypesThroughConstructor)) {
-                        Write91_KnownTypesThroughConstructor(n, ns,(global::SerializationTypes.KnownTypesThroughConstructor)o, isNullable, true);
+                        Write93_KnownTypesThroughConstructor(n, ns,(global::SerializationTypes.KnownTypesThroughConstructor)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithAnyAttribute)) {
-                        Write90_TypeWithAnyAttribute(n, ns,(global::SerializationTypes.TypeWithAnyAttribute)o, isNullable, true);
+                        Write92_TypeWithAnyAttribute(n, ns,(global::SerializationTypes.TypeWithAnyAttribute)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.XmlSerializerAttributes)) {
-                        Write89_XmlSerializerAttributes(n, ns,(global::SerializationTypes.XmlSerializerAttributes)o, isNullable, true);
+                        Write91_XmlSerializerAttributes(n, ns,(global::SerializationTypes.XmlSerializerAttributes)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.WithNullables)) {
-                        Write82_WithNullables(n, ns,(global::SerializationTypes.WithNullables)o, isNullable, true);
+                        Write84_WithNullables(n, ns,(global::SerializationTypes.WithNullables)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.WithEnums)) {
-                        Write81_WithEnums(n, ns,(global::SerializationTypes.WithEnums)o, isNullable, true);
+                        Write83_WithEnums(n, ns,(global::SerializationTypes.WithEnums)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.WithStruct)) {
-                        Write78_WithStruct(n, ns,(global::SerializationTypes.WithStruct)o, isNullable, true);
+                        Write80_WithStruct(n, ns,(global::SerializationTypes.WithStruct)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.SomeStruct)) {
-                        Write77_SomeStruct(n, ns,(global::SerializationTypes.SomeStruct)o, true);
+                        Write79_SomeStruct(n, ns,(global::SerializationTypes.SomeStruct)o, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ClassImplementsInterface)) {
-                        Write76_ClassImplementsInterface(n, ns,(global::SerializationTypes.ClassImplementsInterface)o, isNullable, true);
+                        Write78_ClassImplementsInterface(n, ns,(global::SerializationTypes.ClassImplementsInterface)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithXmlTextAttributeOnArray)) {
-                        Write74_Item(n, ns,(global::SerializationTypes.TypeWithXmlTextAttributeOnArray)o, isNullable, true);
+                        Write76_Item(n, ns,(global::SerializationTypes.TypeWithXmlTextAttributeOnArray)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.SimpleDC)) {
-                        Write73_SimpleDC(n, ns,(global::SerializationTypes.SimpleDC)o, isNullable, true);
+                        Write75_SimpleDC(n, ns,(global::SerializationTypes.SimpleDC)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithByteArrayAsXmlText)) {
-                        Write72_TypeWithByteArrayAsXmlText(n, ns,(global::SerializationTypes.TypeWithByteArrayAsXmlText)o, isNullable, true);
+                        Write74_TypeWithByteArrayAsXmlText(n, ns,(global::SerializationTypes.TypeWithByteArrayAsXmlText)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)) {
-                        Write71_Item(n, ns,(global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)o, isNullable, true);
+                        Write73_Item(n, ns,(global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.BaseClassWithSamePropertyName)) {
-                        Write68_BaseClassWithSamePropertyName(n, ns,(global::SerializationTypes.BaseClassWithSamePropertyName)o, isNullable, true);
+                        Write70_BaseClassWithSamePropertyName(n, ns,(global::SerializationTypes.BaseClassWithSamePropertyName)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty)) {
-                        Write69_DerivedClassWithSameProperty(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty)o, isNullable, true);
+                        Write71_DerivedClassWithSameProperty(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty2)) {
-                        Write70_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
+                        Write72_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)) {
-                        Write67_Item(n, ns,(global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)o, isNullable, true);
+                        Write69_Item(n, ns,(global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeHasArrayOfASerializedAsB)) {
-                        Write66_TypeHasArrayOfASerializedAsB(n, ns,(global::SerializationTypes.TypeHasArrayOfASerializedAsB)o, isNullable, true);
+                        Write68_TypeHasArrayOfASerializedAsB(n, ns,(global::SerializationTypes.TypeHasArrayOfASerializedAsB)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeB)) {
-                        Write65_TypeB(n, ns,(global::SerializationTypes.TypeB)o, isNullable, true);
+                        Write67_TypeB(n, ns,(global::SerializationTypes.TypeB)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeA)) {
-                        Write64_TypeA(n, ns,(global::SerializationTypes.TypeA)o, isNullable, true);
+                        Write66_TypeA(n, ns,(global::SerializationTypes.TypeA)o, isNullable, true);
+                        return;
+                    }
+                    if (t == typeof(global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)) {
+                        Write65_Item(n, ns,(global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)o, isNullable, true);
+                        return;
+                    }
+                    if (t == typeof(global::SerializationTypes.TypeWithBuiltInTypedMembers)) {
+                        Write64_TypeWithBuiltInTypedMembers(n, ns,(global::SerializationTypes.TypeWithBuiltInTypedMembers)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.BuiltInTypes)) {
@@ -2037,7 +2065,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             global::SerializationTypes.TypeA[] a = (global::SerializationTypes.TypeA[])o;
                             if (a != null) {
                                 for (int ia = 0; ia < a.Length; ia++) {
-                                    Write64_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)a[ia]), true, false);
+                                    Write66_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)a[ia]), true, false);
                                 }
                             }
                         }
@@ -2047,63 +2075,63 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     if (t == typeof(global::SerializationTypes.EnumFlags)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"EnumFlags", @"");
-                        Writer.WriteString(Write75_EnumFlags((global::SerializationTypes.EnumFlags)o));
+                        Writer.WriteString(Write77_EnumFlags((global::SerializationTypes.EnumFlags)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.IntEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"IntEnum", @"");
-                        Writer.WriteString(Write79_IntEnum((global::SerializationTypes.IntEnum)o));
+                        Writer.WriteString(Write81_IntEnum((global::SerializationTypes.IntEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ShortEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"ShortEnum", @"");
-                        Writer.WriteString(Write80_ShortEnum((global::SerializationTypes.ShortEnum)o));
+                        Writer.WriteString(Write82_ShortEnum((global::SerializationTypes.ShortEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ByteEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"ByteEnum", @"");
-                        Writer.WriteString(Write83_ByteEnum((global::SerializationTypes.ByteEnum)o));
+                        Writer.WriteString(Write85_ByteEnum((global::SerializationTypes.ByteEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.SByteEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"SByteEnum", @"");
-                        Writer.WriteString(Write84_SByteEnum((global::SerializationTypes.SByteEnum)o));
+                        Writer.WriteString(Write86_SByteEnum((global::SerializationTypes.SByteEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.UIntEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"UIntEnum", @"");
-                        Writer.WriteString(Write85_UIntEnum((global::SerializationTypes.UIntEnum)o));
+                        Writer.WriteString(Write87_UIntEnum((global::SerializationTypes.UIntEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.LongEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"LongEnum", @"");
-                        Writer.WriteString(Write86_LongEnum((global::SerializationTypes.LongEnum)o));
+                        Writer.WriteString(Write88_LongEnum((global::SerializationTypes.LongEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ULongEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"ULongEnum", @"");
-                        Writer.WriteString(Write87_ULongEnum((global::SerializationTypes.ULongEnum)o));
+                        Writer.WriteString(Write89_ULongEnum((global::SerializationTypes.ULongEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ItemChoiceType)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"ItemChoiceType", @"");
-                        Writer.WriteString(Write88_ItemChoiceType((global::SerializationTypes.ItemChoiceType)o));
+                        Writer.WriteString(Write90_ItemChoiceType((global::SerializationTypes.ItemChoiceType)o));
                         Writer.WriteEndElement();
                         return;
                     }
@@ -2114,7 +2142,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             global::SerializationTypes.ItemChoiceType[] a = (global::SerializationTypes.ItemChoiceType[])o;
                             if (a != null) {
                                 for (int ia = 0; ia < a.Length; ia++) {
-                                    WriteElementString(@"ItemChoiceType", @"", Write88_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)a[ia])));
+                                    WriteElementString(@"ItemChoiceType", @"", Write90_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)a[ia])));
                                 }
                             }
                         }
@@ -2182,7 +2210,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     if (t == typeof(global::SerializationTypes.MoreChoices)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"MoreChoices", @"");
-                        Writer.WriteString(Write113_MoreChoices((global::SerializationTypes.MoreChoices)o));
+                        Writer.WriteString(Write115_MoreChoices((global::SerializationTypes.MoreChoices)o));
                         Writer.WriteEndElement();
                         return;
                     }
@@ -2194,7 +2222,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        string Write113_MoreChoices(global::SerializationTypes.MoreChoices v) {
+        string Write115_MoreChoices(global::SerializationTypes.MoreChoices v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.MoreChoices.@None: s = @"None"; break;
@@ -2225,7 +2253,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        string Write88_ItemChoiceType(global::SerializationTypes.ItemChoiceType v) {
+        string Write90_ItemChoiceType(global::SerializationTypes.ItemChoiceType v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.ItemChoiceType.@None: s = @"None"; break;
@@ -2237,7 +2265,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write87_ULongEnum(global::SerializationTypes.ULongEnum v) {
+        string Write89_ULongEnum(global::SerializationTypes.ULongEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.ULongEnum.@Option0: s = @"Option0"; break;
@@ -2248,7 +2276,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write86_LongEnum(global::SerializationTypes.LongEnum v) {
+        string Write88_LongEnum(global::SerializationTypes.LongEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.LongEnum.@Option0: s = @"Option0"; break;
@@ -2259,7 +2287,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write85_UIntEnum(global::SerializationTypes.UIntEnum v) {
+        string Write87_UIntEnum(global::SerializationTypes.UIntEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.UIntEnum.@Option0: s = @"Option0"; break;
@@ -2270,7 +2298,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write84_SByteEnum(global::SerializationTypes.SByteEnum v) {
+        string Write86_SByteEnum(global::SerializationTypes.SByteEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.SByteEnum.@Option0: s = @"Option0"; break;
@@ -2281,7 +2309,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write83_ByteEnum(global::SerializationTypes.ByteEnum v) {
+        string Write85_ByteEnum(global::SerializationTypes.ByteEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.ByteEnum.@Option0: s = @"Option0"; break;
@@ -2292,7 +2320,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write80_ShortEnum(global::SerializationTypes.ShortEnum v) {
+        string Write82_ShortEnum(global::SerializationTypes.ShortEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.ShortEnum.@Option0: s = @"Option0"; break;
@@ -2303,7 +2331,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write79_IntEnum(global::SerializationTypes.IntEnum v) {
+        string Write81_IntEnum(global::SerializationTypes.IntEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.IntEnum.@Option0: s = @"Option0"; break;
@@ -2314,7 +2342,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write75_EnumFlags(global::SerializationTypes.EnumFlags v) {
+        string Write77_EnumFlags(global::SerializationTypes.EnumFlags v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.EnumFlags.@One: s = @"One"; break;
@@ -2332,7 +2360,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        void Write64_TypeA(string n, string ns, global::SerializationTypes.TypeA o, bool isNullable, bool needType) {
+        void Write66_TypeA(string n, string ns, global::SerializationTypes.TypeA o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3946,7 +3974,98 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write65_TypeB(string n, string ns, global::SerializationTypes.TypeB o, bool isNullable, bool needType) {
+        void Write64_TypeWithBuiltInTypedMembers(string n, string ns, global::SerializationTypes.TypeWithBuiltInTypedMembers o, bool isNullable, bool needType) {
+            if ((object)o == null) {
+                if (isNullable) WriteNullTagLiteral(n, ns);
+                return;
+            }
+            if (!needType) {
+                System.Type t = o.GetType();
+                if (t == typeof(global::SerializationTypes.TypeWithBuiltInTypedMembers)) {
+                }
+                else {
+                    throw CreateUnknownTypeException(o);
+                }
+            }
+            WriteStartElement(n, ns, o, false, null);
+            if (needType) WriteXsiType(@"TypeWithBuiltInTypedMembers", @"");
+            WriteElementString(@"StringMember", @"", ((global::System.String)o.@StringMember));
+            WriteElementStringRaw(@"IntMember", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)o.@IntMember)));
+            if (o.@NullableIntMember != null) {
+                WriteNullableStringLiteralRaw(@"NullableIntMember", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)o.@NullableIntMember)));
+            }
+            else {
+                WriteNullTagLiteral(@"NullableIntMember", @"");
+            }
+            {
+                global::System.Collections.Generic.List<global::System.String> a = (global::System.Collections.Generic.List<global::System.String>)((global::System.Collections.Generic.List<global::System.String>)o.@ListMember);
+                if (a != null){
+                    WriteStartElement(@"ListMember", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteNullableStringLiteral(@"string", @"", ((global::System.String)a[ia]));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
+                global::System.Int32[] a = (global::System.Int32[])((global::System.Int32[])o.@ArrayMember);
+                if (a != null){
+                    WriteStartElement(@"ArrayMember", @"", null, false);
+                    for (int ia = 0; ia < a.Length; ia++) {
+                        WriteElementStringRaw(@"int", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)a[ia])));
+                    }
+                    WriteEndElement();
+                }
+            }
+            WriteEndElement(o);
+        }
+
+        void Write65_Item(string n, string ns, global::SerializationTypes.TypeWithNullableBuiltInTypedMembers o, bool isNullable, bool needType) {
+            if ((object)o == null) {
+                if (isNullable) WriteNullTagLiteral(n, ns);
+                return;
+            }
+            if (!needType) {
+                System.Type t = o.GetType();
+                if (t == typeof(global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)) {
+                }
+                else {
+                    throw CreateUnknownTypeException(o);
+                }
+            }
+            WriteStartElement(n, ns, o, false, null);
+            if (needType) WriteXsiType(@"TypeWithNullableBuiltInTypedMembers", @"");
+            WriteNullableStringLiteral(@"StringMember", @"", ((global::System.String)o.@StringMember));
+            if (o.@NullableIntMember != null) {
+                WriteNullableStringLiteralRaw(@"NullableIntMember", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)o.@NullableIntMember)));
+            }
+            else {
+                WriteNullTagLiteral(@"NullableIntMember", @"");
+            }
+            {
+                global::System.Int32[] a = (global::System.Int32[])((global::System.Int32[])o.@ArrayMember);
+                if (a != null){
+                    WriteStartElement(@"ArrayMember", @"", null, false);
+                    for (int ia = 0; ia < a.Length; ia++) {
+                        WriteElementStringRaw(@"int", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)a[ia])));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
+                global::System.Collections.Generic.List<global::System.String> a = (global::System.Collections.Generic.List<global::System.String>)((global::System.Collections.Generic.List<global::System.String>)o.@ListMember);
+                if (a != null){
+                    WriteStartElement(@"ListMember", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteNullableStringLiteral(@"string", @"", ((global::System.String)a[ia]));
+                    }
+                    WriteEndElement();
+                }
+            }
+            WriteEndElement(o);
+        }
+
+        void Write67_TypeB(string n, string ns, global::SerializationTypes.TypeB o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3965,7 +4084,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write66_TypeHasArrayOfASerializedAsB(string n, string ns, global::SerializationTypes.TypeHasArrayOfASerializedAsB o, bool isNullable, bool needType) {
+        void Write68_TypeHasArrayOfASerializedAsB(string n, string ns, global::SerializationTypes.TypeHasArrayOfASerializedAsB o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3985,7 +4104,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (a != null){
                     WriteStartElement(@"Items", @"", null, false);
                     for (int ia = 0; ia < a.Length; ia++) {
-                        Write64_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)a[ia]), true, false);
+                        Write66_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)a[ia]), true, false);
                     }
                     WriteEndElement();
                 }
@@ -3993,7 +4112,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write67_Item(string n, string ns, global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ o, bool isNullable, bool needType) {
+        void Write69_Item(string n, string ns, global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4012,7 +4131,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write70_DerivedClassWithSameProperty2(string n, string ns, global::SerializationTypes.DerivedClassWithSameProperty2 o, bool isNullable, bool needType) {
+        void Write72_DerivedClassWithSameProperty2(string n, string ns, global::SerializationTypes.DerivedClassWithSameProperty2 o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4043,7 +4162,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write69_DerivedClassWithSameProperty(string n, string ns, global::SerializationTypes.DerivedClassWithSameProperty o, bool isNullable, bool needType) {
+        void Write71_DerivedClassWithSameProperty(string n, string ns, global::SerializationTypes.DerivedClassWithSameProperty o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4054,7 +4173,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty2)) {
-                        Write70_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
+                        Write72_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
                         return;
                     }
                     throw CreateUnknownTypeException(o);
@@ -4078,7 +4197,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write68_BaseClassWithSamePropertyName(string n, string ns, global::SerializationTypes.BaseClassWithSamePropertyName o, bool isNullable, bool needType) {
+        void Write70_BaseClassWithSamePropertyName(string n, string ns, global::SerializationTypes.BaseClassWithSamePropertyName o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4089,11 +4208,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty)) {
-                        Write69_DerivedClassWithSameProperty(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty)o, isNullable, true);
+                        Write71_DerivedClassWithSameProperty(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty2)) {
-                        Write70_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
+                        Write72_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
                         return;
                     }
                     throw CreateUnknownTypeException(o);
@@ -4117,7 +4236,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write71_Item(string n, string ns, global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime o, bool isNullable, bool needType) {
+        void Write73_Item(string n, string ns, global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4138,7 +4257,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write72_TypeWithByteArrayAsXmlText(string n, string ns, global::SerializationTypes.TypeWithByteArrayAsXmlText o, bool isNullable, bool needType) {
+        void Write74_TypeWithByteArrayAsXmlText(string n, string ns, global::SerializationTypes.TypeWithByteArrayAsXmlText o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4159,7 +4278,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write73_SimpleDC(string n, string ns, global::SerializationTypes.SimpleDC o, bool isNullable, bool needType) {
+        void Write75_SimpleDC(string n, string ns, global::SerializationTypes.SimpleDC o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4178,7 +4297,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write74_Item(string n, string ns, global::SerializationTypes.TypeWithXmlTextAttributeOnArray o, bool isNullable, bool needType) {
+        void Write76_Item(string n, string ns, global::SerializationTypes.TypeWithXmlTextAttributeOnArray o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4206,7 +4325,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write76_ClassImplementsInterface(string n, string ns, global::SerializationTypes.ClassImplementsInterface o, bool isNullable, bool needType) {
+        void Write78_ClassImplementsInterface(string n, string ns, global::SerializationTypes.ClassImplementsInterface o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4228,7 +4347,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write77_SomeStruct(string n, string ns, global::SerializationTypes.SomeStruct o, bool needType) {
+        void Write79_SomeStruct(string n, string ns, global::SerializationTypes.SomeStruct o, bool needType) {
             if (!needType) {
                 System.Type t = o.GetType();
                 if (t == typeof(global::SerializationTypes.SomeStruct)) {
@@ -4244,7 +4363,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write78_WithStruct(string n, string ns, global::SerializationTypes.WithStruct o, bool isNullable, bool needType) {
+        void Write80_WithStruct(string n, string ns, global::SerializationTypes.WithStruct o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4259,11 +4378,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"WithStruct", @"");
-            Write77_SomeStruct(@"Some", @"", ((global::SerializationTypes.SomeStruct)o.@Some), false);
+            Write79_SomeStruct(@"Some", @"", ((global::SerializationTypes.SomeStruct)o.@Some), false);
             WriteEndElement(o);
         }
 
-        void Write81_WithEnums(string n, string ns, global::SerializationTypes.WithEnums o, bool isNullable, bool needType) {
+        void Write83_WithEnums(string n, string ns, global::SerializationTypes.WithEnums o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4278,12 +4397,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"WithEnums", @"");
-            WriteElementString(@"Int", @"", Write79_IntEnum(((global::SerializationTypes.IntEnum)o.@Int)));
-            WriteElementString(@"Short", @"", Write80_ShortEnum(((global::SerializationTypes.ShortEnum)o.@Short)));
+            WriteElementString(@"Int", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o.@Int)));
+            WriteElementString(@"Short", @"", Write82_ShortEnum(((global::SerializationTypes.ShortEnum)o.@Short)));
             WriteEndElement(o);
         }
 
-        void Write82_WithNullables(string n, string ns, global::SerializationTypes.WithNullables o, bool isNullable, bool needType) {
+        void Write84_WithNullables(string n, string ns, global::SerializationTypes.WithNullables o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4299,13 +4418,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"WithNullables", @"");
             if (o.@Optional != null) {
-                WriteElementString(@"Optional", @"", Write79_IntEnum(((global::SerializationTypes.IntEnum)o.@Optional)));
+                WriteElementString(@"Optional", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o.@Optional)));
             }
             else {
                 WriteNullTagLiteral(@"Optional", @"");
             }
             if (o.@Optionull != null) {
-                WriteElementString(@"Optionull", @"", Write79_IntEnum(((global::SerializationTypes.IntEnum)o.@Optionull)));
+                WriteElementString(@"Optionull", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o.@Optionull)));
             }
             else {
                 WriteNullTagLiteral(@"Optionull", @"");
@@ -4323,13 +4442,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 WriteNullTagLiteral(@"OptionullInt", @"");
             }
             if (o.@Struct1 != null) {
-                Write77_SomeStruct(@"Struct1", @"", ((global::SerializationTypes.SomeStruct)o.@Struct1), false);
+                Write79_SomeStruct(@"Struct1", @"", ((global::SerializationTypes.SomeStruct)o.@Struct1), false);
             }
             else {
                 WriteNullTagLiteral(@"Struct1", @"");
             }
             if (o.@Struct2 != null) {
-                Write77_SomeStruct(@"Struct2", @"", ((global::SerializationTypes.SomeStruct)o.@Struct2), false);
+                Write79_SomeStruct(@"Struct2", @"", ((global::SerializationTypes.SomeStruct)o.@Struct2), false);
             }
             else {
                 WriteNullTagLiteral(@"Struct2", @"");
@@ -4337,7 +4456,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write89_XmlSerializerAttributes(string n, string ns, global::SerializationTypes.XmlSerializerAttributes o, bool isNullable, bool needType) {
+        void Write91_XmlSerializerAttributes(string n, string ns, global::SerializationTypes.XmlSerializerAttributes o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4376,7 +4495,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (a != null){
                     WriteStartElement(@"XmlEnumProperty", @"", null, false);
                     for (int ia = 0; ia < a.Length; ia++) {
-                        WriteElementString(@"ItemChoiceType", @"", Write88_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)a[ia])));
+                        WriteElementString(@"ItemChoiceType", @"", Write90_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)a[ia])));
                     }
                     WriteEndElement();
                 }
@@ -4399,7 +4518,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write90_TypeWithAnyAttribute(string n, string ns, global::SerializationTypes.TypeWithAnyAttribute o, bool isNullable, bool needType) {
+        void Write92_TypeWithAnyAttribute(string n, string ns, global::SerializationTypes.TypeWithAnyAttribute o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4428,7 +4547,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write91_KnownTypesThroughConstructor(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructor o, bool isNullable, bool needType) {
+        void Write93_KnownTypesThroughConstructor(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructor o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4448,7 +4567,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write92_SimpleKnownTypeValue(string n, string ns, global::SerializationTypes.SimpleKnownTypeValue o, bool isNullable, bool needType) {
+        void Write94_SimpleKnownTypeValue(string n, string ns, global::SerializationTypes.SimpleKnownTypeValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4467,7 +4586,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write93_TypeWithPropertyNameSpecified(string n, string ns, global::SerializationTypes.TypeWithPropertyNameSpecified o, bool isNullable, bool needType) {
+        void Write95_TypeWithPropertyNameSpecified(string n, string ns, global::SerializationTypes.TypeWithPropertyNameSpecified o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4491,7 +4610,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write94_TypeWithXmlSchemaFormAttribute(string n, string ns, global::SerializationTypes.TypeWithXmlSchemaFormAttribute o, bool isNullable, bool needType) {
+        void Write96_TypeWithXmlSchemaFormAttribute(string n, string ns, global::SerializationTypes.TypeWithXmlSchemaFormAttribute o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4539,7 +4658,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write95_Item(string n, string ns, global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute o, bool isNullable, bool needType) {
+        void Write97_Item(string n, string ns, global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4558,7 +4677,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write97_CustomElement(string n, string ns, global::SerializationTypes.CustomElement o, bool isNullable, bool needType) {
+        void Write99_CustomElement(string n, string ns, global::SerializationTypes.CustomElement o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4595,7 +4714,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write98_CustomDocument(string n, string ns, global::SerializationTypes.CustomDocument o, bool isNullable, bool needType) {
+        void Write100_CustomDocument(string n, string ns, global::SerializationTypes.CustomDocument o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4614,7 +4733,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 global::System.Collections.Generic.List<global::SerializationTypes.CustomElement> a = (global::System.Collections.Generic.List<global::SerializationTypes.CustomElement>)o.@CustomItems;
                 if (a != null) {
                     for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
-                        Write97_CustomElement(@"customElement", @"", ((global::SerializationTypes.CustomElement)a[ia]), false, false);
+                        Write99_CustomElement(@"customElement", @"", ((global::SerializationTypes.CustomElement)a[ia]), false, false);
                     }
                 }
             }
@@ -4634,7 +4753,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write99_Item(string n, string ns, global::SerializationTypes.TypeWithNonPublicDefaultConstructor o, bool isNullable, bool needType) {
+        void Write101_Item(string n, string ns, global::SerializationTypes.TypeWithNonPublicDefaultConstructor o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4653,7 +4772,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write100_ServerSettings(string n, string ns, global::SerializationTypes.ServerSettings o, bool isNullable, bool needType) {
+        void Write102_ServerSettings(string n, string ns, global::SerializationTypes.ServerSettings o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4673,7 +4792,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write101_TypeWithXmlQualifiedName(string n, string ns, global::SerializationTypes.TypeWithXmlQualifiedName o, bool isNullable, bool needType) {
+        void Write103_TypeWithXmlQualifiedName(string n, string ns, global::SerializationTypes.TypeWithXmlQualifiedName o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4692,7 +4811,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write102_TypeWith2DArrayProperty2(string n, string ns, global::SerializationTypes.TypeWith2DArrayProperty2 o, bool isNullable, bool needType) {
+        void Write104_TypeWith2DArrayProperty2(string n, string ns, global::SerializationTypes.TypeWith2DArrayProperty2 o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4729,7 +4848,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write103_Item(string n, string ns, global::SerializationTypes.TypeWithPropertiesHavingDefaultValue o, bool isNullable, bool needType) {
+        void Write105_Item(string n, string ns, global::SerializationTypes.TypeWithPropertiesHavingDefaultValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4757,7 +4876,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write104_Item(string n, string ns, global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue o, bool isNullable, bool needType) {
+        void Write106_Item(string n, string ns, global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4773,12 +4892,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"TypeWithEnumPropertyHavingDefaultValue", @"");
             if (((global::SerializationTypes.IntEnum)o.@EnumProperty) != global::SerializationTypes.IntEnum.@Option1) {
-                WriteElementString(@"EnumProperty", @"", Write79_IntEnum(((global::SerializationTypes.IntEnum)o.@EnumProperty)));
+                WriteElementString(@"EnumProperty", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o.@EnumProperty)));
             }
             WriteEndElement(o);
         }
 
-        void Write105_Item(string n, string ns, global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue o, bool isNullable, bool needType) {
+        void Write107_Item(string n, string ns, global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4795,12 +4914,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             if (needType) WriteXsiType(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"");
             if (((global::SerializationTypes.EnumFlags)o.@EnumProperty) != (global::SerializationTypes.EnumFlags.@One | 
             global::SerializationTypes.EnumFlags.@Four)) {
-                WriteElementString(@"EnumProperty", @"", Write75_EnumFlags(((global::SerializationTypes.EnumFlags)o.@EnumProperty)));
+                WriteElementString(@"EnumProperty", @"", Write77_EnumFlags(((global::SerializationTypes.EnumFlags)o.@EnumProperty)));
             }
             WriteEndElement(o);
         }
 
-        void Write106_TypeWithShouldSerializeMethod(string n, string ns, global::SerializationTypes.TypeWithShouldSerializeMethod o, bool isNullable, bool needType) {
+        void Write108_TypeWithShouldSerializeMethod(string n, string ns, global::SerializationTypes.TypeWithShouldSerializeMethod o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4821,7 +4940,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write108_Item(string n, string ns, global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize o, bool isNullable, bool needType) {
+        void Write110_Item(string n, string ns, global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4845,7 +4964,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write107_Item(string n, string ns, global::SerializationTypes.BaseTypeWithShouldSerializeMethod o, bool isNullable, bool needType) {
+        void Write109_Item(string n, string ns, global::SerializationTypes.BaseTypeWithShouldSerializeMethod o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4856,7 +4975,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)) {
-                        Write108_Item(n, ns,(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o, isNullable, true);
+                        Write110_Item(n, ns,(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o, isNullable, true);
                         return;
                     }
                     throw CreateUnknownTypeException(o);
@@ -4873,7 +4992,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write109_Item(string n, string ns, global::SerializationTypes.TypeWithFieldBackedSpecifiedMember o, bool isNullable, bool needType) {
+        void Write111_Item(string n, string ns, global::SerializationTypes.TypeWithFieldBackedSpecifiedMember o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4894,7 +5013,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write110_Item(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties o, bool isNullable, bool needType) {
+        void Write112_Item(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4914,7 +5033,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write111_Item(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructorWithValue o, bool isNullable, bool needType) {
+        void Write113_Item(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructorWithValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4933,7 +5052,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write112_Item(string n, string ns, global::SerializationTypes.TypeWithTypesHavingCustomFormatter o, bool isNullable, bool needType) {
+        void Write114_Item(string n, string ns, global::SerializationTypes.TypeWithTypesHavingCustomFormatter o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4960,7 +5079,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write114_Item(string n, string ns, global::SerializationTypes.TypeWithArrayPropertyHavingChoice o, bool isNullable, bool needType) {
+        void Write116_Item(string n, string ns, global::SerializationTypes.TypeWithArrayPropertyHavingChoice o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5003,7 +5122,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write115_ComplexChoiceB(string n, string ns, global::SerializationTypes.ComplexChoiceB o, bool isNullable, bool needType) {
+        void Write117_ComplexChoiceB(string n, string ns, global::SerializationTypes.ComplexChoiceB o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5022,7 +5141,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write116_ComplexChoiceA(string n, string ns, global::SerializationTypes.ComplexChoiceA o, bool isNullable, bool needType) {
+        void Write118_ComplexChoiceA(string n, string ns, global::SerializationTypes.ComplexChoiceA o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5033,7 +5152,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::SerializationTypes.ComplexChoiceB)) {
-                        Write115_ComplexChoiceB(n, ns,(global::SerializationTypes.ComplexChoiceB)o, isNullable, true);
+                        Write117_ComplexChoiceB(n, ns,(global::SerializationTypes.ComplexChoiceB)o, isNullable, true);
                         return;
                     }
                     throw CreateUnknownTypeException(o);
@@ -5045,7 +5164,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write117_Item(string n, string ns, global::SerializationTypes.TypeWithPropertyHavingComplexChoice o, bool isNullable, bool needType) {
+        void Write119_Item(string n, string ns, global::SerializationTypes.TypeWithPropertyHavingComplexChoice o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5076,7 +5195,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             else if (ci == SerializationTypes.MoreChoices.@Item && ((object)(ai) != null)) {
                                 if (((object)ai) != null && !(ai is global::SerializationTypes.ComplexChoiceA)) throw CreateMismatchChoiceException(@"SerializationTypes.ComplexChoiceA", @"ChoiceArray", @"SerializationTypes.MoreChoices.@Item");
-                                Write116_ComplexChoiceA(@"Item", @"", ((global::SerializationTypes.ComplexChoiceA)ai), false, false);
+                                Write118_ComplexChoiceA(@"Item", @"", ((global::SerializationTypes.ComplexChoiceA)ai), false, false);
                             }
                             else  if ((object)(ai) != null){
                                 throw CreateUnknownTypeException(ai);
@@ -5088,7 +5207,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write118_TypeWithFieldsOrdered(string n, string ns, global::SerializationTypes.TypeWithFieldsOrdered o, bool isNullable, bool needType) {
+        void Write120_TypeWithFieldsOrdered(string n, string ns, global::SerializationTypes.TypeWithFieldsOrdered o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5110,7 +5229,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write96_Item(string n, string ns, global::SerializationTypes.TypeWithSchemaFormInXmlAttribute o, bool isNullable, bool needType) {
+        void Write98_Item(string n, string ns, global::SerializationTypes.TypeWithSchemaFormInXmlAttribute o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5135,7 +5254,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
 
     public class XmlSerializationReader1 : System.Xml.Serialization.XmlSerializationReader {
 
-        public object Read130_TypeWithXmlElementProperty() {
+        public object Read132_TypeWithXmlElementProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5153,7 +5272,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read131_TypeWithXmlDocumentProperty() {
+        public object Read133_TypeWithXmlDocumentProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5171,7 +5290,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read132_TypeWithBinaryProperty() {
+        public object Read134_TypeWithBinaryProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5189,7 +5308,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read133_Item() {
+        public object Read135_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5207,7 +5326,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read134_Item() {
+        public object Read136_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5225,7 +5344,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read135_DateOnlyWrapper() {
+        public object Read137_DateOnlyWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5243,7 +5362,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read136_TimeOnlyWrapper() {
+        public object Read138_TimeOnlyWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5261,7 +5380,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read137_TimeOnlyAsXsdTimeWrapper() {
+        public object Read139_TimeOnlyAsXsdTimeWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5279,7 +5398,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read138_DateTimeDateWrapper() {
+        public object Read140_DateTimeDateWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5297,7 +5416,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read139_DateTimeTimeWrapper() {
+        public object Read141_DateTimeTimeWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5315,7 +5434,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read140_TypeWithTimeSpanProperty() {
+        public object Read142_TypeWithTimeSpanProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5333,7 +5452,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read141_Item() {
+        public object Read143_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5351,7 +5470,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read142_TypeWithByteProperty() {
+        public object Read144_TypeWithByteProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5369,7 +5488,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read143_TypeWithXmlNodeArrayProperty() {
+        public object Read145_TypeWithXmlNodeArrayProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5387,7 +5506,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read144_Animal() {
+        public object Read146_Animal() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5405,7 +5524,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read145_Dog() {
+        public object Read147_Dog() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5423,12 +5542,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read146_DogBreed() {
+        public object Read148_DogBreed() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
                     if (((object) Reader.LocalName == (object)id18_DogBreed && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
                             o = Read20_DogBreed(Reader.ReadElementString());
                         }
@@ -5443,7 +5570,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read147_Group() {
+        public object Read149_Group() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5461,7 +5588,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read148_Vehicle() {
+        public object Read150_Vehicle() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5479,7 +5606,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read149_Employee() {
+        public object Read151_Employee() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5497,7 +5624,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read150_BaseClass() {
+        public object Read152_BaseClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5515,7 +5642,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read151_DerivedClass() {
+        public object Read153_DerivedClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5533,7 +5660,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read152_SimpleBaseClass() {
+        public object Read154_SimpleBaseClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5551,7 +5678,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read153_SimpleDerivedClass() {
+        public object Read155_SimpleDerivedClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5569,7 +5696,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read154_BaseIXmlSerializable() {
+        public object Read156_BaseIXmlSerializable() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5596,7 +5723,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read155_DerivedIXmlSerializable() {
+        public object Read157_DerivedIXmlSerializable() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5614,7 +5741,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read156_PurchaseOrder() {
+        public object Read158_PurchaseOrder() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5632,7 +5759,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read157_Address() {
+        public object Read159_Address() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5650,7 +5777,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read158_OrderedItem() {
+        public object Read160_OrderedItem() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5668,7 +5795,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read159_AliasedTestType() {
+        public object Read161_AliasedTestType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5686,7 +5813,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read160_BaseClass1() {
+        public object Read162_BaseClass1() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5704,7 +5831,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read161_DerivedClass1() {
+        public object Read163_DerivedClass1() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5722,12 +5849,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read162_ArrayOfDateTime() {
+        public object Read164_ArrayOfDateTime() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
                     if (((object) Reader.LocalName == (object)id36_ArrayOfDateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(o) == null) o = new global::MyCollection1();
                             global::MyCollection1 a_0_0 = (global::MyCollection1)o;
@@ -5741,6 +5876,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
                                             if (((object) Reader.LocalName == (object)id37_dateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 {
                                                     a_0_0.Add(ToDateTime(Reader.ReadElementString()));
                                                 }
@@ -5772,7 +5915,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read163_Orchestra() {
+        public object Read165_Orchestra() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5790,7 +5933,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read164_Instrument() {
+        public object Read166_Instrument() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5808,7 +5951,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read165_Brass() {
+        public object Read167_Brass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5826,7 +5969,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read166_Trumpet() {
+        public object Read168_Trumpet() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5844,7 +5987,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read167_Pet() {
+        public object Read169_Pet() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5862,7 +6005,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read168_DefaultValuesSetToNaN() {
+        public object Read170_DefaultValuesSetToNaN() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5880,7 +6023,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read169_Item() {
+        public object Read171_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5898,7 +6041,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read170_Item() {
+        public object Read172_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5916,7 +6059,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read171_RootElement() {
+        public object Read173_RootElement() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5934,7 +6077,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read172_TypeWithLinkedProperty() {
+        public object Read174_TypeWithLinkedProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5952,7 +6095,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read173_Document() {
+        public object Read175_Document() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5970,7 +6113,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read174_RootClass() {
+        public object Read176_RootClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5988,7 +6131,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read175_Parameter() {
+        public object Read177_Parameter() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6006,7 +6149,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read176_XElementWrapper() {
+        public object Read178_XElementWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6024,7 +6167,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read177_XElementStruct() {
+        public object Read179_XElementStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6042,7 +6185,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read178_XElementArrayWrapper() {
+        public object Read180_XElementArrayWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6060,7 +6203,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read179_Item() {
+        public object Read181_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6078,7 +6221,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read180_TypeWithDateTimeStringProperty() {
+        public object Read182_TypeWithDateTimeStringProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6096,7 +6239,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read181_SimpleType() {
+        public object Read183_SimpleType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6114,7 +6257,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read182_TypeWithGetSetArrayMembers() {
+        public object Read184_TypeWithGetSetArrayMembers() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6132,7 +6275,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read183_TypeWithGetOnlyArrayProperties() {
+        public object Read185_TypeWithGetOnlyArrayProperties() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6150,7 +6293,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read184_TypeWithArraylikeMembers() {
+        public object Read186_TypeWithArraylikeMembers() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6168,7 +6311,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read185_StructNotSerializable() {
+        public object Read187_StructNotSerializable() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6186,7 +6329,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read186_TypeWithMyCollectionField() {
+        public object Read188_TypeWithMyCollectionField() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6204,7 +6347,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read187_Item() {
+        public object Read189_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6222,12 +6365,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read188_ArrayOfAnyType() {
+        public object Read190_ArrayOfAnyType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
                     if (((object) Reader.LocalName == (object)id64_ArrayOfAnyType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(o) == null) o = new global::SerializationTypes.MyList();
                             global::SerializationTypes.MyList a_0_0 = (global::SerializationTypes.MyList)o;
@@ -6270,12 +6421,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read189_MyEnum() {
+        public object Read191_MyEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
                     if (((object) Reader.LocalName == (object)id66_MyEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
                             o = Read62_MyEnum(Reader.ReadElementString());
                         }
@@ -6290,7 +6449,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read190_TypeWithEnumMembers() {
+        public object Read192_TypeWithEnumMembers() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6308,7 +6467,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read191_DCStruct() {
+        public object Read193_DCStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6326,7 +6485,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read192_DCClassWithEnumAndStruct() {
+        public object Read194_DCClassWithEnumAndStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6344,7 +6503,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read193_BuiltInTypes() {
+        public object Read195_BuiltInTypes() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6362,13 +6521,49 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read194_TypeA() {
+        public object Read196_TypeWithBuiltInTypedMembers() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id71_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read67_TypeA(true, true);
+                    if (((object) Reader.LocalName == (object)id71_TypeWithBuiltInTypedMembers && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read68_TypeWithBuiltInTypedMembers(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":TypeWithBuiltInTypedMembers");
+            }
+            return (object)o;
+        }
+
+        public object Read197_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id72_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read69_Item(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":TypeWithNullableBuiltInTypedMembers");
+            }
+            return (object)o;
+        }
+
+        public object Read198_TypeA() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id73_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read70_TypeA(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6380,13 +6575,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read195_TypeB() {
+        public object Read199_TypeB() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id72_TypeB && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read68_TypeB(true, true);
+                    if (((object) Reader.LocalName == (object)id74_TypeB && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read71_TypeB(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6398,13 +6593,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read196_TypeHasArrayOfASerializedAsB() {
+        public object Read200_TypeHasArrayOfASerializedAsB() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id73_TypeHasArrayOfASerializedAsB && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read69_TypeHasArrayOfASerializedAsB(true, true);
+                    if (((object) Reader.LocalName == (object)id75_TypeHasArrayOfASerializedAsB && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read72_TypeHasArrayOfASerializedAsB(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6416,13 +6611,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read197_Item() {
+        public object Read201_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id74_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read70_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id76_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read73_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6434,13 +6629,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read198_BaseClassWithSamePropertyName() {
+        public object Read202_BaseClassWithSamePropertyName() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id75_BaseClassWithSamePropertyName && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read71_BaseClassWithSamePropertyName(true, true);
+                    if (((object) Reader.LocalName == (object)id77_BaseClassWithSamePropertyName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read74_BaseClassWithSamePropertyName(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6452,13 +6647,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read199_DerivedClassWithSameProperty() {
+        public object Read203_DerivedClassWithSameProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id76_DerivedClassWithSameProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read72_DerivedClassWithSameProperty(true, true);
+                    if (((object) Reader.LocalName == (object)id78_DerivedClassWithSameProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read75_DerivedClassWithSameProperty(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6470,13 +6665,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read200_DerivedClassWithSameProperty2() {
+        public object Read204_DerivedClassWithSameProperty2() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id77_DerivedClassWithSameProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read73_DerivedClassWithSameProperty2(true, true);
+                    if (((object) Reader.LocalName == (object)id79_DerivedClassWithSameProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read76_DerivedClassWithSameProperty2(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6488,13 +6683,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read201_Item() {
+        public object Read205_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id78_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read74_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id80_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read77_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6506,13 +6701,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read202_TypeWithByteArrayAsXmlText() {
+        public object Read206_TypeWithByteArrayAsXmlText() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id79_TypeWithByteArrayAsXmlText && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read75_TypeWithByteArrayAsXmlText(true, true);
+                    if (((object) Reader.LocalName == (object)id81_TypeWithByteArrayAsXmlText && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read78_TypeWithByteArrayAsXmlText(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6524,13 +6719,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read203_SimpleDC() {
+        public object Read207_SimpleDC() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id80_SimpleDC && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read76_SimpleDC(true, true);
+                    if (((object) Reader.LocalName == (object)id82_SimpleDC && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read79_SimpleDC(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6542,13 +6737,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read204_Item() {
+        public object Read208_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id81_Item && (object) Reader.NamespaceURI == (object)id82_Item)) {
-                        o = Read77_Item(false, true);
+                    if (((object) Reader.LocalName == (object)id83_Item && (object) Reader.NamespaceURI == (object)id84_Item)) {
+                        o = Read80_Item(false, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6560,14 +6755,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read205_EnumFlags() {
+        public object Read209_EnumFlags() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id83_EnumFlags && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id85_EnumFlags && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read78_EnumFlags(Reader.ReadElementString());
+                            o = Read81_EnumFlags(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6580,13 +6783,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read206_ClassImplementsInterface() {
+        public object Read210_ClassImplementsInterface() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id84_ClassImplementsInterface && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read79_ClassImplementsInterface(true, true);
+                    if (((object) Reader.LocalName == (object)id86_ClassImplementsInterface && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read82_ClassImplementsInterface(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6598,13 +6801,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read207_WithStruct() {
+        public object Read211_WithStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id85_WithStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read81_WithStruct(true, true);
+                    if (((object) Reader.LocalName == (object)id87_WithStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read84_WithStruct(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6616,13 +6819,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read208_SomeStruct() {
+        public object Read212_SomeStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id86_SomeStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read80_SomeStruct(true);
+                    if (((object) Reader.LocalName == (object)id88_SomeStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read83_SomeStruct(true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6634,13 +6837,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read209_WithEnums() {
+        public object Read213_WithEnums() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id87_WithEnums && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read84_WithEnums(true, true);
+                    if (((object) Reader.LocalName == (object)id89_WithEnums && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read87_WithEnums(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6652,13 +6855,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read210_WithNullables() {
+        public object Read214_WithNullables() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id88_WithNullables && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read88_WithNullables(true, true);
+                    if (((object) Reader.LocalName == (object)id90_WithNullables && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read90_WithNullables(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6670,14 +6873,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read211_ByteEnum() {
+        public object Read215_ByteEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id89_ByteEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id91_ByteEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read89_ByteEnum(Reader.ReadElementString());
+                            o = Read91_ByteEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6690,14 +6901,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read212_SByteEnum() {
+        public object Read216_SByteEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id90_SByteEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id92_SByteEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read90_SByteEnum(Reader.ReadElementString());
+                            o = Read92_SByteEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6710,14 +6929,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read213_ShortEnum() {
+        public object Read217_ShortEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id91_ShortEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id93_ShortEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read83_ShortEnum(Reader.ReadElementString());
+                            o = Read86_ShortEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6730,14 +6957,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read214_IntEnum() {
+        public object Read218_IntEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id92_IntEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id94_IntEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read82_IntEnum(Reader.ReadElementString());
+                            o = Read85_IntEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6750,14 +6985,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read215_UIntEnum() {
+        public object Read219_UIntEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id93_UIntEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id95_UIntEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read91_UIntEnum(Reader.ReadElementString());
+                            o = Read93_UIntEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6770,14 +7013,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read216_LongEnum() {
+        public object Read220_LongEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id94_LongEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id96_LongEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read92_LongEnum(Reader.ReadElementString());
+                            o = Read94_LongEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6790,14 +7041,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read217_ULongEnum() {
+        public object Read221_ULongEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id95_ULongEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id97_ULongEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read93_ULongEnum(Reader.ReadElementString());
+                            o = Read95_ULongEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6810,13 +7069,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read218_AttributeTesting() {
+        public object Read222_AttributeTesting() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id96_AttributeTesting && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read95_XmlSerializerAttributes(false, true);
+                    if (((object) Reader.LocalName == (object)id98_AttributeTesting && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read97_XmlSerializerAttributes(false, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6828,14 +7087,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read219_ItemChoiceType() {
+        public object Read223_ItemChoiceType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id97_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id99_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read94_ItemChoiceType(Reader.ReadElementString());
+                            o = Read96_ItemChoiceType(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6848,13 +7115,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read220_TypeWithAnyAttribute() {
+        public object Read224_TypeWithAnyAttribute() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id98_TypeWithAnyAttribute && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read96_TypeWithAnyAttribute(true, true);
+                    if (((object) Reader.LocalName == (object)id100_TypeWithAnyAttribute && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read98_TypeWithAnyAttribute(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6866,13 +7133,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read221_KnownTypesThroughConstructor() {
+        public object Read225_KnownTypesThroughConstructor() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id99_KnownTypesThroughConstructor && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read97_KnownTypesThroughConstructor(true, true);
+                    if (((object) Reader.LocalName == (object)id101_KnownTypesThroughConstructor && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read99_KnownTypesThroughConstructor(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6884,13 +7151,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read222_SimpleKnownTypeValue() {
+        public object Read226_SimpleKnownTypeValue() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id100_SimpleKnownTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read98_SimpleKnownTypeValue(true, true);
+                    if (((object) Reader.LocalName == (object)id102_SimpleKnownTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read100_SimpleKnownTypeValue(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6902,12 +7169,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read223_Item() {
+        public object Read227_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id101_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id103_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         o = (global::SerializationTypes.ClassImplementingIXmlSerializable)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::SerializationTypes.ClassImplementingIXmlSerializable());
                         break;
                     }
@@ -6920,12 +7187,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read224_Item() {
+        public object Read228_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id102_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id104_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         o = (global::SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)System.Activator.CreateInstance(typeof(global::SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor), System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.CreateInstance | System.Reflection.BindingFlags.NonPublic, null, new object[0], null));
                         break;
                     }
@@ -6938,12 +7205,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read225_Item() {
+        public object Read229_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id103_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id105_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         o = (global::SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor());
                         break;
                     }
@@ -6956,13 +7223,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read226_TypeWithPropertyNameSpecified() {
+        public object Read230_TypeWithPropertyNameSpecified() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id104_TypeWithPropertyNameSpecified && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read99_TypeWithPropertyNameSpecified(true, true);
+                    if (((object) Reader.LocalName == (object)id106_TypeWithPropertyNameSpecified && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read101_TypeWithPropertyNameSpecified(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6974,13 +7241,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read227_TypeWithXmlSchemaFormAttribute() {
+        public object Read231_TypeWithXmlSchemaFormAttribute() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id105_TypeWithXmlSchemaFormAttribute && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read100_TypeWithXmlSchemaFormAttribute(true, true);
+                    if (((object) Reader.LocalName == (object)id107_TypeWithXmlSchemaFormAttribute && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read102_TypeWithXmlSchemaFormAttribute(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6992,13 +7259,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read228_MyXmlType() {
+        public object Read232_MyXmlType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id106_MyXmlType && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read101_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id108_MyXmlType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read103_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7010,13 +7277,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read229_Item() {
+        public object Read233_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id107_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read102_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id109_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read104_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7028,13 +7295,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read230_CustomDocument() {
+        public object Read234_CustomDocument() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id108_CustomDocument && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read104_CustomDocument(true, true);
+                    if (((object) Reader.LocalName == (object)id110_CustomDocument && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read106_CustomDocument(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7046,13 +7313,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read231_CustomElement() {
+        public object Read235_CustomElement() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id109_CustomElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read103_CustomElement(true, true);
+                    if (((object) Reader.LocalName == (object)id111_CustomElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read105_CustomElement(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7064,7 +7331,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read232_Item() {
+        public object Read236_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7076,13 +7343,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read233_Item() {
+        public object Read237_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id110_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read105_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id112_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read107_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7094,13 +7361,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read234_ServerSettings() {
+        public object Read238_ServerSettings() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id111_ServerSettings && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read106_ServerSettings(true, true);
+                    if (((object) Reader.LocalName == (object)id113_ServerSettings && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read108_ServerSettings(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7112,13 +7379,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read235_TypeWithXmlQualifiedName() {
+        public object Read239_TypeWithXmlQualifiedName() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id112_TypeWithXmlQualifiedName && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read107_TypeWithXmlQualifiedName(true, true);
+                    if (((object) Reader.LocalName == (object)id114_TypeWithXmlQualifiedName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read109_TypeWithXmlQualifiedName(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7130,13 +7397,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read236_TypeWith2DArrayProperty2() {
+        public object Read240_TypeWith2DArrayProperty2() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id113_TypeWith2DArrayProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read108_TypeWith2DArrayProperty2(true, true);
+                    if (((object) Reader.LocalName == (object)id115_TypeWith2DArrayProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read110_TypeWith2DArrayProperty2(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7148,43 +7415,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read237_Item() {
-            object o = null;
-            Reader.MoveToContent();
-            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                do {
-                    if (((object) Reader.LocalName == (object)id114_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read109_Item(true, true);
-                        break;
-                    }
-                    throw CreateUnknownNodeException();
-                } while (false);
-            }
-            else {
-                UnknownNode(null, @":TypeWithPropertiesHavingDefaultValue");
-            }
-            return (object)o;
-        }
-
-        public object Read238_Item() {
-            object o = null;
-            Reader.MoveToContent();
-            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                do {
-                    if (((object) Reader.LocalName == (object)id115_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read110_Item(true, true);
-                        break;
-                    }
-                    throw CreateUnknownNodeException();
-                } while (false);
-            }
-            else {
-                UnknownNode(null, @":TypeWithEnumPropertyHavingDefaultValue");
-            }
-            return (object)o;
-        }
-
-        public object Read239_Item() {
+        public object Read241_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7197,30 +7428,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":TypeWithEnumFlagPropertyHavingDefaultValue");
+                UnknownNode(null, @":TypeWithPropertiesHavingDefaultValue");
             }
             return (object)o;
         }
 
-        public object Read240_TypeWithShouldSerializeMethod() {
+        public object Read242_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id117_TypeWithShouldSerializeMethod && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read112_TypeWithShouldSerializeMethod(true, true);
+                    if (((object) Reader.LocalName == (object)id117_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read112_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
                 } while (false);
             }
             else {
-                UnknownNode(null, @":TypeWithShouldSerializeMethod");
+                UnknownNode(null, @":TypeWithEnumPropertyHavingDefaultValue");
             }
             return (object)o;
         }
 
-        public object Read241_Item() {
+        public object Read243_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7233,30 +7464,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":BaseTypeWithShouldSerializeMethod");
+                UnknownNode(null, @":TypeWithEnumFlagPropertyHavingDefaultValue");
             }
             return (object)o;
         }
 
-        public object Read242_Item() {
+        public object Read244_TypeWithShouldSerializeMethod() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id119_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read114_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id119_TypeWithShouldSerializeMethod && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read114_TypeWithShouldSerializeMethod(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
                 } while (false);
             }
             else {
-                UnknownNode(null, @":DerivedTypeWithInheritedShouldSerialize");
+                UnknownNode(null, @":TypeWithShouldSerializeMethod");
             }
             return (object)o;
         }
 
-        public object Read243_Item() {
+        public object Read245_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7269,12 +7500,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":TypeWithFieldBackedSpecifiedMember");
+                UnknownNode(null, @":BaseTypeWithShouldSerializeMethod");
             }
             return (object)o;
         }
 
-        public object Read244_Item() {
+        public object Read246_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7287,12 +7518,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":KnownTypesThroughConstructorWithArrayProperties");
+                UnknownNode(null, @":DerivedTypeWithInheritedShouldSerialize");
             }
             return (object)o;
         }
 
-        public object Read245_Item() {
+        public object Read247_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7305,12 +7536,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":KnownTypesThroughConstructorWithValue");
+                UnknownNode(null, @":TypeWithFieldBackedSpecifiedMember");
             }
             return (object)o;
         }
 
-        public object Read246_Item() {
+        public object Read248_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7323,18 +7554,54 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":TypeWithTypesHavingCustomFormatter");
+                UnknownNode(null, @":KnownTypesThroughConstructorWithArrayProperties");
             }
             return (object)o;
         }
 
-        public object Read247_Item() {
+        public object Read249_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
                     if (((object) Reader.LocalName == (object)id124_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read119_Item(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":KnownTypesThroughConstructorWithValue");
+            }
+            return (object)o;
+        }
+
+        public object Read250_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id125_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         o = Read120_Item(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":TypeWithTypesHavingCustomFormatter");
+            }
+            return (object)o;
+        }
+
+        public object Read251_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id126_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read122_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7346,13 +7613,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read248_Item() {
+        public object Read252_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id125_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read123_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id127_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read125_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7364,14 +7631,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read249_MoreChoices() {
+        public object Read253_MoreChoices() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id126_MoreChoices && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id128_MoreChoices && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         {
-                            o = Read119_MoreChoices(Reader.ReadElementString());
+                            o = Read121_MoreChoices(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -7384,13 +7659,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read250_ComplexChoiceA() {
+        public object Read254_ComplexChoiceA() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id127_ComplexChoiceA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read122_ComplexChoiceA(true, true);
+                    if (((object) Reader.LocalName == (object)id129_ComplexChoiceA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read124_ComplexChoiceA(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7402,13 +7677,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read251_ComplexChoiceB() {
+        public object Read255_ComplexChoiceB() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id128_ComplexChoiceB && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read121_ComplexChoiceB(true, true);
+                    if (((object) Reader.LocalName == (object)id130_ComplexChoiceB && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read123_ComplexChoiceB(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7420,13 +7695,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read252_TypeWithFieldsOrdered() {
+        public object Read256_TypeWithFieldsOrdered() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id129_TypeWithFieldsOrdered && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read124_TypeWithFieldsOrdered(true, true);
+                    if (((object) Reader.LocalName == (object)id131_TypeWithFieldsOrdered && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read126_TypeWithFieldsOrdered(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7438,13 +7713,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read253_Item() {
+        public object Read257_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id130_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read125_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id132_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read127_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7456,13 +7731,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read254_Root() {
+        public object Read258_Root() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id131_Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read128_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id133_Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read130_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7474,13 +7749,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read255_TypeClashB() {
+        public object Read259_TypeClashB() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id132_TypeClashB && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read127_TypeNameClash(true, true);
+                    if (((object) Reader.LocalName == (object)id134_TypeClashB && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read129_TypeNameClash(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7492,13 +7767,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read256_TypeClashA() {
+        public object Read260_TypeClashA() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id133_TypeClashA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read126_TypeNameClash(true, true);
+                    if (((object) Reader.LocalName == (object)id135_TypeClashA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read128_TypeNameClash(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7510,13 +7785,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read257_Person() {
+        public object Read261_Person() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id134_Person && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read129_Person(true, true);
+                    if (((object) Reader.LocalName == (object)id136_Person && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read131_Person(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7528,12 +7803,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        global::Outer.Person Read129_Person(bool isNullable, bool checkType) {
+        global::Outer.Person Read131_Person(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id134_Person && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id136_Person && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -7558,21 +7833,45 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id135_FirstName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id137_FirstName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@FirstName = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id136_MiddleName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id138_MiddleName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@MiddleName = Reader.ReadElementString();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id137_LastName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id139_LastName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@LastName = Reader.ReadElementString();
                             }
@@ -7591,12 +7890,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeNameClashA.TypeNameClash Read126_TypeNameClash(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeNameClashA.TypeNameClash Read128_TypeNameClash(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id133_TypeClashA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id135_TypeClashA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -7621,7 +7920,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -7640,12 +7947,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeNameClashB.TypeNameClash Read127_TypeNameClash(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeNameClashB.TypeNameClash Read129_TypeNameClash(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id132_TypeClashB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id134_TypeClashB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -7670,7 +7977,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -7689,12 +8004,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.NamespaceTypeNameClashContainer Read128_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.NamespaceTypeNameClashContainer Read130_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id139_ContainerType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id141_ContainerType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -7725,12 +8040,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id140_A && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            a_0 = (global::SerializationTypes.TypeNameClashA.TypeNameClash[])EnsureArrayIndex(a_0, ca_0, typeof(global::SerializationTypes.TypeNameClashA.TypeNameClash));a_0[ca_0++] = Read126_TypeNameClash(false, true);
+                        if (((object) Reader.LocalName == (object)id142_A && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            a_0 = (global::SerializationTypes.TypeNameClashA.TypeNameClash[])EnsureArrayIndex(a_0, ca_0, typeof(global::SerializationTypes.TypeNameClashA.TypeNameClash));a_0[ca_0++] = Read128_TypeNameClash(false, true);
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id141_B && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            a_1 = (global::SerializationTypes.TypeNameClashB.TypeNameClash[])EnsureArrayIndex(a_1, ca_1, typeof(global::SerializationTypes.TypeNameClashB.TypeNameClash));a_1[ca_1++] = Read127_TypeNameClash(false, true);
+                        if (((object) Reader.LocalName == (object)id143_B && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            a_1 = (global::SerializationTypes.TypeNameClashB.TypeNameClash[])EnsureArrayIndex(a_1, ca_1, typeof(global::SerializationTypes.TypeNameClashB.TypeNameClash));a_1[ca_1++] = Read129_TypeNameClash(false, true);
                             break;
                         }
                         UnknownNode((object)o, @":A, :B");
@@ -7747,12 +8062,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName Read125_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName Read127_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id132_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -7777,12 +8092,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id142_Value1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id144_Value1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Value1 = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id143_Value2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id145_Value2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Value2 = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -7812,104 +8127,108 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     return ReadTypedPrimitive(new System.Xml.XmlQualifiedName("anyType", "http://www.w3.org/2001/XMLSchema"));
                 }
                 else {
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id134_Person && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read129_Person(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id139_ContainerType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read128_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id132_TypeClashB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read127_TypeNameClash(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id133_TypeClashA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read126_TypeNameClash(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id136_Person && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read131_Person(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id141_ContainerType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read130_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id134_TypeClashB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read129_TypeNameClash(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id135_TypeClashA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read128_TypeNameClash(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id132_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read127_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id131_TypeWithFieldsOrdered && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read126_TypeWithFieldsOrdered(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id127_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read125_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id129_TypeWithFieldsOrdered && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read124_TypeWithFieldsOrdered(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id129_ComplexChoiceA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read124_ComplexChoiceA(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read123_ComplexChoiceB(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id126_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read122_Item(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id125_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read123_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id127_ComplexChoiceA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read122_ComplexChoiceA(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id128_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read121_ComplexChoiceB(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id124_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read120_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id124_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read119_Item(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id123_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read118_Item(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id122_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read117_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id121_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read116_Item(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id120_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read115_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id121_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read116_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id119_TypeWithShouldSerializeMethod && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read114_TypeWithShouldSerializeMethod(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id118_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read113_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id119_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read114_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id117_TypeWithShouldSerializeMethod && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read112_TypeWithShouldSerializeMethod(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id117_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read112_Item(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id116_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read111_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id115_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read110_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id114_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read109_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id113_TypeWith2DArrayProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read108_TypeWith2DArrayProperty2(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id112_TypeWithXmlQualifiedName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read107_TypeWithXmlQualifiedName(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id111_ServerSettings && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read106_ServerSettings(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id110_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read105_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id108_CustomDocument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read104_CustomDocument(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id109_CustomElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read103_CustomElement(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id106_MyXmlType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read101_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id105_TypeWithXmlSchemaFormAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read100_TypeWithXmlSchemaFormAttribute(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id104_TypeWithPropertyNameSpecified && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read99_TypeWithPropertyNameSpecified(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id100_SimpleKnownTypeValue && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read98_SimpleKnownTypeValue(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id99_KnownTypesThroughConstructor && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read97_KnownTypesThroughConstructor(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id98_TypeWithAnyAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read96_TypeWithAnyAttribute(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id144_XmlSerializerAttributes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read95_XmlSerializerAttributes(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id88_WithNullables && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read88_WithNullables(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id87_WithEnums && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read84_WithEnums(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id85_WithStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read81_WithStruct(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id86_SomeStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read80_SomeStruct(false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id84_ClassImplementsInterface && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read79_ClassImplementsInterface(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id81_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id82_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id115_TypeWith2DArrayProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read110_TypeWith2DArrayProperty2(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id114_TypeWithXmlQualifiedName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read109_TypeWithXmlQualifiedName(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id113_ServerSettings && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read108_ServerSettings(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id112_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read107_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id110_CustomDocument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read106_CustomDocument(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id111_CustomElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read105_CustomElement(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id108_MyXmlType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read103_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id107_TypeWithXmlSchemaFormAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read102_TypeWithXmlSchemaFormAttribute(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id106_TypeWithPropertyNameSpecified && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read101_TypeWithPropertyNameSpecified(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id102_SimpleKnownTypeValue && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read100_SimpleKnownTypeValue(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id101_KnownTypesThroughConstructor && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read99_KnownTypesThroughConstructor(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id100_TypeWithAnyAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read98_TypeWithAnyAttribute(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id146_XmlSerializerAttributes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read97_XmlSerializerAttributes(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id90_WithNullables && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read90_WithNullables(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id89_WithEnums && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read87_WithEnums(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id87_WithStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read84_WithStruct(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id88_SomeStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read83_SomeStruct(false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id86_ClassImplementsInterface && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read82_ClassImplementsInterface(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id83_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id84_Item))
+                        return Read80_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id82_SimpleDC && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read79_SimpleDC(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id81_TypeWithByteArrayAsXmlText && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read78_TypeWithByteArrayAsXmlText(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id80_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read77_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id80_SimpleDC && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read76_SimpleDC(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_TypeWithByteArrayAsXmlText && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read75_TypeWithByteArrayAsXmlText(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read74_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id75_BaseClassWithSamePropertyName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read71_BaseClassWithSamePropertyName(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id76_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read72_DerivedClassWithSameProperty(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read73_DerivedClassWithSameProperty2(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id74_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read70_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id73_TypeHasArrayOfASerializedAsB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read69_TypeHasArrayOfASerializedAsB(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id72_TypeB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read68_TypeB(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id71_TypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read67_TypeA(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_BaseClassWithSamePropertyName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read74_BaseClassWithSamePropertyName(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read75_DerivedClassWithSameProperty(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read76_DerivedClassWithSameProperty2(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id76_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read73_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id75_TypeHasArrayOfASerializedAsB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read72_TypeHasArrayOfASerializedAsB(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id74_TypeB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read71_TypeB(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id73_TypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read70_TypeA(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id72_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read69_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id71_TypeWithBuiltInTypedMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read68_TypeWithBuiltInTypedMembers(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id70_BuiltInTypes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read66_BuiltInTypes(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id69_DCClassWithEnumAndStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
@@ -7944,13 +8263,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         return Read50_RootClass(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id51_Parameter && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read49_Parameter(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id145_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id147_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read48_ParameterOfString(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id146_MsgDocumentType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id49_httpexamplecom))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id148_MsgDocumentType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id49_httpexamplecom))
                         return Read47_MsgDocumentType(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id47_TypeWithLinkedProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read46_TypeWithLinkedProperty(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id147_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id149_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read45_Item(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id45_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read44_Item(isNullable, false);
@@ -8036,8 +8355,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id148_ArrayOfOrderedItem && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id30_httpwwwcontoso1com)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id150_ArrayOfOrderedItem && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id30_httpwwwcontoso1com)) {
                         global::OrderedItem[] a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             global::OrderedItem[] z_0_0 = null;
                             int cz_0_0 = 0;
@@ -8068,8 +8395,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id149_ArrayOfInt && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id151_ArrayOfInt && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.Int32> a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(a) == null) a = new global::System.Collections.Generic.List<global::System.Int32>();
                             global::System.Collections.Generic.List<global::System.Int32> z_0_0 = (global::System.Collections.Generic.List<global::System.Int32>)a;
@@ -8082,7 +8417,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 {
                                                     z_0_0.Add(System.Xml.XmlConvert.ToInt32(Reader.ReadElementString()));
                                                 }
@@ -8101,8 +8444,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id151_ArrayOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id153_ArrayOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.String> a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(a) == null) a = new global::System.Collections.Generic.List<global::System.String>();
                             global::System.Collections.Generic.List<global::System.String> z_0_0 = (global::System.Collections.Generic.List<global::System.String>)a;
@@ -8115,7 +8466,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id152_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 if (ReadNull()) {
                                                     z_0_0.Add(null);
                                                 }
@@ -8137,8 +8496,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id153_ArrayOfDouble && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id155_ArrayOfDouble && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.Double> a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(a) == null) a = new global::System.Collections.Generic.List<global::System.Double>();
                             global::System.Collections.Generic.List<global::System.Double> z_0_0 = (global::System.Collections.Generic.List<global::System.Double>)a;
@@ -8151,7 +8518,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id154_double && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id156_double && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 {
                                                     z_0_0.Add(System.Xml.XmlConvert.ToDouble(Reader.ReadElementString()));
                                                 }
@@ -8172,6 +8547,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     }
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id36_ArrayOfDateTime && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::MyCollection1 a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(a) == null) a = new global::MyCollection1();
                             global::MyCollection1 z_0_0 = (global::MyCollection1)a;
@@ -8185,6 +8568,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
                                             if (((object) Reader.LocalName == (object)id37_dateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 {
                                                     z_0_0.Add(ToDateTime(Reader.ReadElementString()));
                                                 }
@@ -8203,8 +8594,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id155_ArrayOfInstrument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id157_ArrayOfInstrument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::Instrument[] a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             global::Instrument[] z_0_0 = null;
                             int cz_0_0 = 0;
@@ -8235,8 +8634,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id156_ArrayOfTypeWithLinkedProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id158_ArrayOfTypeWithLinkedProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::TypeWithLinkedProperty> a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(a) == null) a = new global::System.Collections.Generic.List<global::TypeWithLinkedProperty>();
                             global::System.Collections.Generic.List<global::TypeWithLinkedProperty> z_0_0 = (global::System.Collections.Generic.List<global::TypeWithLinkedProperty>)a;
@@ -8266,8 +8673,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id157_ArrayOfParameter && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id159_ArrayOfParameter && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::Parameter> a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(a) == null) a = new global::System.Collections.Generic.List<global::Parameter>();
                             global::System.Collections.Generic.List<global::Parameter> z_0_0 = (global::System.Collections.Generic.List<global::Parameter>)a;
@@ -8297,8 +8712,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id158_ArrayOfXElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id160_ArrayOfXElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Xml.Linq.XElement[] a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             global::System.Xml.Linq.XElement[] z_0_0 = null;
                             int cz_0_0 = 0;
@@ -8311,7 +8734,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id159_XElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id161_XElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 z_0_0 = (global::System.Xml.Linq.XElement[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::System.Xml.Linq.XElement));z_0_0[cz_0_0++] = (global::System.Xml.Linq.XElement)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::System.Xml.Linq.XElement("default"), true
                                                 );
                                                 break;
@@ -8330,8 +8753,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id160_ArrayOfSimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id162_ArrayOfSimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.SimpleType[] a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             global::SerializationTypes.SimpleType[] z_0_0 = null;
                             int cz_0_0 = 0;
@@ -8364,6 +8795,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     }
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id64_ArrayOfAnyType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.MyList a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(a) == null) a = new global::SerializationTypes.MyList();
                             global::SerializationTypes.MyList z_0_0 = (global::SerializationTypes.MyList)a;
@@ -8399,8 +8838,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id161_ArrayOfTypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id163_ArrayOfTypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.TypeA[] a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             global::SerializationTypes.TypeA[] z_0_0 = null;
                             int cz_0_0 = 0;
@@ -8413,8 +8860,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id71_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                z_0_0 = (global::SerializationTypes.TypeA[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.TypeA));z_0_0[cz_0_0++] = Read67_TypeA(true, true);
+                                            if (((object) Reader.LocalName == (object)id73_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                z_0_0 = (global::SerializationTypes.TypeA[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.TypeA));z_0_0[cz_0_0++] = Read70_TypeA(true, true);
                                                 break;
                                             }
                                             UnknownNode(null, @":TypeA");
@@ -8431,62 +8878,70 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id83_EnumFlags && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id85_EnumFlags && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read78_EnumFlags(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read81_EnumFlags(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id92_IntEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id94_IntEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read82_IntEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read85_IntEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id91_ShortEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id93_ShortEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read83_ShortEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read86_ShortEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id89_ByteEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id91_ByteEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read89_ByteEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read91_ByteEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id90_SByteEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id92_SByteEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read90_SByteEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read92_SByteEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id93_UIntEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id95_UIntEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read91_UIntEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read93_UIntEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id94_LongEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id96_LongEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read92_LongEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read94_LongEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id95_ULongEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id97_ULongEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read93_ULongEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read95_ULongEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id97_ItemChoiceType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id99_ItemChoiceType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read94_ItemChoiceType(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read96_ItemChoiceType(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id162_ArrayOfItemChoiceType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id164_ArrayOfItemChoiceType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.ItemChoiceType[] a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             global::SerializationTypes.ItemChoiceType[] z_0_0 = null;
                             int cz_0_0 = 0;
@@ -8499,9 +8954,17 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id97_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id99_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 {
-                                                    z_0_0 = (global::SerializationTypes.ItemChoiceType[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.ItemChoiceType));z_0_0[cz_0_0++] = Read94_ItemChoiceType(Reader.ReadElementString());
+                                                    z_0_0 = (global::SerializationTypes.ItemChoiceType[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.ItemChoiceType));z_0_0[cz_0_0++] = Read96_ItemChoiceType(Reader.ReadElementString());
                                                 }
                                                 break;
                                             }
@@ -8519,8 +8982,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id151_ArrayOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id163_httpmynamespace)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id153_ArrayOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id165_httpmynamespace)) {
                         global::System.Object[] a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             global::System.Object[] z_0_0 = null;
                             int cz_0_0 = 0;
@@ -8533,7 +9004,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id152_string && (object) Reader.NamespaceURI == (object)id163_httpmynamespace)) {
+                                            if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id165_httpmynamespace)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 if (ReadNull()) {
                                                     z_0_0 = (global::System.Object[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::System.Object));z_0_0[cz_0_0++] = null;
                                                 }
@@ -8556,8 +9035,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id164_ArrayOfString1 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id166_ArrayOfString1 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.String> a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(a) == null) a = new global::System.Collections.Generic.List<global::System.String>();
                             global::System.Collections.Generic.List<global::System.String> z_0_0 = (global::System.Collections.Generic.List<global::System.String>)a;
@@ -8570,7 +9057,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id165_NoneParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id167_NoneParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 {
                                                     z_0_0.Add(Reader.ReadElementString());
                                                 }
@@ -8589,8 +9084,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id166_ArrayOfBoolean && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id168_ArrayOfBoolean && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.Boolean> a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             if ((object)(a) == null) a = new global::System.Collections.Generic.List<global::System.Boolean>();
                             global::System.Collections.Generic.List<global::System.Boolean> z_0_0 = (global::System.Collections.Generic.List<global::System.Boolean>)a;
@@ -8603,7 +9106,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id167_QualifiedParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id169_QualifiedParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 {
                                                     z_0_0.Add(System.Xml.XmlConvert.ToBoolean(Reader.ReadElementString()));
                                                 }
@@ -8622,8 +9133,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id168_ArrayOfArrayOfSimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id170_ArrayOfArrayOfSimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.SimpleType[][] a = null;
+                        if (!GetNullAttr()) {
+                            while (Reader.MoveToNextAttribute()) {
+                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                    UnknownNode(null);
+                                }
+                            }
+                            Reader.MoveToElement();
+                        }
                         if (!ReadNull()) {
                             global::SerializationTypes.SimpleType[][] z_0_0 = null;
                             int cz_0_0 = 0;
@@ -8637,6 +9156,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
                                             if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (!GetNullAttr()) {
+                                                    while (Reader.MoveToNextAttribute()) {
+                                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                                            UnknownNode(null);
+                                                        }
+                                                    }
+                                                    Reader.MoveToElement();
+                                                }
                                                 if (!ReadNull()) {
                                                     global::SerializationTypes.SimpleType[] z_0_0_0 = null;
                                                     int cz_0_0_0 = 0;
@@ -8681,9 +9208,9 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id126_MoreChoices && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id128_MoreChoices && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read119_MoreChoices(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read121_MoreChoices(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
@@ -8719,7 +9246,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.MoreChoices Read119_MoreChoices(string s) {
+        global::SerializationTypes.MoreChoices Read121_MoreChoices(string s) {
             switch (s) {
                 case @"None": return global::SerializationTypes.MoreChoices.@None;
                 case @"Item": return global::SerializationTypes.MoreChoices.@Item;
@@ -8758,14 +9285,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id169_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id171_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@P1 = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id170_P2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id172_P2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@P2 = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
@@ -8784,7 +9327,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ItemChoiceType Read94_ItemChoiceType(string s) {
+        global::SerializationTypes.ItemChoiceType Read96_ItemChoiceType(string s) {
             switch (s) {
                 case @"None": return global::SerializationTypes.ItemChoiceType.@None;
                 case @"Word": return global::SerializationTypes.ItemChoiceType.@Word;
@@ -8794,7 +9337,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.ULongEnum Read93_ULongEnum(string s) {
+        global::SerializationTypes.ULongEnum Read95_ULongEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.ULongEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.ULongEnum.@Option1;
@@ -8803,7 +9346,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.LongEnum Read92_LongEnum(string s) {
+        global::SerializationTypes.LongEnum Read94_LongEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.LongEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.LongEnum.@Option1;
@@ -8812,7 +9355,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.UIntEnum Read91_UIntEnum(string s) {
+        global::SerializationTypes.UIntEnum Read93_UIntEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.UIntEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.UIntEnum.@Option1;
@@ -8821,7 +9364,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.SByteEnum Read90_SByteEnum(string s) {
+        global::SerializationTypes.SByteEnum Read92_SByteEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.SByteEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.SByteEnum.@Option1;
@@ -8830,7 +9373,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.ByteEnum Read89_ByteEnum(string s) {
+        global::SerializationTypes.ByteEnum Read91_ByteEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.ByteEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.ByteEnum.@Option1;
@@ -8839,7 +9382,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.ShortEnum Read83_ShortEnum(string s) {
+        global::SerializationTypes.ShortEnum Read86_ShortEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.ShortEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.ShortEnum.@Option1;
@@ -8848,7 +9391,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.IntEnum Read82_IntEnum(string s) {
+        global::SerializationTypes.IntEnum Read85_IntEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.IntEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.IntEnum.@Option1;
@@ -8873,16 +9416,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.EnumFlags Read78_EnumFlags(string s) {
+        global::SerializationTypes.EnumFlags Read81_EnumFlags(string s) {
             return (global::SerializationTypes.EnumFlags)ToEnum(s, EnumFlagsValues, @"global::SerializationTypes.EnumFlags");
         }
 
-        global::SerializationTypes.TypeA Read67_TypeA(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeA Read70_TypeA(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id71_TypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id73_TypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -8907,7 +9450,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -8943,7 +9494,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id51_Parameter && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id145_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id147_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                     return Read48_ParameterOfString(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
@@ -8953,7 +9504,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::Parameter();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -8986,7 +9537,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id145_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id147_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -8997,7 +9548,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::Parameter<global::System.String>();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -9015,7 +9566,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id171_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Value = Reader.ReadElementString();
                             }
@@ -9066,12 +9625,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id172_Child && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id174_Child && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Child = Read46_TypeWithLinkedProperty(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id173_Children && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id175_Children && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@Children) == null) o.@Children = new global::System.Collections.Generic.List<global::TypeWithLinkedProperty>();
                                 global::System.Collections.Generic.List<global::TypeWithLinkedProperty> a_1_0 = (global::System.Collections.Generic.List<global::TypeWithLinkedProperty>)o.@Children;
@@ -9147,7 +9714,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -9196,21 +9771,45 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id174_IsValved && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id176_IsValved && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@IsValved = System.Xml.XmlConvert.ToBoolean(Reader.ReadElementString());
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id175_Modulation && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id177_Modulation && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Modulation = ToChar(Reader.ReadElementString());
                             }
@@ -9261,14 +9860,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id174_IsValved && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id176_IsValved && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@IsValved = System.Xml.XmlConvert.ToBoolean(Reader.ReadElementString());
                             }
@@ -9317,35 +9932,75 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id176_ItemName && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id178_ItemName && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@ItemName = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id177_Description && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id179_Description && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Description = Reader.ReadElementString();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id178_UnitPrice && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id180_UnitPrice && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@UnitPrice = System.Xml.XmlConvert.ToDecimal(Reader.ReadElementString());
                             }
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id179_Quantity && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id181_Quantity && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Quantity = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id180_LineTotal && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id182_LineTotal && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@LineTotal = System.Xml.XmlConvert.ToDecimal(Reader.ReadElementString());
                             }
@@ -9493,14 +10148,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id181_BinaryHexContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id183_BinaryHexContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@BinaryHexContent = ToByteArrayHex(false);
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id182_Base64Content && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id184_Base64Content && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Base64Content = ToByteArrayBase64(false);
                             }
@@ -9549,7 +10220,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id183_DTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id185_DTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -9562,7 +10241,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id184_DTO2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id186_DTO2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -9575,7 +10262,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id185_DefaultDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id187_DefaultDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -9591,12 +10286,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id186_NullableDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id188_NullableDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDTO = Read5_NullableOfDateTimeOffset(true);
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id187_NullableDefaultDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id189_NullableDefaultDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDTOWithDefault = Read5_NullableOfDateTimeOffset(true);
                             paramsRead[4] = true;
                             break;
@@ -9617,6 +10312,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             global::System.Nullable<global::System.DateTimeOffset> o = default(global::System.Nullable<global::System.DateTimeOffset>);
             if (ReadNull())
                 return o;
+            if (!GetNullAttr()) {
+                while (Reader.MoveToNextAttribute()) {
+                    if (!IsXmlnsAttribute(Reader.Name)) {
+                        UnknownNode(null);
+                    }
+                }
+                Reader.MoveToElement();
+            }
             {
                 if (Reader.IsEmptyElement) {
                     Reader.Skip();
@@ -9659,7 +10362,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id188_Today && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id190_Today && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -9672,7 +10383,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id189_MyDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id191_MyDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -9685,7 +10404,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id190_DefaultDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id192_DefaultDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -9701,22 +10428,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id191_NullableDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id193_NullableDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDate = Read7_NullableOfDateOnly(true);
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id192_NullableDateWithValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id194_NullableDateWithValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDateWithValue = Read7_NullableOfDateOnly(true);
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id193_NullableDefaultDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id195_NullableDefaultDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDefaultDate = Read7_NullableOfDateOnly(true);
                             paramsRead[5] = true;
                             break;
                         }
-                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id194_Now && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id196_Now && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -9729,7 +10464,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[6] = true;
                             break;
                         }
-                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id195_MyTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id197_MyTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -9742,7 +10485,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[7] = true;
                             break;
                         }
-                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id196_DefaultTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id198_DefaultTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -9758,17 +10509,17 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[8] = true;
                             break;
                         }
-                        if (!paramsRead[9] && ((object) Reader.LocalName == (object)id197_NullableTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[9] && ((object) Reader.LocalName == (object)id199_NullableTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableTime = Read8_NullableOfTimeOnly(true);
                             paramsRead[9] = true;
                             break;
                         }
-                        if (!paramsRead[10] && ((object) Reader.LocalName == (object)id198_NullableTimeWithValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[10] && ((object) Reader.LocalName == (object)id200_NullableTimeWithValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableTimeWithValue = Read8_NullableOfTimeOnly(true);
                             paramsRead[10] = true;
                             break;
                         }
-                        if (!paramsRead[11] && ((object) Reader.LocalName == (object)id199_NullableDefaultTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[11] && ((object) Reader.LocalName == (object)id201_NullableDefaultTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDefaultTime = Read8_NullableOfTimeOnly(true);
                             paramsRead[11] = true;
                             break;
@@ -9789,6 +10540,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             global::System.Nullable<global::System.TimeOnly> o = default(global::System.Nullable<global::System.TimeOnly>);
             if (ReadNull())
                 return o;
+            if (!GetNullAttr()) {
+                while (Reader.MoveToNextAttribute()) {
+                    if (!IsXmlnsAttribute(Reader.Name)) {
+                        UnknownNode(null);
+                    }
+                }
+                Reader.MoveToElement();
+            }
             {
                 if (Reader.IsEmptyElement) {
                     Reader.Skip();
@@ -9805,6 +10564,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             global::System.Nullable<global::System.DateOnly> o = default(global::System.Nullable<global::System.DateOnly>);
             if (ReadNull())
                 return o;
+            if (!GetNullAttr()) {
+                while (Reader.MoveToNextAttribute()) {
+                    if (!IsXmlnsAttribute(Reader.Name)) {
+                        UnknownNode(null);
+                    }
+                }
+                Reader.MoveToElement();
+            }
             {
                 if (Reader.IsEmptyElement) {
                     Reader.Skip();
@@ -9847,7 +10614,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id200_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -9902,7 +10677,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id200_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -9957,7 +10740,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id200_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -10012,7 +10803,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id200_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@TestValue = ToDate(Reader.ReadElementString());
                             }
@@ -10061,7 +10860,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id200_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@TestValue = ToTime(Reader.ReadElementString());
                             }
@@ -10110,7 +10917,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id201_TimeSpanProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id203_TimeSpanProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 if (Reader.IsEmptyElement) {
                                     Reader.Skip();
@@ -10165,7 +10980,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id201_TimeSpanProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id203_TimeSpanProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -10181,7 +11004,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id202_TimeSpanProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id204_TimeSpanProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -10239,7 +11070,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id203_ByteProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id205_ByteProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@ByteProperty = System.Xml.XmlConvert.ToByte(Reader.ReadElementString());
                             }
@@ -10339,21 +11178,45 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id204_Age && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id206_Age && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Age = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id205_Breed && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id207_Breed && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Breed = Read20_DogBreed(Reader.ReadElementString());
                             }
@@ -10404,14 +11267,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id204_Age && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id206_Age && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Age = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -10460,7 +11339,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id206_LicenseNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id208_LicenseNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@LicenseNumber = Reader.ReadElementString();
                             }
@@ -10509,14 +11396,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id207_GroupName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id209_GroupName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@GroupName = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id208_GroupVehicle && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id210_GroupVehicle && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@GroupVehicle = Read22_Vehicle(false, true);
                             paramsRead[1] = true;
                             break;
@@ -10563,7 +11458,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id209_EmployeeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id211_EmployeeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@EmployeeName = Reader.ReadElementString();
                             }
@@ -10612,14 +11515,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id171_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Value = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id210_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id212_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@value = Reader.ReadElementString();
                             }
@@ -10670,14 +11589,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id171_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Value = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id210_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id212_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@value = Reader.ReadElementString();
                             }
@@ -10712,15 +11647,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SimpleDerivedClass();
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id211_AttributeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id213_AttributeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@AttributeString = Reader.Value;
                     paramsRead[0] = true;
                 }
-                else if (!paramsRead[1] && ((object) Reader.LocalName == (object)id212_DateTimeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                else if (!paramsRead[1] && ((object) Reader.LocalName == (object)id214_DateTimeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@DateTimeValue = ToDateTime(Reader.Value);
                     paramsRead[1] = true;
                 }
-                else if (!paramsRead[2] && ((object) Reader.LocalName == (object)id213_BoolValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                else if (!paramsRead[2] && ((object) Reader.LocalName == (object)id215_BoolValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@BoolValue = System.Xml.XmlConvert.ToBoolean(Reader.Value);
                     paramsRead[2] = true;
                 }
@@ -10766,11 +11701,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SimpleBaseClass();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id211_AttributeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id213_AttributeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@AttributeString = Reader.Value;
                     paramsRead[0] = true;
                 }
-                else if (!paramsRead[1] && ((object) Reader.LocalName == (object)id212_DateTimeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                else if (!paramsRead[1] && ((object) Reader.LocalName == (object)id214_DateTimeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@DateTimeValue = ToDateTime(Reader.Value);
                     paramsRead[1] = true;
                 }
@@ -10814,7 +11749,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::Address();
             System.Span<bool> paramsRead = stackalloc bool[5];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -10832,28 +11767,60 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id214_Line1 && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id216_Line1 && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Line1 = Reader.ReadElementString();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id215_City && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id217_City && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@City = Reader.ReadElementString();
                             }
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id216_State && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id218_State && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@State = Reader.ReadElementString();
                             }
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id217_Zip && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id219_Zip && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Zip = Reader.ReadElementString();
                             }
@@ -10904,19 +11871,35 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id218_ShipTo && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id220_ShipTo && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             o.@ShipTo = Read29_Address(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id219_OrderDate && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id221_OrderDate && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@OrderDate = Reader.ReadElementString();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id220_Items && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (((object) Reader.LocalName == (object)id222_Items && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::OrderedItem[] a_2_0 = null;
                                 int ca_2_0 = 0;
@@ -10947,21 +11930,45 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id221_SubTotal && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id223_SubTotal && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@SubTotal = System.Xml.XmlConvert.ToDecimal(Reader.ReadElementString());
                             }
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id222_ShipCost && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id224_ShipCost && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@ShipCost = System.Xml.XmlConvert.ToDecimal(Reader.ReadElementString());
                             }
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id223_TotalCost && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id225_TotalCost && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@TotalCost = System.Xml.XmlConvert.ToDecimal(Reader.ReadElementString());
                             }
@@ -10996,7 +12003,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::Address();
             System.Span<bool> paramsRead = stackalloc bool[5];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -11014,28 +12021,60 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id214_Line1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id216_Line1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Line1 = Reader.ReadElementString();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id215_City && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id217_City && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@City = Reader.ReadElementString();
                             }
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id216_State && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id218_State && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@State = Reader.ReadElementString();
                             }
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id217_Zip && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id219_Zip && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Zip = Reader.ReadElementString();
                             }
@@ -11084,35 +12123,75 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id176_ItemName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id178_ItemName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@ItemName = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id177_Description && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id179_Description && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Description = Reader.ReadElementString();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id178_UnitPrice && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id180_UnitPrice && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@UnitPrice = System.Xml.XmlConvert.ToDecimal(Reader.ReadElementString());
                             }
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id179_Quantity && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id181_Quantity && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Quantity = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id180_LineTotal && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id182_LineTotal && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@LineTotal = System.Xml.XmlConvert.ToDecimal(Reader.ReadElementString());
                             }
@@ -11161,7 +12240,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id224_X && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id226_X && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@Aliased) == null) o.@Aliased = new global::System.Collections.Generic.List<global::System.Int32>();
                                 global::System.Collections.Generic.List<global::System.Int32> a_0_0 = (global::System.Collections.Generic.List<global::System.Int32>)o.@Aliased;
@@ -11174,7 +12261,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_0_0.Add(System.Xml.XmlConvert.ToInt32(Reader.ReadElementString()));
                                                     }
@@ -11194,7 +12289,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id225_Y && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id227_Y && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@Aliased) == null) o.@Aliased = new global::System.Collections.Generic.List<global::System.String>();
                                 global::System.Collections.Generic.List<global::System.String> a_0_0 = (global::System.Collections.Generic.List<global::System.String>)o.@Aliased;
@@ -11207,7 +12310,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     if (ReadNull()) {
                                                         a_0_0.Add(null);
                                                     }
@@ -11230,7 +12341,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id226_Z && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id228_Z && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@Aliased) == null) o.@Aliased = new global::System.Collections.Generic.List<global::System.Double>();
                                 global::System.Collections.Generic.List<global::System.Double> a_0_0 = (global::System.Collections.Generic.List<global::System.Double>)o.@Aliased;
@@ -11243,7 +12362,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_double && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id156_double && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_0_0.Add(System.Xml.XmlConvert.ToDouble(Reader.ReadElementString()));
                                                     }
@@ -11307,7 +12434,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id227_Prop && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id229_Prop && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 a_0.Add(ToDateTime(Reader.ReadElementString()));
                             }
@@ -11359,7 +12494,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id227_Prop && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id229_Prop && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 a_0.Add(ToDateTime(Reader.ReadElementString()));
                             }
@@ -11409,7 +12552,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id228_Instruments && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id230_Instruments && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::Instrument[] a_0_0 = null;
                                 int ca_0_0 = 0;
@@ -11483,13 +12634,29 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
                         if (!paramsRead[0] && ((object) Reader.LocalName == (object)id16_Animal && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Animal = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id229_Comment2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id231_Comment2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Comment2 = Reader.ReadElementString();
                             }
@@ -11538,7 +12705,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id230_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id232_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11548,7 +12723,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id231_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id233_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11558,7 +12741,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id232_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id234_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11568,7 +12759,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id233_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id235_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11620,7 +12819,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id230_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id232_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11630,7 +12837,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id231_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id233_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11640,7 +12855,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id232_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id234_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11650,7 +12873,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id233_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id235_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11702,7 +12933,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id230_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id232_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11712,7 +12951,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id231_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id233_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11722,7 +12969,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id232_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id234_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11732,7 +12987,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id233_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id235_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -11759,7 +13022,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id147_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id149_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -11770,7 +13033,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::TypeWithMismatchBetweenAttributeAndPropertyType();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id234_IntValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id236_IntValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@IntValue = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[0] = true;
                 }
@@ -11803,7 +13066,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id146_MsgDocumentType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id49_httpexamplecom)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id148_MsgDocumentType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id49_httpexamplecom)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -11816,11 +13079,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_1 = 0;
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id235_id && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id237_id && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Id = CollapseWhitespace(Reader.Value);
                     paramsRead[0] = true;
                 }
-                else if (((object) Reader.LocalName == (object)id236_refs && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                else if (((object) Reader.LocalName == (object)id238_refs && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     string listValues = Reader.Value;
                     string[] vals = listValues.Split(null);
                     for (int i = 0; i < vals.Length; i++) {
@@ -11885,7 +13148,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id237_Parameters && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id239_Parameters && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@Parameters) == null) o.@Parameters = new global::System.Collections.Generic.List<global::Parameter>();
                                 global::System.Collections.Generic.List<global::Parameter> a_0_0 = (global::System.Collections.Generic.List<global::Parameter>)o.@Parameters;
@@ -11957,7 +13228,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id171_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Value = (global::System.Xml.Linq.XElement)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::System.Xml.Linq.XElement("default"), true
                             );
                             paramsRead[0] = true;
@@ -12011,7 +13282,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id238_xelement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id240_xelement && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@xelement = (global::System.Xml.Linq.XElement)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::System.Xml.Linq.XElement("default"), true
                             );
                             paramsRead[0] = true;
@@ -12061,7 +13332,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id239_xelements && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id241_xelements && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::System.Xml.Linq.XElement[] a_0_0 = null;
                                 int ca_0_0 = 0;
@@ -12074,7 +13353,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id159_XElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id161_XElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     a_0_0 = (global::System.Xml.Linq.XElement[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::System.Xml.Linq.XElement));a_0_0[ca_0_0++] = (global::System.Xml.Linq.XElement)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::System.Xml.Linq.XElement("default"), true
                                                     );
                                                     break;
@@ -12135,14 +13414,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id240_DateTimeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id242_DateTimeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@DateTimeString = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id241_CurrentDateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id243_CurrentDateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@CurrentDateTime = ToDateTime(Reader.ReadElementString());
                             }
@@ -12199,7 +13494,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id242_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id244_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::SerializationTypes.SimpleType[] a_0_0 = null;
                                 int ca_0_0 = 0;
@@ -12230,7 +13533,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id243_F2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id245_F2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::System.Int32[] a_1_0 = null;
                                 int ca_1_0 = 0;
@@ -12243,7 +13554,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_1_0 = (global::System.Int32[])EnsureArrayIndex(a_1_0, ca_1_0, typeof(global::System.Int32));a_1_0[ca_1_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                                                     }
@@ -12263,7 +13582,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id169_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id171_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::SerializationTypes.SimpleType[] a_2_0 = null;
                                 int ca_2_0 = 0;
@@ -12294,7 +13621,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id170_P2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id172_P2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::System.Int32[] a_3_0 = null;
                                 int ca_3_0 = 0;
@@ -12307,7 +13642,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_3_0 = (global::System.Int32[])EnsureArrayIndex(a_3_0, ca_3_0, typeof(global::System.Int32));a_3_0[ca_3_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                                                     }
@@ -12425,7 +13768,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id244_IntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id246_IntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::System.Int32[] a_0_0 = null;
                                 int ca_0_0 = 0;
@@ -12438,7 +13789,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_0_0 = (global::System.Int32[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::System.Int32));a_0_0[ca_0_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                                                     }
@@ -12458,7 +13817,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id245_NIntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id247_NIntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::System.Int32[] a_1_0 = null;
                                 int ca_1_0 = 0;
@@ -12471,7 +13838,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_1_0 = (global::System.Int32[])EnsureArrayIndex(a_1_0, ca_1_0, typeof(global::System.Int32));a_1_0[ca_1_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                                                     }
@@ -12491,7 +13866,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id246_IntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id248_IntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@IntLField) == null) o.@IntLField = new global::System.Collections.Generic.List<global::System.Int32>();
                                 global::System.Collections.Generic.List<global::System.Int32> a_2_0 = (global::System.Collections.Generic.List<global::System.Int32>)o.@IntLField;
@@ -12504,7 +13887,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_2_0.Add(System.Xml.XmlConvert.ToInt32(Reader.ReadElementString()));
                                                     }
@@ -12523,7 +13914,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id247_NIntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id249_NIntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@NIntLField) == null) o.@NIntLField = new global::System.Collections.Generic.List<global::System.Int32>();
                                 global::System.Collections.Generic.List<global::System.Int32> a_3_0 = (global::System.Collections.Generic.List<global::System.Int32>)o.@NIntLField;
@@ -12536,7 +13935,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_3_0.Add(System.Xml.XmlConvert.ToInt32(Reader.ReadElementString()));
                                                     }
@@ -12559,7 +13966,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id248_IntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id250_IntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::System.Int32[] a_4_0 = null;
                                 int ca_4_0 = 0;
@@ -12572,7 +13987,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_4_0 = (global::System.Int32[])EnsureArrayIndex(a_4_0, ca_4_0, typeof(global::System.Int32));a_4_0[ca_4_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                                                     }
@@ -12592,7 +14015,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id249_NIntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id251_NIntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::System.Int32[] a_5_0 = null;
                                 int ca_5_0 = 0;
@@ -12605,7 +14036,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_5_0 = (global::System.Int32[])EnsureArrayIndex(a_5_0, ca_5_0, typeof(global::System.Int32));a_5_0[ca_5_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                                                     }
@@ -12630,7 +14069,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id250_IntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id252_IntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@IntLProp) == null) o.@IntLProp = new global::System.Collections.Generic.List<global::System.Int32>();
                                 global::System.Collections.Generic.List<global::System.Int32> a_6_0 = (global::System.Collections.Generic.List<global::System.Int32>)o.@IntLProp;
@@ -12643,7 +14090,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_6_0.Add(System.Xml.XmlConvert.ToInt32(Reader.ReadElementString()));
                                                     }
@@ -12662,7 +14117,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id251_NIntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id253_NIntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@NIntLProp) == null) o.@NIntLProp = new global::System.Collections.Generic.List<global::System.Int32>();
                                 global::System.Collections.Generic.List<global::System.Int32> a_7_0 = (global::System.Collections.Generic.List<global::System.Int32>)o.@NIntLProp;
@@ -12675,7 +14138,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_7_0.Add(System.Xml.XmlConvert.ToInt32(Reader.ReadElementString()));
                                                     }
@@ -12742,7 +14213,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id210_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id212_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@value = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
@@ -12793,7 +14272,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id252_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id254_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@Collection) == null) o.@Collection = new global::SerializationTypes.MyCollection<global::System.String>();
                                 global::SerializationTypes.MyCollection<global::System.String> a_0_0 = (global::SerializationTypes.MyCollection<global::System.String>)o.@Collection;
@@ -12806,7 +14293,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     if (ReadNull()) {
                                                         a_0_0.Add(null);
                                                     }
@@ -12871,7 +14366,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id252_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id254_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::SerializationTypes.MyCollection<global::System.String> a_0_0 = (global::SerializationTypes.MyCollection<global::System.String>)o.@Collection;
                                 if (((object)(a_0_0) == null) || (Reader.IsEmptyElement)) {
@@ -12883,7 +14386,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     if (ReadNull()) {
                                                         a_0_0.Add(null);
                                                     }
@@ -12947,14 +14458,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id242_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id244_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@F1 = Read62_MyEnum(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id169_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id171_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@P1 = Read62_MyEnum(Reader.ReadElementString());
                             }
@@ -13009,7 +14536,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id253_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id255_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Data = Reader.ReadElementString();
                             }
@@ -13058,12 +14593,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id254_MyStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id256_MyStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyStruct = Read64_DCStruct(true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id255_MyEnum1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id257_MyEnum1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@MyEnum1 = Read62_MyEnum(Reader.ReadElementString());
                             }
@@ -13112,7 +14655,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id256_ByteArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id258_ByteArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@ByteArray = ToByteArrayBase64(false);
                             }
@@ -13131,12 +14682,380 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeB Read68_TypeB(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithBuiltInTypedMembers Read68_TypeWithBuiltInTypedMembers(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id72_TypeB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id71_TypeWithBuiltInTypedMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            }
+            else {
+                throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
+            }
+            }
+            if (isNull) return null;
+            global::SerializationTypes.TypeWithBuiltInTypedMembers o;
+            o = new global::SerializationTypes.TypeWithBuiltInTypedMembers();
+            if ((object)(o.@ListMember) == null) o.@ListMember = new global::System.Collections.Generic.List<global::System.String>();
+            global::System.Collections.Generic.List<global::System.String> a_3 = (global::System.Collections.Generic.List<global::System.String>)o.@ListMember;
+            global::System.Int32[] a_4 = null;
+            int ca_4 = 0;
+            System.Span<bool> paramsRead = stackalloc bool[5];
+            while (Reader.MoveToNextAttribute()) {
+                if (!IsXmlnsAttribute(Reader.Name)) {
+                    UnknownNode((object)o);
+                }
+            }
+            Reader.MoveToElement();
+            if (Reader.IsEmptyElement) {
+                Reader.Skip();
+                return o;
+            }
+            Reader.ReadStartElement();
+            Reader.MoveToContent();
+            while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                    do {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id259_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
+                            {
+                                o.@StringMember = Reader.ReadElementString();
+                            }
+                            paramsRead[0] = true;
+                            break;
+                        }
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id260_IntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
+                            {
+                                o.@IntMember = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                            }
+                            paramsRead[1] = true;
+                            break;
+                        }
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id261_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@NullableIntMember = Read67_NullableOfInt32(true);
+                            paramsRead[2] = true;
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id262_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
+                            if (!ReadNull()) {
+                                if ((object)(o.@ListMember) == null) o.@ListMember = new global::System.Collections.Generic.List<global::System.String>();
+                                global::System.Collections.Generic.List<global::System.String> a_3_0 = (global::System.Collections.Generic.List<global::System.String>)o.@ListMember;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    if (ReadNull()) {
+                                                        a_3_0.Add(null);
+                                                    }
+                                                    else {
+                                                        a_3_0.Add(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":string");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":string");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id263_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
+                            if (!ReadNull()) {
+                                global::System.Int32[] a_4_0 = null;
+                                int ca_4_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_4_0 = (global::System.Int32[])EnsureArrayIndex(a_4_0, ca_4_0, typeof(global::System.Int32));a_4_0[ca_4_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@ArrayMember = (global::System.Int32[])ShrinkArray(a_4_0, ca_4_0, typeof(global::System.Int32), false);
+                            }
+                            break;
+                        }
+                        UnknownNode((object)o, @":StringMember, :IntMember, :NullableIntMember, :ListMember, :ArrayMember");
+                    } while (false);
+                }
+                else {
+                    UnknownNode((object)o, @":StringMember, :IntMember, :NullableIntMember, :ListMember, :ArrayMember");
+                }
+                Reader.MoveToContent();
+            }
+            ReadEndElement();
+            return o;
+        }
+
+        global::System.Nullable<global::System.Int32> Read67_NullableOfInt32(bool checkType) {
+            global::System.Nullable<global::System.Int32> o = default(global::System.Nullable<global::System.Int32>);
+            if (ReadNull())
+                return o;
+            if (!GetNullAttr()) {
+                while (Reader.MoveToNextAttribute()) {
+                    if (!IsXmlnsAttribute(Reader.Name)) {
+                        UnknownNode(null);
+                    }
+                }
+                Reader.MoveToElement();
+            }
+            {
+                o = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+            }
+            return o;
+        }
+
+        global::SerializationTypes.TypeWithNullableBuiltInTypedMembers Read69_Item(bool isNullable, bool checkType) {
+            System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
+            bool isNull = false;
+            if (isNullable) isNull = ReadNull();
+            if (checkType) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id72_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            }
+            else {
+                throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
+            }
+            }
+            if (isNull) return null;
+            global::SerializationTypes.TypeWithNullableBuiltInTypedMembers o;
+            o = new global::SerializationTypes.TypeWithNullableBuiltInTypedMembers();
+            global::System.Int32[] a_2 = null;
+            int ca_2 = 0;
+            if ((object)(o.@ListMember) == null) o.@ListMember = new global::System.Collections.Generic.List<global::System.String>();
+            global::System.Collections.Generic.List<global::System.String> a_3 = (global::System.Collections.Generic.List<global::System.String>)o.@ListMember;
+            System.Span<bool> paramsRead = stackalloc bool[4];
+            while (Reader.MoveToNextAttribute()) {
+                if (!IsXmlnsAttribute(Reader.Name)) {
+                    UnknownNode((object)o);
+                }
+            }
+            Reader.MoveToElement();
+            if (Reader.IsEmptyElement) {
+                Reader.Skip();
+                return o;
+            }
+            Reader.ReadStartElement();
+            Reader.MoveToContent();
+            while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                    do {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id259_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
+                            if (ReadNull()) {
+                                o.@StringMember = null;
+                            }
+                            else {
+                                o.@StringMember = Reader.ReadElementString();
+                            }
+                            paramsRead[0] = true;
+                            break;
+                        }
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id261_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@NullableIntMember = Read67_NullableOfInt32(true);
+                            paramsRead[1] = true;
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id263_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
+                            if (!ReadNull()) {
+                                global::System.Int32[] a_2_0 = null;
+                                int ca_2_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_2_0 = (global::System.Int32[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::System.Int32));a_2_0[ca_2_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@ArrayMember = (global::System.Int32[])ShrinkArray(a_2_0, ca_2_0, typeof(global::System.Int32), false);
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id262_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
+                            if (!ReadNull()) {
+                                if ((object)(o.@ListMember) == null) o.@ListMember = new global::System.Collections.Generic.List<global::System.String>();
+                                global::System.Collections.Generic.List<global::System.String> a_3_0 = (global::System.Collections.Generic.List<global::System.String>)o.@ListMember;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    if (ReadNull()) {
+                                                        a_3_0.Add(null);
+                                                    }
+                                                    else {
+                                                        a_3_0.Add(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":string");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":string");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                            }
+                            break;
+                        }
+                        UnknownNode((object)o, @":StringMember, :NullableIntMember, :ArrayMember, :ListMember");
+                    } while (false);
+                }
+                else {
+                    UnknownNode((object)o, @":StringMember, :NullableIntMember, :ArrayMember, :ListMember");
+                }
+                Reader.MoveToContent();
+            }
+            ReadEndElement();
+            return o;
+        }
+
+        global::SerializationTypes.TypeB Read71_TypeB(bool isNullable, bool checkType) {
+            System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
+            bool isNull = false;
+            if (isNullable) isNull = ReadNull();
+            if (checkType) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id74_TypeB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13161,7 +15080,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -13180,12 +15107,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeHasArrayOfASerializedAsB Read69_TypeHasArrayOfASerializedAsB(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeHasArrayOfASerializedAsB Read72_TypeHasArrayOfASerializedAsB(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id73_TypeHasArrayOfASerializedAsB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id75_TypeHasArrayOfASerializedAsB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13212,7 +15139,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id220_Items && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id222_Items && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::SerializationTypes.TypeA[] a_0_0 = null;
                                 int ca_0_0 = 0;
@@ -13225,8 +15160,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id71_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                    a_0_0 = (global::SerializationTypes.TypeA[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::SerializationTypes.TypeA));a_0_0[ca_0_0++] = Read67_TypeA(true, true);
+                                                if (((object) Reader.LocalName == (object)id73_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    a_0_0 = (global::SerializationTypes.TypeA[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::SerializationTypes.TypeA));a_0_0[ca_0_0++] = Read70_TypeA(true, true);
                                                     break;
                                                 }
                                                 UnknownNode(null, @":TypeA");
@@ -13255,12 +15190,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ Read70_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ Read73_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id74_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id76_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13285,7 +15220,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id257_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id264_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@PropertyNameWithSpecialCharacters漢ñ = Reader.ReadElementString();
                             }
@@ -13304,12 +15247,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.DerivedClassWithSameProperty2 Read73_DerivedClassWithSameProperty2(bool isNullable, bool checkType) {
+        global::SerializationTypes.DerivedClassWithSameProperty2 Read76_DerivedClassWithSameProperty2(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13336,28 +15279,60 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id258_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@StringProperty = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id259_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@IntProperty = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id260_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id267_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@DateTimeProperty = ToDateTime(Reader.ReadElementString());
                             }
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id261_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id268_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@ListProperty) == null) o.@ListProperty = new global::System.Collections.Generic.List<global::System.String>();
                                 global::System.Collections.Generic.List<global::System.String> a_3_0 = (global::System.Collections.Generic.List<global::System.String>)o.@ListProperty;
@@ -13370,7 +15345,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     if (ReadNull()) {
                                                         a_3_0.Add(null);
                                                     }
@@ -13404,16 +15387,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.DerivedClassWithSameProperty Read72_DerivedClassWithSameProperty(bool isNullable, bool checkType) {
+        global::SerializationTypes.DerivedClassWithSameProperty Read75_DerivedClassWithSameProperty(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id76_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read73_DerivedClassWithSameProperty2(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read76_DerivedClassWithSameProperty2(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
             }
@@ -13438,28 +15421,60 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id258_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@StringProperty = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id259_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@IntProperty = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id260_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id267_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@DateTimeProperty = ToDateTime(Reader.ReadElementString());
                             }
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id261_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id268_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@ListProperty) == null) o.@ListProperty = new global::System.Collections.Generic.List<global::System.String>();
                                 global::System.Collections.Generic.List<global::System.String> a_3_0 = (global::System.Collections.Generic.List<global::System.String>)o.@ListProperty;
@@ -13472,7 +15487,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     if (ReadNull()) {
                                                         a_3_0.Add(null);
                                                     }
@@ -13506,18 +15529,18 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.BaseClassWithSamePropertyName Read71_BaseClassWithSamePropertyName(bool isNullable, bool checkType) {
+        global::SerializationTypes.BaseClassWithSamePropertyName Read74_BaseClassWithSamePropertyName(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id75_BaseClassWithSamePropertyName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_BaseClassWithSamePropertyName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id76_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read72_DerivedClassWithSameProperty(isNullable, false);
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read73_DerivedClassWithSameProperty2(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read75_DerivedClassWithSameProperty(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read76_DerivedClassWithSameProperty2(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
             }
@@ -13542,28 +15565,60 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id258_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@StringProperty = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id259_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@IntProperty = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id260_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id267_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@DateTimeProperty = ToDateTime(Reader.ReadElementString());
                             }
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id261_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id268_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@ListProperty) == null) o.@ListProperty = new global::System.Collections.Generic.List<global::System.String>();
                                 global::System.Collections.Generic.List<global::System.String> a_3_0 = (global::System.Collections.Generic.List<global::System.String>)o.@ListProperty;
@@ -13576,7 +15631,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     if (ReadNull()) {
                                                         a_3_0.Add(null);
                                                     }
@@ -13610,12 +15673,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime Read74_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime Read77_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id80_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13657,12 +15720,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithByteArrayAsXmlText Read75_TypeWithByteArrayAsXmlText(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithByteArrayAsXmlText Read78_TypeWithByteArrayAsXmlText(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_TypeWithByteArrayAsXmlText && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id81_TypeWithByteArrayAsXmlText && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13704,12 +15767,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.SimpleDC Read76_SimpleDC(bool isNullable, bool checkType) {
+        global::SerializationTypes.SimpleDC Read79_SimpleDC(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id80_SimpleDC && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id82_SimpleDC && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13734,7 +15797,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id253_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id255_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Data = Reader.ReadElementString();
                             }
@@ -13753,12 +15824,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithXmlTextAttributeOnArray Read77_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithXmlTextAttributeOnArray Read80_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id81_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id82_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id83_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id84_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13804,12 +15875,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ClassImplementsInterface Read79_ClassImplementsInterface(bool isNullable, bool checkType) {
+        global::SerializationTypes.ClassImplementsInterface Read82_ClassImplementsInterface(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id84_ClassImplementsInterface && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id86_ClassImplementsInterface && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13834,28 +15905,60 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id262_ClassID && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id269_ClassID && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@ClassID = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id263_DisplayName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id270_DisplayName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@DisplayName = Reader.ReadElementString();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id264_Id && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id271_Id && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Id = Reader.ReadElementString();
                             }
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id265_IsLoaded && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id272_IsLoaded && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@IsLoaded = System.Xml.XmlConvert.ToBoolean(Reader.ReadElementString());
                             }
@@ -13874,11 +15977,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.SomeStruct Read80_SomeStruct(bool checkType) {
+        global::SerializationTypes.SomeStruct Read83_SomeStruct(bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id86_SomeStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id88_SomeStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13910,14 +16013,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_A && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id142_A && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@A = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id141_B && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id143_B && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@B = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
@@ -13936,12 +16055,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.WithStruct Read81_WithStruct(bool isNullable, bool checkType) {
+        global::SerializationTypes.WithStruct Read84_WithStruct(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id85_WithStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id87_WithStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13966,8 +16085,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id266_Some && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Some = Read80_SomeStruct(true);
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id273_Some && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Some = Read83_SomeStruct(true);
                             paramsRead[0] = true;
                             break;
                         }
@@ -13983,12 +16102,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.WithEnums Read84_WithEnums(bool isNullable, bool checkType) {
+        global::SerializationTypes.WithEnums Read87_WithEnums(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id87_WithEnums && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id89_WithEnums && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14013,16 +16132,32 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id267_Int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id274_Int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
-                                o.@Int = Read82_IntEnum(Reader.ReadElementString());
+                                o.@Int = Read85_IntEnum(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id268_Short && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id275_Short && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
-                                o.@Short = Read83_ShortEnum(Reader.ReadElementString());
+                                o.@Short = Read86_ShortEnum(Reader.ReadElementString());
                             }
                             paramsRead[1] = true;
                             break;
@@ -14039,12 +16174,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.WithNullables Read88_WithNullables(bool isNullable, bool checkType) {
+        global::SerializationTypes.WithNullables Read90_WithNullables(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id88_WithNullables && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id90_WithNullables && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14069,33 +16204,33 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id269_Optional && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Optional = Read85_NullableOfIntEnum(true);
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_Optional && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Optional = Read88_NullableOfIntEnum(true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id270_Optionull && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Optionull = Read85_NullableOfIntEnum(true);
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_Optionull && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Optionull = Read88_NullableOfIntEnum(true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id271_OptionalInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@OptionalInt = Read86_NullableOfInt32(true);
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id278_OptionalInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@OptionalInt = Read67_NullableOfInt32(true);
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id272_OptionullInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@OptionullInt = Read86_NullableOfInt32(true);
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id279_OptionullInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@OptionullInt = Read67_NullableOfInt32(true);
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id273_Struct1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Struct1 = Read87_NullableOfSomeStruct(true);
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id280_Struct1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Struct1 = Read89_NullableOfSomeStruct(true);
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id274_Struct2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Struct2 = Read87_NullableOfSomeStruct(true);
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id281_Struct2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Struct2 = Read89_NullableOfSomeStruct(true);
                             paramsRead[5] = true;
                             break;
                         }
@@ -14111,40 +16246,38 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::System.Nullable<global::SerializationTypes.SomeStruct> Read87_NullableOfSomeStruct(bool checkType) {
+        global::System.Nullable<global::SerializationTypes.SomeStruct> Read89_NullableOfSomeStruct(bool checkType) {
             global::System.Nullable<global::SerializationTypes.SomeStruct> o = default(global::System.Nullable<global::SerializationTypes.SomeStruct>);
             if (ReadNull())
                 return o;
-            o = Read80_SomeStruct(true);
+            o = Read83_SomeStruct(true);
             return o;
         }
 
-        global::System.Nullable<global::System.Int32> Read86_NullableOfInt32(bool checkType) {
-            global::System.Nullable<global::System.Int32> o = default(global::System.Nullable<global::System.Int32>);
-            if (ReadNull())
-                return o;
-            {
-                o = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
-            }
-            return o;
-        }
-
-        global::System.Nullable<global::SerializationTypes.IntEnum> Read85_NullableOfIntEnum(bool checkType) {
+        global::System.Nullable<global::SerializationTypes.IntEnum> Read88_NullableOfIntEnum(bool checkType) {
             global::System.Nullable<global::SerializationTypes.IntEnum> o = default(global::System.Nullable<global::SerializationTypes.IntEnum>);
             if (ReadNull())
                 return o;
+            if (!GetNullAttr()) {
+                while (Reader.MoveToNextAttribute()) {
+                    if (!IsXmlnsAttribute(Reader.Name)) {
+                        UnknownNode(null);
+                    }
+                }
+                Reader.MoveToElement();
+            }
             {
-                o = Read82_IntEnum(Reader.ReadElementString());
+                o = Read85_IntEnum(Reader.ReadElementString());
             }
             return o;
         }
 
-        global::SerializationTypes.XmlSerializerAttributes Read95_XmlSerializerAttributes(bool isNullable, bool checkType) {
+        global::SerializationTypes.XmlSerializerAttributes Read97_XmlSerializerAttributes(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id144_XmlSerializerAttributes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id146_XmlSerializerAttributes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14159,7 +16292,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_7 = 0;
             System.Span<bool> paramsRead = stackalloc bool[8];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[6] && ((object) Reader.LocalName == (object)id275_XmlAttributeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[6] && ((object) Reader.LocalName == (object)id282_XmlAttributeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@XmlAttributeProperty = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[6] = true;
                 }
@@ -14178,7 +16311,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 string tmp = null;
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_Word && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id283_Word && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@MyChoice = Reader.ReadElementString();
                             }
@@ -14186,7 +16327,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id277_Number && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id284_Number && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@MyChoice = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
@@ -14194,7 +16343,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id278_DecimalNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id285_DecimalNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@MyChoice = System.Xml.XmlConvert.ToDouble(Reader.ReadElementString());
                             }
@@ -14202,12 +16359,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id279_XmlIncludeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id286_XmlIncludeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@XmlIncludeProperty = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id280_XmlEnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id287_XmlEnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::SerializationTypes.ItemChoiceType[] a_2_0 = null;
                                 int ca_2_0 = 0;
@@ -14220,9 +16385,17 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id97_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id99_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
-                                                        a_2_0 = (global::SerializationTypes.ItemChoiceType[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::SerializationTypes.ItemChoiceType));a_2_0[ca_2_0++] = Read94_ItemChoiceType(Reader.ReadElementString());
+                                                        a_2_0 = (global::SerializationTypes.ItemChoiceType[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::SerializationTypes.ItemChoiceType));a_2_0[ca_2_0++] = Read96_ItemChoiceType(Reader.ReadElementString());
                                                     }
                                                     break;
                                                 }
@@ -14240,21 +16413,45 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id281_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id288_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@XmlNamespaceDeclarationsProperty = Reader.ReadElementString();
                             }
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id282_XmlElementPropertyNode && (object) Reader.NamespaceURI == (object)id283_httpelement)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id289_XmlElementPropertyNode && (object) Reader.NamespaceURI == (object)id290_httpelement)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@XmlElementProperty = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
                             paramsRead[5] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id284_CustomXmlArrayProperty && (object) Reader.NamespaceURI == (object)id163_httpmynamespace)) {
+                        if (((object) Reader.LocalName == (object)id291_CustomXmlArrayProperty && (object) Reader.NamespaceURI == (object)id165_httpmynamespace)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::System.Object[] a_7_0 = null;
                                 int ca_7_0 = 0;
@@ -14267,7 +16464,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_string && (object) Reader.NamespaceURI == (object)id163_httpmynamespace)) {
+                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id165_httpmynamespace)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     if (ReadNull()) {
                                                         a_7_0 = (global::System.Object[])EnsureArrayIndex(a_7_0, ca_7_0, typeof(global::System.Object));a_7_0[ca_7_0++] = null;
                                                     }
@@ -14309,12 +16514,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithAnyAttribute Read96_TypeWithAnyAttribute(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithAnyAttribute Read98_TypeWithAnyAttribute(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id98_TypeWithAnyAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id100_TypeWithAnyAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14327,7 +16532,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_2 = 0;
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id259_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@IntProperty = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[1] = true;
                 }
@@ -14349,7 +16554,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -14369,12 +16582,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.KnownTypesThroughConstructor Read97_KnownTypesThroughConstructor(bool isNullable, bool checkType) {
+        global::SerializationTypes.KnownTypesThroughConstructor Read99_KnownTypesThroughConstructor(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id99_KnownTypesThroughConstructor && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id101_KnownTypesThroughConstructor && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14399,12 +16612,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id285_EnumValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id292_EnumValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@EnumValue = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id286_SimpleTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id293_SimpleTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@SimpleTypeValue = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -14421,12 +16634,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.SimpleKnownTypeValue Read98_SimpleKnownTypeValue(bool isNullable, bool checkType) {
+        global::SerializationTypes.SimpleKnownTypeValue Read100_SimpleKnownTypeValue(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id100_SimpleKnownTypeValue && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id102_SimpleKnownTypeValue && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14451,7 +16664,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id287_StrProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id294_StrProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@StrProperty = Reader.ReadElementString();
                             }
@@ -14470,12 +16691,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithPropertyNameSpecified Read99_TypeWithPropertyNameSpecified(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithPropertyNameSpecified Read101_TypeWithPropertyNameSpecified(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id104_TypeWithPropertyNameSpecified && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id106_TypeWithPropertyNameSpecified && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14500,16 +16721,32 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id288_MyField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id295_MyField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyFieldSpecified = true;
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@MyField = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id289_MyFieldIgnored && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id296_MyFieldIgnored && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyFieldIgnoredSpecified = true;
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@MyFieldIgnored = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
@@ -14528,12 +16765,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithXmlSchemaFormAttribute Read100_TypeWithXmlSchemaFormAttribute(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithXmlSchemaFormAttribute Read102_TypeWithXmlSchemaFormAttribute(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id105_TypeWithXmlSchemaFormAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id107_TypeWithXmlSchemaFormAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14564,7 +16801,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id290_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id297_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@UnqualifiedSchemaFormListProperty) == null) o.@UnqualifiedSchemaFormListProperty = new global::System.Collections.Generic.List<global::System.Int32>();
                                 global::System.Collections.Generic.List<global::System.Int32> a_0_0 = (global::System.Collections.Generic.List<global::System.Int32>)o.@UnqualifiedSchemaFormListProperty;
@@ -14577,7 +16822,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id150_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_0_0.Add(System.Xml.XmlConvert.ToInt32(Reader.ReadElementString()));
                                                     }
@@ -14596,7 +16849,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id291_NoneSchemaFormListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id298_NoneSchemaFormListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@NoneSchemaFormListProperty) == null) o.@NoneSchemaFormListProperty = new global::System.Collections.Generic.List<global::System.String>();
                                 global::System.Collections.Generic.List<global::System.String> a_1_0 = (global::System.Collections.Generic.List<global::System.String>)o.@NoneSchemaFormListProperty;
@@ -14609,7 +16870,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id165_NoneParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id167_NoneParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_1_0.Add(Reader.ReadElementString());
                                                     }
@@ -14628,7 +16897,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id292_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id299_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 if ((object)(o.@QualifiedSchemaFormListProperty) == null) o.@QualifiedSchemaFormListProperty = new global::System.Collections.Generic.List<global::System.Boolean>();
                                 global::System.Collections.Generic.List<global::System.Boolean> a_2_0 = (global::System.Collections.Generic.List<global::System.Boolean>)o.@QualifiedSchemaFormListProperty;
@@ -14641,7 +16918,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id167_QualifiedParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id169_QualifiedParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     {
                                                         a_2_0.Add(System.Xml.XmlConvert.ToBoolean(Reader.ReadElementString()));
                                                     }
@@ -14672,12 +16957,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute Read101_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute Read103_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id106_MyXmlType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id108_MyXmlType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14688,7 +16973,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id293_XmlAttributeForm && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id300_XmlAttributeForm && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@XmlAttributeForm = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -14716,12 +17001,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.CustomElement Read103_CustomElement(bool isNullable, bool checkType) {
+        global::SerializationTypes.CustomElement Read105_CustomElement(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id109_CustomElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id111_CustomElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14736,7 +17021,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_2 = 0;
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id294_name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id301_name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -14774,12 +17059,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.CustomDocument Read104_CustomDocument(bool isNullable, bool checkType) {
+        global::SerializationTypes.CustomDocument Read106_CustomDocument(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id108_CustomDocument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id110_CustomDocument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14809,8 +17094,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id295_customElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            if ((object)(a_0) == null) Reader.Skip(); else a_0.Add(Read103_CustomElement(false, true));
+                        if (((object) Reader.LocalName == (object)id302_customElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if ((object)(a_0) == null) Reader.Skip(); else a_0.Add(Read105_CustomElement(false, true));
                             break;
                         }
                         a_1 = (global::System.Xml.XmlNode[])EnsureArrayIndex(a_1, ca_1, typeof(global::System.Xml.XmlNode));a_1[ca_1++] = (global::System.Xml.XmlNode)ReadXmlNode(false);
@@ -14826,12 +17111,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithNonPublicDefaultConstructor Read105_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithNonPublicDefaultConstructor Read107_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id110_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id112_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14864,7 +17149,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -14883,12 +17176,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ServerSettings Read106_ServerSettings(bool isNullable, bool checkType) {
+        global::SerializationTypes.ServerSettings Read108_ServerSettings(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id111_ServerSettings && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id113_ServerSettings && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14913,14 +17206,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id296_DS2Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id303_DS2Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@DS2Root = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id297_MetricConfigUrl && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id304_MetricConfigUrl && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@MetricConfigUrl = Reader.ReadElementString();
                             }
@@ -14939,12 +17248,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithXmlQualifiedName Read107_TypeWithXmlQualifiedName(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithXmlQualifiedName Read109_TypeWithXmlQualifiedName(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id112_TypeWithXmlQualifiedName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id114_TypeWithXmlQualifiedName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14969,7 +17278,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id171_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Value = ReadElementQualifiedName();
                             }
@@ -14988,12 +17305,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWith2DArrayProperty2 Read108_TypeWith2DArrayProperty2(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWith2DArrayProperty2 Read110_TypeWith2DArrayProperty2(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id113_TypeWith2DArrayProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id115_TypeWith2DArrayProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15020,7 +17337,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id298_TwoDArrayOfSimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id305_TwoDArrayOfSimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (!ReadNull()) {
                                 global::SerializationTypes.SimpleType[][] a_0_0 = null;
                                 int ca_0_0 = 0;
@@ -15034,6 +17359,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
                                                 if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (!GetNullAttr()) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
                                                     if (!ReadNull()) {
                                                         global::SerializationTypes.SimpleType[] a_0_0_0 = null;
                                                         int ca_0_0_0 = 0;
@@ -15090,12 +17423,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithPropertiesHavingDefaultValue Read109_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithPropertiesHavingDefaultValue Read111_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id114_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id116_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15120,21 +17453,45 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id299_EmptyStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id306_EmptyStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@EmptyStringProperty = Reader.ReadElementString();
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id258_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id265_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@StringProperty = Reader.ReadElementString();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id259_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -15144,7 +17501,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id300_CharProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id307_CharProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
@@ -15166,12 +17531,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue Read110_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue Read112_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id115_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id117_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15196,12 +17561,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id301_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id308_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
                             else {
-                                o.@EnumProperty = Read82_IntEnum(Reader.ReadElementString());
+                                o.@EnumProperty = Read85_IntEnum(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
@@ -15218,12 +17591,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue Read111_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue Read113_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id116_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id118_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15248,12 +17621,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id301_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id308_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             if (Reader.IsEmptyElement) {
                                 Reader.Skip();
                             }
                             else {
-                                o.@EnumProperty = Read78_EnumFlags(Reader.ReadElementString());
+                                o.@EnumProperty = Read81_EnumFlags(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
@@ -15270,12 +17651,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithShouldSerializeMethod Read112_TypeWithShouldSerializeMethod(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithShouldSerializeMethod Read114_TypeWithShouldSerializeMethod(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id117_TypeWithShouldSerializeMethod && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id119_TypeWithShouldSerializeMethod && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15300,7 +17681,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id302_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id309_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Foo = Reader.ReadElementString();
                             }
@@ -15319,12 +17708,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize Read114_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize Read116_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id119_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id121_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15335,7 +17724,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id303_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id310_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Bar = Reader.Value;
                     paramsRead[1] = true;
                 }
@@ -15353,7 +17742,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id302_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id309_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Foo = Reader.ReadElementString();
                             }
@@ -15372,16 +17769,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.BaseTypeWithShouldSerializeMethod Read113_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.BaseTypeWithShouldSerializeMethod Read115_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id118_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id120_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id119_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read114_Item(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id121_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read116_Item(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
             }
@@ -15390,7 +17787,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.BaseTypeWithShouldSerializeMethod();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id303_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id310_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Bar = Reader.Value;
                     paramsRead[1] = true;
                 }
@@ -15408,7 +17805,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id302_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id309_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Foo = Reader.ReadElementString();
                             }
@@ -15427,12 +17832,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithFieldBackedSpecifiedMember Read115_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithFieldBackedSpecifiedMember Read117_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id120_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id122_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15457,8 +17862,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id302_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id309_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@FooSpecified = true;
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Foo = Reader.ReadElementString();
                             }
@@ -15477,12 +17890,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties Read116_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties Read118_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id121_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id123_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15507,12 +17920,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id304_StringArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id311_StringArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@StringArrayValue = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id305_IntArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id312_IntArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@IntArrayValue = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -15529,12 +17942,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.KnownTypesThroughConstructorWithValue Read117_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.KnownTypesThroughConstructorWithValue Read119_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id122_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id124_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15559,7 +17972,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id171_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Value = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
@@ -15576,12 +17989,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithTypesHavingCustomFormatter Read118_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithTypesHavingCustomFormatter Read120_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id123_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id125_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15606,63 +18019,135 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id306_DateTimeContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id313_DateTimeContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@DateTimeContent = ToDateTime(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id307_QNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id314_QNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@QNameContent = ReadElementQualifiedName();
                             }
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id308_DateContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id315_DateContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@DateContent = ToDate(Reader.ReadElementString());
                             }
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id309_NameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id316_NameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@NameContent = ToXmlName(Reader.ReadElementString());
                             }
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id310_NCNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id317_NCNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@NCNameContent = ToXmlNCName(Reader.ReadElementString());
                             }
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id311_NMTOKENContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id318_NMTOKENContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@NMTOKENContent = ToXmlNmToken(Reader.ReadElementString());
                             }
                             paramsRead[5] = true;
                             break;
                         }
-                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id312_NMTOKENSContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id319_NMTOKENSContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@NMTOKENSContent = ToXmlNmTokens(Reader.ReadElementString());
                             }
                             paramsRead[6] = true;
                             break;
                         }
-                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id313_Base64BinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id320_Base64BinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Base64BinaryContent = ToByteArrayBase64(false);
                             }
                             paramsRead[7] = true;
                             break;
                         }
-                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id314_HexBinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id321_HexBinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@HexBinaryContent = ToByteArrayHex(false);
                             }
@@ -15681,12 +18166,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithArrayPropertyHavingChoice Read120_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithArrayPropertyHavingChoice Read122_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id124_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id126_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15717,14 +18202,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id315_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id322_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 a_0 = (global::System.Object[])EnsureArrayIndex(a_0, ca_0, typeof(global::System.Object));a_0[ca_0++] = Reader.ReadElementString();
                             }
                             choice_a_0 = (global::SerializationTypes.MoreChoices[])EnsureArrayIndex(choice_a_0, cchoice_a_0, typeof(global::SerializationTypes.MoreChoices));choice_a_0[cchoice_a_0++] = global::SerializationTypes.MoreChoices.@Item;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id316_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id323_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 a_0 = (global::System.Object[])EnsureArrayIndex(a_0, ca_0, typeof(global::System.Object));a_0[ca_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
@@ -15745,12 +18246,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ComplexChoiceB Read121_ComplexChoiceB(bool isNullable, bool checkType) {
+        global::SerializationTypes.ComplexChoiceB Read123_ComplexChoiceB(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id128_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15775,7 +18276,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -15794,16 +18303,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ComplexChoiceA Read122_ComplexChoiceA(bool isNullable, bool checkType) {
+        global::SerializationTypes.ComplexChoiceA Read124_ComplexChoiceA(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id127_ComplexChoiceA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id129_ComplexChoiceA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id128_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read121_ComplexChoiceB(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read123_ComplexChoiceB(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
             }
@@ -15826,7 +18335,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id138_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@Name = Reader.ReadElementString();
                             }
@@ -15845,12 +18362,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithPropertyHavingComplexChoice Read123_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithPropertyHavingComplexChoice Read125_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id125_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id127_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15881,12 +18398,20 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id315_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            a_0 = (global::System.Object[])EnsureArrayIndex(a_0, ca_0, typeof(global::System.Object));a_0[ca_0++] = Read122_ComplexChoiceA(false, true);
+                        if (((object) Reader.LocalName == (object)id322_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            a_0 = (global::System.Object[])EnsureArrayIndex(a_0, ca_0, typeof(global::System.Object));a_0[ca_0++] = Read124_ComplexChoiceA(false, true);
                             choice_a_0 = (global::SerializationTypes.MoreChoices[])EnsureArrayIndex(choice_a_0, cchoice_a_0, typeof(global::SerializationTypes.MoreChoices));choice_a_0[cchoice_a_0++] = global::SerializationTypes.MoreChoices.@Item;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id316_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id323_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 a_0 = (global::System.Object[])EnsureArrayIndex(a_0, ca_0, typeof(global::System.Object));a_0[ca_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
@@ -15907,12 +18432,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithFieldsOrdered Read124_TypeWithFieldsOrdered(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithFieldsOrdered Read126_TypeWithFieldsOrdered(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id129_TypeWithFieldsOrdered && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id131_TypeWithFieldsOrdered && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15939,7 +18464,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     switch (state) {
                     case 0:
-                        if (((object) Reader.LocalName == (object)id317_IntField2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id324_IntField2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@IntField2 = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
@@ -15947,7 +18480,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 1;
                         break;
                     case 1:
-                        if (((object) Reader.LocalName == (object)id318_IntField1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id325_IntField1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@IntField1 = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                             }
@@ -15955,7 +18496,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 2;
                         break;
                     case 2:
-                        if (((object) Reader.LocalName == (object)id319_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id326_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@StringField2 = Reader.ReadElementString();
                             }
@@ -15963,7 +18512,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 3;
                         break;
                     case 3:
-                        if (((object) Reader.LocalName == (object)id319_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id326_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!GetNullAttr()) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
                             {
                                 o.@StringField1 = Reader.ReadElementString();
                             }
@@ -15984,7 +18541,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithSchemaFormInXmlAttribute Read102_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithSchemaFormInXmlAttribute Read104_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
@@ -16000,7 +18557,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.TypeWithSchemaFormInXmlAttribute();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_TestProperty && (object) Reader.NamespaceURI == (object)id321_httptestcom)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id327_TestProperty && (object) Reader.NamespaceURI == (object)id328_httptestcom)) {
                     o.@TestProperty = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -16031,650 +18588,664 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         protected override void InitCallbacks() {
         }
 
-        string id309_NameContent;
-        string id85_WithStruct;
-        string id271_OptionalInt;
-        string id240_DateTimeString;
-        string id135_FirstName;
-        string id307_QNameContent;
-        string id302_Foo;
-        string id279_XmlIncludeProperty;
-        string id128_ComplexChoiceB;
-        string id283_httpelement;
-        string id167_QualifiedParameter;
-        string id46_RootElement;
-        string id44_Item;
-        string id113_TypeWith2DArrayProperty2;
-        string id45_Item;
-        string id96_AttributeTesting;
-        string id105_TypeWithXmlSchemaFormAttribute;
-        string id55_Item;
-        string id194_Now;
-        string id316_Amount;
-        string id178_UnitPrice;
-        string id272_OptionullInt;
-        string id193_NullableDefaultDate;
-        string id155_ArrayOfInstrument;
-        string id163_httpmynamespace;
-        string id151_ArrayOfString;
-        string id160_ArrayOfSimpleType;
-        string id258_StringProperty;
-        string id301_EnumProperty;
-        string id245_NIntAField;
-        string id210_value;
-        string id233_FloatProp;
-        string id297_MetricConfigUrl;
-        string id39_Instrument;
-        string id50_RootClass;
-        string id164_ArrayOfString1;
-        string id182_Base64Content;
-        string id244_IntAField;
-        string id143_Value2;
-        string id315_Item;
-        string id120_Item;
-        string id17_Dog;
-        string id76_DerivedClassWithSameProperty;
-        string id216_State;
-        string id10_DateTimeDateWrapper;
-        string id103_Item;
-        string id187_NullableDefaultDTO;
-        string id214_Line1;
-        string id223_TotalCost;
-        string id291_NoneSchemaFormListProperty;
-        string id278_DecimalNumber;
-        string id89_ByteEnum;
-        string id59_TypeWithGetOnlyArrayProperties;
-        string id156_ArrayOfTypeWithLinkedProperty;
-        string id20_Vehicle;
-        string id239_xelements;
-        string id241_CurrentDateTime;
-        string id222_ShipCost;
-        string id115_Item;
-        string id153_ArrayOfDouble;
-        string id14_TypeWithByteProperty;
-        string id162_ArrayOfItemChoiceType;
-        string id68_DCStruct;
-        string id248_IntAProp;
-        string id95_ULongEnum;
-        string id220_Items;
-        string id38_Orchestra;
-        string id126_MoreChoices;
-        string id146_MsgDocumentType;
-        string id13_Item;
-        string id242_F1;
-        string id138_Name;
-        string id41_Trumpet;
-        string id23_DerivedClass;
-        string id7_DateOnlyWrapper;
-        string id144_XmlSerializerAttributes;
-        string id204_Age;
-        string id270_Optionull;
-        string id42_Pet;
-        string id312_NMTOKENSContent;
-        string id64_ArrayOfAnyType;
-        string id90_SByteEnum;
-        string id79_TypeWithByteArrayAsXmlText;
-        string id261_ListProperty;
-        string id207_GroupName;
-        string id229_Comment2;
-        string id149_ArrayOfInt;
-        string id299_EmptyStringProperty;
-        string id80_SimpleDC;
-        string id227_Prop;
-        string id158_ArrayOfXElement;
-        string id267_Int;
-        string id5_Item;
-        string id287_StrProperty;
-        string id3_TypeWithXmlDocumentProperty;
-        string id295_customElement;
-        string id256_ByteArray;
-        string id262_ClassID;
-        string id176_ItemName;
-        string id249_NIntAProp;
-        string id246_IntLField;
-        string id282_XmlElementPropertyNode;
-        string id84_ClassImplementsInterface;
-        string id107_Item;
-        string id94_LongEnum;
-        string id16_Animal;
-        string id88_WithNullables;
-        string id280_XmlEnumProperty;
-        string id101_Item;
-        string id192_NullableDateWithValue;
-        string id116_Item;
-        string id286_SimpleTypeValue;
-        string id259_IntProperty;
-        string id189_MyDate;
-        string id1_TypeWithXmlElementProperty;
-        string id319_strfld;
-        string id321_httptestcom;
-        string id91_ShortEnum;
-        string id22_BaseClass;
-        string id121_Item;
-        string id28_DerivedIXmlSerializable;
-        string id274_Struct2;
-        string id19_Group;
-        string id268_Short;
-        string id202_TimeSpanProperty2;
-        string id32_OrderedItem;
-        string id97_ItemChoiceType;
-        string id303_Bar;
-        string id225_Y;
-        string id236_refs;
-        string id75_BaseClassWithSamePropertyName;
-        string id99_KnownTypesThroughConstructor;
-        string id275_XmlAttributeName;
-        string id169_P1;
-        string id27_Item;
-        string id161_ArrayOfTypeA;
-        string id108_CustomDocument;
-        string id111_ServerSettings;
-        string id4_TypeWithBinaryProperty;
-        string id30_httpwwwcontoso1com;
-        string id318_IntField1;
-        string id171_Value;
-        string id217_Zip;
-        string id157_ArrayOfParameter;
-        string id232_DoubleProp;
-        string id175_Modulation;
-        string id213_BoolValue;
-        string id224_X;
-        string id277_Number;
-        string id72_TypeB;
-        string id127_ComplexChoiceA;
-        string id228_Instruments;
-        string id257_Item;
-        string id65_anyType;
-        string id11_DateTimeTimeWrapper;
-        string id285_EnumValue;
-        string id281_Item;
-        string id264_Id;
-        string id154_double;
-        string id125_Item;
-        string id31_Address;
-        string id250_IntLProp;
-        string id173_Children;
-        string id137_LastName;
-        string id266_Some;
-        string id168_ArrayOfArrayOfSimpleType;
-        string id247_NIntLField;
-        string id117_TypeWithShouldSerializeMethod;
+        string id191_MyDate;
+        string id310_Bar;
+        string id309_Foo;
+        string id143_B;
+        string id131_TypeWithFieldsOrdered;
+        string id113_ServerSettings;
         string id118_Item;
-        string id33_AliasedTestType;
-        string id35_DerivedClass1;
-        string id131_Root;
-        string id43_DefaultValuesSetToNaN;
-        string id49_httpexamplecom;
-        string id304_StringArrayValue;
-        string id139_ContainerType;
-        string id212_DateTimeValue;
-        string id317_IntField2;
-        string id181_BinaryHexContent;
-        string id51_Parameter;
-        string id86_SomeStruct;
-        string id235_id;
-        string id54_XElementArrayWrapper;
-        string id110_Item;
-        string id174_IsValved;
-        string id62_TypeWithMyCollectionField;
-        string id201_TimeSpanProperty;
-        string id52_XElementWrapper;
-        string id195_MyTime;
-        string id8_TimeOnlyWrapper;
-        string id63_Item;
-        string id209_EmployeeName;
-        string id9_TimeOnlyAsXsdTimeWrapper;
-        string id134_Person;
-        string id77_DerivedClassWithSameProperty2;
-        string id73_TypeHasArrayOfASerializedAsB;
-        string id314_HexBinaryContent;
-        string id206_LicenseNumber;
-        string id15_TypeWithXmlNodeArrayProperty;
-        string id34_BaseClass1;
-        string id109_CustomElement;
-        string id185_DefaultDTO;
-        string id218_ShipTo;
-        string id221_SubTotal;
-        string id2_Item;
-        string id67_TypeWithEnumMembers;
-        string id305_IntArrayValue;
-        string id298_TwoDArrayOfSimpleType;
-        string id47_TypeWithLinkedProperty;
-        string id254_MyStruct;
-        string id98_TypeWithAnyAttribute;
-        string id29_PurchaseOrder;
-        string id243_F2;
-        string id60_TypeWithArraylikeMembers;
-        string id300_CharProperty;
-        string id141_B;
-        string id205_Breed;
-        string id122_Item;
-        string id288_MyField;
-        string id296_DS2Root;
-        string id37_dateTime;
-        string id26_BaseIXmlSerializable;
-        string id190_DefaultDate;
-        string id129_TypeWithFieldsOrdered;
-        string id152_string;
-        string id320_TestProperty;
-        string id24_SimpleBaseClass;
-        string id147_Item;
-        string id231_SingleField;
-        string id142_Value1;
-        string id83_EnumFlags;
-        string id87_WithEnums;
-        string id293_XmlAttributeForm;
-        string id114_Item;
-        string id48_Document;
-        string id82_Item;
-        string id306_DateTimeContent;
-        string id273_Struct1;
-        string id292_Item;
-        string id289_MyFieldIgnored;
-        string id6_Item;
-        string id188_Today;
-        string id81_Item;
-        string id69_DCClassWithEnumAndStruct;
-        string id253_Data;
-        string id226_Z;
-        string id124_Item;
-        string id58_TypeWithGetSetArrayMembers;
-        string id276_Word;
-        string id40_Brass;
-        string id265_IsLoaded;
+        string id263_ArrayMember;
+        string id237_id;
+        string id226_X;
+        string id327_TestProperty;
+        string id243_CurrentDateTime;
+        string id152_int;
+        string id132_Item;
+        string id276_Optional;
+        string id293_SimpleTypeValue;
+        string id81_TypeWithByteArrayAsXmlText;
+        string id216_Line1;
+        string id139_LastName;
+        string id171_P1;
         string id123_Item;
-        string id269_Optional;
-        string id74_Item;
+        string id262_ListMember;
+        string id303_DS2Root;
+        string id284_Number;
+        string id278_OptionalInt;
+        string id318_NMTOKENContent;
+        string id106_TypeWithPropertyNameSpecified;
+        string id214_DateTimeValue;
+        string id225_TotalCost;
+        string id280_Struct1;
+        string id141_ContainerType;
+        string id250_IntAProp;
+        string id203_TimeSpanProperty;
+        string id1_TypeWithXmlElementProperty;
+        string id224_ShipCost;
+        string id60_TypeWithArraylikeMembers;
+        string id23_DerivedClass;
         string id25_SimpleDerivedClass;
-        string id102_Item;
-        string id184_DTO2;
-        string id70_BuiltInTypes;
-        string id234_IntValue;
-        string id197_NullableTime;
-        string id100_SimpleKnownTypeValue;
-        string id310_NCNameContent;
-        string id208_GroupVehicle;
-        string id57_SimpleType;
-        string id290_Item;
-        string id136_MiddleName;
-        string id53_XElementStruct;
-        string id179_Quantity;
-        string id172_Child;
-        string id140_A;
-        string id170_P2;
-        string id284_CustomXmlArrayProperty;
-        string id211_AttributeString;
-        string id263_DisplayName;
-        string id148_ArrayOfOrderedItem;
-        string id255_MyEnum1;
-        string id183_DTO;
-        string id199_NullableDefaultTime;
-        string id119_Item;
-        string id106_MyXmlType;
-        string id145_ParameterOfString;
-        string id71_TypeA;
-        string id12_TypeWithTimeSpanProperty;
-        string id21_Employee;
-        string id112_TypeWithXmlQualifiedName;
-        string id177_Description;
-        string id230_DoubleField;
-        string id133_TypeClashA;
-        string id237_Parameters;
+        string id107_TypeWithXmlSchemaFormAttribute;
+        string id156_double;
+        string id254_Collection;
+        string id182_LineTotal;
+        string id164_ArrayOfItemChoiceType;
+        string id249_NIntLField;
+        string id135_TypeClashA;
+        string id88_SomeStruct;
+        string id71_TypeWithBuiltInTypedMembers;
+        string id89_WithEnums;
+        string id69_DCClassWithEnumAndStruct;
+        string id127_Item;
+        string id270_DisplayName;
+        string id257_MyEnum1;
+        string id189_NullableDefaultDTO;
+        string id242_DateTimeString;
+        string id306_EmptyStringProperty;
+        string id157_ArrayOfInstrument;
+        string id167_NoneParameter;
+        string id91_ByteEnum;
+        string id178_ItemName;
+        string id290_httpelement;
+        string id213_AttributeString;
+        string id44_Item;
+        string id239_Parameters;
+        string id144_Value1;
+        string id209_GroupName;
+        string id55_Item;
         string id61_StructNotSerializable;
-        string id252_Collection;
-        string id165_NoneParameter;
-        string id186_NullableDTO;
-        string id251_NIntLProp;
-        string id132_TypeClashB;
-        string id196_DefaultTime;
-        string id313_Base64BinaryContent;
-        string id308_DateContent;
-        string id92_IntEnum;
-        string id180_LineTotal;
-        string id56_TypeWithDateTimeStringProperty;
-        string id159_XElement;
-        string id294_name;
-        string id260_DateTimeProperty;
-        string id238_xelement;
-        string id191_NullableDate;
-        string id93_UIntEnum;
-        string id150_int;
-        string id200_TestValue;
-        string id203_ByteProperty;
-        string id198_NullableTimeWithValue;
+        string id133_Root;
+        string id222_Items;
+        string id58_TypeWithGetSetArrayMembers;
+        string id187_DefaultDTO;
+        string id15_TypeWithXmlNodeArrayProperty;
+        string id8_TimeOnlyWrapper;
+        string id104_Item;
+        string id185_DTO;
+        string id40_Brass;
+        string id198_DefaultTime;
+        string id80_Item;
+        string id174_Child;
+        string id291_CustomXmlArrayProperty;
+        string id180_UnitPrice;
+        string id256_MyStruct;
+        string id38_Orchestra;
+        string id62_TypeWithMyCollectionField;
+        string id116_Item;
+        string id192_DefaultDate;
+        string id241_xelements;
+        string id259_StringMember;
+        string id30_httpwwwcontoso1com;
+        string id193_NullableDate;
+        string id296_MyFieldIgnored;
+        string id160_ArrayOfXElement;
+        string id328_httptestcom;
+        string id230_Instruments;
+        string id39_Instrument;
+        string id288_Item;
+        string id24_SimpleBaseClass;
+        string id59_TypeWithGetOnlyArrayProperties;
+        string id121_Item;
+        string id246_IntAField;
+        string id110_CustomDocument;
+        string id49_httpexamplecom;
         string id66_MyEnum;
-        string id18_DogBreed;
-        string id219_OrderDate;
-        string id311_NMTOKENContent;
-        string id78_Item;
-        string id104_TypeWithPropertyNameSpecified;
+        string id252_IntLProp;
+        string id140_Name;
+        string id16_Animal;
+        string id159_ArrayOfParameter;
+        string id148_MsgDocumentType;
+        string id321_HexBinaryContent;
+        string id27_Item;
+        string id228_Z;
+        string id255_Data;
+        string id99_ItemChoiceType;
+        string id165_httpmynamespace;
+        string id251_NIntAProp;
+        string id301_name;
+        string id76_Item;
+        string id168_ArrayOfBoolean;
+        string id176_IsValved;
+        string id172_P2;
+        string id221_OrderDate;
+        string id311_StringArrayValue;
+        string id269_ClassID;
+        string id196_Now;
+        string id274_Int;
+        string id78_DerivedClassWithSameProperty;
+        string id47_TypeWithLinkedProperty;
+        string id64_ArrayOfAnyType;
+        string id75_TypeHasArrayOfASerializedAsB;
+        string id20_Vehicle;
+        string id147_ParameterOfString;
+        string id218_State;
+        string id272_IsLoaded;
+        string id204_TimeSpanProperty2;
+        string id298_NoneSchemaFormListProperty;
+        string id260_IntMember;
+        string id268_ListProperty;
+        string id93_ShortEnum;
+        string id314_QNameContent;
+        string id245_F2;
+        string id83_Item;
+        string id142_A;
+        string id68_DCStruct;
+        string id120_Item;
+        string id261_NullableIntMember;
+        string id258_ByteArray;
+        string id138_MiddleName;
+        string id267_DateTimeProperty;
+        string id279_OptionullInt;
+        string id207_Breed;
+        string id244_F1;
+        string id17_Dog;
+        string id9_TimeOnlyAsXsdTimeWrapper;
+        string id308_EnumProperty;
+        string id22_BaseClass;
+        string id325_IntField1;
+        string id129_ComplexChoiceA;
+        string id253_NIntLProp;
+        string id6_Item;
+        string id92_SByteEnum;
+        string id173_Value;
+        string id3_TypeWithXmlDocumentProperty;
+        string id109_Item;
+        string id14_TypeWithByteProperty;
+        string id11_DateTimeTimeWrapper;
+        string id114_TypeWithXmlQualifiedName;
+        string id286_XmlIncludeProperty;
+        string id155_ArrayOfDouble;
+        string id32_OrderedItem;
+        string id158_ArrayOfTypeWithLinkedProperty;
+        string id82_SimpleDC;
+        string id181_Quantity;
+        string id312_IntArrayValue;
+        string id45_Item;
+        string id183_BinaryHexContent;
+        string id37_dateTime;
+        string id205_ByteProperty;
+        string id289_XmlElementPropertyNode;
+        string id273_Some;
+        string id35_DerivedClass1;
+        string id315_DateContent;
+        string id186_DTO2;
+        string id271_Id;
+        string id201_NullableDefaultTime;
+        string id117_Item;
+        string id73_TypeA;
+        string id195_NullableDefaultDate;
+        string id219_Zip;
+        string id197_MyTime;
+        string id145_Value2;
+        string id211_EmployeeName;
+        string id316_NameContent;
+        string id161_XElement;
+        string id307_CharProperty;
+        string id95_UIntEnum;
+        string id319_NMTOKENSContent;
+        string id322_Item;
+        string id65_anyType;
+        string id275_Short;
+        string id94_IntEnum;
+        string id4_TypeWithBinaryProperty;
+        string id108_MyXmlType;
+        string id277_Optionull;
+        string id10_DateTimeDateWrapper;
+        string id232_DoubleField;
+        string id247_NIntAField;
+        string id84_Item;
+        string id2_Item;
+        string id48_Document;
+        string id217_City;
+        string id50_RootClass;
+        string id236_IntValue;
+        string id210_GroupVehicle;
+        string id282_XmlAttributeName;
+        string id302_customElement;
+        string id101_KnownTypesThroughConstructor;
+        string id283_Word;
+        string id126_Item;
+        string id150_ArrayOfOrderedItem;
+        string id90_WithNullables;
+        string id169_QualifiedParameter;
+        string id153_ArrayOfString;
+        string id285_DecimalNumber;
+        string id323_Amount;
+        string id128_MoreChoices;
+        string id305_TwoDArrayOfSimpleType;
+        string id151_ArrayOfInt;
+        string id227_Y;
+        string id281_Struct2;
+        string id26_BaseIXmlSerializable;
+        string id13_Item;
+        string id265_StringProperty;
+        string id212_value;
+        string id200_NullableTimeWithValue;
+        string id56_TypeWithDateTimeStringProperty;
+        string id5_Item;
+        string id223_SubTotal;
+        string id266_IntProperty;
+        string id100_TypeWithAnyAttribute;
+        string id21_Employee;
+        string id324_IntField2;
+        string id112_Item;
+        string id299_Item;
+        string id124_Item;
+        string id46_RootElement;
+        string id149_Item;
+        string id190_Today;
+        string id188_NullableDTO;
+        string id320_Base64BinaryContent;
+        string id74_TypeB;
+        string id231_Comment2;
+        string id86_ClassImplementsInterface;
+        string id292_EnumValue;
+        string id103_Item;
+        string id41_Trumpet;
+        string id137_FirstName;
+        string id162_ArrayOfSimpleType;
+        string id34_BaseClass1;
+        string id98_AttributeTesting;
+        string id67_TypeWithEnumMembers;
+        string id119_TypeWithShouldSerializeMethod;
+        string id304_MetricConfigUrl;
+        string id166_ArrayOfString1;
+        string id295_MyField;
         string id36_ArrayOfDateTime;
-        string id215_City;
-        string id130_Item;
-        string id166_ArrayOfBoolean;
+        string id175_Children;
+        string id313_DateTimeContent;
+        string id220_ShipTo;
+        string id31_Address;
+        string id33_AliasedTestType;
+        string id43_DefaultValuesSetToNaN;
+        string id294_StrProperty;
+        string id215_BoolValue;
+        string id51_Parameter;
+        string id206_Age;
+        string id229_Prop;
+        string id79_DerivedClassWithSameProperty2;
+        string id53_XElementStruct;
+        string id264_Item;
+        string id130_ComplexChoiceB;
+        string id18_DogBreed;
+        string id96_LongEnum;
+        string id297_Item;
+        string id111_CustomElement;
+        string id115_TypeWith2DArrayProperty2;
+        string id317_NCNameContent;
+        string id234_DoubleProp;
+        string id235_FloatProp;
+        string id300_XmlAttributeForm;
+        string id85_EnumFlags;
+        string id146_XmlSerializerAttributes;
+        string id199_NullableTime;
+        string id7_DateOnlyWrapper;
+        string id177_Modulation;
+        string id57_SimpleType;
+        string id52_XElementWrapper;
+        string id97_ULongEnum;
+        string id42_Pet;
+        string id154_string;
+        string id70_BuiltInTypes;
+        string id134_TypeClashB;
+        string id202_TestValue;
+        string id233_SingleField;
+        string id54_XElementArrayWrapper;
+        string id125_Item;
+        string id208_LicenseNumber;
+        string id105_Item;
+        string id12_TypeWithTimeSpanProperty;
+        string id63_Item;
+        string id238_refs;
+        string id72_Item;
+        string id122_Item;
+        string id102_SimpleKnownTypeValue;
+        string id163_ArrayOfTypeA;
+        string id240_xelement;
+        string id194_NullableDateWithValue;
+        string id19_Group;
+        string id248_IntLField;
+        string id28_DerivedIXmlSerializable;
+        string id136_Person;
+        string id170_ArrayOfArrayOfSimpleType;
+        string id326_strfld;
+        string id77_BaseClassWithSamePropertyName;
+        string id29_PurchaseOrder;
+        string id184_Base64Content;
+        string id179_Description;
+        string id287_XmlEnumProperty;
+        string id87_WithStruct;
 
         protected override void InitIDs() {
-            id309_NameContent = Reader.NameTable.Add(@"NameContent");
-            id85_WithStruct = Reader.NameTable.Add(@"WithStruct");
-            id271_OptionalInt = Reader.NameTable.Add(@"OptionalInt");
-            id240_DateTimeString = Reader.NameTable.Add(@"DateTimeString");
-            id135_FirstName = Reader.NameTable.Add(@"FirstName");
-            id307_QNameContent = Reader.NameTable.Add(@"QNameContent");
-            id302_Foo = Reader.NameTable.Add(@"Foo");
-            id279_XmlIncludeProperty = Reader.NameTable.Add(@"XmlIncludeProperty");
-            id128_ComplexChoiceB = Reader.NameTable.Add(@"ComplexChoiceB");
-            id283_httpelement = Reader.NameTable.Add(@"http://element");
-            id167_QualifiedParameter = Reader.NameTable.Add(@"QualifiedParameter");
-            id46_RootElement = Reader.NameTable.Add(@"RootElement");
-            id44_Item = Reader.NameTable.Add(@"DefaultValuesSetToPositiveInfinity");
-            id113_TypeWith2DArrayProperty2 = Reader.NameTable.Add(@"TypeWith2DArrayProperty2");
-            id45_Item = Reader.NameTable.Add(@"DefaultValuesSetToNegativeInfinity");
-            id96_AttributeTesting = Reader.NameTable.Add(@"AttributeTesting");
-            id105_TypeWithXmlSchemaFormAttribute = Reader.NameTable.Add(@"TypeWithXmlSchemaFormAttribute");
-            id55_Item = Reader.NameTable.Add(@"DateTimeOffsetIXmlSerializableContainer");
-            id194_Now = Reader.NameTable.Add(@"Now");
-            id316_Amount = Reader.NameTable.Add(@"Amount");
-            id178_UnitPrice = Reader.NameTable.Add(@"UnitPrice");
-            id272_OptionullInt = Reader.NameTable.Add(@"OptionullInt");
-            id193_NullableDefaultDate = Reader.NameTable.Add(@"NullableDefaultDate");
-            id155_ArrayOfInstrument = Reader.NameTable.Add(@"ArrayOfInstrument");
-            id163_httpmynamespace = Reader.NameTable.Add(@"http://mynamespace");
-            id151_ArrayOfString = Reader.NameTable.Add(@"ArrayOfString");
-            id160_ArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfSimpleType");
-            id258_StringProperty = Reader.NameTable.Add(@"StringProperty");
-            id301_EnumProperty = Reader.NameTable.Add(@"EnumProperty");
-            id245_NIntAField = Reader.NameTable.Add(@"NIntAField");
-            id210_value = Reader.NameTable.Add(@"value");
-            id233_FloatProp = Reader.NameTable.Add(@"FloatProp");
-            id297_MetricConfigUrl = Reader.NameTable.Add(@"MetricConfigUrl");
-            id39_Instrument = Reader.NameTable.Add(@"Instrument");
-            id50_RootClass = Reader.NameTable.Add(@"RootClass");
-            id164_ArrayOfString1 = Reader.NameTable.Add(@"ArrayOfString1");
-            id182_Base64Content = Reader.NameTable.Add(@"Base64Content");
-            id244_IntAField = Reader.NameTable.Add(@"IntAField");
-            id143_Value2 = Reader.NameTable.Add(@"Value2");
-            id315_Item = Reader.NameTable.Add(@"Item");
-            id120_Item = Reader.NameTable.Add(@"TypeWithFieldBackedSpecifiedMember");
-            id17_Dog = Reader.NameTable.Add(@"Dog");
-            id76_DerivedClassWithSameProperty = Reader.NameTable.Add(@"DerivedClassWithSameProperty");
-            id216_State = Reader.NameTable.Add(@"State");
-            id10_DateTimeDateWrapper = Reader.NameTable.Add(@"DateTimeDateWrapper");
-            id103_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithParameterlessConstructor");
-            id187_NullableDefaultDTO = Reader.NameTable.Add(@"NullableDefaultDTO");
-            id214_Line1 = Reader.NameTable.Add(@"Line1");
-            id223_TotalCost = Reader.NameTable.Add(@"TotalCost");
-            id291_NoneSchemaFormListProperty = Reader.NameTable.Add(@"NoneSchemaFormListProperty");
-            id278_DecimalNumber = Reader.NameTable.Add(@"DecimalNumber");
-            id89_ByteEnum = Reader.NameTable.Add(@"ByteEnum");
-            id59_TypeWithGetOnlyArrayProperties = Reader.NameTable.Add(@"TypeWithGetOnlyArrayProperties");
-            id156_ArrayOfTypeWithLinkedProperty = Reader.NameTable.Add(@"ArrayOfTypeWithLinkedProperty");
-            id20_Vehicle = Reader.NameTable.Add(@"Vehicle");
-            id239_xelements = Reader.NameTable.Add(@"xelements");
-            id241_CurrentDateTime = Reader.NameTable.Add(@"CurrentDateTime");
-            id222_ShipCost = Reader.NameTable.Add(@"ShipCost");
-            id115_Item = Reader.NameTable.Add(@"TypeWithEnumPropertyHavingDefaultValue");
-            id153_ArrayOfDouble = Reader.NameTable.Add(@"ArrayOfDouble");
-            id14_TypeWithByteProperty = Reader.NameTable.Add(@"TypeWithByteProperty");
-            id162_ArrayOfItemChoiceType = Reader.NameTable.Add(@"ArrayOfItemChoiceType");
-            id68_DCStruct = Reader.NameTable.Add(@"DCStruct");
-            id248_IntAProp = Reader.NameTable.Add(@"IntAProp");
-            id95_ULongEnum = Reader.NameTable.Add(@"ULongEnum");
-            id220_Items = Reader.NameTable.Add(@"Items");
-            id38_Orchestra = Reader.NameTable.Add(@"Orchestra");
-            id126_MoreChoices = Reader.NameTable.Add(@"MoreChoices");
-            id146_MsgDocumentType = Reader.NameTable.Add(@"MsgDocumentType");
-            id13_Item = Reader.NameTable.Add(@"TypeWithDefaultTimeSpanProperty");
-            id242_F1 = Reader.NameTable.Add(@"F1");
-            id138_Name = Reader.NameTable.Add(@"Name");
-            id41_Trumpet = Reader.NameTable.Add(@"Trumpet");
-            id23_DerivedClass = Reader.NameTable.Add(@"DerivedClass");
-            id7_DateOnlyWrapper = Reader.NameTable.Add(@"DateOnlyWrapper");
-            id144_XmlSerializerAttributes = Reader.NameTable.Add(@"XmlSerializerAttributes");
-            id204_Age = Reader.NameTable.Add(@"Age");
-            id270_Optionull = Reader.NameTable.Add(@"Optionull");
-            id42_Pet = Reader.NameTable.Add(@"Pet");
-            id312_NMTOKENSContent = Reader.NameTable.Add(@"NMTOKENSContent");
-            id64_ArrayOfAnyType = Reader.NameTable.Add(@"ArrayOfAnyType");
-            id90_SByteEnum = Reader.NameTable.Add(@"SByteEnum");
-            id79_TypeWithByteArrayAsXmlText = Reader.NameTable.Add(@"TypeWithByteArrayAsXmlText");
-            id261_ListProperty = Reader.NameTable.Add(@"ListProperty");
-            id207_GroupName = Reader.NameTable.Add(@"GroupName");
-            id229_Comment2 = Reader.NameTable.Add(@"Comment2");
-            id149_ArrayOfInt = Reader.NameTable.Add(@"ArrayOfInt");
-            id299_EmptyStringProperty = Reader.NameTable.Add(@"EmptyStringProperty");
-            id80_SimpleDC = Reader.NameTable.Add(@"SimpleDC");
-            id227_Prop = Reader.NameTable.Add(@"Prop");
-            id158_ArrayOfXElement = Reader.NameTable.Add(@"ArrayOfXElement");
-            id267_Int = Reader.NameTable.Add(@"Int");
-            id5_Item = Reader.NameTable.Add(@"TypeWithDateTimeOffsetProperties");
-            id287_StrProperty = Reader.NameTable.Add(@"StrProperty");
-            id3_TypeWithXmlDocumentProperty = Reader.NameTable.Add(@"TypeWithXmlDocumentProperty");
-            id295_customElement = Reader.NameTable.Add(@"customElement");
-            id256_ByteArray = Reader.NameTable.Add(@"ByteArray");
-            id262_ClassID = Reader.NameTable.Add(@"ClassID");
-            id176_ItemName = Reader.NameTable.Add(@"ItemName");
-            id249_NIntAProp = Reader.NameTable.Add(@"NIntAProp");
-            id246_IntLField = Reader.NameTable.Add(@"IntLField");
-            id282_XmlElementPropertyNode = Reader.NameTable.Add(@"XmlElementPropertyNode");
-            id84_ClassImplementsInterface = Reader.NameTable.Add(@"ClassImplementsInterface");
-            id107_Item = Reader.NameTable.Add(@"TypeWithSchemaFormInXmlAttribute");
-            id94_LongEnum = Reader.NameTable.Add(@"LongEnum");
-            id16_Animal = Reader.NameTable.Add(@"Animal");
-            id88_WithNullables = Reader.NameTable.Add(@"WithNullables");
-            id280_XmlEnumProperty = Reader.NameTable.Add(@"XmlEnumProperty");
-            id101_Item = Reader.NameTable.Add(@"ClassImplementingIXmlSerializable");
-            id192_NullableDateWithValue = Reader.NameTable.Add(@"NullableDateWithValue");
-            id116_Item = Reader.NameTable.Add(@"TypeWithEnumFlagPropertyHavingDefaultValue");
-            id286_SimpleTypeValue = Reader.NameTable.Add(@"SimpleTypeValue");
-            id259_IntProperty = Reader.NameTable.Add(@"IntProperty");
-            id189_MyDate = Reader.NameTable.Add(@"MyDate");
+            id191_MyDate = Reader.NameTable.Add(@"MyDate");
+            id310_Bar = Reader.NameTable.Add(@"Bar");
+            id309_Foo = Reader.NameTable.Add(@"Foo");
+            id143_B = Reader.NameTable.Add(@"B");
+            id131_TypeWithFieldsOrdered = Reader.NameTable.Add(@"TypeWithFieldsOrdered");
+            id113_ServerSettings = Reader.NameTable.Add(@"ServerSettings");
+            id118_Item = Reader.NameTable.Add(@"TypeWithEnumFlagPropertyHavingDefaultValue");
+            id263_ArrayMember = Reader.NameTable.Add(@"ArrayMember");
+            id237_id = Reader.NameTable.Add(@"id");
+            id226_X = Reader.NameTable.Add(@"X");
+            id327_TestProperty = Reader.NameTable.Add(@"TestProperty");
+            id243_CurrentDateTime = Reader.NameTable.Add(@"CurrentDateTime");
+            id152_int = Reader.NameTable.Add(@"int");
+            id132_Item = Reader.NameTable.Add(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName");
+            id276_Optional = Reader.NameTable.Add(@"Optional");
+            id293_SimpleTypeValue = Reader.NameTable.Add(@"SimpleTypeValue");
+            id81_TypeWithByteArrayAsXmlText = Reader.NameTable.Add(@"TypeWithByteArrayAsXmlText");
+            id216_Line1 = Reader.NameTable.Add(@"Line1");
+            id139_LastName = Reader.NameTable.Add(@"LastName");
+            id171_P1 = Reader.NameTable.Add(@"P1");
+            id123_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithArrayProperties");
+            id262_ListMember = Reader.NameTable.Add(@"ListMember");
+            id303_DS2Root = Reader.NameTable.Add(@"DS2Root");
+            id284_Number = Reader.NameTable.Add(@"Number");
+            id278_OptionalInt = Reader.NameTable.Add(@"OptionalInt");
+            id318_NMTOKENContent = Reader.NameTable.Add(@"NMTOKENContent");
+            id106_TypeWithPropertyNameSpecified = Reader.NameTable.Add(@"TypeWithPropertyNameSpecified");
+            id214_DateTimeValue = Reader.NameTable.Add(@"DateTimeValue");
+            id225_TotalCost = Reader.NameTable.Add(@"TotalCost");
+            id280_Struct1 = Reader.NameTable.Add(@"Struct1");
+            id141_ContainerType = Reader.NameTable.Add(@"ContainerType");
+            id250_IntAProp = Reader.NameTable.Add(@"IntAProp");
+            id203_TimeSpanProperty = Reader.NameTable.Add(@"TimeSpanProperty");
             id1_TypeWithXmlElementProperty = Reader.NameTable.Add(@"TypeWithXmlElementProperty");
-            id319_strfld = Reader.NameTable.Add(@"strfld");
-            id321_httptestcom = Reader.NameTable.Add(@"http://test.com");
-            id91_ShortEnum = Reader.NameTable.Add(@"ShortEnum");
-            id22_BaseClass = Reader.NameTable.Add(@"BaseClass");
-            id121_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithArrayProperties");
-            id28_DerivedIXmlSerializable = Reader.NameTable.Add(@"DerivedIXmlSerializable");
-            id274_Struct2 = Reader.NameTable.Add(@"Struct2");
-            id19_Group = Reader.NameTable.Add(@"Group");
-            id268_Short = Reader.NameTable.Add(@"Short");
-            id202_TimeSpanProperty2 = Reader.NameTable.Add(@"TimeSpanProperty2");
-            id32_OrderedItem = Reader.NameTable.Add(@"OrderedItem");
-            id97_ItemChoiceType = Reader.NameTable.Add(@"ItemChoiceType");
-            id303_Bar = Reader.NameTable.Add(@"Bar");
-            id225_Y = Reader.NameTable.Add(@"Y");
-            id236_refs = Reader.NameTable.Add(@"refs");
-            id75_BaseClassWithSamePropertyName = Reader.NameTable.Add(@"BaseClassWithSamePropertyName");
-            id99_KnownTypesThroughConstructor = Reader.NameTable.Add(@"KnownTypesThroughConstructor");
-            id275_XmlAttributeName = Reader.NameTable.Add(@"XmlAttributeName");
-            id169_P1 = Reader.NameTable.Add(@"P1");
-            id27_Item = Reader.NameTable.Add(@"http://example.com/serializer-test-namespace");
-            id161_ArrayOfTypeA = Reader.NameTable.Add(@"ArrayOfTypeA");
-            id108_CustomDocument = Reader.NameTable.Add(@"CustomDocument");
-            id111_ServerSettings = Reader.NameTable.Add(@"ServerSettings");
-            id4_TypeWithBinaryProperty = Reader.NameTable.Add(@"TypeWithBinaryProperty");
-            id30_httpwwwcontoso1com = Reader.NameTable.Add(@"http://www.contoso1.com");
-            id318_IntField1 = Reader.NameTable.Add(@"IntField1");
-            id171_Value = Reader.NameTable.Add(@"Value");
-            id217_Zip = Reader.NameTable.Add(@"Zip");
-            id157_ArrayOfParameter = Reader.NameTable.Add(@"ArrayOfParameter");
-            id232_DoubleProp = Reader.NameTable.Add(@"DoubleProp");
-            id175_Modulation = Reader.NameTable.Add(@"Modulation");
-            id213_BoolValue = Reader.NameTable.Add(@"BoolValue");
-            id224_X = Reader.NameTable.Add(@"X");
-            id277_Number = Reader.NameTable.Add(@"Number");
-            id72_TypeB = Reader.NameTable.Add(@"TypeB");
-            id127_ComplexChoiceA = Reader.NameTable.Add(@"ComplexChoiceA");
-            id228_Instruments = Reader.NameTable.Add(@"Instruments");
-            id257_Item = Reader.NameTable.Add(@"PropertyNameWithSpecialCharacters漢ñ");
-            id65_anyType = Reader.NameTable.Add(@"anyType");
-            id11_DateTimeTimeWrapper = Reader.NameTable.Add(@"DateTimeTimeWrapper");
-            id285_EnumValue = Reader.NameTable.Add(@"EnumValue");
-            id281_Item = Reader.NameTable.Add(@"XmlNamespaceDeclarationsProperty");
-            id264_Id = Reader.NameTable.Add(@"Id");
-            id154_double = Reader.NameTable.Add(@"double");
-            id125_Item = Reader.NameTable.Add(@"TypeWithPropertyHavingComplexChoice");
-            id31_Address = Reader.NameTable.Add(@"Address");
-            id250_IntLProp = Reader.NameTable.Add(@"IntLProp");
-            id173_Children = Reader.NameTable.Add(@"Children");
-            id137_LastName = Reader.NameTable.Add(@"LastName");
-            id266_Some = Reader.NameTable.Add(@"Some");
-            id168_ArrayOfArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfArrayOfSimpleType");
-            id247_NIntLField = Reader.NameTable.Add(@"NIntLField");
-            id117_TypeWithShouldSerializeMethod = Reader.NameTable.Add(@"TypeWithShouldSerializeMethod");
-            id118_Item = Reader.NameTable.Add(@"BaseTypeWithShouldSerializeMethod");
-            id33_AliasedTestType = Reader.NameTable.Add(@"AliasedTestType");
-            id35_DerivedClass1 = Reader.NameTable.Add(@"DerivedClass1");
-            id131_Root = Reader.NameTable.Add(@"Root");
-            id43_DefaultValuesSetToNaN = Reader.NameTable.Add(@"DefaultValuesSetToNaN");
-            id49_httpexamplecom = Reader.NameTable.Add(@"http://example.com");
-            id304_StringArrayValue = Reader.NameTable.Add(@"StringArrayValue");
-            id139_ContainerType = Reader.NameTable.Add(@"ContainerType");
-            id212_DateTimeValue = Reader.NameTable.Add(@"DateTimeValue");
-            id317_IntField2 = Reader.NameTable.Add(@"IntField2");
-            id181_BinaryHexContent = Reader.NameTable.Add(@"BinaryHexContent");
-            id51_Parameter = Reader.NameTable.Add(@"Parameter");
-            id86_SomeStruct = Reader.NameTable.Add(@"SomeStruct");
-            id235_id = Reader.NameTable.Add(@"id");
-            id54_XElementArrayWrapper = Reader.NameTable.Add(@"XElementArrayWrapper");
-            id110_Item = Reader.NameTable.Add(@"TypeWithNonPublicDefaultConstructor");
-            id174_IsValved = Reader.NameTable.Add(@"IsValved");
-            id62_TypeWithMyCollectionField = Reader.NameTable.Add(@"TypeWithMyCollectionField");
-            id201_TimeSpanProperty = Reader.NameTable.Add(@"TimeSpanProperty");
-            id52_XElementWrapper = Reader.NameTable.Add(@"XElementWrapper");
-            id195_MyTime = Reader.NameTable.Add(@"MyTime");
-            id8_TimeOnlyWrapper = Reader.NameTable.Add(@"TimeOnlyWrapper");
-            id63_Item = Reader.NameTable.Add(@"TypeWithReadOnlyMyCollectionProperty");
-            id209_EmployeeName = Reader.NameTable.Add(@"EmployeeName");
-            id9_TimeOnlyAsXsdTimeWrapper = Reader.NameTable.Add(@"TimeOnlyAsXsdTimeWrapper");
-            id134_Person = Reader.NameTable.Add(@"Person");
-            id77_DerivedClassWithSameProperty2 = Reader.NameTable.Add(@"DerivedClassWithSameProperty2");
-            id73_TypeHasArrayOfASerializedAsB = Reader.NameTable.Add(@"TypeHasArrayOfASerializedAsB");
-            id314_HexBinaryContent = Reader.NameTable.Add(@"HexBinaryContent");
-            id206_LicenseNumber = Reader.NameTable.Add(@"LicenseNumber");
-            id15_TypeWithXmlNodeArrayProperty = Reader.NameTable.Add(@"TypeWithXmlNodeArrayProperty");
-            id34_BaseClass1 = Reader.NameTable.Add(@"BaseClass1");
-            id109_CustomElement = Reader.NameTable.Add(@"CustomElement");
-            id185_DefaultDTO = Reader.NameTable.Add(@"DefaultDTO");
-            id218_ShipTo = Reader.NameTable.Add(@"ShipTo");
-            id221_SubTotal = Reader.NameTable.Add(@"SubTotal");
-            id2_Item = Reader.NameTable.Add(@"");
-            id67_TypeWithEnumMembers = Reader.NameTable.Add(@"TypeWithEnumMembers");
-            id305_IntArrayValue = Reader.NameTable.Add(@"IntArrayValue");
-            id298_TwoDArrayOfSimpleType = Reader.NameTable.Add(@"TwoDArrayOfSimpleType");
-            id47_TypeWithLinkedProperty = Reader.NameTable.Add(@"TypeWithLinkedProperty");
-            id254_MyStruct = Reader.NameTable.Add(@"MyStruct");
-            id98_TypeWithAnyAttribute = Reader.NameTable.Add(@"TypeWithAnyAttribute");
-            id29_PurchaseOrder = Reader.NameTable.Add(@"PurchaseOrder");
-            id243_F2 = Reader.NameTable.Add(@"F2");
+            id224_ShipCost = Reader.NameTable.Add(@"ShipCost");
             id60_TypeWithArraylikeMembers = Reader.NameTable.Add(@"TypeWithArraylikeMembers");
-            id300_CharProperty = Reader.NameTable.Add(@"CharProperty");
-            id141_B = Reader.NameTable.Add(@"B");
-            id205_Breed = Reader.NameTable.Add(@"Breed");
-            id122_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithValue");
-            id288_MyField = Reader.NameTable.Add(@"MyField");
-            id296_DS2Root = Reader.NameTable.Add(@"DS2Root");
-            id37_dateTime = Reader.NameTable.Add(@"dateTime");
-            id26_BaseIXmlSerializable = Reader.NameTable.Add(@"BaseIXmlSerializable");
-            id190_DefaultDate = Reader.NameTable.Add(@"DefaultDate");
-            id129_TypeWithFieldsOrdered = Reader.NameTable.Add(@"TypeWithFieldsOrdered");
-            id152_string = Reader.NameTable.Add(@"string");
-            id320_TestProperty = Reader.NameTable.Add(@"TestProperty");
-            id24_SimpleBaseClass = Reader.NameTable.Add(@"SimpleBaseClass");
-            id147_Item = Reader.NameTable.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType");
-            id231_SingleField = Reader.NameTable.Add(@"SingleField");
-            id142_Value1 = Reader.NameTable.Add(@"Value1");
-            id83_EnumFlags = Reader.NameTable.Add(@"EnumFlags");
-            id87_WithEnums = Reader.NameTable.Add(@"WithEnums");
-            id293_XmlAttributeForm = Reader.NameTable.Add(@"XmlAttributeForm");
-            id114_Item = Reader.NameTable.Add(@"TypeWithPropertiesHavingDefaultValue");
-            id48_Document = Reader.NameTable.Add(@"Document");
-            id82_Item = Reader.NameTable.Add(@"http://schemas.xmlsoap.org/ws/2005/04/discovery");
-            id306_DateTimeContent = Reader.NameTable.Add(@"DateTimeContent");
-            id273_Struct1 = Reader.NameTable.Add(@"Struct1");
-            id292_Item = Reader.NameTable.Add(@"QualifiedSchemaFormListProperty");
-            id289_MyFieldIgnored = Reader.NameTable.Add(@"MyFieldIgnored");
-            id6_Item = Reader.NameTable.Add(@"TypeWithDateAndTimeOnlyProperties");
-            id188_Today = Reader.NameTable.Add(@"Today");
-            id81_Item = Reader.NameTable.Add(@"TypeWithXmlTextAttributeOnArray");
-            id69_DCClassWithEnumAndStruct = Reader.NameTable.Add(@"DCClassWithEnumAndStruct");
-            id253_Data = Reader.NameTable.Add(@"Data");
-            id226_Z = Reader.NameTable.Add(@"Z");
-            id124_Item = Reader.NameTable.Add(@"TypeWithArrayPropertyHavingChoice");
-            id58_TypeWithGetSetArrayMembers = Reader.NameTable.Add(@"TypeWithGetSetArrayMembers");
-            id276_Word = Reader.NameTable.Add(@"Word");
-            id40_Brass = Reader.NameTable.Add(@"Brass");
-            id265_IsLoaded = Reader.NameTable.Add(@"IsLoaded");
-            id123_Item = Reader.NameTable.Add(@"TypeWithTypesHavingCustomFormatter");
-            id269_Optional = Reader.NameTable.Add(@"Optional");
-            id74_Item = Reader.NameTable.Add(@"__TypeNameWithSpecialCharacters漢ñ");
+            id23_DerivedClass = Reader.NameTable.Add(@"DerivedClass");
             id25_SimpleDerivedClass = Reader.NameTable.Add(@"SimpleDerivedClass");
-            id102_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor");
-            id184_DTO2 = Reader.NameTable.Add(@"DTO2");
-            id70_BuiltInTypes = Reader.NameTable.Add(@"BuiltInTypes");
-            id234_IntValue = Reader.NameTable.Add(@"IntValue");
-            id197_NullableTime = Reader.NameTable.Add(@"NullableTime");
-            id100_SimpleKnownTypeValue = Reader.NameTable.Add(@"SimpleKnownTypeValue");
-            id310_NCNameContent = Reader.NameTable.Add(@"NCNameContent");
-            id208_GroupVehicle = Reader.NameTable.Add(@"GroupVehicle");
-            id57_SimpleType = Reader.NameTable.Add(@"SimpleType");
-            id290_Item = Reader.NameTable.Add(@"UnqualifiedSchemaFormListProperty");
-            id136_MiddleName = Reader.NameTable.Add(@"MiddleName");
-            id53_XElementStruct = Reader.NameTable.Add(@"XElementStruct");
-            id179_Quantity = Reader.NameTable.Add(@"Quantity");
-            id172_Child = Reader.NameTable.Add(@"Child");
-            id140_A = Reader.NameTable.Add(@"A");
-            id170_P2 = Reader.NameTable.Add(@"P2");
-            id284_CustomXmlArrayProperty = Reader.NameTable.Add(@"CustomXmlArrayProperty");
-            id211_AttributeString = Reader.NameTable.Add(@"AttributeString");
-            id263_DisplayName = Reader.NameTable.Add(@"DisplayName");
-            id148_ArrayOfOrderedItem = Reader.NameTable.Add(@"ArrayOfOrderedItem");
-            id255_MyEnum1 = Reader.NameTable.Add(@"MyEnum1");
-            id183_DTO = Reader.NameTable.Add(@"DTO");
-            id199_NullableDefaultTime = Reader.NameTable.Add(@"NullableDefaultTime");
-            id119_Item = Reader.NameTable.Add(@"DerivedTypeWithInheritedShouldSerialize");
-            id106_MyXmlType = Reader.NameTable.Add(@"MyXmlType");
-            id145_ParameterOfString = Reader.NameTable.Add(@"ParameterOfString");
-            id71_TypeA = Reader.NameTable.Add(@"TypeA");
-            id12_TypeWithTimeSpanProperty = Reader.NameTable.Add(@"TypeWithTimeSpanProperty");
-            id21_Employee = Reader.NameTable.Add(@"Employee");
-            id112_TypeWithXmlQualifiedName = Reader.NameTable.Add(@"TypeWithXmlQualifiedName");
-            id177_Description = Reader.NameTable.Add(@"Description");
-            id230_DoubleField = Reader.NameTable.Add(@"DoubleField");
-            id133_TypeClashA = Reader.NameTable.Add(@"TypeClashA");
-            id237_Parameters = Reader.NameTable.Add(@"Parameters");
+            id107_TypeWithXmlSchemaFormAttribute = Reader.NameTable.Add(@"TypeWithXmlSchemaFormAttribute");
+            id156_double = Reader.NameTable.Add(@"double");
+            id254_Collection = Reader.NameTable.Add(@"Collection");
+            id182_LineTotal = Reader.NameTable.Add(@"LineTotal");
+            id164_ArrayOfItemChoiceType = Reader.NameTable.Add(@"ArrayOfItemChoiceType");
+            id249_NIntLField = Reader.NameTable.Add(@"NIntLField");
+            id135_TypeClashA = Reader.NameTable.Add(@"TypeClashA");
+            id88_SomeStruct = Reader.NameTable.Add(@"SomeStruct");
+            id71_TypeWithBuiltInTypedMembers = Reader.NameTable.Add(@"TypeWithBuiltInTypedMembers");
+            id89_WithEnums = Reader.NameTable.Add(@"WithEnums");
+            id69_DCClassWithEnumAndStruct = Reader.NameTable.Add(@"DCClassWithEnumAndStruct");
+            id127_Item = Reader.NameTable.Add(@"TypeWithPropertyHavingComplexChoice");
+            id270_DisplayName = Reader.NameTable.Add(@"DisplayName");
+            id257_MyEnum1 = Reader.NameTable.Add(@"MyEnum1");
+            id189_NullableDefaultDTO = Reader.NameTable.Add(@"NullableDefaultDTO");
+            id242_DateTimeString = Reader.NameTable.Add(@"DateTimeString");
+            id306_EmptyStringProperty = Reader.NameTable.Add(@"EmptyStringProperty");
+            id157_ArrayOfInstrument = Reader.NameTable.Add(@"ArrayOfInstrument");
+            id167_NoneParameter = Reader.NameTable.Add(@"NoneParameter");
+            id91_ByteEnum = Reader.NameTable.Add(@"ByteEnum");
+            id178_ItemName = Reader.NameTable.Add(@"ItemName");
+            id290_httpelement = Reader.NameTable.Add(@"http://element");
+            id213_AttributeString = Reader.NameTable.Add(@"AttributeString");
+            id44_Item = Reader.NameTable.Add(@"DefaultValuesSetToPositiveInfinity");
+            id239_Parameters = Reader.NameTable.Add(@"Parameters");
+            id144_Value1 = Reader.NameTable.Add(@"Value1");
+            id209_GroupName = Reader.NameTable.Add(@"GroupName");
+            id55_Item = Reader.NameTable.Add(@"DateTimeOffsetIXmlSerializableContainer");
             id61_StructNotSerializable = Reader.NameTable.Add(@"StructNotSerializable");
-            id252_Collection = Reader.NameTable.Add(@"Collection");
-            id165_NoneParameter = Reader.NameTable.Add(@"NoneParameter");
-            id186_NullableDTO = Reader.NameTable.Add(@"NullableDTO");
-            id251_NIntLProp = Reader.NameTable.Add(@"NIntLProp");
-            id132_TypeClashB = Reader.NameTable.Add(@"TypeClashB");
-            id196_DefaultTime = Reader.NameTable.Add(@"DefaultTime");
-            id313_Base64BinaryContent = Reader.NameTable.Add(@"Base64BinaryContent");
-            id308_DateContent = Reader.NameTable.Add(@"DateContent");
-            id92_IntEnum = Reader.NameTable.Add(@"IntEnum");
-            id180_LineTotal = Reader.NameTable.Add(@"LineTotal");
-            id56_TypeWithDateTimeStringProperty = Reader.NameTable.Add(@"TypeWithDateTimeStringProperty");
-            id159_XElement = Reader.NameTable.Add(@"XElement");
-            id294_name = Reader.NameTable.Add(@"name");
-            id260_DateTimeProperty = Reader.NameTable.Add(@"DateTimeProperty");
-            id238_xelement = Reader.NameTable.Add(@"xelement");
-            id191_NullableDate = Reader.NameTable.Add(@"NullableDate");
-            id93_UIntEnum = Reader.NameTable.Add(@"UIntEnum");
-            id150_int = Reader.NameTable.Add(@"int");
-            id200_TestValue = Reader.NameTable.Add(@"TestValue");
-            id203_ByteProperty = Reader.NameTable.Add(@"ByteProperty");
-            id198_NullableTimeWithValue = Reader.NameTable.Add(@"NullableTimeWithValue");
+            id133_Root = Reader.NameTable.Add(@"Root");
+            id222_Items = Reader.NameTable.Add(@"Items");
+            id58_TypeWithGetSetArrayMembers = Reader.NameTable.Add(@"TypeWithGetSetArrayMembers");
+            id187_DefaultDTO = Reader.NameTable.Add(@"DefaultDTO");
+            id15_TypeWithXmlNodeArrayProperty = Reader.NameTable.Add(@"TypeWithXmlNodeArrayProperty");
+            id8_TimeOnlyWrapper = Reader.NameTable.Add(@"TimeOnlyWrapper");
+            id104_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor");
+            id185_DTO = Reader.NameTable.Add(@"DTO");
+            id40_Brass = Reader.NameTable.Add(@"Brass");
+            id198_DefaultTime = Reader.NameTable.Add(@"DefaultTime");
+            id80_Item = Reader.NameTable.Add(@"TypeWithDateTimePropertyAsXmlTime");
+            id174_Child = Reader.NameTable.Add(@"Child");
+            id291_CustomXmlArrayProperty = Reader.NameTable.Add(@"CustomXmlArrayProperty");
+            id180_UnitPrice = Reader.NameTable.Add(@"UnitPrice");
+            id256_MyStruct = Reader.NameTable.Add(@"MyStruct");
+            id38_Orchestra = Reader.NameTable.Add(@"Orchestra");
+            id62_TypeWithMyCollectionField = Reader.NameTable.Add(@"TypeWithMyCollectionField");
+            id116_Item = Reader.NameTable.Add(@"TypeWithPropertiesHavingDefaultValue");
+            id192_DefaultDate = Reader.NameTable.Add(@"DefaultDate");
+            id241_xelements = Reader.NameTable.Add(@"xelements");
+            id259_StringMember = Reader.NameTable.Add(@"StringMember");
+            id30_httpwwwcontoso1com = Reader.NameTable.Add(@"http://www.contoso1.com");
+            id193_NullableDate = Reader.NameTable.Add(@"NullableDate");
+            id296_MyFieldIgnored = Reader.NameTable.Add(@"MyFieldIgnored");
+            id160_ArrayOfXElement = Reader.NameTable.Add(@"ArrayOfXElement");
+            id328_httptestcom = Reader.NameTable.Add(@"http://test.com");
+            id230_Instruments = Reader.NameTable.Add(@"Instruments");
+            id39_Instrument = Reader.NameTable.Add(@"Instrument");
+            id288_Item = Reader.NameTable.Add(@"XmlNamespaceDeclarationsProperty");
+            id24_SimpleBaseClass = Reader.NameTable.Add(@"SimpleBaseClass");
+            id59_TypeWithGetOnlyArrayProperties = Reader.NameTable.Add(@"TypeWithGetOnlyArrayProperties");
+            id121_Item = Reader.NameTable.Add(@"DerivedTypeWithInheritedShouldSerialize");
+            id246_IntAField = Reader.NameTable.Add(@"IntAField");
+            id110_CustomDocument = Reader.NameTable.Add(@"CustomDocument");
+            id49_httpexamplecom = Reader.NameTable.Add(@"http://example.com");
             id66_MyEnum = Reader.NameTable.Add(@"MyEnum");
-            id18_DogBreed = Reader.NameTable.Add(@"DogBreed");
-            id219_OrderDate = Reader.NameTable.Add(@"OrderDate");
-            id311_NMTOKENContent = Reader.NameTable.Add(@"NMTOKENContent");
-            id78_Item = Reader.NameTable.Add(@"TypeWithDateTimePropertyAsXmlTime");
-            id104_TypeWithPropertyNameSpecified = Reader.NameTable.Add(@"TypeWithPropertyNameSpecified");
+            id252_IntLProp = Reader.NameTable.Add(@"IntLProp");
+            id140_Name = Reader.NameTable.Add(@"Name");
+            id16_Animal = Reader.NameTable.Add(@"Animal");
+            id159_ArrayOfParameter = Reader.NameTable.Add(@"ArrayOfParameter");
+            id148_MsgDocumentType = Reader.NameTable.Add(@"MsgDocumentType");
+            id321_HexBinaryContent = Reader.NameTable.Add(@"HexBinaryContent");
+            id27_Item = Reader.NameTable.Add(@"http://example.com/serializer-test-namespace");
+            id228_Z = Reader.NameTable.Add(@"Z");
+            id255_Data = Reader.NameTable.Add(@"Data");
+            id99_ItemChoiceType = Reader.NameTable.Add(@"ItemChoiceType");
+            id165_httpmynamespace = Reader.NameTable.Add(@"http://mynamespace");
+            id251_NIntAProp = Reader.NameTable.Add(@"NIntAProp");
+            id301_name = Reader.NameTable.Add(@"name");
+            id76_Item = Reader.NameTable.Add(@"__TypeNameWithSpecialCharacters漢ñ");
+            id168_ArrayOfBoolean = Reader.NameTable.Add(@"ArrayOfBoolean");
+            id176_IsValved = Reader.NameTable.Add(@"IsValved");
+            id172_P2 = Reader.NameTable.Add(@"P2");
+            id221_OrderDate = Reader.NameTable.Add(@"OrderDate");
+            id311_StringArrayValue = Reader.NameTable.Add(@"StringArrayValue");
+            id269_ClassID = Reader.NameTable.Add(@"ClassID");
+            id196_Now = Reader.NameTable.Add(@"Now");
+            id274_Int = Reader.NameTable.Add(@"Int");
+            id78_DerivedClassWithSameProperty = Reader.NameTable.Add(@"DerivedClassWithSameProperty");
+            id47_TypeWithLinkedProperty = Reader.NameTable.Add(@"TypeWithLinkedProperty");
+            id64_ArrayOfAnyType = Reader.NameTable.Add(@"ArrayOfAnyType");
+            id75_TypeHasArrayOfASerializedAsB = Reader.NameTable.Add(@"TypeHasArrayOfASerializedAsB");
+            id20_Vehicle = Reader.NameTable.Add(@"Vehicle");
+            id147_ParameterOfString = Reader.NameTable.Add(@"ParameterOfString");
+            id218_State = Reader.NameTable.Add(@"State");
+            id272_IsLoaded = Reader.NameTable.Add(@"IsLoaded");
+            id204_TimeSpanProperty2 = Reader.NameTable.Add(@"TimeSpanProperty2");
+            id298_NoneSchemaFormListProperty = Reader.NameTable.Add(@"NoneSchemaFormListProperty");
+            id260_IntMember = Reader.NameTable.Add(@"IntMember");
+            id268_ListProperty = Reader.NameTable.Add(@"ListProperty");
+            id93_ShortEnum = Reader.NameTable.Add(@"ShortEnum");
+            id314_QNameContent = Reader.NameTable.Add(@"QNameContent");
+            id245_F2 = Reader.NameTable.Add(@"F2");
+            id83_Item = Reader.NameTable.Add(@"TypeWithXmlTextAttributeOnArray");
+            id142_A = Reader.NameTable.Add(@"A");
+            id68_DCStruct = Reader.NameTable.Add(@"DCStruct");
+            id120_Item = Reader.NameTable.Add(@"BaseTypeWithShouldSerializeMethod");
+            id261_NullableIntMember = Reader.NameTable.Add(@"NullableIntMember");
+            id258_ByteArray = Reader.NameTable.Add(@"ByteArray");
+            id138_MiddleName = Reader.NameTable.Add(@"MiddleName");
+            id267_DateTimeProperty = Reader.NameTable.Add(@"DateTimeProperty");
+            id279_OptionullInt = Reader.NameTable.Add(@"OptionullInt");
+            id207_Breed = Reader.NameTable.Add(@"Breed");
+            id244_F1 = Reader.NameTable.Add(@"F1");
+            id17_Dog = Reader.NameTable.Add(@"Dog");
+            id9_TimeOnlyAsXsdTimeWrapper = Reader.NameTable.Add(@"TimeOnlyAsXsdTimeWrapper");
+            id308_EnumProperty = Reader.NameTable.Add(@"EnumProperty");
+            id22_BaseClass = Reader.NameTable.Add(@"BaseClass");
+            id325_IntField1 = Reader.NameTable.Add(@"IntField1");
+            id129_ComplexChoiceA = Reader.NameTable.Add(@"ComplexChoiceA");
+            id253_NIntLProp = Reader.NameTable.Add(@"NIntLProp");
+            id6_Item = Reader.NameTable.Add(@"TypeWithDateAndTimeOnlyProperties");
+            id92_SByteEnum = Reader.NameTable.Add(@"SByteEnum");
+            id173_Value = Reader.NameTable.Add(@"Value");
+            id3_TypeWithXmlDocumentProperty = Reader.NameTable.Add(@"TypeWithXmlDocumentProperty");
+            id109_Item = Reader.NameTable.Add(@"TypeWithSchemaFormInXmlAttribute");
+            id14_TypeWithByteProperty = Reader.NameTable.Add(@"TypeWithByteProperty");
+            id11_DateTimeTimeWrapper = Reader.NameTable.Add(@"DateTimeTimeWrapper");
+            id114_TypeWithXmlQualifiedName = Reader.NameTable.Add(@"TypeWithXmlQualifiedName");
+            id286_XmlIncludeProperty = Reader.NameTable.Add(@"XmlIncludeProperty");
+            id155_ArrayOfDouble = Reader.NameTable.Add(@"ArrayOfDouble");
+            id32_OrderedItem = Reader.NameTable.Add(@"OrderedItem");
+            id158_ArrayOfTypeWithLinkedProperty = Reader.NameTable.Add(@"ArrayOfTypeWithLinkedProperty");
+            id82_SimpleDC = Reader.NameTable.Add(@"SimpleDC");
+            id181_Quantity = Reader.NameTable.Add(@"Quantity");
+            id312_IntArrayValue = Reader.NameTable.Add(@"IntArrayValue");
+            id45_Item = Reader.NameTable.Add(@"DefaultValuesSetToNegativeInfinity");
+            id183_BinaryHexContent = Reader.NameTable.Add(@"BinaryHexContent");
+            id37_dateTime = Reader.NameTable.Add(@"dateTime");
+            id205_ByteProperty = Reader.NameTable.Add(@"ByteProperty");
+            id289_XmlElementPropertyNode = Reader.NameTable.Add(@"XmlElementPropertyNode");
+            id273_Some = Reader.NameTable.Add(@"Some");
+            id35_DerivedClass1 = Reader.NameTable.Add(@"DerivedClass1");
+            id315_DateContent = Reader.NameTable.Add(@"DateContent");
+            id186_DTO2 = Reader.NameTable.Add(@"DTO2");
+            id271_Id = Reader.NameTable.Add(@"Id");
+            id201_NullableDefaultTime = Reader.NameTable.Add(@"NullableDefaultTime");
+            id117_Item = Reader.NameTable.Add(@"TypeWithEnumPropertyHavingDefaultValue");
+            id73_TypeA = Reader.NameTable.Add(@"TypeA");
+            id195_NullableDefaultDate = Reader.NameTable.Add(@"NullableDefaultDate");
+            id219_Zip = Reader.NameTable.Add(@"Zip");
+            id197_MyTime = Reader.NameTable.Add(@"MyTime");
+            id145_Value2 = Reader.NameTable.Add(@"Value2");
+            id211_EmployeeName = Reader.NameTable.Add(@"EmployeeName");
+            id316_NameContent = Reader.NameTable.Add(@"NameContent");
+            id161_XElement = Reader.NameTable.Add(@"XElement");
+            id307_CharProperty = Reader.NameTable.Add(@"CharProperty");
+            id95_UIntEnum = Reader.NameTable.Add(@"UIntEnum");
+            id319_NMTOKENSContent = Reader.NameTable.Add(@"NMTOKENSContent");
+            id322_Item = Reader.NameTable.Add(@"Item");
+            id65_anyType = Reader.NameTable.Add(@"anyType");
+            id275_Short = Reader.NameTable.Add(@"Short");
+            id94_IntEnum = Reader.NameTable.Add(@"IntEnum");
+            id4_TypeWithBinaryProperty = Reader.NameTable.Add(@"TypeWithBinaryProperty");
+            id108_MyXmlType = Reader.NameTable.Add(@"MyXmlType");
+            id277_Optionull = Reader.NameTable.Add(@"Optionull");
+            id10_DateTimeDateWrapper = Reader.NameTable.Add(@"DateTimeDateWrapper");
+            id232_DoubleField = Reader.NameTable.Add(@"DoubleField");
+            id247_NIntAField = Reader.NameTable.Add(@"NIntAField");
+            id84_Item = Reader.NameTable.Add(@"http://schemas.xmlsoap.org/ws/2005/04/discovery");
+            id2_Item = Reader.NameTable.Add(@"");
+            id48_Document = Reader.NameTable.Add(@"Document");
+            id217_City = Reader.NameTable.Add(@"City");
+            id50_RootClass = Reader.NameTable.Add(@"RootClass");
+            id236_IntValue = Reader.NameTable.Add(@"IntValue");
+            id210_GroupVehicle = Reader.NameTable.Add(@"GroupVehicle");
+            id282_XmlAttributeName = Reader.NameTable.Add(@"XmlAttributeName");
+            id302_customElement = Reader.NameTable.Add(@"customElement");
+            id101_KnownTypesThroughConstructor = Reader.NameTable.Add(@"KnownTypesThroughConstructor");
+            id283_Word = Reader.NameTable.Add(@"Word");
+            id126_Item = Reader.NameTable.Add(@"TypeWithArrayPropertyHavingChoice");
+            id150_ArrayOfOrderedItem = Reader.NameTable.Add(@"ArrayOfOrderedItem");
+            id90_WithNullables = Reader.NameTable.Add(@"WithNullables");
+            id169_QualifiedParameter = Reader.NameTable.Add(@"QualifiedParameter");
+            id153_ArrayOfString = Reader.NameTable.Add(@"ArrayOfString");
+            id285_DecimalNumber = Reader.NameTable.Add(@"DecimalNumber");
+            id323_Amount = Reader.NameTable.Add(@"Amount");
+            id128_MoreChoices = Reader.NameTable.Add(@"MoreChoices");
+            id305_TwoDArrayOfSimpleType = Reader.NameTable.Add(@"TwoDArrayOfSimpleType");
+            id151_ArrayOfInt = Reader.NameTable.Add(@"ArrayOfInt");
+            id227_Y = Reader.NameTable.Add(@"Y");
+            id281_Struct2 = Reader.NameTable.Add(@"Struct2");
+            id26_BaseIXmlSerializable = Reader.NameTable.Add(@"BaseIXmlSerializable");
+            id13_Item = Reader.NameTable.Add(@"TypeWithDefaultTimeSpanProperty");
+            id265_StringProperty = Reader.NameTable.Add(@"StringProperty");
+            id212_value = Reader.NameTable.Add(@"value");
+            id200_NullableTimeWithValue = Reader.NameTable.Add(@"NullableTimeWithValue");
+            id56_TypeWithDateTimeStringProperty = Reader.NameTable.Add(@"TypeWithDateTimeStringProperty");
+            id5_Item = Reader.NameTable.Add(@"TypeWithDateTimeOffsetProperties");
+            id223_SubTotal = Reader.NameTable.Add(@"SubTotal");
+            id266_IntProperty = Reader.NameTable.Add(@"IntProperty");
+            id100_TypeWithAnyAttribute = Reader.NameTable.Add(@"TypeWithAnyAttribute");
+            id21_Employee = Reader.NameTable.Add(@"Employee");
+            id324_IntField2 = Reader.NameTable.Add(@"IntField2");
+            id112_Item = Reader.NameTable.Add(@"TypeWithNonPublicDefaultConstructor");
+            id299_Item = Reader.NameTable.Add(@"QualifiedSchemaFormListProperty");
+            id124_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithValue");
+            id46_RootElement = Reader.NameTable.Add(@"RootElement");
+            id149_Item = Reader.NameTable.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType");
+            id190_Today = Reader.NameTable.Add(@"Today");
+            id188_NullableDTO = Reader.NameTable.Add(@"NullableDTO");
+            id320_Base64BinaryContent = Reader.NameTable.Add(@"Base64BinaryContent");
+            id74_TypeB = Reader.NameTable.Add(@"TypeB");
+            id231_Comment2 = Reader.NameTable.Add(@"Comment2");
+            id86_ClassImplementsInterface = Reader.NameTable.Add(@"ClassImplementsInterface");
+            id292_EnumValue = Reader.NameTable.Add(@"EnumValue");
+            id103_Item = Reader.NameTable.Add(@"ClassImplementingIXmlSerializable");
+            id41_Trumpet = Reader.NameTable.Add(@"Trumpet");
+            id137_FirstName = Reader.NameTable.Add(@"FirstName");
+            id162_ArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfSimpleType");
+            id34_BaseClass1 = Reader.NameTable.Add(@"BaseClass1");
+            id98_AttributeTesting = Reader.NameTable.Add(@"AttributeTesting");
+            id67_TypeWithEnumMembers = Reader.NameTable.Add(@"TypeWithEnumMembers");
+            id119_TypeWithShouldSerializeMethod = Reader.NameTable.Add(@"TypeWithShouldSerializeMethod");
+            id304_MetricConfigUrl = Reader.NameTable.Add(@"MetricConfigUrl");
+            id166_ArrayOfString1 = Reader.NameTable.Add(@"ArrayOfString1");
+            id295_MyField = Reader.NameTable.Add(@"MyField");
             id36_ArrayOfDateTime = Reader.NameTable.Add(@"ArrayOfDateTime");
-            id215_City = Reader.NameTable.Add(@"City");
-            id130_Item = Reader.NameTable.Add(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName");
-            id166_ArrayOfBoolean = Reader.NameTable.Add(@"ArrayOfBoolean");
+            id175_Children = Reader.NameTable.Add(@"Children");
+            id313_DateTimeContent = Reader.NameTable.Add(@"DateTimeContent");
+            id220_ShipTo = Reader.NameTable.Add(@"ShipTo");
+            id31_Address = Reader.NameTable.Add(@"Address");
+            id33_AliasedTestType = Reader.NameTable.Add(@"AliasedTestType");
+            id43_DefaultValuesSetToNaN = Reader.NameTable.Add(@"DefaultValuesSetToNaN");
+            id294_StrProperty = Reader.NameTable.Add(@"StrProperty");
+            id215_BoolValue = Reader.NameTable.Add(@"BoolValue");
+            id51_Parameter = Reader.NameTable.Add(@"Parameter");
+            id206_Age = Reader.NameTable.Add(@"Age");
+            id229_Prop = Reader.NameTable.Add(@"Prop");
+            id79_DerivedClassWithSameProperty2 = Reader.NameTable.Add(@"DerivedClassWithSameProperty2");
+            id53_XElementStruct = Reader.NameTable.Add(@"XElementStruct");
+            id264_Item = Reader.NameTable.Add(@"PropertyNameWithSpecialCharacters漢ñ");
+            id130_ComplexChoiceB = Reader.NameTable.Add(@"ComplexChoiceB");
+            id18_DogBreed = Reader.NameTable.Add(@"DogBreed");
+            id96_LongEnum = Reader.NameTable.Add(@"LongEnum");
+            id297_Item = Reader.NameTable.Add(@"UnqualifiedSchemaFormListProperty");
+            id111_CustomElement = Reader.NameTable.Add(@"CustomElement");
+            id115_TypeWith2DArrayProperty2 = Reader.NameTable.Add(@"TypeWith2DArrayProperty2");
+            id317_NCNameContent = Reader.NameTable.Add(@"NCNameContent");
+            id234_DoubleProp = Reader.NameTable.Add(@"DoubleProp");
+            id235_FloatProp = Reader.NameTable.Add(@"FloatProp");
+            id300_XmlAttributeForm = Reader.NameTable.Add(@"XmlAttributeForm");
+            id85_EnumFlags = Reader.NameTable.Add(@"EnumFlags");
+            id146_XmlSerializerAttributes = Reader.NameTable.Add(@"XmlSerializerAttributes");
+            id199_NullableTime = Reader.NameTable.Add(@"NullableTime");
+            id7_DateOnlyWrapper = Reader.NameTable.Add(@"DateOnlyWrapper");
+            id177_Modulation = Reader.NameTable.Add(@"Modulation");
+            id57_SimpleType = Reader.NameTable.Add(@"SimpleType");
+            id52_XElementWrapper = Reader.NameTable.Add(@"XElementWrapper");
+            id97_ULongEnum = Reader.NameTable.Add(@"ULongEnum");
+            id42_Pet = Reader.NameTable.Add(@"Pet");
+            id154_string = Reader.NameTable.Add(@"string");
+            id70_BuiltInTypes = Reader.NameTable.Add(@"BuiltInTypes");
+            id134_TypeClashB = Reader.NameTable.Add(@"TypeClashB");
+            id202_TestValue = Reader.NameTable.Add(@"TestValue");
+            id233_SingleField = Reader.NameTable.Add(@"SingleField");
+            id54_XElementArrayWrapper = Reader.NameTable.Add(@"XElementArrayWrapper");
+            id125_Item = Reader.NameTable.Add(@"TypeWithTypesHavingCustomFormatter");
+            id208_LicenseNumber = Reader.NameTable.Add(@"LicenseNumber");
+            id105_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithParameterlessConstructor");
+            id12_TypeWithTimeSpanProperty = Reader.NameTable.Add(@"TypeWithTimeSpanProperty");
+            id63_Item = Reader.NameTable.Add(@"TypeWithReadOnlyMyCollectionProperty");
+            id238_refs = Reader.NameTable.Add(@"refs");
+            id72_Item = Reader.NameTable.Add(@"TypeWithNullableBuiltInTypedMembers");
+            id122_Item = Reader.NameTable.Add(@"TypeWithFieldBackedSpecifiedMember");
+            id102_SimpleKnownTypeValue = Reader.NameTable.Add(@"SimpleKnownTypeValue");
+            id163_ArrayOfTypeA = Reader.NameTable.Add(@"ArrayOfTypeA");
+            id240_xelement = Reader.NameTable.Add(@"xelement");
+            id194_NullableDateWithValue = Reader.NameTable.Add(@"NullableDateWithValue");
+            id19_Group = Reader.NameTable.Add(@"Group");
+            id248_IntLField = Reader.NameTable.Add(@"IntLField");
+            id28_DerivedIXmlSerializable = Reader.NameTable.Add(@"DerivedIXmlSerializable");
+            id136_Person = Reader.NameTable.Add(@"Person");
+            id170_ArrayOfArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfArrayOfSimpleType");
+            id326_strfld = Reader.NameTable.Add(@"strfld");
+            id77_BaseClassWithSamePropertyName = Reader.NameTable.Add(@"BaseClassWithSamePropertyName");
+            id29_PurchaseOrder = Reader.NameTable.Add(@"PurchaseOrder");
+            id184_Base64Content = Reader.NameTable.Add(@"Base64Content");
+            id179_Description = Reader.NameTable.Add(@"Description");
+            id287_XmlEnumProperty = Reader.NameTable.Add(@"XmlEnumProperty");
+            id87_WithStruct = Reader.NameTable.Add(@"WithStruct");
         }
     }
 
@@ -16694,11 +19265,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write124_TypeWithXmlElementProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write126_TypeWithXmlElementProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read130_TypeWithXmlElementProperty();
+            return ((XmlSerializationReader1)reader).Read132_TypeWithXmlElementProperty();
         }
     }
 
@@ -16709,11 +19280,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write125_TypeWithXmlDocumentProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write127_TypeWithXmlDocumentProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read131_TypeWithXmlDocumentProperty();
+            return ((XmlSerializationReader1)reader).Read133_TypeWithXmlDocumentProperty();
         }
     }
 
@@ -16724,11 +19295,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write126_TypeWithBinaryProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write128_TypeWithBinaryProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read132_TypeWithBinaryProperty();
+            return ((XmlSerializationReader1)reader).Read134_TypeWithBinaryProperty();
         }
     }
 
@@ -16739,11 +19310,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write127_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write129_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read133_Item();
+            return ((XmlSerializationReader1)reader).Read135_Item();
         }
     }
 
@@ -16754,11 +19325,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write128_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write130_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read134_Item();
+            return ((XmlSerializationReader1)reader).Read136_Item();
         }
     }
 
@@ -16769,11 +19340,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write129_DateOnlyWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write131_DateOnlyWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read135_DateOnlyWrapper();
+            return ((XmlSerializationReader1)reader).Read137_DateOnlyWrapper();
         }
     }
 
@@ -16784,11 +19355,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write130_TimeOnlyWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write132_TimeOnlyWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read136_TimeOnlyWrapper();
+            return ((XmlSerializationReader1)reader).Read138_TimeOnlyWrapper();
         }
     }
 
@@ -16799,11 +19370,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write131_TimeOnlyAsXsdTimeWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write133_TimeOnlyAsXsdTimeWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read137_TimeOnlyAsXsdTimeWrapper();
+            return ((XmlSerializationReader1)reader).Read139_TimeOnlyAsXsdTimeWrapper();
         }
     }
 
@@ -16814,11 +19385,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write132_DateTimeDateWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write134_DateTimeDateWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read138_DateTimeDateWrapper();
+            return ((XmlSerializationReader1)reader).Read140_DateTimeDateWrapper();
         }
     }
 
@@ -16829,11 +19400,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write133_DateTimeTimeWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write135_DateTimeTimeWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read139_DateTimeTimeWrapper();
+            return ((XmlSerializationReader1)reader).Read141_DateTimeTimeWrapper();
         }
     }
 
@@ -16844,11 +19415,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write134_TypeWithTimeSpanProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write136_TypeWithTimeSpanProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read140_TypeWithTimeSpanProperty();
+            return ((XmlSerializationReader1)reader).Read142_TypeWithTimeSpanProperty();
         }
     }
 
@@ -16859,11 +19430,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write135_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write137_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read141_Item();
+            return ((XmlSerializationReader1)reader).Read143_Item();
         }
     }
 
@@ -16874,11 +19445,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write136_TypeWithByteProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write138_TypeWithByteProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read142_TypeWithByteProperty();
+            return ((XmlSerializationReader1)reader).Read144_TypeWithByteProperty();
         }
     }
 
@@ -16889,11 +19460,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write137_TypeWithXmlNodeArrayProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write139_TypeWithXmlNodeArrayProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read143_TypeWithXmlNodeArrayProperty();
+            return ((XmlSerializationReader1)reader).Read145_TypeWithXmlNodeArrayProperty();
         }
     }
 
@@ -16904,11 +19475,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write138_Animal(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write140_Animal(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read144_Animal();
+            return ((XmlSerializationReader1)reader).Read146_Animal();
         }
     }
 
@@ -16919,11 +19490,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write139_Dog(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write141_Dog(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read145_Dog();
+            return ((XmlSerializationReader1)reader).Read147_Dog();
         }
     }
 
@@ -16934,11 +19505,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write140_DogBreed(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write142_DogBreed(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read146_DogBreed();
+            return ((XmlSerializationReader1)reader).Read148_DogBreed();
         }
     }
 
@@ -16949,11 +19520,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write141_Group(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write143_Group(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read147_Group();
+            return ((XmlSerializationReader1)reader).Read149_Group();
         }
     }
 
@@ -16964,11 +19535,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write142_Vehicle(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write144_Vehicle(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read148_Vehicle();
+            return ((XmlSerializationReader1)reader).Read150_Vehicle();
         }
     }
 
@@ -16979,11 +19550,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write143_Employee(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write145_Employee(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read149_Employee();
+            return ((XmlSerializationReader1)reader).Read151_Employee();
         }
     }
 
@@ -16994,11 +19565,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write144_BaseClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write146_BaseClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read150_BaseClass();
+            return ((XmlSerializationReader1)reader).Read152_BaseClass();
         }
     }
 
@@ -17009,11 +19580,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write145_DerivedClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write147_DerivedClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read151_DerivedClass();
+            return ((XmlSerializationReader1)reader).Read153_DerivedClass();
         }
     }
 
@@ -17024,11 +19595,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write146_SimpleBaseClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write148_SimpleBaseClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read152_SimpleBaseClass();
+            return ((XmlSerializationReader1)reader).Read154_SimpleBaseClass();
         }
     }
 
@@ -17039,11 +19610,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write147_SimpleDerivedClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write149_SimpleDerivedClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read153_SimpleDerivedClass();
+            return ((XmlSerializationReader1)reader).Read155_SimpleDerivedClass();
         }
     }
 
@@ -17054,11 +19625,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write148_BaseIXmlSerializable(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write150_BaseIXmlSerializable(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read154_BaseIXmlSerializable();
+            return ((XmlSerializationReader1)reader).Read156_BaseIXmlSerializable();
         }
     }
 
@@ -17069,11 +19640,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write149_DerivedIXmlSerializable(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write151_DerivedIXmlSerializable(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read155_DerivedIXmlSerializable();
+            return ((XmlSerializationReader1)reader).Read157_DerivedIXmlSerializable();
         }
     }
 
@@ -17084,11 +19655,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write150_PurchaseOrder(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write152_PurchaseOrder(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read156_PurchaseOrder();
+            return ((XmlSerializationReader1)reader).Read158_PurchaseOrder();
         }
     }
 
@@ -17099,11 +19670,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write151_Address(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write153_Address(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read157_Address();
+            return ((XmlSerializationReader1)reader).Read159_Address();
         }
     }
 
@@ -17114,11 +19685,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write152_OrderedItem(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write154_OrderedItem(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read158_OrderedItem();
+            return ((XmlSerializationReader1)reader).Read160_OrderedItem();
         }
     }
 
@@ -17129,11 +19700,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write153_AliasedTestType(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write155_AliasedTestType(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read159_AliasedTestType();
+            return ((XmlSerializationReader1)reader).Read161_AliasedTestType();
         }
     }
 
@@ -17144,11 +19715,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write154_BaseClass1(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write156_BaseClass1(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read160_BaseClass1();
+            return ((XmlSerializationReader1)reader).Read162_BaseClass1();
         }
     }
 
@@ -17159,11 +19730,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write155_DerivedClass1(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write157_DerivedClass1(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read161_DerivedClass1();
+            return ((XmlSerializationReader1)reader).Read163_DerivedClass1();
         }
     }
 
@@ -17174,11 +19745,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write156_ArrayOfDateTime(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write158_ArrayOfDateTime(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read162_ArrayOfDateTime();
+            return ((XmlSerializationReader1)reader).Read164_ArrayOfDateTime();
         }
     }
 
@@ -17189,11 +19760,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write157_Orchestra(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write159_Orchestra(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read163_Orchestra();
+            return ((XmlSerializationReader1)reader).Read165_Orchestra();
         }
     }
 
@@ -17204,11 +19775,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write158_Instrument(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write160_Instrument(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read164_Instrument();
+            return ((XmlSerializationReader1)reader).Read166_Instrument();
         }
     }
 
@@ -17219,11 +19790,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write159_Brass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write161_Brass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read165_Brass();
+            return ((XmlSerializationReader1)reader).Read167_Brass();
         }
     }
 
@@ -17234,11 +19805,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write160_Trumpet(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write162_Trumpet(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read166_Trumpet();
+            return ((XmlSerializationReader1)reader).Read168_Trumpet();
         }
     }
 
@@ -17249,11 +19820,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write161_Pet(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write163_Pet(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read167_Pet();
+            return ((XmlSerializationReader1)reader).Read169_Pet();
         }
     }
 
@@ -17264,11 +19835,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write162_DefaultValuesSetToNaN(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write164_DefaultValuesSetToNaN(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read168_DefaultValuesSetToNaN();
+            return ((XmlSerializationReader1)reader).Read170_DefaultValuesSetToNaN();
         }
     }
 
@@ -17279,11 +19850,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write163_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write165_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read169_Item();
+            return ((XmlSerializationReader1)reader).Read171_Item();
         }
     }
 
@@ -17294,11 +19865,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write164_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write166_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read170_Item();
+            return ((XmlSerializationReader1)reader).Read172_Item();
         }
     }
 
@@ -17309,11 +19880,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write165_RootElement(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write167_RootElement(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read171_RootElement();
+            return ((XmlSerializationReader1)reader).Read173_RootElement();
         }
     }
 
@@ -17324,11 +19895,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write166_TypeWithLinkedProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write168_TypeWithLinkedProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read172_TypeWithLinkedProperty();
+            return ((XmlSerializationReader1)reader).Read174_TypeWithLinkedProperty();
         }
     }
 
@@ -17339,11 +19910,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write167_Document(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write169_Document(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read173_Document();
+            return ((XmlSerializationReader1)reader).Read175_Document();
         }
     }
 
@@ -17354,11 +19925,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write168_RootClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write170_RootClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read174_RootClass();
+            return ((XmlSerializationReader1)reader).Read176_RootClass();
         }
     }
 
@@ -17369,11 +19940,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write169_Parameter(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write171_Parameter(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read175_Parameter();
+            return ((XmlSerializationReader1)reader).Read177_Parameter();
         }
     }
 
@@ -17384,11 +19955,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write170_XElementWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write172_XElementWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read176_XElementWrapper();
+            return ((XmlSerializationReader1)reader).Read178_XElementWrapper();
         }
     }
 
@@ -17399,11 +19970,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write171_XElementStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write173_XElementStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read177_XElementStruct();
+            return ((XmlSerializationReader1)reader).Read179_XElementStruct();
         }
     }
 
@@ -17414,11 +19985,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write172_XElementArrayWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write174_XElementArrayWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read178_XElementArrayWrapper();
+            return ((XmlSerializationReader1)reader).Read180_XElementArrayWrapper();
         }
     }
 
@@ -17429,11 +20000,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write173_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write175_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read179_Item();
+            return ((XmlSerializationReader1)reader).Read181_Item();
         }
     }
 
@@ -17444,11 +20015,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write174_TypeWithDateTimeStringProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write176_TypeWithDateTimeStringProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read180_TypeWithDateTimeStringProperty();
+            return ((XmlSerializationReader1)reader).Read182_TypeWithDateTimeStringProperty();
         }
     }
 
@@ -17459,11 +20030,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write175_SimpleType(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write177_SimpleType(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read181_SimpleType();
+            return ((XmlSerializationReader1)reader).Read183_SimpleType();
         }
     }
 
@@ -17474,11 +20045,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write176_TypeWithGetSetArrayMembers(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write178_TypeWithGetSetArrayMembers(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read182_TypeWithGetSetArrayMembers();
+            return ((XmlSerializationReader1)reader).Read184_TypeWithGetSetArrayMembers();
         }
     }
 
@@ -17489,11 +20060,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write177_TypeWithGetOnlyArrayProperties(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write179_TypeWithGetOnlyArrayProperties(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read183_TypeWithGetOnlyArrayProperties();
+            return ((XmlSerializationReader1)reader).Read185_TypeWithGetOnlyArrayProperties();
         }
     }
 
@@ -17504,11 +20075,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write178_TypeWithArraylikeMembers(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write180_TypeWithArraylikeMembers(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read184_TypeWithArraylikeMembers();
+            return ((XmlSerializationReader1)reader).Read186_TypeWithArraylikeMembers();
         }
     }
 
@@ -17519,11 +20090,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write179_StructNotSerializable(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write181_StructNotSerializable(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read185_StructNotSerializable();
+            return ((XmlSerializationReader1)reader).Read187_StructNotSerializable();
         }
     }
 
@@ -17534,11 +20105,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write180_TypeWithMyCollectionField(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write182_TypeWithMyCollectionField(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read186_TypeWithMyCollectionField();
+            return ((XmlSerializationReader1)reader).Read188_TypeWithMyCollectionField();
         }
     }
 
@@ -17549,11 +20120,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write181_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write183_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read187_Item();
+            return ((XmlSerializationReader1)reader).Read189_Item();
         }
     }
 
@@ -17564,11 +20135,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write182_ArrayOfAnyType(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write184_ArrayOfAnyType(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read188_ArrayOfAnyType();
+            return ((XmlSerializationReader1)reader).Read190_ArrayOfAnyType();
         }
     }
 
@@ -17579,11 +20150,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write183_MyEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write185_MyEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read189_MyEnum();
+            return ((XmlSerializationReader1)reader).Read191_MyEnum();
         }
     }
 
@@ -17594,11 +20165,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write184_TypeWithEnumMembers(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write186_TypeWithEnumMembers(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read190_TypeWithEnumMembers();
+            return ((XmlSerializationReader1)reader).Read192_TypeWithEnumMembers();
         }
     }
 
@@ -17609,11 +20180,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write185_DCStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write187_DCStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read191_DCStruct();
+            return ((XmlSerializationReader1)reader).Read193_DCStruct();
         }
     }
 
@@ -17624,11 +20195,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write186_DCClassWithEnumAndStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write188_DCClassWithEnumAndStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read192_DCClassWithEnumAndStruct();
+            return ((XmlSerializationReader1)reader).Read194_DCClassWithEnumAndStruct();
         }
     }
 
@@ -17639,63 +20210,33 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write187_BuiltInTypes(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write189_BuiltInTypes(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read193_BuiltInTypes();
+            return ((XmlSerializationReader1)reader).Read195_BuiltInTypes();
         }
     }
 
-    public sealed class TypeASerializer : XmlSerializer1 {
+    public sealed class TypeWithBuiltInTypedMembersSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeA", @"");
+            return xmlReader.IsStartElement(@"TypeWithBuiltInTypedMembers", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write188_TypeA(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write190_TypeWithBuiltInTypedMembers(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read194_TypeA();
+            return ((XmlSerializationReader1)reader).Read196_TypeWithBuiltInTypedMembers();
         }
     }
 
-    public sealed class TypeBSerializer : XmlSerializer1 {
+    public sealed class TypeWithNullableBuiltInTypedMembersSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeB", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write189_TypeB(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read195_TypeB();
-        }
-    }
-
-    public sealed class TypeHasArrayOfASerializedAsBSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeHasArrayOfASerializedAsB", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write190_TypeHasArrayOfASerializedAsB(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read196_TypeHasArrayOfASerializedAsB();
-        }
-    }
-
-    public sealed class @__TypeNameWithSpecialCharacters漢ñSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"__TypeNameWithSpecialCharacters漢ñ", @"");
+            return xmlReader.IsStartElement(@"TypeWithNullableBuiltInTypedMembers", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -17707,55 +20248,55 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class BaseClassWithSamePropertyNameSerializer : XmlSerializer1 {
+    public sealed class TypeASerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"BaseClassWithSamePropertyName", @"");
+            return xmlReader.IsStartElement(@"TypeA", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write192_BaseClassWithSamePropertyName(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write192_TypeA(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read198_BaseClassWithSamePropertyName();
+            return ((XmlSerializationReader1)reader).Read198_TypeA();
         }
     }
 
-    public sealed class DerivedClassWithSamePropertySerializer : XmlSerializer1 {
+    public sealed class TypeBSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"DerivedClassWithSameProperty", @"");
+            return xmlReader.IsStartElement(@"TypeB", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write193_DerivedClassWithSameProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write193_TypeB(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read199_DerivedClassWithSameProperty();
+            return ((XmlSerializationReader1)reader).Read199_TypeB();
         }
     }
 
-    public sealed class DerivedClassWithSameProperty2Serializer : XmlSerializer1 {
+    public sealed class TypeHasArrayOfASerializedAsBSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"DerivedClassWithSameProperty2", @"");
+            return xmlReader.IsStartElement(@"TypeHasArrayOfASerializedAsB", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write194_DerivedClassWithSameProperty2(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write194_TypeHasArrayOfASerializedAsB(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read200_DerivedClassWithSameProperty2();
+            return ((XmlSerializationReader1)reader).Read200_TypeHasArrayOfASerializedAsB();
         }
     }
 
-    public sealed class TypeWithDateTimePropertyAsXmlTimeSerializer : XmlSerializer1 {
+    public sealed class @__TypeNameWithSpecialCharacters漢ñSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithDateTimePropertyAsXmlTime", @"");
+            return xmlReader.IsStartElement(@"__TypeNameWithSpecialCharacters漢ñ", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -17767,6 +20308,66 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
+    public sealed class BaseClassWithSamePropertyNameSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"BaseClassWithSamePropertyName", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write196_BaseClassWithSamePropertyName(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read202_BaseClassWithSamePropertyName();
+        }
+    }
+
+    public sealed class DerivedClassWithSamePropertySerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"DerivedClassWithSameProperty", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write197_DerivedClassWithSameProperty(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read203_DerivedClassWithSameProperty();
+        }
+    }
+
+    public sealed class DerivedClassWithSameProperty2Serializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"DerivedClassWithSameProperty2", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write198_DerivedClassWithSameProperty2(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read204_DerivedClassWithSameProperty2();
+        }
+    }
+
+    public sealed class TypeWithDateTimePropertyAsXmlTimeSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithDateTimePropertyAsXmlTime", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write199_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read205_Item();
+        }
+    }
+
     public sealed class TypeWithByteArrayAsXmlTextSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
@@ -17774,11 +20375,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write196_TypeWithByteArrayAsXmlText(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write200_TypeWithByteArrayAsXmlText(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read202_TypeWithByteArrayAsXmlText();
+            return ((XmlSerializationReader1)reader).Read206_TypeWithByteArrayAsXmlText();
         }
     }
 
@@ -17789,11 +20390,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write197_SimpleDC(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write201_SimpleDC(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read203_SimpleDC();
+            return ((XmlSerializationReader1)reader).Read207_SimpleDC();
         }
     }
 
@@ -17804,11 +20405,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write198_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write202_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read204_Item();
+            return ((XmlSerializationReader1)reader).Read208_Item();
         }
     }
 
@@ -17819,11 +20420,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write199_EnumFlags(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write203_EnumFlags(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read205_EnumFlags();
+            return ((XmlSerializationReader1)reader).Read209_EnumFlags();
         }
     }
 
@@ -17834,11 +20435,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write200_ClassImplementsInterface(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write204_ClassImplementsInterface(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read206_ClassImplementsInterface();
+            return ((XmlSerializationReader1)reader).Read210_ClassImplementsInterface();
         }
     }
 
@@ -17849,11 +20450,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write201_WithStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write205_WithStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read207_WithStruct();
+            return ((XmlSerializationReader1)reader).Read211_WithStruct();
         }
     }
 
@@ -17864,11 +20465,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write202_SomeStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write206_SomeStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read208_SomeStruct();
+            return ((XmlSerializationReader1)reader).Read212_SomeStruct();
         }
     }
 
@@ -17879,11 +20480,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write203_WithEnums(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write207_WithEnums(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read209_WithEnums();
+            return ((XmlSerializationReader1)reader).Read213_WithEnums();
         }
     }
 
@@ -17894,11 +20495,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write204_WithNullables(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write208_WithNullables(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read210_WithNullables();
+            return ((XmlSerializationReader1)reader).Read214_WithNullables();
         }
     }
 
@@ -17909,11 +20510,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write205_ByteEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write209_ByteEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read211_ByteEnum();
+            return ((XmlSerializationReader1)reader).Read215_ByteEnum();
         }
     }
 
@@ -17924,11 +20525,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write206_SByteEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write210_SByteEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read212_SByteEnum();
+            return ((XmlSerializationReader1)reader).Read216_SByteEnum();
         }
     }
 
@@ -17939,11 +20540,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write207_ShortEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write211_ShortEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read213_ShortEnum();
+            return ((XmlSerializationReader1)reader).Read217_ShortEnum();
         }
     }
 
@@ -17954,11 +20555,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write208_IntEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write212_IntEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read214_IntEnum();
+            return ((XmlSerializationReader1)reader).Read218_IntEnum();
         }
     }
 
@@ -17969,11 +20570,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write209_UIntEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write213_UIntEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read215_UIntEnum();
+            return ((XmlSerializationReader1)reader).Read219_UIntEnum();
         }
     }
 
@@ -17984,11 +20585,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write210_LongEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write214_LongEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read216_LongEnum();
+            return ((XmlSerializationReader1)reader).Read220_LongEnum();
         }
     }
 
@@ -17999,11 +20600,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write211_ULongEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write215_ULongEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read217_ULongEnum();
+            return ((XmlSerializationReader1)reader).Read221_ULongEnum();
         }
     }
 
@@ -18014,11 +20615,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write212_AttributeTesting(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write216_AttributeTesting(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read218_AttributeTesting();
+            return ((XmlSerializationReader1)reader).Read222_AttributeTesting();
         }
     }
 
@@ -18029,11 +20630,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write213_ItemChoiceType(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write217_ItemChoiceType(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read219_ItemChoiceType();
+            return ((XmlSerializationReader1)reader).Read223_ItemChoiceType();
         }
     }
 
@@ -18044,11 +20645,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write214_TypeWithAnyAttribute(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write218_TypeWithAnyAttribute(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read220_TypeWithAnyAttribute();
+            return ((XmlSerializationReader1)reader).Read224_TypeWithAnyAttribute();
         }
     }
 
@@ -18059,11 +20660,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write215_KnownTypesThroughConstructor(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write219_KnownTypesThroughConstructor(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read221_KnownTypesThroughConstructor();
+            return ((XmlSerializationReader1)reader).Read225_KnownTypesThroughConstructor();
         }
     }
 
@@ -18074,11 +20675,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write216_SimpleKnownTypeValue(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write220_SimpleKnownTypeValue(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read222_SimpleKnownTypeValue();
+            return ((XmlSerializationReader1)reader).Read226_SimpleKnownTypeValue();
         }
     }
 
@@ -18089,11 +20690,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write217_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write221_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read223_Item();
+            return ((XmlSerializationReader1)reader).Read227_Item();
         }
     }
 
@@ -18104,11 +20705,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write218_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write222_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read224_Item();
+            return ((XmlSerializationReader1)reader).Read228_Item();
         }
     }
 
@@ -18116,66 +20717,6 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
             return xmlReader.IsStartElement(@"StructImplementingIXmlSerializableWithParameterlessConstructor", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write219_Item(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read225_Item();
-        }
-    }
-
-    public sealed class TypeWithPropertyNameSpecifiedSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithPropertyNameSpecified", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write220_TypeWithPropertyNameSpecified(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read226_TypeWithPropertyNameSpecified();
-        }
-    }
-
-    public sealed class TypeWithXmlSchemaFormAttributeSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithXmlSchemaFormAttribute", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write221_TypeWithXmlSchemaFormAttribute(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read227_TypeWithXmlSchemaFormAttribute();
-        }
-    }
-
-    public sealed class TypeWithTypeNameInXmlTypeAttributeSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"MyXmlType", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write222_MyXmlType(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read228_MyXmlType();
-        }
-    }
-
-    public sealed class TypeWithSchemaFormInXmlAttributeSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithSchemaFormInXmlAttribute", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18187,55 +20728,55 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class CustomDocumentSerializer : XmlSerializer1 {
+    public sealed class TypeWithPropertyNameSpecifiedSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"CustomDocument", @"");
+            return xmlReader.IsStartElement(@"TypeWithPropertyNameSpecified", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write224_CustomDocument(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write224_TypeWithPropertyNameSpecified(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read230_CustomDocument();
+            return ((XmlSerializationReader1)reader).Read230_TypeWithPropertyNameSpecified();
         }
     }
 
-    public sealed class CustomElementSerializer : XmlSerializer1 {
+    public sealed class TypeWithXmlSchemaFormAttributeSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"CustomElement", @"");
+            return xmlReader.IsStartElement(@"TypeWithXmlSchemaFormAttribute", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write225_CustomElement(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write225_TypeWithXmlSchemaFormAttribute(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read231_CustomElement();
+            return ((XmlSerializationReader1)reader).Read231_TypeWithXmlSchemaFormAttribute();
         }
     }
 
-    public sealed class CustomAttributeSerializer : XmlSerializer1 {
+    public sealed class TypeWithTypeNameInXmlTypeAttributeSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return true;
+            return xmlReader.IsStartElement(@"MyXmlType", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write226_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write226_MyXmlType(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read232_Item();
+            return ((XmlSerializationReader1)reader).Read232_MyXmlType();
         }
     }
 
-    public sealed class TypeWithNonPublicDefaultConstructorSerializer : XmlSerializer1 {
+    public sealed class TypeWithSchemaFormInXmlAttributeSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithNonPublicDefaultConstructor", @"");
+            return xmlReader.IsStartElement(@"TypeWithSchemaFormInXmlAttribute", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18247,55 +20788,55 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class ServerSettingsSerializer : XmlSerializer1 {
+    public sealed class CustomDocumentSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"ServerSettings", @"");
+            return xmlReader.IsStartElement(@"CustomDocument", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write228_ServerSettings(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write228_CustomDocument(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read234_ServerSettings();
+            return ((XmlSerializationReader1)reader).Read234_CustomDocument();
         }
     }
 
-    public sealed class TypeWithXmlQualifiedNameSerializer : XmlSerializer1 {
+    public sealed class CustomElementSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithXmlQualifiedName", @"");
+            return xmlReader.IsStartElement(@"CustomElement", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write229_TypeWithXmlQualifiedName(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write229_CustomElement(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read235_TypeWithXmlQualifiedName();
+            return ((XmlSerializationReader1)reader).Read235_CustomElement();
         }
     }
 
-    public sealed class TypeWith2DArrayProperty2Serializer : XmlSerializer1 {
+    public sealed class CustomAttributeSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWith2DArrayProperty2", @"");
+            return true;
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write230_TypeWith2DArrayProperty2(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write230_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read236_TypeWith2DArrayProperty2();
+            return ((XmlSerializationReader1)reader).Read236_Item();
         }
     }
 
-    public sealed class TypeWithPropertiesHavingDefaultValueSerializer : XmlSerializer1 {
+    public sealed class TypeWithNonPublicDefaultConstructorSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithPropertiesHavingDefaultValue", @"");
+            return xmlReader.IsStartElement(@"TypeWithNonPublicDefaultConstructor", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18307,55 +20848,55 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class TypeWithEnumPropertyHavingDefaultValueSerializer : XmlSerializer1 {
+    public sealed class ServerSettingsSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithEnumPropertyHavingDefaultValue", @"");
+            return xmlReader.IsStartElement(@"ServerSettings", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write232_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write232_ServerSettings(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read238_Item();
+            return ((XmlSerializationReader1)reader).Read238_ServerSettings();
         }
     }
 
-    public sealed class TypeWithEnumFlagPropertyHavingDefaultValueSerializer : XmlSerializer1 {
+    public sealed class TypeWithXmlQualifiedNameSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"");
+            return xmlReader.IsStartElement(@"TypeWithXmlQualifiedName", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write233_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write233_TypeWithXmlQualifiedName(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read239_Item();
+            return ((XmlSerializationReader1)reader).Read239_TypeWithXmlQualifiedName();
         }
     }
 
-    public sealed class TypeWithShouldSerializeMethodSerializer : XmlSerializer1 {
+    public sealed class TypeWith2DArrayProperty2Serializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithShouldSerializeMethod", @"");
+            return xmlReader.IsStartElement(@"TypeWith2DArrayProperty2", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write234_TypeWithShouldSerializeMethod(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write234_TypeWith2DArrayProperty2(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read240_TypeWithShouldSerializeMethod();
+            return ((XmlSerializationReader1)reader).Read240_TypeWith2DArrayProperty2();
         }
     }
 
-    public sealed class BaseTypeWithShouldSerializeMethodSerializer : XmlSerializer1 {
+    public sealed class TypeWithPropertiesHavingDefaultValueSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"BaseTypeWithShouldSerializeMethod", @"");
+            return xmlReader.IsStartElement(@"TypeWithPropertiesHavingDefaultValue", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18367,10 +20908,10 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class DerivedTypeWithInheritedShouldSerializeSerializer : XmlSerializer1 {
+    public sealed class TypeWithEnumPropertyHavingDefaultValueSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"DerivedTypeWithInheritedShouldSerialize", @"");
+            return xmlReader.IsStartElement(@"TypeWithEnumPropertyHavingDefaultValue", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18382,10 +20923,10 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class TypeWithFieldBackedSpecifiedMemberSerializer : XmlSerializer1 {
+    public sealed class TypeWithEnumFlagPropertyHavingDefaultValueSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithFieldBackedSpecifiedMember", @"");
+            return xmlReader.IsStartElement(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18397,25 +20938,25 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class KnownTypesThroughConstructorWithArrayPropertiesSerializer : XmlSerializer1 {
+    public sealed class TypeWithShouldSerializeMethodSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"KnownTypesThroughConstructorWithArrayProperties", @"");
+            return xmlReader.IsStartElement(@"TypeWithShouldSerializeMethod", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write238_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write238_TypeWithShouldSerializeMethod(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read244_Item();
+            return ((XmlSerializationReader1)reader).Read244_TypeWithShouldSerializeMethod();
         }
     }
 
-    public sealed class KnownTypesThroughConstructorWithValueSerializer : XmlSerializer1 {
+    public sealed class BaseTypeWithShouldSerializeMethodSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"KnownTypesThroughConstructorWithValue", @"");
+            return xmlReader.IsStartElement(@"BaseTypeWithShouldSerializeMethod", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18427,10 +20968,10 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class TypeWithTypesHavingCustomFormatterSerializer : XmlSerializer1 {
+    public sealed class DerivedTypeWithInheritedShouldSerializeSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithTypesHavingCustomFormatter", @"");
+            return xmlReader.IsStartElement(@"DerivedTypeWithInheritedShouldSerialize", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18442,10 +20983,10 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class TypeWithArrayPropertyHavingChoiceSerializer : XmlSerializer1 {
+    public sealed class TypeWithFieldBackedSpecifiedMemberSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithArrayPropertyHavingChoice", @"");
+            return xmlReader.IsStartElement(@"TypeWithFieldBackedSpecifiedMember", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18457,10 +20998,10 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class TypeWithPropertyHavingComplexChoiceSerializer : XmlSerializer1 {
+    public sealed class KnownTypesThroughConstructorWithArrayPropertiesSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithPropertyHavingComplexChoice", @"");
+            return xmlReader.IsStartElement(@"KnownTypesThroughConstructorWithArrayProperties", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -18472,6 +21013,66 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
+    public sealed class KnownTypesThroughConstructorWithValueSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"KnownTypesThroughConstructorWithValue", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write243_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read249_Item();
+        }
+    }
+
+    public sealed class TypeWithTypesHavingCustomFormatterSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithTypesHavingCustomFormatter", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write244_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read250_Item();
+        }
+    }
+
+    public sealed class TypeWithArrayPropertyHavingChoiceSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithArrayPropertyHavingChoice", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write245_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read251_Item();
+        }
+    }
+
+    public sealed class TypeWithPropertyHavingComplexChoiceSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithPropertyHavingComplexChoice", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write246_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read252_Item();
+        }
+    }
+
     public sealed class MoreChoicesSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
@@ -18479,11 +21080,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write243_MoreChoices(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write247_MoreChoices(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read249_MoreChoices();
+            return ((XmlSerializationReader1)reader).Read253_MoreChoices();
         }
     }
 
@@ -18494,11 +21095,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write244_ComplexChoiceA(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write248_ComplexChoiceA(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read250_ComplexChoiceA();
+            return ((XmlSerializationReader1)reader).Read254_ComplexChoiceA();
         }
     }
 
@@ -18509,11 +21110,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write245_ComplexChoiceB(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write249_ComplexChoiceB(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read251_ComplexChoiceB();
+            return ((XmlSerializationReader1)reader).Read255_ComplexChoiceB();
         }
     }
 
@@ -18524,11 +21125,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write246_TypeWithFieldsOrdered(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write250_TypeWithFieldsOrdered(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read252_TypeWithFieldsOrdered();
+            return ((XmlSerializationReader1)reader).Read256_TypeWithFieldsOrdered();
         }
     }
 
@@ -18539,11 +21140,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write247_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write251_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read253_Item();
+            return ((XmlSerializationReader1)reader).Read257_Item();
         }
     }
 
@@ -18554,11 +21155,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write248_Root(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write252_Root(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read254_Root();
+            return ((XmlSerializationReader1)reader).Read258_Root();
         }
     }
 
@@ -18569,11 +21170,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write249_TypeClashB(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write253_TypeClashB(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read255_TypeClashB();
+            return ((XmlSerializationReader1)reader).Read259_TypeClashB();
         }
     }
 
@@ -18584,11 +21185,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write250_TypeClashA(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write254_TypeClashA(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read256_TypeClashA();
+            return ((XmlSerializationReader1)reader).Read260_TypeClashA();
         }
     }
 
@@ -18599,11 +21200,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write251_Person(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write255_Person(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read257_Person();
+            return ((XmlSerializationReader1)reader).Read261_Person();
         }
     }
 
@@ -18615,134 +21216,136 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             get {
                 if (readMethods == null) {
                     System.Collections.Hashtable _tmp = new System.Collections.Hashtable();
-                    _tmp[@"TypeWithXmlElementProperty::"] = @"Read130_TypeWithXmlElementProperty";
-                    _tmp[@"TypeWithXmlDocumentProperty::"] = @"Read131_TypeWithXmlDocumentProperty";
-                    _tmp[@"TypeWithBinaryProperty::"] = @"Read132_TypeWithBinaryProperty";
-                    _tmp[@"TypeWithDateTimeOffsetProperties::"] = @"Read133_Item";
-                    _tmp[@"TypeWithDateAndTimeOnlyProperties::"] = @"Read134_Item";
-                    _tmp[@"DateOnlyWrapper::"] = @"Read135_DateOnlyWrapper";
-                    _tmp[@"TimeOnlyWrapper::"] = @"Read136_TimeOnlyWrapper";
-                    _tmp[@"TimeOnlyAsXsdTimeWrapper::"] = @"Read137_TimeOnlyAsXsdTimeWrapper";
-                    _tmp[@"DateTimeDateWrapper::"] = @"Read138_DateTimeDateWrapper";
-                    _tmp[@"DateTimeTimeWrapper::"] = @"Read139_DateTimeTimeWrapper";
-                    _tmp[@"TypeWithTimeSpanProperty::"] = @"Read140_TypeWithTimeSpanProperty";
-                    _tmp[@"TypeWithDefaultTimeSpanProperty::"] = @"Read141_Item";
-                    _tmp[@"TypeWithByteProperty::"] = @"Read142_TypeWithByteProperty";
-                    _tmp[@"TypeWithXmlNodeArrayProperty:::True:"] = @"Read143_TypeWithXmlNodeArrayProperty";
-                    _tmp[@"Animal::"] = @"Read144_Animal";
-                    _tmp[@"Dog::"] = @"Read145_Dog";
-                    _tmp[@"DogBreed::"] = @"Read146_DogBreed";
-                    _tmp[@"Group::"] = @"Read147_Group";
-                    _tmp[@"Vehicle::"] = @"Read148_Vehicle";
-                    _tmp[@"Employee::"] = @"Read149_Employee";
-                    _tmp[@"BaseClass::"] = @"Read150_BaseClass";
-                    _tmp[@"DerivedClass::"] = @"Read151_DerivedClass";
-                    _tmp[@"SimpleBaseClass::"] = @"Read152_SimpleBaseClass";
-                    _tmp[@"SimpleDerivedClass::"] = @"Read153_SimpleDerivedClass";
-                    _tmp[@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:"] = @"Read154_BaseIXmlSerializable";
-                    _tmp[@"XmlSerializableDerivedClass::"] = @"Read155_DerivedIXmlSerializable";
-                    _tmp[@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:"] = @"Read156_PurchaseOrder";
-                    _tmp[@"Address::"] = @"Read157_Address";
-                    _tmp[@"OrderedItem::"] = @"Read158_OrderedItem";
-                    _tmp[@"AliasedTestType::"] = @"Read159_AliasedTestType";
-                    _tmp[@"BaseClass1::"] = @"Read160_BaseClass1";
-                    _tmp[@"DerivedClass1::"] = @"Read161_DerivedClass1";
-                    _tmp[@"MyCollection1::"] = @"Read162_ArrayOfDateTime";
-                    _tmp[@"Orchestra::"] = @"Read163_Orchestra";
-                    _tmp[@"Instrument::"] = @"Read164_Instrument";
-                    _tmp[@"Brass::"] = @"Read165_Brass";
-                    _tmp[@"Trumpet::"] = @"Read166_Trumpet";
-                    _tmp[@"Pet::"] = @"Read167_Pet";
-                    _tmp[@"DefaultValuesSetToNaN::"] = @"Read168_DefaultValuesSetToNaN";
-                    _tmp[@"DefaultValuesSetToPositiveInfinity::"] = @"Read169_Item";
-                    _tmp[@"DefaultValuesSetToNegativeInfinity::"] = @"Read170_Item";
-                    _tmp[@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:"] = @"Read171_RootElement";
-                    _tmp[@"TypeWithLinkedProperty::"] = @"Read172_TypeWithLinkedProperty";
-                    _tmp[@"MsgDocumentType:http://example.com:Document:True:"] = @"Read173_Document";
-                    _tmp[@"RootClass::"] = @"Read174_RootClass";
-                    _tmp[@"Parameter::"] = @"Read175_Parameter";
-                    _tmp[@"XElementWrapper::"] = @"Read176_XElementWrapper";
-                    _tmp[@"XElementStruct::"] = @"Read177_XElementStruct";
-                    _tmp[@"XElementArrayWrapper::"] = @"Read178_XElementArrayWrapper";
-                    _tmp[@"DateTimeOffsetIXmlSerializableContainer::"] = @"Read179_Item";
-                    _tmp[@"SerializationTypes.TypeWithDateTimeStringProperty::"] = @"Read180_TypeWithDateTimeStringProperty";
-                    _tmp[@"SerializationTypes.SimpleType::"] = @"Read181_SimpleType";
-                    _tmp[@"SerializationTypes.TypeWithGetSetArrayMembers::"] = @"Read182_TypeWithGetSetArrayMembers";
-                    _tmp[@"SerializationTypes.TypeWithGetOnlyArrayProperties::"] = @"Read183_TypeWithGetOnlyArrayProperties";
-                    _tmp[@"SerializationTypes.TypeWithArraylikeMembers::"] = @"Read184_TypeWithArraylikeMembers";
-                    _tmp[@"SerializationTypes.StructNotSerializable::"] = @"Read185_StructNotSerializable";
-                    _tmp[@"SerializationTypes.TypeWithMyCollectionField::"] = @"Read186_TypeWithMyCollectionField";
-                    _tmp[@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::"] = @"Read187_Item";
-                    _tmp[@"SerializationTypes.MyList::"] = @"Read188_ArrayOfAnyType";
-                    _tmp[@"SerializationTypes.MyEnum::"] = @"Read189_MyEnum";
-                    _tmp[@"SerializationTypes.TypeWithEnumMembers::"] = @"Read190_TypeWithEnumMembers";
-                    _tmp[@"SerializationTypes.DCStruct::"] = @"Read191_DCStruct";
-                    _tmp[@"SerializationTypes.DCClassWithEnumAndStruct::"] = @"Read192_DCClassWithEnumAndStruct";
-                    _tmp[@"SerializationTypes.BuiltInTypes::"] = @"Read193_BuiltInTypes";
-                    _tmp[@"SerializationTypes.TypeA::"] = @"Read194_TypeA";
-                    _tmp[@"SerializationTypes.TypeB::"] = @"Read195_TypeB";
-                    _tmp[@"SerializationTypes.TypeHasArrayOfASerializedAsB::"] = @"Read196_TypeHasArrayOfASerializedAsB";
-                    _tmp[@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::"] = @"Read197_Item";
-                    _tmp[@"SerializationTypes.BaseClassWithSamePropertyName::"] = @"Read198_BaseClassWithSamePropertyName";
-                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty::"] = @"Read199_DerivedClassWithSameProperty";
-                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty2::"] = @"Read200_DerivedClassWithSameProperty2";
-                    _tmp[@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::"] = @"Read201_Item";
-                    _tmp[@"SerializationTypes.TypeWithByteArrayAsXmlText::"] = @"Read202_TypeWithByteArrayAsXmlText";
-                    _tmp[@"SerializationTypes.SimpleDC::"] = @"Read203_SimpleDC";
-                    _tmp[@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:"] = @"Read204_Item";
-                    _tmp[@"SerializationTypes.EnumFlags::"] = @"Read205_EnumFlags";
-                    _tmp[@"SerializationTypes.ClassImplementsInterface::"] = @"Read206_ClassImplementsInterface";
-                    _tmp[@"SerializationTypes.WithStruct::"] = @"Read207_WithStruct";
-                    _tmp[@"SerializationTypes.SomeStruct::"] = @"Read208_SomeStruct";
-                    _tmp[@"SerializationTypes.WithEnums::"] = @"Read209_WithEnums";
-                    _tmp[@"SerializationTypes.WithNullables::"] = @"Read210_WithNullables";
-                    _tmp[@"SerializationTypes.ByteEnum::"] = @"Read211_ByteEnum";
-                    _tmp[@"SerializationTypes.SByteEnum::"] = @"Read212_SByteEnum";
-                    _tmp[@"SerializationTypes.ShortEnum::"] = @"Read213_ShortEnum";
-                    _tmp[@"SerializationTypes.IntEnum::"] = @"Read214_IntEnum";
-                    _tmp[@"SerializationTypes.UIntEnum::"] = @"Read215_UIntEnum";
-                    _tmp[@"SerializationTypes.LongEnum::"] = @"Read216_LongEnum";
-                    _tmp[@"SerializationTypes.ULongEnum::"] = @"Read217_ULongEnum";
-                    _tmp[@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:"] = @"Read218_AttributeTesting";
-                    _tmp[@"SerializationTypes.ItemChoiceType::"] = @"Read219_ItemChoiceType";
-                    _tmp[@"SerializationTypes.TypeWithAnyAttribute::"] = @"Read220_TypeWithAnyAttribute";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructor::"] = @"Read221_KnownTypesThroughConstructor";
-                    _tmp[@"SerializationTypes.SimpleKnownTypeValue::"] = @"Read222_SimpleKnownTypeValue";
-                    _tmp[@"SerializationTypes.ClassImplementingIXmlSerializable::"] = @"Read223_Item";
-                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::"] = @"Read224_Item";
-                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::"] = @"Read225_Item";
-                    _tmp[@"SerializationTypes.TypeWithPropertyNameSpecified::"] = @"Read226_TypeWithPropertyNameSpecified";
-                    _tmp[@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:"] = @"Read227_TypeWithXmlSchemaFormAttribute";
-                    _tmp[@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::"] = @"Read228_MyXmlType";
-                    _tmp[@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::"] = @"Read229_Item";
-                    _tmp[@"SerializationTypes.CustomDocument::"] = @"Read230_CustomDocument";
-                    _tmp[@"SerializationTypes.CustomElement::"] = @"Read231_CustomElement";
-                    _tmp[@"SerializationTypes.CustomAttribute::"] = @"Read232_Item";
-                    _tmp[@"SerializationTypes.TypeWithNonPublicDefaultConstructor::"] = @"Read233_Item";
-                    _tmp[@"SerializationTypes.ServerSettings::"] = @"Read234_ServerSettings";
-                    _tmp[@"SerializationTypes.TypeWithXmlQualifiedName::"] = @"Read235_TypeWithXmlQualifiedName";
-                    _tmp[@"SerializationTypes.TypeWith2DArrayProperty2::"] = @"Read236_TypeWith2DArrayProperty2";
-                    _tmp[@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::"] = @"Read237_Item";
-                    _tmp[@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::"] = @"Read238_Item";
-                    _tmp[@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::"] = @"Read239_Item";
-                    _tmp[@"SerializationTypes.TypeWithShouldSerializeMethod::"] = @"Read240_TypeWithShouldSerializeMethod";
-                    _tmp[@"SerializationTypes.BaseTypeWithShouldSerializeMethod::"] = @"Read241_Item";
-                    _tmp[@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::"] = @"Read242_Item";
-                    _tmp[@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::"] = @"Read243_Item";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::"] = @"Read244_Item";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithValue::"] = @"Read245_Item";
-                    _tmp[@"SerializationTypes.TypeWithTypesHavingCustomFormatter::"] = @"Read246_Item";
-                    _tmp[@"SerializationTypes.TypeWithArrayPropertyHavingChoice::"] = @"Read247_Item";
-                    _tmp[@"SerializationTypes.TypeWithPropertyHavingComplexChoice::"] = @"Read248_Item";
-                    _tmp[@"SerializationTypes.MoreChoices::"] = @"Read249_MoreChoices";
-                    _tmp[@"SerializationTypes.ComplexChoiceA::"] = @"Read250_ComplexChoiceA";
-                    _tmp[@"SerializationTypes.ComplexChoiceB::"] = @"Read251_ComplexChoiceB";
-                    _tmp[@"SerializationTypes.TypeWithFieldsOrdered::"] = @"Read252_TypeWithFieldsOrdered";
-                    _tmp[@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::"] = @"Read253_Item";
-                    _tmp[@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:"] = @"Read254_Root";
-                    _tmp[@"SerializationTypes.TypeNameClashB.TypeNameClash::"] = @"Read255_TypeClashB";
-                    _tmp[@"SerializationTypes.TypeNameClashA.TypeNameClash::"] = @"Read256_TypeClashA";
-                    _tmp[@"Outer+Person::"] = @"Read257_Person";
+                    _tmp[@"TypeWithXmlElementProperty::"] = @"Read132_TypeWithXmlElementProperty";
+                    _tmp[@"TypeWithXmlDocumentProperty::"] = @"Read133_TypeWithXmlDocumentProperty";
+                    _tmp[@"TypeWithBinaryProperty::"] = @"Read134_TypeWithBinaryProperty";
+                    _tmp[@"TypeWithDateTimeOffsetProperties::"] = @"Read135_Item";
+                    _tmp[@"TypeWithDateAndTimeOnlyProperties::"] = @"Read136_Item";
+                    _tmp[@"DateOnlyWrapper::"] = @"Read137_DateOnlyWrapper";
+                    _tmp[@"TimeOnlyWrapper::"] = @"Read138_TimeOnlyWrapper";
+                    _tmp[@"TimeOnlyAsXsdTimeWrapper::"] = @"Read139_TimeOnlyAsXsdTimeWrapper";
+                    _tmp[@"DateTimeDateWrapper::"] = @"Read140_DateTimeDateWrapper";
+                    _tmp[@"DateTimeTimeWrapper::"] = @"Read141_DateTimeTimeWrapper";
+                    _tmp[@"TypeWithTimeSpanProperty::"] = @"Read142_TypeWithTimeSpanProperty";
+                    _tmp[@"TypeWithDefaultTimeSpanProperty::"] = @"Read143_Item";
+                    _tmp[@"TypeWithByteProperty::"] = @"Read144_TypeWithByteProperty";
+                    _tmp[@"TypeWithXmlNodeArrayProperty:::True:"] = @"Read145_TypeWithXmlNodeArrayProperty";
+                    _tmp[@"Animal::"] = @"Read146_Animal";
+                    _tmp[@"Dog::"] = @"Read147_Dog";
+                    _tmp[@"DogBreed::"] = @"Read148_DogBreed";
+                    _tmp[@"Group::"] = @"Read149_Group";
+                    _tmp[@"Vehicle::"] = @"Read150_Vehicle";
+                    _tmp[@"Employee::"] = @"Read151_Employee";
+                    _tmp[@"BaseClass::"] = @"Read152_BaseClass";
+                    _tmp[@"DerivedClass::"] = @"Read153_DerivedClass";
+                    _tmp[@"SimpleBaseClass::"] = @"Read154_SimpleBaseClass";
+                    _tmp[@"SimpleDerivedClass::"] = @"Read155_SimpleDerivedClass";
+                    _tmp[@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:"] = @"Read156_BaseIXmlSerializable";
+                    _tmp[@"XmlSerializableDerivedClass::"] = @"Read157_DerivedIXmlSerializable";
+                    _tmp[@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:"] = @"Read158_PurchaseOrder";
+                    _tmp[@"Address::"] = @"Read159_Address";
+                    _tmp[@"OrderedItem::"] = @"Read160_OrderedItem";
+                    _tmp[@"AliasedTestType::"] = @"Read161_AliasedTestType";
+                    _tmp[@"BaseClass1::"] = @"Read162_BaseClass1";
+                    _tmp[@"DerivedClass1::"] = @"Read163_DerivedClass1";
+                    _tmp[@"MyCollection1::"] = @"Read164_ArrayOfDateTime";
+                    _tmp[@"Orchestra::"] = @"Read165_Orchestra";
+                    _tmp[@"Instrument::"] = @"Read166_Instrument";
+                    _tmp[@"Brass::"] = @"Read167_Brass";
+                    _tmp[@"Trumpet::"] = @"Read168_Trumpet";
+                    _tmp[@"Pet::"] = @"Read169_Pet";
+                    _tmp[@"DefaultValuesSetToNaN::"] = @"Read170_DefaultValuesSetToNaN";
+                    _tmp[@"DefaultValuesSetToPositiveInfinity::"] = @"Read171_Item";
+                    _tmp[@"DefaultValuesSetToNegativeInfinity::"] = @"Read172_Item";
+                    _tmp[@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:"] = @"Read173_RootElement";
+                    _tmp[@"TypeWithLinkedProperty::"] = @"Read174_TypeWithLinkedProperty";
+                    _tmp[@"MsgDocumentType:http://example.com:Document:True:"] = @"Read175_Document";
+                    _tmp[@"RootClass::"] = @"Read176_RootClass";
+                    _tmp[@"Parameter::"] = @"Read177_Parameter";
+                    _tmp[@"XElementWrapper::"] = @"Read178_XElementWrapper";
+                    _tmp[@"XElementStruct::"] = @"Read179_XElementStruct";
+                    _tmp[@"XElementArrayWrapper::"] = @"Read180_XElementArrayWrapper";
+                    _tmp[@"DateTimeOffsetIXmlSerializableContainer::"] = @"Read181_Item";
+                    _tmp[@"SerializationTypes.TypeWithDateTimeStringProperty::"] = @"Read182_TypeWithDateTimeStringProperty";
+                    _tmp[@"SerializationTypes.SimpleType::"] = @"Read183_SimpleType";
+                    _tmp[@"SerializationTypes.TypeWithGetSetArrayMembers::"] = @"Read184_TypeWithGetSetArrayMembers";
+                    _tmp[@"SerializationTypes.TypeWithGetOnlyArrayProperties::"] = @"Read185_TypeWithGetOnlyArrayProperties";
+                    _tmp[@"SerializationTypes.TypeWithArraylikeMembers::"] = @"Read186_TypeWithArraylikeMembers";
+                    _tmp[@"SerializationTypes.StructNotSerializable::"] = @"Read187_StructNotSerializable";
+                    _tmp[@"SerializationTypes.TypeWithMyCollectionField::"] = @"Read188_TypeWithMyCollectionField";
+                    _tmp[@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::"] = @"Read189_Item";
+                    _tmp[@"SerializationTypes.MyList::"] = @"Read190_ArrayOfAnyType";
+                    _tmp[@"SerializationTypes.MyEnum::"] = @"Read191_MyEnum";
+                    _tmp[@"SerializationTypes.TypeWithEnumMembers::"] = @"Read192_TypeWithEnumMembers";
+                    _tmp[@"SerializationTypes.DCStruct::"] = @"Read193_DCStruct";
+                    _tmp[@"SerializationTypes.DCClassWithEnumAndStruct::"] = @"Read194_DCClassWithEnumAndStruct";
+                    _tmp[@"SerializationTypes.BuiltInTypes::"] = @"Read195_BuiltInTypes";
+                    _tmp[@"SerializationTypes.TypeWithBuiltInTypedMembers::"] = @"Read196_TypeWithBuiltInTypedMembers";
+                    _tmp[@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::"] = @"Read197_Item";
+                    _tmp[@"SerializationTypes.TypeA::"] = @"Read198_TypeA";
+                    _tmp[@"SerializationTypes.TypeB::"] = @"Read199_TypeB";
+                    _tmp[@"SerializationTypes.TypeHasArrayOfASerializedAsB::"] = @"Read200_TypeHasArrayOfASerializedAsB";
+                    _tmp[@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::"] = @"Read201_Item";
+                    _tmp[@"SerializationTypes.BaseClassWithSamePropertyName::"] = @"Read202_BaseClassWithSamePropertyName";
+                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty::"] = @"Read203_DerivedClassWithSameProperty";
+                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty2::"] = @"Read204_DerivedClassWithSameProperty2";
+                    _tmp[@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::"] = @"Read205_Item";
+                    _tmp[@"SerializationTypes.TypeWithByteArrayAsXmlText::"] = @"Read206_TypeWithByteArrayAsXmlText";
+                    _tmp[@"SerializationTypes.SimpleDC::"] = @"Read207_SimpleDC";
+                    _tmp[@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:"] = @"Read208_Item";
+                    _tmp[@"SerializationTypes.EnumFlags::"] = @"Read209_EnumFlags";
+                    _tmp[@"SerializationTypes.ClassImplementsInterface::"] = @"Read210_ClassImplementsInterface";
+                    _tmp[@"SerializationTypes.WithStruct::"] = @"Read211_WithStruct";
+                    _tmp[@"SerializationTypes.SomeStruct::"] = @"Read212_SomeStruct";
+                    _tmp[@"SerializationTypes.WithEnums::"] = @"Read213_WithEnums";
+                    _tmp[@"SerializationTypes.WithNullables::"] = @"Read214_WithNullables";
+                    _tmp[@"SerializationTypes.ByteEnum::"] = @"Read215_ByteEnum";
+                    _tmp[@"SerializationTypes.SByteEnum::"] = @"Read216_SByteEnum";
+                    _tmp[@"SerializationTypes.ShortEnum::"] = @"Read217_ShortEnum";
+                    _tmp[@"SerializationTypes.IntEnum::"] = @"Read218_IntEnum";
+                    _tmp[@"SerializationTypes.UIntEnum::"] = @"Read219_UIntEnum";
+                    _tmp[@"SerializationTypes.LongEnum::"] = @"Read220_LongEnum";
+                    _tmp[@"SerializationTypes.ULongEnum::"] = @"Read221_ULongEnum";
+                    _tmp[@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:"] = @"Read222_AttributeTesting";
+                    _tmp[@"SerializationTypes.ItemChoiceType::"] = @"Read223_ItemChoiceType";
+                    _tmp[@"SerializationTypes.TypeWithAnyAttribute::"] = @"Read224_TypeWithAnyAttribute";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructor::"] = @"Read225_KnownTypesThroughConstructor";
+                    _tmp[@"SerializationTypes.SimpleKnownTypeValue::"] = @"Read226_SimpleKnownTypeValue";
+                    _tmp[@"SerializationTypes.ClassImplementingIXmlSerializable::"] = @"Read227_Item";
+                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::"] = @"Read228_Item";
+                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::"] = @"Read229_Item";
+                    _tmp[@"SerializationTypes.TypeWithPropertyNameSpecified::"] = @"Read230_TypeWithPropertyNameSpecified";
+                    _tmp[@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:"] = @"Read231_TypeWithXmlSchemaFormAttribute";
+                    _tmp[@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::"] = @"Read232_MyXmlType";
+                    _tmp[@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::"] = @"Read233_Item";
+                    _tmp[@"SerializationTypes.CustomDocument::"] = @"Read234_CustomDocument";
+                    _tmp[@"SerializationTypes.CustomElement::"] = @"Read235_CustomElement";
+                    _tmp[@"SerializationTypes.CustomAttribute::"] = @"Read236_Item";
+                    _tmp[@"SerializationTypes.TypeWithNonPublicDefaultConstructor::"] = @"Read237_Item";
+                    _tmp[@"SerializationTypes.ServerSettings::"] = @"Read238_ServerSettings";
+                    _tmp[@"SerializationTypes.TypeWithXmlQualifiedName::"] = @"Read239_TypeWithXmlQualifiedName";
+                    _tmp[@"SerializationTypes.TypeWith2DArrayProperty2::"] = @"Read240_TypeWith2DArrayProperty2";
+                    _tmp[@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::"] = @"Read241_Item";
+                    _tmp[@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::"] = @"Read242_Item";
+                    _tmp[@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::"] = @"Read243_Item";
+                    _tmp[@"SerializationTypes.TypeWithShouldSerializeMethod::"] = @"Read244_TypeWithShouldSerializeMethod";
+                    _tmp[@"SerializationTypes.BaseTypeWithShouldSerializeMethod::"] = @"Read245_Item";
+                    _tmp[@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::"] = @"Read246_Item";
+                    _tmp[@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::"] = @"Read247_Item";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::"] = @"Read248_Item";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithValue::"] = @"Read249_Item";
+                    _tmp[@"SerializationTypes.TypeWithTypesHavingCustomFormatter::"] = @"Read250_Item";
+                    _tmp[@"SerializationTypes.TypeWithArrayPropertyHavingChoice::"] = @"Read251_Item";
+                    _tmp[@"SerializationTypes.TypeWithPropertyHavingComplexChoice::"] = @"Read252_Item";
+                    _tmp[@"SerializationTypes.MoreChoices::"] = @"Read253_MoreChoices";
+                    _tmp[@"SerializationTypes.ComplexChoiceA::"] = @"Read254_ComplexChoiceA";
+                    _tmp[@"SerializationTypes.ComplexChoiceB::"] = @"Read255_ComplexChoiceB";
+                    _tmp[@"SerializationTypes.TypeWithFieldsOrdered::"] = @"Read256_TypeWithFieldsOrdered";
+                    _tmp[@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::"] = @"Read257_Item";
+                    _tmp[@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:"] = @"Read258_Root";
+                    _tmp[@"SerializationTypes.TypeNameClashB.TypeNameClash::"] = @"Read259_TypeClashB";
+                    _tmp[@"SerializationTypes.TypeNameClashA.TypeNameClash::"] = @"Read260_TypeClashA";
+                    _tmp[@"Outer+Person::"] = @"Read261_Person";
                     if (readMethods == null) readMethods = _tmp;
                 }
                 return readMethods;
@@ -18753,134 +21356,136 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             get {
                 if (writeMethods == null) {
                     System.Collections.Hashtable _tmp = new System.Collections.Hashtable();
-                    _tmp[@"TypeWithXmlElementProperty::"] = @"Write124_TypeWithXmlElementProperty";
-                    _tmp[@"TypeWithXmlDocumentProperty::"] = @"Write125_TypeWithXmlDocumentProperty";
-                    _tmp[@"TypeWithBinaryProperty::"] = @"Write126_TypeWithBinaryProperty";
-                    _tmp[@"TypeWithDateTimeOffsetProperties::"] = @"Write127_Item";
-                    _tmp[@"TypeWithDateAndTimeOnlyProperties::"] = @"Write128_Item";
-                    _tmp[@"DateOnlyWrapper::"] = @"Write129_DateOnlyWrapper";
-                    _tmp[@"TimeOnlyWrapper::"] = @"Write130_TimeOnlyWrapper";
-                    _tmp[@"TimeOnlyAsXsdTimeWrapper::"] = @"Write131_TimeOnlyAsXsdTimeWrapper";
-                    _tmp[@"DateTimeDateWrapper::"] = @"Write132_DateTimeDateWrapper";
-                    _tmp[@"DateTimeTimeWrapper::"] = @"Write133_DateTimeTimeWrapper";
-                    _tmp[@"TypeWithTimeSpanProperty::"] = @"Write134_TypeWithTimeSpanProperty";
-                    _tmp[@"TypeWithDefaultTimeSpanProperty::"] = @"Write135_Item";
-                    _tmp[@"TypeWithByteProperty::"] = @"Write136_TypeWithByteProperty";
-                    _tmp[@"TypeWithXmlNodeArrayProperty:::True:"] = @"Write137_TypeWithXmlNodeArrayProperty";
-                    _tmp[@"Animal::"] = @"Write138_Animal";
-                    _tmp[@"Dog::"] = @"Write139_Dog";
-                    _tmp[@"DogBreed::"] = @"Write140_DogBreed";
-                    _tmp[@"Group::"] = @"Write141_Group";
-                    _tmp[@"Vehicle::"] = @"Write142_Vehicle";
-                    _tmp[@"Employee::"] = @"Write143_Employee";
-                    _tmp[@"BaseClass::"] = @"Write144_BaseClass";
-                    _tmp[@"DerivedClass::"] = @"Write145_DerivedClass";
-                    _tmp[@"SimpleBaseClass::"] = @"Write146_SimpleBaseClass";
-                    _tmp[@"SimpleDerivedClass::"] = @"Write147_SimpleDerivedClass";
-                    _tmp[@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:"] = @"Write148_BaseIXmlSerializable";
-                    _tmp[@"XmlSerializableDerivedClass::"] = @"Write149_DerivedIXmlSerializable";
-                    _tmp[@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:"] = @"Write150_PurchaseOrder";
-                    _tmp[@"Address::"] = @"Write151_Address";
-                    _tmp[@"OrderedItem::"] = @"Write152_OrderedItem";
-                    _tmp[@"AliasedTestType::"] = @"Write153_AliasedTestType";
-                    _tmp[@"BaseClass1::"] = @"Write154_BaseClass1";
-                    _tmp[@"DerivedClass1::"] = @"Write155_DerivedClass1";
-                    _tmp[@"MyCollection1::"] = @"Write156_ArrayOfDateTime";
-                    _tmp[@"Orchestra::"] = @"Write157_Orchestra";
-                    _tmp[@"Instrument::"] = @"Write158_Instrument";
-                    _tmp[@"Brass::"] = @"Write159_Brass";
-                    _tmp[@"Trumpet::"] = @"Write160_Trumpet";
-                    _tmp[@"Pet::"] = @"Write161_Pet";
-                    _tmp[@"DefaultValuesSetToNaN::"] = @"Write162_DefaultValuesSetToNaN";
-                    _tmp[@"DefaultValuesSetToPositiveInfinity::"] = @"Write163_Item";
-                    _tmp[@"DefaultValuesSetToNegativeInfinity::"] = @"Write164_Item";
-                    _tmp[@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:"] = @"Write165_RootElement";
-                    _tmp[@"TypeWithLinkedProperty::"] = @"Write166_TypeWithLinkedProperty";
-                    _tmp[@"MsgDocumentType:http://example.com:Document:True:"] = @"Write167_Document";
-                    _tmp[@"RootClass::"] = @"Write168_RootClass";
-                    _tmp[@"Parameter::"] = @"Write169_Parameter";
-                    _tmp[@"XElementWrapper::"] = @"Write170_XElementWrapper";
-                    _tmp[@"XElementStruct::"] = @"Write171_XElementStruct";
-                    _tmp[@"XElementArrayWrapper::"] = @"Write172_XElementArrayWrapper";
-                    _tmp[@"DateTimeOffsetIXmlSerializableContainer::"] = @"Write173_Item";
-                    _tmp[@"SerializationTypes.TypeWithDateTimeStringProperty::"] = @"Write174_TypeWithDateTimeStringProperty";
-                    _tmp[@"SerializationTypes.SimpleType::"] = @"Write175_SimpleType";
-                    _tmp[@"SerializationTypes.TypeWithGetSetArrayMembers::"] = @"Write176_TypeWithGetSetArrayMembers";
-                    _tmp[@"SerializationTypes.TypeWithGetOnlyArrayProperties::"] = @"Write177_TypeWithGetOnlyArrayProperties";
-                    _tmp[@"SerializationTypes.TypeWithArraylikeMembers::"] = @"Write178_TypeWithArraylikeMembers";
-                    _tmp[@"SerializationTypes.StructNotSerializable::"] = @"Write179_StructNotSerializable";
-                    _tmp[@"SerializationTypes.TypeWithMyCollectionField::"] = @"Write180_TypeWithMyCollectionField";
-                    _tmp[@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::"] = @"Write181_Item";
-                    _tmp[@"SerializationTypes.MyList::"] = @"Write182_ArrayOfAnyType";
-                    _tmp[@"SerializationTypes.MyEnum::"] = @"Write183_MyEnum";
-                    _tmp[@"SerializationTypes.TypeWithEnumMembers::"] = @"Write184_TypeWithEnumMembers";
-                    _tmp[@"SerializationTypes.DCStruct::"] = @"Write185_DCStruct";
-                    _tmp[@"SerializationTypes.DCClassWithEnumAndStruct::"] = @"Write186_DCClassWithEnumAndStruct";
-                    _tmp[@"SerializationTypes.BuiltInTypes::"] = @"Write187_BuiltInTypes";
-                    _tmp[@"SerializationTypes.TypeA::"] = @"Write188_TypeA";
-                    _tmp[@"SerializationTypes.TypeB::"] = @"Write189_TypeB";
-                    _tmp[@"SerializationTypes.TypeHasArrayOfASerializedAsB::"] = @"Write190_TypeHasArrayOfASerializedAsB";
-                    _tmp[@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::"] = @"Write191_Item";
-                    _tmp[@"SerializationTypes.BaseClassWithSamePropertyName::"] = @"Write192_BaseClassWithSamePropertyName";
-                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty::"] = @"Write193_DerivedClassWithSameProperty";
-                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty2::"] = @"Write194_DerivedClassWithSameProperty2";
-                    _tmp[@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::"] = @"Write195_Item";
-                    _tmp[@"SerializationTypes.TypeWithByteArrayAsXmlText::"] = @"Write196_TypeWithByteArrayAsXmlText";
-                    _tmp[@"SerializationTypes.SimpleDC::"] = @"Write197_SimpleDC";
-                    _tmp[@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:"] = @"Write198_Item";
-                    _tmp[@"SerializationTypes.EnumFlags::"] = @"Write199_EnumFlags";
-                    _tmp[@"SerializationTypes.ClassImplementsInterface::"] = @"Write200_ClassImplementsInterface";
-                    _tmp[@"SerializationTypes.WithStruct::"] = @"Write201_WithStruct";
-                    _tmp[@"SerializationTypes.SomeStruct::"] = @"Write202_SomeStruct";
-                    _tmp[@"SerializationTypes.WithEnums::"] = @"Write203_WithEnums";
-                    _tmp[@"SerializationTypes.WithNullables::"] = @"Write204_WithNullables";
-                    _tmp[@"SerializationTypes.ByteEnum::"] = @"Write205_ByteEnum";
-                    _tmp[@"SerializationTypes.SByteEnum::"] = @"Write206_SByteEnum";
-                    _tmp[@"SerializationTypes.ShortEnum::"] = @"Write207_ShortEnum";
-                    _tmp[@"SerializationTypes.IntEnum::"] = @"Write208_IntEnum";
-                    _tmp[@"SerializationTypes.UIntEnum::"] = @"Write209_UIntEnum";
-                    _tmp[@"SerializationTypes.LongEnum::"] = @"Write210_LongEnum";
-                    _tmp[@"SerializationTypes.ULongEnum::"] = @"Write211_ULongEnum";
-                    _tmp[@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:"] = @"Write212_AttributeTesting";
-                    _tmp[@"SerializationTypes.ItemChoiceType::"] = @"Write213_ItemChoiceType";
-                    _tmp[@"SerializationTypes.TypeWithAnyAttribute::"] = @"Write214_TypeWithAnyAttribute";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructor::"] = @"Write215_KnownTypesThroughConstructor";
-                    _tmp[@"SerializationTypes.SimpleKnownTypeValue::"] = @"Write216_SimpleKnownTypeValue";
-                    _tmp[@"SerializationTypes.ClassImplementingIXmlSerializable::"] = @"Write217_Item";
-                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::"] = @"Write218_Item";
-                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::"] = @"Write219_Item";
-                    _tmp[@"SerializationTypes.TypeWithPropertyNameSpecified::"] = @"Write220_TypeWithPropertyNameSpecified";
-                    _tmp[@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:"] = @"Write221_TypeWithXmlSchemaFormAttribute";
-                    _tmp[@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::"] = @"Write222_MyXmlType";
-                    _tmp[@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::"] = @"Write223_Item";
-                    _tmp[@"SerializationTypes.CustomDocument::"] = @"Write224_CustomDocument";
-                    _tmp[@"SerializationTypes.CustomElement::"] = @"Write225_CustomElement";
-                    _tmp[@"SerializationTypes.CustomAttribute::"] = @"Write226_Item";
-                    _tmp[@"SerializationTypes.TypeWithNonPublicDefaultConstructor::"] = @"Write227_Item";
-                    _tmp[@"SerializationTypes.ServerSettings::"] = @"Write228_ServerSettings";
-                    _tmp[@"SerializationTypes.TypeWithXmlQualifiedName::"] = @"Write229_TypeWithXmlQualifiedName";
-                    _tmp[@"SerializationTypes.TypeWith2DArrayProperty2::"] = @"Write230_TypeWith2DArrayProperty2";
-                    _tmp[@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::"] = @"Write231_Item";
-                    _tmp[@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::"] = @"Write232_Item";
-                    _tmp[@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::"] = @"Write233_Item";
-                    _tmp[@"SerializationTypes.TypeWithShouldSerializeMethod::"] = @"Write234_TypeWithShouldSerializeMethod";
-                    _tmp[@"SerializationTypes.BaseTypeWithShouldSerializeMethod::"] = @"Write235_Item";
-                    _tmp[@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::"] = @"Write236_Item";
-                    _tmp[@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::"] = @"Write237_Item";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::"] = @"Write238_Item";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithValue::"] = @"Write239_Item";
-                    _tmp[@"SerializationTypes.TypeWithTypesHavingCustomFormatter::"] = @"Write240_Item";
-                    _tmp[@"SerializationTypes.TypeWithArrayPropertyHavingChoice::"] = @"Write241_Item";
-                    _tmp[@"SerializationTypes.TypeWithPropertyHavingComplexChoice::"] = @"Write242_Item";
-                    _tmp[@"SerializationTypes.MoreChoices::"] = @"Write243_MoreChoices";
-                    _tmp[@"SerializationTypes.ComplexChoiceA::"] = @"Write244_ComplexChoiceA";
-                    _tmp[@"SerializationTypes.ComplexChoiceB::"] = @"Write245_ComplexChoiceB";
-                    _tmp[@"SerializationTypes.TypeWithFieldsOrdered::"] = @"Write246_TypeWithFieldsOrdered";
-                    _tmp[@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::"] = @"Write247_Item";
-                    _tmp[@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:"] = @"Write248_Root";
-                    _tmp[@"SerializationTypes.TypeNameClashB.TypeNameClash::"] = @"Write249_TypeClashB";
-                    _tmp[@"SerializationTypes.TypeNameClashA.TypeNameClash::"] = @"Write250_TypeClashA";
-                    _tmp[@"Outer+Person::"] = @"Write251_Person";
+                    _tmp[@"TypeWithXmlElementProperty::"] = @"Write126_TypeWithXmlElementProperty";
+                    _tmp[@"TypeWithXmlDocumentProperty::"] = @"Write127_TypeWithXmlDocumentProperty";
+                    _tmp[@"TypeWithBinaryProperty::"] = @"Write128_TypeWithBinaryProperty";
+                    _tmp[@"TypeWithDateTimeOffsetProperties::"] = @"Write129_Item";
+                    _tmp[@"TypeWithDateAndTimeOnlyProperties::"] = @"Write130_Item";
+                    _tmp[@"DateOnlyWrapper::"] = @"Write131_DateOnlyWrapper";
+                    _tmp[@"TimeOnlyWrapper::"] = @"Write132_TimeOnlyWrapper";
+                    _tmp[@"TimeOnlyAsXsdTimeWrapper::"] = @"Write133_TimeOnlyAsXsdTimeWrapper";
+                    _tmp[@"DateTimeDateWrapper::"] = @"Write134_DateTimeDateWrapper";
+                    _tmp[@"DateTimeTimeWrapper::"] = @"Write135_DateTimeTimeWrapper";
+                    _tmp[@"TypeWithTimeSpanProperty::"] = @"Write136_TypeWithTimeSpanProperty";
+                    _tmp[@"TypeWithDefaultTimeSpanProperty::"] = @"Write137_Item";
+                    _tmp[@"TypeWithByteProperty::"] = @"Write138_TypeWithByteProperty";
+                    _tmp[@"TypeWithXmlNodeArrayProperty:::True:"] = @"Write139_TypeWithXmlNodeArrayProperty";
+                    _tmp[@"Animal::"] = @"Write140_Animal";
+                    _tmp[@"Dog::"] = @"Write141_Dog";
+                    _tmp[@"DogBreed::"] = @"Write142_DogBreed";
+                    _tmp[@"Group::"] = @"Write143_Group";
+                    _tmp[@"Vehicle::"] = @"Write144_Vehicle";
+                    _tmp[@"Employee::"] = @"Write145_Employee";
+                    _tmp[@"BaseClass::"] = @"Write146_BaseClass";
+                    _tmp[@"DerivedClass::"] = @"Write147_DerivedClass";
+                    _tmp[@"SimpleBaseClass::"] = @"Write148_SimpleBaseClass";
+                    _tmp[@"SimpleDerivedClass::"] = @"Write149_SimpleDerivedClass";
+                    _tmp[@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:"] = @"Write150_BaseIXmlSerializable";
+                    _tmp[@"XmlSerializableDerivedClass::"] = @"Write151_DerivedIXmlSerializable";
+                    _tmp[@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:"] = @"Write152_PurchaseOrder";
+                    _tmp[@"Address::"] = @"Write153_Address";
+                    _tmp[@"OrderedItem::"] = @"Write154_OrderedItem";
+                    _tmp[@"AliasedTestType::"] = @"Write155_AliasedTestType";
+                    _tmp[@"BaseClass1::"] = @"Write156_BaseClass1";
+                    _tmp[@"DerivedClass1::"] = @"Write157_DerivedClass1";
+                    _tmp[@"MyCollection1::"] = @"Write158_ArrayOfDateTime";
+                    _tmp[@"Orchestra::"] = @"Write159_Orchestra";
+                    _tmp[@"Instrument::"] = @"Write160_Instrument";
+                    _tmp[@"Brass::"] = @"Write161_Brass";
+                    _tmp[@"Trumpet::"] = @"Write162_Trumpet";
+                    _tmp[@"Pet::"] = @"Write163_Pet";
+                    _tmp[@"DefaultValuesSetToNaN::"] = @"Write164_DefaultValuesSetToNaN";
+                    _tmp[@"DefaultValuesSetToPositiveInfinity::"] = @"Write165_Item";
+                    _tmp[@"DefaultValuesSetToNegativeInfinity::"] = @"Write166_Item";
+                    _tmp[@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:"] = @"Write167_RootElement";
+                    _tmp[@"TypeWithLinkedProperty::"] = @"Write168_TypeWithLinkedProperty";
+                    _tmp[@"MsgDocumentType:http://example.com:Document:True:"] = @"Write169_Document";
+                    _tmp[@"RootClass::"] = @"Write170_RootClass";
+                    _tmp[@"Parameter::"] = @"Write171_Parameter";
+                    _tmp[@"XElementWrapper::"] = @"Write172_XElementWrapper";
+                    _tmp[@"XElementStruct::"] = @"Write173_XElementStruct";
+                    _tmp[@"XElementArrayWrapper::"] = @"Write174_XElementArrayWrapper";
+                    _tmp[@"DateTimeOffsetIXmlSerializableContainer::"] = @"Write175_Item";
+                    _tmp[@"SerializationTypes.TypeWithDateTimeStringProperty::"] = @"Write176_TypeWithDateTimeStringProperty";
+                    _tmp[@"SerializationTypes.SimpleType::"] = @"Write177_SimpleType";
+                    _tmp[@"SerializationTypes.TypeWithGetSetArrayMembers::"] = @"Write178_TypeWithGetSetArrayMembers";
+                    _tmp[@"SerializationTypes.TypeWithGetOnlyArrayProperties::"] = @"Write179_TypeWithGetOnlyArrayProperties";
+                    _tmp[@"SerializationTypes.TypeWithArraylikeMembers::"] = @"Write180_TypeWithArraylikeMembers";
+                    _tmp[@"SerializationTypes.StructNotSerializable::"] = @"Write181_StructNotSerializable";
+                    _tmp[@"SerializationTypes.TypeWithMyCollectionField::"] = @"Write182_TypeWithMyCollectionField";
+                    _tmp[@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::"] = @"Write183_Item";
+                    _tmp[@"SerializationTypes.MyList::"] = @"Write184_ArrayOfAnyType";
+                    _tmp[@"SerializationTypes.MyEnum::"] = @"Write185_MyEnum";
+                    _tmp[@"SerializationTypes.TypeWithEnumMembers::"] = @"Write186_TypeWithEnumMembers";
+                    _tmp[@"SerializationTypes.DCStruct::"] = @"Write187_DCStruct";
+                    _tmp[@"SerializationTypes.DCClassWithEnumAndStruct::"] = @"Write188_DCClassWithEnumAndStruct";
+                    _tmp[@"SerializationTypes.BuiltInTypes::"] = @"Write189_BuiltInTypes";
+                    _tmp[@"SerializationTypes.TypeWithBuiltInTypedMembers::"] = @"Write190_TypeWithBuiltInTypedMembers";
+                    _tmp[@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::"] = @"Write191_Item";
+                    _tmp[@"SerializationTypes.TypeA::"] = @"Write192_TypeA";
+                    _tmp[@"SerializationTypes.TypeB::"] = @"Write193_TypeB";
+                    _tmp[@"SerializationTypes.TypeHasArrayOfASerializedAsB::"] = @"Write194_TypeHasArrayOfASerializedAsB";
+                    _tmp[@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::"] = @"Write195_Item";
+                    _tmp[@"SerializationTypes.BaseClassWithSamePropertyName::"] = @"Write196_BaseClassWithSamePropertyName";
+                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty::"] = @"Write197_DerivedClassWithSameProperty";
+                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty2::"] = @"Write198_DerivedClassWithSameProperty2";
+                    _tmp[@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::"] = @"Write199_Item";
+                    _tmp[@"SerializationTypes.TypeWithByteArrayAsXmlText::"] = @"Write200_TypeWithByteArrayAsXmlText";
+                    _tmp[@"SerializationTypes.SimpleDC::"] = @"Write201_SimpleDC";
+                    _tmp[@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:"] = @"Write202_Item";
+                    _tmp[@"SerializationTypes.EnumFlags::"] = @"Write203_EnumFlags";
+                    _tmp[@"SerializationTypes.ClassImplementsInterface::"] = @"Write204_ClassImplementsInterface";
+                    _tmp[@"SerializationTypes.WithStruct::"] = @"Write205_WithStruct";
+                    _tmp[@"SerializationTypes.SomeStruct::"] = @"Write206_SomeStruct";
+                    _tmp[@"SerializationTypes.WithEnums::"] = @"Write207_WithEnums";
+                    _tmp[@"SerializationTypes.WithNullables::"] = @"Write208_WithNullables";
+                    _tmp[@"SerializationTypes.ByteEnum::"] = @"Write209_ByteEnum";
+                    _tmp[@"SerializationTypes.SByteEnum::"] = @"Write210_SByteEnum";
+                    _tmp[@"SerializationTypes.ShortEnum::"] = @"Write211_ShortEnum";
+                    _tmp[@"SerializationTypes.IntEnum::"] = @"Write212_IntEnum";
+                    _tmp[@"SerializationTypes.UIntEnum::"] = @"Write213_UIntEnum";
+                    _tmp[@"SerializationTypes.LongEnum::"] = @"Write214_LongEnum";
+                    _tmp[@"SerializationTypes.ULongEnum::"] = @"Write215_ULongEnum";
+                    _tmp[@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:"] = @"Write216_AttributeTesting";
+                    _tmp[@"SerializationTypes.ItemChoiceType::"] = @"Write217_ItemChoiceType";
+                    _tmp[@"SerializationTypes.TypeWithAnyAttribute::"] = @"Write218_TypeWithAnyAttribute";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructor::"] = @"Write219_KnownTypesThroughConstructor";
+                    _tmp[@"SerializationTypes.SimpleKnownTypeValue::"] = @"Write220_SimpleKnownTypeValue";
+                    _tmp[@"SerializationTypes.ClassImplementingIXmlSerializable::"] = @"Write221_Item";
+                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::"] = @"Write222_Item";
+                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::"] = @"Write223_Item";
+                    _tmp[@"SerializationTypes.TypeWithPropertyNameSpecified::"] = @"Write224_TypeWithPropertyNameSpecified";
+                    _tmp[@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:"] = @"Write225_TypeWithXmlSchemaFormAttribute";
+                    _tmp[@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::"] = @"Write226_MyXmlType";
+                    _tmp[@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::"] = @"Write227_Item";
+                    _tmp[@"SerializationTypes.CustomDocument::"] = @"Write228_CustomDocument";
+                    _tmp[@"SerializationTypes.CustomElement::"] = @"Write229_CustomElement";
+                    _tmp[@"SerializationTypes.CustomAttribute::"] = @"Write230_Item";
+                    _tmp[@"SerializationTypes.TypeWithNonPublicDefaultConstructor::"] = @"Write231_Item";
+                    _tmp[@"SerializationTypes.ServerSettings::"] = @"Write232_ServerSettings";
+                    _tmp[@"SerializationTypes.TypeWithXmlQualifiedName::"] = @"Write233_TypeWithXmlQualifiedName";
+                    _tmp[@"SerializationTypes.TypeWith2DArrayProperty2::"] = @"Write234_TypeWith2DArrayProperty2";
+                    _tmp[@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::"] = @"Write235_Item";
+                    _tmp[@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::"] = @"Write236_Item";
+                    _tmp[@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::"] = @"Write237_Item";
+                    _tmp[@"SerializationTypes.TypeWithShouldSerializeMethod::"] = @"Write238_TypeWithShouldSerializeMethod";
+                    _tmp[@"SerializationTypes.BaseTypeWithShouldSerializeMethod::"] = @"Write239_Item";
+                    _tmp[@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::"] = @"Write240_Item";
+                    _tmp[@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::"] = @"Write241_Item";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::"] = @"Write242_Item";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithValue::"] = @"Write243_Item";
+                    _tmp[@"SerializationTypes.TypeWithTypesHavingCustomFormatter::"] = @"Write244_Item";
+                    _tmp[@"SerializationTypes.TypeWithArrayPropertyHavingChoice::"] = @"Write245_Item";
+                    _tmp[@"SerializationTypes.TypeWithPropertyHavingComplexChoice::"] = @"Write246_Item";
+                    _tmp[@"SerializationTypes.MoreChoices::"] = @"Write247_MoreChoices";
+                    _tmp[@"SerializationTypes.ComplexChoiceA::"] = @"Write248_ComplexChoiceA";
+                    _tmp[@"SerializationTypes.ComplexChoiceB::"] = @"Write249_ComplexChoiceB";
+                    _tmp[@"SerializationTypes.TypeWithFieldsOrdered::"] = @"Write250_TypeWithFieldsOrdered";
+                    _tmp[@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::"] = @"Write251_Item";
+                    _tmp[@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:"] = @"Write252_Root";
+                    _tmp[@"SerializationTypes.TypeNameClashB.TypeNameClash::"] = @"Write253_TypeClashB";
+                    _tmp[@"SerializationTypes.TypeNameClashA.TypeNameClash::"] = @"Write254_TypeClashA";
+                    _tmp[@"Outer+Person::"] = @"Write255_Person";
                     if (writeMethods == null) writeMethods = _tmp;
                 }
                 return writeMethods;
@@ -18891,134 +21496,136 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             get {
                 if (typedSerializers == null) {
                     System.Collections.Hashtable _tmp = new System.Collections.Hashtable();
-                    _tmp.Add(@"SerializationTypes.LongEnum::", new LongEnumSerializer());
-                    _tmp.Add(@"DefaultValuesSetToNaN::", new DefaultValuesSetToNaNSerializer());
-                    _tmp.Add(@"TypeWithLinkedProperty::", new TypeWithLinkedPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertyHavingComplexChoice::", new TypeWithPropertyHavingComplexChoiceSerializer());
-                    _tmp.Add(@"Employee::", new EmployeeSerializer());
-                    _tmp.Add(@"TypeWithXmlNodeArrayProperty:::True:", new TypeWithXmlNodeArrayPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeB::", new TypeBSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::", new TypeWithSchemaFormInXmlAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:", new TypeWithXmlTextAttributeOnArraySerializer());
-                    _tmp.Add(@"Vehicle::", new VehicleSerializer());
-                    _tmp.Add(@"SerializationTypes.WithEnums::", new WithEnumsSerializer());
-                    _tmp.Add(@"SerializationTypes.MyEnum::", new MyEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::", new KnownTypesThroughConstructorWithArrayPropertiesSerializer());
-                    _tmp.Add(@"XElementWrapper::", new XElementWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.ULongEnum::", new ULongEnumSerializer());
-                    _tmp.Add(@"Group::", new GroupSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:", new TypeWithXmlSchemaFormAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty::", new DerivedClassWithSamePropertySerializer());
-                    _tmp.Add(@"SerializationTypes.IntEnum::", new IntEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.ComplexChoiceB::", new ComplexChoiceBSerializer());
-                    _tmp.Add(@"SerializationTypes.ClassImplementsInterface::", new ClassImplementsInterfaceSerializer());
-                    _tmp.Add(@"DateOnlyWrapper::", new DateOnlyWrapperSerializer());
                     _tmp.Add(@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::", new DerivedTypeWithInheritedShouldSerializeSerializer());
-                    _tmp.Add(@"SerializationTypes.ComplexChoiceA::", new ComplexChoiceASerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithGetOnlyArrayProperties::", new TypeWithGetOnlyArrayPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.WithNullables::", new WithNullablesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::", new TypeWithEnumFlagPropertyHavingDefaultValueSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWith2DArrayProperty2::", new TypeWith2DArrayProperty2Serializer());
-                    _tmp.Add(@"SerializationTypes.MyList::", new MyListSerializer());
+                    _tmp.Add(@"SerializationTypes.ComplexChoiceB::", new ComplexChoiceBSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithTypesHavingCustomFormatter::", new TypeWithTypesHavingCustomFormatterSerializer());
+                    _tmp.Add(@"DateOnlyWrapper::", new DateOnlyWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.EnumFlags::", new EnumFlagsSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::", new TypeWithTypeNameInXmlTypeAttributeSerializer());
+                    _tmp.Add(@"XElementWrapper::", new XElementWrapperSerializer());
+                    _tmp.Add(@"XmlSerializableDerivedClass::", new XmlSerializableDerivedClassSerializer());
+                    _tmp.Add(@"SimpleDerivedClass::", new SimpleDerivedClassSerializer());
+                    _tmp.Add(@"DogBreed::", new DogBreedSerializer());
+                    _tmp.Add(@"XElementArrayWrapper::", new XElementArrayWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.IntEnum::", new IntEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty2::", new DerivedClassWithSameProperty2Serializer());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::", new KnownTypesThroughConstructorWithArrayPropertiesSerializer());
+                    _tmp.Add(@"Vehicle::", new VehicleSerializer());
+                    _tmp.Add(@"TypeWithDateAndTimeOnlyProperties::", new TypeWithDateAndTimeOnlyPropertiesSerializer());
                     _tmp.Add(@"SerializationTypes.ShortEnum::", new ShortEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeHasArrayOfASerializedAsB::", new TypeHasArrayOfASerializedAsBSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumMembers::", new TypeWithEnumMembersSerializer());
-                    _tmp.Add(@"Animal::", new AnimalSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithByteArrayAsXmlText::", new TypeWithByteArrayAsXmlTextSerializer());
-                    _tmp.Add(@"Dog::", new DogSerializer());
-                    _tmp.Add(@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:", new XmlSerializableBaseClassSerializer());
-                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::", new StructImplementingIXmlSerializableWithParameterlessConstructorSerializer());
-                    _tmp.Add(@"Trumpet::", new TrumpetSerializer());
-                    _tmp.Add(@"TypeWithTimeSpanProperty::", new TypeWithTimeSpanPropertySerializer());
-                    _tmp.Add(@"DateTimeDateWrapper::", new DateTimeDateWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.WithEnums::", new WithEnumsSerializer());
+                    _tmp.Add(@"SerializationTypes.ServerSettings::", new ServerSettingsSerializer());
+                    _tmp.Add(@"TypeWithXmlElementProperty::", new TypeWithXmlElementPropertySerializer());
+                    _tmp.Add(@"Address::", new AddressSerializer());
+                    _tmp.Add(@"RootClass::", new RootClassSerializer());
+                    _tmp.Add(@"SerializationTypes.MoreChoices::", new MoreChoicesSerializer());
+                    _tmp.Add(@"SerializationTypes.ClassImplementingIXmlSerializable::", new ClassImplementingIXmlSerializableSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleType::", new SimpleTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithValue::", new KnownTypesThroughConstructorWithValueSerializer());
+                    _tmp.Add(@"DefaultValuesSetToPositiveInfinity::", new DefaultValuesSetToPositiveInfinitySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::", new TypeWithFieldBackedSpecifiedMemberSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::", new TypeWithEnumFlagPropertyHavingDefaultValueSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleKnownTypeValue::", new SimpleKnownTypeValueSerializer());
+                    _tmp.Add(@"TimeOnlyAsXsdTimeWrapper::", new TimeOnlyAsXsdTimeWrapperSerializer());
+                    _tmp.Add(@"TypeWithLinkedProperty::", new TypeWithLinkedPropertySerializer());
+                    _tmp.Add(@"TimeOnlyWrapper::", new TimeOnlyWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::", new TypeWithNullableBuiltInTypedMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWith2DArrayProperty2::", new TypeWith2DArrayProperty2Serializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertyNameSpecified::", new TypeWithPropertyNameSpecifiedSerializer());
+                    _tmp.Add(@"SerializationTypes.StructNotSerializable::", new StructNotSerializableSerializer());
+                    _tmp.Add(@"TypeWithXmlDocumentProperty::", new TypeWithXmlDocumentPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:", new TypeWithXmlSchemaFormAttributeSerializer());
                     _tmp.Add(@"SerializationTypes.DCClassWithEnumAndStruct::", new DCClassWithEnumAndStructSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::", new TypeWithReadOnlyMyCollectionPropertySerializer());
-                    _tmp.Add(@"TypeWithByteProperty::", new TypeWithBytePropertySerializer());
-                    _tmp.Add(@"BaseClass1::", new BaseClass1Serializer());
+                    _tmp.Add(@"SerializationTypes.TypeNameClashA.TypeNameClash::", new TypeNameClashSerializer1());
+                    _tmp.Add(@"Instrument::", new InstrumentSerializer());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructor::", new KnownTypesThroughConstructorSerializer());
+                    _tmp.Add(@"SerializationTypes.BaseClassWithSamePropertyName::", new BaseClassWithSamePropertyNameSerializer());
+                    _tmp.Add(@"Trumpet::", new TrumpetSerializer());
+                    _tmp.Add(@"SerializationTypes.ComplexChoiceA::", new ComplexChoiceASerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlQualifiedName::", new TypeWithXmlQualifiedNameSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:", new TypeWithXmlTextAttributeOnArraySerializer());
                     _tmp.Add(@"DateTimeOffsetIXmlSerializableContainer::", new DateTimeOffsetIXmlSerializableContainerSerializer());
                     _tmp.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:", new TypeWithMismatchBetweenAttributeAndPropertyTypeSerializer());
-                    _tmp.Add(@"DefaultValuesSetToPositiveInfinity::", new DefaultValuesSetToPositiveInfinitySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithMyCollectionField::", new TypeWithMyCollectionFieldSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithNonPublicDefaultConstructor::", new TypeWithNonPublicDefaultConstructorSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithShouldSerializeMethod::", new TypeWithShouldSerializeMethodSerializer());
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithValue::", new KnownTypesThroughConstructorWithValueSerializer());
-                    _tmp.Add(@"SerializationTypes.ItemChoiceType::", new ItemChoiceTypeSerializer());
-                    _tmp.Add(@"DerivedClass1::", new DerivedClass1Serializer());
-                    _tmp.Add(@"SerializationTypes.SByteEnum::", new SByteEnumSerializer());
-                    _tmp.Add(@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:", new PurchaseOrderSerializer());
-                    _tmp.Add(@"SerializationTypes.WithStruct::", new WithStructSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithArraylikeMembers::", new TypeWithArraylikeMembersSerializer());
-                    _tmp.Add(@"DogBreed::", new DogBreedSerializer());
-                    _tmp.Add(@"SerializationTypes.UIntEnum::", new UIntEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::", new __TypeNameWithSpecialCharacters漢ñSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::", new TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithGetSetArrayMembers::", new TypeWithGetSetArrayMembersSerializer());
-                    _tmp.Add(@"TimeOnlyWrapper::", new TimeOnlyWrapperSerializer());
-                    _tmp.Add(@"MyCollection1::", new MyCollection1Serializer());
-                    _tmp.Add(@"SerializationTypes.MoreChoices::", new MoreChoicesSerializer());
-                    _tmp.Add(@"TimeOnlyAsXsdTimeWrapper::", new TimeOnlyAsXsdTimeWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleDC::", new SimpleDCSerializer());
-                    _tmp.Add(@"SerializationTypes.ClassImplementingIXmlSerializable::", new ClassImplementingIXmlSerializableSerializer());
-                    _tmp.Add(@"SerializationTypes.StructNotSerializable::", new StructNotSerializableSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomDocument::", new CustomDocumentSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::", new TypeWithDateTimePropertyAsXmlTimeSerializer());
-                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::", new StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer());
-                    _tmp.Add(@"OrderedItem::", new OrderedItemSerializer());
-                    _tmp.Add(@"MsgDocumentType:http://example.com:Document:True:", new MsgDocumentTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::", new TypeWithEnumPropertyHavingDefaultValueSerializer());
+                    _tmp.Add(@"Employee::", new EmployeeSerializer());
                     _tmp.Add(@"AliasedTestType::", new AliasedTestTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.BaseClassWithSamePropertyName::", new BaseClassWithSamePropertyNameSerializer());
-                    _tmp.Add(@"BaseClass::", new BaseClassSerializer());
-                    _tmp.Add(@"SimpleBaseClass::", new SimpleBaseClassSerializer());
-                    _tmp.Add(@"TypeWithDateAndTimeOnlyProperties::", new TypeWithDateAndTimeOnlyPropertiesSerializer());
-                    _tmp.Add(@"Brass::", new BrassSerializer());
-                    _tmp.Add(@"Instrument::", new InstrumentSerializer());
-                    _tmp.Add(@"SerializationTypes.BuiltInTypes::", new BuiltInTypesSerializer());
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructor::", new KnownTypesThroughConstructorSerializer());
-                    _tmp.Add(@"XmlSerializableDerivedClass::", new XmlSerializableDerivedClassSerializer());
-                    _tmp.Add(@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:", new NamespaceTypeNameClashContainerSerializer());
                     _tmp.Add(@"SerializationTypes.ByteEnum::", new ByteEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeNameClashB.TypeNameClash::", new TypeNameClashSerializer());
+                    _tmp.Add(@"SerializationTypes.MyEnum::", new MyEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithGetOnlyArrayProperties::", new TypeWithGetOnlyArrayPropertiesSerializer());
                     _tmp.Add(@"DefaultValuesSetToNegativeInfinity::", new DefaultValuesSetToNegativeInfinitySerializer());
-                    _tmp.Add(@"SerializationTypes.CustomElement::", new CustomElementSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeA::", new TypeASerializer());
-                    _tmp.Add(@"XElementArrayWrapper::", new XElementArrayWrapperSerializer());
-                    _tmp.Add(@"TypeWithBinaryProperty::", new TypeWithBinaryPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::", new TypeWithFieldBackedSpecifiedMemberSerializer());
                     _tmp.Add(@"Outer+Person::", new PersonSerializer());
-                    _tmp.Add(@"SerializationTypes.EnumFlags::", new EnumFlagsSerializer());
-                    _tmp.Add(@"Pet::", new PetSerializer());
-                    _tmp.Add(@"SerializationTypes.SomeStruct::", new SomeStructSerializer());
-                    _tmp.Add(@"XElementStruct::", new XElementStructSerializer());
-                    _tmp.Add(@"TypeWithDefaultTimeSpanProperty::", new TypeWithDefaultTimeSpanPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleKnownTypeValue::", new SimpleKnownTypeValueSerializer());
-                    _tmp.Add(@"Address::", new AddressSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::", new TypeWithTypeNameInXmlTypeAttributeSerializer());
-                    _tmp.Add(@"RootClass::", new RootClassSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithTypesHavingCustomFormatter::", new TypeWithTypesHavingCustomFormatterSerializer());
-                    _tmp.Add(@"TypeWithXmlElementProperty::", new TypeWithXmlElementPropertySerializer());
-                    _tmp.Add(@"DerivedClass::", new DerivedClassSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty2::", new DerivedClassWithSameProperty2Serializer());
-                    _tmp.Add(@"SimpleDerivedClass::", new SimpleDerivedClassSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomAttribute::", new CustomAttributeSerializer());
-                    _tmp.Add(@"DateTimeTimeWrapper::", new DateTimeTimeWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertyNameSpecified::", new TypeWithPropertyNameSpecifiedSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeNameClashA.TypeNameClash::", new TypeNameClashSerializer1());
-                    _tmp.Add(@"SerializationTypes.ServerSettings::", new ServerSettingsSerializer());
-                    _tmp.Add(@"SerializationTypes.DCStruct::", new DCStructSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::", new TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer());
                     _tmp.Add(@"Orchestra::", new OrchestraSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithFieldsOrdered::", new TypeWithFieldsOrderedSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlQualifiedName::", new TypeWithXmlQualifiedNameSerializer());
+                    _tmp.Add(@"DerivedClass::", new DerivedClassSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithGetSetArrayMembers::", new TypeWithGetSetArrayMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.WithNullables::", new WithNullablesSerializer());
                     _tmp.Add(@"SerializationTypes.TypeWithArrayPropertyHavingChoice::", new TypeWithArrayPropertyHavingChoiceSerializer());
-                    _tmp.Add(@"SerializationTypes.BaseTypeWithShouldSerializeMethod::", new BaseTypeWithShouldSerializeMethodSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeHasArrayOfASerializedAsB::", new TypeHasArrayOfASerializedAsBSerializer());
+                    _tmp.Add(@"Dog::", new DogSerializer());
+                    _tmp.Add(@"DerivedClass1::", new DerivedClass1Serializer());
+                    _tmp.Add(@"SimpleBaseClass::", new SimpleBaseClassSerializer());
+                    _tmp.Add(@"Pet::", new PetSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithMyCollectionField::", new TypeWithMyCollectionFieldSerializer());
+                    _tmp.Add(@"SerializationTypes.DCStruct::", new DCStructSerializer());
+                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::", new StructImplementingIXmlSerializableWithParameterlessConstructorSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithArraylikeMembers::", new TypeWithArraylikeMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertyHavingComplexChoice::", new TypeWithPropertyHavingComplexChoiceSerializer());
+                    _tmp.Add(@"SerializationTypes.ItemChoiceType::", new ItemChoiceTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleDC::", new SimpleDCSerializer());
                     _tmp.Add(@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:", new XmlSerializerAttributesSerializer());
-                    _tmp.Add(@"TypeWithXmlDocumentProperty::", new TypeWithXmlDocumentPropertySerializer());
-                    _tmp.Add(@"Parameter::", new ParameterSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithAnyAttribute::", new TypeWithAnyAttributeSerializer());
+                    _tmp.Add(@"OrderedItem::", new OrderedItemSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomElement::", new CustomElementSerializer());
+                    _tmp.Add(@"BaseClass1::", new BaseClass1Serializer());
+                    _tmp.Add(@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::", new __TypeNameWithSpecialCharacters漢ñSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::", new TypeWithDateTimePropertyAsXmlTimeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithBuiltInTypedMembers::", new TypeWithBuiltInTypedMembersSerializer());
+                    _tmp.Add(@"Animal::", new AnimalSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithShouldSerializeMethod::", new TypeWithShouldSerializeMethodSerializer());
                     _tmp.Add(@"SerializationTypes.TypeWithDateTimeStringProperty::", new TypeWithDateTimeStringPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::", new TypeWithPropertiesHavingDefaultValueSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithFieldsOrdered::", new TypeWithFieldsOrderedSerializer());
+                    _tmp.Add(@"Group::", new GroupSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomDocument::", new CustomDocumentSerializer());
+                    _tmp.Add(@"SerializationTypes.ClassImplementsInterface::", new ClassImplementsInterfaceSerializer());
+                    _tmp.Add(@"SerializationTypes.LongEnum::", new LongEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty::", new DerivedClassWithSamePropertySerializer());
+                    _tmp.Add(@"Parameter::", new ParameterSerializer());
+                    _tmp.Add(@"SerializationTypes.SByteEnum::", new SByteEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.ULongEnum::", new ULongEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithByteArrayAsXmlText::", new TypeWithByteArrayAsXmlTextSerializer());
+                    _tmp.Add(@"TypeWithTimeSpanProperty::", new TypeWithTimeSpanPropertySerializer());
+                    _tmp.Add(@"MsgDocumentType:http://example.com:Document:True:", new MsgDocumentTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::", new StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer());
+                    _tmp.Add(@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:", new NamespaceTypeNameClashContainerSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::", new TypeWithEnumPropertyHavingDefaultValueSerializer());
+                    _tmp.Add(@"DateTimeTimeWrapper::", new DateTimeTimeWrapperSerializer());
+                    _tmp.Add(@"MyCollection1::", new MyCollection1Serializer());
                     _tmp.Add(@"TypeWithDateTimeOffsetProperties::", new TypeWithDateTimeOffsetPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleType::", new SimpleTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.WithStruct::", new WithStructSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithAnyAttribute::", new TypeWithAnyAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.BuiltInTypes::", new BuiltInTypesSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomAttribute::", new CustomAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::", new TypeWithReadOnlyMyCollectionPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithNonPublicDefaultConstructor::", new TypeWithNonPublicDefaultConstructorSerializer());
+                    _tmp.Add(@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:", new XmlSerializableBaseClassSerializer());
+                    _tmp.Add(@"TypeWithBinaryProperty::", new TypeWithBinaryPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumMembers::", new TypeWithEnumMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.SomeStruct::", new SomeStructSerializer());
+                    _tmp.Add(@"TypeWithDefaultTimeSpanProperty::", new TypeWithDefaultTimeSpanPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.UIntEnum::", new UIntEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::", new TypeWithSchemaFormInXmlAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.BaseTypeWithShouldSerializeMethod::", new BaseTypeWithShouldSerializeMethodSerializer());
+                    _tmp.Add(@"BaseClass::", new BaseClassSerializer());
+                    _tmp.Add(@"XElementStruct::", new XElementStructSerializer());
+                    _tmp.Add(@"Brass::", new BrassSerializer());
+                    _tmp.Add(@"DateTimeDateWrapper::", new DateTimeDateWrapperSerializer());
+                    _tmp.Add(@"TypeWithByteProperty::", new TypeWithBytePropertySerializer());
+                    _tmp.Add(@"TypeWithXmlNodeArrayProperty:::True:", new TypeWithXmlNodeArrayPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeB::", new TypeBSerializer());
+                    _tmp.Add(@"SerializationTypes.MyList::", new MyListSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::", new TypeWithPropertiesHavingDefaultValueSerializer());
+                    _tmp.Add(@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:", new PurchaseOrderSerializer());
+                    _tmp.Add(@"DefaultValuesSetToNaN::", new DefaultValuesSetToNaNSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeA::", new TypeASerializer());
+                    _tmp.Add(@"SerializationTypes.TypeNameClashB.TypeNameClash::", new TypeNameClashSerializer());
                     if (typedSerializers == null) typedSerializers = _tmp;
                 }
                 return typedSerializers;
@@ -19089,6 +21696,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             if (type == typeof(global::SerializationTypes.DCStruct)) return true;
             if (type == typeof(global::SerializationTypes.DCClassWithEnumAndStruct)) return true;
             if (type == typeof(global::SerializationTypes.BuiltInTypes)) return true;
+            if (type == typeof(global::SerializationTypes.TypeWithBuiltInTypedMembers)) return true;
+            if (type == typeof(global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)) return true;
             if (type == typeof(global::SerializationTypes.TypeA)) return true;
             if (type == typeof(global::SerializationTypes.TypeB)) return true;
             if (type == typeof(global::SerializationTypes.TypeHasArrayOfASerializedAsB)) return true;
@@ -19220,6 +21829,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             if (type == typeof(global::SerializationTypes.DCStruct)) return new DCStructSerializer();
             if (type == typeof(global::SerializationTypes.DCClassWithEnumAndStruct)) return new DCClassWithEnumAndStructSerializer();
             if (type == typeof(global::SerializationTypes.BuiltInTypes)) return new BuiltInTypesSerializer();
+            if (type == typeof(global::SerializationTypes.TypeWithBuiltInTypedMembers)) return new TypeWithBuiltInTypedMembersSerializer();
+            if (type == typeof(global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)) return new TypeWithNullableBuiltInTypedMembersSerializer();
             if (type == typeof(global::SerializationTypes.TypeA)) return new TypeASerializer();
             if (type == typeof(global::SerializationTypes.TypeB)) return new TypeBSerializer();
             if (type == typeof(global::SerializationTypes.TypeHasArrayOfASerializedAsB)) return new TypeHasArrayOfASerializedAsBSerializer();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -854,6 +854,7 @@ namespace System.Xml.Serialization
             }
             else if (!element.Mapping!.IsSoap && (element.Mapping is PrimitiveMapping))
             {
+                HandleUnknownAttributes();
                 if (element.IsNullable && ReadNull())
                 {
                     if (element.Mapping.TypeDesc!.IsValueType)
@@ -1127,6 +1128,7 @@ namespace System.Xml.Serialization
             }
             else
             {
+                HandleUnknownAttributes();
                 if (!ReadNull())
                 {
                     var memberMapping = new MemberMapping()
@@ -1890,6 +1892,29 @@ namespace System.Xml.Serialization
 
             o = null;
             return false;
+        }
+
+        // Walks the attributes on the current element and raises the UnknownNode/UnknownAttribute
+        // events for any non-namespace attribute. This mirrors the attribute handling that already
+        // happens for elements mapped to structs (via WriteAttributes), so that unknown attributes
+        // on elements mapped to primitives, arrays, and collections are surfaced consistently.
+        private void HandleUnknownAttributes()
+        {
+            // When the element is marked xsi:nil, the nil marker (and the element itself) is consumed
+            // by the following ReadNull() call, so its attributes must not be surfaced as unknown. This
+            // also matches the struct path, where a nil element returns before its attributes are read.
+            if (GetNullAttr())
+            {
+                return;
+            }
+            while (Reader.MoveToNextAttribute())
+            {
+                if (!IsXmlnsAttribute(Reader.Name))
+                {
+                    UnknownNode(null);
+                }
+            }
+            Reader.MoveToElement();
         }
 
         private void WriteAttributes(Member[] members, Member? anyAttribute, UnknownNodeAction elseCall, ref object? o)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -4560,6 +4560,32 @@ namespace System.Xml.Serialization
                 Writer.Write("})");
         }
 
+        // Emits code that walks the attributes on the current element and raises the
+        // UnknownNode/UnknownAttribute events for any non-namespace attribute. This mirrors the
+        // attribute handling that already happens for elements mapped to structs (via WriteAttributes),
+        // so that unknown attributes on elements mapped to primitives, arrays, and collections are
+        // surfaced consistently.
+        private void WriteHandleUnknownAttributes()
+        {
+            // When the element is marked xsi:nil, the nil marker (and the element itself) is consumed
+            // by the following ReadNull() call, so its attributes must not be surfaced as unknown. This
+            // also matches the struct path, where a nil element returns before its attributes are read.
+            Writer.WriteLine("if (!GetNullAttr()) {");
+            Writer.Indent++;
+            Writer.WriteLine("while (Reader.MoveToNextAttribute()) {");
+            Writer.Indent++;
+            Writer.WriteLine("if (!IsXmlnsAttribute(Reader.Name)) {");
+            Writer.Indent++;
+            Writer.WriteLine("UnknownNode(null);");
+            Writer.Indent--;
+            Writer.WriteLine("}");
+            Writer.Indent--;
+            Writer.WriteLine("}");
+            Writer.WriteLine("Reader.MoveToElement();");
+            Writer.Indent--;
+            Writer.WriteLine("}");
+        }
+
         private void WriteArray(string source, string? arrayName, ArrayMapping arrayMapping, bool readOnly, bool isNullable, int fixupIndex)
         {
             if (arrayMapping.IsSoap)
@@ -4601,6 +4627,7 @@ namespace System.Xml.Serialization
             }
             else
             {
+                WriteHandleUnknownAttributes();
                 Writer.WriteLine("if (!ReadNull()) {");
                 Writer.Indent++;
 
@@ -4689,6 +4716,7 @@ namespace System.Xml.Serialization
             }
             else if (!element.Mapping!.IsSoap && (element.Mapping is PrimitiveMapping))
             {
+                WriteHandleUnknownAttributes();
                 if (element.IsNullable)
                 {
                     Writer.WriteLine("if (ReadNull()) {");

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -2843,8 +2843,102 @@ namespace System.Xml.Serialization
             throw Globals.NotSupported($"Unexpected: {source}");
         }
 
+        // Emits IL that walks the attributes on the current element and raises the
+        // UnknownNode/UnknownAttribute events for any non-namespace attribute. This mirrors the
+        // attribute handling that already happens for elements mapped to structs (via WriteAttributes),
+        // so that unknown attributes on elements mapped to primitives, arrays, and collections are
+        // surfaced consistently.
+        private void WriteHandleUnknownAttributes()
+        {
+            MethodInfo XmlSerializationReader_GetNullAttr = typeof(XmlSerializationReader).GetMethod(
+                "GetNullAttr",
+                CodeGenerator.InstanceBindingFlags,
+                Type.EmptyTypes
+                )!;
+            MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
+                "get_Reader",
+                CodeGenerator.InstanceBindingFlags,
+                Type.EmptyTypes
+                )!;
+            MethodInfo XmlReader_MoveToNextAttribute = typeof(XmlReader).GetMethod(
+                "MoveToNextAttribute",
+                CodeGenerator.InstanceBindingFlags,
+                Type.EmptyTypes
+                )!;
+            MethodInfo XmlReader_get_Name = typeof(XmlReader).GetMethod(
+                "get_Name",
+                CodeGenerator.InstanceBindingFlags,
+                Type.EmptyTypes
+                )!;
+            MethodInfo XmlSerializationReader_IsXmlnsAttribute = typeof(XmlSerializationReader).GetMethod(
+                "IsXmlnsAttribute",
+                CodeGenerator.InstanceBindingFlags,
+                new Type[] { typeof(string) }
+                )!;
+            MethodInfo XmlSerializationReader_UnknownNode = typeof(XmlSerializationReader).GetMethod(
+                "UnknownNode",
+                CodeGenerator.InstanceBindingFlags,
+                new Type[] { typeof(object) }
+                )!;
+            MethodInfo XmlReader_MoveToElement = typeof(XmlReader).GetMethod(
+                "MoveToElement",
+                CodeGenerator.InstanceBindingFlags,
+                Type.EmptyTypes
+                )!;
+
+            // When the element is marked xsi:nil, the nil marker (and the element itself) is consumed
+            // by the following ReadNull() call, so its attributes must not be surfaced as unknown. This
+            // also matches the struct path, where a nil element returns before its attributes are read.
+            // if (!GetNullAttr()) {
+            ilg.Ldarg(0);
+            ilg.Call(XmlSerializationReader_GetNullAttr);
+            ilg.Ldc(false);
+            ilg.If(Cmp.EqualTo);
+            {
+                // while (Reader.MoveToNextAttribute()) {
+                //     if (!IsXmlnsAttribute(Reader.Name)) {
+                //         UnknownNode(null);
+                //     }
+                // }
+                ilg.WhileBegin();
+                ilg.Ldarg(0);
+                ilg.Ldarg(0);
+                ilg.Call(XmlSerializationReader_get_Reader);
+                ilg.Call(XmlReader_get_Name);
+                ilg.Call(XmlSerializationReader_IsXmlnsAttribute);
+                ilg.Ldc(false);
+                ilg.If(Cmp.EqualTo);
+                {
+                    ilg.Ldarg(0);
+                    ilg.Load(null);
+                    ilg.Call(XmlSerializationReader_UnknownNode);
+                }
+                ilg.EndIf();
+                ilg.WhileBeginCondition();
+                {
+                    ilg.Ldarg(0);
+                    ilg.Call(XmlSerializationReader_get_Reader);
+                    ilg.Call(XmlReader_MoveToNextAttribute);
+                }
+                ilg.WhileEndCondition();
+                ilg.WhileEnd();
+
+                // Reader.MoveToElement();
+                ilg.Ldarg(0);
+                ilg.Call(XmlSerializationReader_get_Reader);
+                ilg.Call(XmlReader_MoveToElement);
+                ilg.Pop();
+            }
+            ilg.EndIf();
+        }
+
         private void WriteArray(string source, string? arrayName, ArrayMapping arrayMapping, bool readOnly, bool isNullable, int elementIndex)
         {
+            if (!arrayMapping.IsSoap)
+            {
+                WriteHandleUnknownAttributes();
+            }
+
             MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                 "ReadNull",
                 CodeGenerator.InstanceBindingFlags,
@@ -2992,6 +3086,10 @@ namespace System.Xml.Serialization
             }
             else if (element.Mapping is PrimitiveMapping)
             {
+                if (!element.Mapping.IsSoap)
+                {
+                    WriteHandleUnknownAttributes();
+                }
                 bool doEndIf = false;
                 if (element.IsNullable)
                 {

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -2114,6 +2114,82 @@ WithXmlHeader(@"<SimpleType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instanc
         bool b = grouplists.Contains("GroupType") && grouplists.Contains("GroupNumber") && grouplists.Contains("GroupBase");
         Assert.True(b);
     }
+
+    [Fact]
+    public static void XmlUnknownAttributeOnBuiltInTypedMembersTest()
+    {
+        var unknownAttributes = new List<string>();
+        XmlSerializer serializer = new XmlSerializer(typeof(TypeWithBuiltInTypedMembers));
+        serializer.UnknownAttribute += new XmlAttributeEventHandler((o, args) =>
+        {
+            unknownAttributes.Add(args.Attr.LocalName);
+        });
+
+        string xmlFileContent = WithXmlHeader(@"<TypeWithBuiltInTypedMembers xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+            <StringMember strayA=""1"">hello</StringMember>
+            <IntMember strayB=""2"">42</IntMember>
+            <NullableIntMember strayC=""3"">7</NullableIntMember>
+            <ListMember strayD=""4"">
+                <string strayE=""5"">a</string>
+                <string>b</string>
+            </ListMember>
+            <ArrayMember strayF=""6"">
+                <int strayG=""7"">1</int>
+                <int>2</int>
+            </ArrayMember>
+        </TypeWithBuiltInTypedMembers>");
+        var result = (TypeWithBuiltInTypedMembers)serializer.Deserialize(GetStreamFromString(xmlFileContent));
+
+        // The stray attributes must not disrupt deserialization of the element content.
+        Assert.NotNull(result);
+        Assert.Equal("hello", result.StringMember);
+        Assert.Equal(42, result.IntMember);
+        Assert.Equal(7, result.NullableIntMember);
+        Assert.Equal(2, result.ListMember.Count);
+        Assert.Equal("a", result.ListMember[0]);
+        Assert.Equal("b", result.ListMember[1]);
+        Assert.Equal(new int[] { 1, 2 }, result.ArrayMember);
+
+        // Prior to the fix, unknown attributes on elements mapped to primitives, arrays, and
+        // collection items were silently dropped and never surfaced through the event.
+        Assert.Equal(7, unknownAttributes.Count);
+        foreach (string name in new[] { "strayA", "strayB", "strayC", "strayD", "strayE", "strayF", "strayG" })
+        {
+            Assert.Contains(name, unknownAttributes);
+        }
+    }
+
+    [Fact]
+    public static void XmlNilAttributeOnBuiltInTypedMembersNotReportedTest()
+    {
+        var unknownAttributes = new List<string>();
+        XmlSerializer serializer = new XmlSerializer(typeof(TypeWithNullableBuiltInTypedMembers));
+        serializer.UnknownAttribute += new XmlAttributeEventHandler((o, args) =>
+        {
+            unknownAttributes.Add(args.Attr.LocalName);
+        });
+
+        string xmlFileContent = WithXmlHeader(@"<TypeWithNullableBuiltInTypedMembers xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+            <StringMember xsi:nil=""true"" />
+            <NullableIntMember xsi:nil=""true"" />
+            <ArrayMember xsi:nil=""true"" />
+            <ListMember xsi:nil=""true"" />
+        </TypeWithNullableBuiltInTypedMembers>");
+        var result = (TypeWithNullableBuiltInTypedMembers)serializer.Deserialize(GetStreamFromString(xmlFileContent));
+
+        Assert.NotNull(result);
+        Assert.Null(result.StringMember);
+        Assert.Null(result.NullableIntMember);
+        Assert.Null(result.ArrayMember);
+        Assert.NotNull(result.ListMember);
+        Assert.Empty(result.ListMember);
+
+        // xsi:nil is meaningful for these members (it drives the null result) and is consumed by the
+        // serializer, so it must not be surfaced as an unknown attribute. This matches how elements
+        // mapped to structs behave, where a nil element returns before its attributes are inspected.
+        Assert.Empty(unknownAttributes);
+    }
+
     private static Stream GetStreamFromString(string s)
     {
         MemoryStream stream = new MemoryStream();
@@ -3478,4 +3554,25 @@ internal sealed class XmlSerializerAppContextSwitchScope : IDisposable
         }
         throw new ArgumentException($"Cannot guess cached field name from switch name '{name}'");
     }
+}
+
+public class TypeWithBuiltInTypedMembers
+{
+    public string StringMember;
+    public int IntMember;
+    public int? NullableIntMember;
+    public List<string> ListMember;
+    public int[] ArrayMember;
+}
+
+public class TypeWithNullableBuiltInTypedMembers
+{
+    [XmlElement(IsNullable = true)]
+    public string StringMember;
+
+    public int? NullableIntMember;
+
+    public int[] ArrayMember;
+
+    public List<string> ListMember;
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -2115,6 +2115,7 @@ WithXmlHeader(@"<SimpleType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instanc
         Assert.True(b);
     }
 
+#if !XMLSERIALIZERGENERATORTESTS
     [Fact]
     public static void XmlUnknownAttributeOnBuiltInTypedMembersTest()
     {
@@ -2189,6 +2190,7 @@ WithXmlHeader(@"<SimpleType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instanc
         // mapped to structs behave, where a nil element returns before its attributes are inspected.
         Assert.Empty(unknownAttributes);
     }
+#endif
 
     private static Stream GetStreamFromString(string s)
     {
@@ -3554,25 +3556,4 @@ internal sealed class XmlSerializerAppContextSwitchScope : IDisposable
         }
         throw new ArgumentException($"Cannot guess cached field name from switch name '{name}'");
     }
-}
-
-public class TypeWithBuiltInTypedMembers
-{
-    public string StringMember;
-    public int IntMember;
-    public int? NullableIntMember;
-    public List<string> ListMember;
-    public int[] ArrayMember;
-}
-
-public class TypeWithNullableBuiltInTypedMembers
-{
-    [XmlElement(IsNullable = true)]
-    public string StringMember;
-
-    public int? NullableIntMember;
-
-    public int[] ArrayMember;
-
-    public List<string> ListMember;
 }

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -4642,3 +4642,24 @@ public class PrimiveAttributeTestDerived : PrimiveAttributeTestBase
     [XmlText]
     public int Number { get; set; }
 }
+
+public class TypeWithBuiltInTypedMembers
+{
+    public string StringMember;
+    public int IntMember;
+    public int? NullableIntMember;
+    public List<string> ListMember;
+    public int[] ArrayMember;
+}
+
+public class TypeWithNullableBuiltInTypedMembers
+{
+    [XmlElement(IsNullable = true)]
+    public string StringMember;
+
+    public int? NullableIntMember;
+
+    public int[] ArrayMember;
+
+    public List<string> ListMember;
+}

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -4642,24 +4642,3 @@ public class PrimiveAttributeTestDerived : PrimiveAttributeTestBase
     [XmlText]
     public int Number { get; set; }
 }
-
-public class TypeWithBuiltInTypedMembers
-{
-    public string StringMember;
-    public int IntMember;
-    public int? NullableIntMember;
-    public List<string> ListMember;
-    public int[] ArrayMember;
-}
-
-public class TypeWithNullableBuiltInTypedMembers
-{
-    [XmlElement(IsNullable = true)]
-    public string StringMember;
-
-    public int? NullableIntMember;
-
-    public int[] ArrayMember;
-
-    public List<string> ListMember;
-}

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -370,6 +370,27 @@ namespace SerializationTypes
         public byte[] ByteArray { get; set; }
     }
 
+    public class TypeWithBuiltInTypedMembers
+    {
+        public string StringMember;
+        public int IntMember;
+        public int? NullableIntMember;
+        public List<string> ListMember;
+        public int[] ArrayMember;
+    }
+
+    public class TypeWithNullableBuiltInTypedMembers
+    {
+        [XmlElement(IsNullable = true)]
+        public string StringMember;
+
+        public int? NullableIntMember;
+
+        public int[] ArrayMember;
+
+        public List<string> ListMember;
+    }
+
     public class TypeA
     {
         public string Name;


### PR DESCRIPTION
## Summary

`XmlSerializer`'s `UnknownAttribute` event only fired for unknown attributes on elements mapped to user-defined struct types. Elements mapped to built-in types (primitives, arrays, and collections) read their content directly and never inspected attributes, so stray attributes on those elements were silently dropped and never surfaced through the event.

This fixes #96683 by making the primitive/array/collection paths walk the element's attributes the same way the struct path already does.

## Approach

When an element is mapped to a primitive, array, or collection, the reader now walks the current element's attributes and raises `UnknownNode`/`UnknownAttribute` for any non-namespace attribute, mirroring the existing struct handling in `WriteAttributes`. The same change is applied consistently to all three readers:

- Reflection reader (`ReflectionXmlSerializationReader`)
- IL-gen reader (`XmlSerializationReaderILGen`, the default runtime reader)
- Code-gen reader (`XmlSerializationReader`/sgen)

`xsi:nil` elements are deliberately skipped (guarded by `GetNullAttr()`). The nil marker is consumed by the subsequent `ReadNull()` call, and surfacing it would be wrong; this matches the struct path, where a nil element returns before its attributes are inspected.

## Compatibility

There is no app-compat switch and no new public API surface. When no handler is subscribed, `UnknownNode` is a no-op, so behavior is unchanged unless a caller has explicitly subscribed to the `UnknownAttribute` event, in which case they now also get notified about attributes on built-in typed elements. Anyone subscribed to that event almost certainly wants this to work correctly.

## Tests

Added two regression tests to `XmlSerializerTests`:

- `XmlUnknownAttributeOnBuiltInTypedMembersTest` verifies that stray attributes on string/int/nullable-int/list/array members and their items are all reported, and that they do not disrupt deserialization of the element content.
- `XmlNilAttributeOnBuiltInTypedMembersNotReportedTest` verifies that `xsi:nil` is not surfaced as an unknown attribute and still drives the expected null results.

Verified across the IL-gen and reflection-only test legs; the full `XmlSerializerTests` class passes (324 tests, 0 failures). The tests fail without the fix and pass with it.

Fixes #96683

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.