### PR TITLE
Define `REPO_COMMIT_HASH` for singlefilehost

### DIFF
--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -5,6 +5,7 @@
     <_BuildNativeTargetOS Condition="'$(TargetsLinuxBionic)' == 'true'">linux-bionic</_BuildNativeTargetOS>
     <HasCdacBuildTool Condition="'$(ClrFullNativeBuild)' == 'true' or '$(ClrRuntimeSubset)' == 'true' or '$(ClrDebugSubset)' == 'true' or '$(ClrCrossComponentsSubset)' == 'true' or '$(ClrNativeAotSubset)' == 'true'">true</HasCdacBuildTool>
     <BuildRuntimeDependsOnTargets>GetPgoDataPackagePath</BuildRuntimeDependsOnTargets>
+    <BuildRuntimeDependsOnTargets Condition="'$(EnableSourceControlManagerQueries)' == 'true'">$(BuildRuntimeDependsOnTargets);InitializeSourceControlInformationFromSourceControlManager</BuildRuntimeDependsOnTargets>
     <BuildRuntimeDependsOnTargets Condition="'$(TargetsBrowser)' == 'true'">AcquireEmscriptenSdk;$(BuildRuntimeDependsOnTargets);GenerateEmccExports</BuildRuntimeDependsOnTargets>
     <BuildRuntimeDependsOnTargets Condition="'$(TargetsWasi)' == 'true'">AcquireWasiSdk;$(BuildRuntimeDependsOnTargets)</BuildRuntimeDependsOnTargets>
   </PropertyGroup>
@@ -57,6 +58,7 @@
       <_CoreClrBuildArg Condition="'$(FeatureXplatEventSource)' == 'false'" Include="-cmakeargs &quot;-DFEATURE_EVENTSOURCE_XPLAT=0&quot;" />
       <_CoreClrBuildArg Condition="'$(FeatureInterpreter)' == 'true'" Include="-cmakeargs &quot;-DFEATURE_INTERPRETER=1&quot;" />
       <_CoreClrBuildArg Condition="'$(FeatureDynamicCodeCompiled)' == 'true' or '$(FeatureDynamicCodeCompiled)' == ''" Include="-cmakeargs &quot;-DFEATURE_DYNAMIC_CODE_COMPILED=1&quot;" />
+      <_CoreClrBuildArg Include="-cmakeargs &quot;-DCLI_CMAKE_COMMIT_HASH=$([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A'))&quot;" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(CxxStandardLibrary)' != ''">

--- a/src/native/corehost/configure.h.in
+++ b/src/native/corehost/configure.h.in
@@ -1,16 +1,7 @@
 #ifndef PAL_HOST_CONFIGURE_H_INCLUDED
 #define PAL_HOST_CONFIGURE_H_INCLUDED
 
-#cmakedefine CLR_SINGLE_FILE_HOST_ONLY
-
-#ifdef CLR_SINGLE_FILE_HOST_ONLY
-// When hosting components are all statically linked,
-// the versioning information is irrelevant and may only come up in tracing.
-// so we will use "static"
-#define REPO_COMMIT_HASH "static"
-#else
 #define REPO_COMMIT_HASH "@CLI_CMAKE_COMMIT_HASH@"
-#endif
 
 #define FALLBACK_HOST_OS "@CLI_CMAKE_FALLBACK_OS@"
 #define CURRENT_OS_NAME "@CLR_CMAKE_TARGET_OS@"


### PR DESCRIPTION
singlefilehost statically links the hosting components, which use `REPO_COMMIT_HASH` (in `dotnet --info`, `hostfxr_get_dotnet_environment_info`, and tracing). Because it's built as part of coreclr, which never passed the commit hash, it always reported `static` instead of the real commit.

This plumbs the commit hash into the coreclr native build via `SourceRevisionId`, the same way `corehost.proj` does for the rest of the host, so singlefilehost now contains the actual version like `dotnet`/`hostfxr`/`apphost`.

cc @dotnet/appmodel @AaronRobinsonMSFT 

> [!NOTE]
> This PR description was drafted with the assistance of GitHub Copilot.