### PR TITLE
Fix Tensor.ResizeTo

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -1637,10 +1637,11 @@ namespace System.Numerics.Tensors
 
         /// <summary>
         /// Copies the data from <paramref name="tensor"/>. If the final shape is smaller all data after that point is ignored.
-        /// If the final shape is bigger it is filled with 0s.
+        /// If the final shape is bigger it is filled with 0s (<code>default(T)</code>).
         /// </summary>
         /// <param name="tensor">Input <see cref="Tensor{T}"/>.</param>
         /// <param name="destination">Destination <see cref="TensorSpan{T}"/> with the desired new shape.</param>
+        /// <remarks>This method does works for incompatible shapes as both source and destination are reinterpreted as flattened.</remarks>
         public static void ResizeTo<T>(scoped in Tensor<T> tensor, in TensorSpan<T> destination)
         {
             ResizeTo(tensor.AsReadOnlyTensorSpan(), destination);
@@ -1648,10 +1649,11 @@ namespace System.Numerics.Tensors
 
         /// <summary>
         /// Copies the data from <paramref name="tensor"/>. If the final shape is smaller all data after that point is ignored.
-        /// If the final shape is bigger it is filled with 0s.
+        /// If the final shape is bigger it is filled with 0s (<code>default(T)</code>).
         /// </summary>
         /// <param name="tensor">Input <see cref="TensorSpan{T}"/>.</param>
         /// <param name="destination">Destination <see cref="TensorSpan{T}"/> with the desired new shape.</param>
+        /// <remarks>This method does works for incompatible shapes as both source and destination are reinterpreted as flattened.</remarks>
         public static void ResizeTo<T>(scoped in TensorSpan<T> tensor, in TensorSpan<T> destination)
         {
             ResizeTo(tensor.AsReadOnlyTensorSpan(), destination);
@@ -1659,10 +1661,11 @@ namespace System.Numerics.Tensors
 
         /// <summary>
         /// Copies the data from <paramref name="tensor"/>. If the final shape is smaller all data after that point is ignored.
-        /// If the final shape is bigger it is filled with 0s.
+        /// If the final shape is bigger it is filled with 0s (<code>default(T)</code>).
         /// </summary>
         /// <param name="tensor">Input <see cref="ReadOnlyTensorSpan{T}"/>.</param>
         /// <param name="destination">Destination <see cref="TensorSpan{T}"/> with the desired new shape.</param>
+        /// <remarks>This method does works for incompatible shapes as both source and destination are reinterpreted as flattened.</remarks>
         public static void ResizeTo<T>(scoped in ReadOnlyTensorSpan<T> tensor, in TensorSpan<T> destination)
         {
             if (tensor.IsDense && destination.IsDense)

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -1672,6 +1672,7 @@ namespace System.Numerics.Tensors
                 if (ospan.Length >= span.Length)
                 {
                     span.CopyTo(ospan);
+                    ospan.Slice(span.Length).Clear();
                 }
                 else
                 {
@@ -1690,6 +1691,19 @@ namespace System.Numerics.Tensors
                     bool dstMoved = dstEnumerator.MoveNext();
                     Debug.Assert(srcMoved && dstMoved);
                     dstEnumerator.Current = srcEnumerator.Current;
+                }
+
+                if (destination.IsDense)
+                {
+                    Span<T> ospan = MemoryMarshal.CreateSpan(ref destination._reference, (int)destination.FlattenedLength);
+                    ospan.Slice((int)copyLength).Clear();
+                }
+                else
+                {
+                    while (dstEnumerator.MoveNext())
+                    {
+                        dstEnumerator.Current = default!;
+                    }
                 }
             }
         }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
@@ -1113,7 +1113,7 @@ namespace System.Numerics.Tensors.Tests
             var src = new ReadOnlyTensorSpan<int>(data, shape, strides);
             Assert.False(src.IsDense);
 
-            // Resize to a larger dense destination
+            // Resize to a smaller dense destination
             nint srcFlatLen = src.FlattenedLength;
             int[] dstData = new int[(int)srcFlatLen - 1];
             Array.Fill(dstData, -1);

--- a/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
@@ -1081,7 +1081,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(NonDenseTensorData))]
-        public static void TensorResizeToNonDenseSourceTests(int[] data, nint[] shape, nint[] strides, int[] expectedLogical)
+        public static void TensorResizeToBigNonDenseSourceTests(int[] data, nint[] shape, nint[] strides, int[] expectedLogical)
         {
             var src = new ReadOnlyTensorSpan<int>(data, shape, strides);
             Assert.False(src.IsDense);
@@ -1089,6 +1089,7 @@ namespace System.Numerics.Tensors.Tests
             // Resize to a larger dense destination
             nint srcFlatLen = src.FlattenedLength;
             int[] dstData = new int[(int)srcFlatLen + 2];
+            Array.Fill(dstData, -1);
             var dst = new TensorSpan<int>(dstData, [(nint)dstData.Length], [1]);
             Assert.True(dst.IsDense);
 
@@ -1107,30 +1108,128 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(NonDenseTensorData))]
-        public static void TensorResizeToNonDenseDestinationTests(int[] data, nint[] shape, nint[] strides, int[] expectedLogical)
+        public static void TensorResizeToSmallNonDenseSourceTests(int[] data, nint[] shape, nint[] strides, int[] expectedLogical)
+        {
+            var src = new ReadOnlyTensorSpan<int>(data, shape, strides);
+            Assert.False(src.IsDense);
+
+            // Resize to a larger dense destination
+            nint srcFlatLen = src.FlattenedLength;
+            int[] dstData = new int[(int)srcFlatLen - 1];
+            Array.Fill(dstData, -1);
+            var dst = new TensorSpan<int>(dstData);
+            Assert.True(dst.IsDense);
+
+            Tensor.ResizeTo(src, dst);
+
+            for (int i = 0; i < dstData.Length; i++)
+            {
+                Assert.Equal(expectedLogical[i], dstData[i]);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NonDenseTensorData))]
+        public static void TensorResizeToBigNonDenseDestinationTests(int[] data, nint[] shape, nint[] strides, int[] expectedLogical)
         {
             // Create a dense source with known values
-            var src = new ReadOnlyTensorSpan<int>(expectedLogical, [(nint)expectedLogical.Length], [1]);
+            var srcData = expectedLogical.AsSpan().Slice(0, expectedLogical.Length - 1);
+            var src = new ReadOnlyTensorSpan<int>(srcData);
             Assert.True(src.IsDense);
 
             // Create a non-dense destination
             int[] dstData = new int[data.Length];
+            Array.Fill(dstData, -1);
             var dst = new TensorSpan<int>(dstData, shape, strides);
             Assert.False(dst.IsDense);
 
-            nint copyLength = Math.Min(src.FlattenedLength, dst.FlattenedLength);
             Tensor.ResizeTo(src, dst);
 
             // Verify logical elements were written correctly
             int logicalIdx = 0;
             foreach (int val in dst)
             {
-                if (logicalIdx < expectedLogical.Length)
+                if (logicalIdx < srcData.Length)
                 {
-                    Assert.Equal(expectedLogical[logicalIdx], val);
+                    Assert.Equal(srcData[logicalIdx], val);
+                }
+                else
+                {
+                    Assert.Equal(0, val);
                 }
                 logicalIdx++;
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(NonDenseTensorData))]
+        public static void TensorResizeToSmallNonDenseDestinationTests(int[] data, nint[] shape, nint[] strides, int[] expectedLogical)
+        {
+            // Create a dense source with known values
+            var srcData = new int[expectedLogical.Length + 1];
+            expectedLogical.CopyTo(srcData);
+            srcData[^1] = -2;
+            var src = new ReadOnlyTensorSpan<int>(srcData, [(nint)expectedLogical.Length + 1], [1]);
+            Assert.True(src.IsDense);
+
+            // Create a non-dense destination
+            int[] dstData = new int[data.Length];
+            Array.Fill(dstData, -1);
+            var dst = new TensorSpan<int>(dstData, shape, strides);
+            Assert.False(dst.IsDense);
+
+            Tensor.ResizeTo(src, dst);
+
+            // Verify logical elements were written correctly
+            int logicalIdx = 0;
+            foreach (int val in dst)
+            {
+                Assert.Equal(srcData[logicalIdx], val);
+                logicalIdx++;
+            }
+        }
+
+        [Fact]
+        public static void TensorResizeToDenseSmallDestinationTests()
+        {
+            // Create a dense source with known values
+            var srcData = new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            var src = new ReadOnlyTensorSpan<int>(srcData, [9]);
+            Assert.True(src.IsDense);
+
+            var dstData = new int[4];
+            var dst = new TensorSpan<int>(dstData, [2, 2]);
+            Assert.True(src.IsDense);
+
+            Tensor.ResizeTo(src, dst);
+
+            Assert.Equal(1, dstData[0]);
+            Assert.Equal(2, dstData[1]);
+            Assert.Equal(3, dstData[2]);
+            Assert.Equal(4, dstData[3]);
+        }
+
+        [Fact]
+        public static void TensorResizeToDenseBigDestinationTests()
+        {
+            // Create a dense source with known values
+            var srcData = new int[] { 1, 2, 3, 4 };
+            var src = new ReadOnlyTensorSpan<int>(srcData, [4]);
+            Assert.True(src.IsDense);
+
+            var dstData = new int[6];
+            Array.Fill(dstData, -1);
+            var dst = new TensorSpan<int>(dstData, [3, 2]);
+            Assert.True(src.IsDense);
+
+            Tensor.ResizeTo(src, dst);
+
+            Assert.Equal(1, dstData[0]);
+            Assert.Equal(2, dstData[1]);
+            Assert.Equal(3, dstData[2]);
+            Assert.Equal(4, dstData[3]);
+            Assert.Equal(0, dstData[4]);
+            Assert.Equal(0, dstData[5]);
         }
 
         [Fact]


### PR DESCRIPTION
- Clear destination that is "beyond" flattened length of source
- Add unit test coverage for ResizeTo for this and n general
- I try to clarify the behiour of ResizeTo with regards to shape (I guess the intent is to make it work a bit like [Pytorch's resize_](https://docs.pytorch.org/docs/2.13/generated/torch.Tensor.resize_.html))

But perhaps the implementation is correct and only the docs needs to be adjusted?