### PR TITLE
[cDAC] Implement GetFieldAlignment via EEClass layout alignment

### DIFF
--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -86,6 +86,10 @@ partial interface IRuntimeTypeSystem : IContract
     public virtual bool TryGetHFAElementSize(ITypeHandle typeHandle, out int elementSize);
     // True if the type requires 8-byte alignment on platforms that don't 8-byte align by default (FEATURE_64BIT_ALIGNMENT)
     public virtual bool RequiresAlign8(ITypeHandle typeHandle);
+    // Returns the alignment requirement of a type. Mirrors
+    // CEEInfo::getClassAlignmentRequirementStatic in src/coreclr/vm/jitinterface.cpp. The result is
+    // unclamped -- callers such as ArgIterator apply their own clamping.
+    public virtual int GetClassAlignmentRequirement(ITypeHandle typeHandle);
     // Returns the cached SystemV AMD64 eightbyte register-passing classification for a value type
     // (used to decide how a struct is passed in registers), or false if the type has no such
     // classification (not applicable, or the runtime was not built with UNIX_AMD64_ABI).
@@ -552,6 +556,10 @@ static class RuntimeTypeSystem_1_Helpers
 | `EEClass` | `NumStaticFields` | `uint16` | Count of static fields of the EEClass |
 | `EEClass` | `NumThreadStaticFields` | `uint16` | Count of threadstatic fields of the EEClass |
 | `EEClass` | `OptionalFields` | `pointer` | Pointer to the `EEClassOptionalFields` for this type, or null if it has none |
+| `EEClass` | `VMFlags` | `uint32` | Flags for the EEClass. Bit `0x40` (`VMFLAG_HASLAYOUT`) indicates the EEClass is a `LayoutEEClass` and its `LayoutInfo` may be read |
+| `EEClassLayoutInfo` | `AlignmentRequirement` | `uint8` | Largest alignment requirement of all members of the type |
+| `EEClassLayoutInfo` | `Flags` | `uint8` | Layout flags. Bit `0x01` (`e_BLITTABLE`) indicates the type is blittable |
+| `EEClassLayoutInfo` | `LayoutType` | `uint8` | Layout kind: `Auto` (0), `Sequential` (1), `Explicit` (2), `CStruct` (3), `CUnion` (4) |
 | `EEClassOptionalFields` | `EightByteRegistersInfo` | `SystemVEightByteRegistersInfo` | Inline `SystemVEightByteRegistersInfo` describing the SystemV AMD64 register-passing classification (only populated on UNIX_AMD64_ABI builds) |
 | `EEImplMethodDesc` | *(type size)* | `uint32` | Base size for mcEEImpl classification |
 | `FCallMethodDesc` | *(type size)* | `uint32` | Base size for mcFCall classification |
@@ -570,6 +578,7 @@ static class RuntimeTypeSystem_1_Helpers
 | `InstantiatedMethodDesc` | `Flags2` | `uint16` | Flags for the InstantiatedMethodDesc |
 | `InstantiatedMethodDesc` | `NumGenericArgs` | `uint16` | How many generic args the method has |
 | `InstantiatedMethodDesc` | `PerInstInfo` | `pointer` | The pointer to the method's type arguments |
+| `LayoutEEClass` | `LayoutInfo` | `EEClassLayoutInfo` | Inline `EEClassLayoutInfo` for a type with layout. Only the offset is used - the reader constructs an `EEClassLayoutInfo` at that offset from the `EEClass` address. Only valid when `EEClass.VMFlags` has `VMFLAG_HASLAYOUT` |
 | `LoaderAllocator` | `CreationNumber` | `uint64` | Monotonically-increasing creation number assigned to each collectible LoaderAllocator. |
 | `LoaderAllocator` | `DynamicHelpersStubHeap` | `pointer` | Dynamic-helper stub heap (optional, present when ReadyToRun dynamic-helper stubs are enabled) |
 | `LoaderAllocator` | `ExecutableHeap` | `pointer` | Executable-code heap |
@@ -843,6 +852,25 @@ static class RuntimeTypeSystem_1_Helpers
     public bool TryGetHFAElementSize(ITypeHandle typeHandle, out int elementSize) { ... }
 
     public bool RequiresAlign8(ITypeHandle typeHandle) => !typeHandle.IsMethodTable() ? false : _methodTables[typeHandle.Address].Flags.RequiresAlign8;
+
+    // Mirrors CEEInfo::getClassAlignmentRequirementStatic in src/coreclr/vm/jitinterface.cpp.
+    //   result = target pointer size
+    //   if the type is a MethodTable and has an EEClass:
+    //     if EEClass.VMFlags has VMFLAG_HASLAYOUT:
+    //       // LayoutEEClass derives from EEClass, so its layout info lives at a fixed offset from
+    //       // the same address. Reading it without the HasLayout check interprets unrelated memory.
+    //       layoutInfo = EEClassLayoutInfo at (eeClass + offsetof(LayoutEEClass, LayoutInfo))
+    //       if layoutInfo.LayoutType == Sequential or layoutInfo.Flags has e_BLITTABLE:
+    //         result = layoutInfo.AlignmentRequirement
+    //   // FEATURE_64BIT_ALIGNMENT (ARM, WASM). RequiresAlign8 is only set on targets with that
+    //   // requirement, so this is a no-op elsewhere.
+    //   if result < 8 and RequiresAlign8(typeHandle): result = 8
+    //   return result
+    //
+    // Note: the native implementation also handles the native (marshalled) value type view via
+    // TypeHandle::IsNativeValueType. That is a marshalling-only concept that is not reachable from
+    // the managed argument layout this contract serves, so it is not mirrored here.
+    public int GetClassAlignmentRequirement(ITypeHandle typeHandle) { ... }
 
     public bool IsCanonicalMethodTable(ITypeHandle typeHandle)
         => typeHandle.IsMethodTable() && _methodTables[typeHandle.Address].IsCanonMT;

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -537,6 +537,15 @@ class EEClassLayoutInfo
         };
 
         static NestedFieldFlags GetNestedFieldFlags(Module* pModule, FieldDesc *pFD, ULONG cFields, CorNativeLinkType nlType, MethodTable** pByValueClassCache);
+
+        friend struct ::cdac_data<EEClassLayoutInfo>;
+};
+
+template<> struct cdac_data<EEClassLayoutInfo>
+{
+    static constexpr size_t LayoutType = offsetof(EEClassLayoutInfo, m_LayoutType);
+    static constexpr size_t AlignmentRequirement = offsetof(EEClassLayoutInfo, m_ManagedLargestAlignmentRequirementOfAllMembers);
+    static constexpr size_t Flags = offsetof(EEClassLayoutInfo, m_bFlags);
 };
 
 //
@@ -1787,6 +1796,7 @@ template<> struct cdac_data<EEClass>
     static constexpr size_t NumNonVirtualSlots = offsetof(EEClass, m_NumNonVirtualSlots);
     static constexpr size_t BaseSizePadding = offsetof(EEClass, m_cbBaseSizePadding);
     static constexpr size_t OptionalFields = offsetof(EEClass, m_rpOptionalFields);
+    static constexpr size_t VMFlags = offsetof(EEClass, m_VMFlags);
 };
 
 template<> struct cdac_data<EEClassOptionalFields>
@@ -1866,6 +1876,11 @@ public:
         m_nativeLayoutInfo = NULL;
     }
 #endif // !DACCESS_COMPILE
+};
+
+template<> struct cdac_data<LayoutEEClass>
+{
+    static constexpr size_t LayoutInfo = offsetof(LayoutEEClass, m_LayoutInfo);
 };
 
 class UMThunkMarshInfo;

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -582,7 +582,25 @@ CDAC_TYPE_FIELD(EEClass, T_UINT16, NumThreadStaticFields, cdac_data<EEClass>::Nu
 CDAC_TYPE_FIELD(EEClass, T_UINT16, NumNonVirtualSlots, cdac_data<EEClass>::NumNonVirtualSlots)
 CDAC_TYPE_FIELD(EEClass, T_UINT8, BaseSizePadding, cdac_data<EEClass>::BaseSizePadding)
 CDAC_TYPE_FIELD(EEClass, T_POINTER, OptionalFields, cdac_data<EEClass>::OptionalFields)
+CDAC_TYPE_FIELD(EEClass, T_UINT32, VMFlags, cdac_data<EEClass>::VMFlags)
 CDAC_TYPE_END(EEClass)
+
+// LayoutEEClass derives from EEClass and carries the managed layout info for types with
+// explicit/sequential layout (EEClass::HasLayout()). Only the offset of LayoutInfo is needed --
+// the reader constructs an EEClassLayoutInfo at that offset from the EEClass address. Reading it
+// on an EEClass that does not have layout interprets unrelated memory, so consumers must check
+// the HasLayout VMFlag first.
+CDAC_TYPE_BEGIN(LayoutEEClass)
+CDAC_TYPE_INDETERMINATE(LayoutEEClass)
+CDAC_TYPE_FIELD(LayoutEEClass, TYPE(EEClassLayoutInfo), LayoutInfo, cdac_data<LayoutEEClass>::LayoutInfo)
+CDAC_TYPE_END(LayoutEEClass)
+
+CDAC_TYPE_BEGIN(EEClassLayoutInfo)
+CDAC_TYPE_INDETERMINATE(EEClassLayoutInfo)
+CDAC_TYPE_FIELD(EEClassLayoutInfo, T_UINT8, LayoutType, cdac_data<EEClassLayoutInfo>::LayoutType)
+CDAC_TYPE_FIELD(EEClassLayoutInfo, T_UINT8, AlignmentRequirement, cdac_data<EEClassLayoutInfo>::AlignmentRequirement)
+CDAC_TYPE_FIELD(EEClassLayoutInfo, T_UINT8, Flags, cdac_data<EEClassLayoutInfo>::Flags)
+CDAC_TYPE_END(EEClassLayoutInfo)
 
 CDAC_TYPE_BEGIN(EEClassOptionalFields)
 CDAC_TYPE_INDETERMINATE(EEClassOptionalFields)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -190,6 +190,13 @@ public interface IRuntimeTypeSystem : IContract
     bool TryGetHFAElementSize(ITypeHandle typeHandle, out int elementSize) => throw new NotImplementedException();
     // True if the type requires 8-byte alignment on platforms that don't 8-byte align by default (FEATURE_64BIT_ALIGNMENT)
     bool RequiresAlign8(ITypeHandle typeHandle) => throw new NotImplementedException();
+    // Returns the alignment requirement of a type, mirroring
+    // CEEInfo::getClassAlignmentRequirementStatic in src/coreclr/vm/jitinterface.cpp. Defaults to
+    // the target pointer size; types with sequential or blittable layout report their managed
+    // layout alignment, and targets requiring 64-bit alignment (FEATURE_64BIT_ALIGNMENT: ARM,
+    // WASM) report at least 8 for types that need it. The result is unclamped -- callers such as
+    // ArgIterator apply their own clamping.
+    int GetClassAlignmentRequirement(ITypeHandle typeHandle) => throw new NotImplementedException();
     // Returns the cached SystemV AMD64 eightbyte register-passing classification for a value type
     // (used to decide how a struct is passed in registers), or false if the type has no such
     // classification (not applicable, or the runtime was not built with UNIX_AMD64_ABI). Mirrors

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CallingConvention/CdacTypeHandle.cs
@@ -229,11 +229,12 @@ internal readonly struct CdacTypeHandle : Internal.CallingConvention.ITypeHandle
         }
     }
 
-    // Only used by ArgIterator on WASM32 for stack alignment of value types.
+    // Only used by ArgIterator on WASM32 for stack alignment of value types. Mirrors the runtime's
+    // CEEInfo::getClassAlignmentRequirementStatic, which the native wasm ArgIterator reads for the
+    // same purpose (src/coreclr/vm/callingconvention.h). Returns the unclamped alignment; the
+    // shared ArgIterator applies its own clamp.
     public int GetFieldAlignment()
-    {
-        throw new NotImplementedException("Field alignment is not yet implemented.");
-    }
+        => _typeHandle is null ? _target.PointerSize : Rts.GetClassAlignmentRequirement(_typeHandle);
 
     /// <summary>
     /// Maps cDAC CorElementType (short names like I4) to the shared CorElementType

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -817,9 +817,16 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
     // Mirrors CEEInfo::getClassAlignmentRequirementStatic in src/coreclr/vm/jitinterface.cpp.
     // The result is unclamped; callers (e.g. ArgIterator) apply their own clamping.
-    // Note: the native implementation also handles the native (marshalled) value type view via
-    // TypeHandle::IsNativeValueType. That is a marshalling-only concept and is not reachable from
-    // the managed argument layout this contract serves, so it is intentionally not mirrored here.
+    //
+    // Two deliberate differences from the native helper, both unreachable from the managed
+    // argument layout this contract serves:
+    //  - The native helper starts from TypeHandle::GetMethodTable, which also resolves a
+    //    MethodTable for a TypeDesc. Here a non-MethodTable handle simply reports the default,
+    //    since the ArgIterator only consults alignment for ELEMENT_TYPE_VALUETYPE arguments.
+    //  - The native helper handles the unmanaged (marshalled) view of a type via
+    //    TypeHandle::IsNativeValueType, which is a TypeDesc produced for native signatures
+    //    (ELEMENT_TYPE_NATIVE_VALUETYPE_ZAPSIG) rather than by decoding an ECMA metadata
+    //    signature, so it cannot appear here.
     private const string LayoutInfoFieldName = "LayoutInfo";
 
     public int GetClassAlignmentRequirement(ITypeHandle typeHandle)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -814,6 +814,54 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             || t == CorElementType.I
             || t == CorElementType.U;
     public bool RequiresAlign8(ITypeHandle typeHandle) => !typeHandle.IsMethodTable() ? false : _methodTables[typeHandle.Address].Flags.RequiresAlign8;
+
+    // Mirrors CEEInfo::getClassAlignmentRequirementStatic in src/coreclr/vm/jitinterface.cpp.
+    // The result is unclamped; callers (e.g. ArgIterator) apply their own clamping.
+    // Note: the native implementation also handles the native (marshalled) value type view via
+    // TypeHandle::IsNativeValueType. That is a marshalling-only concept and is not reachable from
+    // the managed argument layout this contract serves, so it is intentionally not mirrored here.
+    private const string LayoutInfoFieldName = "LayoutInfo";
+
+    public int GetClassAlignmentRequirement(ITypeHandle typeHandle)
+    {
+        // Default alignment is sizeof(void*).
+        int result = _target.PointerSize;
+        if (!typeHandle.IsMethodTable())
+            return result;
+
+        TargetPointer eeClassPtr = GetClassPointer(typeHandle);
+        if (eeClassPtr != TargetPointer.Null)
+        {
+            Data.EEClass eeClass = _target.ProcessedData.GetOrAdd<Data.EEClass>(eeClassPtr);
+
+            // Only a LayoutEEClass carries layout info; reading it otherwise interprets unrelated
+            // memory. The managed alignment requirement is only used for sequential or blittable
+            // layout, matching the native implementation.
+            if (eeClass.HasLayout)
+            {
+                // LayoutEEClass derives from EEClass, so its layout info lives at a fixed offset
+                // from the same address.
+                Target.TypeInfo layoutClassType = _target.GetTypeInfo(DataType.LayoutEEClass);
+                TargetPointer layoutInfoPtr = eeClassPtr + (ulong)layoutClassType.Fields[LayoutInfoFieldName].Offset;
+                Data.EEClassLayoutInfo layoutInfo = _target.ProcessedData.GetOrAdd<Data.EEClassLayoutInfo>(layoutInfoPtr);
+                if (layoutInfo.LayoutType == (byte)Data.EEClassLayoutInfo.Type.Sequential || layoutInfo.IsBlittable)
+                {
+                    result = layoutInfo.AlignmentRequirement;
+                }
+            }
+        }
+
+        // FEATURE_64BIT_ALIGNMENT: some 32-bit ABIs (ARM, WASM) require 8-byte alignment for
+        // 64-bit primitives. RequiresAlign8 is only set on targets with that requirement, so this
+        // is a no-op elsewhere.
+        if (result < 8 && RequiresAlign8(typeHandle))
+        {
+            result = 8;
+        }
+
+        return result;
+    }
+
     public bool IsContinuationWithoutMetadata(ITypeHandle typeHandle) => typeHandle.IsMethodTable()
         && ContinuationMethodTablePointer != TargetPointer.Null
         && _methodTables[typeHandle.Address].ParentMethodTable == ContinuationMethodTablePointer

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EEClass.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EEClass.cs
@@ -26,4 +26,15 @@ internal sealed partial class EEClass : IData<EEClass>
     [Field] public partial ushort NumNonVirtualSlots { get; }
     [Field] public partial byte BaseSizePadding { get; }
     [Field] public partial TargetPointer OptionalFields { get; }
+
+    // EEClass::VMFLAG_HASLAYOUT -- the EEClass is a LayoutEEClass carrying managed layout info.
+    private const uint HasLayoutFlag = 0x00000040;
+
+    [Field] public partial uint VMFlags { get; }
+
+    /// <summary>
+    /// Mirrors <c>EEClass::HasLayout</c>. When true the class is a <see cref="LayoutEEClass"/> and
+    /// its <see cref="LayoutEEClass.LayoutInfo"/> may be read.
+    /// </summary>
+    public bool HasLayout => (VMFlags & HasLayoutFlag) != 0;
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EEClassLayoutInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EEClassLayoutInfo.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+[CdacType(nameof(DataType.EEClassLayoutInfo))]
+internal sealed partial class EEClassLayoutInfo : IData<EEClassLayoutInfo>
+{
+    // Mirrors EEClassLayoutInfo::LayoutType in src/coreclr/vm/class.h.
+    public enum Type : byte
+    {
+        Auto = 0,
+        Sequential = 1,
+        Explicit = 2,
+        CStruct = 3,
+        CUnion = 4,
+    }
+
+    // EEClassLayoutInfo::e_BLITTABLE
+    private const byte BlittableFlag = 0x01;
+
+    [Field] public partial byte LayoutType { get; }
+
+    // EEClassLayoutInfo::GetAlignmentRequirement -- the largest alignment requirement of all
+    // members (m_ManagedLargestAlignmentRequirementOfAllMembers).
+    [Field] public partial byte AlignmentRequirement { get; }
+
+    [Field] public partial byte Flags { get; }
+
+    public bool IsBlittable => (Flags & BlittableFlag) != 0;
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
@@ -63,6 +63,8 @@ public enum DataType
     DynamicStaticsInfo,
     EEClass,
     EEClassOptionalFields,
+    LayoutEEClass,
+    EEClassLayoutInfo,
     SystemVEightByteRegistersInfo,
     CoreLibBinder,
     MethodTableAuxiliaryData,

--- a/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
@@ -1555,4 +1555,38 @@ public class MethodTableTests
 
         Assert.Equal(target.PointerSize, contract.GetClassAlignmentRequirement(handle));
     }
+
+    // FEATURE_64BIT_ALIGNMENT (ARM, WASM): a type whose alignment would otherwise be below 8 is
+    // bumped to 8 when the MethodTable carries the RequiresAlign8 flag. The flag is only ever set
+    // on targets with that requirement, so this branch is inert elsewhere.
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetClassAlignmentRequirement_RequiresAlign8_BumpsToEight(MockTarget.Architecture arch)
+    {
+        const uint RequiresAlign8Flag = 0x00800000; // MethodTableFlags_1.WFLAGS_HIGH.RequiresAlign8
+
+        TargetPointer methodTablePtr = default;
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            rtsBuilder =>
+            {
+                // Sequential layout reporting 4-byte alignment: below 8, so the flag applies.
+                MockEEClass eeClass = rtsBuilder.AddLayoutEEClass(
+                    "Align8", (byte)Data.EEClassLayoutInfo.Type.Sequential, alignmentRequirement: 4, flags: 0);
+                MockMethodTable methodTable = rtsBuilder.AddMethodTable("Align8");
+                methodTable.BaseSize = rtsBuilder.Builder.TargetTestHelpers.ObjectBaseSize;
+                methodTable.NumVirtuals = 3;
+                methodTable.MTFlags = RequiresAlign8Flag;
+                methodTable.ParentMethodTable = rtsBuilder.SystemObjectMethodTable.Address;
+                methodTable.EEClassOrCanonMT = eeClass.Address;
+                eeClass.MethodTable = methodTable.Address;
+                methodTablePtr = methodTable.Address;
+            });
+
+        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
+        ITypeHandle handle = contract.GetTypeHandle(methodTablePtr);
+
+        Assert.True(contract.RequiresAlign8(handle));
+        Assert.Equal(8, contract.GetClassAlignmentRequirement(handle));
+    }
 }

--- a/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MethodTableTests.cs
@@ -26,6 +26,8 @@ public class MethodTableTests
         {
             [DataType.MethodTable] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.MethodTableLayout),
             [DataType.EEClass] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.EEClassLayout),
+            [DataType.LayoutEEClass] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.LayoutEEClassLayout),
+            [DataType.EEClassLayoutInfo] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.EEClassLayoutInfoLayout),
             [DataType.MethodTableAuxiliaryData] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.MethodTableAuxiliaryDataLayout),
             [DataType.TypeDesc] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.TypeDescLayout),
             [DataType.FnPtrTypeDesc] = TargetTestHelpers.CreateTypeInfo(rtsBuilder.FnPtrTypeDescLayout),
@@ -1462,5 +1464,95 @@ public class MethodTableTests
         var blobBuilder = new BlobBuilder();
         rootBuilder.Serialize(blobBuilder, 0, 0);
         return blobBuilder.ToArray();
+    }
+
+    // GetClassAlignmentRequirement mirrors CEEInfo::getClassAlignmentRequirementStatic. A type
+    // without layout info reports the target pointer size, regardless of any bytes that happen to
+    // follow the EEClass.
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetClassAlignmentRequirement_NoLayout_ReturnsPointerSize(MockTarget.Architecture arch)
+    {
+        TargetPointer methodTablePtr = default;
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            rtsBuilder =>
+            {
+                MockEEClass eeClass = rtsBuilder.AddEEClass("NoLayout");
+                MockMethodTable methodTable = rtsBuilder.AddMethodTable("NoLayout");
+                methodTable.BaseSize = rtsBuilder.Builder.TargetTestHelpers.ObjectBaseSize;
+                methodTable.NumVirtuals = 3;
+                methodTable.ParentMethodTable = rtsBuilder.SystemObjectMethodTable.Address;
+                methodTable.EEClassOrCanonMT = eeClass.Address;
+                eeClass.MethodTable = methodTable.Address;
+                methodTablePtr = methodTable.Address;
+            });
+
+        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
+        ITypeHandle handle = contract.GetTypeHandle(methodTablePtr);
+
+        Assert.Equal(target.PointerSize, contract.GetClassAlignmentRequirement(handle));
+    }
+
+    // Sequential and blittable layouts report the managed layout alignment. 16 is the value the
+    // runtime assigns to v128 SIMD types and Int128/UInt128 on WASM.
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetClassAlignmentRequirement_SequentialOrBlittableLayout_ReturnsLayoutAlignment(MockTarget.Architecture arch)
+    {
+        const byte Sequential = (byte)Data.EEClassLayoutInfo.Type.Auto + 1; // LayoutType.Sequential
+        const byte Blittable = 0x01;
+        const byte Alignment = 16;
+
+        foreach ((byte layoutType, byte flags) in new[] { (Sequential, (byte)0), ((byte)0, Blittable) })
+        {
+            TargetPointer methodTablePtr = default;
+            TestPlaceholderTarget target = CreateTarget(
+                arch,
+                rtsBuilder =>
+                {
+                    MockEEClass eeClass = rtsBuilder.AddLayoutEEClass("Layout", layoutType, Alignment, flags);
+                    MockMethodTable methodTable = rtsBuilder.AddMethodTable("Layout");
+                    methodTable.BaseSize = rtsBuilder.Builder.TargetTestHelpers.ObjectBaseSize;
+                    methodTable.NumVirtuals = 3;
+                    methodTable.ParentMethodTable = rtsBuilder.SystemObjectMethodTable.Address;
+                    methodTable.EEClassOrCanonMT = eeClass.Address;
+                    eeClass.MethodTable = methodTable.Address;
+                    methodTablePtr = methodTable.Address;
+                });
+
+            IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
+            ITypeHandle handle = contract.GetTypeHandle(methodTablePtr);
+
+            Assert.Equal(Alignment, contract.GetClassAlignmentRequirement(handle));
+        }
+    }
+
+    // Auto layout that is not blittable does not report the layout alignment, even though the
+    // layout info is present -- it falls back to the pointer size.
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetClassAlignmentRequirement_AutoNonBlittableLayout_ReturnsPointerSize(MockTarget.Architecture arch)
+    {
+        TargetPointer methodTablePtr = default;
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            rtsBuilder =>
+            {
+                MockEEClass eeClass = rtsBuilder.AddLayoutEEClass(
+                    "AutoLayout", (byte)Data.EEClassLayoutInfo.Type.Auto, alignmentRequirement: 16, flags: 0);
+                MockMethodTable methodTable = rtsBuilder.AddMethodTable("AutoLayout");
+                methodTable.BaseSize = rtsBuilder.Builder.TargetTestHelpers.ObjectBaseSize;
+                methodTable.NumVirtuals = 3;
+                methodTable.ParentMethodTable = rtsBuilder.SystemObjectMethodTable.Address;
+                methodTable.EEClassOrCanonMT = eeClass.Address;
+                eeClass.MethodTable = methodTable.Address;
+                methodTablePtr = methodTable.Address;
+            });
+
+        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
+        ITypeHandle handle = contract.GetTypeHandle(methodTablePtr);
+
+        Assert.Equal(target.PointerSize, contract.GetClassAlignmentRequirement(handle));
     }
 }

--- a/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
@@ -95,6 +95,38 @@ internal sealed class MockMethodTable : TypedView
     }
 }
 
+internal sealed class MockEEClassLayoutInfo : TypedView
+{
+    private const string LayoutTypeFieldName = nameof(Data.EEClassLayoutInfo.LayoutType);
+    private const string AlignmentRequirementFieldName = nameof(Data.EEClassLayoutInfo.AlignmentRequirement);
+    private const string FlagsFieldName = nameof(Data.EEClassLayoutInfo.Flags);
+
+    public static Layout<MockEEClassLayoutInfo> CreateLayout(MockTarget.Architecture architecture)
+        => new SequentialLayoutBuilder("EEClassLayoutInfo", architecture)
+            .AddByteField(LayoutTypeFieldName)
+            .AddByteField(AlignmentRequirementFieldName)
+            .AddByteField(FlagsFieldName)
+            .Build<MockEEClassLayoutInfo>();
+
+    public byte LayoutType
+    {
+        get => ReadByteField(LayoutTypeFieldName);
+        set => WriteByteField(LayoutTypeFieldName, value);
+    }
+
+    public byte AlignmentRequirement
+    {
+        get => ReadByteField(AlignmentRequirementFieldName);
+        set => WriteByteField(AlignmentRequirementFieldName, value);
+    }
+
+    public byte Flags
+    {
+        get => ReadByteField(FlagsFieldName);
+        set => WriteByteField(FlagsFieldName, value);
+    }
+}
+
 internal sealed class MockEEClass : TypedView
 {
     private const string MethodTableFieldName = nameof(Data.EEClass.MethodTable);
@@ -109,6 +141,7 @@ internal sealed class MockEEClass : TypedView
     private const string NumNonVirtualSlotsFieldName = nameof(Data.EEClass.NumNonVirtualSlots);
     private const string BaseSizePaddingFieldName = nameof(Data.EEClass.BaseSizePadding);
     private const string OptionalFieldsFieldName = nameof(Data.EEClass.OptionalFields);
+    private const string VMFlagsFieldName = nameof(Data.EEClass.VMFlags);
 
     public static Layout<MockEEClass> CreateLayout(MockTarget.Architecture architecture)
         => new SequentialLayoutBuilder("EEClass", architecture)
@@ -124,7 +157,14 @@ internal sealed class MockEEClass : TypedView
             .AddUInt16Field(NumNonVirtualSlotsFieldName)
             .AddByteField(BaseSizePaddingFieldName)
             .AddPointerField(OptionalFieldsFieldName)
+            .AddUInt32Field(VMFlagsFieldName)
             .Build<MockEEClass>();
+
+    public uint VMFlags
+    {
+        get => ReadUInt32Field(VMFlagsFieldName);
+        set => WriteUInt32Field(VMFlagsFieldName, value);
+    }
 
     public ulong MethodTable
     {
@@ -378,6 +418,11 @@ internal partial class MockDescriptors
         internal Layout<MockTypeVarTypeDesc> TypeVarTypeDescLayout { get; }
         internal Layout<MockFieldDesc> FieldDescLayout { get; }
         internal Layout<MockGCCoverageInfo> GCCoverageInfoLayout { get; }
+        internal Layout<MockEEClassLayoutInfo> EEClassLayoutInfoLayout { get; }
+
+        // LayoutEEClass derives from EEClass, so its LayoutInfo sits immediately after the EEClass
+        // fields. Only the offset is consumed by the reader.
+        internal Layout<TypedView> LayoutEEClassLayout { get; }
 
         internal MockEEClass SystemObjectEEClass { get; private set; } = null!;
         internal MockMethodTable SystemObjectMethodTable { get; private set; } = null!;
@@ -414,6 +459,11 @@ internal partial class MockDescriptors
             TypeVarTypeDescLayout = MockTypeVarTypeDesc.CreateLayout(Builder.TargetTestHelpers.Arch);
             FieldDescLayout = MockFieldDesc.CreateLayout(Builder.TargetTestHelpers.Arch);
             GCCoverageInfoLayout = MockGCCoverageInfo.CreateLayout(Builder.TargetTestHelpers.Arch);
+            EEClassLayoutInfoLayout = MockEEClassLayoutInfo.CreateLayout(Builder.TargetTestHelpers.Arch);
+            LayoutEEClassLayout = new SequentialLayoutBuilder("LayoutEEClass", Builder.TargetTestHelpers.Arch)
+                .AddField("EEClassFields", EEClassLayout.Size)
+                .AddField("LayoutInfo", EEClassLayoutInfoLayout.Size)
+                .Build<TypedView>();
 
             AddGlobalPointers();
             AddDefaultTypes();
@@ -524,6 +574,26 @@ internal partial class MockDescriptors
 
         internal MockEEClass AddEEClass(string name)
             => Add(EEClassLayout, $"EEClass '{name}'");
+
+        /// <summary>
+        /// Allocates an EEClass sized as a LayoutEEClass (EEClass fields followed by the layout
+        /// info), sets the HasLayout VMFlag, and returns a view over the embedded layout info.
+        /// </summary>
+        internal MockEEClass AddLayoutEEClass(string name, byte layoutType, byte alignmentRequirement, byte flags)
+        {
+            MockEEClass eeClass = Add(EEClassLayout, (ulong)LayoutEEClassLayout.Size, $"LayoutEEClass '{name}'");
+            eeClass.VMFlags = HasLayoutVMFlag;
+
+            ulong layoutInfoAddress = eeClass.Address + (ulong)LayoutEEClassLayout.GetField("LayoutInfo").Offset;
+            Span<byte> layoutInfoBytes = Builder.BorrowAddressRange(layoutInfoAddress, EEClassLayoutInfoLayout.Size);
+            layoutInfoBytes[EEClassLayoutInfoLayout.GetField(nameof(Data.EEClassLayoutInfo.LayoutType)).Offset] = layoutType;
+            layoutInfoBytes[EEClassLayoutInfoLayout.GetField(nameof(Data.EEClassLayoutInfo.AlignmentRequirement)).Offset] = alignmentRequirement;
+            layoutInfoBytes[EEClassLayoutInfoLayout.GetField(nameof(Data.EEClassLayoutInfo.Flags)).Offset] = flags;
+            return eeClass;
+        }
+
+        // EEClass::VMFLAG_HASLAYOUT
+        internal const uint HasLayoutVMFlag = 0x00000040;
 
         internal MockMethodTable AddMethodTable(string name)
             => Add(MethodTableLayout, $"MethodTable '{name}'");


### PR DESCRIPTION
Fixes #131343.

## Problem

`CdacTypeHandle.GetFieldAlignment` threw `NotImplementedException`, so the shared `ArgIterator` could not reconstruct the stack layout of **any** value-type argument on WASM — the `Wasm32` case computes `Math.Clamp(_argTypeHandle.GetFieldAlignment(), 8, 16)`. Any managed stack walk over a wasm frame whose signature contains a value type (`Guid`, `DateTime`, an ordinary struct, `Int128`, a SIMD vector, …) threw instead of producing an argument layout.

## Approach

Read the real alignment, mirroring `CEEInfo::getClassAlignmentRequirementStatic` (`src/coreclr/vm/jitinterface.cpp`) — the same value the runtime's own wasm `ArgIterator` consumes via `getClassAlignmentRequirementStatic` in `callingconvention.h`:

```
result = target pointer size
if EEClass.HasLayout (VMFLAG_HASLAYOUT) and the layout is Sequential or blittable:
    result = EEClassLayoutInfo.AlignmentRequirement
if result < 8 and RequiresAlign8: result = 8   // FEATURE_64BIT_ALIGNMENT (ARM, WASM)
```

The result is **unclamped**; `ArgIterator` applies its own clamp, matching the runtime. Reading the real value fixes every value type at once, rather than special-casing one family — the runtime's set of 16-byte-aligned wasm types is broader than the SIMD vectors (`Int128`/`UInt128` get `SetAlignmentRequirement(16)` under `TARGET_WASM` in `methodtablebuilder.cpp`), so any name-matching predicate would drift from the runtime as that policy evolves.

## New data descriptors

Reading the alignment requires three additions:

- `EEClass.VMFlags` — to test `HasLayout`
- `LayoutEEClass.LayoutInfo` — `LayoutEEClass` derives from `EEClass`, so only the field offset is needed; the reader constructs an `EEClassLayoutInfo` at that offset from the `EEClass` address
- `EEClassLayoutInfo.{LayoutType, AlignmentRequirement, Flags}`

Consumers must check `HasLayout` before reading `LayoutInfo` — otherwise it interprets unrelated memory. That constraint is noted in the descriptor, the data type, and the contract doc.

Note that `EEClass.VMFlags` is an eager `[Field]`, so any consumer constructing its own `EEClass` layout needs the corresponding addition (`MockEEClass` is updated here).

## Deliberate differences from the native helper

Both are unreachable from the managed argument layout this contract serves, and both are documented in code and in `RuntimeTypeSystem.md`:

- The native helper starts from `TypeHandle::GetMethodTable`, which also resolves a MethodTable for a `TypeDesc`. Here a non-MethodTable handle reports the default, since `ArgIterator` only consults alignment for `ELEMENT_TYPE_VALUETYPE` arguments.
- The native helper handles the unmanaged (marshalled) view via `TypeHandle::IsNativeValueType`. That is a `TypeDesc` produced for native signatures (`ELEMENT_TYPE_NATIVE_VALUETYPE_ZAPSIG`) rather than by decoding an ECMA metadata signature, so it cannot appear on this path.

## Testing

Five cases × four architectures in `MethodTableTests`:

- no layout → target pointer size
- sequential layout → the stored alignment
- blittable layout → the stored alignment
- auto layout, not blittable → pointer size (layout info present but correctly not consulted)
- `RequiresAlign8` with a sub-8 alignment → 8

Each was mutation-verified rather than only observed green: disabling the `(Sequential || IsBlittable)` condition fails four tests, and disabling the `RequiresAlign8` bump yields 4 instead of 8.

Full cDAC suite: **3042 passed / 0 failed / 16 skipped**. `clr.native` builds clean (0 warnings / 0 errors), and the emitted contract descriptor was checked directly to confirm the new entries and their offsets.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.
