### PR TITLE
Hide remaining managed EH helpers from the debugger stack

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -253,6 +253,8 @@ namespace System.Runtime
             RH_EH_FIRST_RETHROW_FRAME = 2,
         }
 
+        [StackTraceHidden]
+        [DebuggerHidden]
         private static void AppendExceptionStackFrameViaClasslib(object exception, IntPtr ip,
             UIntPtr sp, ref ExInfo exInfo,
             ref bool isFirstRethrowFrame, ref bool isFirstFrame)
@@ -994,6 +996,8 @@ namespace System.Runtime
             return codeOffset;
         }
 
+        [StackTraceHidden]
+        [DebuggerHidden]
         private static void UpdateStackTrace(object exceptionObj, UIntPtr curFramePtr, IntPtr ip, UIntPtr sp,
             ref bool isFirstRethrowFrame, ref UIntPtr prevFramePtr, ref bool isFirstFrame, ref ExInfo exInfo)
         {

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/StackFrameIterator.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/StackFrameIterator.cs
@@ -68,16 +68,22 @@ namespace System.Runtime
             return InternalCalls.RhpSfiInit(ref this, pStackwalkCtx, instructionFault, fIsExceptionIntercepted);
         }
 
+        [StackTraceHidden]
+        [DebuggerHidden]
         internal bool Next()
         {
             return Next(null, null, null);
         }
 
+        [StackTraceHidden]
+        [DebuggerHidden]
         internal bool Next(uint* uExCollideClauseIdx, bool* fIsExceptionIntercepted)
         {
             return Next(uExCollideClauseIdx, null, fIsExceptionIntercepted);
         }
 
+        [StackTraceHidden]
+        [DebuggerHidden]
         internal bool Next(uint* uExCollideClauseIdx, bool* fUnwoundReversePInvoke, bool* fIsExceptionIntercepted)
         {
             return InternalCalls.RhpSfiNext(ref this, uExCollideClauseIdx, fUnwoundReversePInvoke, fIsExceptionIntercepted);


### PR DESCRIPTION
After #130646 replaced DAC-side frame filtering with attribute-based hiding, managed exception-handling helpers that were previously hidden by class-wide DBI filtering now appear in the logical call stack (mdbg `where`, current-location, and stepping) on arm64/interpreter configurations. #130646 annotated most of these helpers but missed a few:

- System.Runtime.EH.AppendExceptionStackFrameViaClasslib
- System.Runtime.EH.UpdateStackTrace
- System.Runtime.StackFrameIterator.Next (all three overloads)

Annotate each with both [StackTraceHidden] and [DebuggerHidden], matching the convention already used by every other annotated helper in this shared code (the 8 EH.* throw/dispatch helpers, StackFrameIterator.Init, and System.Environment.CallEntryPoint).

Validated on x64 and arm64: StackWalking.ExceptionStack/BigStackTest and the Exceptions suite (DivZeroTest, FirstChanceSuppressTest, ReflectionTest, TooManyTest) pass.