### PR TITLE
JIT: cache the wasm image base in a local

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -613,6 +613,9 @@ protected:
     void genReserveEpilog(BasicBlock* block);
     void genFnProlog();
     void genBeginFnProlog();
+#ifdef TARGET_WASM
+    void genInitImageBaseLocal(FuncInfoDsc* func);
+#endif
     void genFnEpilog(BasicBlock* block);
 
     void genReserveFuncletProlog(BasicBlock* block);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -116,6 +116,28 @@ void CodeGen::genBeginFnProlog()
         GetEmitter()->emitIns_I_Ty(INS_local_decl, decl.Count, decl.Type, localsCount);
         localsCount += decl.Count;
     }
+
+    genInitImageBaseLocal(func);
+}
+
+//------------------------------------------------------------------------
+// genInitImageBaseLocal: initialize the wasm local caching the image base, if this
+//   function has one.
+//
+// Arguments:
+//   func - the function or funclet whose prolog is being generated
+//
+// Notes:
+//   Emitted in the prolog, which dominates every use. The imageBase global is immutable,
+//   so the cached value never needs refreshing.
+//
+void CodeGen::genInitImageBaseLocal(FuncInfoDsc* func)
+{
+    if (func->funWasmImageBaseLocalIndex != UINT_MAX)
+    {
+        GetEmitter()->emitImageBaseGlobal();
+        GetEmitter()->emitIns_I(INS_local_set, EA_PTRSIZE, func->funWasmImageBaseLocalIndex);
+    }
 }
 
 //------------------------------------------------------------------------
@@ -442,6 +464,8 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
         GetEmitter()->emitIns_I_Ty(INS_local_decl, decl.Count, decl.Type, localsCount);
         localsCount += decl.Count;
     }
+
+    genInitImageBaseLocal(func);
 
     // All the funclet params are used from their home registers, so nothing
     // needs homing here.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1776,6 +1776,7 @@ struct FuncInfoDsc
     jitstd::vector<WasmLocalsDecl>* funWasmLocalDecls;
     unsigned funWasmFrameSize;
     unsigned funWasmExnRefLocalIndex = UINT_MAX;
+    unsigned funWasmImageBaseLocalIndex = UINT_MAX;
     bool needsUnwindableFrame;
     emitLocation* startLoc;
     emitLocation* endLoc;

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -183,12 +183,33 @@ bool emitter::emitInsIsStore(instruction ins)
 }
 
 //------------------------------------------------------------------------
-// emitImageBase: Emit the module base (imageBase global) onto the stack.
+// emitImageBaseGlobal: Emit the module base onto the stack, reading the imageBase global.
 //
-void emitter::emitImageBase()
+void emitter::emitImageBaseGlobal()
 {
     emitIns_I(INS_global_get, EA_HANDLE_CNS_RELOC,
               (cnsval_ssize_t)(size_t)m_compiler->eeGetWasmWellKnownGlobals()->imageBase);
+}
+
+//------------------------------------------------------------------------
+// emitImageBase: Emit the module base (imageBase global) onto the stack.
+//
+// Notes:
+//   When this function caches the image base in a wasm local, read it from there instead. The
+//   local is initialized in the prolog, which dominates every use.
+//
+void emitter::emitImageBase()
+{
+    FuncInfoDsc* const func = m_compiler->funCurrentFunc();
+
+    if (func->funWasmImageBaseLocalIndex != UINT_MAX)
+    {
+        emitIns_I(INS_local_get, EA_PTRSIZE, func->funWasmImageBaseLocalIndex);
+    }
+    else
+    {
+        emitImageBaseGlobal();
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/emitwasm.h
+++ b/src/coreclr/jit/emitwasm.h
@@ -38,6 +38,7 @@ void emitIns_Lane(instruction ins, uint8_t laneIdx);
 void emitIns_MemargLane(instruction ins, emitAttr attr, cnsval_ssize_t offset, uint8_t laneIdx);
 
 void emitImageBase();
+void emitImageBaseGlobal();
 void emitAddressConstant(void* address);
 void emitFuncletAddressConstant(cnsval_ssize_t funcletId);
 void emitIns_MemargAddress(instruction ins, emitAttr attr, void* address);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3159,8 +3159,9 @@ PhaseStatus Compiler::fgCreateFunclets()
         funcInfo[i].funFramePointerReg = REG_NA;
 #endif
 #ifdef TARGET_WASM
-        funcInfo[i].funWasmLocalDecls       = nullptr;
-        funcInfo[i].funWasmExnRefLocalIndex = UINT_MAX;
+        funcInfo[i].funWasmLocalDecls          = nullptr;
+        funcInfo[i].funWasmExnRefLocalIndex    = UINT_MAX;
+        funcInfo[i].funWasmImageBaseLocalIndex = UINT_MAX;
 #endif
     }
 #endif

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -431,6 +431,14 @@ void WasmRegAlloc::CollectReferencesForBlock(BasicBlock* block)
 //
 void WasmRegAlloc::CollectReferencesForNode(GenTree* node)
 {
+    // Track how many times this funclet will materialize the image base, so we can
+    // decide below whether to cache it in a wasm local.
+    //
+    if (node->IsCnsIntOrI() && node->IsIconHandle() && node->AsIntConCommon()->ImmedValNeedsReloc(m_compiler))
+    {
+        m_perFuncletData[m_currentFunclet]->m_imageBaseUses++;
+    }
+
     switch (node->OperGet())
     {
         case GT_NULLCHECK:
@@ -1089,12 +1097,35 @@ void WasmRegAlloc::ResolveReferences()
                 unreached();
         }
 
+        // Decide up front whether to cache the image base in a wasm local, so the local can be
+        // declared as part of an existing group rather than one of its own.
+        //
+        // Each use costs 6 bytes as a `global.get` (the global index is a padded relocation) and
+        // 2 bytes as a `local.get`, against 8 bytes to initialize the local in the prolog. So
+        // three uses is the first count that wins.
+        //
+        PhysicalRegBank& imageBaseBank  = virtToPhysRegMap[static_cast<unsigned>(TypeToWasmValueType(TYP_I_IMPL))];
+        const bool       cacheImageBase = data->m_imageBaseUses >= 3;
+
+        if (cacheImageBase)
+        {
+            imageBaseBank.DeclaredCount++;
+        }
+
         for (WasmValueType type = WasmValueType::First; type < WasmValueType::Count; ++type)
         {
             PhysicalRegBank& physRegs = virtToPhysRegMap[static_cast<unsigned>(type)];
             physRegs.IndexBase        = indexBase;
             physRegs.Index            = indexBase;
             indexBase += physRegs.DeclaredCount;
+        }
+
+        // Reserve the last slot of the bank for the image base. The allocator below only ever
+        // hands out the slots the virtual registers need, so it never reaches this one.
+        //
+        if (cacheImageBase)
+        {
+            funcInfo->funWasmImageBaseLocalIndex = imageBaseBank.IndexBase + imageBaseBank.DeclaredCount - 1;
         }
 
         // Allocate all our virtual registers to physical ones.

--- a/src/coreclr/jit/regallocwasm.h
+++ b/src/coreclr/jit/regallocwasm.h
@@ -92,6 +92,7 @@ class WasmRegAlloc : public RegAllocInterface
             , m_fpReg(REG_NA)
             , m_lastVirtualRegRefsCount(0)
             , m_virtualRegRefs(nullptr)
+            , m_imageBaseUses(0)
             , m_physicalRegAssignments(comp->lvaTrackedCount, REG_STK, comp->getAllocator(CMK_LSRA))
         {
         }
@@ -110,6 +111,10 @@ class WasmRegAlloc : public RegAllocInterface
         //
         unsigned              m_lastVirtualRegRefsCount;
         VirtualRegReferences* m_virtualRegRefs;
+
+        // Count of nodes in this funclet that will materialize the image base.
+        //
+        unsigned m_imageBaseUses;
 
         // Map from local tracked index to phys reg for that local, in this funclet.
         //


### PR DESCRIPTION
Materializing the image base costs 6 bytes each time, since the global index is a padded relocation. When a wasm function needs it 3 or more times, cache it in a local instead.

SPC R2R code section: 21,820,681 -> 21,010,052 (-810,629 bytes, -3.71%).