### PR TITLE
[browser] Turn the >2GB memory test into an interop conformance test

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/MemoryTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/MemoryTests.cs
@@ -39,10 +39,14 @@ public class MemoryTests : WasmTemplateTestsBase
 
         if (BuildTestBase.IsUsingWorkloads)
         {
-            await RunForBuildWithDotnetRun(new BrowserRunOptions(
+            RunResult result = await RunForBuildWithDotnetRun(new BrowserRunOptions(
                 Configuration: config,
                 TestScenario: "AllocateLargeHeapThenInterop"
             ));
+
+            Assert.Contains(result.TestOutput, line => line.Contains("Great success, MemoryTest finished without errors."));
+            // above the 2GB boundary the jiterpreter used to encode negative pointers and emit invalid wasm modules
+            Assert.DoesNotContain(result.ConsoleOutput, line => line.Contains("code generation failed"));
         }
     }
 }

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/MemoryTest.cs
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/MemoryTest.cs
@@ -2,23 +2,137 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.IO;
-using System.Text.Json;
-using System.Text;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.InteropServices.JavaScript;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
 
 public partial class MemoryTest
 {
+    private static readonly List<string> s_errors = new();
+
     [JSImport("countChars", "main.js")]
     internal static partial int CountChars(string testArray);
 
+    [JSImport("echoString", "main.js")]
+    internal static partial string EchoString(string value);
+
+    [JSImport("createBytes", "main.js")]
+    internal static partial byte[] CreateBytes(int length);
+
+    [JSImport("sumBytes", "main.js")]
+    internal static partial int SumBytes(byte[] value);
+
+    [JSImport("sumMemoryView", "main.js")]
+    internal static partial int SumSpan([JSMarshalAs<JSType.MemoryView>] Span<byte> value);
+
+    [JSImport("sumMemoryView", "main.js")]
+    internal static partial int SumSegment([JSMarshalAs<JSType.MemoryView>] ArraySegment<byte> value);
+
+    [JSImport("echoInt32Array", "main.js")]
+    internal static partial int[] EchoInt32Array(int[] value);
+
+    [JSImport("echoDoubleArray", "main.js")]
+    internal static partial double[] EchoDoubleArray(double[] value);
+
+    [JSImport("createObject", "main.js")]
+    internal static partial JSObject CreateObject(string name, int value);
+
+    [JSImport("throwError", "main.js")]
+    internal static partial void ThrowError(string message);
+
+    [JSImport("delayedSum", "main.js")]
+    internal static partial Task<int> DelayedSum(int a, int b);
+
+    [JSImport("callManagedExports", "main.js")]
+    internal static partial string CallManagedExports();
+
     [JSExport]
-    internal static void Run()
+    internal static int SumBytesManaged(byte[] value)
+    {
+        int sum = 0;
+        foreach (byte b in value)
+        {
+            sum += b;
+        }
+
+        return sum;
+    }
+
+    [JSExport]
+    internal static byte[] CreateBytesManaged(int length)
+    {
+        byte[] result = new byte[length];
+        for (int i = 0; i < length; i++)
+        {
+            result[i] = unchecked((byte)(i * 3));
+        }
+
+        return result;
+    }
+
+    [JSExport]
+    internal static string EchoStringManaged(string value) => value;
+
+    [JSExport]
+    internal static async Task RunAsync()
+    {
+        ReportAllocationAddress();
+        AllocateManagedArrays();
+        TierUpInterop();
+
+        Run("string round trip", StringRoundTrip);
+        Run("large string marshaling", LargeStringMarshaling);
+        Run("byte[] JS to C#", BytesFromJs);
+        Run("byte[] C# to JS", BytesToJs);
+        Run("int[] round trip", Int32ArrayRoundTrip);
+        Run("double[] round trip", DoubleArrayRoundTrip);
+        Run("Span<byte> memory view", SpanMemoryView);
+        Run("ArraySegment<byte> memory view", ArraySegmentMemoryView);
+        Run("JSObject properties", JSObjectProperties);
+        Run("exception propagation", ExceptionPropagation);
+        Run("crypto RandomNumberGenerator", CryptoRandomBytes);
+        Run("globalization", Globalization);
+        Run("JSExport round trips", ManagedExports);
+
+        await RunAsync("Task<int> round trip", TaskRoundTrip);
+
+        if (s_errors.Count != 0)
+        {
+            string message = string.Join(Environment.NewLine, s_errors);
+            TestOutput.WriteLine(message);
+            throw new Exception(message);
+        }
+
+        TestOutput.WriteLine("Great success, MemoryTest finished without errors.");
+    }
+
+    private static void ReportAllocationAddress()
+    {
+        byte[] pinned = GC.AllocateArray<byte>(1024, pinned: true);
+        ulong address;
+        unsafe
+        {
+            fixed (byte* p = pinned)
+            {
+                address = (ulong)(nuint)p;
+            }
+        }
+
+        TestOutput.WriteLine($"Pinned buffer allocated at 0x{address:X}");
+        if (address < 0x8000_0000)
+        {
+            s_errors.Add($"Allocations are below the 2GB boundary (0x{address:X}), the test is not exercising >2GB pointers.");
+        }
+    }
+
+    private static void AllocateManagedArrays()
     {
         // Allocate 250MB managed space above 2GB already wasted before startup
         const int arrayCnt = 10;
         int[][] arrayHolder = new int[arrayCnt][];
-        string errors = "";
         TestOutput.WriteLine("Starting managed array allocation");
         for (int i = 0; i < arrayCnt; i++)
         {
@@ -28,11 +142,15 @@ public partial class MemoryTest
             }
             catch (Exception ex)
             {
-                errors += $"Exception {ex} was thrown on i={i}";
+                s_errors.Add($"Exception {ex} was thrown on i={i}");
             }
         }
-        TestOutput.WriteLine("Finished managed array allocation");
 
+        TestOutput.WriteLine("Finished managed array allocation");
+    }
+
+    private static void TierUpInterop()
+    {
         // call a method many times to trigger tier-up optimization
         string randomString = GenerateRandomString(1000);
         try
@@ -41,22 +159,218 @@ public partial class MemoryTest
             {
                 int count = CountChars(randomString);
                 if (count != randomString.Length)
-                    errors += $"CountChars returned {count} instead of {randomString.Length} for {i}-th string.";
+                {
+                    s_errors.Add($"CountChars returned {count} instead of {randomString.Length} for {i}-th string.");
+                }
             }
         }
         catch (Exception ex)
         {
-            errors += $"Exception {ex} was thrown when CountChars was called in a loop";
+            s_errors.Add($"Exception {ex} was thrown when CountChars was called in a loop");
         }
-        if (!string.IsNullOrEmpty(errors))
+    }
+
+    private static void Run(string name, Action test)
+    {
+        try
         {
-            TestOutput.WriteLine(errors);
-            throw new Exception(errors);
+            test();
+            TestOutput.WriteLine($"PASS {name}");
         }
-        else
+        catch (Exception ex)
         {
-            TestOutput.WriteLine("Great success, MemoryTest finished without errors.");
+            s_errors.Add($"FAIL {name}: {ex.GetType().Name}: {ex.Message}");
         }
+    }
+
+    private static async Task RunAsync(string name, Func<Task> test)
+    {
+        try
+        {
+            await test();
+            TestOutput.WriteLine($"PASS {name}");
+        }
+        catch (Exception ex)
+        {
+            s_errors.Add($"FAIL {name}: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static void Assert(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new Exception(message);
+        }
+    }
+
+    private static void StringRoundTrip()
+    {
+        foreach (string value in new[] { "", "a", "Příliš žluťoučký kůň", "🔥 emoji \u00e9\u00e8" })
+        {
+            string result = EchoString(value);
+            Assert(result == value, $"echo mismatch for '{value}', got '{result}'");
+        }
+    }
+
+    private static void LargeStringMarshaling()
+    {
+        string value = string.Concat(new string('ě', 500_000), new string('a', 500_000));
+        string result = EchoString(value);
+        Assert(result.Length == value.Length, $"expected {value.Length} chars, got {result.Length}");
+        Assert(result == value, "large string content mismatch");
+    }
+
+    private static void BytesFromJs()
+    {
+        const int length = 64 * 1024;
+        byte[] bytes = CreateBytes(length);
+        Assert(bytes.Length == length, $"expected {length} bytes, got {bytes.Length}");
+        for (int i = 0; i < length; i++)
+        {
+            Assert(bytes[i] == unchecked((byte)i), $"byte[{i}] expected {unchecked((byte)i)}, got {bytes[i]}");
+        }
+    }
+
+    private static void BytesToJs()
+    {
+        byte[] bytes = new byte[64 * 1024];
+        int expected = 0;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] = unchecked((byte)(i * 7));
+            expected += bytes[i];
+        }
+
+        int actual = SumBytes(bytes);
+        Assert(actual == expected, $"expected sum {expected}, got {actual}");
+    }
+
+    private static void Int32ArrayRoundTrip()
+    {
+        int[] values = new int[10_000];
+        for (int i = 0; i < values.Length; i++)
+        {
+            values[i] = i * 3 - 5;
+        }
+
+        int[] result = EchoInt32Array(values);
+        Assert(result.Length == values.Length, $"expected {values.Length} items, got {result.Length}");
+        for (int i = 0; i < values.Length; i++)
+        {
+            Assert(result[i] == values[i], $"int[{i}] expected {values[i]}, got {result[i]}");
+        }
+    }
+
+    private static void DoubleArrayRoundTrip()
+    {
+        double[] values = new double[10_000];
+        for (int i = 0; i < values.Length; i++)
+        {
+            values[i] = i / 3.0;
+        }
+
+        double[] result = EchoDoubleArray(values);
+        Assert(result.Length == values.Length, $"expected {values.Length} items, got {result.Length}");
+        for (int i = 0; i < values.Length; i++)
+        {
+            Assert(result[i] == values[i], $"double[{i}] expected {values[i]}, got {result[i]}");
+        }
+    }
+
+    private static void SpanMemoryView()
+    {
+        byte[] bytes = new byte[32 * 1024];
+        int expected = 0;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] = unchecked((byte)(i * 11));
+            expected += bytes[i];
+        }
+
+        int actual = SumSpan(bytes.AsSpan());
+        Assert(actual == expected, $"expected sum {expected}, got {actual}");
+    }
+
+    private static void ArraySegmentMemoryView()
+    {
+        byte[] bytes = new byte[32 * 1024];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] = unchecked((byte)(i * 13));
+        }
+
+        var segment = new ArraySegment<byte>(bytes, 1024, 4096);
+        int expected = 0;
+        for (int i = 0; i < segment.Count; i++)
+        {
+            expected += segment[i];
+        }
+
+        int actual = SumSegment(segment);
+        Assert(actual == expected, $"expected sum {expected}, got {actual}");
+    }
+
+    private static void JSObjectProperties()
+    {
+        using JSObject obj = CreateObject("answer", 42);
+        Assert(obj.GetPropertyAsString("name") == "answer", "name property mismatch");
+        Assert(obj.GetPropertyAsInt32("value") == 42, "value property mismatch");
+        obj.SetProperty("value", 43);
+        Assert(obj.GetPropertyAsInt32("value") == 43, "value property was not updated");
+    }
+
+    private static void ExceptionPropagation()
+    {
+        try
+        {
+            ThrowError("boom");
+        }
+        catch (JSException ex)
+        {
+            Assert(ex.Message.Contains("boom"), $"unexpected message: {ex.Message}");
+            return;
+        }
+
+        throw new Exception("expected a JSException");
+    }
+
+    private static void CryptoRandomBytes()
+    {
+        // the buffer is filled by JavaScript, writing to a wrong offset leaves it silently zeroed
+        byte[] buffer = new byte[4096];
+        RandomNumberGenerator.Fill(buffer);
+
+        int zeros = 0;
+        foreach (byte b in buffer)
+        {
+            if (b == 0)
+            {
+                zeros++;
+            }
+        }
+
+        Assert(zeros < buffer.Length / 4, $"buffer looks unfilled, {zeros} zero bytes out of {buffer.Length}");
+    }
+
+    private static void Globalization()
+    {
+        var culture = new CultureInfo("cs-CZ");
+        Assert(string.Compare("a", "b", culture, CompareOptions.None) < 0, "unexpected compare result");
+        Assert(new DateTime(2026, 1, 2).ToString("MMMM", culture).Length > 0, "empty month name");
+        Assert(Encoding.UTF8.GetString(Encoding.UTF8.GetBytes("žluťoučký")) == "žluťoučký", "UTF8 round trip failed");
+    }
+
+    private static void ManagedExports()
+    {
+        string errors = CallManagedExports();
+        Assert(string.IsNullOrEmpty(errors), errors);
+    }
+
+    private static async Task TaskRoundTrip()
+    {
+        int result = await DelayedSum(20, 22);
+        Assert(result == 42, $"expected 42, got {result}");
     }
 
     private static Random random = new Random();
@@ -69,6 +383,7 @@ public partial class MemoryTest
         {
             stringBuilder.Append(chars[random.Next(chars.Length)]);
         }
+
         return stringBuilder.ToString();
     }
 }

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -20,6 +20,44 @@ function countChars(str) {
     return length;
 }
 
+const memoryTestImports = {
+    countChars,
+    echoString: (value) => value,
+    createBytes: (length) => {
+        const result = new Uint8Array(length);
+        for (let i = 0; i < length; i++) {
+            result[i] = i & 0xFF;
+        }
+        return result;
+    },
+    sumBytes: (value) => {
+        let sum = 0;
+        for (let i = 0; i < value.length; i++) {
+            sum += value[i];
+        }
+        return sum;
+    },
+    sumMemoryView: (view) => {
+        const copy = view.slice();
+        let sum = 0;
+        for (let i = 0; i < copy.length; i++) {
+            sum += copy[i];
+        }
+        return sum;
+    },
+    echoInt32Array: (value) => value,
+    echoDoubleArray: (value) => value,
+    createObject: (name, value) => ({ name, value }),
+    throwError: (message) => { throw new Error(message); },
+    delayedSum: async (a, b) => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        return a + b;
+    },
+    callManagedExports: () => memoryTestCallManagedExports(),
+};
+
+let memoryTestCallManagedExports = () => "managed exports were not initialized";
+
 // Prepare base runtime parameters
 dotnet.withConfig({ appendElementOnExit: true, exitOnUnhandledError: true, logExitCode: true });
 
@@ -348,10 +386,38 @@ try {
             exit(0);
             break;
         case "AllocateLargeHeapThenInterop":
-            setModuleImports('main.js', {
-                countChars
-            });
-            exports.MemoryTest.Run();
+            setModuleImports('main.js', memoryTestImports);
+            memoryTestCallManagedExports = () => {
+                const errors = [];
+                const check = (condition, message) => {
+                    if (!condition) {
+                        errors.push(message);
+                    }
+                };
+
+                const bytes = new Uint8Array(64 * 1024);
+                let expected = 0;
+                for (let i = 0; i < bytes.length; i++) {
+                    bytes[i] = (i * 5) & 0xFF;
+                    expected += bytes[i];
+                }
+                check(exports.MemoryTest.SumBytesManaged(bytes) === expected, "SumBytesManaged returned a wrong sum");
+
+                const made = exports.MemoryTest.CreateBytesManaged(64 * 1024);
+                check(made.length === 64 * 1024, `CreateBytesManaged returned ${made.length} bytes`);
+                for (let i = 0; i < made.length; i++) {
+                    if (made[i] !== ((i * 3) & 0xFF)) {
+                        check(false, `CreateBytesManaged[${i}] is ${made[i]}`);
+                        break;
+                    }
+                }
+
+                const text = 'ě'.repeat(200000) + 'abc';
+                check(exports.MemoryTest.EchoStringManaged(text) === text, "EchoStringManaged returned a different string");
+
+                return errors.join('; ');
+            };
+            await exports.MemoryTest.RunAsync();
             exit(0);
             break;
         case "DevServer_UploadPattern":


### PR DESCRIPTION
Rewrites the `AllocateLargeHeapThenInterop` scenario into an actual conformance test for interop above the 2GB boundary.

## Why

The wasm/JS boundary does not preserve signedness. A wasm `i32` arrives in JavaScript as a signed number, so every pointer above 2GB shows up negative. The failure modes are mostly *silent* — a negative `subarray` start is clamped relative to the end of the heap, a negative `HEAPU8` index yields `undefined` — so a scenario that only checks "a string `JSImport` still returns the right length" cannot detect them.

## What

The scenario now asserts data integrity across the interop surface while every runtime allocation lives above 2GB:

- strings (short, non-ASCII, and a 1M char one), `byte[]` / `int[]` / `double[]` in both directions
- `Span<byte>` and `ArraySegment<byte>` memory views
- `JSObject` properties, exception propagation, `Task<int>`
- the `JSExport` direction (JS calling into managed with `byte[]`/`string` payloads)
- `RandomNumberGenerator.Fill` and globalization

It also reports the address of a pinned buffer and fails if allocations did not actually land above 2GB, so the test cannot silently stop testing what it is named after. The `MemoryTests` WBT additionally asserts that the run produced no jiterpreter `code generation failed` messages, which is how invalid pointer encoding surfaces in the trace compiler.

## Validation

Ran the same test app against the shipped runtime packs with `EmccMaximumHeapSize=4294901760` and 2.2GB / 3.6GB of heap wasted before startup:

| runtime pack | result |
| --- | --- |
| 11.0.0-preview.6 @ 2.2GB and 3.6GB | all checks pass, no jiterpreter errors |
| 10.0.9 @ 2.2GB | `RandomNumberGenerator.Fill` silently returns an all-zero buffer; jiterpreter logs `code generation failed: CompileError … extra bits in varint` |

So the new assertions catch the pre-#121221 behaviour rather than just passing everywhere.

> [!NOTE]
> This pull request was authored with GitHub Copilot.