### PR TITLE
Fix the net481 build break in AllocationHelper

### DIFF
--- a/src/libraries/Common/tests/System/Runtime/InteropServices/NativeMemory.cs
+++ b/src/libraries/Common/tests/System/Runtime/InteropServices/NativeMemory.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// Minimal polyfill of the .NET Core <c>NativeMemory</c> APIs for .NETFramework test targets.
+    /// </summary>
+    internal static unsafe class NativeMemory
+    {
+        public static void* Alloc(nuint byteCount) => (void*)Marshal.AllocHGlobal((IntPtr)(void*)byteCount);
+
+        public static void Free(void* ptr) => Marshal.FreeHGlobal((IntPtr)ptr);
+    }
+}

--- a/src/libraries/Microsoft.Bcl.Memory/tests/Microsoft.Bcl.Memory.Tests.csproj
+++ b/src/libraries/Microsoft.Bcl.Memory/tests/Microsoft.Bcl.Memory.Tests.csproj
@@ -39,6 +39,7 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Compile Include="..\..\Common\tests\System\Runtime\CompilerServices\RuntimeHelpers.cs" Link="System\Runtime\CompilerServices\RuntimeHelpers.cs" />
+    <Compile Include="..\..\Common\tests\System\Runtime\InteropServices\NativeMemory.cs" Link="System\Runtime\InteropServices\NativeMemory.cs" />
     <ProjectReference Include="..\src\Microsoft.Bcl.Memory.csproj" />
   </ItemGroup>
 

--- a/src/libraries/System.Memory/tests/AllocationHelper.cs
+++ b/src/libraries/System.Memory/tests/AllocationHelper.cs
@@ -26,7 +26,8 @@ namespace System.SpanTests
 
             try
             {
-                memory = (IntPtr)NativeMemory.Alloc((nuint)size);
+                // .NETFramework has no IntPtr -> nuint conversion; round-trip through a pointer instead.
+                memory = (IntPtr)NativeMemory.Alloc((nuint)(void*)size);
             }
             catch (OutOfMemoryException)
             {
@@ -35,8 +36,7 @@ namespace System.SpanTests
             finally
             {
                 // Only a successful allocation keeps the mutex; the matching ReleaseNative frees it.
-                // Any failure (OOM, a null result, or an unexpected throw) must release it here so a
-                // later large allocation doesn't hang waiting on a mutex that will never be freed.
+                // Any failure must release it here or a later allocation hangs on a mutex nothing frees.
                 if (memory == IntPtr.Zero)
                     s_memoryLock.ReleaseMutex();
             }

--- a/src/libraries/System.Memory/tests/AllocationHelper.cs
+++ b/src/libraries/System.Memory/tests/AllocationHelper.cs
@@ -36,7 +36,8 @@ namespace System.SpanTests
             finally
             {
                 // Only a successful allocation keeps the mutex; the matching ReleaseNative frees it.
-                // Any failure must release it here or a later allocation hangs on a mutex nothing frees.
+                // Any failure (OOM, a null result, or an unexpected throw) must release it here so a
+                // later large allocation doesn't hang waiting on a mutex that will never be freed.
                 if (memory == IntPtr.Zero)
                     s_memoryLock.ReleaseMutex();
             }


### PR DESCRIPTION
Fixes #131390.

`Microsoft.Bcl.Memory.Tests` links `System.Memory/tests/AllocationHelper.cs` and targets `net481`, where `NativeMemory` doesn't exist. #131280 switched that helper from `Marshal.AllocHGlobal` to `NativeMemory` without accounting for the shared compile, breaking `windows-x64 Release Libraries_NET481`.

Rather than reverting to `Marshal.AllocHGlobal` -- which is `LocalAlloc` on Windows and would pessimize every modern .NET consumer to fix a `net481`-only compile error -- this adds a test-only `NativeMemory` polyfill under `Common/tests`, alongside the `RuntimeHelpers` polyfill already linked into the same `.NETFramework` `ItemGroup`.

`System.Memory.Tests` is `$(NetCoreAppCurrent)`-only, so `Microsoft.Bcl.Memory.Tests` is the only project that picks the polyfill up.

----------

The one unavoidable change in `AllocationHelper` itself is the argument cast:

```diff
-                memory = (IntPtr)NativeMemory.Alloc((nuint)size);
+                memory = (IntPtr)NativeMemory.Alloc((nuint)(void*)size);
```

`IntPtr`/`UIntPtr` aren't the numeric types on .NETFramework, so `(nuint)size` is `CS0030` there -- that's the second error in the issue, and it's independent of the polyfill. The pointer round-trip is legal on both and compiles to nothing.

----------

Validated locally on Windows x64:

| Leg | Result |
| --- | --- |
| `Microsoft.Bcl.Memory.Tests` `net481` innerloop | 548 passed |
| `Microsoft.Bcl.Memory.Tests` `net481` outerloop | 2 passed |
| `Microsoft.Bcl.Memory.Tests` netcoreapp innerloop | 548 passed |
| `System.Memory.Tests` innerloop | 52,929 passed |
| `System.Memory.Tests` outerloop | 31 passed |

The outerloop runs cover the remaining `AllocationHelper` consumers (`Overflow`, `Clear`, `BinarySearch`, `Base64`, `Base64Url`). Stashing the fix reproduces the exact `CS0103`/`CS0030` errors from the issue.

CC. @dotnet/area-system-memory

> [!NOTE]
> This PR description and the code changes were drafted with GitHub Copilot.
