### PR TITLE
Make Uri non-ASCII hex unescaping a bit faster

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/PercentEncodingHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/PercentEncodingHelper.cs
@@ -29,34 +29,20 @@ namespace System
             int i = totalCharsConsumed + (bytesLeftInBuffer * 3);
 
         ReadByteFromInput:
-            if ((uint)(input.Length - i) <= 2 || input[i] != '%')
+            if ((uint)(i + 2) >= (uint)input.Length || input[i] != '%')
                 goto NoMoreOrInvalidInput;
 
-            uint value = input[i + 1];
-            if ((uint)((value - 'A') & ~0x20) <= ('F' - 'A'))
-            {
-                value = (value | 0x20) - 'a' + 10;
-            }
-            else if ((value - '8') <= ('9' - '8'))
-            {
-                value -= '0';
-            }
-            else goto NoMoreOrInvalidInput; // First character wasn't hex or was <= 7F (Ascii)
+            uint value = (uint)HexConverter.FromChar(input[i + 1]);
 
-            uint second = (uint)input[i + 2] - '0';
-            if (second <= 9)
-            {
-                // second is already [0, 9]
-            }
-            else if ((uint)((second - ('A' - '0')) & ~0x20) <= ('F' - 'A'))
-            {
-                second = ((second + '0') | 0x20) - 'a' + 10;
-            }
-            else goto NoMoreOrInvalidInput; // Second character wasn't Hex
+            // Check if the first character is 0 to avoid the case where "%0_" passes the "(value - 128) > 127" guard below since
+            // an invalid second character decodes to 0xFF on its own. If we exclude 0, all invalid values will map outside the range.
+            if (value == 0)
+                goto NoMoreOrInvalidInput;
 
-            value = (value << 4) | second;
+            value = (value << 4) | (uint)HexConverter.FromChar(input[i + 2]);
 
-            Debug.Assert(value >= 128);
+            if ((value - 128) > 127)
+                goto NoMoreOrInvalidInput; // Either not Hex or the decoded value is ASCII
 
             // Rotate the buffer and overwrite the last byte
             if (BitConverter.IsLittleEndian)

--- a/src/libraries/System.Private.Uri/src/System/PercentEncodingHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/PercentEncodingHelper.cs
@@ -39,7 +39,7 @@ namespace System
             if (value == 0)
                 goto NoMoreOrInvalidInput;
 
-            value = (value << 4) | (uint)HexConverter.FromChar(input[i + 2]);
+            value = (value << 4) + (uint)HexConverter.FromChar(input[i + 2]);
 
             if ((value - 128) > 127)
                 goto NoMoreOrInvalidInput; // Either not Hex or the decoded value is ASCII


### PR DESCRIPTION
Avoid some bounds checks and use a table lookup instead of manual hex calculations.
Closes #121413, followup to #121016

```c#
public class UriTest
{
    private char[] _buffer = new char[1024];

    [Benchmark]
    [Arguments("%E4%BD%A0%E5%A5%BD")]
    [Arguments("%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD")]
    public bool TryUnescapeDataString(string input) => Uri.TryUnescapeDataString(input, _buffer, out _);
}
```

| Method                | Toolchain         | input                | Mean      | Error    | Ratio |
|---------------------- |------------------ |--------------------- |----------:|---------:|------:|
| TryUnescapeDataString | \main\corerun.exe | %E4%BD%A0%E5%A5%BD   |  43.34 ns | 0.454 ns |  1.00 |
| TryUnescapeDataString | \pr\corerun.exe   | %E4%BD%A0%E5%A5%BD   |  40.43 ns | 0.364 ns |  0.93 |
|                       |                   |                      |           |          |       |
| TryUnescapeDataString | \main\corerun.exe | %E4%B(...)A5%BD [72] | 103.86 ns | 0.151 ns |  1.00 |
| TryUnescapeDataString | \pr\corerun.exe   | %E4%B(...)A5%BD [72] |  97.55 ns | 0.203 ns |  0.94 |