### PR TITLE
[Wasm RyuJit] assert function regions are contiguous after control flow

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9897,6 +9897,7 @@ public:
     void         funSetCurrentFunc(unsigned funcIdx);
     FuncInfoDsc* funGetFunc(unsigned funcIdx);
     unsigned int funGetFuncIdx(BasicBlock* block);
+    unsigned int bbFuncletRegionOf(BasicBlock* block);
     bool         bbIsInSameFunclet(BasicBlock* block1, BasicBlock* block2);
 
     // LIVENESS

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -860,6 +860,35 @@ inline unsigned Compiler::funGetFuncIdx(BasicBlock* block)
 }
 
 /*****************************************************************************
+ *  Return the index of the function region (funclet) that physically contains
+ *  `block`. The main method is region 0. Unlike funGetFuncIdx, this works for
+ *  an arbitrary block (not just a funclet entry), distinguishing a filter
+ *  funclet (FUNC_FILTER) from its filter-handler. Only valid after funclets
+ *  are created.
+ *
+ */
+inline unsigned Compiler::bbFuncletRegionOf(BasicBlock* block)
+{
+    assert(fgFuncletsCreated);
+
+    if (!block->hasHndIndex())
+    {
+        return 0;
+    }
+
+    EHblkDsc* const eh      = ehGetDsc(block->getHndIndex());
+    unsigned        funcIdx = eh->ebdFuncIndex;
+
+    if (eh->HasFilter() && eh->InFilterRegionBBRange(block))
+    {
+        // The filter is the funclet immediately preceding its filter-handler.
+        funcIdx--;
+    }
+
+    return funcIdx;
+}
+
+/*****************************************************************************
  *  Are two blocks physically contained in the same function region (funclet)?
  *  The main method is region 0. Unlike funGetFuncIdx, this works for an
  *  arbitrary block (not just a funclet entry), distinguishing a filter
@@ -869,27 +898,7 @@ inline unsigned Compiler::funGetFuncIdx(BasicBlock* block)
  */
 inline bool Compiler::bbIsInSameFunclet(BasicBlock* block1, BasicBlock* block2)
 {
-    assert(fgFuncletsCreated);
-
-    auto funcRegionOf = [this](BasicBlock* blk) -> unsigned {
-        if (!blk->hasHndIndex())
-        {
-            return 0;
-        }
-
-        EHblkDsc* const eh      = ehGetDsc(blk->getHndIndex());
-        unsigned        funcIdx = eh->ebdFuncIndex;
-
-        if (eh->HasFilter() && eh->InFilterRegionBBRange(blk))
-        {
-            // The filter is the funclet immediately preceding its filter-handler.
-            funcIdx--;
-        }
-
-        return funcIdx;
-    };
-
-    return funcRegionOf(block1) == funcRegionOf(block2);
+    return bbFuncletRegionOf(block1) == bbFuncletRegionOf(block2);
 }
 #if HAS_FIXED_REGISTER_SET
 //------------------------------------------------------------------------------

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -1837,6 +1837,36 @@ PhaseStatus Compiler::fgWasmControlFlow()
             order++;
         }
     }
+
+    {
+        // Verify that each funclet's blocks are contiguous.
+        //
+        jitstd::vector<bool> regionClosed(compFuncInfoCount, false, getAllocator(CMK_DebugOnly));
+        unsigned             prevRegion = UINT_MAX;
+        for (BasicBlock* const block : Blocks())
+        {
+            const unsigned region = bbFuncletRegionOf(block);
+            assert(region < compFuncInfoCount);
+
+            if (region != prevRegion)
+            {
+                if (prevRegion != UINT_MAX)
+                {
+                    regionClosed[prevRegion] = true;
+                }
+
+                if (regionClosed[region])
+                {
+                    JITDUMP("Wasm function region %u is not contiguous: " FMT_BB " re-enters it\n", region,
+                            block->bbNum);
+                }
+                assert(!regionClosed[region] &&
+                       "wasm function region (main method / funclet) blocks are not contiguous");
+
+                prevRegion = region;
+            }
+        }
+    }
 #endif // DEBUG
 
     JITDUMPEXEC(fgDumpWasmControlFlow());


### PR DESCRIPTION
Codegen emits one wasm function body per region (main method and each funclet) by walking the block order. Add a debug check after fgWasmControlFlow that each region's blocks are contiguous in the order.