### PR TITLE
[wasm][R2R] Request flat layout for composite image on WebAssembly

### DIFF
--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -142,7 +142,7 @@ namespace
             PEImageLayout* loaded = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_FLAT);
 #else
             PEImageLayout* loaded = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_LOADED);
-#endif // TARGET_WASM
+#endif // PEIMAGE_FLAT_LAYOUT_ONLY
             // We will let pImage instance be freed after exiting this scope, but we will keep the layout,
             // thus the layout needs an AddRef, or it will be gone together with pImage.
             loaded->AddRef();

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -138,10 +138,7 @@ namespace
             // Composite r2r PE image is not a part of anyone's identity.
             // We only need it to obtain the native image, which will be cached at AppDomain level.
             PEImageHolder pImage(PEImage::OpenImage(fullPath, MDInternalImport_NoCache, probeExtensionResult));
-#ifdef TARGET_WASM
-            // WebAssembly is flat-layout only (PEIMAGE_FLAT_LAYOUT_ONLY): a webcil composite has no
-            // OS-loadable/mapped layout, so requesting LAYOUT_LOADED yields no layout and trips the
-            // flat-suitability assert in GetOrCreateLayoutInternal. Request the flat layout explicitly.
+#ifdef PEIMAGE_FLAT_LAYOUT_ONLY
             PEImageLayout* loaded = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_FLAT);
 #else
             PEImageLayout* loaded = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_LOADED);

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -138,7 +138,14 @@ namespace
             // Composite r2r PE image is not a part of anyone's identity.
             // We only need it to obtain the native image, which will be cached at AppDomain level.
             PEImageHolder pImage(PEImage::OpenImage(fullPath, MDInternalImport_NoCache, probeExtensionResult));
+#ifdef TARGET_WASM
+            // WebAssembly is flat-layout only (PEIMAGE_FLAT_LAYOUT_ONLY): a webcil composite has no
+            // OS-loadable/mapped layout, so requesting LAYOUT_LOADED yields no layout and trips the
+            // flat-suitability assert in GetOrCreateLayoutInternal. Request the flat layout explicitly.
+            PEImageLayout* loaded = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_FLAT);
+#else
             PEImageLayout* loaded = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_LOADED);
+#endif // TARGET_WASM
             // We will let pImage instance be freed after exiting this scope, but we will keep the layout,
             // thus the layout needs an AddRef, or it will be gone together with pImage.
             loaded->AddRef();


### PR DESCRIPTION
On WebAssembly, PE images are flat-layout only (`PEIMAGE_FLAT_LAYOUT_ONLY`). A webcil composite R2R image has no OS-loadable/mapped layout, so requesting `LAYOUT_LOADED` yields no layout and trips the flat-suitability assert in `GetOrCreateLayoutInternal`. Request the flat layout explicitly under `TARGET_WASM` when obtaining the composite image layout in `NativeImage::Open`.

Guarded by `#ifdef TARGET_WASM`, so no behavior change on any other target.

> [!NOTE]
> This pull request was authored with assistance from GitHub Copilot.