### PR TITLE
Fix foreground shutdown test

### DIFF
--- a/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.cs
+++ b/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Runtime.InteropServices;
-using System.Reflection;
 using System.Threading;
-using Xunit;
-using TestLibrary;
 
 /*
  * Issue description:
@@ -16,12 +12,11 @@ using TestLibrary;
 
 public class Test_foreground_shutdown
 {
-    [Fact]
-    public static int TestEntryPoint()
+    public static int Main()
     {
         new Thread(() =>
         {
-            Thread.Sleep(TimeSpan.FromSeconds(1));
+            Thread.Sleep(TimeSpan.FromSeconds(2));
             Environment.Exit(100);
         }).Start();
 

--- a/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.csproj
+++ b/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.csproj
@@ -2,12 +2,11 @@
   <PropertyGroup>
     <!-- Needed for Environment.Exit -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- Test checks the behavior of Main -->
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="foreground-shutdown.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We had a race between the xunit wrapper and the foreground thread (which thread sets the exit code) which is easier to trigger under JIT stress. Adding one more second to `Thread.Sleep` and removing the wrapper should be enough to make this test pass even with JIT stress I think.

Fixes #131403.