### PR TITLE
Vectorize Base64 DecodeFromUtf8InPlace

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
@@ -356,6 +356,47 @@ namespace System.Buffers.Text
 
                 ref sbyte decodingMap = ref MemoryMarshal.GetReference(decoder.DecodingMap);
 
+#if NET
+                // Decode in place using the same vectorized helpers as DecodeFrom. This is safe because the
+                // write cursor (dest) always trails the read cursor (src) by 25%, so each vector store -- including
+                // its zero-padded overshoot -- ends at or before the next vector load and never clobbers source
+                // that hasn't been read yet.
+                if (bufferLength >= 24)
+                {
+                    byte* src = bufferBytes;
+                    byte* dest = bufferBytes;
+                    int length = (int)bufferLength;
+                    byte* srcMax = bufferBytes + length;
+
+                    byte* end = srcMax - 88;
+                    if (Vector512.IsHardwareAccelerated && Avx512Vbmi.IsSupported && (end >= src))
+                    {
+                        Avx512Decode(decoder, ref src, ref dest, end, length, length, bufferBytes, bufferBytes);
+                    }
+
+                    end = srcMax - 45;
+                    if (Avx2.IsSupported && (end >= src))
+                    {
+                        Avx2Decode(decoder, ref src, ref dest, end, length, length, bufferBytes, bufferBytes);
+                    }
+
+                    end = srcMax - 66;
+                    if (AdvSimd.Arm64.IsSupported && (end >= src))
+                    {
+                        AdvSimdDecode(decoder, ref src, ref dest, end, length, length, bufferBytes, bufferBytes);
+                    }
+
+                    end = srcMax - 24;
+                    if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) && BitConverter.IsLittleEndian && (end >= src))
+                    {
+                        Vector128Decode(decoder, ref src, ref dest, end, length, length, bufferBytes, bufferBytes);
+                    }
+
+                    sourceIndex = (uint)(src - bufferBytes);
+                    destIndex = (uint)(dest - bufferBytes);
+                }
+#endif
+
                 if (bufferLength > 4)
                 {
                     while (sourceIndex < bufferLength - 4)


### PR DESCRIPTION
Fixes #105707.

`Base64.DecodeFromUtf8InPlace` (and the Base64Url in-place decode) ran a pure scalar loop, unlike `DecodeFrom` which already had AVX-512 / AVX2 / AdvSimd / SSSE3 fast paths. That scalar loop is why the 200 MB `Base64DecodeInPlace` benchmark was ~395 ms, and why it was sensitive enough to layout that #105262 -- a correctness fix that only touched the once-per-call tail, leaving the hot loop's codegen byte-for-byte identical -- surfaced as a ~12% regression from alignment/layout alone.

This reuses the existing `Avx512Decode` / `Avx2Decode` / `AdvSimdDecode` / `Vector128Decode` helpers for the in-place path, mirroring `DecodeFrom` exactly. The decode is safe in place because the write cursor trails the read cursor by 25% (3 bytes written per 4 read), so each vector store -- including its zero-padded overshoot -- ends at or before the next vector load and never clobbers source that hasn't been read yet. The final overshoot of whichever path runs last lands strictly before the post-vector `src`, so the narrower SIMD phases and the scalar remainder read unclobbered data.

----------

Measured locally on win-x64 (AVX-512 capable), 200 MB in-place decode, release runtime:

| Config | Time | vs scalar |
| -- | -- | -- |
| Scalar (`DOTNET_EnableHWIntrinsic=0`, prior behavior) | 63.9 ms | 1.0x |
| Vector128 (`DOTNET_EnableAVX2=0`) | 24.4 ms | 2.6x |
| AVX2/AVX-512 | 10.9 ms | 5.9x |

So this doesn't just recover the 12% regression -- it makes the in-place path ~2.6-5.9x faster depending on hardware.

----------

Testing: all `System.Memory.Tests` pass (52,929) with the debug `AssertRead`/`AssertWrite` bounds checks active, including under `DOTNET_EnableAVX2=0` and `DOTNET_EnableHWIntrinsic=0`. The existing `EncodeAndDecodeInPlace` test roundtrips every length 1-256, which exercises all in-place SIMD widths with byte-exact overlap validation. No JIT changes.

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.
