### PR TITLE
Switch runtime iOS jobs to simulator temporarily

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1169,7 +1169,8 @@ extends:
                     eq(variables['isRollingBuild'], true))
 
       #
-      # iOS devices
+      # iOS Simulator
+      # Temporarily use the iOS Simulator instead of iOS devices until https://github.com/dotnet/runtime/issues/123796 is resolved.
       # Build the whole product using Native AOT and run libraries tests
       #
       - template: /eng/pipelines/common/platform-matrix.yml
@@ -1179,7 +1180,7 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
+            - iossimulator_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange
@@ -1212,7 +1213,8 @@ extends:
                     eq(variables['isRollingBuild'], true))
 
       #
-      # iOS devices
+      # iOS Simulator
+      # Temporarily use the iOS Simulator instead of iOS devices until https://github.com/dotnet/runtime/issues/123796 is resolved.
       # Build the whole product using CoreCLR and run libraries tests
       #
       - template: /eng/pipelines/common/platform-matrix.yml
@@ -1222,7 +1224,7 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
+            - iossimulator_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange


### PR DESCRIPTION
- Switch the runtime pipeline's NativeAOT and CoreCLR library-test jobs from `ios_arm64` to `iossimulator_arm64`.
- Temporary until #123796 is resolved.
