### PR TITLE
Round-trip TimeZoneInfo.ToSerializedString on Unix (#19794)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.StringSerializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.StringSerializer.cs
@@ -98,14 +98,26 @@ namespace System
                     serializedText.Append(Sep);
                     SerializeTransitionTime(legacyEnd, ref serializedText);
                     serializedText.Append(Sep);
-                    if (rule.BaseUtcOffsetDelta != TimeSpan.Zero)
+                    if (rule.BaseUtcOffsetDelta != TimeSpan.Zero || rule.NoDaylightTransitions)
                     {
                         // Serialize it only when BaseUtcOffsetDelta has a value to reduce the impact of adding rule.BaseUtcOffsetDelta.
                         // The legacy format stores this offset in whole minutes and its reader rejects a fractional value, so write a
                         // whole-minute value here. Some Unix rules carry a sub-minute BaseUtcOffsetDelta; its exact value is preserved
                         // in the full-fidelity trailer below, and this whole-minute value keeps the legacy portion parseable for readers
                         // that ignore the trailer.
+                        // It is also written (as 0 when absent) whenever the NoDaylightTransitions marker below is emitted, because the
+                        // legacy reader distinguishes these two optional fields positionally: it consumes a leading digit as the
+                        // BaseUtcOffsetDelta, so without a preceding offset token the '1' marker would be misread as a one-minute offset.
                         serializedText.AppendSpanFormattable(rule.BaseUtcOffsetDelta.Ticks / TimeSpan.TicksPerMinute, format: default, CultureInfo.InvariantCulture);
+                        serializedText.Append(Sep);
+                    }
+                    if (rule.NoDaylightTransitions)
+                    {
+                        // Emit the NoDaylightTransitions marker so a reader that ignores the full-fidelity trailer (for example an
+                        // older runtime) reconstructs a Linux-style rule and treats DateStart/DateEnd as the UTC window. Without it,
+                        // such a reader would parse the rule as a Windows-style seasonal rule and interpret the placeholder transitions
+                        // as local-time transitions, changing the calculated offsets. The exact rule is still preserved in the trailer.
+                        serializedText.Append('1');
                         serializedText.Append(Sep);
                     }
                     serializedText.Append(Rhs);

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.StringSerializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.StringSerializer.cs
@@ -651,6 +651,11 @@ namespace System
                 long daylightDeltaTicks = GetNextInt64Value();
                 long baseUtcOffsetDeltaTicks = GetNextInt64Value();
                 int noDaylightTransitions = GetNextInt32Value();
+                if (noDaylightTransitions is not (0 or 1))
+                {
+                    // The writer only emits 0 or 1; reject any other value rather than treating it as true.
+                    throw new SerializationException(SR.Serialization_InvalidData);
+                }
                 TransitionTime daylightStart = GetNextFullFidelityTransitionTimeValue();
                 TransitionTime daylightEnd = GetNextFullFidelityTransitionTimeValue();
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.StringSerializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.StringSerializer.cs
@@ -36,6 +36,23 @@ namespace System
             private const string DateTimeFormat = "MM:dd:yyyy";
             private const string TimeOfDayFormat = "HH:mm:ss.FFF";
 
+            // Marks the start of the optional full-fidelity adjustment rule data that is appended
+            // after the separator terminating the adjustment rule list. Older readers stop at that
+            // separator and never see this data, so it is backward compatible.
+            private const char FullFidelityRulesMarker = '!';
+
+            // Version of the full-fidelity trailer layout. It is written right after the marker so a
+            // future revision of the layout can be detected. A reader that does not recognize the
+            // version ignores the trailer and falls back to the legacy rules instead of misparsing
+            // newer data.
+            private const int FullFidelityRulesVersion = 1;
+
+            // Minimum number of separator characters a single full-fidelity rule occupies: one after each
+            // of its seven numeric fields plus one after each of its two transitions (both encoded as the
+            // one-character "D" form). A rule can only be longer than this, so this is used to bound the
+            // rule count against the remaining input length before allocating.
+            private const int MinSeparatorsPerFullFidelityRule = 9;
+
             /// <summary>
             /// Creates the custom serialized string representation of a TimeZoneInfo instance.
             /// </summary>
@@ -58,35 +75,55 @@ namespace System
                 serializedText.Append(Sep);
 
                 AdjustmentRule[] rules = zone.GetAdjustmentRules();
+                DateTime? previousLegacyEndDate = null;
                 foreach (AdjustmentRule rule in rules)
                 {
+                    // Compute the whole-day, strictly ordered boundaries written to the legacy portion.
+                    // The exact boundaries are preserved in the full-fidelity trailer below.
+                    GetLegacyRuleDates(rule, ref previousLegacyEndDate, out DateTime legacyDateStart, out DateTime legacyDateEnd);
+
                     serializedText.Append(Lhs);
-                    serializedText.AppendSpanFormattable(rule.DateStart, DateTimeFormat, DateTimeFormatInfo.InvariantInfo);
+                    serializedText.AppendSpanFormattable(legacyDateStart, DateTimeFormat, DateTimeFormatInfo.InvariantInfo);
                     serializedText.Append(Sep);
-                    serializedText.AppendSpanFormattable(rule.DateEnd, DateTimeFormat, DateTimeFormatInfo.InvariantInfo);
+                    serializedText.AppendSpanFormattable(legacyDateEnd, DateTimeFormat, DateTimeFormatInfo.InvariantInfo);
                     serializedText.Append(Sep);
                     serializedText.AppendSpanFormattable(rule.DaylightDelta.TotalMinutes, format: default, CultureInfo.InvariantCulture);
                     serializedText.Append(Sep);
-                    // serialize the TransitionTime's
-                    SerializeTransitionTime(rule.DaylightTransitionStart, ref serializedText);
+                    // Serialize the TransitionTime's. The legacy format cannot represent an empty
+                    // transition (used by rules that carry no daylight transition) and requires the two
+                    // transitions to differ when NoDaylightTransitions is not set, so substitute distinct
+                    // parseable placeholders. The exact values are preserved in the full-fidelity trailer.
+                    GetLegacyTransitionTimes(rule, out TransitionTime legacyStart, out TransitionTime legacyEnd);
+                    SerializeTransitionTime(legacyStart, ref serializedText);
                     serializedText.Append(Sep);
-                    SerializeTransitionTime(rule.DaylightTransitionEnd, ref serializedText);
+                    SerializeTransitionTime(legacyEnd, ref serializedText);
                     serializedText.Append(Sep);
                     if (rule.BaseUtcOffsetDelta != TimeSpan.Zero)
                     {
-                        // Serialize it only when BaseUtcOffsetDelta has a value to reduce the impact of adding rule.BaseUtcOffsetDelta
-                        serializedText.AppendSpanFormattable(rule.BaseUtcOffsetDelta.TotalMinutes, format: default, CultureInfo.InvariantCulture);
-                        serializedText.Append(Sep);
-                    }
-                    if (rule.NoDaylightTransitions)
-                    {
-                        // Serialize it only when NoDaylightTransitions is true to reduce the impact of adding rule.NoDaylightTransitions
-                        serializedText.Append('1');
+                        // Serialize it only when BaseUtcOffsetDelta has a value to reduce the impact of adding rule.BaseUtcOffsetDelta.
+                        // The legacy format stores this offset in whole minutes and its reader rejects a fractional value, so write a
+                        // whole-minute value here. Some Unix rules carry a sub-minute BaseUtcOffsetDelta; its exact value is preserved
+                        // in the full-fidelity trailer below, and this whole-minute value keeps the legacy portion parseable for readers
+                        // that ignore the trailer.
+                        serializedText.AppendSpanFormattable(rule.BaseUtcOffsetDelta.Ticks / TimeSpan.TicksPerMinute, format: default, CultureInfo.InvariantCulture);
                         serializedText.Append(Sep);
                     }
                     serializedText.Append(Rhs);
                 }
                 serializedText.Append(Sep);
+
+                // The public rules serialized above are a Windows-shaped projection of the internal
+                // rules. On Unix that projection is lossy (for example NoDaylightTransitions rules,
+                // UTC sub-day boundaries, or multi-year rules that get split). When it cannot reproduce
+                // the internal rules exactly, append a full-fidelity copy of the internal rules so the
+                // round trip is exact. This is placed after the separator that terminates the rule list,
+                // which older readers ignore, so existing serialized strings and Windows output are
+                // unchanged.
+                AdjustmentRule[]? internalRules = zone._adjustmentRules;
+                if (internalRules is not null && RequiresFullFidelityRules(rules, internalRules))
+                {
+                    SerializeFullFidelityRules(internalRules, ref serializedText);
+                }
 
                 return serializedText.ToString();
             }
@@ -104,6 +141,10 @@ namespace System
                 string standardName = s.GetNextStringValue();
                 string daylightName = s.GetNextStringValue();
                 AdjustmentRule[]? rules = s.GetNextAdjustmentRuleArrayValue();
+
+                // If a full-fidelity copy of the internal rules was appended, use it instead of the
+                // legacy (public projection) rules so the round trip is exact.
+                rules = s.GetFullFidelityAdjustmentRulesIfPresent(rules);
 
                 try
                 {
@@ -124,6 +165,158 @@ namespace System
                 _serializedText = str;
                 _currentTokenStartIndex = 0;
                 _state = State.StartOfToken;
+            }
+
+            /// <summary>
+            /// Produces the transitions to write for the legacy portion of a rule. Empty transitions
+            /// (Month == 0), used by rules that carry no daylight transition, cannot be represented by
+            /// the legacy format because it reconstructs transitions through the TransitionTime factory
+            /// methods (which reject a zero month). They are replaced by placeholders. The placeholders
+            /// are also forced to differ from each other so the rule passes validation on readers that
+            /// do not honor the full-fidelity trailer. The exact values are preserved in that trailer.
+            /// </summary>
+            private static void GetLegacyTransitionTimes(AdjustmentRule rule, out TransitionTime start, out TransitionTime end)
+            {
+                start = rule.DaylightTransitionStart.Month != 0 ? rule.DaylightTransitionStart : s_legacyTransitionPlaceholderStart;
+                end = rule.DaylightTransitionEnd.Month != 0 ? rule.DaylightTransitionEnd : s_legacyTransitionPlaceholderEnd;
+
+                if (start.Equals(end))
+                {
+                    // The two transitions must differ (see TimeZoneInfo.AdjustmentRule validation). Pick a
+                    // month that is guaranteed to be different from the one already used.
+                    end = TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1), start.Month == 12 ? 6 : 12, 1);
+                }
+            }
+
+            private static readonly TransitionTime s_legacyTransitionPlaceholderStart = TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1), 1, 1);
+            private static readonly TransitionTime s_legacyTransitionPlaceholderEnd = TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1), 12, 31);
+
+            /// <summary>
+            /// Produces the whole-day, strictly ordered boundaries to write for the legacy portion of a
+            /// rule. The legacy format stores only the date component (see <see cref="DateTimeFormat"/>),
+            /// so internal rules whose boundaries are sub-day UTC instants can collapse onto the same
+            /// calendar day and make consecutive rules overlap. Readers that do not honor the
+            /// full-fidelity trailer validate the legacy rules for chronological order, so nudge the start
+            /// past the previous rule's end when they would collide. For Windows-shaped rules (already
+            /// whole-day and non-overlapping) this is a no-op, keeping the output byte-identical. The exact
+            /// boundaries are preserved in the full-fidelity trailer.
+            /// </summary>
+            private static void GetLegacyRuleDates(AdjustmentRule rule, ref DateTime? previousEndDate, out DateTime startDate, out DateTime endDate)
+            {
+                startDate = rule.DateStart.Date;
+                endDate = rule.DateEnd.Date;
+
+                if (previousEndDate is DateTime previous && startDate <= previous && previous < DateTime.MaxValue.Date)
+                {
+                    startDate = previous.AddDays(1);
+                    if (startDate > endDate)
+                    {
+                        endDate = startDate;
+                    }
+                }
+
+                previousEndDate = endDate;
+            }
+
+            /// <summary>
+            /// Determines whether the internal adjustment rules can be reproduced exactly from the
+            /// legacy (public projection) serialization. When they cannot, a full-fidelity copy of the
+            /// internal rules is appended to the serialized string.
+            /// </summary>
+            private static bool RequiresFullFidelityRules(AdjustmentRule[] publicRules, AdjustmentRule[] internalRules)
+            {
+                if (publicRules.Length != internalRules.Length)
+                {
+                    return true;
+                }
+
+                for (int i = 0; i < internalRules.Length; i++)
+                {
+                    AdjustmentRule internalRule = internalRules[i];
+
+                    // The legacy format only represents Windows-shaped rules: Unspecified-kind, whole-day
+                    // boundaries, whole-minute offsets, real daylight transitions, and no
+                    // NoDaylightTransitions marker. Anything else (produced on Unix) loses information when
+                    // projected through GetAdjustmentRules().
+                    if (internalRule.NoDaylightTransitions ||
+                        internalRule.DateStart.Kind == DateTimeKind.Utc ||
+                        internalRule.DateEnd.Kind == DateTimeKind.Utc ||
+                        internalRule.BaseUtcOffsetDelta.Ticks % TimeSpan.TicksPerMinute != 0 ||
+                        !publicRules[i].Equals(internalRule))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            /// <summary>
+            /// Appends a full-fidelity copy of the internal adjustment rules. It is written after the
+            /// separator that terminates the legacy rule list, which older readers ignore. The layout is
+            /// the marker, the format version, the rule count, then each rule.
+            /// </summary>
+            private static void SerializeFullFidelityRules(AdjustmentRule[] rules, ref ValueStringBuilder serializedText)
+            {
+                serializedText.Append(FullFidelityRulesMarker);
+                AppendInt32Value(FullFidelityRulesVersion, ref serializedText);
+                AppendInt32Value(rules.Length, ref serializedText);
+
+                foreach (AdjustmentRule rule in rules)
+                {
+                    AppendInt64Value(rule.DateStart.Ticks, ref serializedText);
+                    AppendInt32Value((int)rule.DateStart.Kind, ref serializedText);
+                    AppendInt64Value(rule.DateEnd.Ticks, ref serializedText);
+                    AppendInt32Value((int)rule.DateEnd.Kind, ref serializedText);
+                    AppendInt64Value(rule.DaylightDelta.Ticks, ref serializedText);
+                    AppendInt64Value(rule.BaseUtcOffsetDelta.Ticks, ref serializedText);
+                    AppendInt32Value(rule.NoDaylightTransitions ? 1 : 0, ref serializedText);
+                    SerializeFullFidelityTransitionTime(rule.DaylightTransitionStart, ref serializedText);
+                    SerializeFullFidelityTransitionTime(rule.DaylightTransitionEnd, ref serializedText);
+                }
+            }
+
+            /// <summary>
+            /// Serializes a TransitionTime with full fidelity, including empty (default) transitions.
+            /// </summary>
+            private static void SerializeFullFidelityTransitionTime(TransitionTime transition, ref ValueStringBuilder serializedText)
+            {
+                if (transition == default)
+                {
+                    serializedText.Append('D');
+                    serializedText.Append(Sep);
+                    return;
+                }
+
+                if (transition.IsFixedDateRule)
+                {
+                    serializedText.Append('F');
+                    serializedText.Append(Sep);
+                    AppendInt64Value(transition.TimeOfDay.Ticks, ref serializedText);
+                    AppendInt32Value(transition.Month, ref serializedText);
+                    AppendInt32Value(transition.Day, ref serializedText);
+                }
+                else
+                {
+                    serializedText.Append('W');
+                    serializedText.Append(Sep);
+                    AppendInt64Value(transition.TimeOfDay.Ticks, ref serializedText);
+                    AppendInt32Value(transition.Month, ref serializedText);
+                    AppendInt32Value(transition.Week, ref serializedText);
+                    AppendInt32Value((int)transition.DayOfWeek, ref serializedText);
+                }
+            }
+
+            private static void AppendInt32Value(int value, ref ValueStringBuilder serializedText)
+            {
+                serializedText.AppendSpanFormattable(value, format: default, CultureInfo.InvariantCulture);
+                serializedText.Append(Sep);
+            }
+
+            private static void AppendInt64Value(long value, ref ValueStringBuilder serializedText)
+            {
+                serializedText.AppendSpanFormattable(value, format: default, CultureInfo.InvariantCulture);
+                serializedText.Append(Sep);
             }
 
             /// <summary>
@@ -365,6 +558,144 @@ namespace System
                     throw new SerializationException(SR.Serialization_InvalidData);
                 }
                 return value;
+            }
+
+            /// <summary>
+            /// Helper function to read an Int64 token.
+            /// </summary>
+            private long GetNextInt64Value()
+            {
+                string token = GetNextStringValue();
+                if (!long.TryParse(token, NumberStyles.AllowLeadingSign /* "[sign]digits" */, CultureInfo.InvariantCulture, out long value))
+                {
+                    throw new SerializationException(SR.Serialization_InvalidData);
+                }
+                return value;
+            }
+
+            /// <summary>
+            /// Reads the optional full-fidelity adjustment rules that follow the separator terminating
+            /// the legacy rule list. When present, they replace the legacy rules so the round trip is
+            /// exact; when absent (or unrecognized future data), the legacy rules are returned unchanged.
+            /// </summary>
+            private AdjustmentRule[]? GetFullFidelityAdjustmentRulesIfPresent(AdjustmentRule[]? legacyRules)
+            {
+                // The legacy rule array reader stops on the separator that terminates the list without
+                // consuming it. If there is nothing after that separator, there is no full-fidelity data.
+                if (_state == State.EndOfLine ||
+                    _currentTokenStartIndex >= _serializedText.Length ||
+                    _serializedText[_currentTokenStartIndex] != Sep)
+                {
+                    return legacyRules;
+                }
+
+                _currentTokenStartIndex++;
+                if (_currentTokenStartIndex >= _serializedText.Length ||
+                    _serializedText[_currentTokenStartIndex] != FullFidelityRulesMarker)
+                {
+                    // No marker: either end of string or unknown trailing data from a newer format. Keep
+                    // the legacy rules.
+                    return legacyRules;
+                }
+
+                _currentTokenStartIndex++;
+                _state = State.StartOfToken;
+
+                int version = GetNextInt32Value();
+                if (version != FullFidelityRulesVersion)
+                {
+                    // A trailer written by a newer runtime using a layout this reader does not understand.
+                    // Ignore it and keep the legacy rules rather than misparsing the newer data.
+                    return legacyRules;
+                }
+
+                int count = GetNextInt32Value();
+
+                // Guard against a corrupt or malicious count driving an unbounded allocation. Every rule
+                // occupies at least MinSeparatorsPerFullFidelityRule characters, so a count larger than the
+                // remaining characters can hold cannot be valid.
+                if (count <= 0 || count > (_serializedText.Length - _currentTokenStartIndex) / MinSeparatorsPerFullFidelityRule)
+                {
+                    throw new SerializationException(SR.Serialization_InvalidData);
+                }
+
+                AdjustmentRule[] rules = new AdjustmentRule[count];
+                for (int i = 0; i < count; i++)
+                {
+                    rules[i] = GetNextFullFidelityAdjustmentRuleValue();
+                }
+                return rules;
+            }
+
+            /// <summary>
+            /// Reads a single full-fidelity AdjustmentRule.
+            /// </summary>
+            private AdjustmentRule GetNextFullFidelityAdjustmentRuleValue()
+            {
+                long dateStartTicks = GetNextInt64Value();
+                int dateStartKind = GetNextInt32Value();
+                long dateEndTicks = GetNextInt64Value();
+                int dateEndKind = GetNextInt32Value();
+                long daylightDeltaTicks = GetNextInt64Value();
+                long baseUtcOffsetDeltaTicks = GetNextInt64Value();
+                int noDaylightTransitions = GetNextInt32Value();
+                TransitionTime daylightStart = GetNextFullFidelityTransitionTimeValue();
+                TransitionTime daylightEnd = GetNextFullFidelityTransitionTimeValue();
+
+                try
+                {
+                    return AdjustmentRule.CreateAdjustmentRule(
+                        new DateTime(dateStartTicks, (DateTimeKind)dateStartKind),
+                        new DateTime(dateEndTicks, (DateTimeKind)dateEndKind),
+                        new TimeSpan(daylightDeltaTicks),
+                        daylightStart,
+                        daylightEnd,
+                        new TimeSpan(baseUtcOffsetDeltaTicks),
+                        noDaylightTransitions != 0);
+                }
+                catch (Exception e) when (e is ArgumentException or OverflowException)
+                {
+                    // The tick values are untrusted. Out-of-range dates surface as ArgumentException, and
+                    // extreme delta values can overflow while CreateAdjustmentRule normalizes them; both
+                    // are reported as corrupt serialized data.
+                    throw new SerializationException(SR.Serialization_InvalidData, e);
+                }
+            }
+
+            /// <summary>
+            /// Reads a full-fidelity TransitionTime, including empty (default) transitions.
+            /// </summary>
+            private TransitionTime GetNextFullFidelityTransitionTimeValue()
+            {
+                string kind = GetNextStringValue();
+                try
+                {
+                    switch (kind)
+                    {
+                        case "D":
+                            return default;
+
+                        case "F":
+                            long fixedTicks = GetNextInt64Value();
+                            int fixedMonth = GetNextInt32Value();
+                            int fixedDay = GetNextInt32Value();
+                            return TransitionTime.CreateFixedDateRule(new DateTime(fixedTicks), fixedMonth, fixedDay);
+
+                        case "W":
+                            long floatingTicks = GetNextInt64Value();
+                            int floatingMonth = GetNextInt32Value();
+                            int floatingWeek = GetNextInt32Value();
+                            int floatingDayOfWeek = GetNextInt32Value();
+                            return TransitionTime.CreateFloatingDateRule(new DateTime(floatingTicks), floatingMonth, floatingWeek, (DayOfWeek)floatingDayOfWeek);
+
+                        default:
+                            throw new SerializationException(SR.Serialization_InvalidData);
+                    }
+                }
+                catch (ArgumentException e)
+                {
+                    throw new SerializationException(SR.Serialization_InvalidData, e);
+                }
             }
 
             /// <summary>

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2208,6 +2208,34 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void FullFidelitySerialization_RuleAndTransitionFields_AreKnown()
+        {
+            // The full-fidelity trailer serializes every instance field of AdjustmentRule and TransitionTime.
+            // If a field is added or removed, update SerializeFullFidelityRules / GetNextFullFidelityRules (and
+            // the transition serialization), bump FullFidelityRulesVersion, and then update the expected sets
+            // below. This guard exists so the format is not silently left incomplete when the types change.
+            AssertInstanceFieldNames(typeof(TimeZoneInfo.AdjustmentRule), new[]
+            {
+                "_dateStart", "_dateEnd", "_daylightDelta", "_daylightTransitionStart",
+                "_daylightTransitionEnd", "_baseUtcOffsetDelta", "_noDaylightTransitions",
+            });
+            AssertInstanceFieldNames(typeof(TimeZoneInfo.TransitionTime), new[]
+            {
+                "_timeOfDay", "_month", "_week", "_day", "_dayOfWeek", "_isFixedDateRule",
+            });
+        }
+
+        private static void AssertInstanceFieldNames(Type type, string[] expected)
+        {
+            string[] actual = type
+                .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Select(f => f.Name)
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToArray();
+            Assert.Equal(expected.OrderBy(n => n, StringComparer.Ordinal).ToArray(), actual);
+        }
+
+        [Fact]
         public static void FromSerializedString_FullFidelityRules_RoundTripsExactly()
         {
             // Native (Unix) time zones store rules that the Windows-shaped public projection cannot

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2192,6 +2192,21 @@ namespace System.Tests
             Assert.Equal(serialized, deserialized.ToSerializedString());
         }
 
+        private static void AssertAllRulesHaveNoDaylightTransitions(TimeZoneInfo tz, bool expected)
+        {
+            // AdjustmentRule.Equals (used by TimeZoneInfo.Equals) does not compare NoDaylightTransitions, so
+            // asserting zone equality cannot verify that this flag round-trips. Check it directly on the internal
+            // rules, which keep the flag on every platform (GetAdjustmentRules() projects it away on Unix).
+            FieldInfo rulesField = typeof(TimeZoneInfo).GetField("_adjustmentRules", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            PropertyInfo noDstProp = typeof(TimeZoneInfo.AdjustmentRule).GetProperty("NoDaylightTransitions", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var rules = (TimeZoneInfo.AdjustmentRule[])rulesField.GetValue(tz)!;
+            Assert.NotEmpty(rules);
+            foreach (TimeZoneInfo.AdjustmentRule rule in rules)
+            {
+                Assert.Equal(expected, (bool)noDstProp.GetValue(rule)!);
+            }
+        }
+
         [Fact]
         public static void FromSerializedString_FullFidelityRules_RoundTripsExactly()
         {
@@ -2222,6 +2237,7 @@ namespace System.Tests
             TimeZoneInfo roundTripped = TimeZoneInfo.FromSerializedString(reserialized);
             Assert.Equal(zone, roundTripped);
             Assert.Equal(reserialized, roundTripped.ToSerializedString());
+            AssertAllRulesHaveNoDaylightTransitions(roundTripped, expected: true);
         }
 
         [Fact]
@@ -2260,6 +2276,7 @@ namespace System.Tests
             TimeZoneInfo roundTripped = TimeZoneInfo.FromSerializedString(reserialized);
             Assert.Equal(zone, roundTripped);
             Assert.Equal(reserialized, roundTripped.ToSerializedString());
+            AssertAllRulesHaveNoDaylightTransitions(roundTripped, expected: true);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2389,16 +2389,21 @@ namespace System.Tests
             string baseSerialized = baseZone.ToSerializedString();
 
             // Two adjacent NoDaylightTransitions rules whose UTC boundaries land on the same calendar day
-            // (rule 1 ends at 2000-10-01 01:59:59.9999999Z, rule 2 starts at 2000-10-01 02:00:00Z).
-            DateTime rule1Start = new DateTime(1999, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            // (rule 1 ends at 2000-10-01 01:59:59.9999999Z, rule 2 starts at 2000-10-01 02:00:00Z). Both
+            // rules stay within a single calendar year so the Unix projection does not split them across
+            // years, and both carry a non-zero whole-minute BaseUtcOffsetDelta so the Unix projection keeps
+            // them (it drops NoDaylightTransitions rules only when every delta is zero). That way the legacy
+            // portion contains the two rules on every platform and the ordering check below is not vacuous.
+            DateTime rule1Start = new DateTime(2000, 3, 1, 0, 0, 0, DateTimeKind.Utc);
             DateTime rule1End = new DateTime(2000, 10, 1, 2, 0, 0, DateTimeKind.Utc).AddTicks(-1);
             DateTime rule2Start = new DateTime(2000, 10, 1, 2, 0, 0, DateTimeKind.Utc);
-            DateTime rule2End = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(-1);
+            DateTime rule2End = new DateTime(2000, 12, 31, 0, 0, 0, DateTimeKind.Utc);
             int utc = (int)DateTimeKind.Utc;
+            long baseUtcOffsetDeltaTicks = TimeSpan.FromHours(1).Ticks;
 
             string trailer =
-                $"!1;2;{rule1Start.Ticks};{utc};{rule1End.Ticks};{utc};0;0;1;D;D;" +
-                $"{rule2Start.Ticks};{utc};{rule2End.Ticks};{utc};0;0;1;D;D;";
+                $"!1;2;{rule1Start.Ticks};{utc};{rule1End.Ticks};{utc};0;{baseUtcOffsetDeltaTicks};1;D;D;" +
+                $"{rule2Start.Ticks};{utc};{rule2End.Ticks};{utc};0;{baseUtcOffsetDeltaTicks};1;D;D;";
 
             TimeZoneInfo zone = TimeZoneInfo.FromSerializedString(baseSerialized + trailer);
             string serialized = zone.ToSerializedString();
@@ -2411,13 +2416,15 @@ namespace System.Tests
             // rule boundaries (two per rule) and verify each rule's start is on or before its end, and each
             // rule ends strictly before the next rule starts. Without the ordering fix, the first rule's end
             // and the second rule's start both land on 2000-10-01 and overlap, which an older reader rejects.
-            // The exact rule shape differs by platform (Windows returns the raw rules; Unix projects them),
-            // so this checks the ordering invariant rather than a fixed rule count.
+            // Both rules survive the Unix projection, so the legacy portion carries at least the two rules
+            // (four dates) on every platform; asserting that minimum keeps the ordering check from passing
+            // vacuously.
             List<DateTime> legacyDates = new List<DateTime>();
             foreach (Match match in Regex.Matches(legacyOnly, @"\b\d{2}:\d{2}:\d{4}\b"))
             {
                 legacyDates.Add(DateTime.ParseExact(match.Value, "MM:dd:yyyy", CultureInfo.InvariantCulture));
             }
+            Assert.True(legacyDates.Count >= 4, "The legacy portion must contain at least the two colliding rules so the ordering check is exercised.");
             Assert.Equal(0, legacyDates.Count % 2);
             for (int i = 0; i + 1 < legacyDates.Count; i += 2)
             {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2207,7 +2207,7 @@ namespace System.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public static void FullFidelitySerialization_RuleAndTransitionFields_AreKnown()
         {
             // The full-fidelity trailer serializes every instance field of AdjustmentRule and TransitionTime.

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2384,6 +2384,58 @@ namespace System.Tests
             Assert.NotNull(legacyZone);
         }
 
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // GetAdjustmentRules() returns NoDaylightTransitions rules verbatim only on Windows; Unix projects them to Windows-shaped rules.
+        public static void ToSerializedString_NoDaylightTransitionsRule_LegacyPortionPreservesMarker()
+        {
+            // A NoDaylightTransitions rule is carried in the full-fidelity trailer, but its legacy portion
+            // must also emit the NoDaylightTransitions marker so a reader that ignores the trailer (for
+            // example an older runtime) reconstructs a Linux-style rule and treats DateStart/DateEnd as an
+            // exact UTC window. Without the marker the same reader parses a Windows-style seasonal rule and
+            // interprets the placeholder transitions as local time, changing the calculated offsets.
+            //
+            // The legacy reader distinguishes the optional BaseUtcOffsetDelta and NoDaylightTransitions
+            // fields positionally, so a zero BaseUtcOffsetDelta must be written before the marker; otherwise
+            // a bare '1' is misread as a one-minute BaseUtcOffsetDelta. This rule uses a zero
+            // BaseUtcOffsetDelta to exercise that positional case.
+            TimeZoneInfo baseZone = TimeZoneInfo.CreateCustomTimeZone(
+                "NoDstMarker", TimeSpan.FromHours(2), "NoDstMarker", "NoDstMarker");
+            string baseSerialized = baseZone.ToSerializedString();
+
+            DateTime dateStart = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime dateEnd = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(-1);
+            TimeSpan daylightDelta = TimeSpan.FromHours(1);
+            int utc = (int)DateTimeKind.Utc;
+
+            // NoDaylightTransitions rule, zero BaseUtcOffsetDelta, default (empty) transitions.
+            string trailer =
+                $"!1;1;{dateStart.Ticks};{utc};{dateEnd.Ticks};{utc};{daylightDelta.Ticks};0;1;D;D;";
+
+            TimeZoneInfo zone = TimeZoneInfo.FromSerializedString(baseSerialized + trailer);
+            string serialized = zone.ToSerializedString();
+            Assert.Contains('!', serialized);
+
+            // Simulate a reader that ignores the full-fidelity trailer: strip it and parse the legacy rules alone.
+            string legacyOnly = serialized.Substring(0, serialized.IndexOf('!'));
+            TimeZoneInfo legacyZone = TimeZoneInfo.FromSerializedString(legacyOnly);
+            TimeZoneInfo.AdjustmentRule legacyRule = Assert.Single(legacyZone.GetAdjustmentRules());
+
+            // The marker must survive in the legacy portion so the rule keeps the UTC-window (Linux) dialect.
+            // Reverting the serializer change drops the marker and this reads false.
+            bool noDaylightTransitions = (bool)legacyRule.GetType()
+                .GetProperty("NoDaylightTransitions", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(legacyRule)!;
+            Assert.True(noDaylightTransitions, "The legacy portion must preserve the NoDaylightTransitions marker.");
+
+            // The marker must land in its own field, not be misread as a one-minute BaseUtcOffsetDelta.
+            Assert.Equal(TimeSpan.Zero, legacyRule.BaseUtcOffsetDelta);
+
+            // The full string (legacy portion plus trailer) must still round trip exactly.
+            TimeZoneInfo roundTripped = TimeZoneInfo.FromSerializedString(serialized);
+            Assert.Equal(zone, roundTripped);
+            Assert.Equal(serialized, roundTripped.ToSerializedString());
+        }
+
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(SystemTimeZonesTestData))]
         public static void BinaryFormatter_RoundTrips(TimeZoneInfo timeZone)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2346,6 +2346,8 @@ namespace System.Tests
         [InlineData("!1;2147483647;")]
         [InlineData("!1;1;123;9;")]
         [InlineData("!1;1;123;0;456;0;0;0;0;Z;D;")]
+        // A NoDaylightTransitions flag other than 0 or 1 is rejected rather than treated as true.
+        [InlineData("!1;1;0;0;630000000000000000;0;0;0;2;D;D;")]
         // Valid dates but extreme delta ticks that overflow while CreateAdjustmentRule normalizes them.
         [InlineData("!1;1;0;0;630000000000000000;0;9223372036854775807;9223372036854775807;1;D;D;")]
         public static void FromSerializedString_MalformedFullFidelityTrailer_Throws(string trailer)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.RemoteExecutor;
@@ -2310,7 +2311,8 @@ namespace System.Tests
                 "Malformed", TimeSpan.FromHours(2), "Malformed", "Malformed");
             string baseSerialized = baseZone.ToSerializedString();
 
-            Assert.Throws<System.Runtime.Serialization.SerializationException>(() => TimeZoneInfo.FromSerializedString(baseSerialized + trailer));
+            Assert.Throws<SerializationException>(() => TimeZoneInfo.FromSerializedString(baseSerialized + trailer));
+            Assert.NotNull(TimeZoneInfo.FromSerializedString(baseSerialized));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2159,7 +2159,6 @@ namespace System.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/19794", TestPlatforms.AnyUnix)]
         [Theory]
         [MemberData(nameof(SystemTimeZonesTestData))]
         public static void ToSerializedString_FromSerializedString_RoundTrips(TimeZoneInfo timeZone)
@@ -2168,6 +2167,221 @@ namespace System.Tests
             TimeZoneInfo deserializedTimeZone = TimeZoneInfo.FromSerializedString(serialized);
             Assert.Equal(timeZone, deserializedTimeZone);
             Assert.Equal(serialized, deserializedTimeZone.ToSerializedString());
+        }
+
+        [Fact]
+        public static void ToSerializedString_WindowsShapedRules_HasNoFullFidelityData()
+        {
+            // A time zone whose rules are already in the Windows-shaped public form must serialize
+            // without the full-fidelity trailer, keeping the string byte-identical to older runtimes.
+            TimeZoneInfo.TransitionTime start = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 2, 0, 0), 3, 15);
+            TimeZoneInfo.TransitionTime end = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 2, 0, 0), 10, 15);
+            TimeZoneInfo.AdjustmentRule rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+                DateTime.MinValue.Date, DateTime.MaxValue.Date, TimeSpan.FromHours(1), start, end);
+
+            TimeZoneInfo tz = TimeZoneInfo.CreateCustomTimeZone(
+                "Custom Standard Time", TimeSpan.FromHours(2), "Custom", "Custom Standard", "Custom Daylight",
+                new[] { rule });
+
+            string serialized = tz.ToSerializedString();
+            Assert.DoesNotContain('!', serialized);
+
+            TimeZoneInfo deserialized = TimeZoneInfo.FromSerializedString(serialized);
+            Assert.Equal(tz, deserialized);
+            Assert.Equal(serialized, deserialized.ToSerializedString());
+        }
+
+        [Fact]
+        public static void FromSerializedString_FullFidelityRules_RoundTripsExactly()
+        {
+            // Native (Unix) time zones store rules that the Windows-shaped public projection cannot
+            // represent losslessly: NoDaylightTransitions rules whose boundaries are exact UTC instants
+            // with a sub-day time component. These rules are carried in the full-fidelity trailer.
+            // This validates that once such rules are present, the round trip preserves them exactly on
+            // every platform.
+            TimeZoneInfo baseZone = TimeZoneInfo.CreateCustomTimeZone(
+                "FullFidelity", TimeSpan.FromHours(2), "FullFidelity", "FullFidelity");
+            string baseSerialized = baseZone.ToSerializedString();
+
+            DateTime dateStart = new DateTime(2000, 6, 1, 3, 30, 15, DateTimeKind.Utc);
+            DateTime dateEnd = new DateTime(2000, 10, 1, 2, 0, 0, DateTimeKind.Utc).AddTicks(-1);
+            TimeSpan daylightDelta = TimeSpan.FromHours(1);
+
+            // !<version>;<count>; then one rule:
+            // <startTicks>;<startKind>;<endTicks>;<endKind>;<daylightDeltaTicks>;<baseUtcOffsetDeltaTicks>;<noDst>;<transStart><transEnd>
+            // where a default (empty) transition is encoded as "D;".
+            string trailer =
+                $"!1;1;{dateStart.Ticks};{(int)DateTimeKind.Utc};{dateEnd.Ticks};{(int)DateTimeKind.Utc};{daylightDelta.Ticks};0;1;D;D;";
+
+            TimeZoneInfo zone = TimeZoneInfo.FromSerializedString(baseSerialized + trailer);
+
+            string reserialized = zone.ToSerializedString();
+            Assert.Contains('!', reserialized);
+
+            TimeZoneInfo roundTripped = TimeZoneInfo.FromSerializedString(reserialized);
+            Assert.Equal(zone, roundTripped);
+            Assert.Equal(reserialized, roundTripped.ToSerializedString());
+        }
+
+        [Fact]
+        public static void FromSerializedString_FullFidelityRules_PreservesSubMinuteBaseUtcOffsetDelta()
+        {
+            // A rule with a sub-minute BaseUtcOffsetDelta cannot be represented by the legacy format, whose
+            // offset is written in whole minutes. Such a rule must be carried in the full-fidelity trailer
+            // and round trip with its exact tick value preserved on every platform. This is the only field
+            // in the trailer that the legacy public projection also stores, so a mismatch here would go
+            // unnoticed without an explicit sub-minute value.
+            TimeZoneInfo baseZone = TimeZoneInfo.CreateCustomTimeZone(
+                "SubMinute", TimeSpan.FromHours(2), "SubMinute", "SubMinute");
+            string baseSerialized = baseZone.ToSerializedString();
+
+            DateTime dateStart = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime dateEnd = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(-1);
+            TimeSpan baseUtcOffsetDelta = TimeSpan.FromSeconds(90); // 1.5 minutes: not representable in the legacy whole-minute offset.
+
+            string trailer =
+                $"!1;1;{dateStart.Ticks};{(int)DateTimeKind.Utc};{dateEnd.Ticks};{(int)DateTimeKind.Utc};0;{baseUtcOffsetDelta.Ticks};1;D;D;";
+
+            TimeZoneInfo zone = TimeZoneInfo.FromSerializedString(baseSerialized + trailer);
+
+            string reserialized = zone.ToSerializedString();
+            // The sub-minute delta must force the full-fidelity trailer and appear in it with its exact ticks.
+            Assert.Contains('!', reserialized);
+            Assert.Contains($";{baseUtcOffsetDelta.Ticks};", reserialized.Substring(reserialized.IndexOf('!')));
+
+            // The legacy portion stores the offset in whole minutes; a reader that ignores the trailer (for
+            // example an older runtime) must still be able to parse it, so it must not contain a fractional
+            // minute value. Simulate that reader by stripping the trailer and parsing the legacy rules alone.
+            string legacyOnly = reserialized.Substring(0, reserialized.IndexOf('!'));
+            TimeZoneInfo legacyZone = TimeZoneInfo.FromSerializedString(legacyOnly);
+            Assert.NotNull(legacyZone);
+
+            TimeZoneInfo roundTripped = TimeZoneInfo.FromSerializedString(reserialized);
+            Assert.Equal(zone, roundTripped);
+            Assert.Equal(reserialized, roundTripped.ToSerializedString());
+        }
+
+        [Fact]
+        public static void ToSerializedString_FullFidelityRules_PreservesFixedAndFloatingTransitions()
+        {
+            // A rule whose boundaries are exact UTC instants cannot be represented by the Windows-shaped
+            // public projection, so it is carried in the full-fidelity trailer. This exercises the trailer
+            // encode and decode of both a fixed-date and a floating-date transition on every platform.
+            TimeZoneInfo.TransitionTime fixedStart = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 2, 0, 0), 3, 15);
+            TimeZoneInfo.TransitionTime floatingEnd = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 2, 0, 0), 10, 5, DayOfWeek.Sunday);
+            TimeZoneInfo.AdjustmentRule rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+                new DateTime(2000, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+                new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(-1),
+                TimeSpan.FromHours(1), fixedStart, floatingEnd);
+
+            TimeZoneInfo tz = TimeZoneInfo.CreateCustomTimeZone(
+                "Utc Boundary Time", TimeSpan.FromHours(2), "Utc Boundary", "Utc Boundary Standard", "Utc Boundary Daylight",
+                new[] { rule });
+
+            string serialized = tz.ToSerializedString();
+            Assert.Contains('!', serialized);
+            // The trailer must be stamped with the current version (1) so a reader can detect and skip a
+            // newer, unrecognized layout. This guards against changing the trailer layout without bumping
+            // the version constant.
+            Assert.StartsWith("!1;", serialized.Substring(serialized.IndexOf('!')));
+            // The fixed ('F') and floating ('W') transitions must be present in the full-fidelity trailer.
+            Assert.Contains(";F;", serialized);
+            Assert.Contains(";W;", serialized);
+
+            TimeZoneInfo deserialized = TimeZoneInfo.FromSerializedString(serialized);
+            Assert.Equal(tz, deserialized);
+            Assert.Equal(serialized, deserialized.ToSerializedString());
+        }
+
+        [Theory]
+        [InlineData("!x;")]
+        [InlineData("!1;x;")]
+        [InlineData("!1;0;")]
+        [InlineData("!1;2147483647;")]
+        [InlineData("!1;1;123;9;")]
+        [InlineData("!1;1;123;0;456;0;0;0;0;Z;D;")]
+        // Valid dates but extreme delta ticks that overflow while CreateAdjustmentRule normalizes them.
+        [InlineData("!1;1;0;0;630000000000000000;0;9223372036854775807;9223372036854775807;1;D;D;")]
+        public static void FromSerializedString_MalformedFullFidelityTrailer_Throws(string trailer)
+        {
+            // The full-fidelity trailer is untrusted input. Any malformed marker, version, count, or token
+            // must surface as SerializationException, never as an unbounded allocation or an unexpected type.
+            TimeZoneInfo baseZone = TimeZoneInfo.CreateCustomTimeZone(
+                "Malformed", TimeSpan.FromHours(2), "Malformed", "Malformed");
+            string baseSerialized = baseZone.ToSerializedString();
+
+            Assert.Throws<System.Runtime.Serialization.SerializationException>(() => TimeZoneInfo.FromSerializedString(baseSerialized + trailer));
+        }
+
+        [Fact]
+        public static void FromSerializedString_UnknownFullFidelityVersion_IsIgnored()
+        {
+            // A trailer written by a newer runtime (unrecognized version) must be ignored so the string
+            // still deserializes using the legacy rules, rather than throwing or misparsing newer data.
+            TimeZoneInfo baseZone = TimeZoneInfo.CreateCustomTimeZone(
+                "FutureVersion", TimeSpan.FromHours(2), "FutureVersion", "FutureVersion");
+            string baseSerialized = baseZone.ToSerializedString();
+
+            TimeZoneInfo zone = TimeZoneInfo.FromSerializedString(baseSerialized + "!99;whatever;data;");
+
+            Assert.Equal(baseZone, zone);
+        }
+
+        [Fact]
+        public static void ToSerializedString_LegacyRulesRemainValid_WhenFullFidelityTrailerIgnored()
+        {
+            // Internal rules with sub-day UTC boundaries can collapse onto the same calendar day in the
+            // legacy (date-only) format, which would make consecutive legacy rules overlap. A reader that
+            // ignores the full-fidelity trailer (for example an older runtime) validates the legacy rules
+            // for chronological order, so the serializer must keep them ordered. Simulate that reader by
+            // stripping the trailer and verifying the legacy rules alone still form a valid TimeZoneInfo.
+            TimeZoneInfo baseZone = TimeZoneInfo.CreateCustomTimeZone(
+                "Colliding", TimeSpan.FromHours(2), "Colliding", "Colliding");
+            string baseSerialized = baseZone.ToSerializedString();
+
+            // Two adjacent NoDaylightTransitions rules whose UTC boundaries land on the same calendar day
+            // (rule 1 ends at 2000-10-01 01:59:59.9999999Z, rule 2 starts at 2000-10-01 02:00:00Z).
+            DateTime rule1Start = new DateTime(1999, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime rule1End = new DateTime(2000, 10, 1, 2, 0, 0, DateTimeKind.Utc).AddTicks(-1);
+            DateTime rule2Start = new DateTime(2000, 10, 1, 2, 0, 0, DateTimeKind.Utc);
+            DateTime rule2End = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(-1);
+            int utc = (int)DateTimeKind.Utc;
+
+            string trailer =
+                $"!1;2;{rule1Start.Ticks};{utc};{rule1End.Ticks};{utc};0;0;1;D;D;" +
+                $"{rule2Start.Ticks};{utc};{rule2End.Ticks};{utc};0;0;1;D;D;";
+
+            TimeZoneInfo zone = TimeZoneInfo.FromSerializedString(baseSerialized + trailer);
+            string serialized = zone.ToSerializedString();
+
+            int markerIndex = serialized.IndexOf('!');
+            Assert.True(markerIndex > 0);
+            string legacyOnly = serialized.Substring(0, markerIndex);
+
+            // Prove the serializer never emits overlapping legacy rules: extract the whole-day MM:dd:yyyy
+            // rule boundaries (two per rule) and verify each rule's start is on or before its end, and each
+            // rule ends strictly before the next rule starts. Without the ordering fix, the first rule's end
+            // and the second rule's start both land on 2000-10-01 and overlap, which an older reader rejects.
+            // The exact rule shape differs by platform (Windows returns the raw rules; Unix projects them),
+            // so this checks the ordering invariant rather than a fixed rule count.
+            List<DateTime> legacyDates = new List<DateTime>();
+            foreach (Match match in Regex.Matches(legacyOnly, @"\b\d{2}:\d{2}:\d{4}\b"))
+            {
+                legacyDates.Add(DateTime.ParseExact(match.Value, "MM:dd:yyyy", CultureInfo.InvariantCulture));
+            }
+            Assert.Equal(0, legacyDates.Count % 2);
+            for (int i = 0; i + 1 < legacyDates.Count; i += 2)
+            {
+                Assert.True(legacyDates[i] <= legacyDates[i + 1], "A legacy rule's start date must not be after its end date.");
+                if (i + 2 < legacyDates.Count)
+                {
+                    Assert.True(legacyDates[i + 1] < legacyDates[i + 2], "Consecutive legacy rules must not overlap on the same calendar day.");
+                }
+            }
+
+            // Must not throw: the legacy rules must be chronologically valid on their own.
+            TimeZoneInfo legacyZone = TimeZoneInfo.FromSerializedString(legacyOnly);
+            Assert.NotNull(legacyZone);
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]


### PR DESCRIPTION
Fixes #19794

## Problem

`TimeZoneInfo.ToSerializedString` / `FromSerializedString` did not round-trip on Unix. The custom string format only represents the Windows-shaped public projection of the adjustment rules (the output of `GetAdjustmentRules()`). Unix rules can carry information that projection cannot express, so the deserialized instance did not equal the original. Lossy cases include:

- rules with `NoDaylightTransitions` set,
- `DateStart` / `DateEnd` with `DateTimeKind.Utc` and sub-day boundaries,
- sub-minute `BaseUtcOffsetDelta`,
- multi-year internal rules that the public projection splits.

## Fix

Append an optional full-fidelity copy of the internal adjustment rules after the separator that terminates the legacy rule list. This placement is backward compatible: older readers stop at that separator and never see the trailer, so previously serialized strings and Windows output are unchanged and remain valid.

- A modern reader consumes the trailer and reconstructs the exact internal rules.
- When the trailer is absent, or written with an unknown future version, the reader falls back to the legacy rules.
- The trailer is only emitted when the legacy projection is actually lossy, so Windows-shaped time zones produce byte-identical output to before.

The legacy portion is also kept self-consistent for readers that ignore the trailer:

- whole-day legacy boundaries are ordered so consecutive rules never overlap,
- `BaseUtcOffsetDelta` is written in whole minutes, because the legacy reader rejects a fractional value.

The trailer count and rule ticks are untrusted input, so the rule count is bounded against the remaining input length, and out-of-range or overflowing tick values are translated into `SerializationException`.

## Testing

Added and re-enabled tests in `TimeZoneInfoTests`:

- re-enabled the Unix round-trip test over all system time zones,
- Windows-shaped rules emit no trailer (byte-identical output),
- full-fidelity round-trip including fixed and floating transitions and sub-minute `BaseUtcOffsetDelta`,
- legacy rules remain valid and non-overlapping when the trailer is ignored,
- malformed and overflowing trailers throw `SerializationException`,
- an unknown trailer version is ignored.

Validated on Windows (618 tests) and Linux/WSL (2044 tests); all pass.