### PR TITLE
Ensure that Decimal32/64/128 ToString roundtrips and preserves the cohort

### DIFF
--- a/src/libraries/Common/src/System/Number.Formatting.Common.cs
+++ b/src/libraries/Common/src/System/Number.Formatting.Common.cs
@@ -1120,6 +1120,30 @@ namespace System
                     return false;
                 }
 
+                if (numberKind == NumberBufferKind.DecimalIeee754)
+                {
+                    // The buffer holds the exact coefficient, so a '5' followed by nothing but zeros is a
+                    // true tie rather than an artifact of a truncated expansion. IEEE 754 §5.12.1 requires
+                    // the conversion to be correctly rounded under the applicable rounding-direction
+                    // attribute, which is roundTiesToEven.
+
+                    if (digit != '5')
+                    {
+                        return digit > '5';
+                    }
+
+                    for (int j = i + 1; dig[j] != '\0'; j++)
+                    {
+                        if (dig[j] != '0')
+                        {
+                            return true;
+                        }
+                    }
+
+                    // A tie with no preceding digit rounds toward the implicit leading zero, which is even.
+                    return (i > 0) && (((dig[i - 1] - '0') & 1) != 0);
+                }
+
                 // Values greater than or equal to 5 should round up, otherwise we round down. The IEEE
                 // 754 spec actually dictates that ties (exactly 5) should round to the nearest even number
                 // but that can have undesired behavior for custom numeric format strings. This probably

--- a/src/libraries/Common/src/System/Number.Formatting.Common.cs
+++ b/src/libraries/Common/src/System/Number.Formatting.Common.cs
@@ -435,7 +435,7 @@ namespace System
                 }
                 else
                 {
-                    if (number.Kind != NumberBufferKind.FloatingPoint)
+                    if (number.Kind is not (NumberBufferKind.FloatingPoint or NumberBufferKind.DecimalIeee754))
                     {
                         // The integer types don't have a concept of -0 and decimal always format -0 as 0
                         number.IsNegative = false;
@@ -1085,7 +1085,7 @@ namespace System
 
             if (i == 0)
             {
-                if (number.Kind != NumberBufferKind.FloatingPoint)
+                if (number.Kind is not (NumberBufferKind.FloatingPoint or NumberBufferKind.DecimalIeee754))
                 {
                     // The integer types don't have a concept of -0 and decimal always format -0 as 0
                     number.IsNegative = false;

--- a/src/libraries/Common/src/System/Number.NumberBuffer.cs
+++ b/src/libraries/Common/src/System/Number.NumberBuffer.cs
@@ -129,8 +129,10 @@ namespace System
             FloatingPoint = 3,
 
             /// <summary>
-            /// An IEEE 754 decimal interchange format. This rounds like <see cref="NumberBufferKind.Decimal"/> but, like
-            /// <see cref="NumberBufferKind.FloatingPoint"/>, has a signed zero that must survive formatting.
+            /// An IEEE 754 decimal interchange format. Unlike <see cref="NumberBufferKind.FloatingPoint"/> the buffer
+            /// holds the exact coefficient rather than a pre-rounded shortest representation, so formatting must round
+            /// it; unlike <see cref="NumberBufferKind.Decimal"/> that rounding is ties-to-even and a signed zero must
+            /// survive it.
             /// </summary>
             DecimalIeee754 = 4,
         }

--- a/src/libraries/Common/src/System/Number.NumberBuffer.cs
+++ b/src/libraries/Common/src/System/Number.NumberBuffer.cs
@@ -65,7 +65,7 @@ namespace System
             public void CheckConsistency()
             {
 #if DEBUG
-                Debug.Assert(Kind is NumberBufferKind.Integer or NumberBufferKind.Decimal or NumberBufferKind.FloatingPoint);
+                Debug.Assert(Kind is NumberBufferKind.Integer or NumberBufferKind.Decimal or NumberBufferKind.FloatingPoint or NumberBufferKind.DecimalIeee754);
                 Debug.Assert(Digits[0] != '0', "Leading zeros should never be stored in a Number");
 
                 int numDigits;
@@ -127,6 +127,12 @@ namespace System
             Integer = 1,
             Decimal = 2,
             FloatingPoint = 3,
+
+            /// <summary>
+            /// An IEEE 754 decimal interchange format. This rounds like <see cref="Decimal"/> but, like
+            /// <see cref="FloatingPoint"/>, has a signed zero that must survive formatting.
+            /// </summary>
+            DecimalIeee754 = 4,
         }
     }
 }

--- a/src/libraries/Common/src/System/Number.NumberBuffer.cs
+++ b/src/libraries/Common/src/System/Number.NumberBuffer.cs
@@ -129,8 +129,8 @@ namespace System
             FloatingPoint = 3,
 
             /// <summary>
-            /// An IEEE 754 decimal interchange format. This rounds like <see cref="Decimal"/> but, like
-            /// <see cref="FloatingPoint"/>, has a signed zero that must survive formatting.
+            /// An IEEE 754 decimal interchange format. This rounds like <see cref="NumberBufferKind.Decimal"/> but, like
+            /// <see cref="NumberBufferKind.FloatingPoint"/>, has a signed zero that must survive formatting.
             /// </summary>
             DecimalIeee754 = 4,
         }

--- a/src/libraries/Common/src/System/Number.Parsing.Common.cs
+++ b/src/libraries/Common/src/System/Number.Parsing.Common.cs
@@ -268,7 +268,7 @@ namespace System
                 {
                     if ((state & StateNonZero) == 0)
                     {
-                        if (number.Kind != NumberBufferKind.Decimal)
+                        if (number.Kind is not (NumberBufferKind.Decimal or NumberBufferKind.DecimalIeee754))
                         {
                             number.Scale = 0;
                         }

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -440,7 +440,9 @@ namespace System
         {
             Debug.Assert(number.Kind == NumberBufferKind.Decimal);
 
-            if ((nMaxDigits > 0) && (nMaxDigits < number.DigitsCount))
+            bool rounded = (nMaxDigits > 0) && (nMaxDigits < number.DigitsCount);
+
+            if (rounded)
             {
                 RoundNumber(ref number, nMaxDigits, isCorrectlyRounded: false);
             }
@@ -453,12 +455,17 @@ namespace System
             byte* dig = number.DigitsPtr;
             int digitCount = number.DigitsCount;
 
-            // `Scale` is the coefficient digit count plus the quantum exponent. A zero coefficient has no
-            // stored digits but still participates as the single digit `0` when computing the adjusted exponent.
-            int exponent = number.Scale - digitCount;
-            int adjustedExponent = (digitCount != 0) ? (number.Scale - 1) : exponent;
+            // `Scale` is the coefficient digit count plus the quantum exponent, so `Scale` exceeding the number
+            // of significant digits means the quantum exponent is positive. Rounding drops trailing coefficient
+            // digits without touching `Scale`, so the requested precision is what remains significant in that
+            // case; the dropped digits are recovered as trailing zeros below.
+            int significantDigits = rounded ? nMaxDigits : digitCount;
 
-            if ((exponent > 0) || (adjustedExponent < -4))
+            // A zero coefficient has no stored digits but still participates as the single digit `0` when
+            // computing the adjusted exponent.
+            int adjustedExponent = (digitCount != 0) ? (number.Scale - 1) : number.Scale;
+
+            if ((number.Scale > significantDigits) || (adjustedExponent < -4))
             {
                 vlb.Append(TChar.CastFrom((digitCount != 0) ? (char)dig[0] : '0'));
 
@@ -477,13 +484,14 @@ namespace System
             }
 
             int integerDigits = number.Scale;
-            Debug.Assert(integerDigits <= digitCount);
 
             if (integerDigits > 0)
             {
                 for (int i = 0; i < integerDigits; i++)
                 {
-                    vlb.Append(TChar.CastFrom((char)dig[i]));
+                    // Rounding can leave fewer digits than the scale requires, in which case the remaining
+                    // integer positions are trailing zeros of the rounded coefficient.
+                    vlb.Append(TChar.CastFrom((i < digitCount) ? (char)dig[i] : '0'));
                 }
             }
             else
@@ -491,7 +499,7 @@ namespace System
                 vlb.Append(TChar.CastFrom('0'));
             }
 
-            if (exponent < 0)
+            if (integerDigits < digitCount)
             {
                 vlb.Append(info.NumberDecimalSeparatorTChar<TChar>());
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -384,7 +384,14 @@ namespace System
             {
                 if (fmt is 'G' or 'R' or 'g' or 'r')
                 {
-                    FormatGeneralAndRoundTripDecimalIeee754(ref vlb, ref number, fmt, digits, info);
+                    if (fmt is 'R' or 'r')
+                    {
+                        // The roundtrip specifier ignores any precision specifier and is otherwise identical to the general specifier
+                        fmt = (char)(fmt - ('R' - 'G'));
+                        digits = -1;
+                    }
+
+                    FormatGeneralAndRoundTripDecimalIeee754(ref vlb, ref number, (char)(fmt - ('G' - 'E')), digits, info);
                 }
                 else
                 {
@@ -418,14 +425,86 @@ namespace System
             return success;
         }
 
-        private static void FormatGeneralAndRoundTripDecimalIeee754<TChar>(ref ValueListBuilder<TChar> vlb, ref NumberBuffer number, char fmt, int digits, NumberFormatInfo info)
+        /// <summary>
+        /// Formats <paramref name="number"/> using the general format, preserving the quantum exponent so that
+        /// reparsing the result recovers the same member of the cohort.
+        /// </summary>
+        /// <remarks>
+        /// Fixed-point notation can only spell a quantum exponent that is at or below zero, since a positive
+        /// quantum would require trailing zeros that reparse as a larger coefficient. Scientific notation is
+        /// therefore required whenever the quantum exponent is positive, and is otherwise picked using the same
+        /// compactness heuristic as the binary floating-point types.
+        /// </remarks>
+        private static unsafe void FormatGeneralAndRoundTripDecimalIeee754<TChar>(ref ValueListBuilder<TChar> vlb, ref NumberBuffer number, char expChar, int nMaxDigits, NumberFormatInfo info)
             where TChar : unmanaged, IUtfChar<TChar>
         {
+            Debug.Assert(number.Kind == NumberBufferKind.Decimal);
+
+            if ((nMaxDigits > 0) && (nMaxDigits < number.DigitsCount))
+            {
+                RoundNumber(ref number, nMaxDigits, isCorrectlyRounded: false);
+            }
+
             if (number.IsNegative)
             {
                 vlb.Append(info.NegativeSignTChar<TChar>());
             }
-            FormatGeneral(ref vlb, ref number, digits, info, (char)(fmt - ('G' - 'E')), suppressScientific: true);
+
+            byte* dig = number.DigitsPtr;
+            int digitCount = number.DigitsCount;
+
+            // `Scale` is the coefficient digit count plus the quantum exponent. A zero coefficient has no
+            // stored digits but still participates as the single digit `0` when computing the adjusted exponent.
+            int exponent = number.Scale - digitCount;
+            int adjustedExponent = (digitCount != 0) ? (number.Scale - 1) : exponent;
+
+            if ((exponent > 0) || (adjustedExponent < -4))
+            {
+                vlb.Append(TChar.CastFrom((digitCount != 0) ? (char)dig[0] : '0'));
+
+                if (digitCount > 1)
+                {
+                    vlb.Append(info.NumberDecimalSeparatorTChar<TChar>());
+
+                    for (int i = 1; i < digitCount; i++)
+                    {
+                        vlb.Append(TChar.CastFrom((char)dig[i]));
+                    }
+                }
+
+                FormatExponent(ref vlb, info, adjustedExponent, expChar, minDigits: 2, positiveSign: true);
+                return;
+            }
+
+            int integerDigits = number.Scale;
+            Debug.Assert(integerDigits <= digitCount);
+
+            if (integerDigits > 0)
+            {
+                for (int i = 0; i < integerDigits; i++)
+                {
+                    vlb.Append(TChar.CastFrom((char)dig[i]));
+                }
+            }
+            else
+            {
+                vlb.Append(TChar.CastFrom('0'));
+            }
+
+            if (exponent < 0)
+            {
+                vlb.Append(info.NumberDecimalSeparatorTChar<TChar>());
+
+                for (int i = integerDigits; i < 0; i++)
+                {
+                    vlb.Append(TChar.CastFrom('0'));
+                }
+
+                for (int i = Math.Max(integerDigits, 0); i < digitCount; i++)
+                {
+                    vlb.Append(TChar.CastFrom((char)dig[i]));
+                }
+            }
         }
 
         public static unsafe string FormatDecimal(decimal value, ReadOnlySpan<char> format, NumberFormatInfo info)
@@ -491,7 +570,9 @@ namespace System
 
             if (TValue.IsZero(unpackDecimal.Significand))
             {
-                number.Scale = unpackDecimal.UnbiasedExponent < 0 ? unpackDecimal.UnbiasedExponent : 0;
+                // A zero coefficient has no stored digits, so `Scale` carries the quantum exponent directly.
+                // Every other format specifier calls `RoundNumber` (or resets `Scale` itself) before reading it.
+                number.Scale = unpackDecimal.UnbiasedExponent;
                 number.DigitsCount = 0;
                 number.Digits[0] = (byte)'\0';
                 number.CheckConsistency();

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -376,7 +376,7 @@ namespace System
             char fmt = ParseFormatSpecifier(format, out int digits);
 
             byte* pDigits = stackalloc byte[TDecimal.BufferLength];
-            NumberBuffer number = new NumberBuffer(NumberBufferKind.Decimal, pDigits, TDecimal.BufferLength);
+            NumberBuffer number = new NumberBuffer(NumberBufferKind.DecimalIeee754, pDigits, TDecimal.BufferLength);
 
             DecimalIeee754ToNumber<TDecimal, TValue>(value, ref number);
 
@@ -438,7 +438,7 @@ namespace System
         private static unsafe void FormatGeneralAndRoundTripDecimalIeee754<TChar>(ref ValueListBuilder<TChar> vlb, ref NumberBuffer number, char expChar, int nMaxDigits, NumberFormatInfo info)
             where TChar : unmanaged, IUtfChar<TChar>
         {
-            Debug.Assert(number.Kind == NumberBufferKind.Decimal);
+            Debug.Assert(number.Kind == NumberBufferKind.DecimalIeee754);
 
             bool rounded = (nMaxDigits > 0) && (nMaxDigits < number.DigitsCount);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -994,7 +994,7 @@ namespace System
             where TDecimal : unmanaged, IDecimalIeee754ParseAndFormatInfo<TDecimal, TValue>
             where TValue : unmanaged, IBinaryInteger<TValue>
         {
-            NumberBuffer number = new NumberBuffer(NumberBufferKind.Decimal, stackalloc byte[TDecimal.BufferLength]);
+            NumberBuffer number = new NumberBuffer(NumberBufferKind.DecimalIeee754, stackalloc byte[TDecimal.BufferLength]);
             result = default;
 
             if (!TryStringToNumber(value, styles, ref number, info, out elementsConsumed))

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
@@ -116,13 +116,13 @@ namespace System.Tests
         public static IEnumerable<object[]> Parse_Preserve_TrailingZero_TestData()
         {
             yield return new object[] { "0.00", "0.00" };
-            yield return new object[] { "0." + new string('0', 6176), "0." + new string('0', 6176) };
-            yield return new object[] { "0." + new string('0', 10000), "0." + new string('0', 6176) };
-            yield return new object[] { "0." + new string('0', 10000) + "1234567", "0." + new string('0', 6176) };
+            yield return new object[] { "0." + new string('0', 6176), "0E-6176" };
+            yield return new object[] { "0." + new string('0', 10000), "0E-6176" };
+            yield return new object[] { "0." + new string('0', 10000) + "1234567", "0E-6176" };
             yield return new object[] { "0e-2", "0.00" };
-            yield return new object[] { "0e-6176", "0." + new string('0', 6176) };
-            yield return new object[] { "0e-10000", "0." + new string('0', 6176) };
-            yield return new object[] { "0.123e-10000", "0." + new string('0', 6176) };
+            yield return new object[] { "0e-6176", "0E-6176" };
+            yield return new object[] { "0e-10000", "0E-6176" };
+            yield return new object[] { "0.123e-10000", "0E-6176" };
         }
 
         public static IEnumerable<object[]> Parse_Invalid_TestData()
@@ -396,28 +396,40 @@ namespace System.Tests
                 yield return new object[] { Decimal128.Parse("0"), "G", defaultFormat, "0" };
                 yield return new object[] { Decimal128.Zero, "G", defaultFormat, "0" };
                 yield return new object[] { Decimal128.Parse("0.0000"), "G", defaultFormat, "0.0000" };
-                yield return new object[] { Decimal128.Parse($"{Int128.MinValue}"), "G", defaultFormat, "-170141183460469231731687303715884100000" };
-                yield return new object[] { Decimal128.Parse($"{Int128.MaxValue}"), "G", defaultFormat, "170141183460469231731687303715884100000" };
-                yield return new object[] { Decimal128.Parse("3e6144"), "G", defaultFormat, "3" + new string('0', 6144) };
-                yield return new object[] { Decimal128.Parse("-3e6144"), "G", defaultFormat, "-3" + new string('0', 6144) };
+                yield return new object[] { Decimal128.Parse($"{Int128.MinValue}"), "G", defaultFormat, "-1.701411834604692317316873037158841E+38" };
+                yield return new object[] { Decimal128.Parse($"{Int128.MaxValue}"), "G", defaultFormat, "1.701411834604692317316873037158841E+38" };
+                yield return new object[] { Decimal128.Parse("3e6144"), "G", defaultFormat, "3." + new string('0', 33) + "E+6144" };
+                yield return new object[] { Decimal128.Parse("-3e6144"), "G", defaultFormat, "-3." + new string('0', 33) + "E+6144" };
                 yield return new object[] { Decimal128.Parse("-4567"), "G", defaultFormat, "-4567" };
                 yield return new object[] { Decimal128.Parse("-4567.891"), "G", defaultFormat, "-4567.891" };
                 yield return new object[] { Decimal128.Parse("0"), "G", defaultFormat, "0" };
                 yield return new object[] { Decimal128.Parse("4567"), "G", defaultFormat, "4567" };
                 yield return new object[] { Decimal128.Parse("4567.891"), "G", defaultFormat, "4567.891" };
 
+                // A positive quantum exponent has no fixed-point spelling, so scientific notation is required
+                yield return new object[] { Decimal128.Parse("1e7"), "G", defaultFormat, "1E+07" };
+                yield return new object[] { Decimal128.Parse("10e6"), "G", defaultFormat, "1.0E+07" };
+                yield return new object[] { Decimal128.Parse("0e2"), "G", defaultFormat, "0E+02" };
+                yield return new object[] { Decimal128.Parse("-0e2"), "G", defaultFormat, "-0E+02" };
+                yield return new object[] { Decimal128.Parse("0.0001"), "G", defaultFormat, "0.0001" };
+                yield return new object[] { Decimal128.Parse("0.00001"), "G", defaultFormat, "1E-05" };
+                yield return new object[] { Decimal128.Parse("0.000100"), "G", defaultFormat, "0.000100" };
+                yield return new object[] { Decimal128.MaxValue, "G", defaultFormat, "9." + new string('9', 33) + "E+6144" };
+                yield return new object[] { Decimal128.MinValue, "G", defaultFormat, "-9." + new string('9', 33) + "E+6144" };
+                yield return new object[] { Decimal128.Epsilon, "G", defaultFormat, "1E-6176" };
+
                 yield return new object[] { Decimal128.Parse("2468"), "N", defaultFormat, "2,468.00" };
 
                 yield return new object[] { Decimal128.Parse("2467"), "[#-##-#]", defaultFormat, "[2-46-7]" };
 
-                yield return new object[] { Decimal128.Parse("4e-6177"), "G", defaultFormat, "0." + new string('0', 6176) };
-                yield return new object[] { Decimal128.Parse("5e-6177"), "G", defaultFormat, "0." + new string('0', 6176) };
-                yield return new object[] { Decimal128.Parse("5.00000000000000000000000000000000000000001e-6177"), "G", defaultFormat, "0." + new string('0', 6175) + "1" };
-                yield return new object[] { Decimal128.Parse("6e-6177"), "G", defaultFormat, "0." + new string('0', 6175) + "1" };
-                yield return new object[] { Decimal128.Parse("-4e-6177"), "G", defaultFormat, "-0." + new string('0', 6176) };
-                yield return new object[] { Decimal128.Parse("-5e-6177"), "G", defaultFormat, "-0." + new string('0', 6176) };
-                yield return new object[] { Decimal128.Parse("-5.00000000000000000000000000000000000000001e-6177"), "G", defaultFormat, "-0." + new string('0', 6175) + "1" };
-                yield return new object[] { Decimal128.Parse("-6e-6177"), "G", defaultFormat, "-0." + new string('0', 6175) + "1" };
+                yield return new object[] { Decimal128.Parse("4e-6177"), "G", defaultFormat, "0E-6176" };
+                yield return new object[] { Decimal128.Parse("5e-6177"), "G", defaultFormat, "0E-6176" };
+                yield return new object[] { Decimal128.Parse("5.00000000000000000000000000000000000000001e-6177"), "G", defaultFormat, "1E-6176" };
+                yield return new object[] { Decimal128.Parse("6e-6177"), "G", defaultFormat, "1E-6176" };
+                yield return new object[] { Decimal128.Parse("-4e-6177"), "G", defaultFormat, "-0E-6176" };
+                yield return new object[] { Decimal128.Parse("-5e-6177"), "G", defaultFormat, "-0E-6176" };
+                yield return new object[] { Decimal128.Parse("-5.00000000000000000000000000000000000000001e-6177"), "G", defaultFormat, "-1E-6176" };
+                yield return new object[] { Decimal128.Parse("-6e-6177"), "G", defaultFormat, "-1E-6176" };
 
             }
         }
@@ -455,6 +467,46 @@ namespace System.Tests
             }
             Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), provider));
             Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), provider));
+        }
+
+        public static IEnumerable<object[]> ToString_Roundtrip_TestData()
+        {
+            yield return new object[] { "0" };
+            yield return new object[] { "-0" };
+            yield return new object[] { "0.00" };
+            yield return new object[] { "0e2" };
+            yield return new object[] { "0e6111" };
+            yield return new object[] { "0e-6176" };
+            yield return new object[] { "-0e-6176" };
+            yield return new object[] { "1" };
+            yield return new object[] { "1.0" };
+            yield return new object[] { "1." + new string('0', 33) };
+            yield return new object[] { "1e7" };
+            yield return new object[] { "10e6" };
+            yield return new object[] { "1" + new string('0', 33) + "e1" };
+            yield return new object[] { "-4567.891" };
+            yield return new object[] { "0.0001" };
+            yield return new object[] { "0.00001" };
+            yield return new object[] { "0.000100" };
+            yield return new object[] { "170141183460469231731687303715884105728" };
+            yield return new object[] { new string('9', 34) + "e6111" };
+            yield return new object[] { "-" + new string('9', 34) + "e6111" };
+            yield return new object[] { "1e-6176" };
+            yield return new object[] { "1234567890123456789012345678901234e-6176" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_Roundtrip_TestData))]
+        public static void ToString_Roundtrips_And_PreservesQuantum(string value)
+        {
+            Decimal128 expected = Decimal128.Parse(value, CultureInfo.InvariantCulture);
+
+            foreach (string format in new[] { null, "G", "g", "R", "r" })
+            {
+                string formatted = expected.ToString(format, CultureInfo.InvariantCulture);
+                Decimal128 actual = Decimal128.Parse(formatted, CultureInfo.InvariantCulture);
+                Assert.Equal(Decimal128.EncodeDecimal(expected), Decimal128.EncodeDecimal(actual));
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
@@ -392,6 +392,16 @@ namespace System.Tests
             {
                 yield return new object[] { Decimal128.Parse("-0"), "G", defaultFormat, "-0" };
                 yield return new object[] { Decimal128.NegativeZero, "G", defaultFormat, "-0" };
+
+                // A signed zero is a distinct IEEE value, so the sign survives every specifier, as it does for double
+                yield return new object[] { Decimal128.NegativeZero, "E2", defaultFormat, "-0.00E+000" };
+                yield return new object[] { Decimal128.NegativeZero, "F2", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal128.NegativeZero, "N2", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal128.NegativeZero, "P0", defaultFormat, "-0 %" };
+                yield return new object[] { Decimal128.NegativeZero, "C2", defaultFormat, "(\u00A40.00)" };
+                yield return new object[] { Decimal128.NegativeZero, "0.00", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal128.Parse("-0e2"), "F2", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal128.Parse("-0.001"), "F2", defaultFormat, "-0.00" };
                 yield return new object[] { Decimal128.Parse("-0.0000"), "G", defaultFormat, "-0.0000" };
                 yield return new object[] { Decimal128.Parse("0"), "G", defaultFormat, "0" };
                 yield return new object[] { Decimal128.Zero, "G", defaultFormat, "0" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
@@ -418,13 +418,21 @@ namespace System.Tests
                 yield return new object[] { Decimal128.MinValue, "G", defaultFormat, "-9." + new string('9', 33) + "E+6144" };
                 yield return new object[] { Decimal128.Epsilon, "G", defaultFormat, "1E-6176" };
 
-                // The general specifier honors a precision specifier, where-as the roundtrip specifier ignores it
+                // The general specifier honors a precision specifier, whereas the roundtrip specifier ignores it
                 yield return new object[] { Decimal128.Parse("1234"), "G3", defaultFormat, "1.23E+03" };
                 yield return new object[] { Decimal128.Parse("999"), "G2", defaultFormat, "1E+03" };
                 yield return new object[] { Decimal128.Parse("1." + new string('0', 33)), "G1", defaultFormat, "1" };
                 yield return new object[] { Decimal128.MaxValue, "G1", defaultFormat, "1E+6145" };
                 yield return new object[] { Decimal128.Parse("1234567890123456789012345678901234"), "R5", defaultFormat, "1234567890123456789012345678901234" };
                 yield return new object[] { Decimal128.Parse("1234567890123456789012345678901234"), "G5", defaultFormat, "1.2346E+33" };
+
+                // Rounding drops trailing coefficient digits without changing the quantum exponent
+                yield return new object[] { Decimal128.Parse("10.00000"), "G2", defaultFormat, "10" };
+                yield return new object[] { Decimal128.Parse("10.00000"), "G3", defaultFormat, "10" };
+                yield return new object[] { Decimal128.Parse("1000.400"), "G4", defaultFormat, "1000" };
+                yield return new object[] { Decimal128.Parse("1000.500"), "G3", defaultFormat, "1E+03" };
+                yield return new object[] { Decimal128.Parse("100.0"), "G2", defaultFormat, "1E+02" };
+                yield return new object[] { Decimal128.Parse("0.00012345"), "G2", defaultFormat, "0.00012" };
 
                 yield return new object[] { Decimal128.Parse("2468"), "N", defaultFormat, "2,468.00" };
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
@@ -462,7 +462,9 @@ namespace System.Tests
                 yield return new object[] { Decimal128.Parse("12.5"), "G2", defaultFormat, "12" };
                 yield return new object[] { Decimal128.Parse("1000.500"), "G4", defaultFormat, "1000" };
                 yield return new object[] { Decimal128.Parse("0.25"), "0.0", defaultFormat, "0.2" };
+                yield return new object[] { Decimal128.Parse("0.75"), "0.0", defaultFormat, "0.8" };
                 yield return new object[] { Decimal128.Parse("1.25"), "#.#", defaultFormat, "1.2" };
+                yield return new object[] { Decimal128.Parse("1.75"), "#.#", defaultFormat, "1.8" };
 
                 yield return new object[] { Decimal128.Parse("2468"), "N", defaultFormat, "2,468.00" };
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
@@ -444,6 +444,26 @@ namespace System.Tests
                 yield return new object[] { Decimal128.Parse("100.0"), "G2", defaultFormat, "1E+02" };
                 yield return new object[] { Decimal128.Parse("0.00012345"), "G2", defaultFormat, "0.00012" };
 
+                // Ties round to even, as IEEE 754 §5.12.1 requires of every conversion to a character
+                // sequence, including the custom formats where the binary types round away from zero
+                yield return new object[] { Decimal128.Parse("0.5"), "F0", defaultFormat, "0" };
+                yield return new object[] { Decimal128.Parse("1.5"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal128.Parse("2.5"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal128.Parse("3.5"), "F0", defaultFormat, "4" };
+                yield return new object[] { Decimal128.Parse("-0.5"), "F0", defaultFormat, "-0" };
+                yield return new object[] { Decimal128.Parse("-2.5"), "F0", defaultFormat, "-2" };
+                yield return new object[] { Decimal128.Parse("2.500"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal128.Parse("2.5001"), "F0", defaultFormat, "3" };
+                yield return new object[] { Decimal128.Parse("2.4999"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal128.Parse("0.25"), "F1", defaultFormat, "0.2" };
+                yield return new object[] { Decimal128.Parse("0.35"), "F1", defaultFormat, "0.4" };
+                yield return new object[] { Decimal128.Parse("1.25"), "E1", defaultFormat, "1.2E+000" };
+                yield return new object[] { Decimal128.Parse("12.5"), "N0", defaultFormat, "12" };
+                yield return new object[] { Decimal128.Parse("12.5"), "G2", defaultFormat, "12" };
+                yield return new object[] { Decimal128.Parse("1000.500"), "G4", defaultFormat, "1000" };
+                yield return new object[] { Decimal128.Parse("0.25"), "0.0", defaultFormat, "0.2" };
+                yield return new object[] { Decimal128.Parse("1.25"), "#.#", defaultFormat, "1.2" };
+
                 yield return new object[] { Decimal128.Parse("2468"), "N", defaultFormat, "2,468.00" };
 
                 yield return new object[] { Decimal128.Parse("2467"), "[#-##-#]", defaultFormat, "[2-46-7]" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal128Tests.cs
@@ -418,6 +418,14 @@ namespace System.Tests
                 yield return new object[] { Decimal128.MinValue, "G", defaultFormat, "-9." + new string('9', 33) + "E+6144" };
                 yield return new object[] { Decimal128.Epsilon, "G", defaultFormat, "1E-6176" };
 
+                // The general specifier honors a precision specifier, where-as the roundtrip specifier ignores it
+                yield return new object[] { Decimal128.Parse("1234"), "G3", defaultFormat, "1.23E+03" };
+                yield return new object[] { Decimal128.Parse("999"), "G2", defaultFormat, "1E+03" };
+                yield return new object[] { Decimal128.Parse("1." + new string('0', 33)), "G1", defaultFormat, "1" };
+                yield return new object[] { Decimal128.MaxValue, "G1", defaultFormat, "1E+6145" };
+                yield return new object[] { Decimal128.Parse("1234567890123456789012345678901234"), "R5", defaultFormat, "1234567890123456789012345678901234" };
+                yield return new object[] { Decimal128.Parse("1234567890123456789012345678901234"), "G5", defaultFormat, "1.2346E+33" };
+
                 yield return new object[] { Decimal128.Parse("2468"), "N", defaultFormat, "2,468.00" };
 
                 yield return new object[] { Decimal128.Parse("2467"), "[#-##-#]", defaultFormat, "[2-46-7]" };
@@ -507,6 +515,10 @@ namespace System.Tests
                 Decimal128 actual = Decimal128.Parse(formatted, CultureInfo.InvariantCulture);
                 Assert.Equal(Decimal128.EncodeDecimal(expected), Decimal128.EncodeDecimal(actual));
             }
+
+            // The roundtrip specifier ignores any precision specifier
+            Assert.Equal(expected.ToString("R", CultureInfo.InvariantCulture), expected.ToString("R1", CultureInfo.InvariantCulture));
+            Assert.Equal(expected.ToString("r", CultureInfo.InvariantCulture), expected.ToString("r5", CultureInfo.InvariantCulture));
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
@@ -444,6 +444,26 @@ namespace System.Tests
                 yield return new object[] { Decimal32.Parse("100.0"), "G2", defaultFormat, "1E+02" };
                 yield return new object[] { Decimal32.Parse("0.00012345"), "G2", defaultFormat, "0.00012" };
 
+                // Ties round to even, as IEEE 754 §5.12.1 requires of every conversion to a character
+                // sequence, including the custom formats where the binary types round away from zero
+                yield return new object[] { Decimal32.Parse("0.5"), "F0", defaultFormat, "0" };
+                yield return new object[] { Decimal32.Parse("1.5"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal32.Parse("2.5"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal32.Parse("3.5"), "F0", defaultFormat, "4" };
+                yield return new object[] { Decimal32.Parse("-0.5"), "F0", defaultFormat, "-0" };
+                yield return new object[] { Decimal32.Parse("-2.5"), "F0", defaultFormat, "-2" };
+                yield return new object[] { Decimal32.Parse("2.500"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal32.Parse("2.5001"), "F0", defaultFormat, "3" };
+                yield return new object[] { Decimal32.Parse("2.4999"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal32.Parse("0.25"), "F1", defaultFormat, "0.2" };
+                yield return new object[] { Decimal32.Parse("0.35"), "F1", defaultFormat, "0.4" };
+                yield return new object[] { Decimal32.Parse("1.25"), "E1", defaultFormat, "1.2E+000" };
+                yield return new object[] { Decimal32.Parse("12.5"), "N0", defaultFormat, "12" };
+                yield return new object[] { Decimal32.Parse("12.5"), "G2", defaultFormat, "12" };
+                yield return new object[] { Decimal32.Parse("1000.500"), "G4", defaultFormat, "1000" };
+                yield return new object[] { Decimal32.Parse("0.25"), "0.0", defaultFormat, "0.2" };
+                yield return new object[] { Decimal32.Parse("1.25"), "#.#", defaultFormat, "1.2" };
+
                 yield return new object[] { Decimal32.Parse("2468"), "N", defaultFormat, "2,468.00" };
 
                 yield return new object[] { Decimal32.Parse("2467"), "[#-##-#]", defaultFormat, "[2-46-7]" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
@@ -417,6 +417,15 @@ namespace System.Tests
                 yield return new object[] { Decimal32.MinValue, "G", defaultFormat, "-9.999999E+96" };
                 yield return new object[] { Decimal32.Epsilon, "G", defaultFormat, "1E-101" };
 
+                // The general specifier honors a precision specifier, where-as the roundtrip specifier ignores it
+                yield return new object[] { Decimal32.Parse("1234"), "G3", defaultFormat, "1.23E+03" };
+                yield return new object[] { Decimal32.Parse("999"), "G2", defaultFormat, "1E+03" };
+                yield return new object[] { Decimal32.Parse("1.000000"), "G1", defaultFormat, "1" };
+                yield return new object[] { Decimal32.Parse("1000000e1"), "G3", defaultFormat, "1E+07" };
+                yield return new object[] { Decimal32.MaxValue, "G1", defaultFormat, "1E+97" };
+                yield return new object[] { Decimal32.Parse("1234567"), "R5", defaultFormat, "1234567" };
+                yield return new object[] { Decimal32.Parse("1234567"), "G5", defaultFormat, "1.2346E+06" };
+
                 yield return new object[] { Decimal32.Parse("2468"), "N", defaultFormat, "2,468.00" };
 
                 yield return new object[] { Decimal32.Parse("2467"), "[#-##-#]", defaultFormat, "[2-46-7]" };
@@ -505,6 +514,10 @@ namespace System.Tests
                 Decimal32 actual = Decimal32.Parse(formatted, CultureInfo.InvariantCulture);
                 Assert.Equal(Decimal32.EncodeDecimal(expected), Decimal32.EncodeDecimal(actual));
             }
+
+            // The roundtrip specifier ignores any precision specifier
+            Assert.Equal(expected.ToString("R", CultureInfo.InvariantCulture), expected.ToString("R1", CultureInfo.InvariantCulture));
+            Assert.Equal(expected.ToString("r", CultureInfo.InvariantCulture), expected.ToString("r5", CultureInfo.InvariantCulture));
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
@@ -417,7 +417,7 @@ namespace System.Tests
                 yield return new object[] { Decimal32.MinValue, "G", defaultFormat, "-9.999999E+96" };
                 yield return new object[] { Decimal32.Epsilon, "G", defaultFormat, "1E-101" };
 
-                // The general specifier honors a precision specifier, where-as the roundtrip specifier ignores it
+                // The general specifier honors a precision specifier, whereas the roundtrip specifier ignores it
                 yield return new object[] { Decimal32.Parse("1234"), "G3", defaultFormat, "1.23E+03" };
                 yield return new object[] { Decimal32.Parse("999"), "G2", defaultFormat, "1E+03" };
                 yield return new object[] { Decimal32.Parse("1.000000"), "G1", defaultFormat, "1" };
@@ -425,6 +425,14 @@ namespace System.Tests
                 yield return new object[] { Decimal32.MaxValue, "G1", defaultFormat, "1E+97" };
                 yield return new object[] { Decimal32.Parse("1234567"), "R5", defaultFormat, "1234567" };
                 yield return new object[] { Decimal32.Parse("1234567"), "G5", defaultFormat, "1.2346E+06" };
+
+                // Rounding drops trailing coefficient digits without changing the quantum exponent
+                yield return new object[] { Decimal32.Parse("10.00000"), "G2", defaultFormat, "10" };
+                yield return new object[] { Decimal32.Parse("10.00000"), "G3", defaultFormat, "10" };
+                yield return new object[] { Decimal32.Parse("1000.400"), "G4", defaultFormat, "1000" };
+                yield return new object[] { Decimal32.Parse("1000.500"), "G3", defaultFormat, "1E+03" };
+                yield return new object[] { Decimal32.Parse("100.0"), "G2", defaultFormat, "1E+02" };
+                yield return new object[] { Decimal32.Parse("0.00012345"), "G2", defaultFormat, "0.00012" };
 
                 yield return new object[] { Decimal32.Parse("2468"), "N", defaultFormat, "2,468.00" };
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
@@ -462,7 +462,9 @@ namespace System.Tests
                 yield return new object[] { Decimal32.Parse("12.5"), "G2", defaultFormat, "12" };
                 yield return new object[] { Decimal32.Parse("1000.500"), "G4", defaultFormat, "1000" };
                 yield return new object[] { Decimal32.Parse("0.25"), "0.0", defaultFormat, "0.2" };
+                yield return new object[] { Decimal32.Parse("0.75"), "0.0", defaultFormat, "0.8" };
                 yield return new object[] { Decimal32.Parse("1.25"), "#.#", defaultFormat, "1.2" };
+                yield return new object[] { Decimal32.Parse("1.75"), "#.#", defaultFormat, "1.8" };
 
                 yield return new object[] { Decimal32.Parse("2468"), "N", defaultFormat, "2,468.00" };
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
@@ -389,6 +389,16 @@ namespace System.Tests
             {
                 yield return new object[] { Decimal32.Parse("-0"), "G", defaultFormat, "-0" };
                 yield return new object[] { Decimal32.NegativeZero, "G", defaultFormat, "-0" };
+
+                // A signed zero is a distinct IEEE value, so the sign survives every specifier, as it does for double
+                yield return new object[] { Decimal32.NegativeZero, "E2", defaultFormat, "-0.00E+000" };
+                yield return new object[] { Decimal32.NegativeZero, "F2", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal32.NegativeZero, "N2", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal32.NegativeZero, "P0", defaultFormat, "-0 %" };
+                yield return new object[] { Decimal32.NegativeZero, "C2", defaultFormat, "(\u00A40.00)" };
+                yield return new object[] { Decimal32.NegativeZero, "0.00", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal32.Parse("-0e2"), "F2", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal32.Parse("-0.001"), "F2", defaultFormat, "-0.00" };
                 yield return new object[] { Decimal32.Parse("-0.0000"), "G", defaultFormat, "-0.0000" };
                 yield return new object[] { Decimal32.Parse("0"), "G", defaultFormat, "0" };
                 yield return new object[] { Decimal32.Zero, "G", defaultFormat, "0" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal32Tests.cs
@@ -116,13 +116,13 @@ namespace System.Tests
         public static IEnumerable<object[]> Parse_Preserve_TrailingZero_TestData()
         {
             yield return new object[] { "0.00", "0.00" };
-            yield return new object[] { "0." + new string('0', 101), "0." + new string('0', 101) };
-            yield return new object[] { "0." + new string('0', 1000), "0." + new string('0', 101) };
-            yield return new object[] { "0." + new string('0', 1000) + "1234567", "0." + new string('0', 101) };
+            yield return new object[] { "0." + new string('0', 101), "0E-101" };
+            yield return new object[] { "0." + new string('0', 1000), "0E-101" };
+            yield return new object[] { "0." + new string('0', 1000) + "1234567", "0E-101" };
             yield return new object[] { "0e-2", "0.00" };
-            yield return new object[] { "0e-101", "0." + new string('0', 101) };
-            yield return new object[] { "0e-1000", "0." + new string('0', 101) };
-            yield return new object[] { "0.123e-1000", "0." + new string('0', 101) };
+            yield return new object[] { "0e-101", "0E-101" };
+            yield return new object[] { "0e-1000", "0E-101" };
+            yield return new object[] { "0.123e-1000", "0E-101" };
         }
 
         public static IEnumerable<object[]> Parse_Invalid_TestData()
@@ -393,27 +393,41 @@ namespace System.Tests
                 yield return new object[] { Decimal32.Parse("0"), "G", defaultFormat, "0" };
                 yield return new object[] { Decimal32.Zero, "G", defaultFormat, "0" };
                 yield return new object[] { Decimal32.Parse("0.0000"), "G", defaultFormat, "0.0000" };
-                yield return new object[] { Decimal32.Parse($"{int.MinValue}"), "G", defaultFormat, "-2147484000" };
-                yield return new object[] { Decimal32.Parse($"{int.MaxValue}"), "G", defaultFormat, "2147484000" };
-                yield return new object[] { Decimal32.Parse("3" + new string('0', 96)), "G", defaultFormat, "3" + new string('0', 96) };
-                yield return new object[] { Decimal32.Parse("-3" + new string('0', 96)), "G", defaultFormat, "-3" + new string('0', 96) };
+                yield return new object[] { Decimal32.Parse($"{int.MinValue}"), "G", defaultFormat, "-2.147484E+09" };
+                yield return new object[] { Decimal32.Parse($"{int.MaxValue}"), "G", defaultFormat, "2.147484E+09" };
+                yield return new object[] { Decimal32.Parse("3" + new string('0', 96)), "G", defaultFormat, "3.000000E+96" };
+                yield return new object[] { Decimal32.Parse("-3" + new string('0', 96)), "G", defaultFormat, "-3.000000E+96" };
                 yield return new object[] { Decimal32.Parse("-4567"), "G", defaultFormat, "-4567" };
                 yield return new object[] { Decimal32.Parse("-4567.891"), "G", defaultFormat, "-4567.891" };
                 yield return new object[] { Decimal32.Parse("0"), "G", defaultFormat, "0" };
                 yield return new object[] { Decimal32.Parse("4567"), "G", defaultFormat, "4567" };
                 yield return new object[] { Decimal32.Parse("4567.891"), "G", defaultFormat, "4567.891" };
 
+                // A positive quantum exponent has no fixed-point spelling, so scientific notation is required
+                yield return new object[] { Decimal32.Parse("1e7"), "G", defaultFormat, "1E+07" };
+                yield return new object[] { Decimal32.Parse("10e6"), "G", defaultFormat, "1.0E+07" };
+                yield return new object[] { Decimal32.Parse("1000000e1"), "G", defaultFormat, "1.000000E+07" };
+                yield return new object[] { Decimal32.Parse("10000000"), "G", defaultFormat, "1.000000E+07" };
+                yield return new object[] { Decimal32.Parse("0e2"), "G", defaultFormat, "0E+02" };
+                yield return new object[] { Decimal32.Parse("-0e2"), "G", defaultFormat, "-0E+02" };
+                yield return new object[] { Decimal32.Parse("0.0001"), "G", defaultFormat, "0.0001" };
+                yield return new object[] { Decimal32.Parse("0.00001"), "G", defaultFormat, "1E-05" };
+                yield return new object[] { Decimal32.Parse("0.000100"), "G", defaultFormat, "0.000100" };
+                yield return new object[] { Decimal32.MaxValue, "G", defaultFormat, "9.999999E+96" };
+                yield return new object[] { Decimal32.MinValue, "G", defaultFormat, "-9.999999E+96" };
+                yield return new object[] { Decimal32.Epsilon, "G", defaultFormat, "1E-101" };
+
                 yield return new object[] { Decimal32.Parse("2468"), "N", defaultFormat, "2,468.00" };
 
                 yield return new object[] { Decimal32.Parse("2467"), "[#-##-#]", defaultFormat, "[2-46-7]" };
-                yield return new object[] { Decimal32.Parse("4e-102"), "G", defaultFormat, "0." + new string('0', 101) };
-                yield return new object[] { Decimal32.Parse("5e-102"), "G", defaultFormat, "0." + new string('0', 101) };
-                yield return new object[] { Decimal32.Parse("5.000000000000001e-102"), "G", defaultFormat, "0." + new string('0', 100) + "1" };
-                yield return new object[] { Decimal32.Parse("6e-102"), "G", defaultFormat, "0." + new string('0', 100) + "1" };
-                yield return new object[] { Decimal32.Parse("-4e-102"), "G", defaultFormat, "-0." + new string('0', 101) };
-                yield return new object[] { Decimal32.Parse("-5e-102"), "G", defaultFormat, "-0." + new string('0', 101) };
-                yield return new object[] { Decimal32.Parse("-5.000000000000001e-102"), "G", defaultFormat, "-0." + new string('0', 100) + "1" };
-                yield return new object[] { Decimal32.Parse("-6e-102"), "G", defaultFormat, "-0." + new string('0', 100) + "1" };
+                yield return new object[] { Decimal32.Parse("4e-102"), "G", defaultFormat, "0E-101" };
+                yield return new object[] { Decimal32.Parse("5e-102"), "G", defaultFormat, "0E-101" };
+                yield return new object[] { Decimal32.Parse("5.000000000000001e-102"), "G", defaultFormat, "1E-101" };
+                yield return new object[] { Decimal32.Parse("6e-102"), "G", defaultFormat, "1E-101" };
+                yield return new object[] { Decimal32.Parse("-4e-102"), "G", defaultFormat, "-0E-101" };
+                yield return new object[] { Decimal32.Parse("-5e-102"), "G", defaultFormat, "-0E-101" };
+                yield return new object[] { Decimal32.Parse("-5.000000000000001e-102"), "G", defaultFormat, "-1E-101" };
+                yield return new object[] { Decimal32.Parse("-6e-102"), "G", defaultFormat, "-1E-101" };
 
             }
         }
@@ -451,6 +465,46 @@ namespace System.Tests
             }
             Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), provider));
             Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), provider));
+        }
+
+        public static IEnumerable<object[]> ToString_Roundtrip_TestData()
+        {
+            yield return new object[] { "0" };
+            yield return new object[] { "-0" };
+            yield return new object[] { "0.00" };
+            yield return new object[] { "0e2" };
+            yield return new object[] { "0e90" };
+            yield return new object[] { "0e-101" };
+            yield return new object[] { "-0e-101" };
+            yield return new object[] { "1" };
+            yield return new object[] { "1.0" };
+            yield return new object[] { "1.000000" };
+            yield return new object[] { "1e7" };
+            yield return new object[] { "10e6" };
+            yield return new object[] { "1000000e1" };
+            yield return new object[] { "-4567.891" };
+            yield return new object[] { "0.0001" };
+            yield return new object[] { "0.00001" };
+            yield return new object[] { "0.000100" };
+            yield return new object[] { "2147483648" };
+            yield return new object[] { "9999999e90" };
+            yield return new object[] { "-9999999e90" };
+            yield return new object[] { "1e-101" };
+            yield return new object[] { "1234567e-101" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_Roundtrip_TestData))]
+        public static void ToString_Roundtrips_And_PreservesQuantum(string value)
+        {
+            Decimal32 expected = Decimal32.Parse(value, CultureInfo.InvariantCulture);
+
+            foreach (string format in new[] { null, "G", "g", "R", "r" })
+            {
+                string formatted = expected.ToString(format, CultureInfo.InvariantCulture);
+                Decimal32 actual = Decimal32.Parse(formatted, CultureInfo.InvariantCulture);
+                Assert.Equal(Decimal32.EncodeDecimal(expected), Decimal32.EncodeDecimal(actual));
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
@@ -421,13 +421,21 @@ namespace System.Tests
                 yield return new object[] { Decimal64.MinValue, "G", defaultFormat, "-9.999999999999999E+384" };
                 yield return new object[] { Decimal64.Epsilon, "G", defaultFormat, "1E-398" };
 
-                // The general specifier honors a precision specifier, where-as the roundtrip specifier ignores it
+                // The general specifier honors a precision specifier, whereas the roundtrip specifier ignores it
                 yield return new object[] { Decimal64.Parse("1234"), "G3", defaultFormat, "1.23E+03" };
                 yield return new object[] { Decimal64.Parse("999"), "G2", defaultFormat, "1E+03" };
                 yield return new object[] { Decimal64.Parse("1.000000000000000"), "G1", defaultFormat, "1" };
                 yield return new object[] { Decimal64.MaxValue, "G1", defaultFormat, "1E+385" };
                 yield return new object[] { Decimal64.Parse("1234567890123456"), "R5", defaultFormat, "1234567890123456" };
                 yield return new object[] { Decimal64.Parse("1234567890123456"), "G5", defaultFormat, "1.2346E+15" };
+
+                // Rounding drops trailing coefficient digits without changing the quantum exponent
+                yield return new object[] { Decimal64.Parse("10.00000"), "G2", defaultFormat, "10" };
+                yield return new object[] { Decimal64.Parse("10.00000"), "G3", defaultFormat, "10" };
+                yield return new object[] { Decimal64.Parse("1000.400"), "G4", defaultFormat, "1000" };
+                yield return new object[] { Decimal64.Parse("1000.500"), "G3", defaultFormat, "1E+03" };
+                yield return new object[] { Decimal64.Parse("100.0"), "G2", defaultFormat, "1E+02" };
+                yield return new object[] { Decimal64.Parse("0.00012345"), "G2", defaultFormat, "0.00012" };
 
                 yield return new object[] { Decimal64.Parse("2468e0"), "N", defaultFormat, "2,468.00" };
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
@@ -421,6 +421,14 @@ namespace System.Tests
                 yield return new object[] { Decimal64.MinValue, "G", defaultFormat, "-9.999999999999999E+384" };
                 yield return new object[] { Decimal64.Epsilon, "G", defaultFormat, "1E-398" };
 
+                // The general specifier honors a precision specifier, where-as the roundtrip specifier ignores it
+                yield return new object[] { Decimal64.Parse("1234"), "G3", defaultFormat, "1.23E+03" };
+                yield return new object[] { Decimal64.Parse("999"), "G2", defaultFormat, "1E+03" };
+                yield return new object[] { Decimal64.Parse("1.000000000000000"), "G1", defaultFormat, "1" };
+                yield return new object[] { Decimal64.MaxValue, "G1", defaultFormat, "1E+385" };
+                yield return new object[] { Decimal64.Parse("1234567890123456"), "R5", defaultFormat, "1234567890123456" };
+                yield return new object[] { Decimal64.Parse("1234567890123456"), "G5", defaultFormat, "1.2346E+15" };
+
                 yield return new object[] { Decimal64.Parse("2468e0"), "N", defaultFormat, "2,468.00" };
 
                 yield return new object[] { Decimal64.Parse("2467e0"), "[#-##-#]", defaultFormat, "[2-46-7]" };
@@ -509,6 +517,10 @@ namespace System.Tests
                 Decimal64 actual = Decimal64.Parse(formatted, CultureInfo.InvariantCulture);
                 Assert.Equal(Decimal64.EncodeDecimal(expected), Decimal64.EncodeDecimal(actual));
             }
+
+            // The roundtrip specifier ignores any precision specifier
+            Assert.Equal(expected.ToString("R", CultureInfo.InvariantCulture), expected.ToString("R1", CultureInfo.InvariantCulture));
+            Assert.Equal(expected.ToString("r", CultureInfo.InvariantCulture), expected.ToString("r5", CultureInfo.InvariantCulture));
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
@@ -465,7 +465,9 @@ namespace System.Tests
                 yield return new object[] { Decimal64.Parse("12.5"), "G2", defaultFormat, "12" };
                 yield return new object[] { Decimal64.Parse("1000.500"), "G4", defaultFormat, "1000" };
                 yield return new object[] { Decimal64.Parse("0.25"), "0.0", defaultFormat, "0.2" };
+                yield return new object[] { Decimal64.Parse("0.75"), "0.0", defaultFormat, "0.8" };
                 yield return new object[] { Decimal64.Parse("1.25"), "#.#", defaultFormat, "1.2" };
+                yield return new object[] { Decimal64.Parse("1.75"), "#.#", defaultFormat, "1.8" };
 
                 yield return new object[] { Decimal64.Parse("2468e0"), "N", defaultFormat, "2,468.00" };
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
@@ -395,6 +395,16 @@ namespace System.Tests
             {
                 yield return new object[] { Decimal64.Parse("-0"), "G", defaultFormat, "-0" };
                 yield return new object[] { Decimal64.NegativeZero, "G", defaultFormat, "-0" };
+
+                // A signed zero is a distinct IEEE value, so the sign survives every specifier, as it does for double
+                yield return new object[] { Decimal64.NegativeZero, "E2", defaultFormat, "-0.00E+000" };
+                yield return new object[] { Decimal64.NegativeZero, "F2", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal64.NegativeZero, "N2", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal64.NegativeZero, "P0", defaultFormat, "-0 %" };
+                yield return new object[] { Decimal64.NegativeZero, "C2", defaultFormat, "(\u00A40.00)" };
+                yield return new object[] { Decimal64.NegativeZero, "0.00", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal64.Parse("-0e2"), "F2", defaultFormat, "-0.00" };
+                yield return new object[] { Decimal64.Parse("-0.001"), "F2", defaultFormat, "-0.00" };
                 yield return new object[] { Decimal64.Parse("-0.0000"), "G", defaultFormat, "-0.0000" };
                 yield return new object[] { Decimal64.Parse("0"), "G", defaultFormat, "0" };
                 yield return new object[] { Decimal64.Zero, "G", defaultFormat, "0" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
@@ -447,6 +447,26 @@ namespace System.Tests
                 yield return new object[] { Decimal64.Parse("100.0"), "G2", defaultFormat, "1E+02" };
                 yield return new object[] { Decimal64.Parse("0.00012345"), "G2", defaultFormat, "0.00012" };
 
+                // Ties round to even, as IEEE 754 §5.12.1 requires of every conversion to a character
+                // sequence, including the custom formats where the binary types round away from zero
+                yield return new object[] { Decimal64.Parse("0.5"), "F0", defaultFormat, "0" };
+                yield return new object[] { Decimal64.Parse("1.5"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal64.Parse("2.5"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal64.Parse("3.5"), "F0", defaultFormat, "4" };
+                yield return new object[] { Decimal64.Parse("-0.5"), "F0", defaultFormat, "-0" };
+                yield return new object[] { Decimal64.Parse("-2.5"), "F0", defaultFormat, "-2" };
+                yield return new object[] { Decimal64.Parse("2.500"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal64.Parse("2.5001"), "F0", defaultFormat, "3" };
+                yield return new object[] { Decimal64.Parse("2.4999"), "F0", defaultFormat, "2" };
+                yield return new object[] { Decimal64.Parse("0.25"), "F1", defaultFormat, "0.2" };
+                yield return new object[] { Decimal64.Parse("0.35"), "F1", defaultFormat, "0.4" };
+                yield return new object[] { Decimal64.Parse("1.25"), "E1", defaultFormat, "1.2E+000" };
+                yield return new object[] { Decimal64.Parse("12.5"), "N0", defaultFormat, "12" };
+                yield return new object[] { Decimal64.Parse("12.5"), "G2", defaultFormat, "12" };
+                yield return new object[] { Decimal64.Parse("1000.500"), "G4", defaultFormat, "1000" };
+                yield return new object[] { Decimal64.Parse("0.25"), "0.0", defaultFormat, "0.2" };
+                yield return new object[] { Decimal64.Parse("1.25"), "#.#", defaultFormat, "1.2" };
+
                 yield return new object[] { Decimal64.Parse("2468e0"), "N", defaultFormat, "2,468.00" };
 
                 yield return new object[] { Decimal64.Parse("2467e0"), "[#-##-#]", defaultFormat, "[2-46-7]" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Decimal64Tests.cs
@@ -117,13 +117,13 @@ namespace System.Tests
         public static IEnumerable<object[]> Parse_Preserve_TrailingZero_TestData()
         {
             yield return new object[] { "0.00", "0.00" };
-            yield return new object[] { "0." + new string('0', 398), "0." + new string('0', 398) };
-            yield return new object[] { "0." + new string('0', 1000), "0." + new string('0', 398) };
-            yield return new object[] { "0." + new string('0', 1000) + "1234567", "0." + new string('0', 398) };
+            yield return new object[] { "0." + new string('0', 398), "0E-398" };
+            yield return new object[] { "0." + new string('0', 1000), "0E-398" };
+            yield return new object[] { "0." + new string('0', 1000) + "1234567", "0E-398" };
             yield return new object[] { "0e-2", "0.00" };
-            yield return new object[] { "0e-398", "0." + new string('0', 398) };
-            yield return new object[] { "0e-10000", "0." + new string('0', 398) };
-            yield return new object[] { "0.123e-10000", "0." + new string('0', 398) };
+            yield return new object[] { "0e-398", "0E-398" };
+            yield return new object[] { "0e-10000", "0E-398" };
+            yield return new object[] { "0.123e-10000", "0E-398" };
         }
 
         public static IEnumerable<object[]> Parse_Invalid_TestData()
@@ -399,27 +399,39 @@ namespace System.Tests
                 yield return new object[] { Decimal64.Parse("0"), "G", defaultFormat, "0" };
                 yield return new object[] { Decimal64.Zero, "G", defaultFormat, "0" };
                 yield return new object[] { Decimal64.Parse("0.0000"), "G", defaultFormat, "0.0000" };
-                yield return new object[] { Decimal64.Parse($"{long.MinValue}"), "G", defaultFormat, "-9223372036854776000" };
-                yield return new object[] { Decimal64.Parse($"{long.MaxValue}"), "G", defaultFormat, "9223372036854776000" };
-                yield return new object[] { Decimal64.Parse("3e384"), "G", defaultFormat, "3" + new string('0', 384) };
-                yield return new object[] { Decimal64.Parse("-3e384"), "G", defaultFormat, "-3" + new string('0', 384) };
+                yield return new object[] { Decimal64.Parse($"{long.MinValue}"), "G", defaultFormat, "-9.223372036854776E+18" };
+                yield return new object[] { Decimal64.Parse($"{long.MaxValue}"), "G", defaultFormat, "9.223372036854776E+18" };
+                yield return new object[] { Decimal64.Parse("3e384"), "G", defaultFormat, "3." + new string('0', 15) + "E+384" };
+                yield return new object[] { Decimal64.Parse("-3e384"), "G", defaultFormat, "-3." + new string('0', 15) + "E+384" };
                 yield return new object[] { Decimal64.Parse("-4567e0"), "G", defaultFormat, "-4567" };
                 yield return new object[] { Decimal64.Parse("-4567891e-3"), "G", defaultFormat, "-4567.891" };
                 yield return new object[] { Decimal64.Parse("0e0"), "G", defaultFormat, "0" };
                 yield return new object[] { Decimal64.Parse("4567e0"), "G", defaultFormat, "4567" };
                 yield return new object[] { Decimal64.Parse("4567891e-3"), "G", defaultFormat, "4567.891" };
 
+                // A positive quantum exponent has no fixed-point spelling, so scientific notation is required
+                yield return new object[] { Decimal64.Parse("1e7"), "G", defaultFormat, "1E+07" };
+                yield return new object[] { Decimal64.Parse("10e6"), "G", defaultFormat, "1.0E+07" };
+                yield return new object[] { Decimal64.Parse("0e2"), "G", defaultFormat, "0E+02" };
+                yield return new object[] { Decimal64.Parse("-0e2"), "G", defaultFormat, "-0E+02" };
+                yield return new object[] { Decimal64.Parse("0.0001"), "G", defaultFormat, "0.0001" };
+                yield return new object[] { Decimal64.Parse("0.00001"), "G", defaultFormat, "1E-05" };
+                yield return new object[] { Decimal64.Parse("0.000100"), "G", defaultFormat, "0.000100" };
+                yield return new object[] { Decimal64.MaxValue, "G", defaultFormat, "9.999999999999999E+384" };
+                yield return new object[] { Decimal64.MinValue, "G", defaultFormat, "-9.999999999999999E+384" };
+                yield return new object[] { Decimal64.Epsilon, "G", defaultFormat, "1E-398" };
+
                 yield return new object[] { Decimal64.Parse("2468e0"), "N", defaultFormat, "2,468.00" };
 
                 yield return new object[] { Decimal64.Parse("2467e0"), "[#-##-#]", defaultFormat, "[2-46-7]" };
-                yield return new object[] { Decimal64.Parse("4e-399"), "G", defaultFormat, "0." + new string('0', 398) };
-                yield return new object[] { Decimal64.Parse("5e-399"), "G", defaultFormat, "0." + new string('0', 398) };
-                yield return new object[] { Decimal64.Parse("5.00000000000000000000000001e-399"), "G", defaultFormat, "0." + new string('0', 397) + "1" };
-                yield return new object[] { Decimal64.Parse("6e-399"), "G", defaultFormat, "0." + new string('0', 397) + "1" };
-                yield return new object[] { Decimal64.Parse("-4e-399"), "G", defaultFormat, "-0." + new string('0', 398) };
-                yield return new object[] { Decimal64.Parse("-5e-399"), "G", defaultFormat, "-0." + new string('0', 398) };
-                yield return new object[] { Decimal64.Parse("-5.00000000000000000000000001e-399"), "G", defaultFormat, "-0." + new string('0', 397) + "1" };
-                yield return new object[] { Decimal64.Parse("-6e-399"), "G", defaultFormat, "-0." + new string('0', 397) + "1" };
+                yield return new object[] { Decimal64.Parse("4e-399"), "G", defaultFormat, "0E-398" };
+                yield return new object[] { Decimal64.Parse("5e-399"), "G", defaultFormat, "0E-398" };
+                yield return new object[] { Decimal64.Parse("5.00000000000000000000000001e-399"), "G", defaultFormat, "1E-398" };
+                yield return new object[] { Decimal64.Parse("6e-399"), "G", defaultFormat, "1E-398" };
+                yield return new object[] { Decimal64.Parse("-4e-399"), "G", defaultFormat, "-0E-398" };
+                yield return new object[] { Decimal64.Parse("-5e-399"), "G", defaultFormat, "-0E-398" };
+                yield return new object[] { Decimal64.Parse("-5.00000000000000000000000001e-399"), "G", defaultFormat, "-1E-398" };
+                yield return new object[] { Decimal64.Parse("-6e-399"), "G", defaultFormat, "-1E-398" };
 
             }
         }
@@ -457,6 +469,46 @@ namespace System.Tests
             }
             Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), provider));
             Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), provider));
+        }
+
+        public static IEnumerable<object[]> ToString_Roundtrip_TestData()
+        {
+            yield return new object[] { "0" };
+            yield return new object[] { "-0" };
+            yield return new object[] { "0.00" };
+            yield return new object[] { "0e2" };
+            yield return new object[] { "0e369" };
+            yield return new object[] { "0e-398" };
+            yield return new object[] { "-0e-398" };
+            yield return new object[] { "1" };
+            yield return new object[] { "1.0" };
+            yield return new object[] { "1.000000000000000" };
+            yield return new object[] { "1e7" };
+            yield return new object[] { "10e6" };
+            yield return new object[] { "1000000000000000e1" };
+            yield return new object[] { "-4567.891" };
+            yield return new object[] { "0.0001" };
+            yield return new object[] { "0.00001" };
+            yield return new object[] { "0.000100" };
+            yield return new object[] { "9223372036854775808" };
+            yield return new object[] { "9999999999999999e369" };
+            yield return new object[] { "-9999999999999999e369" };
+            yield return new object[] { "1e-398" };
+            yield return new object[] { "1234567890123456e-398" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_Roundtrip_TestData))]
+        public static void ToString_Roundtrips_And_PreservesQuantum(string value)
+        {
+            Decimal64 expected = Decimal64.Parse(value, CultureInfo.InvariantCulture);
+
+            foreach (string format in new[] { null, "G", "g", "R", "r" })
+            {
+                string formatted = expected.ToString(format, CultureInfo.InvariantCulture);
+                Decimal64 actual = Decimal64.Parse(formatted, CultureInfo.InvariantCulture);
+                Assert.Equal(Decimal64.EncodeDecimal(expected), Decimal64.EncodeDecimal(actual));
+            }
         }
 
         [Theory]


### PR DESCRIPTION
`ToString` for `Decimal32`, `Decimal64`, and `Decimal128` was not producing roundtrippable results and did not preserve the cohort.

The `G`/`R` path went through `FormatGeneral(..., suppressScientific: true)`, which unconditionally emits fixed-point. A **positive** quantum exponent has no fixed-point spelling, so the result reparsed as a different member of the cohort:

| value | old | reparses as | new |
| --- | --- | --- | --- |
| `1e7` | `10000000` | `1000000e1` (doesn't fit in 7 digits) | `1E+07` |
| `10e6` | `10000000` | `1000000e1` | `1.0E+07` |
| `0e2` | `0` | `0e0` | `0E+02` |
| `Decimal32.MaxValue` | `9999999` + 90 zeros | truncated | `9.999999E+96` |

Zeros were worse -- `DecimalIeee754ToNumber` clamped `number.Scale` to `0` for a zero coefficient, so a positive quantum was discarded outright and `0e2` was indistinguishable from `0`.

`FormatGeneralAndRoundTripDecimalIeee754` now emits scientific notation when it is *required* (quantum exponent `> 0`) or when it is *more compact* (adjusted exponent `< -4`). The latter is exactly the existing `G` heuristic for the binary floating-point types (`digPos > nMaxDigits || digPos < -3`), and the exponent goes through the shared `FormatExponent` with `minDigits: 2` and an explicit sign, so the output is stylistically identical to `double`/`float`/`Half`. IEEE 754 §5.12.2 constrains the syntax and requires the roundtrip to recover the quantum, but says nothing about padding -- that part is purely a .NET consistency call.

Two smaller fixes ride along, both needed for the above to be correct:

- `DecimalIeee754ToNumber` no longer clamps `Scale` for a zero coefficient. Every other consumer resets it -- `NumberToString`'s `F`/`N`/`E`/`P`/`C` cases all call `RoundNumber` first (which sets `Scale = 0` when `i == 0`), and `NumberToStringFormat` sets it explicitly in its `dig[0] == 0` branch.
- `R`/`r` now ignores a precision specifier and `G{n}` honors it via `RoundNumber`, matching `double`.

----------

`RoundNumber` strips trailing coefficient digits without adjusting `Scale`, so once a precision specifier has rounded the value, `Scale - DigitsCount` no longer reports the quantum exponent. `G2` on `10.00000` left the buffer as digits `1` / `Scale 2`, which the required-scientific test misread as a positive quantum:

| value | format | before | after | `double` |
| --- | --- | --- | --- | --- |
| `10.00000` | `G2` | `1E+01` | `10` | `10` |
| `1000.400` | `G4` | `1E+03` | `1000` | `1000` |
| `100.0` | `G2` | `1E+02` | `1E+02` | `1E+02` |

The test now compares against the requested precision when rounding occurred, and the fixed-point path recovers the dropped digits as trailing zeros. Thanks @vcsjones for catching this.

----------

The sign of zero was being dropped for every specifier other than `G`/`R`. These types shared `NumberBufferKind.Decimal` with `System.Decimal`, which has no concept of negative zero, so `RoundNumber` and `NumberToStringFormat` cleared `IsNegative` whenever the rounded result was zero. A signed zero is a distinct IEEE value -- `Decimal64.IsNegative(Decimal64.NegativeZero)` is `true` -- so the sign has to survive, exactly as it does for `double`:

| value | format | before | after | `double` |
| --- | --- | --- | --- | --- |
| `-0` | `E2` | `0.00E+000` | `-0.00E+000` | `-0.00E+000` |
| `-0` | `F2` | `0.00` | `-0.00` | `-0.00` |
| `-0` | `C2` | `¤0.00` | `(¤0.00)` | `(¤0.00)` |
| `-0` | `0.00` | `0.00` | `-0.00` | `-0.00` |
| `-0.001` | `F2` | `0.00` | `-0.00` | `-0.00` |

`G`/`R` were only correct by accident, because the rewrite above bypasses `RoundNumber` for a zero coefficient.

This needs a new `NumberBufferKind.DecimalIeee754`; neither existing kind works, and I confirmed both by building them:

- Reusing `FloatingPoint` for the format buffer flips `isCorrectlyRounded` to `true`, and `ShouldRoundUp` then returns `false` unconditionally, so `E`/`F`/`N`/`C`/`P` stop rounding altogether -- 438 divergences from `System.Decimal`, e.g. `0.999` `F0` gives `0` instead of `1`. `double`'s buffer arrives pre-rounded from Dragon4, where this is a no-op; the IEEE decimal buffer holds the raw coefficient and genuinely needs to round.
- Reusing `FloatingPoint` for the parse buffer discards the quantum of a zero, since only `Decimal` preserves `Scale` there -- `0e-101` parses back as `0`.

The requirement is a mix of the two, so the new kind is added and the three existing kinds keep byte-identical behavior; every changed condition in shared code only narrows.

----------

Ties were rounding half away from zero rather than to even. IEEE 754 §5.12.1 requires a conversion to a character sequence to be correctly rounded under the applicable rounding-direction attribute, which defaults to `roundTiesToEven`. This was inherited from `System.Decimal`, whose away-from-zero behavior is itself a back-compat concession -- the comment in `ShouldRoundUp` has said since .NET Core 3.0 that the spec dictates ties-to-even.

| value | format | before | after | `double` |
| --- | --- | --- | --- | --- |
| `0.5` | `F0` | `1` | `0` | `0` |
| `2.5` | `F0` | `3` | `2` | `2` |
| `2.500` | `F0` | `3` | `2` | `2` |
| `-2.5` | `F0` | `-3` | `-2` | `-2` |
| `1.25` | `E1` | `1.3E+000` | `1.2E+000` | `1.2E+000` |
| `12.5` | `G2` | `13` | `12` | `12` |

It also made `ToString` disagree with the rest of the same type: `Round`, `quantize`, parse, and every arithmetic operation were already ties-to-even, so `Decimal64.Round(0.25, 1)` gave `0.2` while `(0.25).ToString("F1")` gave `0.3`.

The `double` custom-format path rounds away from zero because it double-rounds the Dragon4 shortest digits, which is the hazard the existing comment describes. The `DecimalIeee754` buffer holds the exact coefficient, so a `5` followed only by zeros is a genuine tie and there is a single correct rounding -- these types are therefore ties-to-even for custom format strings too. That is a deliberate divergence from `double`, taken because these types are new in .NET 11 and carry no back-compat constraint.

----------

Validation beyond the added tests:

- Swept 1,006,382 sampled finite `Decimal32` encodings, 9,216 explicit (coefficient, quantum) pairs across the full exponent range, and 4,368 `Decimal64`/`Decimal128` values, asserting `EncodeDecimal(Parse(ToString(x))) == EncodeDecimal(x)` for `null`/`G`/`R`. Zero failures.
- Differential-tested `Decimal64` against `System.Decimal` across 30 specifiers (`E`/`F`/`N`/`P`/`C` and custom formats) and against `G{n}` rounding: 7,980 plus 749 comparisons, zero divergences other than the intended tie cases above, which `System.Decimal` rounds away from zero.
- Differential-tested tie behavior against `double` over values that are exact in both radices, across 18 specifiers. The only remaining differences are the deliberate custom-format divergence and cohort preservation (`(2.500).ToString("G4")` is `2.500`, not `2.5`).
- 425 checks across 5 cultures covering cohort roundtrip, `TryFormat` for char and UTF-8 at exact size, and correct `false` on every truncated destination.
- Confirmed arithmetic already honors the IEEE preferred exponent (`2.00 + 1.000` is `3.000`, `1.20 * 1.00` is `1.2000`, `Sqrt(1.00)` is `1.0`); `1e3 * 1e3` giving `1E+06` is only observable because of this fix.
- Confirmed hexadecimal-significand sequences are correctly rejected: all `Parse`/`TryParse` overloads route through `ValidateParseStyleDecimal`, and IEEE 754 §5.12.3 defines that form for binary formats only.

Every regression test was confirmed to fail against the unfixed code. Full `System.Runtime.Tests` passes (76,591 tests) and `System.Runtime.Numerics.Tests` passes (8,422 tests) -- the latter because `BigInteger` compiles the same shared parsing and formatting sources.

CC. @dotnet/area-system-numerics

> [!NOTE]
> This PR description was drafted by GitHub Copilot.
