### PR TITLE
Use Reflection.Emit accessors when dynamic code is supported

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/MemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/MemberAccessor.cs
@@ -31,13 +31,8 @@ namespace System.Text.Json.Serialization.Metadata
                 {
                     MemberAccessor value =
 #if NET
-                        // On platforms where dynamic code is supported but not compiled to native code
-                        // (e.g. the Mono interpreter, WASM and iOS), the IL emitted by the Reflection.Emit
-                        // based accessor is only interpreted, offering no throughput benefit over plain
-                        // reflection while still pulling in the Reflection.Emit stack. Gating on
-                        // IsDynamicCodeCompiled (rather than IsDynamicCodeSupported) keeps Reflection.Emit
-                        // on JIT-backed runtimes but lets the trimmer remove it everywhere else.
-                        RuntimeFeature.IsDynamicCodeCompiled ?
+                        // if dynamic code isn't supported, fallback to reflection
+                        RuntimeFeature.IsDynamicCodeSupported ?
                             new ReflectionEmitCachingMemberAccessor() :
                             new ReflectionMemberAccessor();
 #elif NETFRAMEWORK


### PR DESCRIPTION
This restores the `Reflection.Emit`-based member accessor whenever dynamic code is supported, reverting only the accessor-selection change from #130503. The reflection invocation fixes and exception-propagation tests from that PR remain intact.

## Performance evidence

The accessor-selection change in #130503 was the first bad commit for dotnet/perf-autofiling-issues#76620. On Ubuntu 22.04 x64 with WASM and JavaScriptCore:

| Commit | Reflection | Source generation | Allocation |
|---|---:|---:|---:|
| Parent `8df98c4` | 6.788 us | 3.804 us | 48 B |
| #130503 (`ddb840c`) | 14.115 us | 3.777 us | 128 B |

The reflection-based serializer became 2.08x slower while the source-generation control remained unchanged. Additional JavaScriptCore and V8 benchmarks found interpreted `DynamicMethod` accessors 3–41x faster per repeated invocation than reflection. Creating them was 62–66x slower, but `System.Text.Json` caches generated accessors and amortizes that cost.

## Tradeoff

This intentionally reverses the trimming decision made for #38693. Interpreter deployments will retain the `Reflection.Emit` stack, restoring the approximately 50 KB size cost measured there and increasing accessor creation cost. The measurements above show that interpreted emitted IL does provide a substantial steady-state throughput and allocation benefit for reflection-based serialization, contrary to the premise of #130503.

## Validation

- `dotnet build`
- `dotnet build /t:test .\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj` — 53,409 .NET tests and 53,163 .NET Framework tests passed with zero failures

> [!NOTE]
> This pull request was generated by GitHub Copilot.