### PR TITLE
Update SetCredentialsAttributesW to match the native C API declaration

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -538,8 +538,8 @@ internal static partial class Interop
         [LibraryImport(Interop.Libraries.SspiCli, SetLastError = true)]
         internal static partial SECURITY_STATUS SetCredentialsAttributesW(
             in CredHandle handlePtr,
-            long ulAttribute,
+            uint ulAttribute,
             in SecPkgCred_ClientCertPolicy pBuffer,
-            long cbBuffer);
+            uint cbBuffer);
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -317,9 +317,9 @@ namespace System.Net.Security
                 clientCertPolicy.pwszSslCtlStoreName = ptr;
                 Interop.SECURITY_STATUS errorCode = Interop.SspiCli.SetCredentialsAttributesW(
                             cred._handle,
-                            (long)Interop.SspiCli.ContextAttribute.SECPKG_ATTR_CLIENT_CERT_POLICY,
+                            (uint)Interop.SspiCli.ContextAttribute.SECPKG_ATTR_CLIENT_CERT_POLICY,
                             clientCertPolicy,
-                            sizeof(Interop.SspiCli.SecPkgCred_ClientCertPolicy));
+                            (uint)sizeof(Interop.SspiCli.SecPkgCred_ClientCertPolicy));
 
                 if (errorCode != Interop.SECURITY_STATUS.OK)
                 {


### PR DESCRIPTION
Change the P/Invoke declaration for `SetCredentialsAttributesW` to use uint rather than long, since C unsigned long is 4 bytes on Windows.

Fix #131416