### PR TITLE
JIT: allocate and initialize the LSRA VarToRegMaps in one shot

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1996,7 +1996,15 @@ void LinearScan::initVarRegMaps()
         // The in and out maps of every block are allocated as a single block and initialized in
         // one shot. They are only ever reached through inVarToRegMaps/outVarToRegMaps, which are
         // not modified after this point.
-        size_t          entryCount = (size_t)bbCount * 2 * regMapCount;
+        ClrSafeInt<size_t> entryCountSafe(bbCount);
+        entryCountSafe *= (size_t)2;
+        entryCountSafe *= (size_t)regMapCount;
+        if (entryCountSafe.IsOverflow())
+        {
+            NOMEM();
+        }
+
+        size_t          entryCount = entryCountSafe.Value();
         regNumberSmall* maps       = new (m_compiler, CMK_LSRA) regNumberSmall[entryCount];
 
         if (sizeof(regNumberSmall) == 1)

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1993,18 +1993,28 @@ void LinearScan::initVarRegMaps()
         // This VarToRegMap is used during the resolution of critical edges.
         sharedCriticalVarToRegMap = new (m_compiler, CMK_LSRA) regNumberSmall[regMapCount];
 
+        // The in and out maps of every block are allocated as a single block and initialized in
+        // one shot. They are only ever reached through inVarToRegMaps/outVarToRegMaps, which are
+        // not modified after this point.
+        size_t          entryCount = (size_t)bbCount * 2 * regMapCount;
+        regNumberSmall* maps       = new (m_compiler, CMK_LSRA) regNumberSmall[entryCount];
+
+        if (sizeof(regNumberSmall) == 1)
+        {
+            memset(maps, REG_STK, entryCount * sizeof(regNumberSmall));
+        }
+        else
+        {
+            for (size_t j = 0; j < entryCount; j++)
+            {
+                maps[j] = REG_STK;
+            }
+        }
+
         for (unsigned int i = 0; i < bbCount; i++)
         {
-            VarToRegMap inVarToRegMap  = new (m_compiler, CMK_LSRA) regNumberSmall[regMapCount];
-            VarToRegMap outVarToRegMap = new (m_compiler, CMK_LSRA) regNumberSmall[regMapCount];
-
-            for (unsigned int j = 0; j < regMapCount; j++)
-            {
-                inVarToRegMap[j]  = REG_STK;
-                outVarToRegMap[j] = REG_STK;
-            }
-            inVarToRegMaps[i]  = inVarToRegMap;
-            outVarToRegMaps[i] = outVarToRegMap;
+            inVarToRegMaps[i]  = maps + ((size_t)i * 2 * regMapCount);
+            outVarToRegMaps[i] = inVarToRegMaps[i] + regMapCount;
         }
     }
     else


### PR DESCRIPTION
`initVarRegMaps` made two arena allocations per basic block and filled them one byte at a time, so it cost `O(blocks * tracked locals)` scalar stores plus `2 * blocks` allocator calls.

All of the in/out maps are now allocated as a single block and filled with one `memset`. They are only ever reached through `inVarToRegMaps`/`outVarToRegMaps`, which are not modified after this point, so the maps can live contiguously. Keeping a block's in and out map adjacent also helps locality during resolution.
