### PR TITLE
Feature-detect KMAC key size limits

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/KmacTestDriver.cs
+++ b/src/libraries/System.Security.Cryptography/tests/KmacTestDriver.cs
@@ -141,8 +141,33 @@ namespace System.Security.Cryptography.Tests
                 throw new SkipTestException(nameof(IsNotSupported));
         }
 
-        public static KeySizes? PlatformKeySizeRequirements { get; } =
-            PlatformDetection.IsOpenSslSupported && !PlatformDetection.IsSymCryptOpenSsl ? new KeySizes(4, 512, 1) : null;
+        private static KeySizes? DetectKeySizeLimits()
+        {
+            if (!IsSupported || !PlatformDetection.IsOpenSslSupported)
+            {
+                // Non-OpenSSL has no known key size limitations.
+                return null;
+            }
+
+            TKmac? kmac = null;
+
+            try
+            {
+                kmac = TKmacTrait.Create([], []);
+                return null; // If an empty key worked, then the OpenSSL provider has no known limits.
+            }
+            catch (CryptographicException)
+            {
+                // If an empty key did not work, the only other known key size limits are [4, 512].
+                return new KeySizes(4, 512, 1);
+            }
+            finally
+            {
+                kmac?.Dispose();
+            }
+        }
+
+        public static KeySizes? PlatformKeySizeRequirements { get; } = DetectKeySizeLimits();
 
         public static int? PlatformMaxOutputSize { get; } = PlatformDetection.IsOpenSslSupported ? 0xFFFFFF / 8 : null;
         public static int? PlatformMaxCustomizationStringSize { get; } = PlatformDetection.IsOpenSslSupported ? 512 : null;


### PR DESCRIPTION
KMAC on OpenSSL's default provider has key size limits, the key must be in the range of [4, 512]. Windows does not have this limit, and SymCrypt-OpenSSL does not have this limit, either.

Detecting the presence of which provider is the default is tricky; we can look for a provider's presence on the system, but which is active is not always clear, and sometimes one provider defers to another.

This changes our KMAC tests to do a check it see if can import a zero-length key to determine the key size limits, rather than trying to detect provider presence.

Contributes to #129939 