### PR TITLE
Fix config binder source gen for a sole read-only collection ctor param

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/BindingHelperInfo.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/BindingHelperInfo.cs
@@ -169,7 +169,17 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                                 // an error for config properties that don't map to object properties.
                                 _namespaces.Add("System.Collections.Generic");
 
-                                if (_typeIndex.HasBindableMembers(objectSpec))
+                                bool hasBindableMembers = _typeIndex.HasBindableMembers(objectSpec);
+
+                                // A type with a parameterized constructor gets its constructor parameters bound
+                                // in the Initialize method regardless of whether it also has other bindable
+                                // members; that binding capability must be registered even when
+                                // HasBindableMembers is false (e.g. the only member is a ctor parameter backed
+                                // by a non-bindable read-only collection type), otherwise the emitter can end up
+                                // calling an Initialize method that was never generated.
+                                bool needsInitializeMethod = objectSpec is { InstantiationStrategy: ObjectInstantiationStrategy.ParameterizedConstructor, InitExceptionMessage: null };
+
+                                if (hasBindableMembers || needsInitializeMethod)
                                 {
                                     foreach (PropertySpec property in objectSpec.Properties!)
                                     {
@@ -189,10 +199,13 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                                         }
                                     }
 
-                                    bool registeredForBindCore = TryRegisterTypeForBindCoreGen(objectSpec);
-                                    Debug.Assert(registeredForBindCore);
+                                    if (hasBindableMembers)
+                                    {
+                                        bool registeredForBindCore = TryRegisterTypeForBindCoreGen(objectSpec);
+                                        Debug.Assert(registeredForBindCore);
+                                    }
 
-                                    if (objectSpec is { InstantiationStrategy: ObjectInstantiationStrategy.ParameterizedConstructor, InitExceptionMessage: null })
+                                    if (needsInitializeMethod)
                                     {
                                         RegisterTypeForMethodGen(MethodsToGen_CoreBindingHelper.Initialize, objectSpec);
                                     }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -229,6 +230,22 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
                 throw new InvalidOperationException(errorMessage);
             }
             return stream.ToArray();
+        }
+
+        /// <summary>
+        /// Compiles the source-generated output to an in-memory assembly, invokes its Program.Main(),
+        /// and returns the value of the public static field named <paramref name="resultFieldName"/>.
+        /// Used to assert on real bound values rather than just that the generated code compiles,
+        /// since a generator can emit code that builds cleanly but binds the wrong data.
+        /// </summary>
+        private static object? LoadAndInvokeMain(Compilation compilation, string resultFieldName)
+        {
+            byte[] image = CreateAssemblyImage(compilation);
+            Assembly assembly = AssemblyLoadContext.Default.LoadFromStream(new MemoryStream(image));
+
+            Type programType = assembly.GetType("Program")!;
+            programType.GetMethod("Main", BindingFlags.Public | BindingFlags.Static)!.Invoke(null, null);
+            return programType.GetField(resultFieldName, BindingFlags.Public | BindingFlags.Static)!.GetValue(null);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
@@ -240,6 +240,12 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
         /// </summary>
         private static object? LoadAndInvokeMain(Compilation compilation, string resultFieldName)
         {
+            // Every test project shares the same assembly name ("test", from RoslynTestUtils.CreateTestProject),
+            // and AssemblyLoadContext.Default can't unload. If more than one theory case in a run reaches this
+            // method, loading the second image collides with the first under the identical identity. Give each
+            // load a unique name so they can coexist.
+            compilation = compilation.WithAssemblyName($"test_{Guid.NewGuid():N}");
+
             byte[] image = CreateAssemblyImage(compilation);
             Assembly assembly = AssemblyLoadContext.Default.LoadFromStream(new MemoryStream(image));
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
@@ -9,7 +9,9 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+#if NET
 using System.Runtime.Loader;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -240,6 +242,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
         /// </summary>
         private static object? LoadAndInvokeMain(Compilation compilation, string resultFieldName)
         {
+#if NET
             // Every test project shares the same assembly name ("test", from RoslynTestUtils.CreateTestProject),
             // and AssemblyLoadContext.Default can't unload. If more than one theory case in a run reaches this
             // method, loading the second image collides with the first under the identical identity. Give each
@@ -252,6 +255,12 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Type programType = assembly.GetType("Program")!;
             programType.GetMethod("Main", BindingFlags.Public | BindingFlags.Static)!.Invoke(null, null);
             return programType.GetField(resultFieldName, BindingFlags.Public | BindingFlags.Static)!.GetValue(null);
+#else
+            // Callers are gated with [ConditionalTheory/Fact(..., nameof(PlatformDetection.IsNetCore))],
+            // so this is never actually invoked on .NET Framework; the branch only exists so the file
+            // still compiles there (System.Runtime.Loader.AssemblyLoadContext isn't available on netfx).
+            throw new PlatformNotSupportedException();
+#endif
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -552,6 +552,10 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             // Regression test: a type whose only member is a non-bindable, read-only collection
             // constructor parameter (no other bindable property) used to make the generator emit a
             // call to an Initialize method that was never generated, producing CS0103 at compile time.
+            //
+            // This only covers the top-level GetCore path. Binding this same shape as a *nested*
+            // member (reached via BindCore/EmitObjectInit) silently produces null instead of the
+            // real value, a separate pre-existing bug tracked in dotnet/runtime#131399.
             string source = $$"""
                 using Microsoft.Extensions.Configuration;
                 using System.Collections.Generic;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -558,11 +558,19 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
                 public class Program
                 {
+                    public static object? Result;
+
                     public static void Main()
                     {
                         ConfigurationBuilder configurationBuilder = new();
+                        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                        {
+                            ["Values:0"] = "a",
+                            ["Values:1"] = "b",
+                        });
                         IConfiguration config = configurationBuilder.Build();
                         Options options = config.Get<Options>();
+                        Result = options.Values;
                     }
                 }
 
@@ -573,7 +581,56 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Assert.NotNull(result.GeneratedSource);
             Assert.Empty(result.Diagnostics);
 
-            AssertCanCreateAssemblyImage(result.OutputCompilation);
+            // Compiling only proves the Initialize method the fix registers is emitted; loading and
+            // running the assembly proves it also binds the right values, not just compilable code.
+            var boundValues = (IEnumerable<string>)LoadAndInvokeMain(result.OutputCompilation, "Result")!;
+            Assert.Equal(new[] { "a", "b" }, boundValues);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        public async Task SoleReadOnlyCollectionConstructorParameterOfComplexElementIsBindable()
+        {
+            // Same regression as SoleReadOnlyCollectionConstructorParameterIsBindable, but the element
+            // type is itself a bindable object rather than a string. ComplexReadOnlyListConstructorParameterIsBindable
+            // below covers the complex-element case, but always pairs it with a second, ordinarily-bindable
+            // property, so it never exercises the fixed code path (the type has bindable members either way).
+            string source = """
+                using Microsoft.Extensions.Configuration;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class Program
+                {
+                    public static object? Result;
+
+                    public static void Main()
+                    {
+                        ConfigurationBuilder configurationBuilder = new();
+                        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                        {
+                            ["Values:0:Value"] = "a",
+                            ["Values:1:Value"] = "b",
+                        });
+                        IConfiguration config = configurationBuilder.Build();
+                        Options options = config.Get<Options>();
+                        Result = options.Values.Select(v => v.Value).ToArray();
+                    }
+                }
+
+                public class Child
+                {
+                    public string Value { get; set; }
+                }
+
+                public record Options(IReadOnlyList<Child> Values);
+                """;
+
+            ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source, assemblyReferences: GetAssemblyRefsWithAdditional(typeof(ConfigurationBuilder), typeof(List<>)));
+            Assert.NotNull(result.GeneratedSource);
+            Assert.Empty(result.Diagnostics);
+
+            var boundValues = (string[])LoadAndInvokeMain(result.OutputCompilation, "Result")!;
+            Assert.Equal(new[] { "a", "b" }, boundValues);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -542,6 +542,40 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             AssertCanCreateAssemblyImage(result.OutputCompilation);
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        [InlineData("IReadOnlyList")]
+        [InlineData("IReadOnlyCollection")]
+        [InlineData("IReadOnlySet")]
+        [InlineData("IEnumerable")]
+        public async Task SoleReadOnlyCollectionConstructorParameterIsBindable(string collectionType)
+        {
+            // Regression test: a type whose only member is a non-bindable, read-only collection
+            // constructor parameter (no other bindable property) used to make the generator emit a
+            // call to an Initialize method that was never generated, producing CS0103 at compile time.
+            string source = $$"""
+                using Microsoft.Extensions.Configuration;
+                using System.Collections.Generic;
+
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        ConfigurationBuilder configurationBuilder = new();
+                        IConfiguration config = configurationBuilder.Build();
+                        Options options = config.Get<Options>();
+                    }
+                }
+
+                public record Options({{collectionType}}<string> Values);
+                """;
+
+            ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source, assemblyReferences: GetAssemblyRefsWithAdditional(typeof(ConfigurationBuilder), typeof(List<>)));
+            Assert.NotNull(result.GeneratedSource);
+            Assert.Empty(result.Diagnostics);
+
+            AssertCanCreateAssemblyImage(result.OutputCompilation);
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
         public async Task ComplexReadOnlyListConstructorParameterIsBindable()
         {


### PR DESCRIPTION
Fixes #131320

The configuration binder source generator emitted an uncompilable call to an Initialize method that was never generated, for a parameterized-constructor type whose only member is a non-bindable copy-constructor collection parameter (a positional record with a single IReadOnlyList<T>, IReadOnlyCollection<T>, IReadOnlySet<T>, or IEnumerable<T> parameter and no other bindable property). The reflection binder handles this shape correctly, so this was a parity regression that broke the build instead.

Root cause: `BindingHelperInfo.Builder.TryRegisterTransitiveTypesForMethodGen` only registered a type for Initialize-method generation inside the `HasBindableMembers(objectSpec)` check. But constructor parameters are bound in `Initialize` independently of whether the type has any other bindable property, per the comment already on the ctor-param property loop a few lines above. For a type where the only "property" is a ctor param backed by a non-bindable read-only collection type, `HasBindableMembers` is false, so `Initialize` never got registered/emitted, while the emitter's `EmitBindingLogic`/`EmitObjectInit` still unconditionally calls `InitializeXxx(...)` for any `ParameterizedConstructor` type.

Fix: register the Initialize method (and walk the constructor-parameter properties needed to bind it) whenever the type has a parameterized constructor, regardless of `HasBindableMembers`. `BindCore` registration stays gated on `HasBindableMembers` as before, since that part is unrelated.

Verified by running the incremental generator directly against the repro from the issue:

    var config = new ConfigurationBuilder().Build();
    Options options = config.Get<Options>();
    public record Options(IReadOnlyList<string> Values);

Before this change the generated source calls `InitializeOptions` but never defines it, reproducing `CS0103: The name 'InitializeOptions' does not exist in the current context` exactly. After this change the method is generated and binds the parameter correctly. Confirmed for all four affected collection interfaces (IReadOnlyList, IReadOnlyCollection, IReadOnlySet, IEnumerable).

Added `SoleReadOnlyCollectionConstructorParameterIsBindable` next to the existing `ReadOnlyCollectionConstructorParameterIsBindable` test, covering the case where the collection parameter is the type's only member (the existing test always paired it with a second, ordinarily-bindable property, so it didn't exercise this gap).