### PR TITLE
[wasm] Use ordinary struct alignment for Int128/UInt128 on wasm

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Int128FieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/Int128FieldLayoutAlgorithm.cs
@@ -31,7 +31,7 @@ namespace ILCompiler
             ComputedInstanceFieldLayout layoutFromMetadata = _fallbackAlgorithm.ComputeInstanceLayout(defType, layoutKind);
 
             // 32bit platforms use standard metadata layout engine
-            if (defType.Context.Target.Architecture == TargetArchitecture.ARM)
+            if (defType.Context.Target.Architecture is TargetArchitecture.ARM or TargetArchitecture.Wasm32)
             {
                 layoutFromMetadata.LayoutAbiStable = true;
                 layoutFromMetadata.IsInt128OrHasInt128Fields = true;

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/ArchitectureSpecificFieldLayoutTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/ArchitectureSpecificFieldLayoutTests.cs
@@ -22,6 +22,8 @@ namespace TypeSystemTests
         private ModuleDesc _testModuleARM;
         private TestTypeSystemContext _contextARM64;
         private ModuleDesc _testModuleARM64;
+        private TestTypeSystemContext _contextWasm32;
+        private ModuleDesc _testModuleWasm32;
 
         public ArchitectureSpecificFieldLayoutTests()
         {
@@ -60,6 +62,12 @@ namespace TypeSystemTests
             _contextARM64.SetSystemModule(systemModuleARM64);
 
             _testModuleARM64 = systemModuleARM64;
+
+            _contextWasm32 = new TestTypeSystemContext(TargetArchitecture.Wasm32);
+            var systemModuleWasm32 = _contextWasm32.CreateModuleForSimpleName("CoreTestAssembly");
+            _contextWasm32.SetSystemModule(systemModuleWasm32);
+
+            _testModuleWasm32 = systemModuleWasm32;
         }
 
         [Fact]
@@ -501,11 +509,13 @@ namespace TypeSystemTests
         [InlineData("StructStructByte_Int128StructAuto", "X86", 16, 32)]
         [InlineData("StructStructByte_Int128StructAuto", "X64Linux", 16, 32)]
         [InlineData("StructStructByte_Int128StructAuto", "X64Windows", 16, 32)]
+        [InlineData("StructStructByte_Int128StructAuto", "Wasm32", 8, 24)]
         [InlineData("StructStructByte_UInt128StructAuto", "ARM64", 16, 32)]
         [InlineData("StructStructByte_UInt128StructAuto", "ARM", 8, 24)]
         [InlineData("StructStructByte_UInt128StructAuto", "X86", 16, 32)]
         [InlineData("StructStructByte_UInt128StructAuto", "X64Linux", 16, 32)]
         [InlineData("StructStructByte_UInt128StructAuto", "X64Windows", 16, 32)]
+        [InlineData("StructStructByte_UInt128StructAuto", "Wasm32", 8, 24)]
         // Variation of TestAlignmentBehavior_AutoAlignmentRules above that is able to deal with os specific behavior
         public void TestAlignmentBehavior_AutoAlignmentRulesWithOSDependence(string wrapperType, string osArch, int alignment, int size)
         {
@@ -529,6 +539,9 @@ namespace TypeSystemTests
                     break;
                 case "X86":
                     testModule = _testModuleX86;
+                    break;
+                case "Wasm32":
+                    testModule = _testModuleWasm32;
                     break;
                 default:
                     throw new Exception();

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -10817,7 +10817,8 @@ void MethodTableBuilder::CheckForSystemTypes()
             // even on X86
             pLayout->SetAlignmentRequirement(16); // sizeof(__int128)
 #elif defined(TARGET_WASM)
-            pLayout->SetAlignmentRequirement(16); // sizeof(v128)
+            // Wasm has no 128-bit scalar type to match, so use the natural field alignment.
+            pLayout->SetAlignmentRequirement(8);
 #else
 #error Unknown architecture
 #endif // TARGET_64BIT


### PR DESCRIPTION
`Int128`/`UInt128` were given a 16-byte alignment requirement on wasm by both the VM and crossgen2, annotated `// sizeof(v128)`. `Int128` is not a v128 — the only 128-bit value type in WebAssembly is `v128`, and `WasmLowering.IsWasmV128Type` recognizes only `Vector128<T>` and a 128-bit `Vector<T>`, so `Int128` uses the generic by-reference struct ABI.

Every other alignment override in `CheckForSystemTypes` exists because the managed type corresponds to a fundamental data type in the target ABI (`Vector128<T>`↔`__m128`, and so on). `Int128` has no counterpart on wasm, so it takes ordinary struct alignment — the 8 its two `ulong` fields produce. On the crossgen2 side that means routing wasm through the existing 32-bit path alongside ARM.

### Symptom

The 16 was observable as wrong codegen at the interpreter→R2R boundary:

```
Int128 a = 1, b = 1;
a == b          // True
a.Equals(b)     // False   <-- R2R only
a.CompareTo(b)  // -1      <-- R2R only
```

### Root cause

Wasm signature encoding spells a by-reference struct argument as `S<N>`, and `RaiseSignature` resolves `S16` through `GetCachedStructOfSize`, which keys only on size and keeps the first struct seen at that size. The thunk therefore used that struct's 8-byte alignment while the interpreter used `Int128`'s 16, placing the argument at `argsBase+24` instead of `argsBase+32`. `Equals` and `CompareTo` read a shifted value; `operator ==` takes its operands differently and was unaffected.

This also makes `S<N>` sound rather than accidentally correct. Single-field structs wrapping a v128 are unwrapped by `LowerType` and encode as `V`, and a v128 field is the only source of 16-byte alignment on wasm — so once `Int128` takes its natural alignment, nothing reaching `S<N>` requires more than 8.

The VM and crossgen2 must change together or managed field layout desyncs.

### Validation

Browser wasm, against builds with and without the change, rebuilding both `corerun` and the R2R composite for each variant:

| | R2R off | R2R on |
|---|---|---|
| Int128 repro, before | correct | `Equals=False`, `CompareTo=±1` on equal values |
| Int128 repro, after | correct | correct |

`System.Text.Json`, the `Int128`-bearing classes, 1496 tests, run on a branch carrying the other outstanding wasm R2R fixes so the suite completes:

| | R2R off | R2R on |
|---|---|---|
| before | 2 failed (0 Int128) | 20 failed (15 Int128) |
| after | 2 failed (0 Int128) | 2 failed (0 Int128) |

Those 2 fail with R2R off in both arms — pre-existing and unrelated.

`Microsoft.Bcl.Memory` 550/550 and `System.Runtime.CompilerServices.Unsafe` 128/128, R2R on and off.

### Alternative considered

Encoding `Int128` as `V` instead does not work. `V` is not an alignment tag — it selects a different calling convention, passing the value in a wasm `v128` local rather than by reference. The JIT has no notion of `Int128` at all, so R2R code faults with `RuntimeError: function signature mismatch`. Confirmed experimentally.

`clang` on wasm32 agrees with the by-reference treatment: it legalizes `__int128` into two `i64` parameters rather than any 128-bit entity, and passes an equivalent 16-byte struct as `byval align 8`. `_Alignof(__int128) == 16` there is a memory-layout artifact, not a calling-convention requirement, since there is no 128-bit slot to align to.

wasm-only by construction — the VM change is inside `#elif defined(TARGET_WASM)` and the crossgen2 change adds `TargetArchitecture.Wasm32` to an existing condition.

> [!NOTE]
> This pull request was created with the assistance of GitHub Copilot.