### PR TITLE
Do not allow generic inlining of ldftn requiring a fat function pointer

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1450,15 +1450,26 @@ namespace Internal.JitInterface
 
                 if (pResult->exactContextNeedsRuntimeLookup)
                 {
-                    MethodDesc caller = HandleToObject(callerHandle);
-
                     pResult->codePointerOrStubLookup.lookupKind.needsRuntimeLookup = true;
-                    pResult->codePointerOrStubLookup.runtimeLookup.indirections = CORINFO.USEHELPER;
-                    pResult->codePointerOrStubLookup.runtimeLookup.helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_GENERIC_HANDLE;
-                    pResult->codePointerOrStubLookup.lookupKind.runtimeLookupKind = GetGenericRuntimeLookupKind(caller);
-                    object helperArg = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
-                    ISymbolNode helper = GetGenericLookupHelper(pResult->codePointerOrStubLookup.lookupKind.runtimeLookupKind, ReadyToRunHelperId.MethodEntry, caller, helperArg);
-                    pResult->codePointerOrStubLookup.runtimeLookup.helperEntryPoint = CreateConstLookupToSymbol(helper);
+
+                    // If this is from a different context, abort. The ReadyToRun helper needs to declare
+                    // its dependencies in terms of the dictionary it will be placed in, but the runtime
+                    // determined method we computed is expressed in terms of the inlinee's generic context.
+                    if (pResolvedToken.tokenContext != contextFromMethodBeingCompiled())
+                    {
+                        pResult->codePointerOrStubLookup.lookupKind.runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_NOT_SUPPORTED;
+                    }
+                    else
+                    {
+                        MethodDesc caller = HandleToObject(callerHandle);
+
+                        pResult->codePointerOrStubLookup.runtimeLookup.indirections = CORINFO.USEHELPER;
+                        pResult->codePointerOrStubLookup.runtimeLookup.helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_GENERIC_HANDLE;
+                        pResult->codePointerOrStubLookup.lookupKind.runtimeLookupKind = GetGenericRuntimeLookupKind(caller);
+                        object helperArg = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
+                        ISymbolNode helper = GetGenericLookupHelper(pResult->codePointerOrStubLookup.lookupKind.runtimeLookupKind, ReadyToRunHelperId.MethodEntry, caller, helperArg);
+                        pResult->codePointerOrStubLookup.runtimeLookup.helperEntryPoint = CreateConstLookupToSymbol(helper);
+                    }
                 }
                 else
                 {

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -64,6 +64,7 @@ class Generics
         TestGenericInliningTypeGenericsOnly.Run();
         Test99198Regression.Run();
         Test102259Regression.Run();
+        Test129093Regression.Run();
         Test104913Regression.Run();
         Test105397Regression.Run();
         Test105880Regression.Run();
@@ -3787,6 +3788,32 @@ class Generics
         public static void Run()
         {
             new Gen<object>();
+        }
+    }
+
+    class Test129093Regression
+    {
+        class Gen<T>
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static Type Method() => typeof(T);
+        }
+
+        // Inlineable generic method taking the address of a method that needs a generic context.
+        static unsafe nint GetPtr<U>() => (nint)(delegate*<Type>)&Gen<U>.Method;
+
+        class Caller<X>
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static nint Run() => GetPtr<X>();
+        }
+
+        public static unsafe void Run()
+        {
+            if (((delegate*<Type>)Caller<object>.Run())() != typeof(object))
+                throw new Exception();
+            if (((delegate*<Type>)Caller<string>.Run())() != typeof(string))
+                throw new Exception();
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -3800,6 +3800,7 @@ class Generics
         }
 
         // Inlineable generic method taking the address of a method that needs a generic context.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe nint GetPtr<U>() => (nint)(delegate*<Type>)&Gen<U>.Method;
 
         class Caller<X>


### PR DESCRIPTION
Fixes #129093.

When `ldftn` targets a method that needs a hidden generic context argument, ILC asks the JIT to build a fat function pointer and creates a `ReadyToRunHelperId.MethodEntry` generic lookup helper for it. Unlike every other lookup path in `CorInfoImpl` (`ComputeLookup`, and the delegate ctor path fixed in #102299), this one did not check whether the token came from an inlinee's generic context.

The result is that the runtime determined method - expressed in terms of the *inlinee's* generic parameters - ends up recorded in the *inliner's* dictionary. `ShadowMethodNode.GetStaticDependencies` then substitutes it with the inliner's instantiations, which throws `IndexOutOfRangeException` in `GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution` when the arities don't line up (and would silently look up the wrong dictionary slot when they do).

Repro (crashes `ilc` with the stack reported in #129093):

```csharp
class Gen<T>
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    public static Type Method() => typeof(T);
}

static unsafe nint GetPtr<U>() => (nint)(delegate*<Type>)&Gen<U>.Method;

class Caller<X>
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    public static nint Run() => GetPtr<X>();
}
```

The fix aborts the inline in that case, which the JIT already knows how to handle (`impLookupToTree` notes `CALLSITE_GENERIC_DICTIONARY_LOOKUP` for `CORINFO_LOOKUP_NOT_SUPPORTED`, and both `impMethodPointer` callers check `compDonotInline`).

Validation:

* The added smoke test fails with the reported `Index was outside the bounds of the array` error without the compiler change, and passes with it.
* Full `src/tests/nativeaot` tree builds and the produced binaries run clean on linux-x64.

Cc @dotnet/ilc-contrib

> [!NOTE]
> This change was authored with GitHub Copilot.
