### PR TITLE
[wasm][R2R] Fix Crst level violation between NativeImageEagerFixups and PregeneratedStringThunks

### DIFF
--- a/src/coreclr/inc/CrstTypes.def
+++ b/src/coreclr/inc/CrstTypes.def
@@ -505,7 +505,7 @@ Crst MethodDescBackpatchInfoTracker
 End
 
 Crst NativeImageEagerFixups
-    AcquiredBefore UnresolvedClassLock
+    AcquiredBefore PregeneratedStringThunks UnresolvedClassLock
 End
 
 Crst NativeImageLoad

--- a/src/coreclr/inc/crsttypes_generated.h
+++ b/src/coreclr/inc/crsttypes_generated.h
@@ -195,7 +195,7 @@ int g_rgCrstLevelMap[] =
     3,          // CrstModuleLookupTable
     0,          // CrstMulticoreJitHash
     14,         // CrstMulticoreJitManager
-    7,          // CrstNativeImageEagerFixups
+    8,          // CrstNativeImageEagerFixups
     0,          // CrstNativeImageLoad
     0,          // CrstNotifyGdb
     4,          // CrstPEImage


### PR DESCRIPTION
The WASM R2R path acquires the `NativeImageEagerFixups` and `PregeneratedStringThunks` Crsts without a defined acquisition order between them, which trips a Crst level violation.

Add an `AcquiredBefore PregeneratedStringThunks` edge to `NativeImageEagerFixups` in `CrstTypes.def` so the two locks have a well-defined ordering, and regenerate `crsttypes_generated.h` (CrstNativeImageEagerFixups level 7 -> 8). Nothing acquires `NativeImageEagerFixups` before another lock, so the change does not cascade to any other Crst level.

> [!NOTE]
> This pull request was authored with assistance from GitHub Copilot.