### PR TITLE
Make wasm 'V' signature raising deterministic and add a regression test

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Wasm.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Wasm.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 
 using Internal.TypeSystem;
 
-using Debug = System.Diagnostics.Debug;
-
 namespace ILCompiler
 {
     public partial class CompilerTypeSystemContext
@@ -14,25 +12,26 @@ namespace ILCompiler
         private readonly object _structCacheLock = new object();
         private readonly Dictionary<int, TypeDesc> _structsBySize = new Dictionary<int, TypeDesc>();
         private volatile TypeDesc _cachedEmptyStruct;
-        private volatile TypeDesc _cachedV128Type;
+        private volatile TypeDesc _wasmV128Type;
 
         /// <summary>
-        /// Gets the first SIMD v128 type encountered during lowering, or null if none has been seen.
-        /// Used by RaiseSignature to produce a roundtrippable type for the 'V' encoding.
+        /// Gets the type RaiseSignature produces for the 'V' encoding. All v128 types share the same
+        /// wasm ABI (16 bytes, 16-byte aligned), so any one of them round-trips 'V' identically;
+        /// resolving a fixed one keeps raising independent of the order lowering encountered them in.
         /// </summary>
-        public TypeDesc CachedV128Type => _cachedV128Type;
-
-        /// <summary>
-        /// Caches a SIMD v128 type discovered during lowering. Only the first one is retained.
-        /// </summary>
-        public void CacheV128Type(TypeDesc type)
+        public TypeDesc WasmV128Type
         {
-            // All v128 types share the same wasm ABI (16-byte aligned), so any one round-trips the
-            // 'V' encoding identically; a smaller alignment would change raised signatures silently.
-            Debug.Assert(type is DefType defType && defType.InstanceFieldAlignment.AsInt == 16,
-                $"v128 type {type} must be 16-byte aligned to be interchangeable in raised signatures");
+            get
+            {
+                TypeDesc type = _wasmV128Type;
+                if (type is null)
+                {
+                    var vector128 = (MetadataType)SystemModule.GetType("System.Runtime.Intrinsics"u8, "Vector128`1"u8);
+                    _wasmV128Type = type = vector128.MakeInstantiatedType(GetWellKnownType(WellKnownType.Byte));
+                }
 
-            _cachedV128Type ??= type;
+                return type;
+            }
         }
 
         /// <summary>

--- a/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
+++ b/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
@@ -123,17 +123,21 @@ namespace Internal.JitInterface
             }
 
             // Vector128<T> is always a 16-byte v128.
-            if (Internal.TypeSystem.Interop.InteropTypes.IsSystemRuntimeIntrinsicsVector128T(type.Context, type))
-            {
-                return true;
-            }
-
+            //
             // Vector<T> is target-sized, so it is only a v128 when the target's maximum SIMD width is
             // 128-bit (i.e. it is exactly 16 bytes). This matches the JIT recognizing it as TYP_SIMD16
             // via getVectorTByteLength() and keeps the ABI correct should wasm later gain wider vectors.
-            return type is DefType vectorOfT &&
-                   VectorOfTFieldLayoutAlgorithm.IsVectorOfTType(vectorOfT) &&
-                   type.GetElementSize().AsInt == 16;
+            bool isV128 = Internal.TypeSystem.Interop.InteropTypes.IsSystemRuntimeIntrinsicsVector128T(type.Context, type) ||
+                          (type is DefType vectorOfT &&
+                           VectorOfTFieldLayoutAlgorithm.IsVectorOfTType(vectorOfT) &&
+                           type.GetElementSize().AsInt == 16);
+
+            // The wasm ABI gives every v128 a 16-byte aligned argument slot, so a smaller metadata
+            // alignment would silently misplace it relative to the runtime's own ArgIterator layout.
+            Debug.Assert(!isV128 || ((DefType)type).InstanceFieldAlignment.AsInt == 16,
+                $"v128 type {type} must be 16-byte aligned");
+
+            return isV128;
         }
 
         public static WasmValueType LowerType(TypeDesc type)
@@ -219,8 +223,7 @@ namespace Internal.JitInterface
             'l' => context.GetWellKnownType(WellKnownType.Int64),
             'f' => context.GetWellKnownType(WellKnownType.Single),
             'd' => context.GetWellKnownType(WellKnownType.Double),
-            'V' => ((CompilerTypeSystemContext)context).CachedV128Type
-                   ?? throw new InvalidOperationException("Encountered 'V' in signature but no v128 type was cached during lowering"),
+            'V' => ((CompilerTypeSystemContext)context).WasmV128Type,
             _ => throw new InvalidOperationException($"Unknown signature char: {c}")
         };
 
@@ -402,12 +405,7 @@ namespace Internal.JitInterface
             }
             else
             {
-                WasmValueType returnWasmType = LowerType(loweredReturnType);
-                if (returnWasmType == WasmValueType.V128)
-                {
-                    ((CompilerTypeSystemContext)returnType.Context).CacheV128Type(loweredReturnType);
-                }
-                sigBuilder.Append(WasmValueTypeToSigChar(returnWasmType));
+                sigBuilder.Append(WasmValueTypeToSigChar(LowerType(loweredReturnType)));
             }
 
             // Reserve space for potential implicit this, stack pointer parameter, portable entrypoint parameter,
@@ -484,10 +482,6 @@ namespace Internal.JitInterface
                 else
                 {
                     WasmValueType paramWasmType = LowerType(loweredParamType);
-                    if (paramWasmType == WasmValueType.V128)
-                    {
-                        ((CompilerTypeSystemContext)paramType.Context).CacheV128Type(loweredParamType);
-                    }
                     sigBuilder.Append(WasmValueTypeToSigChar(paramWasmType));
                     result.Add(paramWasmType);
                 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
@@ -21,6 +21,9 @@
 
   <ItemGroup>
     <ProjectReference Include="../ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj" />
+    <!-- Aliased because it redefines the ReadyToRun* constant enums that
+         ILCompiler.Reflection.ReadyToRun already brings into the global namespace. -->
+    <ProjectReference Include="../ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj" Aliases="crossgen2" />
     <ProjectReference Include="../crossgen2/crossgen2_inbuild.csproj" ReferenceOutputAssembly="false">
       <!-- crossgen2 is a CoreCLR artifact, so publish it in the CoreCLR configuration. This keeps it
            alongside the other CoreCLR artifacts the test consumes (System.Private.CoreLib, the JITs)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestRunner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestRunner.cs
@@ -341,21 +341,7 @@ internal sealed class R2RTestRunner
 
         paths.Add(Path.Combine(_paths.RuntimePackDir, "*.dll"));
 
-        // SPCL lives in the runtime pack native/ dir in full builds (placed by
-        // externals.csproj BinPlace during libs.pretest).  In partial CI builds
-        // that skip libs.pretest, the runtime pack layout may not exist, but the
-        // CoreCLR artifacts directory always has SPCL after clr.nativecorelib.
-        string spcl = Path.Combine(_paths.RuntimePackNativeDir, "System.Private.CoreLib.dll");
-        if (!File.Exists(spcl))
-        {
-            string fallback = Path.Combine(_paths.CoreCLRArtifactsDir, "System.Private.CoreLib.dll");
-            if (File.Exists(fallback))
-            {
-                _output.WriteLine($"[R2RTestRunner] SPCL not found at '{spcl}'; using CoreCLR artifacts fallback '{fallback}'");
-                spcl = fallback;
-            }
-        }
-
+        string spcl = _paths.SystemPrivateCoreLibPath;
         Assert.True(File.Exists(spcl),
             $"System.Private.CoreLib.dll not found at '{spcl}'. " +
             $"Searched RuntimePackNativeDir='{_paths.RuntimePackNativeDir}' and " +

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/TestPaths.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/TestPaths.cs
@@ -134,6 +134,30 @@ internal sealed class TestPaths
     }
 
     /// <summary>
+    /// Path to System.Private.CoreLib.dll. It lives in the runtime pack native/ dir in full builds
+    /// (placed by externals.csproj BinPlace during libs.pretest), but partial builds that skip
+    /// libs.pretest only have it in the CoreCLR artifacts directory.
+    /// </summary>
+    public string SystemPrivateCoreLibPath
+    {
+        get
+        {
+            string path = Path.Combine(RuntimePackNativeDir, "System.Private.CoreLib.dll");
+            if (!File.Exists(path))
+            {
+                string fallback = Path.Combine(CoreCLRArtifactsDir, "System.Private.CoreLib.dll");
+                if (File.Exists(fallback))
+                {
+                    _output.WriteLine($"[TestPaths] '{path}' not found; falling back to '{fallback}'");
+                    return fallback;
+                }
+            }
+
+            return path;
+        }
+    }
+
+    /// <summary>
     /// Path to the CoreCLR artifacts directory (contains native bits like corerun).
     /// e.g. artifacts/bin/coreclr/linux.x64.Checked/
     /// Falls back to Checked or Release if the configured path doesn't exist.

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/WasmArgumentLayoutTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/WasmArgumentLayoutTests.cs
@@ -1,0 +1,232 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+extern alias crossgen2;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using crossgen2::ILCompiler;
+using crossgen2::ILCompiler.DependencyAnalysis.ReadyToRun;
+using crossgen2::ILCompiler.DependencyAnalysis.Wasm;
+using crossgen2::Internal.CallingConvention;
+using crossgen2::Internal.JitInterface;
+
+using ILCompiler.ReadyToRun.Tests.TestCasesRunner;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILCompiler.ReadyToRun.Tests;
+
+/// <summary>
+/// Unit tests for the wasm argument layout crossgen2 computes. These drive the compiler's type
+/// system directly, so they need neither a wasm JIT nor a runtime to execute against.
+/// </summary>
+public class WasmArgumentLayoutTests
+{
+    private const string Vector128OfT = "Vector128`1";
+    private const string VectorOfT = "Vector`1";
+    private const string Vector64OfT = "Vector64`1";
+    private const string Vector256OfT = "Vector256`1";
+    private const string Vector512OfT = "Vector512`1";
+
+    private readonly ITestOutputHelper _output;
+
+    public WasmArgumentLayoutTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public static TheoryData<string, WellKnownType> V128Types()
+    {
+        TheoryData<string, WellKnownType> data = new();
+
+        foreach (string vectorType in new[] { Vector128OfT, VectorOfT })
+        {
+            foreach (WellKnownType elementType in new[]
+                     {
+                         WellKnownType.Byte, WellKnownType.Int16, WellKnownType.Int32,
+                         WellKnownType.Int64, WellKnownType.Single, WellKnownType.Double,
+                     })
+            {
+                data.Add(vectorType, elementType);
+            }
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// Every type the wasm ABI passes as a <c>v128</c> must be 16-byte aligned. Both this compiler
+    /// and the runtime align an argument slot by the argument type's own alignment, so an
+    /// under-aligned vector silently disagrees with the frame the runtime builds for the same method.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(V128Types))]
+    public void WasmV128TypesAre16ByteAligned(string vectorType, WellKnownType elementType)
+    {
+        ReadyToRunCompilerContext context = CreateWasmContext();
+        DefType instantiated = InstantiateVector(context, vectorType, elementType);
+
+        Assert.Equal(16, instantiated.InstanceFieldSize.AsInt);
+        Assert.Equal(16, instantiated.InstanceFieldAlignment.AsInt);
+        Assert.Equal(WasmValueType.V128, WasmLowering.LowerType(instantiated));
+    }
+
+    /// <summary>
+    /// A v128 argument must start on a 16-byte boundary. <see cref="System.Numerics.Vector{T}"/>
+    /// previously kept the 8-byte alignment from its metadata layout and produced <c>[0, 8, 24]</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(Vector128OfT)]
+    [InlineData(VectorOfT)]
+    public void WasmV128ArgumentsStartOn16ByteBoundaries(string vectorType)
+    {
+        ReadyToRunCompilerContext context = CreateWasmContext();
+        TypeDesc int32 = context.GetWellKnownType(WellKnownType.Int32);
+
+        MethodSignature signature = MakeStaticVoidSignature(
+            context,
+            context.GetWellKnownType(WellKnownType.Int64),
+            InstantiateVector(context, vectorType, WellKnownType.Int32),
+            int32.MakeByRefType());
+
+        Assert.Equal(new[] { 0, 16, 32 }, GetArgumentOffsets(context, signature));
+    }
+
+    /// <summary>
+    /// Only vectors that are exactly 16 bytes are a <c>v128</c>; the rest use the generic struct ABI.
+    /// </summary>
+    [Theory]
+    [InlineData(Vector64OfT)]
+    [InlineData(Vector256OfT)]
+    [InlineData(Vector512OfT)]
+    public void OtherSimdWidthsAreNotV128(string vectorType)
+    {
+        ReadyToRunCompilerContext context = CreateWasmContext();
+        DefType instantiated = InstantiateVector(context, vectorType, WellKnownType.Int32);
+
+        Assert.NotEqual(16, instantiated.InstanceFieldSize.AsInt);
+        Assert.NotEqual(WasmValueType.V128, WasmLowering.LowerType(instantiated));
+    }
+
+    /// <summary>
+    /// The 'V' encoding says nothing about which vector type produced it, so raising must resolve the
+    /// same type regardless of what lowering saw first. The wasm R2R-to-interpreter thunk derives its
+    /// whole frame layout from the raised signature.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData(Vector128OfT)]
+    [InlineData(VectorOfT)]
+    public void RaisingV128SignatureIsIndependentOfLoweringOrder(string? loweredFirst)
+    {
+        ReadyToRunCompilerContext context = CreateWasmContext();
+
+        if (loweredFirst is not null)
+        {
+            WasmLowering.GetSignature(
+                MakeStaticVoidSignature(context, InstantiateVector(context, loweredFirst, WellKnownType.Int32)),
+                WasmLowering.LoweringFlags.None);
+        }
+
+        MethodSignature signature = MakeStaticVoidSignature(
+            context,
+            context.GetWellKnownType(WellKnownType.Int64),
+            InstantiateVector(context, VectorOfT, WellKnownType.Single),
+            context.GetWellKnownType(WellKnownType.Int32).MakeByRefType());
+
+        WasmSignature lowered = WasmLowering.GetSignature(signature, WasmLowering.LoweringFlags.None);
+        Assert.Equal("vlVip", lowered.SignatureString);
+
+        MethodSignature raised = WasmLowering.RaiseSignature(lowered, context);
+        _output.WriteLine($"lowered '{loweredFirst ?? "(nothing)"}' first; 'V' raised to {raised[1]}");
+
+        Assert.Same(InstantiateVector(context, Vector128OfT, WellKnownType.Byte), raised[1]);
+        Assert.Equal(GetArgumentOffsets(context, signature), GetArgumentOffsets(context, raised));
+    }
+
+    /// <summary>
+    /// Configures a type system context the way crossgen2 does for
+    /// <c>--targetarch wasm --targetos browser</c>.
+    /// </summary>
+    private ReadyToRunCompilerContext CreateWasmContext()
+    {
+        string coreLibPath = new TestPaths(_output).SystemPrivateCoreLibPath;
+        Assert.True(File.Exists(coreLibPath), $"System.Private.CoreLib.dll not found at '{coreLibPath}'");
+
+        InstructionSetSupport instructionSetSupport = new(default, default, TargetArchitecture.Wasm32);
+        TargetDetails target = new(TargetArchitecture.Wasm32, TargetOS.Browser, TargetAbi.NativeAot, instructionSetSupport.GetVectorTSimdVector());
+
+        ReadyToRunCompilerContext context = new(target, SharedGenericsMode.CanonicalReferenceTypes, bubbleIncludesCoreModule: true, instructionSetSupport, oldTypeSystemContext: null)
+        {
+            InputFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "System.Private.CoreLib", coreLibPath } },
+            ReferenceFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+        };
+
+        EcmaModule coreLib = (EcmaModule)context.GetModuleForSimpleName("System.Private.CoreLib");
+        context.SetSystemModule(coreLib);
+
+        // The R2R field layout algorithm reaches into the compilation group to decide whether base
+        // offsets need aligning, so a context without one throws before computing any layout.
+        context.SetCompilationGroup(new ReadyToRunSingleAssemblyCompilationModuleGroup(new ReadyToRunCompilationModuleGroupConfig
+        {
+            Context = context,
+            IsInputBubble = true,
+            CompilationModuleSet = new[] { coreLib },
+            VersionBubbleModuleSet = new ModuleDesc[] { coreLib },
+            CrossModuleInlineable = Array.Empty<ModuleDesc>(),
+            InstructionSetSupport = instructionSetSupport,
+        }));
+
+        return context;
+    }
+
+    private static DefType InstantiateVector(ReadyToRunCompilerContext context, string vectorType, WellKnownType elementType)
+    {
+        MetadataType openType = vectorType switch
+        {
+            Vector128OfT => context.SystemModule.GetType("System.Runtime.Intrinsics"u8, "Vector128`1"u8),
+            Vector64OfT => context.SystemModule.GetType("System.Runtime.Intrinsics"u8, "Vector64`1"u8),
+            Vector256OfT => context.SystemModule.GetType("System.Runtime.Intrinsics"u8, "Vector256`1"u8),
+            Vector512OfT => context.SystemModule.GetType("System.Runtime.Intrinsics"u8, "Vector512`1"u8),
+            VectorOfT => context.SystemModule.GetType("System.Numerics"u8, "Vector`1"u8),
+            _ => throw new ArgumentOutOfRangeException(nameof(vectorType), vectorType, null),
+        };
+
+        return openType.MakeInstantiatedType(context.GetWellKnownType(elementType));
+    }
+
+    private static MethodSignature MakeStaticVoidSignature(TypeSystemContext context, params TypeDesc[] parameters)
+    {
+        return new MethodSignature(
+            MethodSignatureFlags.Static,
+            genericParameterCount: 0,
+            returnType: context.GetWellKnownType(WellKnownType.Void),
+            parameters: parameters);
+    }
+
+    /// <summary>
+    /// Runs the same ArgIterator the wasm R2R-to-interpreter thunk uses, returning each argument's
+    /// offset relative to the start of the arguments area.
+    /// </summary>
+    private static List<int> GetArgumentOffsets(TypeSystemContext context, MethodSignature signature)
+    {
+        var (argIterator, transitionBlock) = GCRefMapBuilder.BuildArgIterator(signature, context);
+
+        List<int> offsets = new();
+        int argOffset;
+
+        while ((argOffset = argIterator.GetNextOffset()) != TransitionBlock.InvalidOffset)
+        {
+            offsets.Add(argOffset - transitionBlock.OffsetOfArgs);
+        }
+
+        return offsets;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -25,6 +25,8 @@
     <ProjectReference Include="..\ILCompiler.Diagnostics\ILCompiler.Diagnostics.csproj" />
     <ProjectReference Include="..\ILCompiler.TypeSystem\ILCompiler.TypeSystem.csproj" />
 
+    <InternalsVisibleTo Include="ILCompiler.ReadyToRun.Tests" />
+
     <PackageReference Condition="'$(DotNetBuildSourceOnly)' != 'true'" Include="StaticCs" Version="$(StaticCsVersion)">
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>contentfiles</ExcludeAssets> <!-- We include our own copy of the ClosedAttribute to work in source build -->


### PR DESCRIPTION
Fixes #131339 -- though not in the way the issue proposed; see the note at the bottom.

`RaiseSignature` resolved the `'V'` (v128) signature char to `CompilerTypeSystemContext.CachedV128Type`, i.e. literally whichever v128 type lowering happened to encounter first, written racily from parallel compilation. `'V'` is fully determined by the wasm ABI (16 bytes, 16-byte aligned), so raising now resolves a fixed canonical `Vector128<byte>` instead. Any v128 type round-trips `'V'` identically, so `RaiseSignature`'s own round-trip assert still holds, and the raised signature no longer depends on compilation order.

The 16-byte alignment `Debug.Assert` that guarded this invariant moved from `CacheV128Type` into `IsWasmV128Type`. `CacheV128Type` only ever saw the first cached type, where-as `IsWasmV128Type` has three call sites and so covers every v128 type.

This also drops the `?? throw new InvalidOperationException(...)` on the `'V'` path -- that failure mode is simply gone, since raising no longer needs lowering to have run first.

----------

`ILCompiler.ReadyToRun.Tests` gains `WasmArgumentLayoutTests`: 20 cases driving crossgen2's type system and `GCRefMapBuilder.BuildArgIterator` directly, so they need neither a wasm JIT nor a runtime to execute against.

- `WasmV128TypesAre16ByteAligned` -- 12 cases over `Vector128<T>`/`Vector<T>` x 6 element types.
- `WasmV128ArgumentsStartOn16ByteBoundaries` -- `static void M(long, TVector, ref int)` must lay out as `[0, 16, 32]`.
- `OtherSimdWidthsAreNotV128` -- `Vector64/256/512<T>` must fall back to the generic struct ABI.
- `RaisingV128SignatureIsIndependentOfLoweringOrder` -- lowers a different vector type first, then asserts the raised `'V'` is unchanged and that its offsets match the original signature's.

These also cover the `Vector<T>` alignment fix from #131328, and I verified they bite: with that fix reverted, 7 cases fail -- the six `Vector<T>` alignment cases report 8 instead of 16, and `WasmV128ArgumentsStartOn16ByteBoundaries` for `Vector<T>` reports `[0, 8, 24]` instead of `[0, 16, 32]`.

----------

On #131339 itself. The issue asks for a test asserting `Vector128<T>` is 16-byte aligned, on the premise that this is what #131328 fixed. That is not correct -- `Vector128<T>` gets alignment 16 from `VectorFieldLayoutAlgorithm` on every architecture except ARM and was untouched by that fix. I confirmed empirically that the proposed test passes unchanged against a compiler with #131328 reverted, so it would have been a no-op. The actual regression was `System.Numerics.Vector<T>`, which kept the 8-byte alignment from its metadata layout. The tests here cover both.

The issue also says the test was deferred for lack of a CI-runnable home. That premise is stale: #130866 added the `WasmSimdModule` wasm crossgen2 suite to `ILCompiler.ReadyToRun.Tests` three days before the issue was filed, and that is where these tests live.

----------

Also hoisted the `System.Private.CoreLib.dll` resolution out of `R2RTestRunner` into `TestPaths.SystemPrivateCoreLibPath` so the new tests share the existing runtime-pack to CoreCLR-artifacts fallback. Without it they would hard-fail in partial builds that skip `libs.pretest`, e.g. a bare `clr.toolstests`.

Out of scope, to be filed separately: `CacheStructBySize`/`GetCachedStructOfSize` has the same first-wins-cache shape for the `'S<N>'` encoding, and there it is a live miscompile rather than a latent hazard. `Guid` and `Int128` are both 16 bytes and both encode `S16`, but their clamped alignments are 8 and 16, so the shared thunk signature `vlS16ip` gets two different frame layouts. Fixing that means changing the on-disk encoding across crossgen2, `src/coreclr/vm/wasm/helpers.cpp`, `WasmAppBuilder`, and the R2R format doc, so it does not belong here.

Local test run: `ILCompiler.ReadyToRun.Tests` is 58 total / 1 failed. The failure is `CompositeManifestAssemblyMvidsArePaddedWhenPdbPresent`, an `ArgumentNullException` out of the native PDB COM writer in my Debug layout. Confirmed pre-existing -- it reproduces identically with this branch's changes stashed.

CC. @lewing @adamperlin -- ready for review.

> [!NOTE]
> This PR description was drafted by Copilot.
