### PR TITLE
[release/10.0] Fix g_gc_lowest_address updating

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -9663,7 +9663,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
 
             if (saved_g_lowest_address < g_gc_lowest_address)
             {
-                if (ps > (size_t)g_gc_lowest_address)
+                if (ps >= (size_t)g_gc_lowest_address)
                     saved_g_lowest_address = (uint8_t*)(size_t)OS_PAGE_SIZE;
                 else
                 {


### PR DESCRIPTION
Backport of #131324 to release/10.0

## Customer Impact

- [x] Customer reported - #131216
- [ ] Found internally

There is a rare issue that occurs when virtual memory blocks allocated by GC end up getting addresses that trigger a code path where the GC address space range maintained by GC in `g_gc_lowest_address` .. `g_gc_highest_address` is expanded down and the `g_gc_lowest_address` is exactly 2/3 of the `g_gc_highest_address`. We end up setting the `g_gc_lowest_address` to 0

This leads to crashes during GC because it starts considering NULL references as valid references being part of the GC heap.

## Regression

- [ ]  Yes
- [x] No

## Testing

Regular coreclr / libraries tests. 

## Risk

Low. The change just makes single condition correct for the edge case causing the issue.