### PR TITLE
Fix WKS BGC access violation from stale ma_committed on unlinked expansion segment (#123490)

### DIFF
--- a/src/coreclr/gc/background.cpp
+++ b/src/coreclr/gc/background.cpp
@@ -1534,7 +1534,12 @@ BOOL gc_heap::commit_new_mark_array (uint32_t* new_mark_array_addr)
         }
     }
 
-#if defined(MULTIPLE_HEAPS) && !defined(USE_REGIONS)
+#ifndef USE_REGIONS
+    // Re-commit the mark array for the expansion segment created during a compacting GC
+    // that has not yet been threaded onto its generation list (see new_heap_segment and
+    // issue #123490). The generation-list walk above cannot reach it, so without this it
+    // would keep a stale heap_segment_flags_ma_committed while its pages on the new array
+    // stay uncommitted, and a later BGC's pinning scan would read an uncommitted page.
     if (new_heap_segment)
     {
         if (!commit_mark_array_with_check (new_heap_segment, new_mark_array_addr))
@@ -1542,7 +1547,7 @@ BOOL gc_heap::commit_new_mark_array (uint32_t* new_mark_array_addr)
             return FALSE;
         }
     }
-#endif //MULTIPLE_HEAPS && !USE_REGIONS
+#endif //!USE_REGIONS
 
     return TRUE;
 }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -1163,6 +1163,10 @@ uint8_t*    gc_heap::min_overflow_address = MAX_PTR;
 
 uint8_t*    gc_heap::max_overflow_address = 0;
 
+#ifndef USE_REGIONS
+heap_segment* gc_heap::new_heap_segment = nullptr;
+#endif //!USE_REGIONS
+
 uint8_t*    gc_heap::shigh = 0;
 
 uint8_t*    gc_heap::slow = MAX_PTR;

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -3555,6 +3555,14 @@ private:
     PER_HEAP_FIELD_SINGLE_GC heap_segment* new_heap_segment;
 #endif //USE_REGIONS
 #else //MULTIPLE_HEAPS
+#ifndef USE_REGIONS
+    // The expansion segment created by soh_get_segment_to_expand during a compacting GC.
+    // It is deliberately not threaded onto the segment chain until relocation/compaction
+    // completes, so a concurrent card-table grow cannot find it via the generation-list
+    // walk. Recording it here lets commit_new_mark_array re-commit its mark array on the
+    // new array during a grow (see issue #123490).
+    PER_HEAP_FIELD_SINGLE_GC heap_segment* new_heap_segment;
+#endif //USE_REGIONS
     PER_HEAP_FIELD_SINGLE_GC uint8_t* shigh; //keeps track of the highest marked object
     PER_HEAP_FIELD_SINGLE_GC uint8_t* slow; //keeps track of the lowest marked object
 #endif //MULTIPLE_HEAPS

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -3546,23 +3546,17 @@ private:
     PER_HEAP_FIELD_SINGLE_GC bool no_gc_oom_p;
     PER_HEAP_FIELD_SINGLE_GC heap_segment* saved_loh_segment_no_gc;
 
+#ifndef USE_REGIONS
+    PER_HEAP_FIELD_SINGLE_GC heap_segment* new_heap_segment;
+#endif //USE_REGIONS
+
 #ifdef MULTIPLE_HEAPS
 #ifdef USE_REGIONS
     PER_HEAP_FIELD_SINGLE_GC min_fl_list_info* min_fl_list;
     PER_HEAP_FIELD_SINGLE_GC size_t num_fl_items_rethreaded_stage2;
     PER_HEAP_FIELD_SINGLE_GC size_t* free_list_space_per_heap;
-#else //USE_REGIONS
-    PER_HEAP_FIELD_SINGLE_GC heap_segment* new_heap_segment;
 #endif //USE_REGIONS
 #else //MULTIPLE_HEAPS
-#ifndef USE_REGIONS
-    // The expansion segment created by soh_get_segment_to_expand during a compacting GC.
-    // It is deliberately not threaded onto the segment chain until relocation/compaction
-    // completes, so a concurrent card-table grow cannot find it via the generation-list
-    // walk. Recording it here lets commit_new_mark_array re-commit its mark array on the
-    // new array during a grow (see issue #123490).
-    PER_HEAP_FIELD_SINGLE_GC heap_segment* new_heap_segment;
-#endif //USE_REGIONS
     PER_HEAP_FIELD_SINGLE_GC uint8_t* shigh; //keeps track of the highest marked object
     PER_HEAP_FIELD_SINGLE_GC uint8_t* slow; //keeps track of the lowest marked object
 #endif //MULTIPLE_HEAPS

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -3548,7 +3548,7 @@ private:
 
 #ifndef USE_REGIONS
     PER_HEAP_FIELD_SINGLE_GC heap_segment* new_heap_segment;
-#endif //USE_REGIONS
+#endif //!USE_REGIONS
 
 #ifdef MULTIPLE_HEAPS
 #ifdef USE_REGIONS

--- a/src/coreclr/gc/plan_phase.cpp
+++ b/src/coreclr/gc/plan_phase.cpp
@@ -4548,11 +4548,11 @@ void gc_heap::plan_phase (int condemned_gen_number)
         settings.loh_compaction = FALSE;
     }
 
-#ifdef MULTIPLE_HEAPS
 #ifndef USE_REGIONS
     new_heap_segment = NULL;
 #endif //!USE_REGIONS
 
+#ifdef MULTIPLE_HEAPS
     if (should_compact && should_expand)
         gc_policy = policy_expand;
     else if (should_compact)
@@ -4854,7 +4854,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
         if (should_expand)
         {
 #ifndef MULTIPLE_HEAPS
-            heap_segment* new_heap_segment = soh_get_segment_to_expand();
+            new_heap_segment = soh_get_segment_to_expand();
 #endif //!MULTIPLE_HEAPS
             if (new_heap_segment)
             {


### PR DESCRIPTION
# Fix #123490: WKS BGC access violation in `background_mark_simple` during pinning-handle scan

Fixes #123490.

The same assertion — an identical `WKS::gc_heap::background_mark_simple` pinning-scan access
violation on x86-Checked in the `GC/Features/HeapExpansion/plug` test — was reported earlier as
intermittent CI failures in #88977, #93162, and #105211. Those were closed as transient / no-repro
(or as a presumed duplicate of an unrelated heap-corruption fix) without a root cause ever being
established; this is the same symptom, now root-caused and fixed.

## Summary

On **x86 Windows with Workstation background GC (segments layout)**, a background GC can crash with
an access violation inside `WKS::gc_heap::background_mark_simple` while the BGC thread scans pinning
handles (`background_promote` ← `PinObject` ← async pinning-handle scan). The faulting object is a
perfectly valid, live, **pinned** object — the crash is not object corruption. The BGC reads an
**uncommitted page of the mark array** for the segment that object lives on.

This ports Server GC's existing safety net to Workstation GC so the mark array for an in-flight
expansion segment is re-committed whenever the card table / mark array grows.

## Root cause

The whole corruption window is a **single foreground (ephemeral) GC that runs mid-BGC with the EE
suspended** — one thread, no concurrent race. The BGC only sets the stage (it forces every new
segment to have a committed mark array) and delivers the delayed crash in a *later* epoch. Here is
the sequence, with addresses from the reproduced dump (`core.4988`):

**1 — A segment `S` is born mid-BGC, off-list.** A compacting foreground GC needs room to promote,
so it creates SOH segment `S = 0x4CB50000`. Because a BGC is in progress, `commit_mark_array_new_seg`
commits `S`'s slice on the *current* mark array (`0x5153C400`) and sets `heap_segment_flags_ma_committed`.
`S` is put in the segment-mapping table, but — per `expand_heap` — it is **deliberately not threaded
onto any generation's segment list** while relocation/compaction runs:

```cpp
//Note: the ephemeral segment shouldn't be threaded onto the segment chain
//because the relocation and compact phases shouldn't see it
```

At this instant the flag is *honest*: `S` really is committed on the array that is live right now.

**2 — A grow fires before `S` is linked, on the same thread.** The same compacting GC keeps
promoting survivors into gen2, and as gen2 fills it acquires further SOH segments; one of them is
reserved *above the heap's current high boundary*, which extends the address range the card/brick/mark
tables must cover. Still inside that one foreground GC, that next segment therefore triggers
`grow_brick_card_tables`. Because a BGC is active, the grow allocates a **new, larger mark array**
(`0x53AAE400`) and re-commits existing segments onto it via `commit_new_mark_array` — which **walks
the generation segment lists**. `S` is on none of them, so the walk **never reaches it**. The live
`mark_array` pointer is switched to the new array, and **`S`'s slice on it was never committed**. The
`ma_committed` flag is now **stale**: it describes the retired array, not the live one.

**3 — The foreground GC finishes.** Relocation/compaction completes, `S` is eventually linked, and
the EE resumes — with `S` still carrying its stale `ma_committed = TRUE`.

**4 — A later BGC trusts the stale flag and crashes.** The next BGC's `commit_mark_array_bgc_init`
commits mark-array pages for each segment *unless* it already claims `ma_committed`; trusting `S`'s
stale flag, it **skips `S`**. When that BGC's concurrent pinning-handle scan later marks a live,
**pinned** object living in `S` (`ScanConsecutiveHandlesWithoutUserData` → `PinObject` →
`background_promote` → `background_mark_simple`), the write to `mark_array[obj >> 8]` hits an
**uncommitted page → access violation**. The object is valid; the mark-array memory being written to
is unmapped.

### Why Workstation only

Server GC already keeps the in-flight expansion segment in a durable per-heap member,
`new_heap_segment` — a **cross-thread hand-off** it needs because the expand decision happens under a
GC-thread join where one thread stashes each heap's segment for the others. `commit_new_mark_array`
re-commits that member *in addition to* the generation-list walk, so on Server the off-list segment
is caught during a grow. Workstation, with a single GC thread and no join, kept the segment in a
**local variable**, so its grow had nothing to re-commit — the crash is Workstation-only. The entire
`new_heap_segment` machinery was previously behind `#ifdef MULTIPLE_HEAPS`.

## The fix

Make Workstation-segments use the same durable member and grow-time re-commit that Server already
has. Every change simply widens an existing Server-only preprocessor guard to also cover
Workstation-segments (`!USE_REGIONS`); `USE_REGIONS` (regions) builds are untouched. After the fix,
Workstation's `new_heap_segment` lifetime is byte-for-byte identical to Server's, which has shipped
this pattern for years.

## Validation

A deterministic repro was built (a temporary env-gated hook that forces the exact
"grow while `S` is unlinked" interleaving), turning an otherwise ~1/2000-over-8h race into an
on-demand crash. Native **x86 Checked** coreclr, Workstation background GC (segments):

| Build | Result |
|-------|--------|
| **Without fix** (repro hook on) | **6/6 crash** — AV on the BGC thread (`WKS::gc_heap`, pinning-scan / background-sweep mark-array read). |
| **With fix** (repro hook on) | **8/8 pass** (exit 100) — the identical forced grow fires 3× per run, no crash. |
| **With fix** (plain `plug.dll`, hook removed) | **4/4 pass** (exit 100). |

- x86 Checked `clr.runtime` builds clean (0 warnings, 0 errors).
- x64 Checked `clr.runtime` builds clean (regions default + Server namespace unaffected).

The repro hook and all diagnostic instrumentation were reverted before finalizing; the committed
diff is the fix only.

## Scope / risk

- Affects **Workstation + segments only** (`!USE_REGIONS`, i.e. 32-bit builds). Regions builds
  (default on 64-bit) are excluded by the guards and unchanged.
- Server GC behavior is unchanged (it already had this member and re-commit).
- No new allocation, no new locking; the field mirrors an existing, long-shipped Server field.

> [!NOTE]
> This pull request description was drafted with the assistance of GitHub Copilot.