### PR TITLE
[wasm] Fix MSB4057 publishing CoreCLR browser-wasm apps

### DIFF
--- a/src/mono/wasm/build/WasmApp.Common.props
+++ b/src/mono/wasm/build/WasmApp.Common.props
@@ -1,7 +1,14 @@
 <Project>
   <PropertyGroup>
     <TargetArchitecture>wasm</TargetArchitecture>
+  </PropertyGroup>
 
+  <!-- These target lists name targets defined in WasmApp.Common.targets, which is only
+       imported for Mono. The CoreCLR flavor imports BrowserWasmApp.CoreCLR.targets instead
+       (see Microsoft.NET.Runtime.WebAssembly.Sdk/Sdk/Sdk.targets.in), and it defines its own
+       equivalents. Seeding the Mono names there would make its WasmNestedPublishApp target
+       depend on the non-existent _WasmBuildAppCore, failing the build with MSB4057. -->
+  <PropertyGroup Condition="'$(UseMonoRuntime)' != 'false'">
     <!-- Top level -->
     <WasmBuildAppDependsOn>
       _WasmBuildAppCore;


### PR DESCRIPTION
Publishing a browser-wasm app with the experimental CoreCLR wasm SDK fails with:

```
error MSB4057: The target "_WasmBuildAppCore" does not exist in the project.
  (BrowserWasmApp.CoreCLR.targets(216))
```

## Why

`Microsoft.NET.Runtime.WebAssembly.Sdk/Sdk/Sdk.targets.in` imports `BrowserWasmApp.props` unconditionally, which pulls in `WasmApp.Common.props`, and only then picks the flavor-specific targets file (`BrowserWasmApp.CoreCLR.targets` when `UseMonoRuntime == 'false'`).

`WasmApp.Common.props` defaulted `WasmNestedPublishAppDependsOn` to `_WasmBuildAppCore`, which is defined in `WasmApp.Common.targets`. The CoreCLR path never imports that file (it defines its own `_CoreCLRWasmBuildAppCore`), so the CoreCLR `WasmNestedPublishApp` target inherited a dependency on a target that does not exist in its import chain.

## Approach

Guard the Mono-only target lists in `WasmApp.Common.props` with `Condition="'$(UseMonoRuntime)' != 'false'"`. The flavor decision happens two lines after that import in `Sdk.targets.in`, so the property is already set when the props are evaluated.

The CoreCLR path now starts from an empty list and relies on its own `_CoreCLRWasmBuildAppCore`, which was already listed explicitly in its `DependsOnTargets`. Contributions that *prepend* to the property still compose correctly, so nothing is lost:

- `_GatherWasmFilesToPublish` (Microsoft.NET.Sdk.WebAssembly.Browser.targets)
- `PrepareForWasmBuildApp` (eng/testing/tests.browser.targets)

## Notes

- The Mono path is unchanged: verified by evaluating the real import chain with msbuild, `UseMonoRuntime=true` still yields `_WasmBuildAppCore` for both `WasmBuildAppDependsOn` and `WasmNestedPublishAppDependsOn`, while `UseMonoRuntime=false` yields empty lists with `TargetArchitecture=wasm` still set.
- In-tree browser CoreCLR builds were already unaffected, since `WasmApp.InTree.props` imports `BrowserWasmApp.props` only for Mono. This only bites consumers of the packaged SDK.
- WASI is not impacted: its CoreCLR path (`WasiApp.CoreCLR.targets`) defines no nested-publish target.

> [!NOTE]
> This change was drafted with GitHub Copilot.