### PR TITLE
Re-enable the ArrayPool PollingEventFires test

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Buffers.Tests/ArrayPool/CollectionTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Buffers.Tests/ArrayPool/CollectionTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.DotNet.RemoteExecutor;
@@ -157,7 +158,9 @@ namespace System.Buffers.ArrayPool.Tests
         {
             RemoteInvokeWithTrimming(() =>
             {
-                bool pollEventFired = false;
+                // The listener callback fires on the finalizer thread (Trim runs from a
+                // Gen2GcCallback), so access the flag with Volatile to observe it reliably.
+                StrongBox<bool> pollEventFired = new(false);
                 float[] buffer = ArrayPool<float>.Shared.Rent(10);
 
                 // Polling doesn't start until the thread locals are created for a pool.
@@ -172,17 +175,17 @@ namespace System.Buffers.ArrayPool.Tests
                 e =>
                 {
                     if (e.EventId == EventIds.BufferTrimPoll)
-                        pollEventFired = true;
+                        Volatile.Write(ref pollEventFired.Value, true);
                 });
 
-                Assert.False(pollEventFired, "collection isn't hooked up until the first item is returned");
+                Assert.False(Volatile.Read(ref pollEventFired.Value), "collection isn't hooked up until the first item is returned");
                 ArrayPool<float>.Shared.Return(buffer);
 
                 // The poll event is emitted from a Gen2GcCallback finalizer, so a single gen2
                 // collection isn't guaranteed to run it. Retry until it fires or we give up.
                 RunWithListener(() =>
                 {
-                    for (int i = 0; i < 10 && !pollEventFired; i++)
+                    for (int i = 0; i < 10 && !Volatile.Read(ref pollEventFired.Value); i++)
                     {
                         GC.Collect(2);
                         GC.WaitForPendingFinalizers();
@@ -192,11 +195,11 @@ namespace System.Buffers.ArrayPool.Tests
                 e =>
                 {
                     if (e.EventId == EventIds.BufferTrimPoll)
-                        pollEventFired = true;
+                        Volatile.Write(ref pollEventFired.Value, true);
                 });
 
                 // Polling events should only fire when trimming is enabled
-                Assert.True(pollEventFired);
+                Assert.True(Volatile.Read(ref pollEventFired.Value));
             });
         }
     }

--- a/src/libraries/System.Runtime/tests/System.Buffers.Tests/ArrayPool/CollectionTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Buffers.Tests/ArrayPool/CollectionTests.cs
@@ -152,7 +152,6 @@ namespace System.Buffers.ArrayPool.Tests
 
         private static bool IsPreciseGcSupportedAndRemoteExecutorSupported => PlatformDetection.IsPreciseGcSupported && RemoteExecutor.IsSupported;
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/44037")]
         [ConditionalFact(typeof(CollectionTests), nameof(IsPreciseGcSupportedAndRemoteExecutorSupported))]
         public void PollingEventFires()
         {
@@ -179,10 +178,15 @@ namespace System.Buffers.ArrayPool.Tests
                 Assert.False(pollEventFired, "collection isn't hooked up until the first item is returned");
                 ArrayPool<float>.Shared.Return(buffer);
 
+                // The poll event is emitted from a Gen2GcCallback finalizer, so a single gen2
+                // collection isn't guaranteed to run it. Retry until it fires or we give up.
                 RunWithListener(() =>
                 {
-                    GC.Collect(2);
-                    GC.WaitForPendingFinalizers();
+                    for (int i = 0; i < 10 && !pollEventFired; i++)
+                    {
+                        GC.Collect(2);
+                        GC.WaitForPendingFinalizers();
+                    }
                 },
                 EventLevel.Informational,
                 e =>


### PR DESCRIPTION
Fixes #44037.

`System.Buffers.ArrayPool.Tests.CollectionTests.PollingEventFires` was disabled in 2020 via `[ActiveIssue]`. The original failure was a remote-process hang (`Half-way through waiting for remote process. Timed out ... after 60000ms`, child process idle at `0.13s` CPU) against the **old** `ArrayPool` implementation, which has since been fully rewritten (`SharedArrayPool<T>`). The stale `ActiveIssue` was never revisited.

----------

The `BufferTrimPoll` event is emitted from `SharedArrayPool<T>.Trim()`, which only runs inside a `Gen2GcCallback` finalizer. A single `GC.Collect(2)` + `GC.WaitForPendingFinalizers()` isn't guaranteed to promote-then-collect that freshly-registered callback object and run its finalizer, so the positive assertion could race. Harden the second poll check to retry a bounded number of times until the event fires.

Validated locally by running the test 30x under the current implementation with no hangs or failures.

> [!NOTE]
> This PR was authored by Copilot (GitHub Copilot CLI) on behalf of @tannergooding.
