### PR TITLE
Support CIDR notation in NO_PROXY env variable

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+
 namespace System.Net.Http
 {
     internal sealed class HttpEnvironmentProxyCredentials : ICredentials
@@ -95,9 +97,10 @@ namespace System.Net.Http
         private const string EnvNoProxyUC = "NO_PROXY";
         private const string EnvCGI = "GATEWAY_INTERFACE"; // Running in a CGI environment.
 
-        private readonly Uri? _httpProxyUri;       // String URI for HTTP requests
-        private readonly Uri? _httpsProxyUri;      // String URI for HTTPS requests
-        private readonly string[]? _bypass;        // list of domains not to proxy
+        private readonly Uri? _httpProxyUri;                  // String URI for HTTP requests
+        private readonly Uri? _httpsProxyUri;                 // String URI for HTTPS requests
+        private readonly List<string>? _bypass;               // list of domains or IP addresses not to proxy
+        private readonly List<IPNetwork>? _bypassNetworks;    // list of subnet ranges not to proxy
         private ICredentials? _credentials;
 
         private HttpEnvironmentProxy(Uri? httpProxy, Uri? httpsProxy, string? bypassList)
@@ -106,7 +109,23 @@ namespace System.Net.Http
             _httpsProxyUri = httpsProxy;
 
             _credentials = HttpEnvironmentProxyCredentials.TryCreate(httpProxy, httpsProxy);
-            _bypass = bypassList?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+            if (bypassList != null)
+            {
+                foreach (string entry in bypassList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                {
+                    if (entry.Contains('/') && IPNetwork.TryParse(entry, out IPNetwork networkEntry))
+                    {
+                        _bypassNetworks ??= new List<IPNetwork>();
+                        _bypassNetworks.Add(networkEntry);
+                    }
+                    else
+                    {
+                        _bypass ??= new List<string>();
+                        _bypass.Add(entry);
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -276,6 +295,16 @@ namespace System.Net.Http
                         {
                             return true;
                         }
+                    }
+                }
+            }
+            if (_bypassNetworks != null && IPAddress.TryParse(input.Host, out IPAddress? ip))
+            {
+                foreach (IPNetwork network in _bypassNetworks)
+                {
+                    if (network.Contains(ip))
+                    {
+                        return true;
                     }
                 }
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -114,7 +114,7 @@ namespace System.Net.Http
             {
                 foreach (string entry in bypassList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                 {
-                    if (entry.Contains('/') && IPNetwork.TryParse(entry, out IPNetwork networkEntry))
+                    if (IPNetwork.TryParse(entry, out IPNetwork networkEntry))
                     {
                         _bypassNetworks ??= new List<IPNetwork>();
                         _bypassNetworks.Add(networkEntry);
@@ -298,6 +298,7 @@ namespace System.Net.Http
                     }
                 }
             }
+
             if (_bypassNetworks != null && IPAddress.TryParse(input.Host, out IPAddress? ip))
             {
                 foreach (IPNetwork network in _bypassNetworks)
@@ -308,6 +309,7 @@ namespace System.Net.Http
                     }
                 }
             }
+
             return false;
         }
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -264,6 +264,37 @@ namespace System.Net.Http.Tests
             }).DisposeAsync();
         }
 
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public async Task HttpProxy_CidrExceptions_Match()
+        {
+            await RemoteExecutor.Invoke(() =>
+            {
+                IWebProxy p;
+
+                Environment.SetEnvironmentVariable("no_proxy", "127.0.0.0/8,2001:db8::/32,192.168.1.0/24,.test.com,foo.com,invalid/cidr");
+                Environment.SetEnvironmentVariable("all_proxy", "http://foo:PLACEHOLDER@1.1.1.1:3000");
+                Assert.True(HttpEnvironmentProxy.TryCreate(out p));
+                Assert.NotNull(p);
+
+                Assert.True(p.IsBypassed(fooHttp));
+                Assert.True(p.IsBypassed(fooHttps));
+                Assert.True(p.IsBypassed(new Uri("http://test.com")));
+                Assert.False(p.IsBypassed(new Uri("http://1test.com")));
+
+                Assert.True(p.IsBypassed(new Uri("http://127.0.0.1")));
+                Assert.True(p.IsBypassed(new Uri("http://127.1.1.1")));
+                Assert.True(p.IsBypassed(new Uri("http://127.1.1.1:8080")));
+                Assert.True(p.IsBypassed(new Uri("http://[::ffff:127.0.0.1]")));
+                Assert.False(p.IsBypassed(new Uri("http://128.0.0.1")));
+
+                Assert.True(p.IsBypassed(new Uri("http://192.168.1.1")));
+                Assert.False(p.IsBypassed(new Uri("http://192.168.2.1")));
+
+                Assert.True(p.IsBypassed(new Uri("http://[2001:db8:ffff:ffff:ffff:ffff:ffff:ffff]")));
+                Assert.False(p.IsBypassed(new Uri("http://[2001:db9:0000:0000:0000:0000:0000:0000]")));
+            }).DisposeAsync();
+        }
+
         public static IEnumerable<object[]> HttpProxyNoProxyEnvVarMemberData()
         {
             yield return new object[] { "http_proxy", "no_proxy" };


### PR DESCRIPTION
CIDR notation like 127.0.0.0/8 in the `NO_PROXY`/`no_proxy` environment variables is currently not handled. These entries will be silently ignored because only exact entries like 127.0.0.1 can cause `HttpEnvironmentProxy.IsBypassed` to return `true`.

Address this by introducing support for IPv4 and IPv6 CIDR notation into `HttpEnvironmentProxy`. The CIDR parsing is done at construction-time to minimize the time spent parsing on each individual HTTP request. Additionally, CIDR-based matching will not be performed unless at least one CIDR block is actually present in `NO_PROXY`.

Fix #131293