### PR TITLE
Shrink large multidimensional array tests to avoid OOM killer

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
@@ -4911,10 +4911,10 @@ namespace System.Tests
     {
         static readonly GCMemoryInfo memoryInfo = GC.GetGCMemoryInfo();
 
-        // 2 * Dim1Length exceeds int.MaxValue so the flattened length crosses the
-        // 32-bit boundary, exercising the native-sized index paths in Copy/Clear.
-        // byte elements keep the allocation to ~2 GB.
-        private const int Dim1Length = 1_073_741_825;
+        // The flattened length (2 * Dim1Length) must exceed int.MaxValue so the
+        // index math crosses the 32-bit boundary, exercising the native-sized
+        // paths in Copy/Clear. byte elements keep the allocation to ~2 GB.
+        private const int Dim1Length = (int.MaxValue / 2) + 2;
 
         [OuterLoop] // Allocates large array
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
@@ -4910,8 +4911,13 @@ namespace System.Tests
     {
         static readonly GCMemoryInfo memoryInfo = GC.GetGCMemoryInfo();
 
+        // 2 * Dim1Length exceeds int.MaxValue so the flattened length crosses the
+        // 32-bit boundary, exercising the native-sized index paths in Copy/Clear.
+        // byte elements keep the allocation to ~2 GB.
+        private const int Dim1Length = 1_073_741_825;
+
         [OuterLoop] // Allocates large array
-        [ConditionalFact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static void Copy_LargeMultiDimensionalArray()
         {
             // If this test is run in a 32-bit process, the large allocation will fail.
@@ -4927,19 +4933,22 @@ namespace System.Tests
                 throw new SkipTestException($"Prone to OOM killer. {memoryInfo.TotalAvailableMemoryBytes} is available.");
             }
 
-            // dim1 is just over int.MaxValue / 2 so the flattened length exceeds
-            // int.MaxValue, exercising the native-sized index paths in Copy/Clear.
-            byte[,] a = AllocateLargeMDArray(2, 1_073_741_825);
-            a[0, 1] = 42;
-            Array.Copy(a, 1, a, Int32.MaxValue, 2);
-            Assert.Equal(42, a[1, Int32.MaxValue - 1_073_741_825]);
+            // Allocate in a child process so that if the OOM killer does fire it
+            // fails just this test instead of taking down the whole test run.
+            RemoteExecutor.Invoke(static () =>
+            {
+                byte[,] a = new byte[2, Dim1Length];
+                a[0, 1] = 42;
+                Array.Copy(a, 1, a, int.MaxValue, 2);
+                Assert.Equal(42, a[1, int.MaxValue - Dim1Length]);
 
-            Array.Clear(a, Int32.MaxValue - 1, 3);
-            Assert.Equal(0, a[1, Int32.MaxValue - 1_073_741_825]);
+                Array.Clear(a, int.MaxValue - 1, 3);
+                Assert.Equal(0, a[1, int.MaxValue - Dim1Length]);
+            }).Dispose();
         }
 
         [OuterLoop] // Allocates large array
-        [ConditionalFact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static void Clear_LargeMultiDimensionalArray()
         {
             // If this test is run in a 32-bit process, the large allocation will fail.
@@ -4955,32 +4964,22 @@ namespace System.Tests
                 throw new SkipTestException($"Prone to OOM killer. {memoryInfo.TotalAvailableMemoryBytes} is available.");
             }
 
-            // dim1 is just over int.MaxValue / 2 so the flattened length exceeds
-            // int.MaxValue, exercising the native-sized index paths in Copy/Clear.
-            byte[,] a = AllocateLargeMDArray(2, 1_073_741_825);
-
-            // Test 1: use Array.Clear
-            a[1, 1_073_741_824] = 0x12;
-            Array.Clear(a);
-            Assert.Equal(0, a[1, 1_073_741_824]);
-
-            // Test 2: use IList.Clear
-            a[1, 1_073_741_824] = 0x12;
-            ((IList)a).Clear();
-            Assert.Equal(0, a[1, 1_073_741_824]);
-        }
-
-        private static byte[,] AllocateLargeMDArray(int dim0Length, int dim1Length)
-        {
-            try
+            // Allocate in a child process so that if the OOM killer does fire it
+            // fails just this test instead of taking down the whole test run.
+            RemoteExecutor.Invoke(static () =>
             {
-                return new byte[dim0Length, dim1Length];
-            }
-            catch (OutOfMemoryException)
-            {
-                // not a fatal error - we'll just skip the test in this case
-                throw new SkipTestException("Unable to allocate enough memory");
-            }
+                byte[,] a = new byte[2, Dim1Length];
+
+                // Test 1: use Array.Clear
+                a[1, Dim1Length - 1] = 0x12;
+                Array.Clear(a);
+                Assert.Equal(0, a[1, Dim1Length - 1]);
+
+                // Test 2: use IList.Clear
+                a[1, Dim1Length - 1] = 0x12;
+                ((IList)a).Clear();
+                Assert.Equal(0, a[1, Dim1Length - 1]);
+            }).Dispose();
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
@@ -4920,20 +4920,22 @@ namespace System.Tests
                 throw new SkipTestException("Unable to allocate enough memory");
             }
 
-            if (memoryInfo.TotalAvailableMemoryBytes < 4_000_000_000 )
+            if (memoryInfo.TotalAvailableMemoryBytes < 4_000_000_000)
             {
-                // On these platforms, occasionally the OOM Killer will terminate the
-                // tests when they're using ~1GB, before they complete.
+                // The array below is ~2 GB; require headroom so the OOM killer
+                // doesn't terminate the process before the test completes.
                 throw new SkipTestException($"Prone to OOM killer. {memoryInfo.TotalAvailableMemoryBytes} is available.");
             }
 
-            short[,] a = AllocateLargeMDArray(2, 2_000_000_000);
+            // dim1 is just over int.MaxValue / 2 so the flattened length exceeds
+            // int.MaxValue, exercising the native-sized index paths in Copy/Clear.
+            byte[,] a = AllocateLargeMDArray(2, 1_073_741_825);
             a[0, 1] = 42;
             Array.Copy(a, 1, a, Int32.MaxValue, 2);
-            Assert.Equal(42, a[1, Int32.MaxValue - 2_000_000_000]);
+            Assert.Equal(42, a[1, Int32.MaxValue - 1_073_741_825]);
 
             Array.Clear(a, Int32.MaxValue - 1, 3);
-            Assert.Equal(0, a[1, Int32.MaxValue - 2_000_000_000]);
+            Assert.Equal(0, a[1, Int32.MaxValue - 1_073_741_825]);
         }
 
         [OuterLoop] // Allocates large array
@@ -4946,31 +4948,33 @@ namespace System.Tests
                 throw new SkipTestException("Unable to allocate enough memory");
             }
 
-            if (memoryInfo.TotalAvailableMemoryBytes < 4_000_000_000 )
+            if (memoryInfo.TotalAvailableMemoryBytes < 4_000_000_000)
             {
-                // On these platforms, occasionally the OOM Killer will terminate the
-                // tests when they're using ~1GB, before they complete.
-                throw new SkipTestException($"Prone to OOM killer. ${memoryInfo.TotalAvailableMemoryBytes} is available.");
+                // The array below is ~2 GB; require headroom so the OOM killer
+                // doesn't terminate the process before the test completes.
+                throw new SkipTestException($"Prone to OOM killer. {memoryInfo.TotalAvailableMemoryBytes} is available.");
             }
 
-            short[,] a = AllocateLargeMDArray(2, 2_000_000_000);
+            // dim1 is just over int.MaxValue / 2 so the flattened length exceeds
+            // int.MaxValue, exercising the native-sized index paths in Copy/Clear.
+            byte[,] a = AllocateLargeMDArray(2, 1_073_741_825);
 
             // Test 1: use Array.Clear
-            a[1, 1_999_999_999] = 0x1234;
+            a[1, 1_073_741_824] = 0x12;
             Array.Clear(a);
-            Assert.Equal(0, a[1, 1_999_999_999]);
+            Assert.Equal(0, a[1, 1_073_741_824]);
 
             // Test 2: use IList.Clear
-            a[1, 1_999_999_999] = 0x1234;
+            a[1, 1_073_741_824] = 0x12;
             ((IList)a).Clear();
-            Assert.Equal(0, a[1, 1_999_999_999]);
+            Assert.Equal(0, a[1, 1_073_741_824]);
         }
 
-        private static short[,] AllocateLargeMDArray(int dim0Length, int dim1Length)
+        private static byte[,] AllocateLargeMDArray(int dim0Length, int dim1Length)
         {
             try
             {
-                return new short[dim0Length, dim1Length];
+                return new byte[dim0Length, dim1Length];
             }
             catch (OutOfMemoryException)
             {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
@@ -4916,41 +4916,67 @@ namespace System.Tests
         // paths in Copy/Clear. byte elements keep the allocation to ~2 GB.
         private const int Dim1Length = (int.MaxValue / 2) + 2;
 
+        // Returned by the child when it can't allocate the array, so the parent
+        // can skip rather than fail on memory pressure.
+        private const int OutOfMemoryExitCode = 3;
+
         [OuterLoop] // Allocates large array
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static void Copy_LargeMultiDimensionalArray()
         {
-            // If this test is run in a 32-bit process, the large allocation will fail.
-            if (IntPtr.Size != sizeof(long))
+            InvokeAllocatingLargeArray(static () =>
             {
-                throw new SkipTestException("Unable to allocate enough memory");
-            }
+                try
+                {
+                    byte[,] a = new byte[2, Dim1Length];
+                    a[0, 1] = 42;
+                    Array.Copy(a, 1, a, int.MaxValue, 2);
+                    Assert.Equal(42, a[1, int.MaxValue - Dim1Length]);
 
-            if (memoryInfo.TotalAvailableMemoryBytes < 4_000_000_000)
-            {
-                // The array below is ~2 GB; require headroom so the OOM killer
-                // doesn't terminate the process before the test completes.
-                throw new SkipTestException($"Prone to OOM killer. {memoryInfo.TotalAvailableMemoryBytes} is available.");
-            }
-
-            // Allocate in a child process so that if the OOM killer does fire it
-            // fails just this test instead of taking down the whole test run.
-            RemoteExecutor.Invoke(static () =>
-            {
-                byte[,] a = new byte[2, Dim1Length];
-                a[0, 1] = 42;
-                Array.Copy(a, 1, a, int.MaxValue, 2);
-                Assert.Equal(42, a[1, int.MaxValue - Dim1Length]);
-
-                Array.Clear(a, int.MaxValue - 1, 3);
-                Assert.Equal(0, a[1, int.MaxValue - Dim1Length]);
-            }).Dispose();
+                    Array.Clear(a, int.MaxValue - 1, 3);
+                    Assert.Equal(0, a[1, int.MaxValue - Dim1Length]);
+                }
+                catch (OutOfMemoryException)
+                {
+                    return OutOfMemoryExitCode;
+                }
+                return RemoteExecutor.SuccessExitCode;
+            });
         }
 
         [OuterLoop] // Allocates large array
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static void Clear_LargeMultiDimensionalArray()
         {
+            InvokeAllocatingLargeArray(static () =>
+            {
+                try
+                {
+                    byte[,] a = new byte[2, Dim1Length];
+
+                    // Test 1: use Array.Clear
+                    a[1, Dim1Length - 1] = 0x12;
+                    Array.Clear(a);
+                    Assert.Equal(0, a[1, Dim1Length - 1]);
+
+                    // Test 2: use IList.Clear
+                    a[1, Dim1Length - 1] = 0x12;
+                    ((IList)a).Clear();
+                    Assert.Equal(0, a[1, Dim1Length - 1]);
+                }
+                catch (OutOfMemoryException)
+                {
+                    return OutOfMemoryExitCode;
+                }
+                return RemoteExecutor.SuccessExitCode;
+            });
+        }
+
+        // Runs the large-array body in a child process so that memory pressure fails
+        // just this test instead of taking down the whole run, and translates an
+        // out-of-memory outcome into a skip rather than a failure.
+        private static void InvokeAllocatingLargeArray(Func<int> body)
+        {
             // If this test is run in a 32-bit process, the large allocation will fail.
             if (IntPtr.Size != sizeof(long))
             {
@@ -4959,27 +4985,23 @@ namespace System.Tests
 
             if (memoryInfo.TotalAvailableMemoryBytes < 4_000_000_000)
             {
-                // The array below is ~2 GB; require headroom so the OOM killer
-                // doesn't terminate the process before the test completes.
+                // The array is ~2 GB; require headroom so the OOM killer doesn't
+                // terminate the process before the test completes.
                 throw new SkipTestException($"Prone to OOM killer. {memoryInfo.TotalAvailableMemoryBytes} is available.");
             }
 
-            // Allocate in a child process so that if the OOM killer does fire it
-            // fails just this test instead of taking down the whole test run.
-            RemoteExecutor.Invoke(static () =>
+            using RemoteInvokeHandle handle = RemoteExecutor.Invoke(body, new RemoteInvokeOptions { CheckExitCode = false });
+            handle.Process.WaitForExit();
+            int exitCode = handle.Process.ExitCode;
+
+            // OutOfMemoryExitCode: the child caught a managed OutOfMemoryException.
+            // 137 == 128 + SIGKILL: the OOM killer terminated the child (Unix).
+            if (exitCode == OutOfMemoryExitCode || exitCode == 137)
             {
-                byte[,] a = new byte[2, Dim1Length];
+                throw new SkipTestException($"Ran out of memory allocating the large array. Exit code {exitCode}.");
+            }
 
-                // Test 1: use Array.Clear
-                a[1, Dim1Length - 1] = 0x12;
-                Array.Clear(a);
-                Assert.Equal(0, a[1, Dim1Length - 1]);
-
-                // Test 2: use IList.Clear
-                a[1, Dim1Length - 1] = 0x12;
-                ((IList)a).Clear();
-                Assert.Equal(0, a[1, Dim1Length - 1]);
-            }).Dispose();
+            Assert.Equal(RemoteExecutor.SuccessExitCode, exitCode);
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
@@ -4916,9 +4916,13 @@ namespace System.Tests
         // paths in Copy/Clear. byte elements keep the allocation to ~2 GB.
         private const int Dim1Length = (int.MaxValue / 2) + 2;
 
-        // Returned by the child when it can't allocate the array, so the parent
-        // can skip rather than fail on memory pressure.
+        // Reported by the child when the allocation throws, so the parent can skip.
+        // RemoteExecutor rethrows an escaping exception regardless of CheckExitCode,
+        // so this has to be caught in the child to be distinguishable from a failure.
         private const int OutOfMemoryExitCode = 3;
+
+        // 128 + SIGKILL, as reported for a child terminated by the Unix OOM killer.
+        private const int SigKillExitCode = 128 + 9;
 
         [OuterLoop] // Allocates large array
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
@@ -4994,9 +4998,10 @@ namespace System.Tests
             handle.Process.WaitForExit();
             int exitCode = handle.Process.ExitCode;
 
-            // OutOfMemoryExitCode: the child caught a managed OutOfMemoryException.
-            // 137 == 128 + SIGKILL: the OOM killer terminated the child (Unix).
-            if (exitCode == OutOfMemoryExitCode || exitCode == 137)
+            // Memory pressure surfaces differently per OS: Windows fails the commit and
+            // throws a catchable OutOfMemoryException, where-as Linux overcommits and the
+            // OOM killer SIGKILLs the child once the pages are touched, with no exception.
+            if (exitCode == OutOfMemoryExitCode || exitCode == SigKillExitCode)
             {
                 throw new SkipTestException($"Ran out of memory allocating the large array. Exit code {exitCode}.");
             }


### PR DESCRIPTION
The `Copy_LargeMultiDimensionalArray` and `Clear_LargeMultiDimensionalArray` OuterLoop tests each allocated `short[2, 2_000_000_000]` == 8 GB, but only skipped when `TotalAvailableMemoryBytes < 4_000_000_000`. On the ~8 GB Debian.10/Debian.11 Helix queues the guard passes and the 8 GB allocation then trips the OOM killer (`exit code 137`), which is what #58616 is tracking.

The tests exist to exercise the native-sized (`nuint`/`nint`) index paths in `Array.Copy`/`Array.Clear`/element access, which only requires the *flattened element count* to exceed `Int32.MaxValue`. Element size is irrelevant to that boundary since the public API indices are all `int`. So switch to `byte[2, 1_073_741_825]` (~2 GB, total `2_147_483_650` elements) and recompute the row/col literals. The allocation now sits at half the unchanged 4 GB guard, so its headroom assumption actually holds, without narrowing where the tests run.

Also removes a stale `~1GB` comment and a stray `$` in one skip message.

Fixes #58616

----------

Validated locally on Windows x64: `System.Runtime.Tests` compiles clean, and both tests run (not skipped) with `outerloop=true` -- `Total: 2, Failed: 0, Skipped: 0`.

> [!NOTE]
> This PR description was drafted by Copilot.