### PR TITLE
Ensure that x64 disassembly names operands at the size actually encoded

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -13222,6 +13222,20 @@ void emitter::emitDispIns(
                             break;
                         }
 
+                        case INS_vbroadcastf32x2:
+                        case INS_vbroadcasti32x2:
+                        case INS_vbroadcastsd:
+                        case INS_vbroadcastss:
+                        case INS_vpbroadcastb:
+                        case INS_vpbroadcastd:
+                        case INS_vpbroadcastq:
+                        case INS_vpbroadcastw:
+                        {
+                            // The source is the low element of a vector, so it is always xmm
+                            srcAttr = EA_16BYTE;
+                            break;
+                        }
+
                         default:
                             break;
                     }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12229,6 +12229,10 @@ void emitter::emitDispConstant(const instrDesc* id, bool skipComma) const
             case INS_roundps:
             case INS_roundsd:
             case INS_roundss:
+            case INS_vextractf32x4:
+            case INS_vextracti32x4:
+            case INS_vinsertf32x4:
+            case INS_vinserti32x4:
             {
                 // These instructions have pseudo-names, but still need to display the immediate
                 break;
@@ -12983,6 +12987,8 @@ void emitter::emitDispIns(
             {
                 switch (ins)
                 {
+                    case INS_movmskpd:
+                    case INS_movmskps:
                     case INS_pmovmskb:
                     {
                         assert(!id->idIsEvexAaaContextSet());

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12320,6 +12320,53 @@ void emitter::emitDispConstant(const instrDesc* id, bool skipComma) const
     emitDispCommentForHandle(cnsVal.cnsVal, id->idDebugOnlyInfo()->idMemCookie, id->idDebugOnlyInfo()->idFlags);
 }
 
+//------------------------------------------------------------------------
+// GetNarrowedDstAttr: Get the size to display for the destination of an
+// instruction that writes fewer bytes than it reads, such as the packed
+// double to single converts.
+//
+// Arguments:
+//    ins     - the instruction
+//    srcAttr - the size of the source operand
+//
+// Return Value:
+//    The size of the destination, or srcAttr when the two match.
+//
+static emitAttr GetNarrowedDstAttr(instruction ins, emitAttr srcAttr)
+{
+    switch (ins)
+    {
+        case INS_cvtpd2dq:
+        case INS_cvtpd2ps:
+        case INS_cvttpd2dq:
+        case INS_vcvtdq2ph:
+        case INS_vcvtneps2bf16:
+        case INS_vcvtpd2udq:
+        case INS_vcvtps2phx:
+        case INS_vcvtqq2ps:
+        case INS_vcvttpd2dqs:
+        case INS_vcvttpd2udq:
+        case INS_vcvttpd2udqs:
+        case INS_vcvtudq2ph:
+        case INS_vcvtuqq2ps:
+        {
+            return std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(srcAttr) / 2));
+        }
+
+        case INS_vcvtpd2ph:
+        case INS_vcvtqq2ph:
+        case INS_vcvtuqq2ph:
+        {
+            return std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(srcAttr) / 4));
+        }
+
+        default:
+        {
+            return srcAttr;
+        }
+    }
+}
+
 //--------------------------------------------------------------------
 // emitDispIns: Dump the given instruction to jitstdout.
 //
@@ -12557,6 +12604,10 @@ void emitter::emitDispIns(
                 // The idReg1 is always 4 bytes, but the size of idReg2 can vary.
                 // This logic ensures that we print `crc32 eax, bx` instead of `crc32 ax, bx`
                 attr = EA_4BYTE;
+            }
+            else
+            {
+                attr = GetNarrowedDstAttr(ins, attr);
             }
             printf("%s", emitRegName(id->idReg1(), attr));
             emitDispEmbMasking(id);
@@ -12831,6 +12882,10 @@ void emitter::emitDispIns(
                 // This logic ensures that we print `crc32 eax, bx` instead of `crc32 ax, bx`
                 attr = EA_4BYTE;
             }
+            else
+            {
+                attr = GetNarrowedDstAttr(ins, attr);
+            }
 
             printf("%s", emitRegName(id->idReg1(), attr));
             emitDispEmbMasking(id);
@@ -13091,6 +13146,8 @@ void emitter::emitDispIns(
 
                 default:
                 {
+                    tgtAttr = GetNarrowedDstAttr(ins, attr);
+
                     switch (ins)
                     {
                         case INS_cvtsi2ss32:
@@ -13100,6 +13157,24 @@ void emitter::emitDispIns(
                         {
                             assert(!id->idIsEvexAaaContextSet());
                             tgtAttr = EA_16BYTE;
+                            srcAttr = EA_ATTR(GetInputSizeInBytes(id));
+                            break;
+                        }
+
+                        case INS_movd32:
+                        case INS_movd64:
+                        {
+                            // Moves between a general purpose register and the low element of a vector
+                            if (isGeneralRegister(id->idReg1()))
+                            {
+                                tgtAttr = EA_ATTR(GetInputSizeInBytes(id));
+                                srcAttr = EA_16BYTE;
+                            }
+                            else
+                            {
+                                tgtAttr = EA_16BYTE;
+                                srcAttr = EA_ATTR(GetInputSizeInBytes(id));
+                            }
                             break;
                         }
 
@@ -13147,32 +13222,6 @@ void emitter::emitDispIns(
                             break;
                         }
 
-                        case INS_cvtpd2dq:
-                        case INS_cvtpd2ps:
-                        case INS_cvttpd2dq:
-                        case INS_vcvtdq2ph:
-                        case INS_vcvtneps2bf16:
-                        case INS_vcvtpd2udq:
-                        case INS_vcvtps2phx:
-                        case INS_vcvtqq2ps:
-                        case INS_vcvttpd2dqs:
-                        case INS_vcvttpd2udq:
-                        case INS_vcvttpd2udqs:
-                        case INS_vcvtudq2ph:
-                        case INS_vcvtuqq2ps:
-                        {
-                            tgtAttr = std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(attr) / 2));
-                            break;
-                        }
-
-                        case INS_vcvtpd2ph:
-                        case INS_vcvtqq2ph:
-                        case INS_vcvtuqq2ph:
-                        {
-                            tgtAttr = std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(attr) / 4));
-                            break;
-                        }
-
                         default:
                             break;
                     }
@@ -13206,16 +13255,45 @@ void emitter::emitDispIns(
                 std::swap(reg2, reg3);
             }
 
-            emitAttr attr3 = attr;
+            emitAttr attr12 = attr;
+            emitAttr attr3  = attr;
+
             if ((insTupleTypeInfo(ins) & INS_TT_MEM128) != 0)
             {
                 // Shift instructions take xmm for the 3rd operand regardless of instruction size.
                 attr3 = EA_16BYTE;
             }
+            else
+            {
+                switch (ins)
+                {
+                    case INS_cvtsi2sd32:
+                    case INS_cvtsi2sd64:
+                    case INS_cvtsi2ss32:
+                    case INS_cvtsi2ss64:
+                    case INS_vcvtsi2sh32:
+                    case INS_vcvtsi2sh64:
+                    case INS_vcvtusi2sd32:
+                    case INS_vcvtusi2sd64:
+                    case INS_vcvtusi2sh32:
+                    case INS_vcvtusi2sh64:
+                    case INS_vcvtusi2ss32:
+                    case INS_vcvtusi2ss64:
+                    {
+                        // The 3rd operand is the general purpose register being converted
+                        attr12 = EA_16BYTE;
+                        attr3  = EA_ATTR(GetInputSizeInBytes(id));
+                        break;
+                    }
 
-            printf("%s", emitRegName(id->idReg1(), attr));
+                    default:
+                        break;
+                }
+            }
+
+            printf("%s", emitRegName(id->idReg1(), attr12));
             emitDispEmbMasking(id);
-            printf(", %s, ", emitRegName(reg2, attr));
+            printf(", %s, ", emitRegName(reg2, attr12));
             printf("%s", emitRegName(reg3, attr3));
             emitDispEmbRounding(id);
             break;
@@ -13426,6 +13504,10 @@ void emitter::emitDispIns(
                 // The idReg1 is always 4 bytes, but the size of idReg2 can vary.
                 // This logic ensures that we print `crc32 eax, bx` instead of `crc32 ax, bx`
                 attr = EA_4BYTE;
+            }
+            else
+            {
+                attr = GetNarrowedDstAttr(ins, attr);
             }
             printf("%s", emitRegName(id->idReg1(), attr));
             emitDispEmbMasking(id);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12448,6 +12448,13 @@ void emitter::emitDispIns(
         }
     }
 
+    // A GC type implies a pointer-sized operand, but the emitter narrows the recorded size when it
+    // drops REX.W (`xor reg, reg`), so the registers must be named at the size actually encoded.
+    if (EA_SIZE(attr) != id->idOpSize())
+    {
+        attr = id->idOpSize();
+    }
+
     /* Now see what instruction format we've got */
 
     // First print the implicit register usage
@@ -12532,9 +12539,14 @@ void emitter::emitDispIns(
             }
             else
 #endif
-                if (ins == INS_movsx || ins == INS_movzx)
+                if (ins == INS_movsx)
             {
                 attr = EA_PTRSIZE;
+            }
+            else if (ins == INS_movzx)
+            {
+                // movzx never encodes REX.W; the 32-bit write already zeroes the upper bits
+                attr = EA_4BYTE;
             }
             else if ((ins == INS_crc32) && (attr != EA_8BYTE))
             {
@@ -12800,9 +12812,14 @@ void emitter::emitDispIns(
             }
             else
 #endif
-                if (ins == INS_movsx || ins == INS_movzx)
+                if (ins == INS_movsx)
             {
                 attr = EA_PTRSIZE;
+            }
+            else if (ins == INS_movzx)
+            {
+                // movzx never encodes REX.W; the 32-bit write already zeroes the upper bits
+                attr = EA_4BYTE;
             }
             else if ((ins == INS_crc32) && (attr != EA_8BYTE))
             {
@@ -12983,9 +13000,15 @@ void emitter::emitDispIns(
 #endif // TARGET_AMD64
 
                     case INS_movsx:
-                    case INS_movzx:
                     {
                         tgtAttr = EA_PTRSIZE;
+                        break;
+                    }
+
+                    case INS_movzx:
+                    {
+                        // movzx never encodes REX.W; the 32-bit write already zeroes the upper bits
+                        tgtAttr = EA_4BYTE;
                         break;
                     }
 
@@ -13377,9 +13400,14 @@ void emitter::emitDispIns(
         case IF_RWR_MRD:
         case IF_RRW_MRD:
         {
-            if (ins == INS_movsx || ins == INS_movzx)
+            if (ins == INS_movsx)
             {
                 attr = EA_PTRSIZE;
+            }
+            else if (ins == INS_movzx)
+            {
+                // movzx never encodes REX.W; the 32-bit write already zeroes the upper bits
+                attr = EA_4BYTE;
             }
 #ifdef TARGET_AMD64
             else if (ins == INS_movsxd)


### PR DESCRIPTION
The x64 disassembler prints some operands at a size that doesn't match the bytes it just encoded. This makes the printed text actively misleading -- `movzx rax, al` and `xor rax, rax` both suggest a 64-bit write where the encoder deliberately emitted a 32-bit one, and a dropped lane selector makes four different `vextracti32x4` instructions render identically.

Everything here is display-only, confined to `emitDispIns` and its helpers. Codegen is unchanged.

----------

**`movzx` printed a 64-bit destination.** `emitOutputRR` only adds `REX.W` when `(size == EA_8BYTE) || (ins == INS_movsx)`, and for `movzx` that `size` is the *source* width, so `REX.W` is never set; `TakesRexWPrefix` excludes it as well. `movsx` printing 64-bit is correct -- all 5,263 in CoreLib genuinely carry `REX.W` -- so the two are split rather than sharing a branch. 4 sites (ARD/SRD/RRD/MRD).

**GC-typed self-zeroing `xor` printed 64-bit.** `emitOutputRR` drops `REX.W` for `xor reg, reg` and records `id->idOpSize(EA_4BYTE)`, but `emitDispIns` derived `attr` from `idGCref()` first and so kept the pointer-sized name. Smoking gun in a single method: `4533C0 xor r8, r8` next to `4533FF xor r15d, r15d`.

**`v{extract,insert}{f,i}32x4` swallowed the imm8 lane selector.** `emitDispConstant` early-returns for every `INS_FLAGS_HasPseudoName` instruction. That's right for `vcmp*`/`vpcmp*`/`pclmulqdq`, where the immediate *is* the name, but these four are only pseudo-named for the VEX-era alias and still need the operand. Proof of loss: CoreLib uses selectors 00/01/02/03 and all four rendered identically.

**`movmskps`/`movmskpd` printed a 64-bit GPR.** `REX_WIG` is `#define`d as `REX_W0`, so `TakesRexWPrefix` returns false and the JIT never emits `REX.W` for these -- the destination is always `r32`. `pmovmskb` already had the case; the other two were missing.

**`cvtsi2*`/`vcvtusi2*`/`vmovd` named their GPR operand from the vector size.** Now taken from `GetInputSizeInBytes`, which reads the `Input_32Bit`/`Input_64Bit` flag. Definitive display-only proof: the identical bytes `C4C17A2AC0` printed `r8d` in one method and `r8` in another.

**Narrowing converts named the destination at the source size in the memory forms.** Only the register form narrowed; the memory paths printed `emitRegName(idReg1(), attr)` raw, giving `vcvtpd2ps ymm0, ymmword ptr [...]`. Extracted `GetNarrowedDstAttr` and shared it across the register and ARD/SRD/MRD paths.

**Broadcasts printed the source at the destination width.** Only the `_gpr` variants had cases; the vector-source ones fell to `default:` where `srcAttr = attr`. These are architecturally `ymm1/zmm1, xmm2` -- the source is the low element. `C4E27D19C1` is `VEX.256.66.0F38.W0 19 /r` = `VBROADCASTSD ymm1, xmm2`, but printed `ymm1, ymm2`.

----------

**Verification.** Byte-accurate PMI corpus of `System.Private.CoreLib` (`--nodiffable` with `DOTNET_JitDisasmWithCodeBytes=1`), decoding the encoding prefixes mechanically and comparing encoded vs printed width for every instruction. Base and diff JITs built from the same source, differing only by this change:

| | base | this PR |
|---|---|---|
| `movzx` with 64-bit dst | 19,815 | 0 |
| self-zeroing `xor` printed 64-bit | 13,256 | 0 |
| `v?movmskp[sd]` with 64-bit dst | 211 | 0 |
| broadcast printed `ymm<-ymm`/`zmm<-zmm` | 89 | 0 |
| `vextract`/`vinsert*32x4` showing the selector | 0 | 52 |

1,134,687 instructions checked, 0 remaining width mismatches. Codegen is unchanged: 75,012 methods compared by (mnemonic, encoded length), and the only 4 differences are P/Invoke inline-frame calls whose helper target moves in and out of `rel32` range with ASLR -- confirmed by a control run of the *same* JIT twice reproducing the same set.

Broadcasts needed a targeted repro since CoreLib never emits the register form of `vpbroadcastb/w/d/q` or `vbroadcast{f,i}32x2` at all. All eight flip correctly with identical encoded bytes:

```
before                                  after
C4E27D78C0    vpbroadcastb ymm0, ymm0   vpbroadcastb ymm0, xmm0
C4E27D79C0    vpbroadcastw ymm0, ymm0   vpbroadcastw ymm0, xmm0
C4E27D58C0    vpbroadcastd ymm0, ymm0   vpbroadcastd ymm0, xmm0
C4E27D59C0    vpbroadcastq ymm0, ymm0   vpbroadcastq ymm0, xmm0
C4E27D18C0    vbroadcastss ymm0, ymm0   vbroadcastss ymm0, xmm0
C4E27D19C0    vbroadcastsd ymm0, ymm0   vbroadcastsd ymm0, xmm0
62F27D4858C0  vpbroadcastd zmm0, zmm0   vpbroadcastd zmm0, xmm0
62F2FD4819C0  vbroadcastsd zmm0, zmm0   vbroadcastsd zmm0, xmm0
```

`vbroadcastss xmm, xmm` (236 in CoreLib) is correct and unchanged, as are the memory-source-only `vbroadcast{f,i}32x4`/`64x2`/`32x8`/`64x4`, which have no register form.

----------

**On coverage.** `GetNarrowedDstAttr` is inherently a hand-maintained list: metadata alone can't separate a narrowing `INS_TT_FULL` convert from a same-size op, since `cvtpd2ps` (`Input_64Bit`, `KMask_Base2`) and `vaddps` (`Input_32Bit`, `KMask_Base4`) both compute 8-vs-8 and 4-vs-4. So I audited it statically, decoding element sizes from the mnemonics rather than from what CoreLib happens to emit: 13 `/2` entries and 3 `/4` entries, no missing narrowing instructions and no dead entries. The widening direction needs no list -- `INS_TT_HALF`/`QUARTER_MEM`/`EIGHTH_MEM` already handle both directions generically.

**Known residual, not addressed here.** `emitDispIns` is also called from `emitDispIG` during `JitDump`, before output, where the `xor` narrowing hasn't happened yet; that path still prints the wide name. It degrades gracefully rather than misprinting -- `EA_SIZE(EA_GCREF) == idOpSize()` there, so the new condition is simply false -- but the pre/post-encode difference is inherent to that call site.

CC. @dotnet/jit-contrib

> [!NOTE]
> This PR was authored with GitHub Copilot.
