### PR TITLE
Fix g_gc_lowest_address updating

### DIFF
--- a/src/coreclr/gc/card_table.cpp
+++ b/src/coreclr/gc/card_table.cpp
@@ -605,7 +605,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
 
             if (saved_g_lowest_address < g_gc_lowest_address)
             {
-                if (ps > (size_t)g_gc_lowest_address)
+                if (ps >= (size_t)g_gc_lowest_address)
                     saved_g_lowest_address = (uint8_t*)(size_t)OS_PAGE_SIZE;
                 else
                 {


### PR DESCRIPTION
There is a rare issue that occurs when virtual memory blocks allocated by GC end up getting addresses that trigger a code path where the `g_gc_lowest_address` .. `g_gc_highest_address` is expanded down and the `g_gc_lowest_address` is exactly 2/3 of the `g_gc_highest_address`. We end up setting the `g_gc_lowest_address` to 0 and that then breaks GC because it starts considering NULL references as being part of the GC heap.
The culprit is a check that uses `>` instead of `>=`, which prevents the `g_gc_lowest_address` to be clamped to OS_PAGE_SIZE as its minimal value.

Close #131216