### PR TITLE
[wasm] Report GC locals held across a safepoint as pinned

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -537,6 +537,12 @@ public:
 #endif
     unsigned char lvPinned : 1; // is this a pinned variable?
 
+#ifdef TARGET_WASM
+    unsigned char lvStackPinned : 1; // the GC must not move this local's referent, because a copy of it is held on
+                                     // the wasm operand stack across a safepoint. Unlike lvPinned this says nothing
+                                     // about the local itself, so it is safe to set after liveness.
+#endif
+
     unsigned char lvMustInit : 1; // must be initialized
 
 private:

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2039,8 +2039,7 @@ PhaseStatus Compiler::fgWasmSpillRefs()
                 continue;
             }
 
-            // A non-address-exposed GT_LCL_VAR is not exempt: the copy pushed onto the operand stack
-            //  goes stale if the referent moves, so record it and pin its home at the next call.
+            // We have a ref that may be live across a future call.
             defs.push_back(tree);
         }
 

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -1850,6 +1850,24 @@ PhaseStatus Compiler::fgWasmControlFlow()
     return PhaseStatus::MODIFIED_EVERYTHING;
 }
 
+// Determine whether `operand` is a direct operand of `user`.
+static bool fgWasmIsOperandOf(GenTree* user, GenTree* operand)
+{
+    bool isOperand = false;
+
+    user->VisitOperands([operand, &isOperand](GenTree* op) {
+        if (op != operand)
+        {
+            return GenTree::VisitResult::Continue;
+        }
+
+        isOperand = true;
+        return GenTree::VisitResult::Abort;
+    });
+
+    return isOperand;
+}
+
 PhaseStatus Compiler::fgWasmSpillRefs()
 {
     bool anyChanges = false;
@@ -1879,6 +1897,41 @@ PhaseStatus Compiler::fgWasmSpillRefs()
         {
             if (tree->IsCall())
             {
+                // A ref sourced from a non-address-exposed local already has a linear-stack home, so
+                //  rather than spilling it to a second slot we report that home as pinned. The GC then
+                //  can't move the referent, and the copy on the operand stack stays valid across the
+                //  call. This is only safe because the local can't be stored to between its def and its
+                //  use, so the home still holds the object the operand stack refers to.
+                //
+                // A value this call consumes directly needs neither: there is no safepoint between
+                //  loading it and the call, and the local's home keeps the referent reachable meanwhile.
+                for (size_t i = defs.size(); i > 0; i--)
+                {
+                    GenTree* const def = defs[i - 1];
+
+                    if (!def->OperIs(GT_LCL_VAR))
+                    {
+                        continue;
+                    }
+
+                    LclVarDsc* const dsc = lvaGetDesc(def->AsLclVarCommon());
+                    if (dsc->IsAddressExposed())
+                    {
+                        continue;
+                    }
+
+                    if (!fgWasmIsOperandOf(tree, def))
+                    {
+                        JITDUMP("Pinning V%02u, held across call\n", def->AsLclVarCommon()->GetLclNum());
+                        dsc->lvStackPinned = true;
+                    }
+
+                    // Swapping with the last element is safe because we walk backwards, so whatever
+                    //  lands here has already been examined.
+                    defs[i - 1] = defs[defs.size() - 1];
+                    defs.pop_back();
+                }
+
                 // For any ref/byref values live at the point of a call, spill them into pinned slots
                 //  on the stack where the GC can see them so it won't move them.
                 if (!defs.empty())
@@ -1986,21 +2039,8 @@ PhaseStatus Compiler::fgWasmSpillRefs()
                 continue;
             }
 
-            // If a value is just a GT_LCL_VAR that isn't address-exposed, by construction we ensure that
-            //  it won't be mutated between its def (here) and its use (the call that would produce a spill)
-            //  and we won't need to spill it.
-            if (tree->OperIs(GT_LCL_VAR))
-            {
-                GenTreeLclVarCommon* lclVar = tree->AsLclVarCommon();
-                LclVarDsc*           dsc    = lvaGetDesc(lclVar);
-                if (!dsc->IsAddressExposed())
-                {
-                    continue;
-                }
-            }
-
-            // We have a ref sourced from something like a call result or an indirection that hasn't been
-            //  spilled yet, so record it for potential spilling at the next call.
+            // A non-address-exposed GT_LCL_VAR is not exempt: the copy pushed onto the operand stack
+            //  goes stale if the referent moves, so record it and pin its home at the next call.
             defs.push_back(tree);
         }
 

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4187,7 +4187,13 @@ void GCInfo::gcMakeRegPtrTable(
                 flags = (GcSlotFlags)(flags | GC_SLOT_INTERIOR);
             }
 
+            // On wasm a local's home is also reported pinned when a copy of it is held on the operand
+            //  stack across a safepoint, since the GC cannot update that copy. See fgWasmSpillRefs.
+#ifdef TARGET_WASM
+            if (varDsc->lvPinned || varDsc->lvStackPinned)
+#else
             if (varDsc->lvPinned)
+#endif
             {
                 // Or in pinned_OFFSET_FLAG for 'pinned' pointer tracking
                 flags = (GcSlotFlags)(flags | GC_SLOT_PINNED);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_131373/Runtime_131373.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_131373/Runtime_131373.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// A GC ref pushed onto the wasm operand stack is a copy the GC can't update, so it goes stale
+// when a call relocates the referent. Only reproduces under crossgen wasm R2R (TargetOS=browser).
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_131373
+{
+    public sealed class Box
+    {
+        public object Slot;
+        public int Tag;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        for (int i = 0; i < 400; i++)
+        {
+            for (int j = 0; j < 32; j++)
+            {
+                byte[] garbage = new byte[8192];
+                GC.KeepAlive(garbage);
+            }
+
+            Box box = new Box { Tag = i };
+            StoreThroughByref(ref box.Slot, i);
+            Assert.NotNull(box.Slot);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void StoreThroughByref(ref object slot, int i)
+    {
+        slot = Allocate(i);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static object Allocate(int i)
+    {
+        for (int j = 0; j < 48; j++)
+        {
+            byte[] garbage = new byte[8192];
+            GC.KeepAlive(garbage);
+        }
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        return new string('x', 1 + (i & 7));
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_131373/Runtime_131373.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_131373/Runtime_131373.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- Force crossgen on the browser leg so this actually runs as wasm R2R. -->
+    <AlwaysUseCrossGen2 Condition="'$(TargetOS)' == 'browser'">true</AlwaysUseCrossGen2>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Alternative to #131374. Same bug, same test, narrower fix — opened as a draft so the two can be compared side by side rather than argued in the abstract.

## Background

On wasm a GC reference loaded from its frame home onto the operand stack is a **copy** the GC can neither see nor update, so it goes stale if the referent is relocated at an intervening call. `fgWasmSpillRefs` already handles this for values with no home by spilling them to pinned slots, but it skips non-address-exposed `GT_LCL_VAR`:

> If a value is just a `GT_LCL_VAR` that isn't address-exposed, by construction we ensure that it won't be mutated between its def (here) and its use (the call that would produce a spill) and we won't need to spill it.

That holds for IR mutation but not for relocation, which is where the hole comes from.

## What this does

Stop skipping those locals; instead of spilling them to a second slot, report the home they already have as pinned.

`lvPinned` is deliberately **not** reused. As @AndyAyersMS noted, it has side effects — it is a source-level concept with ~15 consumers, all of which run before this phase, and setting it here breaks the `lvPinned => !lvTracked` invariant asserted at `gcencode.cpp:4135` and `gcinfo.cpp:608`. That is not hypothetical: a variant doing exactly that fails **8 assertions** (`EC=133`) during *Emit GC+EH tables* under a checked crossgen of CoreLib, where this change is `EC=0`. A wasm-only `lvStackPinned` bit, consulted only when encoding GC info, says just the thing that needs saying and nothing more.

Locals the call consumes directly are excluded — there is no safepoint between loading one and the call, and the home keeps the referent reachable meanwhile.

## Versus #131374

@jakobbotsch's objection to #131374 was that it reports everything pinned always, trading GC behaviour for code size. This addresses that directly. Measured on a browser R2R composite against a common unfixed baseline, with pinning as the only variable:

| | pinned slots | size |
|---|---|---|
| #131374 (pin all on-frame GC slots) | 141,029 (100%) | +22,512 B |
| **this change** | **21,161 (15.0%)** | **+14,256 B** |
| spill to new pinned slots | n/a (bounded duration) | +2,028,932 B |

Same denominator, so the comparison is exact: **85% of the pins #131374 takes are unnecessary**, and targeting is slightly *smaller* rather than costing anything.

**One caveat, stated plainly:** this reduces the number of pins, not their duration. The spill approach zeroes its slots at end of block, releasing the pin; a report-pinned bit on a real local holds until the local is overwritten or the frame returns. On the fragmentation axis the ordering is spill (bounded) < this (6.7× fewer, unbounded) < #131374 (unbounded). GC-pressure measurement could not separate this from #131374 on the available workloads — within noise — so the static pin count is offered as the defensible proxy rather than a runtime claim.

## Validation

Browser R2R rig, all variants sharing an identical base so pinning is the sole variable:

- Byref GC-hole probe: unfixed `ec=1` **3/3**; this change `ec=100` **3/3**.
- `RuntimeCustomAttributeData` NRE, 5 seeds, System.Text.Json 12166 discovered: **0 NREs on all five**. So "held across a call" is not too narrow a criterion — it catches everything the encoder-wide version did.
- Microsoft.Bcl.Memory 550/550 and System.Runtime.CompilerServices.Unsafe 128/128, R2R off and on.
- Checked wasm crossgen of CoreLib: `EC=0`, no assertions.

## Test

`Runtime_131373` is unchanged from #131374. Four shapes look correct here but silently false-pass, which is worth recording:

- **A class field store.** `obj.Field = Call()` lowers to `STOREIND(ADD(LCL_VAR obj, offset), CALL)` because the field is at a non-zero offset; that byref `ADD` has no home and was already spilled. A `ref` parameter store has no `ADD`.
- **A call argument.** `fgMorphArgs` spills an earlier argument to a temp when a later one contains a call, so the load happens after the safepoint.
- **No allocation pressure.** A compacting collect on a small unfragmented heap has nothing to relocate.
- **Test not crossgen'd per variant.** The hole is in the test's own R2R code, so compiling it as IL against an R2R CoreLib passes even unfixed.

Only one of #131374 and this should be taken.

> [!NOTE]
> This change was authored with GitHub Copilot.

