### PR TITLE
Fix EnC static field address cDAC API

### DIFF
--- a/docs/design/datacontracts/RuntimeMutableTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeMutableTypeSystem.md
@@ -24,7 +24,7 @@ TargetPointer GetEnCInstanceFieldAddress(TargetPointer objectAddress, TargetPoin
 | `EnCAddedField` | `Next` | `pointer` | Pointer to the next EnCAddedField entry in the per-object linked list hanging off the SyncBlock. |
 | `EnCAddedFieldElement` | `FieldDesc` | `pointer` | Address of the embedded EnCFieldDesc (layout-compatible with FieldDesc). |
 | `EnCAddedFieldElement` | `Next` | `pointer` | Pointer to the next EnCAddedFieldElement in the linked list. |
-| `EnCAddedStaticField` | `FieldData` | `pointer` | Address of the first byte of static field storage on this entry. |
+| `EnCAddedStaticField` | `FieldData` | `pointer` | Address of the inline storage for a primitive field, or of a pointer to GC-tracked storage for a class or value-type field. |
 | `EnCEEClassData` | `AddedInstanceFields` | `pointer` | Head of the linked list of EnCAddedFieldElement for added instance fields. |
 | `EnCEEClassData` | `AddedStaticFields` | `pointer` | Head of the linked list of EnCAddedFieldElement for added static fields. |
 | `EnCEEClassData` | `MethodTable` | `pointer` | Pointer to the MethodTable whose EnC data is held by this entry. |
@@ -117,8 +117,11 @@ TargetPointer GetEnCStaticFieldDataAddress(TargetPointer encFieldDescPointer)
     if (staticFieldData == TargetPointer.Null)
         return TargetPointer.Null;
 
-    // [FieldAddress] on EnCAddedStaticField::FieldData returns the address of the field slot
-    return staticFieldData + /* EnCAddedStaticField::FieldData offset */;
+    TargetPointer fieldDataAddress = staticFieldData + /* EnCAddedStaticField::FieldData offset */;
+    CorElementType fieldType = target.Contracts.RuntimeTypeSystem.GetFieldDescType(encFieldDescPointer);
+    return fieldType is CorElementType.ValueType or CorElementType.Class
+        ? target.ReadPointer(fieldDataAddress)
+        : fieldDataAddress;
 }
 
 TargetPointer GetEnCInstanceFieldAddress(TargetPointer objectAddress, TargetPointer encFieldDescPointer)

--- a/docs/design/datacontracts/data-descriptor-meanings.json
+++ b/docs/design/datacontracts/data-descriptor-meanings.json
@@ -142,7 +142,7 @@
     "EnCAddedField.Next": "Pointer to the next EnCAddedField entry in the per-object linked list hanging off the SyncBlock.",
     "EnCAddedFieldElement.FieldDesc": "Address of the embedded EnCFieldDesc (layout-compatible with FieldDesc).",
     "EnCAddedFieldElement.Next": "Pointer to the next EnCAddedFieldElement in the linked list.",
-    "EnCAddedStaticField.FieldData": "Address of the first byte of static field storage on this entry.",
+    "EnCAddedStaticField.FieldData": "Address of the inline storage for a primitive field, or of a pointer to GC-tracked storage for a class or value-type field.",
     "EnCEEClassData.AddedInstanceFields": "Head of the linked list of EnCAddedFieldElement for added instance fields.",
     "EnCEEClassData.AddedStaticFields": "Head of the linked list of EnCAddedFieldElement for added static fields.",
     "EnCEEClassData.MethodTable": "Pointer to the MethodTable whose EnC data is held by this entry.",

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeMutableTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeMutableTypeSystem_1.cs
@@ -95,7 +95,11 @@ internal readonly struct RuntimeMutableTypeSystem_1 : IRuntimeMutableTypeSystem
             return TargetPointer.Null;
 
         Data.EnCAddedStaticField staticField = _target.ProcessedData.GetOrAdd<Data.EnCAddedStaticField>(encFieldDesc.StaticFieldData);
-        return staticField.FieldData;
+        TargetPointer fieldDataAddress = staticField.FieldData;
+        CorElementType fieldType = _target.Contracts.RuntimeTypeSystem.GetFieldDescType(encFieldDescPointer);
+        return fieldType is CorElementType.ValueType or CorElementType.Class
+            ? _target.ReadPointer(fieldDataAddress)
+            : fieldDataAddress;
     }
 
     TargetPointer IRuntimeMutableTypeSystem.GetEnCInstanceFieldAddress(TargetPointer objectAddress, TargetPointer encFieldDescPointer)

--- a/src/native/managed/cdac/tests/UnitTests/RuntimeMutableTypeSystemTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/RuntimeMutableTypeSystemTests.cs
@@ -343,14 +343,12 @@ public class RuntimeMutableTypeSystemTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void GetEnCStaticFieldDataAddress_ReturnsFieldDataAddress(MockTarget.Architecture arch)
+    public void GetEnCStaticFieldDataAddress_Primitive_ReturnsFieldDataAddress(MockTarget.Architecture arch)
     {
         var helpers = new TargetTestHelpers(arch);
         var memBuilder = new MockMemorySpace.Builder(helpers);
         var allocator = memBuilder.CreateAllocator(0x0010_0000, 0x0020_0000);
 
-        // EnCAddedStaticField layout: FieldDesc (pointer) + FieldData (pointer-sized blob)
-        // FieldData uses [FieldAddress], so the contract returns the address of the FieldData field itself.
         var encAddedStaticFieldLayout = new SequentialLayoutBuilder("EnCAddedStaticField", arch)
             .AddPointerField(nameof(Data.EnCAddedStaticField.FieldDesc))
             .AddPointerField(nameof(Data.EnCAddedStaticField.FieldData))
@@ -364,7 +362,6 @@ public class RuntimeMutableTypeSystemTests
         // Allocate EnCAddedStaticField
         var staticFieldFragment = allocator.Allocate((ulong)encAddedStaticFieldLayout.Size, "EnCAddedStaticField");
         helpers.WritePointer(staticFieldFragment.Data.AsSpan(encAddedStaticFieldLayout.GetField(nameof(Data.EnCAddedStaticField.FieldDesc)).Offset, helpers.PointerSize), 0xABCD_0000);
-        // FieldData content doesn't matter - we want the address of the field itself
         helpers.WritePointer(staticFieldFragment.Data.AsSpan(encAddedStaticFieldLayout.GetField(nameof(Data.EnCAddedStaticField.FieldData)).Offset, helpers.PointerSize), 0x1234_5678);
 
         // Allocate EnCFieldDesc pointing to the static field
@@ -378,18 +375,72 @@ public class RuntimeMutableTypeSystemTests
             [DataType.EnCAddedStaticField] = TargetTestHelpers.CreateTypeInfo(encAddedStaticFieldLayout),
         };
 
+        var rts = new Mock<IRuntimeTypeSystem>();
+        rts.Setup(r => r.GetFieldDescType(new TargetPointer(fieldDescFragment.Address))).Returns(CorElementType.I4);
+
         var target = new TestPlaceholderTarget.Builder(arch)
             .UseReader(memBuilder.GetMemoryContext().ReadFromTarget)
             .AddTypes(types)
             .AddContract<IRuntimeMutableTypeSystem>(version: EnCContractVersion)
+            .AddMockContract(rts)
             .Build();
 
         IRuntimeMutableTypeSystem contract = target.Contracts.RuntimeMutableTypeSystem;
         TargetPointer result = contract.GetEnCStaticFieldDataAddress(new TargetPointer(fieldDescFragment.Address));
 
-        // The [FieldAddress] attribute means it returns the address of the FieldData field
         ulong expectedAddress = staticFieldFragment.Address + (ulong)encAddedStaticFieldLayout.GetField(nameof(Data.EnCAddedStaticField.FieldData)).Offset;
         Assert.Equal(new TargetPointer(expectedAddress), result);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetEnCStaticFieldDataAddress_ManagedType_ReturnsIndirectStorageAddress(MockTarget.Architecture arch)
+    {
+        var helpers = new TargetTestHelpers(arch);
+        var memBuilder = new MockMemorySpace.Builder(helpers);
+        var allocator = memBuilder.CreateAllocator(0x0010_0000, 0x0020_0000);
+
+        var encAddedStaticFieldLayout = new SequentialLayoutBuilder("EnCAddedStaticField", arch)
+            .AddPointerField(nameof(Data.EnCAddedStaticField.FieldDesc))
+            .AddPointerField(nameof(Data.EnCAddedStaticField.FieldData))
+            .Build();
+
+        var encFieldDescLayout = new SequentialLayoutBuilder("EnCFieldDesc", arch)
+            .AddUInt32Field(nameof(Data.EnCFieldDesc.NeedsFixup))
+            .AddPointerField(nameof(Data.EnCFieldDesc.StaticFieldData))
+            .Build();
+
+        ulong expectedAddress = 0x0018_0000;
+        var staticFieldFragment = allocator.Allocate((ulong)encAddedStaticFieldLayout.Size, "EnCAddedStaticField");
+        helpers.WritePointer(staticFieldFragment.Data.AsSpan(encAddedStaticFieldLayout.GetField(nameof(Data.EnCAddedStaticField.FieldDesc)).Offset, helpers.PointerSize), 0xABCD_0000);
+        helpers.WritePointer(staticFieldFragment.Data.AsSpan(encAddedStaticFieldLayout.GetField(nameof(Data.EnCAddedStaticField.FieldData)).Offset, helpers.PointerSize), expectedAddress);
+
+        var fieldDescFragment = allocator.Allocate((ulong)encFieldDescLayout.Size, "EnCFieldDesc");
+        helpers.Write(fieldDescFragment.Data.AsSpan(encFieldDescLayout.GetField(nameof(Data.EnCFieldDesc.NeedsFixup)).Offset, sizeof(int)), 0);
+        helpers.WritePointer(fieldDescFragment.Data.AsSpan(encFieldDescLayout.GetField(nameof(Data.EnCFieldDesc.StaticFieldData)).Offset, helpers.PointerSize), staticFieldFragment.Address);
+
+        var types = new Dictionary<DataType, Target.TypeInfo>
+        {
+            [DataType.EnCFieldDesc] = TargetTestHelpers.CreateTypeInfo(encFieldDescLayout),
+            [DataType.EnCAddedStaticField] = TargetTestHelpers.CreateTypeInfo(encAddedStaticFieldLayout),
+        };
+
+        var rts = new Mock<IRuntimeTypeSystem>();
+
+        var target = new TestPlaceholderTarget.Builder(arch)
+            .UseReader(memBuilder.GetMemoryContext().ReadFromTarget)
+            .AddTypes(types)
+            .AddContract<IRuntimeMutableTypeSystem>(version: EnCContractVersion)
+            .AddMockContract(rts)
+            .Build();
+
+        IRuntimeMutableTypeSystem contract = target.Contracts.RuntimeMutableTypeSystem;
+        foreach (CorElementType fieldType in new[] { CorElementType.Class, CorElementType.ValueType })
+        {
+            rts.Setup(r => r.GetFieldDescType(new TargetPointer(fieldDescFragment.Address))).Returns(fieldType);
+            TargetPointer result = contract.GetEnCStaticFieldDataAddress(new TargetPointer(fieldDescFragment.Address));
+            Assert.Equal(new TargetPointer(expectedAddress), result);
+        }
     }
 
     #endregion


### PR DESCRIPTION
Fix GetEnCStaticFieldDataAddress to match EnCAddedStaticField::GetFieldData w.r.t value and class types.